### PR TITLE
fix(ci): add COSIGN_EXPERIMENTAL=1 for OCI referrer mode in cosign sign

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -209,9 +209,10 @@ jobs:
         if: github.event_name != 'pull_request'
         env:
           DIGEST: ${{ steps.push.outputs.digest }}
+          COSIGN_EXPERIMENTAL: "1"
         run: |
           if [ -z "$DIGEST" ]; then
-            echo "::error::Push step did not produce a digest — cannot sign image"
+            echo "::error::Push step did not produce a digest -- cannot sign image"
             exit 1
           fi
           cosign sign --yes --registry-referrers-mode=oci-1-1 ghcr.io/aureliolo/synthorg-backend@${DIGEST}
@@ -376,9 +377,10 @@ jobs:
         if: github.event_name != 'pull_request'
         env:
           DIGEST: ${{ steps.push.outputs.digest }}
+          COSIGN_EXPERIMENTAL: "1"
         run: |
           if [ -z "$DIGEST" ]; then
-            echo "::error::Push step did not produce a digest — cannot sign image"
+            echo "::error::Push step did not produce a digest -- cannot sign image"
             exit 1
           fi
           cosign sign --yes --registry-referrers-mode=oci-1-1 ghcr.io/aureliolo/synthorg-web@${DIGEST}
@@ -543,9 +545,10 @@ jobs:
         if: github.event_name != 'pull_request'
         env:
           DIGEST: ${{ steps.push.outputs.digest }}
+          COSIGN_EXPERIMENTAL: "1"
         run: |
           if [ -z "$DIGEST" ]; then
-            echo "::error::Push step did not produce a digest — cannot sign image"
+            echo "::error::Push step did not produce a digest -- cannot sign image"
             exit 1
           fi
           cosign sign --yes --registry-referrers-mode=oci-1-1 ghcr.io/aureliolo/synthorg-sandbox@${DIGEST}


### PR DESCRIPTION
## Summary

- v0.3.3 Docker workflow failed because `cosign sign --registry-referrers-mode=oci-1-1` requires `COSIGN_EXPERIMENTAL=1` with cosign-installer v4.1.0
- Add `COSIGN_EXPERIMENTAL: "1"` to the env block of all 3 image signing steps (backend, web, sandbox)
- Also replaces em-dashes with ASCII dashes in error messages

## Root cause

```
Error: invalid argument "oci-1-1" for "--registry-referrers-mode" flag:
in order to use mode "oci-1-1", you must set COSIGN_EXPERIMENTAL=1
```

The `--registry-referrers-mode=oci-1-1` flag was added in PR #533 but the cosign version pinned by `sigstore/cosign-installer@v4.1.0` gates this behind the experimental flag.

## Test plan

- [ ] Merge this PR, then re-run the Docker workflow for v0.3.3 tag to verify signing succeeds
- [ ] Alternatively, trigger a workflow_dispatch to test before the next release