### PR TITLE
fix(ci): generate required secrets in DAST workflow

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -28,9 +28,12 @@ jobs:
         with:
           persist-credentials: false
 
-      # Create env file before any compose commands (compose requires env_file: .env)
+      # Create env file with generated secrets (compose requires env_file: .env)
       - name: Create env file
-        run: cp docker/.env.example docker/.env
+        run: |
+          cp docker/.env.example docker/.env
+          echo "SYNTHORG_JWT_SECRET=$(python3 -c 'import secrets; print(secrets.token_urlsafe(48))')" >> docker/.env
+          echo "SYNTHORG_SETTINGS_KEY=$(python3 -c 'import base64, os; print(base64.urlsafe_b64encode(os.urandom(32)).decode())')" >> docker/.env
 
       # Build backend image locally (no push, no registry credentials)
       - name: Build backend image


### PR DESCRIPTION
## Summary
- DAST workflow copies `.env.example` as-is, but `SYNTHORG_JWT_SECRET` and `SYNTHORG_SETTINGS_KEY` are now mandatory at startup (from the encryption-key-and-log-flush PR)
- Backend crashes on boot with `ValueError: SYNTHORG_JWT_SECRET is not set`
- Generate both secrets inline with `python3` before starting the container

## Test plan
- [ ] DAST workflow passes after merge (triggers on push to main)
- [ ] Backend starts successfully with generated secrets

## Review
Quick mode -- CI-only change, no agents needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to enhance automated testing environment setup procedures with improved credential handling during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->