### PR TITLE
refactor: replace _ErrorResponseSpec NamedTuple with TypedDict

### DIFF
--- a/src/synthorg/api/openapi.py
+++ b/src/synthorg/api/openapi.py
@@ -349,7 +349,8 @@ def _should_inject(
         # Inject on write methods or replace Litestar's incorrect default.
         "BadRequest": is_write or "400" in operation.get("responses", {}),
         "NotFound": has_params,
-        # DELETE excluded -- idempotent; conflicts are a create/update concern.
+        # DELETE excluded -- this API's deletes are unconditional removals
+        # with no state preconditions, so 409 Conflict does not apply.
         "Conflict": is_write and method != "delete",
         "TooManyRequests": not is_public,
     }


### PR DESCRIPTION
## Summary

- Convert `_ErrorResponseSpec` from `NamedTuple` to `TypedDict` so entries are plain dicts with key-only access, eliminating positional indexing
- Update all field access from attribute style (`spec.field`) to bracket style (`spec["field"]`)
- Replace 5 pre-existing em-dash Unicode escapes (`\u2014`) with ASCII dashes (`--`) in error description strings

Closes #509

## Review coverage

Pre-reviewed by 9 agents: docs-consistency, code-reviewer, python-reviewer, type-design-analyzer, pr-test-analyzer, conventions-enforcer, logging-audit, resilience-audit, issue-resolution-verifier. 2 findings addressed (em-dashes fixed, ReadOnly annotations evaluated and dropped as unnecessary for private module-level constant).

## Test plan

- [ ] All 100 existing unit tests pass unchanged (verified)
- [ ] Full suite: 9409 passed, 0 failures (verified)
- [ ] mypy strict: clean (verified)
- [ ] ruff lint + format: clean (verified)
- [ ] No behavior change -- identical OpenAPI schema output

🤖 Generated with [Claude Code](https://claude.com/claude-code)