### PR TITLE
fix: restore golangci-lint to v2.11.3 (broken by replace_all in #425)

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -66,7 +66,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.14.3
+          version: v2.11.3
           working-directory: cli
 
   # ── Test (multi-platform) ──


### PR DESCRIPTION
## Summary

- Restore golangci-lint version from `v2.14.3` back to `v2.11.3` (which is the latest release of golangci-lint)
- PR #425 used `replace_all` on the string `v2.11.3` which accidentally changed both the goreleaser version (intended) AND the golangci-lint version (unintended)
- `golangci-lint v2.14.3` doesn't exist — the latest is `v2.11.3`
- This broke the CLI Lint job on the `v0.2.1` tag release

## Test plan

- [ ] Verify CLI Lint job passes on this PR
- [ ] After merge, re-trigger CLI release for the latest tag