### PR TITLE
fix: use PAT in dev-release workflow to trigger downstream pipelines

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -26,6 +26,7 @@ jobs:
       && !contains(github.event.head_commit.message, 'Release-As:')
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    environment: release
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary

- Tags created with the default `GITHUB_TOKEN` do not fire `push` events for other workflows (GitHub Actions anti-recursion safeguard)
- The `v0.4.7.dev3` dev pre-release was created successfully but Docker and CLI workflows never triggered
- Switch to `RELEASE_PLEASE_TOKEN` (PAT) for the `gh release create --target` step so downstream workflows trigger on dev tags
- Cleanup step keeps using `github.token` since it doesn't need to trigger anything

## Context

After merging #715, the dev-release workflow ran and created `v0.4.7.dev3` correctly, but the Docker and CLI pipelines never fired. This is the same pattern used by `release.yml` which uses a PAT for Release Please to ensure tag-triggered workflows run.

## Test plan

- [ ] Push to main triggers `dev-release.yml`, creates dev tag + pre-release
- [ ] Docker workflow triggers on the dev tag (was broken before this fix)
- [ ] CLI workflow triggers on the dev tag (was broken before this fix)
- [ ] Finalize-release correctly skips dev pre-releases (unchanged)