### PR TITLE
fix: correct API reference link path in rest-api.md

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -2,6 +2,6 @@
 
 Interactive API documentation powered by [Scalar](https://scalar.com/) and the OpenAPI schema exported from the Litestar application.
 
-**[Open REST API Reference :material-open-in-new:](../_generated/api-reference.html){ .md-button .md-button--primary }**
+**[Open REST API Reference :material-open-in-new:](_generated/api-reference.html){ .md-button .md-button--primary }**
 
 When running the server locally, live interactive docs are available at `/docs/api` (Scalar UI) and `/docs/openapi.json` (OpenAPI schema).


### PR DESCRIPTION
## Summary
- Fix broken link in `docs/rest-api.md`: `../_generated/api-reference.html` → `_generated/api-reference.html`
- The `../` prefix resolved outside the MkDocs docs tree, causing `mkdocs build --strict` to abort with a warning
- This broke both the **GitHub Pages** and **PR Preview** workflows on main

## Test plan
- [x] Verified locally: `uv run mkdocs build --strict` passes clean with no warnings