### PR TITLE
chore(docker): suppress pydantic v1 warning on Python 3.14

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -116,5 +116,10 @@ HEALTHCHECK --interval=10s --timeout=5s --retries=3 --start-period=30s \
 # directly instead of being passed as Python arguments.
 # Exec form (no shell) — works with distroless. Uvicorn reads UVICORN_HOST
 # and UVICORN_PORT env vars natively; compose bridges SYNTHORG_* to these.
+# Suppress Pydantic v1 compatibility warning from Litestar's plugin detection
+# on Python 3.14+ (harmless import-time check, not actual v1 usage).
+# Tracked: Litestar v3 will drop the v1 compat layer entirely (#551).
+ENV PYTHONWARNINGS="ignore::UserWarning:pydantic.v1"
+
 ENTRYPOINT []
 CMD ["/app/.venv/bin/uvicorn", "synthorg.api.app:create_app", "--factory"]


### PR DESCRIPTION
## Summary

Litestar's pydantic plugin imports `pydantic.v1` for version detection, triggering a noisy `UserWarning` on Python 3.14. This spams the container logs on every startup. The warning is harmless -- no actual pydantic v1 usage, just an import-time compatibility check.

Adds `PYTHONWARNINGS="ignore::UserWarning:pydantic.v1"` to the backend Dockerfile to filter it. Will be removed when Litestar v3 drops the v1 compat layer entirely.

## Test plan

- [ ] Rebuild backend image and verify warning no longer appears in logs
- [ ] Verify other warnings and errors are NOT suppressed (only pydantic.v1 UserWarning filtered)

Ref: #551