### PR TITLE
fix: export .intoto.jsonl provenance for OpenSSF Scorecard

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -339,7 +339,7 @@ jobs:
           # Extract DSSE envelope as .intoto.jsonl for OpenSSF Scorecard
           # provenance detection (Scorecard recognises .intoto.jsonl but
           # classifies .sigstore.json as a signature, not provenance).
-          jq -c '.dsseEnvelope' "$BUNDLE" > cli/dist/checksums.txt.intoto.jsonl
+          jq -e -c '.dsseEnvelope' "$BUNDLE" > cli/dist/checksums.txt.intoto.jsonl
 
           gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" --clobber \
             cli/dist/checksums.txt.sigstore.json \


### PR DESCRIPTION
## Summary

- Extract DSSE envelope from the Sigstore bundle and upload as `checksums.txt.intoto.jsonl` alongside the existing `.sigstore.json` release asset
- Scorecard's Signed-Releases check classifies `.sigstore.json` as a signature but not as provenance — `.intoto.jsonl` is the filename pattern it recognizes for SLSA provenance

## Context

OpenSSF Scorecard warns "release artifact does not have provenance" for v0.2.4 even though SLSA L3 attestations exist in GitHub's attestation store. The root cause is that Scorecard looks for `.intoto.jsonl` files in release assets for provenance detection, while our `.sigstore.json` bundle (which contains the same SLSA provenance data) is only recognized as a signature artifact.

## Changes

**`.github/workflows/cli.yml`** — Added `jq -c '.dsseEnvelope'` extraction step in the existing "Upload provenance bundle to release" step to produce `checksums.txt.intoto.jsonl` and upload it as a release asset.

## Test plan

- [ ] Verify `jq` is available on `ubuntu-latest` runners (pre-installed)
- [ ] Next tag push (v0.2.5+) should produce both `.sigstore.json` and `.intoto.jsonl` release assets
- [ ] Subsequent Scorecard run should show provenance recognized for the new release

🤖 Generated with [Claude Code](https://claude.com/claude-code)