### PR TITLE
docs: add ADR-001 memory layer evaluation and selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ src/ai_company/
   config/         # YAML company config loading and validation
   core/           # Shared domain models and base classes
   engine/         # Agent orchestration, execution loops, parallel execution, task decomposition, routing, task assignment, task lifecycle, recovery, shutdown, and workspace isolation
-  memory/         # Persistent agent memory (memory layer TBD)
+  memory/         # Persistent agent memory (Mem0 initial, custom stack future — ADR-001)
   observability/  # Structured logging, correlation tracking, log sinks
   providers/      # LLM provider abstraction (LiteLLM adapter)
   security/       # SecOps agent, approval gates, audit

--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -1229,7 +1229,8 @@ The auto-selector uses task structure, artifact count, and (when available from 
 ├──────────┴──────────┴───────────┴───────────┤
 │            Storage Backend                   │
 │   SQLite / PostgreSQL / File-based           │
-│   + Memory Layer (TBD — see §15.2)           │
+│   + Mem0 (initial) / Custom Stack (future)    │
+│     See ADR-001                               │
 └─────────────────────────────────────────────┘
 ```
 
@@ -1248,7 +1249,11 @@ The auto-selector uses task structure, artifact count, and (when available from 
 ```yaml
 memory:
   level: "full"                 # none, session, project, full
-  backend: "sqlite"             # sqlite, postgresql, file (memory layer library is on top, not a backend itself — see §15.2)
+  backend: "mem0"               # mem0, custom, cognee, graphiti (future) — see ADR-001
+  storage:
+    data_dir: "/data/memory"    # mounted Docker volume path
+    vector_store: "qdrant"      # qdrant (embedded), qdrant-external, etc.
+    history_store: "sqlite"     # sqlite, postgresql
   options:
     retention_days: null         # null = forever
     max_memories_per_agent: 10000
@@ -1319,7 +1324,7 @@ org_memory:
 - Handles policy evolution naturally. Agents understand when and why things changed
 - Most complex. Potentially overkill for small companies or local-first use
 
-> **Extensibility:** All backends implement the `OrgMemoryBackend` protocol (`query(context) → list[OrgFact]`, `write(fact, author)`, `list_policies()`). The MVP ships with Backend 1; Backends 2 and 3 are research directions that may be explored if the default approach proves insufficient. The memory layer candidate (currently evaluating Mem0 and alternatives — see §15.2) may provide graph memory capabilities natively, reducing implementation effort for Backends 2-3.
+> **Extensibility:** All backends implement the `OrgMemoryBackend` protocol (`query(context) → list[OrgFact]`, `write(fact, author)`, `list_policies()`). The MVP ships with Backend 1; Backends 2 and 3 are research directions that may be explored if the default approach proves insufficient. The selected memory layer backend Mem0 (ADR-001) provides optional graph memory via Neo4j/FalkorDB, which could reduce implementation effort for Backends 2-3.
 > **Write access control:** Core policies are human-only. ADRs and procedures can be written by senior+ agents. All writes are versioned and auditable. This prevents agents from corrupting shared organizational knowledge while allowing senior agents to document decisions.
 
 ---
@@ -2319,14 +2324,14 @@ Run: ai-company start acme-corp
 └──────────────────────────────────────────────────────────────┘
 ```
 
-### 15.2 Technology Stack (Candidates - TBD After Research)
+### 15.2 Technology Stack
 
 | Component | Technology | Rationale |
 |-----------|-----------|-----------|
 | **Language** | Python 3.14+ | Best AI/ML ecosystem, all major frameworks use it, LiteLLM/MCP and memory layer candidates all Python-native. PEP 649 native lazy annotations, PEP 758 except syntax. |
 | **API Framework** | FastAPI | Async-native, WebSocket support, auto OpenAPI docs, high performance, type-safe with Pydantic |
 | **LLM Abstraction** | LiteLLM | 100+ providers, unified API, built-in cost tracking, retries/fallbacks |
-| **Agent Memory** | Mem0 (initial) → custom stack (future) + SQLite | Mem0 in-process as initial backend behind pluggable `MemoryBackend` protocol (ADR-001). Qdrant embedded + SQLite for persistence. Custom stack (Neo4j + Qdrant external) as future upgrade. Config-driven backend selection |
+| **Agent Memory** | Mem0 (Qdrant + SQLite) → custom (Neo4j + Qdrant) | Mem0 in-process as initial backend behind pluggable `MemoryBackend` protocol ([ADR-001](docs/decisions/ADR-001-memory-layer.md)). Qdrant embedded + SQLite for persistence. Custom stack (Neo4j + Qdrant external) as future upgrade. Config-driven backend selection |
 | **Message Bus** | Internal (async queues) → Redis | Start with Python asyncio queues, upgrade to Redis for multi-process/distributed |
 | **Task Queue** | Internal → Celery/Redis | Start simple, scale with Celery when needed |
 | **Database** | SQLite → PostgreSQL | Start lightweight, migrate to Postgres for production/multi-user |
@@ -2619,6 +2624,8 @@ ai-company/
 │   ├── integration/
 │   └── e2e/
 ├── docs/
+│   ├── decisions/
+│   │   └── ADR-001-memory-layer.md
 │   └── getting_started.md
 ├── DESIGN_SPEC.md                   # This document
 ├── README.md
@@ -2633,7 +2640,7 @@ ai-company/
 | Language | Python 3.14+ | TypeScript, Go, Rust | AI ecosystem, LiteLLM/MCP and memory layer candidates are Python-native, PEP 649 lazy annotations, PEP 758 except syntax |
 | API | FastAPI | Flask, Django, aiohttp | Async native, Pydantic integration, auto docs, WebSocket support |
 | LLM Layer | LiteLLM | Direct APIs, OpenRouter only | 100+ providers, cost tracking, fallbacks, load balancing built-in |
-| Memory | TBD + SQLite | Mem0, Zep, Letta, Cognee, ChromaDB, custom | Memory layer library TBD — all candidates under evaluation. Must support episodic, semantic, procedural memory types (§7.1–7.3). Org memory served via `OrgMemoryBackend` protocol (§7.4) |
+| Memory | Mem0 (initial) → custom stack (future) + SQLite | Graphiti, Letta, Cognee, custom | Mem0 in-process as initial backend behind pluggable `MemoryBackend` protocol ([ADR-001](docs/decisions/ADR-001-memory-layer.md)). Custom stack (Neo4j + Qdrant) as future upgrade. Must support episodic, semantic, procedural memory types (§7.1–7.3). Org memory served via `OrgMemoryBackend` protocol (§7.4) |
 | Message Bus | asyncio queues → Redis | Kafka, RabbitMQ, NATS | Start simple, Redis well-supported, Kafka overkill for local |
 | Config | YAML + Pydantic | JSON, TOML, Python dicts | Human-friendly, strict validation, good IDE support |
 | CLI | Typer | Click, argparse, Fire | Built on Click, auto-completion, type hints |
@@ -2692,7 +2699,7 @@ These conventions were established during the M0–M2+ review cycle. **Adopted**
 | Full company simulation | Partial | Partial | No | **Yes - complete** |
 | HR (hiring/firing) | No | No | No | **Yes** |
 | Budget management (CFO) | No | No | No | **Yes** |
-| Persistent agent memory | No | No | Basic | **Yes (memory layer TBD — candidates under evaluation)** |
+| Persistent agent memory | No | No | Basic | **Yes (Mem0 initial, custom stack future — ADR-001)** |
 | Agent personalities | Basic | Basic | Basic | **Deep - traits, styles, evolution** |
 | Dynamic team scaling | No | No | Manual | **Yes - auto + manual** |
 | Multiple company types | No | No | Manual | **Yes - templates + builder** |
@@ -2726,12 +2733,12 @@ Rationale:
 - No existing framework covers even 50% of our requirements
 - Our core differentiators (HR, budget, security ops, deep personalities, progressive trust) don't exist in any framework
 - Forking MetaGPT or CrewAI would mean fighting their architecture while adding our features
-- **LiteLLM**, **FastAPI**, **MCP**, and a memory layer library (TBD) give us battle-tested components for the hard parts
+- **LiteLLM**, **FastAPI**, **MCP**, and **Mem0** (memory layer — ADR-001) give us battle-tested components for the hard parts
 - The "company simulation" layer on top is our unique value and must be purpose-built
 
 What we **plan to leverage** (not fork) — subject to evaluation:
 - **LiteLLM** (candidate) - Provider abstraction
-- **Memory layer** (candidates: Mem0, Zep, Letta, Cognee, custom) - Agent memory
+- **Mem0** (selected, ADR-001) - Agent memory (initial backend; custom stack future)
 - **FastAPI** (candidate) - API layer
 - **MCP** - Tool integration standard (strong candidate, emerging industry standard)
 - **Pydantic** (candidate) - Config validation and data models
@@ -2759,7 +2766,7 @@ What we **plan to leverage** (not fork) — subject to evaluation:
 | 11 | What is the agent execution loop architecture? | High | **Resolved** | Multiple configurable loops — see §6.5 Agent Execution Loop |
 | 12 | How should shared organizational memory work? | High | **Resolved** | Modular backends behind protocol — see §7.4 Shared Organizational Memory |
 | 13 | What happens when humans don't respond to approvals? | High | **Resolved** | Configurable timeout policies with task suspension — see §12.4 Approval Timeout |
-| 14 | Which memory layer library to use? | Medium | Open | Mem0, Zep, Letta, Cognee, custom — all candidates, TBD after evaluation (see §15.2) |
+| 14 | Which memory layer library to use? | Medium | **Resolved** | Mem0 (initial) → custom stack (future) behind pluggable `MemoryBackend` protocol — see [ADR-001](docs/decisions/ADR-001-memory-layer.md) |
 | 15 | How to handle agent crashes mid-task? | High | **Resolved** | Pluggable `RecoveryStrategy` protocol — see §6.6 Agent Crash Recovery |
 | 16 | How to test non-deterministic agent behavior? | High | **Resolved** | Scripted providers for unit tests + behavioral assertions for integration — see §15.5 Engineering Conventions |
 | 17 | How to detect orchestration overhead? | Medium | **Resolved** | Incremental LLM call analytics with proxy metrics (M3) → full categorization (M4) — see §10.5 |
@@ -2772,7 +2779,7 @@ What we **plan to leverage** (not fork) — subject to evaluation:
 | Cost explosion from agent loops | High | Budget hard stops, loop detection, max iterations per task |
 | Agent quality degradation with cheap models | Medium | Quality gates, minimum model requirements per task type |
 | Third-party library breaking changes | Medium | Pin versions, integration tests, abstraction layers |
-| Memory retrieval quality | Medium | Evaluate candidates (Mem0, custom, etc.) against our use case |
+| Memory retrieval quality | Medium | Mem0 selected as initial backend (ADR-001). Protocol layer enables backend swap if retrieval quality insufficient. Pin version, test 3.14 compat in CI |
 | Agent personality inconsistency | Low | Strong system prompts, few-shot examples, personality tests |
 | WebSocket scaling | Low | Start local, add Redis pub/sub when needed |
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ AI Company lets you spin up a virtual organization staffed entirely by AI agents
 - **Task Assignment** - Pluggable strategies (manual, role-based, load-balanced, cost-optimized, hierarchical, auction) for matching tasks to capable agents
 - **Workspace Isolation** - Git worktree-based concurrent workspace isolation with sequential merge and conflict escalation
 - **Configurable Autonomy** - From fully autonomous to human-approves-everything, with a Security Ops agent in between
-- **Persistent Memory** - Agents remember past decisions, code, relationships (memory layer TBD)
+- **Persistent Memory** - Agents remember past decisions, code, relationships (Mem0 initial, custom stack future)
 - **HR System** - Hire, fire, promote agents. HR agent analyzes skill gaps and proposes candidates
 - **Real Tool Access** - File system, git, code execution, web, databases - role-based and sandboxed
 - **API-First** - REST + WebSocket API with local web dashboard
@@ -28,7 +28,7 @@ AI Company lets you spin up a virtual organization staffed entirely by AI agents
 
 ## Status
 
-**M3: Single Agent** and **M4: Multi-Agent** in progress (M0 Tooling, M1 Config & Core, M2 Providers — all done). See [DESIGN_SPEC.md](DESIGN_SPEC.md) for the full high-level specification.
+**M5: Memory & Budget** in progress (M0 Tooling, M1 Config & Core, M2 Providers, M3 Single Agent, M4 Multi-Agent — all done). See [DESIGN_SPEC.md](DESIGN_SPEC.md) for the full high-level specification.
 
 ## Tech Stack
 
@@ -36,7 +36,7 @@ AI Company lets you spin up a virtual organization staffed entirely by AI agents
 - **uv** as package manager, **Hatchling** as build backend
 - **LiteLLM** for multi-provider LLM abstraction
 - **structlog** for structured logging and observability
-- **Memory layer TBD** (candidates: Mem0, Zep, Letta, Cognee, custom) for agent memory (planned)
+- **Mem0** for agent memory (initial backend; custom stack future — see [ADR-001](docs/decisions/ADR-001-memory-layer.md))
 - **MCP** for tool integration (planned)
 - **Vue 3** for web dashboard (planned)
 - **SQLite** → PostgreSQL for data persistence (planned)

--- a/docs/decisions/ADR-001-memory-layer.md
+++ b/docs/decisions/ADR-001-memory-layer.md
@@ -11,7 +11,10 @@ Accepted
 ## Context
 
 The `memory/` module in `DESIGN_SPEC.md` (sections 7.1-7.4, 15.2) lists the memory
-layer as "TBD — candidates: Mem0, Zep, Letta, Cognee, custom." This decision blocks
+layer as "TBD — candidates: Mem0, Zep, Letta, Cognee, custom." (Note: Zep pivoted to
+**Graphiti** as their open-source temporal knowledge graph offering; the standalone Zep
+product is now a cloud-only service. This evaluation covers Graphiti as Zep's
+successor.) This decision blocks
 the entire M5 milestone:
 
 - **#32** Memory interface design
@@ -22,9 +25,14 @@ the entire M5 milestone:
 
 ### Key Architecture Constraints (from user)
 
-1. Memory/storage runs in **separate container(s)** from the main Python app
+1. **Target architecture**: memory/storage runs in **separate container(s)** from the
+   main Python app. **MVP exception**: an in-process deployment (e.g., Mem0 inside the
+   `ai-company` container) is acceptable as long as it preserves the same protocol
+   boundary and can be moved out-of-process without refactors.
 2. Does NOT have to be Python — any technology, containerized
-3. Main app uses a **thin async Python client** behind a **pluggable protocol**
+3. Main app uses a **thin async Python client** behind a **pluggable protocol**, which
+   must work for both in-process libraries and remote services so storage can
+   transparently move to separate container(s) later.
 4. **Capability discovery** — protocol exposes what each backend supports
 5. Multiple containers are fine (e.g., graph DB + vector store)
 6. **Graph DB**: both Neo4j (server) and embedded options should be evaluated
@@ -92,7 +100,7 @@ projects launched or matured significantly in 2025.
 
 | Candidate | G1 | G2 | G3 | G4 | G5 | G6 | G7 | Result |
 |-----------|----|----|----|----|----|----|----|----|
-| **Mem0** | PASS | PASS (Apache 2.0) | PASS (3 containers) | PASS (v1.0.5, Mar 2026) | PASS (user/agent/app/run_id) | PASS (11+ providers) | PASS (`>=3.9,<4.0`) | **PASS** |
+| **Mem0** | PASS | PASS (Apache 2.0) | PASS (in-process or 3 containers) | PASS (v1.0.5, Mar 2026) | PASS (user/agent/app/run_id) | PASS (11+ providers) | PASS (`>=3.9,<4.0`) | **PASS** |
 | **Graphiti** | PASS | PASS (Apache 2.0) | PASS (compose) | PASS (v0.28.1, Feb 2026) | PASS (group_id) | PASS (4 providers) | PASS (`>=3.10,<4`) | **PASS** |
 | **Letta** | PASS | PASS (Apache 2.0) | PASS | PASS (v0.16.6) | PASS (inherent) | PASS | **FAIL (`<3.14`)** | **ELIMINATED** |
 | **Cognee** | PASS | PASS (Apache 2.0) | PASS (compose) | PASS (v0.5.3) | PASS (multi-tenant) | PASS (8+) | **FAIL (`<3.14`)** | **ELIMINATED** |
@@ -156,7 +164,7 @@ projects launched or matured significantly in 2025.
 | Criterion | Mem0 | Graphiti | Custom Stack |
 |-----------|------|---------|-------------|
 | **S1** Memory types (15) | **9** — episodic+semantic+procedural+short-term. No explicit social/working. Flat fact model needs wrapping | **7** — episodic+semantic+social via graph. No procedural/working | **15** — full control, maps directly to all 5 types |
-| **S2** Retrieval quality (15) | **12** — +26% vs OpenAI Memory on LOCOMO. Well benchmarked | **11** — +18.5% accuracy, 90% latency reduction. Graph traversal powerful | **10** — depends on implementation. Qdrant + Neo4j individually excellent |
+| **S2** Retrieval quality (15) | **12** — +26% vs. OpenAI Memory on LOCOMO. Well benchmarked | **11** — +18.5% accuracy, 90% latency reduction. Graph traversal powerful | **10** — depends on implementation. Qdrant + Neo4j individually excellent |
 | **S3** Graph capability (12) | **8** — graph is supplementary to vector. Neo4j/Kuzu/FalkorDB. Enriches results but doesn't drive retrieval | **12** — graph IS the primary store. Bi-temporal model. Neo4j/FalkorDB/Kuzu | **11** — Neo4j is best-in-class. Full Cypher. Must implement temporal tracking |
 | **S4** Stability (12) | **11** — v1.0+, 49k stars, YC-backed. v1.0.0 had breaking changes but migration guide exists | **7** — pre-1.0 (v0.28), fast-moving API. Docker image freshness issues. Hallucination bugs reported | **10** — each component individually very mature. No unified project risk |
 | **S5** Protocol compat (10) | **6** — factory-based, opinionated memory structure. Needs adapter layer that fights its own abstractions | **7** — GraphDriver ABC is protocol-like. Async-native. Cleaner wrapping than Mem0 | **10** — built from scratch to match our protocol pattern exactly |
@@ -164,8 +172,8 @@ projects launched or matured significantly in 2025.
 | **S7** Async support (8) | **6** — AsyncMemory added after community request (#2495). Works but secondary path | **8** — fully async throughout. Native design | **8** — Neo4j async driver + Qdrant async client both confirmed |
 | **S8** Consolidation (5) | **4** — built-in memory compression engine | **3** — community detection, entity deduplication | **1** — must implement from scratch |
 | **S9** Community/docs (5) | **5** — largest community (49k stars), good docs, YC backing | **4** — 23k stars, growing fast, good docs | **3** — components have great docs but no unified project |
-| **S10** Resource footprint (5) | **3** — 3 containers (FastAPI + PostgreSQL + Neo4j) for full graph | **3** — graph DB container + heavy LLM usage during ingestion | **3** — 2 containers (Neo4j + Qdrant) + embedded FastEmbed |
-| **S11** Operational complexity (5) | **3** — 3 containers, OpenAI defaults need reconfiguration for local | **2** — graph DB + high LLM cost per episode ingestion (1000+ API calls per 10k chars reported) | **4** — 2 well-understood containers, standard config |
+| **S10** Resource footprint (5) | **3** — full graph stack: 3 containers (FastAPI + PostgreSQL + Neo4j); in-process mode lighter (Qdrant embedded + SQLite) | **3** — graph DB container + heavy LLM usage during ingestion | **3** — 2 containers (Neo4j + Qdrant) + embedded FastEmbed |
+| **S11** Operational complexity (5) | **3** — full graph stack: 3 containers, OpenAI defaults need reconfiguration for local; in-process mode simpler | **2** — graph DB + high LLM cost per episode ingestion (1000+ API calls per 10k chars reported) | **4** — 2 well-understood containers, standard config |
 | | | | |
 | **TOTAL** | **70/100** | **66/100** | **80/100** |
 
@@ -316,7 +324,7 @@ When Mem0's limitations become blocking, swap to custom backend via config:
 │  │  │  working  → in-process                             │     │  │
 │  │  │  episodic → Qdrant (external)                      │     │  │
 │  │  │  semantic → Neo4j (external) + Qdrant              │     │  │
-│  │  │  procedur → Qdrant (external)                      │     │  │
+│  │  │  procedural → Qdrant (external)                    │     │  │
 │  │  │  social   → Neo4j (external)                       │     │  │
 │  │  └───────┬──────────────────────┬─────────────────────┘     │  │
 │  └──────────┼──────────────────────┼──────────────────────────┘  │
@@ -452,8 +460,10 @@ Configuration determines which provider to use. Set via YAML config.
 
 - **Initially**: Graph disabled by default. Enable via config when needed.
 - **When enabled**: Mem0 supports Neo4j (recommended), Memgraph, FalkorDB.
-- **Kuzu NOT recommended**: Archived October 2025. Mem0's Kuzu backend has open
-  concurrency bugs. Use Neo4j or FalkorDB instead.
+- **Kuzu NOT recommended**: Archived October 10, 2025. Its architectural
+  concurrency model (single `Database` per process with `Connection` reuse) is not
+  suited for Mem0's multi-threaded context. Use Neo4j or FalkorDB instead, both of
+  which handle concurrent access patterns out of the box.
 - **Future custom backend**: Neo4j as primary graph DB, behind a `GraphDriver`
   protocol for pluggability.
 
@@ -474,7 +484,7 @@ Configuration determines which provider to use. Set via YAML config.
 | Mem0 flat fact model limits 5-type taxonomy | Certain | Low (initial) | Acceptable for initial backend. Metadata tagging provides partial typing. Custom backend replaces when needed |
 | Mem0 API breaking changes | Possible | Medium | Pin `mem0ai` version. Adapter layer isolates changes from protocol consumers |
 | Mem0 Python 3.14 untested (range allows it) | Possible | High | `>=3.9,<4.0` allows 3.14 but no explicit classifier. Test early in CI. Fallback: custom backend |
-| Neo4j CE resource footprint (JVM, ~512MB+ RAM) | Likely | Low | Deferred to Phase 2. Not needed initially. FalkorDB as lighter alternative |
+| Neo4j CE resource footprint (JVM, ~512 MB+ RAM) | Likely | Low | Deferred to Phase 2. Not needed initially. FalkorDB as lighter alternative |
 | Kuzu ecosystem fragmentation | Likely | None | Archived Oct 2025. Not recommended. All candidates support Neo4j/FalkorDB. Not a factor |
 
 ---
@@ -501,7 +511,7 @@ Most flexible backend support (4+ graph DBs, 3+ vector stores), but:
 - **Python `<3.14` not yet supported** — conservative upper bound, no known technical
   blocker. Check future releases.
 - Early-stage maturity (v0.5.x)
-- Could become an alternative backend behind our protocol once 3.14 lands
+- Could become an alternative backend behind our protocol once 3.14 lands.
 
 ### Letta (OS-Inspired Memory)
 
@@ -509,7 +519,7 @@ Architecturally unique self-editing memory paradigm, but:
 - **Python `<3.14` not yet supported** — conservative upper bound. Check future releases.
 - Full agent platform, not a standalone memory layer
 - Cannot use memory component independently
-- Opinionated architecture conflicts with our pluggable protocol design
+- Opinionated architecture conflicts with our pluggable protocol design.
 
 ---
 
@@ -517,15 +527,15 @@ Architecturally unique self-editing memory paradigm, but:
 
 The protocol-based architecture means **the memory layer decision is never final**.
 Any backend that satisfies the `MemoryBackend` protocol can be added as an alternative
-implementation. The custom stack is the **initial backend**, not the only one.
+implementation. **Mem0 is the initial backend**, not the only one.
 
 Future backends can be added without modifying existing code:
 
-| Candidate | Trigger to Revisit | What It Would Replace |
-|-----------|-------------------|----------------------|
-| **Cognee** | Adds Python 3.14 support | Could replace custom graph+vector layer with unified cognify pipeline |
+| Candidate | Trigger to Revisit | Role in the Architecture |
+|-----------|-------------------|--------------------------|
+| **Custom Stack** | Mem0 adapter limitations become blocking | Full 5-type coverage, bi-temporal tracking, graph-native memory |
+| **Cognee** | Adds Python 3.14 support | Could provide a unified graph+vector pipeline behind the memory protocol |
 | **Letta** | Adds Python 3.14 support + standalone memory extraction | Could power self-editing memory for advanced agents |
-| **Mem0** | If 5-type taxonomy support improves | Could replace custom vector layer with managed extraction |
 | **Graphiti** | Reaches v1.0 + reduces LLM ingestion costs | Could power §7.4 Backend 3 (temporal KG) specifically |
 
 Capability discovery flags (`supports_graph`, `supports_temporal`, etc.) enable
@@ -574,7 +584,7 @@ simpler backend.
 - `memify()` self-improving memory is unique
 - 14 search modes including graph completion and temporal
 - Would be a strong contender if Python 3.14 constraint is lifted
-- **Watch**: revisit when/if 3.14 support is added — strongest alternative backend candidate
+- **Watch**: revisit when/if 3.14 support is added — strongest alternative backend candidate.
 
 ### memU — ELIMINATED (G2: AGPL-3.0)
 


### PR DESCRIPTION
## Summary

- Comprehensive evaluation of 16+ agent memory candidates for the `memory/` module (issue #39)
- Gate checks (local-first, license, Docker, Python 3.14, isolation, embeddings) narrowed to 3 viable candidates: Mem0, Graphiti, Custom Stack
- Scored comparison (S1-S11, 100 points) across memory type coverage, retrieval quality, graph capability, stability, protocol compatibility, async support, and more
- **Decision: Mem0 as initial backend** (in-process, Qdrant embedded + SQLite, persistent to Docker volume) behind pluggable `MemoryBackend` protocol
- Custom stack (Neo4j + Qdrant external) as planned future upgrade
- Cognee/Letta on watch list pending Python 3.14 support
- Updated DESIGN_SPEC.md §15.2 to reflect the decision
- Documented downstream impact on #32 (memory interface), #36 (persistence), #125 (org memory)

## Key Findings

- **Letta/Cognee eliminated**: Python `<3.14` constraint (conservative bounds, not technical — on watch list)
- **Supermemory eliminated**: proprietary engine, SDK-only open source, no self-hosting
- **Kuzu archived** Oct 2025 — optional in all candidates, not a blocker, but not recommended for new projects
- **Protocol-based architecture**: any backend swappable via config, decision is never final

## Test Plan

- [ ] Verify ADR-001 renders correctly on GitHub
- [ ] Verify DESIGN_SPEC.md §15.2 update is accurate
- [ ] No code changes — docs only

Closes #39