### PR TITLE
ci: group major dependabot bumps per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
     groups:
       minor-and-patch:
         update-types: [minor, patch]
+      major:
+        update-types: [major]
     open-pull-requests-limit: 10
     reviewers:
       - Aureliolo
@@ -29,6 +31,8 @@ updates:
     groups:
       minor-and-patch:
         update-types: [minor, patch]
+      major:
+        update-types: [major]
     open-pull-requests-limit: 10
     reviewers:
       - Aureliolo
@@ -46,6 +50,8 @@ updates:
     groups:
       minor-and-patch:
         update-types: [minor, patch]
+      major:
+        update-types: [major]
     open-pull-requests-limit: 5
     reviewers:
       - Aureliolo
@@ -65,6 +71,8 @@ updates:
     groups:
       minor-and-patch:
         update-types: [minor, patch]
+      major:
+        update-types: [major]
     open-pull-requests-limit: 10
     reviewers:
       - Aureliolo
@@ -82,6 +90,8 @@ updates:
     groups:
       minor-and-patch:
         update-types: [minor, patch]
+      major:
+        update-types: [major]
     open-pull-requests-limit: 5
     reviewers:
       - Aureliolo
@@ -96,6 +106,11 @@ updates:
       timezone: Etc/UTC
     commit-message:
       prefix: "chore"
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+      major:
+        update-types: [major]
     open-pull-requests-limit: 5
     reviewers:
       - Aureliolo
@@ -110,6 +125,11 @@ updates:
       timezone: Etc/UTC
     commit-message:
       prefix: "chore"
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+      major:
+        update-types: [major]
     open-pull-requests-limit: 5
     reviewers:
       - Aureliolo
@@ -124,6 +144,11 @@ updates:
       timezone: Etc/UTC
     commit-message:
       prefix: "chore"
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+      major:
+        update-types: [major]
     open-pull-requests-limit: 5
     reviewers:
       - Aureliolo


### PR DESCRIPTION
## Summary
- Add `major` update-type group to all 8 Dependabot ecosystem configs (uv, github-actions, pre-commit, npm x2, docker x3)
- Interdependent major bumps (e.g. echarts 6 + vue-echarts 8) now land in a single PR instead of separate conflicting ones
- Add missing `minor-and-patch` grouping to the 3 Docker configs for consistency

**Motivation:** PRs #380 (echarts 5→6) and #384 (vue-echarts 7→8) are interdependent but arrived as separate PRs, both with broken CI due to peer dependency conflicts. Grouping majors prevents this.

## Test plan
- [x] YAML validated by pre-commit `check-yaml` hook
- [ ] Wait for next Dependabot run to confirm grouped PRs appear correctly
- [ ] Existing open individual major PRs will need to be closed manually (Dependabot will recreate them grouped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)