### PR TITLE
fix(api): auto-wire persistence backend from SYNTHORG_DB_PATH env var

### DIFF
--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -447,6 +447,11 @@ def create_app(  # noqa: PLR0913
     All parameters are optional for testing — provide fakes via
     keyword arguments.
 
+    When ``persistence`` is not provided, the factory checks
+    ``SYNTHORG_DB_PATH`` in the environment and auto-creates a
+    SQLite backend if set (used by the Docker compose template).
+    Explicit ``persistence`` always takes precedence.
+
     Args:
         config: Root company configuration.
         persistence: Persistence backend.

--- a/tests/unit/api/test_app.py
+++ b/tests/unit/api/test_app.py
@@ -74,7 +74,7 @@ class TestCreateAppEnvAutoWire:
             monkeypatch.delenv("SYNTHORG_DB_PATH", raising=False)
         app = create_app(config=root_config)
         state = app.state["app_state"]
-        assert (state._persistence is not None) == expect_persistence
+        assert state.has_persistence == expect_persistence
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- When `create_app()` is called without an explicit persistence backend (uvicorn `--factory` path in Docker), read `SYNTHORG_DB_PATH` from the environment and create a SQLite backend via the persistence factory
- The CLI compose template already sets this env var — the backend just wasn't reading it
- The startup lifecycle handles `connect()`, `migrate()`, and auth service creation automatically once persistence is provided
- This fixes the 503 "Service temporarily unavailable" error on `POST /api/v1/auth/setup` (admin creation)

## Test plan

- [x] `ruff check` — clean
- [x] `mypy` — clean (997 files, no issues)
- [x] `pytest` — 8342 passed, 9 skipped, coverage above 80%
- [ ] Manual: `docker compose up` → `POST /api/v1/auth/setup` succeeds
- [ ] Manual: verify SQLite DB created at `/data/synthorg.db` inside container