### PR TITLE
fix: correct Release Please branch name in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         if: steps.release.outputs.pr != ''
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: release-please--branches--main  # must match the repo default branch name
+          ref: release-please--branches--main--components--synthorg
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Update BSL Change Date (release + 3 years)


### PR DESCRIPTION
## Summary

The BSL Change Date auto-update step was checking out `release-please--branches--main`, but Release Please uses `release-please--branches--main--components--synthorg` (component suffix from `release-please-config.json`). One-line fix.

## Test plan

- [x] Verified actual RP branch name from CI logs: `release-please--branches--main--components--synthorg`
- [x] YAML validates