### PR TITLE
Potential fix for code scanning alert no. 6: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/src/ai_company/api/auth/service.py
+++ b/src/ai_company/api/auth/service.py
@@ -175,15 +175,15 @@ class AuthService:
 
     @staticmethod
     def hash_api_key(raw_key: str) -> str:
-        """Compute SHA-256 hex digest of a raw API key.
+        """Hash an API key using Argon2id.
 
         Args:
             raw_key: The plaintext API key.
 
         Returns:
-            Lowercase hex digest.
+            Argon2id hash string.
         """
-        return hashlib.sha256(raw_key.encode()).hexdigest()
+        return _hasher.hash(raw_key)
 
     @staticmethod
     def generate_api_key() -> str:


### PR DESCRIPTION
Potential fix for [https://github.com/Aureliolo/synthorg/security/code-scanning/6](https://github.com/Aureliolo/synthorg/security/code-scanning/6)

In general terms, to fix this issue we should ensure that sensitive secrets like API keys are not stored using a single, fast hash such as SHA‑256. Instead, they should be stored using a password‑hashing/KDF algorithm designed to be computationally expensive and salted (e.g., Argon2, bcrypt, PBKDF2). Since this project already uses `argon2.PasswordHasher` for password hashing and it is configured at module level, we can reuse the same mechanism for API keys to avoid new dependencies and keep behavior consistent.

The best minimal‑impact fix is:

- Change `AuthService.hash_api_key` to use the existing `_hasher` (Argon2id) instead of `hashlib.sha256`. This means `key_hash` becomes an Argon2 hash string (like passwords) rather than a simple hex digest.
- Update the tests to compare API keys using the same verification logic used in production. However, based on the provided snippets, the tests only create `key_hash` via `AuthService.hash_api_key` and then depend on middleware behavior, not on the internal format of `key_hash`. Thus, switching `hash_api_key` to Argon2 should be transparent to the tests; no change to their assertions is needed.
- Optionally, ensure that any code which validates API keys uses Argon2 verify semantics (but this file isn’t shown, so we cannot alter it).

Concretely:

- In `src/ai_company/api/auth/service.py`, lines 176–186, replace the SHA‑256 implementation of `hash_api_key` with `_hasher.hash(raw_key)` and adjust the docstring accordingly (it no longer returns a SHA‑256 hex digest).
- The tests in `tests/unit/api/auth/test_middleware.py` can remain structurally the same; they call `AuthService.hash_api_key(raw_key)` to generate `key_hash`, which will now be Argon2 instead of SHA‑256. No imports or new helpers are needed; `argon2` is already imported and `_hasher` is already defined at the top of `service.py`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
