### PR TITLE
chore(site): replace hero CTA with license link and scroll arrow

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -40,13 +40,18 @@ import Footer from "../components/Footer.astro";
           Start Building
         </a>
         <a
-          href="#how-it-works"
+          href="#license-usage"
           class="px-8 py-3 border border-teal-400/50 text-teal-400 hover:bg-teal-400/10 rounded-lg font-semibold transition-colors"
         >
-          See How It Works
+          License & Usage Restrictions
         </a>
         <a class="github-button" href="https://github.com/Aureliolo/synthorg" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star Aureliolo/synthorg on GitHub">Star</a>
       </div>
+
+      <!-- Scroll hint -->
+      <a href="#how-it-works" class="mt-12 inline-block text-gray-500 hover:text-gray-300 transition-colors animate-bounce" aria-label="Scroll down for more details">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+      </a>
     </div>
   </section>
 
@@ -307,7 +312,7 @@ import Footer from "../components/Footer.astro";
   <!-- ============================================================ -->
   <!-- LICENSE & USAGE -->
   <!-- ============================================================ -->
-  <section class="py-16 px-6 bg-gradient-to-b from-[#1a1f2e] to-[#0F1219]">
+  <section id="license-usage" class="py-16 px-6 bg-gradient-to-b from-[#1a1f2e] to-[#0F1219]">
     <div class="max-w-5xl mx-auto">
       <h2 class="text-3xl md:text-4xl font-bold text-center mb-4">License & Usage</h2>
       <p class="text-gray-400 text-center max-w-2xl mx-auto mb-16">


### PR DESCRIPTION
## Summary

- Replace "See How It Works" hero button with "License & Usage Restrictions" linking to the `#license-usage` section — more useful for first-time visitors evaluating the project
- Add a subtle bouncing chevron arrow below the CTAs as a scroll-down hint
- Add `id="license-usage"` anchor to the License & Usage section

## Test plan

- [ ] Verify landing page renders correctly (preview deploy)
- [ ] "License & Usage Restrictions" button scrolls to the license section
- [ ] Scroll arrow bounces and links to `#how-it-works`
- [ ] "Start Building" and GitHub Star buttons unchanged
