### PR TITLE
fix: use cosign --bundle flag for checksums signing

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -296,8 +296,7 @@ jobs:
       - name: Sign checksums with cosign (keyless)
         run: |
           cosign sign-blob --yes cli/dist/checksums.txt \
-            --output-signature cli/dist/checksums.txt.sig \
-            --output-certificate cli/dist/checksums.txt.pem
+            --bundle cli/dist/checksums.txt.cosign.bundle
 
       - name: Upload assets to draft release
         env:
@@ -308,7 +307,7 @@ jobs:
           # --clobber overwrites if assets already exist (idempotent on re-run).
           gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" --clobber \
             cli/dist/*.tar.gz cli/dist/*.zip \
-            cli/dist/checksums.txt cli/dist/checksums.txt.sig cli/dist/checksums.txt.pem
+            cli/dist/checksums.txt cli/dist/checksums.txt.cosign.bundle
 
       - name: Attest build provenance (SLSA Level 3)
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
@@ -399,8 +398,7 @@ jobs:
           <!-- CLI_COSIGN_DATA
           \`\`\`bash
           cosign verify-blob checksums.txt \\
-            --signature checksums.txt.sig \\
-            --certificate checksums.txt.pem \\
+            --bundle checksums.txt.cosign.bundle \\
             --certificate-identity-regexp='github\\.com/Aureliolo/synthorg' \\
             --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
           \`\`\`


### PR DESCRIPTION
## Summary

- Newer cosign defaults to `--new-bundle-format`, which ignores the deprecated `--output-signature`/`--output-certificate` flags, causing the CLI Release job to fail with `create bundle file: open : no such file or directory`
- Switch to `--bundle checksums.txt.cosign.bundle` to produce a single bundle file
- Update release asset upload to include `.cosign.bundle` instead of `.sig`/`.pem`
- Update embedded verification instructions to use `cosign verify-blob --bundle`

## Context

This broke the v0.2.4 CLI Release job: https://github.com/Aureliolo/synthorg/actions/runs/23110427175/job/67126909396

The Docker workflow succeeded and container images are on GHCR, but CLI binaries were never uploaded to the draft release. After merging this, a new tag push (v0.2.5) will be needed to ship CLI binaries with correct cosign signatures.

## Test plan

- [ ] CLI Release job succeeds on next tag push
- [ ] `checksums.txt.cosign.bundle` appears in release assets
- [ ] `cosign verify-blob --bundle` command works against the release
- [ ] finalize-release extracts updated cosign verification instructions correctly
