### PR TITLE
fix(ci): remove dst: . from GoReleaser archive config

### DIFF
--- a/cli/.goreleaser.yml
+++ b/cli/.goreleaser.yml
@@ -32,7 +32,6 @@ archives:
     name_template: "synthorg_{{ .Os }}_{{ .Arch }}"
     files:
       - src: LICENSE
-        dst: .
         info:
           mtime: "{{ .CommitDate }}"
 


### PR DESCRIPTION
## Summary

- Remove `dst: .` from GoReleaser archive `files` config to fix Windows installer failure
- The `dst: .` directive creates a literal `.` directory entry in zip archives, causing PowerShell's `Expand-Archive` to fail with "Can not process invalid archive entry '.'"
- Removing it uses GoReleaser's default behavior of placing files at the archive root -- LICENSE still lands alongside the binary without the problematic entry

## Root Cause

GoReleaser's `dst: .` in the archive `files` section is interpreted differently by zip vs tar.gz:
- **tar.gz** (Linux/macOS): `tar` handles `.` entries natively -- no issue
- **zip** (Windows): Creates a literal `.` directory entry that `Expand-Archive` rejects

## Test plan

- [x] Built snapshot archives with `goreleaser release --snapshot --clean`
- [x] Verified zip contains only `LICENSE` and `synthorg.exe` (no `.` entry)
- [x] Verified tar.gz contains only `LICENSE` and `synthorg` (no `.` entry)
- [x] Tested `Expand-Archive` on the fixed zip -- extracts successfully
- [x] Ran `synthorg.exe version` from extracted archive -- works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release archive configuration to streamline packaging while maintaining LICENSE file inclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->