### PR TITLE
fix(site): show success message after contact form submission

### DIFF
--- a/site/src/components/ContactForm.astro
+++ b/site/src/components/ContactForm.astro
@@ -81,7 +81,7 @@ const recaptchaSiteKey = import.meta.env.PUBLIC_RECAPTCHA_SITE_KEY || "6LdQkossA
 </form>
 
 <div id="contact-success" class="hidden bg-[#1a1f2e] rounded-xl p-8 border border-white/10 text-center" role="status" aria-live="polite" tabindex="-1">
-  <div class="text-green-400 text-4xl mb-4">&#10003;</div>
+  <div class="text-green-400 text-4xl mb-4" aria-hidden="true">&#10003;</div>
   <h3 class="text-xl font-semibold text-white mb-2">Message sent</h3>
   <p class="text-gray-400">Thanks for reaching out! We'll get back to you soon.</p>
 </div>


### PR DESCRIPTION
## Summary

- Move `#contact-success` div outside the `<form>` element so it remains visible when the form is hidden on successful submission
- Style as a matching card with checkmark, heading, and confirmation text

## Problem

The success message was a child of the form. On submit, the JS hides the form (`form.classList.add("hidden")`) — which also hid the success div inside it. Result: form vanishes, nothing replaces it.

## Test plan

- [ ] Submit contact form → form disappears, success card with "Message sent" appears
- [ ] Honeypot path also shows success card
- [ ] Error states still display correctly (error div stays inside the form)