### PR TITLE
docs: finalize 23 design decisions (ADR-002)

### DIFF
--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -16,7 +16,7 @@
 8. [HR & Workforce Management](#8-hr--workforce-management)
 9. [Model Provider Layer](#9-model-provider-layer)
 10. [Cost & Budget Management](#10-cost--budget-management)
-11. [Tool & Capability System](#11-tool--capability-system) — 11.3 Progressive Trust
+11. [Tool & Capability System](#11-tool--capability-system) — **11.1.3 MCP Integration**, **11.1.4 Action Type System**, 11.3 Progressive Trust
 12. [Security & Approval System](#12-security--approval-system) — 12.4 Approval Timeout
 13. [Human Interaction Layer](#13-human-interaction-layer)
 14. [Templates & Builder](#14-templates--builder)
@@ -582,7 +582,7 @@ When a loop is detected, the framework:
 3. Escalates to the sender's manager (or human if at top of hierarchy)
 4. Logs the loop for analytics and process improvement
 
-> **Current state (M4 in-progress):** The communication foundation is implemented: `MessageBus` protocol with `InMemoryMessageBus` backend (asyncio queues, pull-model `receive()`), `MessageDispatcher` for concurrent handler routing via `asyncio.TaskGroup`, `AgentMessenger` per-agent facade (auto-fills sender/timestamp/ID, deterministic direct-channel naming `@{sorted_a}:{sorted_b}`), and `DeliveryEnvelope` for delivery tracking. Loop prevention (§5.5) is implemented: `DelegationGuard` orchestrates five mechanisms (ancestry, depth, dedup, rate limit, circuit breaker) with `LoopPreventionConfig`. Hierarchical delegation is implemented via `DelegationService` with `HierarchyResolver` and `AuthorityValidator`. Task model extended with `parent_task_id` and `delegation_chain` fields. Conflict resolution (§5.6) is implemented: `ConflictResolver` protocol with four strategies (Authority, Debate, HumanEscalation, Hybrid), `ConflictResolutionService` orchestrator, `DissentRecord` audit trail, and `HierarchyResolver.get_lowest_common_manager()` for cross-department conflict escalation. Meeting protocol (§5.7) is implemented with all 3 protocols (round-robin, position papers, structured phases) via `MeetingOrchestrator` in `communication/meeting/`.
+> **Current state (M4 complete):** The communication foundation is implemented: `MessageBus` protocol with `InMemoryMessageBus` backend (asyncio queues, pull-model `receive()`), `MessageDispatcher` for concurrent handler routing via `asyncio.TaskGroup`, `AgentMessenger` per-agent facade (auto-fills sender/timestamp/ID, deterministic direct-channel naming `@{sorted_a}:{sorted_b}`), and `DeliveryEnvelope` for delivery tracking. Loop prevention (§5.5) is implemented: `DelegationGuard` orchestrates five mechanisms (ancestry, depth, dedup, rate limit, circuit breaker) with `LoopPreventionConfig`. Hierarchical delegation is implemented via `DelegationService` with `HierarchyResolver` and `AuthorityValidator`. Task model extended with `parent_task_id` and `delegation_chain` fields. Conflict resolution (§5.6) is implemented: `ConflictResolver` protocol with four strategies (Authority, Debate, HumanEscalation, Hybrid), `ConflictResolutionService` orchestrator, `DissentRecord` audit trail, and `HierarchyResolver.get_lowest_common_manager()` for cross-department conflict escalation. Meeting protocol (§5.7) is implemented with all 3 protocols (round-robin, position papers, structured phases) via `MeetingOrchestrator` in `communication/meeting/`.
 
 ### 5.6 Conflict Resolution Protocol
 
@@ -971,7 +971,9 @@ Pipeline steps:
 
 1. **Validate inputs** — agent must be `ACTIVE`, task must be `ASSIGNED` or `IN_PROGRESS`. Raises `ExecutionStateError` on violation.
 2. **Pre-flight budget enforcement** — if `BudgetEnforcer` is provided, check monthly hard stop and daily limit via `check_can_execute()`, then apply auto-downgrade via `resolve_model()`. Raises `BudgetExhaustedError` or `DailyLimitExceededError` on violation.
-3. **Build system prompt** — calls `build_system_prompt()` with agent identity, task, and available tool definitions. Follows the **non-inferable-only principle**: system prompts include only information the agent cannot discover by reading the codebase or environment (role constraints, custom conventions, organizational policies). Generic architecture overviews and file structure descriptions are excluded — [research](https://arxiv.org/abs/2602.11988) shows they reduce success rates while increasing costs 20%+. **Decision ([ADR-002](docs/decisions/ADR-002-design-decisions-batch-1.md) D22):** Do NOT list available tools in the system prompt — the API's `tools` parameter already injects richer tool definitions including JSON schemas. The system prompt listing is strictly inferior (no schemas) and wastes 200-400+ tokens per call. Behavioral guidance ("when to use tool X vs Y") may be added later as non-redundant value.
+3. **Build system prompt** — calls `build_system_prompt()` with agent identity and task. Tool definitions are NOT included — they are supplied via the API's `tools` parameter (see D22 below). Follows the **non-inferable-only principle**: system prompts include only information the agent cannot discover by reading the codebase or environment (role constraints, custom conventions, organizational policies). Generic architecture overviews and file structure descriptions are excluded — [research](https://arxiv.org/abs/2602.11988) shows they reduce success rates while increasing costs 20%+.
+
+> **Decision ([ADR-002](docs/decisions/ADR-002-design-decisions-batch-1.md) D22):** Do NOT list available tools in the system prompt — the API's `tools` parameter already injects richer tool definitions including JSON schemas. The system prompt listing is strictly inferior (no schemas) and wastes 200-400+ tokens per call. Behavioral guidance ("when to use tool X vs Y") may be added later as non-redundant value.
 4. **Create context** — `AgentContext.from_identity()` with the configured `max_turns`.
 5. **Seed conversation** — injects system prompt, optional memory messages, and formatted task instruction as initial messages.
 6. **Transition task** — `ASSIGNED` → `IN_PROGRESS` (pass-through if already `IN_PROGRESS`).
@@ -1556,6 +1558,8 @@ persistence:
 | `CostRecord` | `budget/cost_record.py` | `CostRecordRepository` | by agent, by task, aggregations |
 | `Message` | `communication/message.py` | `MessageRepository` | by channel |
 | Audit entries (planned — M7) | `security/` | `AuditRepository` (planned) | by agent, by action type, time range |
+| `ParkedContext` (planned — M7) | `engine/` | `ParkedContextRepository` (planned) | by execution_id, by agent_id, by task_id |
+| Agent runtime state (planned — M7) | `engine/` | `AgentStateRepository` (planned) | by agent_id, active agents |
 
 #### Migration Strategy
 
@@ -1666,7 +1670,7 @@ The HR system manages the agent workforce dynamically:
 >
 > - **D8.1 — Source:** Templates + LLM customization. Templates for common roles (reuses existing template system §14.1). LLM generates config for novel roles not covered by templates. Approval gate catches invalid/bad configs before instantiation.
 > - **D8.2 — Persistence:** Operational store via `PersistenceBackend` (§7.6). YAML stays as bootstrap seed — operational store wins for runtime state. Enables rehiring, auditable history.
-> - **D8.3 — Hot-plug:** Agents are hot-pluggable at runtime via `AgentEngine.add_agent()`/`remove_agent()`. Thread-safe registry, wired into message bus + tools + budget.
+> - **D8.3 — Hot-plug:** Agents are hot-pluggable at runtime via a dedicated company/registry service (not `AgentEngine`, which remains the per-agent task runner). Thread-safe registry, wired into message bus + tools + budget.
 
 ### 8.2 Firing / Offboarding
 
@@ -2156,7 +2160,7 @@ sandboxing:
 >
 > Action types classify agent actions for use by autonomy presets (§12.2), SecOps validation (§12.3), tiered timeout policies (§12.4), and progressive trust (§11.3). Three sub-decisions:
 >
-> - **D1.1 — Registry:** `StrEnum` for ~20 built-in action types (type safety, autocomplete, typos caught at compile time) + `ActionTypeRegistry` for custom types via explicit registration. Unknown strings rejected at config load time. Critical for security — a typo in `human_approval` list silently means "skip approval."
+> - **D1.1 — Registry:** `StrEnum` for ~25 built-in action types (type safety, autocomplete, typos caught at compile time) + `ActionTypeRegistry` for custom types via explicit registration. Unknown strings rejected at config load time. Critical for security — a typo in `human_approval` list silently means "skip approval."
 > - **D1.2 — Granularity:** Two-level `category:action` hierarchy. Category shortcuts: `auto_approve: ["code"]` expands to all `code:*` actions. Fine-grained: `human_approval: ["code:create"]`.
 >
 > **Proposed taxonomy (~25 leaf types):**
@@ -2375,14 +2379,14 @@ autonomy:
 
     semi:
       description: "Most work is autonomous. Major decisions need approval."
-      auto_approve: ["code_changes", "tests", "docs", "internal_comms"]
-      human_approval: ["deployment", "external_comms", "budget_over_threshold", "hiring"]
+      auto_approve: ["code", "test", "docs", "comms:internal"]
+      human_approval: ["deploy", "comms:external", "budget:exceed", "org:hire"]
       security_agent: true
 
     supervised:
       description: "Human approves major steps. Agents handle details."
-      auto_approve: ["file_edits", "internal_comms"]
-      human_approval: ["architecture", "new_files", "deployment", "git_push"]
+      auto_approve: ["code:write", "comms:internal"]
+      human_approval: ["arch", "code:create", "deploy", "vcs:push"]
       security_agent: true
 
     locked:
@@ -2395,9 +2399,7 @@ autonomy:
 > **Decisions ([ADR-002](docs/decisions/ADR-002-design-decisions-batch-1.md) D6, D7):**
 >
 > - **D6 — Autonomy Scope:** Three-level resolution chain: per-agent → per-department → company default. Optional `autonomy_level` on `AgentIdentity` and department config. Resolution: `agent.autonomy_level or department.autonomy_level or company.autonomy.level`. Seniority validation: Juniors/Interns cannot be set to `full`.
-> - **D7 — Autonomy Changes at Runtime:** Pluggable `AutonomyChangeStrategy` protocol. Initial: human-only promotion via REST API. No agent (including CEO) can escalate privileges. Future strategies: human-only + auto-downgrade (on high error rate → one level down, budget exhausted → supervised, security incident → locked; recovery from auto-downgrade: human-only). Precedent: no real-world security system automatically grants higher privileges.
->
-> **Note:** The `auto_approve` / `human_approval` lists in presets above should use the `category:action` taxonomy (§11.1.4) — e.g. `auto_approve: ["code", "test", "docs", "comms:internal"]` instead of informal strings.
+> - **D7 — Autonomy Changes at Runtime:** Pluggable `AutonomyChangeStrategy` protocol. Initial: **(a+c hybrid)** — human-only promotion via REST API (no agent including CEO can escalate privileges) **plus** automatic downgrade on: high error rate → one level down, budget exhausted → supervised, security incident → locked. Recovery from auto-downgrade: human-only. Precedent: no real-world security system automatically grants higher privileges. Future strategies: fully configurable conditions.
 
 ### 12.3 Security Operations Agent
 
@@ -2459,15 +2461,15 @@ approval_timeout:
     low_risk:
       timeout_minutes: 60
       on_timeout: "approve"          # auto-approve low-risk after 1 hour
-      actions: ["file_edits", "internal_comms", "tests"]
+      actions: ["code:write", "comms:internal", "test"]
     medium_risk:
       timeout_minutes: 240
       on_timeout: "deny"             # auto-deny medium-risk after 4 hours
-      actions: ["new_files", "git_push", "architecture"]
+      actions: ["code:create", "vcs:push", "arch:decide"]
     high_risk:
       timeout_minutes: null          # wait forever
       on_timeout: "wait"
-      actions: ["deployment", "database_admin", "external_comms", "hiring"]
+      actions: ["deploy", "db:admin", "comms:external", "org:hire"]
 ```
 
 - Pragmatic — low-risk stuff doesn't stall, critical stuff stays safe
@@ -3082,7 +3084,8 @@ ai-company/
 │   └── e2e/
 ├── docs/
 │   ├── decisions/
-│   │   └── ADR-001-memory-layer.md
+│   │   ├── ADR-001-memory-layer.md
+│   │   └── ADR-002-design-decisions-batch-1.md
 │   └── getting_started.md
 ├── DESIGN_SPEC.md                   # This document
 ├── README.md

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ AI Company lets you spin up a virtual organization staffed entirely by AI agents
 
 ### Not implemented yet (planned milestones)
 
-- **Memory Backends (M5)** - Initial Mem0 adapter backend ([ADR-001](docs/decisions/ADR-001-memory-layer.md)) pending; research backends (GraphRAG, Temporal KG) planned
+- **Memory Backend Adapter (M5)** - Memory protocols, retrieval pipeline, org memory, and consolidation are complete; initial Mem0 adapter backend ([ADR-001](docs/decisions/ADR-001-memory-layer.md)) pending; research backends (GraphRAG, Temporal KG) planned
 - **CLI Surface** - `cli/` package is placeholder-only
 - **Security/Approval System (M7)** - `security/` package is placeholder-only; real authentication (JWT/OAuth), progressive trust, SecOps agent
 - **Advanced Product Surface** - web dashboard, HR workflows, and external integrations

--- a/docs/decisions/ADR-002-design-decisions-batch-1.md
+++ b/docs/decisions/ADR-002-design-decisions-batch-1.md
@@ -1,7 +1,7 @@
 # ADR-002: Design Decisions Batch 1 (D1–D23)
 
 > **Status:** DECIDED (2026-03-09)
-> **Generated:** 2026-03-09 by 11 parallel research agents.
+> **Generated:** 2026-03-09 by 11 parallel research agents (one per issue group, plus one cross-cutting coordinator).
 > **Decided:** 2026-03-09 — all 23 decisions finalized by user.
 >
 > Each decision includes options, pros/cons, real-world precedents, and the chosen approach.
@@ -22,7 +22,7 @@
 
 **Context:** The autonomy presets reference action types informally (code_changes, tests, docs, deployment, hiring, etc.) but there's no formal enum, no definition of what each covers, and no registry. These action types are used by autonomy presets, SecOps validation, tiered timeout policies, and progressive trust.
 
-**Sub-question 1: Fixed enum vs open/extensible registry?**
+**Sub-question 1 (D1.1): Fixed enum vs open/extensible registry?**
 
 | Option | Pros | Cons |
 |--------|------|------|
@@ -32,9 +32,9 @@
 
 **Precedents:** AWS IAM uses open namespaced strings (`s3:GetObject`). Kubernetes RBAC uses semi-open verbs. GitHub uses closed scopes. OPA/Rego uses open policy strings. Every production security system validates action strings against a known set.
 
-**Decision:** **(c) Enum core + validated registry.** StrEnum for built-in types (~20), plus an `ActionTypeRegistry` that accepts custom strings only if explicitly registered. Unknown strings rejected at config load time. Critical for security — a typo in `human_approval` list silently means "skip approval."
+**Decision:** **(c) Enum core + validated registry.** StrEnum for built-in types (~25), plus an `ActionTypeRegistry` that accepts custom strings only if explicitly registered. Unknown strings rejected at config load time. Critical for security — a typo in `human_approval` list silently means "skip approval."
 
-**Sub-question 2: Granularity — two-level hierarchy?**
+**Sub-question 2 (D1.2): Granularity — two-level hierarchy?**
 
 | Option | Pros | Cons |
 |--------|------|------|
@@ -43,7 +43,8 @@
 | **(c) Three+ levels** | Maximum granularity | Overkill; no one gates by language or sub-sub-type |
 
 **Proposed taxonomy (~25 leaf types):**
-```
+
+```text
 code:read, code:write, code:create, code:delete, code:refactor
 test:write, test:run
 docs:write
@@ -58,7 +59,7 @@ arch:decide
 
 **Decision:** **(b) Two-level `category:action` hierarchy** with category shortcuts. `auto_approve: ["code"]` expands to all code:* actions. Keeps simple configs simple, power configs powerful.
 
-**Sub-question 3: Who classifies an action into a type?**
+**Sub-question 3 (D1.3): Who classifies an action into a type?**
 
 | Option | Pros | Cons |
 |--------|------|------|
@@ -114,7 +115,8 @@ Start with Layer 1 only (free, sufficient for initial trust gates). Add layers i
 | **(d) Human-provided periodically** | Highest fidelity; cannot be gamed | Doesn't scale; too infrequent for real-time decisions | Human time |
 
 **Decision:** **(a) Automated behavioral telemetry** as primary signal:
-```
+
+```text
 collaboration_score = weighted_average(
     delegation_success_rate,
     delegation_response_latency,
@@ -124,6 +126,7 @@ collaboration_score = weighted_average(
     handoff_completeness,
 )
 ```
+
 Weights configurable per-role. Optional: periodic LLM sampling (1% of interactions) for calibration. Human override via REST API.
 
 ---
@@ -138,7 +141,7 @@ Weights configurable per-role. Optional: periodic LLM sampling (1% of interactio
 |--------|------|------|---------|
 | **(a) Pure rule engine** | Fast, deterministic, zero LLM cost; catches 80-90% of predictable threats (credentials, path traversal, destructive ops) | Can't handle novel situations or semantic reasoning | Sub-ms |
 | **(b) Pure LLM agent** | Flexible, reasons about novel actions and intent | 0.5-8.6s per evaluation; non-deterministic; costs tokens on every action; itself vulnerable to prompt injection | 0.5-8.6s |
-| **(c) Hybrid: rule engine fast path + LLM slow path (CHOSEN)** | Rules catch known patterns deterministically; LLM handles uncertain cases; rules serve as backstop if LLM fails | Two systems to maintain; handoff logic needs tuning | Sub-ms (95%), 0.5-2s (5%) |
+| **(c) Hybrid: rule engine fast path + LLM slow path (CHOSEN)** | Rules catch known patterns deterministically; LLM handles uncertain cases; rules serve as backstop if LLM fails | Two systems to maintain; handoff logic needs tuning | Sub-ms (est. 95%), 0.5-2s (est. 5%) |
 
 **Precedents:** AWS GuardDuty (YARA rules + ML anomaly detection), LlamaFirewall (PromptGuard + AlignmentCheck + CodeShield), Google ADK (in-tool guardrails + callback hooks), NeMo Guardrails (Colang DSL + LLM classification). **Every production security system uses a hybrid approach.**
 
@@ -147,7 +150,7 @@ Weights configurable per-role. Optional: periodic LLM sampling (1% of interactio
 - LLM slow path and human escalation disabled in full mode
 - Hard safety rules (credential exposure, data destruction) never bypass
 
-**Decision:** **(c) Hybrid.** Rule engine for known patterns (sub-ms). LLM fallback only for uncertain cases (~5% of actions). Full autonomy mode: rules + audit only, no LLM path.
+**Decision:** **(c) Hybrid.** Rule engine for known patterns (sub-ms). LLM fallback only for uncertain cases (estimated ~5% of actions). Full autonomy mode: rules + audit only, no LLM path.
 
 ---
 
@@ -164,7 +167,7 @@ Weights configurable per-role. Optional: periodic LLM sampling (1% of interactio
 
 **Performance reality:** Our bottleneck is LLM inference (seconds). A sub-ms rule check per tool call is invisible. Even OPA sidecar evaluations are 1-5ms. Total security overhead: milliseconds against minutes of LLM time.
 
-**Decision:** **(a) Before every tool invocation**, with policy strictness (not interception point) configurable per autonomy level. Slots naturally into existing `ToolInvoker` between permission check and tool execution. Add post-tool-call checking for result scanning (detect sensitive data in outputs).
+**Decision:** **(a) Before every tool invocation**, with policy strictness (not interception point) configurable per autonomy level. Implement behind a pluggable `SecurityInterceptionStrategy` protocol. Slots naturally into existing `ToolInvoker` between permission check and tool execution. Add post-tool-call checking for result scanning (detect sensitive data in outputs).
 
 ---
 
@@ -182,7 +185,7 @@ Weights configurable per-role. Optional: periodic LLM sampling (1% of interactio
 
 **Precedents:** CrewAI has 24 per-agent attributes. AutoGen has per-agent `human_input_mode`. LangGraph has per-node `interrupt_before`/`interrupt_after`. CSA Agentic Trust Framework requires per-agent identity and trust level.
 
-**Decision:** **(b) Per-agent override.** Optional `autonomy_level` on `AgentIdentity` (default: None = use company default). Resolution: `agent.autonomy_level or company.autonomy.level`. Add seniority-based validation (Juniors/Interns cannot be set to `full`).
+**Decision:** **(b) Per-agent override.** Optional `autonomy_level` on `AgentIdentity` and department config (default: None = use next level's default). Resolution: `agent.autonomy_level or department.autonomy_level or company.autonomy.level`. Add seniority-based validation (Juniors/Interns cannot be set to `full`).
 
 ---
 
@@ -209,7 +212,7 @@ Weights configurable per-role. Optional: periodic LLM sampling (1% of interactio
 
 **Unblocks:** #45
 
-**Sub-decision 1: Source**
+**Sub-decision 1 (D8.1): Source**
 
 | Option | Pros | Cons |
 |--------|------|------|
@@ -217,7 +220,7 @@ Weights configurable per-role. Optional: periodic LLM sampling (1% of interactio
 | **(b) LLM-generated only** | Maximum flexibility for novel roles | Risk of invalid configs; non-deterministic |
 | **(c) Both: template primary + LLM customization (CHOSEN)** | Templates for common cases; LLM customization for gaps; approval gate catches bad configs | Slightly more complex API surface |
 
-**Sub-decision 2: Persistence**
+**Sub-decision 2 (D8.2): Persistence**
 
 | Option | Pros | Cons |
 |--------|------|------|
@@ -225,7 +228,7 @@ Weights configurable per-role. Optional: periodic LLM sampling (1% of interactio
 | **(b) Persist to YAML** | Config is source of truth | YAML mutation at runtime is error-prone; race conditions |
 | **(c) Operational store via PersistenceBackend (CHOSEN)** | Survives restart; auditable; enables rehiring; YAML stays as bootstrap seed | Need reconciliation strategy (operational store wins for runtime) |
 
-**Sub-decision 3: Hot-plug**
+**Sub-decision 3 (D8.3): Hot-plug**
 
 | Option | Pros | Cons |
 |--------|------|------|
@@ -234,7 +237,7 @@ Weights configurable per-role. Optional: periodic LLM sampling (1% of interactio
 
 **Precedents:** AutoGen is hot-pluggable by design (`register()` at any time). Letta persists everything to database. No serious framework requires restart for agent changes.
 
-**Decision:** **(c) Both sources**, **(c) operational store**, **(b) hot-pluggable**. Template-based MVP. `HiringRequest` model carries template reference + overrides or custom config. Operational store via existing `PersistenceBackend`. Hot-plug via `AgentEngine.add_agent()`.
+**Decision:** **(c) Both sources**, **(c) operational store**, **(b) hot-pluggable**. Template-based MVP. `HiringRequest` model carries template reference + overrides or custom config. Operational store via existing `PersistenceBackend`. Hot-plug via dedicated company/registry service (not `AgentEngine`, which remains the per-agent task runner).
 
 ---
 
@@ -415,7 +418,7 @@ MCP `CallToolResult` has: `content: list[ContentBlock]` (text/image/audio/resour
 | Option | Pros | Cons |
 |--------|------|------|
 | **(a) Extend ToolResult to support multi-modal** | Native support for images/resources | Cascading changes across entire codebase; LLM providers consume tool results as text anyway |
-| **(b) Adapter in MCPBridgeTool; keep ToolResult as-is (CHOSEN)** | Zero disruption; text concatenation for LLM path; metadata dict for rich content; MCP spec requires TextContent block alongside structured content | Non-text content requires metadata extraction |
+| **(b) Adapter in MCPBridgeTool; keep ToolResult as-is (CHOSEN)** | Zero disruption; text concatenation for LLM path; rich content stored in `ToolExecutionResult.metadata` (not `ToolResult`, which has no metadata field); MCP spec requires TextContent block alongside structured content | Non-text content requires metadata extraction |
 
 **Mapping:**
 - Text blocks → concatenate into `content: str`


### PR DESCRIPTION
## Summary

- Rename `PENDING-DECISIONS.md` → `ADR-002-design-decisions-batch-1.md` (status: DECIDED)
- Add 12 decision annotation blocks to `DESIGN_SPEC.md` across 8 sections
- Create 2 new subsections: §11.1.3 MCP Integration, §11.1.4 Action Type System
- All 23 decisions follow pluggable protocol pattern with one initial implementation

### Decisions covered

| Group | Decisions | Issues |
|-------|-----------|--------|
| Cross-cutting | D1 (action types), D2 (quality scoring), D3 (collaboration scoring) | #40, #42, #43, #47, #49, #126 |
| SecOps | D4 (hybrid rules+LLM), D5 (integration point) | #40 |
| Autonomy | D6 (3-level scope), D7 (human-only promotion) | #42 |
| HR | D8 (instantiation), D9 (reassignment), D10 (archival) | #45 |
| Performance | D11 (rolling windows), D12 (trend detection) | #47 |
| Promotions | D13 (criteria), D14 (approval), D15 (model mapping) | #49 |
| Sandbox | D16 (Docker MVP) | #50 |
| MCP | D17 (SDK), D18 (result mapping) | #53 |
| Timeout | D19 (risk tiers), D20 (serialization), D21 (resume) | #126 |
| System prompt | D22 (remove tools section), D23 (memory filter) | #188 |

GitHub issue bodies for all 10 issues (#40, #42, #43, #45, #47, #49, #50, #53, #126, #188) have been updated with their respective decisions.

## Test plan

- [ ] Verify DESIGN_SPEC.md renders correctly (all blockquotes, tables, code blocks)
- [ ] Verify ADR-002 file renders correctly
- [ ] Verify all ADR-002 links in DESIGN_SPEC.md resolve correctly
- [ ] Confirm no existing spec content was modified (only additions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)