### PR TITLE
feat: add issue auto-search and resolution verifier to PR review skill

### DIFF
--- a/.claude/skills/aurelio-review-pr/SKILL.md
+++ b/.claude/skills/aurelio-review-pr/SKILL.md
@@ -65,25 +65,50 @@ gh pr view NUMBER --json body,title --jq '{title: .title, body: .body}'
 
 When no closing keyword is found and the PR doesn't look like partial/investigation work, **actively search** for a matching issue before giving up:
 
-1. **Search open issues** by PR title keywords and branch name:
+1. **Search open issues** by PR title keywords and branch name terms:
+
+   **Extracting search keywords:** Strip the conventional commit type prefix (e.g. `feat: `, `fix: `) from the PR title, then extract 3-5 distinctive nouns and verbs. Avoid generic words like "add", "update", "fix", "implement". Also extract key terms from the branch name (split on `/` and `-`). Combine both sets for the search query. For example, from title "feat: add issue auto-search and resolution verifier to PR review skill" and branch `feat/review-skill-issue-search`, search for `"issue auto-search resolution verifier review skill"`.
 
    ```bash
-   # Search by key terms from the PR title (strip type prefix like "feat: ")
-   gh issue list --repo OWNER/REPO --state open --search "TITLE_KEYWORDS" --json number,title,labels --jq '.[] | {number, title, labels: [.labels[].name]}'
+   # Search by key terms from the PR title + branch name
+   gh issue list --repo OWNER/REPO --state open --limit 20 --search "TITLE_AND_BRANCH_KEYWORDS" --json number,title,labels,milestone --jq '.[] | {number, title, labels: [.labels[]?.name], milestone: .milestone.title}'
 
    # Also search recently closed issues (in case PR was created after issue was closed)
-   gh issue list --repo OWNER/REPO --state closed --search "TITLE_KEYWORDS" --json number,title,labels --jq '.[] | {number, title, labels: [.labels[].name]}' | head -10
+   gh issue list --repo OWNER/REPO --state closed --limit 10 --search "TITLE_AND_BRANCH_KEYWORDS" --json number,title,labels,milestone --jq '.[] | {number, title, labels: [.labels[]?.name], milestone: .milestone.title}'
    ```
 
-2. **Evaluate candidates.** For each candidate issue, compare:
+2. **Evaluate candidates.** For each shortlisted candidate (up to ~5), fetch full issue details before scoring:
+
+   ```bash
+   gh issue view CANDIDATE_N --repo OWNER/REPO --json title,body,labels,milestone --jq '{title: .title, body: .body, labels: [.labels[]?.name], milestone: .milestone.title}'
+   ```
+
+   Then compare:
    - Does the issue title/body describe the same change as the PR title/body?
    - Does the issue's milestone or labels match the PR's scope?
    - Is there a strong keyword overlap between the issue title and the PR branch name or title?
 
 3. **Confidence threshold:**
-   - **High confidence** (single strong match, clear title/scope alignment): auto-link the issue by updating the PR body with `gh pr edit NUMBER --body "EXISTING_BODY\n\nCloses #N"`. Inform the user: "Auto-linked closes #N — issue title closely matches this PR."
-   - **Ambiguous** (multiple plausible matches or weak alignment): present the top candidates to the user via AskUserQuestion and let them pick, or confirm none apply.
+   - **High confidence** (single strong match, clear title/scope alignment): present the match to the user and ask for confirmation before editing the PR body. For example: "Found issue #N (*title*) which closely matches this PR. Link it with `closes #N`?" If confirmed, safely update the PR body (see linking procedure below). Inform the user: "Linked closes #N."
+   - **Ambiguous** (multiple plausible matches or weak alignment): present the top candidates to the user via AskUserQuestion and let them pick, or confirm none apply. If the user selects an issue, persist the link using the same linking procedure below.
    - **No matches**: warn the user: "PR does not reference a GitHub issue and no matching issue was found. Consider adding `closes #N` to the PR body if this resolves an issue."
+
+   **Linking procedure (safe body update):** Never interpolate the existing PR body into a shell argument — it is untrusted input. Instead:
+
+   ```bash
+   # 1. Write the existing body to a temp file
+   tmpfile="$(mktemp)"
+   gh pr view NUMBER --json body --jq '.body' > "$tmpfile"
+
+   # 2. Idempotent: only append if not already present
+   if ! grep -q "Closes #N" "$tmpfile"; then
+     printf '\n\nCloses #N\n' >> "$tmpfile"
+   fi
+
+   # 3. Update using --body-file (avoids shell interpolation)
+   gh pr edit NUMBER --body-file "$tmpfile"
+   rm -f "$tmpfile"
+   ```
 
 4. **Input validation (CRITICAL):** The same input validation rules apply to any issue numbers discovered via search — validate before use in shell commands.
 
@@ -125,6 +150,8 @@ Based on changed files, launch applicable review agents **in parallel** using th
 
 The **issue-resolution-verifier** agent checks whether the PR fully resolves the linked issue. It only runs when an issue is linked — either from a pre-existing `closes #N` in the PR body, or auto-linked/user-selected during Phase 2's search.
 
+**Partial-work context:** If Phase 2 flagged the PR as potential partial work (closing keyword present + non-closing signals) and the user confirmed the closing keyword should stay, inform the verifier of this context. The verifier should still run but should adjust its expectations: flag NOT_RESOLVED items as **informational** rather than blocking, and note which items appear to be intentionally deferred to follow-up work. Present these as "INFO (partial PR)" severity in the triage table instead of CRITICAL.
+
 **What to check:**
 
 Read the linked issue's title, body, acceptance criteria, labels, and comments in full. Then compare against the PR diff and assess:
@@ -143,7 +170,7 @@ Read the linked issue's title, body, acceptance criteria, labels, and comments i
 
 **Key principle:** It is better to flag a false "not resolved" than to let a partially-resolved issue get auto-closed. When in doubt, flag it.
 
-**If the verifier finds NOT_RESOLVED items:** These are surfaced in Phase 5 triage as findings from the "issue-resolution-verifier" source. CRITICAL items (missing acceptance criteria) should block merge consideration. The user decides whether to fix them in this PR or remove the closing keyword.
+**If the verifier finds NOT_RESOLVED items:** These are surfaced in Phase 5 triage as findings from the "issue-resolution-verifier" source. **NOT_RESOLVED items always override the generic confidence-to-severity mapping and are surfaced as CRITICAL (blocking merge)** — regardless of the individual confidence score. This ensures missing acceptance criteria are never downgraded to a lower severity. The user decides whether to fix them in this PR or remove the closing keyword.
 
 The **docs-consistency** agent ensures project documentation never drifts from the codebase. It runs on **every PR** — code changes, config changes, docs-only changes, all of them.
 


### PR DESCRIPTION
## Summary

- When the PR review skill finds no `closes #N` keyword, it now **searches for a matching issue** by PR title keywords instead of immediately warning
- High-confidence matches are auto-linked via `gh pr edit --body`; ambiguous matches are presented to the user for selection
- Adds a new **issue-resolution-verifier** agent that runs whenever an issue is linked — checks acceptance criteria coverage, scope completeness, test coverage, and documentation requirements against the PR diff

## Changes

Only `.claude/skills/aurelio-review-pr/SKILL.md` — no source code changes.

### Phase 2 — Issue linkage

- `No closing keyword + no partial signals` now triggers a 4-step search: query open/closed issues → evaluate candidates → auto-link or ask user → fall back to warning
- Input validation rules extended to cover search-discovered issue numbers

### Phase 3 — New agent

- `issue-resolution-verifier` added to the agent table (runs when issue is linked)
- Checks each acceptance criterion → RESOLVED / PARTIALLY_RESOLVED / NOT_RESOLVED with confidence scores
- NOT_RESOLVED items surface in Phase 5 triage as CRITICAL findings

## Test plan

- [ ] Run `/aurelio-review-pr` on a PR **with** a closing keyword — verify existing behavior unchanged
- [ ] Run `/aurelio-review-pr` on a PR **without** a closing keyword — verify it searches and auto-links
- [ ] Run `/aurelio-review-pr` on a PR with ambiguous matches — verify AskUserQuestion is used
- [ ] Verify issue-resolution-verifier agent launches and reports findings in triage