### PR TITLE
chore(web): adopt @vue/tsconfig preset

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,17 +1,6 @@
 {
+  "extends": "@vue/tsconfig/tsconfig.dom.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "strict": true,
-    "jsx": "preserve",
-    "importHelpers": true,
-    "allowImportingTsExtensions": true,
-    "noEmit": true,
-    "isolatedModules": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
## Summary

- Extend `@vue/tsconfig/tsconfig.dom.json` instead of manually specifying all compiler options
- Gains Vue-recommended settings we were missing: `verbatimModuleSyntax`, `moduleDetection: "force"`, `jsxImportSource: "vue"`, `resolveJsonModule`
- Removed 12 redundant settings already provided by the preset
- Dropped `importHelpers` (no-op with `noEmit: true`, `tslib` not installed) and `isolatedModules` (superseded by `verbatimModuleSyntax`)
- Kept project-specific overrides: `baseUrl`, `paths` (`@/*` alias), `types: ["vitest/globals"]`

Closes #386

## Test plan

- [x] `npm --prefix web run type-check` — passes clean (no `verbatimModuleSyntax` errors)
- [x] `npm --prefix web run build` — production build succeeds (715 modules)
- [x] `npm --prefix web run test` — 520 tests pass
- [x] `npm --prefix web run lint` — no new errors (only pre-existing warnings)