### PR TITLE
fix: add reCAPTCHA v3 to contact form

### DIFF
--- a/site/src/components/ContactForm.astro
+++ b/site/src/components/ContactForm.astro
@@ -60,6 +60,8 @@
     ></textarea>
   </div>
 
+  <input type="hidden" id="captchaResponse" name="g-recaptcha-response" />
+
   <button
     type="submit"
     id="contact-submit"
@@ -106,6 +108,13 @@
       errorMsg.classList.add("hidden");
 
       try {
+        // Get fresh reCAPTCHA v3 token before submission
+        if (typeof grecaptcha !== "undefined") {
+          const token = await grecaptcha.execute("6LdQkossAAAAADwxZo5bt8p6az7P3M6I_8k4_ypu", { action: "contact" });
+          const captchaInput = form.querySelector<HTMLInputElement>("#captchaResponse");
+          if (captchaInput) captchaInput.value = token;
+        }
+
         const res = await fetch(form.action, {
           method: "POST",
           body: new FormData(form),

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -67,5 +67,7 @@ const canonicalUrl = Astro.url;
     <slot />
     <!-- GitHub buttons (https://buttons.github.io/) -->
     <script async defer src="https://buttons.github.io/buttons.js"></script>
+    <!-- Google reCAPTCHA v3 (contact form spam protection) -->
+    <script async defer src="https://www.google.com/recaptcha/api.js?render=6LdQkossAAAAADwxZo5bt8p6az7P3M6I_8k4_ypu"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- Add reCAPTCHA v3 (invisible) integration to the contact form
- Load reCAPTCHA script with site key in Base.astro
- Add hidden `g-recaptcha-response` input field
- Generate fresh token before each form submission
- Fixes Formcarry "Google reCAPTCHA Validation Failed" error (response parameter was missing)

## Test plan

- [ ] Submit contact form — no reCAPTCHA error
- [ ] Form submission reaches email
- [ ] No visible CAPTCHA widget (v3 is invisible)
