### PR TITLE
chore: pin setup-uv action to full SHA

### DIFF
--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v6.0.0
+      uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
       with:
         enable-cache: true
 


### PR DESCRIPTION
## Summary

- Pin `astral-sh/setup-uv` to full commit SHA (`c7f87aa9...`) matching v6.0.0
- Repo Actions policy requires all actions pinned to full-length commit SHA
- Dependabot bumped to v6.0.0 with tag ref only, breaking all CI jobs (lint, type-check, test)

## Test plan

- [ ] CI passes (lint, type-check, tests) — this is the fix for the current CI failure on main

## Review coverage

- Auto-skipped agent review (no substantive code changes — single YAML line change)
- Pre-commit hooks passed