### PR TITLE
docs: add uv cache lock contention handling to worktree skill

### DIFF
--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -137,10 +137,10 @@ Directory suffix is auto-derived from the branch name:
    for f in .claude/*.local.*; do test -f "$f" && cp "$f" "<dir-path>/.claude/$(basename "$f")"; done
    ```
 
-   d. **Pre-sync the venv** to prevent uv cache lock contention when multiple Claude Code instances run concurrently. `uv` uses a global cache lock (`~/.local/uv/cache/.lock` or `$LOCALAPPDATA/uv/cache/.lock`) — if multiple worktrees run `uv run`/`uv sync` simultaneously, they serialize on this lock and all appear to hang. Pre-syncing sequentially here avoids this:
+   d. **Pre-sync the venv** to prevent uv cache lock contention when multiple Claude Code instances run concurrently. `uv` uses a global cache lock (`$LOCALAPPDATA/uv/cache/.lock` on Windows, `$HOME/.cache/uv/.lock` on Linux, `~/Library/Caches/uv/.lock` on macOS) — if multiple worktrees run `uv run`/`uv sync` simultaneously, they serialize on this lock and all appear to hang. Pre-syncing sequentially here avoids this:
 
    ```bash
-   cd <dir-path> && uv sync 2>&1 | tail -3; cd -
+   cd <dir-path> && uv sync; cd -
    ```
 
    Run these **sequentially** (one per worktree, not in parallel) to avoid cache lock contention during setup itself.
@@ -458,7 +458,7 @@ Update all worktrees to latest main. Pulls main first, then rebases clean worktr
   - Owner/repo (from `git remote`): must match `^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$`
   - Directory paths: must not contain shell metacharacters (`;`, `|`, `&`, `$`, `` ` ``, `(`, `)`)
   - Reject and warn if any value fails validation — do not execute the command.
-- **uv cache lock contention:** `uv` uses a global cache lock file (`$LOCALAPPDATA/uv/cache/.lock` on Windows, `~/.cache/uv/.lock` on Linux/macOS). When multiple worktrees run `uv run` or `uv sync` concurrently, they serialize on this lock, causing all instances to appear stuck. The `setup` command pre-syncs each worktree's venv sequentially to avoid this. If users report all instances hanging on python/uv commands, the fix is: `rm -f "$LOCALAPPDATA/uv/cache/.lock"` (Windows) or `rm -f ~/.cache/uv/.lock` (Linux/macOS).
+- **uv cache lock contention:** `uv` uses a global cache lock file (`$LOCALAPPDATA/uv/cache/.lock` on Windows, `$HOME/.cache/uv/.lock` on Linux, `~/Library/Caches/uv/.lock` on macOS). When multiple worktrees run `uv run` or `uv sync` concurrently, they serialize on this lock, causing all instances to appear stuck. The `setup` command pre-syncs each worktree's venv sequentially to avoid this. If users report all instances hanging on python/uv commands, first verify no `uv` processes are still running (`ps aux | grep uv` or Task Manager), then remove the stale lock: `rm -f "$LOCALAPPDATA/uv/cache/.lock"` (Windows), `rm -f ~/.cache/uv/.lock` (Linux), or `rm -f ~/Library/Caches/uv/.lock` (macOS).
 - If `$ARGUMENTS` is empty or doesn't match a command, show a brief usage guide:
 
   ```text


### PR DESCRIPTION
## Summary

- Add sequential venv pre-sync step during worktree setup to prevent concurrent `uv` instances from deadlocking on the global cache lock
- Add troubleshooting guidance for the uv cache lock file location (Windows/Linux/macOS)

## Context

When multiple worktrees run `uv run`/`uv sync` concurrently, they serialize on `uv`'s global cache lock file, causing all instances to appear stuck. The fix is to pre-sync each worktree's venv sequentially during setup before parallel work begins.

## Test plan

- [x] Skill file only — no code changes
- [x] Pre-commit hooks pass