### PR TITLE
fix(api): don't require password change after self-service setup

### DIFF
--- a/src/synthorg/api/auth/controller.py
+++ b/src/synthorg/api/auth/controller.py
@@ -234,7 +234,7 @@ class AuthController(Controller):
             username=data.username,
             password_hash=password_hash,
             role=HumanRole.CEO,
-            must_change_password=True,
+            must_change_password=False,
             created_at=now,
             updated_at=now,
         )

--- a/tests/unit/api/auth/test_controller.py
+++ b/tests/unit/api/auth/test_controller.py
@@ -32,7 +32,7 @@ class TestSetup:
         assert response.status_code == 201
         data = response.json()["data"]
         assert "token" in data
-        assert data["must_change_password"] is True
+        assert data["must_change_password"] is False
         assert data["expires_in"] > 0
 
     def test_setup_409_when_users_exist(


### PR DESCRIPTION
## Summary

- Change `must_change_password` from `True` to `False` in the setup endpoint
- The setup endpoint creates the admin with a user-chosen password — forcing a password change makes no sense
- The `must_change_password=True` pattern is for admin-created accounts with temp passwords, not self-service setup

## Root Cause

After `POST /api/v1/auth/setup`, the user gets a JWT with `must_change_password=True`. The `require_password_changed` guard blocks all non-auth endpoints with 403 "Password change required". Since the dashboard has no change-password UI flow on first login, the user is completely stuck — all pages show forbidden.

## Test plan

- [x] `ruff check` — clean
- [x] `mypy` — clean (997 files)
- [x] `pytest` — 8344 passed, coverage above 80%
- [x] Updated `test_setup_creates_admin` to expect `must_change_password=False`
- [ ] Manual: create admin via setup page, verify dashboard loads without 403