### PR TITLE
refactor: extract _SpendingTotals base class from spending summary models

### DIFF
--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -2178,7 +2178,7 @@ ai-company/
 │       │   ├── config.py           # Budget configuration models
 │       │   ├── cost_record.py      # CostRecord model (frozen)
 │       │   ├── tracker.py          # CostTracker service (records + queries)
-│       │   ├── spending_summary.py # AgentSpending, DepartmentSpending, PeriodSpending
+│       │   ├── spending_summary.py # _SpendingTotals base + spending summary models
 │       │   ├── hierarchy.py        # BudgetHierarchy, BudgetConfig
 │       │   ├── enums.py            # Budget-related enums
 │       │   ├── limits.py           # Budget enforcement (M5)

--- a/src/ai_company/budget/spending_summary.py
+++ b/src/ai_company/budget/spending_summary.py
@@ -1,7 +1,8 @@
 """Spending summary models for aggregated cost reporting.
 
-Provides the aggregation data structures consumed by the CFO agent
-(DESIGN_SPEC Section 10.3) for cost reporting and budget monitoring.
+Provides the aggregation data structures used by
+:class:`~ai_company.budget.tracker.CostTracker` for cost reporting and
+designed for consumption by the CFO agent (DESIGN_SPEC Section 10.3).
 Views of :class:`~ai_company.budget.cost_record.CostRecord` data are
 aggregated by agent, department, and time period.
 """


### PR DESCRIPTION
## Summary

- Extract `_SpendingTotals` base class with shared aggregation fields (`total_cost_usd`, `total_input_tokens`, `total_output_tokens`, `record_count`)
- `AgentSpending`, `DepartmentSpending`, and `PeriodSpending` now extend `_SpendingTotals` instead of independently defining identical fields
- Update DESIGN_SPEC.md §10.2 and §15.5 to reflect "Shared field groups" convention as Adopted (M2.5)
- Net reduction of 41 lines with no behavioral changes

Closes #111

## Details

- `_SpendingTotals` is private (underscore-prefixed, excluded from `__init__.py` exports)
- `model_config = ConfigDict(frozen=True)` defined once on base, inherited by all subclasses
- `PeriodSpending._validate_period_ordering` validator preserved unchanged
- Field constraints (`ge=0`, defaults) remain identical

## Test plan

- [x] All 1830 existing tests pass without modification
- [x] `spending_summary.py` maintains 100% coverage
- [x] Frozen model inheritance verified by existing `test_frozen` tests on each subclass
- [x] JSON roundtrip test confirms serialization unaffected
- [x] mypy strict mode passes
- [x] ruff lint + format clean

## Review coverage

Pre-reviewed by 8 agents (code-reviewer, python-reviewer, pr-test-analyzer, comment-analyzer, type-design-analyzer, logging-audit, resilience-audit, docs-consistency). 6 findings total, 2 implemented, 4 skipped as non-applicable or out-of-scope.