### PR TITLE
fix(cli): add fallback arch detection in PowerShell installer

### DIFF
--- a/cli/scripts/install.ps1
+++ b/cli/scripts/install.ps1
@@ -39,7 +39,7 @@ $OsArch = $null
 try {
     $OsArch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
 } catch {
-    # Type not available — fall through to env var detection.
+    # Type not available - fall through to env var detection.
     Write-Verbose "RuntimeInformation unavailable; using PROCESSOR_ARCHITECTURE fallback."
 }
 
@@ -50,10 +50,13 @@ if ($null -ne $OsArch) {
         default { Write-Error "Unsupported architecture: $OsArch"; exit 1 }
     }
 } else {
-    $WinArch = switch ($env:PROCESSOR_ARCHITECTURE) {
+    # PROCESSOR_ARCHITEW6432 is set when running 32-bit PowerShell on 64-bit
+    # Windows (WOW64). It contains the real OS architecture.
+    $ArchEnv = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
+    $WinArch = switch ($ArchEnv) {
         "AMD64" { "amd64" }
         "ARM64" { "arm64" }
-        default { Write-Error "Unsupported architecture: $env:PROCESSOR_ARCHITECTURE"; exit 1 }
+        default { Write-Error "Unsupported architecture: $ArchEnv"; exit 1 }
     }
 }
 


### PR DESCRIPTION
## Summary

- `RuntimeInformation::OSArchitecture` returns `$null` on some Windows systems where the .NET type isn't loaded (older CLR, misconfigured environments)
- Installer now wraps the `RuntimeInformation` call in `try/catch` and falls back to `$env:PROCESSOR_ARCHITECTURE` — available on every Windows version since XP, every PowerShell since 2.0
- Both detection paths produce the same `amd64` / `arm64` output
- Error message still shows the detected value when architecture is genuinely unsupported

## Test plan

- [ ] Verify installer works on PowerShell 5.1 (Windows 10/11 default)
- [ ] Verify installer works on PowerShell 7+ (where RuntimeInformation always works)
- [ ] Simulate fallback: run with `$env:PROCESSOR_ARCHITECTURE = "AMD64"` after forcing the try/catch to fail
- [ ] Verify unsupported architecture still errors cleanly (e.g. x86)

Closes #521