### PR TITLE
fix: dev-release tag creation, dependabot coverage, go -C cli convention

### DIFF
--- a/.claude/skills/pre-pr-review/SKILL.md
+++ b/.claude/skills/pre-pr-review/SKILL.md
@@ -205,19 +205,19 @@ Run these sequentially, fixing as we go:
 10. **Vet:**
 
    ```bash
-   cd cli && go vet ./...
+   go -C cli vet ./...
    ```
 
 11. **Test:**
 
    ```bash
-   cd cli && go test ./...
+   go -C cli test ./...
    ```
 
 12. **Build check:**
 
    ```bash
-   cd cli && go build ./...
+   go -C cli build ./...
    ```
 
 If steps 10-12 fail, fix the Go code and re-run.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,25 @@ updates:
     labels:
       - type:ci
 
+  - package-ecosystem: github-actions
+    directory: /.github/actions/setup-python-uv
+    schedule:
+      interval: daily
+      time: "06:00"
+      timezone: Etc/UTC
+    commit-message:
+      prefix: "ci"
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+      major:
+        update-types: [major]
+    open-pull-requests-limit: 5
+    reviewers:
+      - Aureliolo
+    labels:
+      - type:ci
+
   - package-ecosystem: pre-commit
     directory: /
     schedule:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -121,11 +121,17 @@ jobs:
         run: |
           SHORT_SHA="${GITHUB_SHA::7}"
 
-          # Create draft pre-release + tag atomically. The draft follows the
-          # same lifecycle as stable releases: Docker + CLI workflows attach
-          # assets, then finalize-release publishes once both succeed.
-          gh release create "$DEV_TAG" \
-            --target "$GITHUB_SHA" \
+          # 1. Create the tag via API (PAT ensures the tag push triggers
+          #    downstream Docker + CLI workflows).
+          gh api "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f ref="refs/tags/$DEV_TAG" \
+            -f sha="$GITHUB_SHA"
+
+          # 2. Create a draft pre-release pointing at the tag. The draft
+          #    follows the same lifecycle as stable releases: Docker + CLI
+          #    workflows attach assets, then finalize-release publishes
+          #    once both succeed. Clean up the tag on failure.
+          if ! gh release create "$DEV_TAG" \
             --draft \
             --prerelease \
             --title "$DEV_TAG" \
@@ -134,7 +140,11 @@ jobs:
           **Commit:** ${SHORT_SHA}
           **Full pipeline:** Docker images, CLI binaries, cosign signatures, and SLSA provenance will be attached by downstream workflows.
 
-          > This is a pre-release for testing. Use \`synthorg config set channel dev\` to opt in."
+          > This is a pre-release for testing. Use \`synthorg config set channel dev\` to opt in."; then
+            echo "::warning::Release creation failed, cleaning up tag"
+            gh api -X DELETE "repos/$GITHUB_REPOSITORY/git/refs/tags/$DEV_TAG" || true
+            exit 1
+          fi
 
       - name: Clean up old dev pre-releases
         if: >-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,14 +57,14 @@ npm --prefix web run test                  # Vitest unit tests
 
 ### CLI (Go Binary)
 
-Note: Go commands require `cd cli` because the Go module is in `cli/` (exception to the "never use cd" rule -- Go tooling requires working directory to be the module root).
+Note: Go tooling requires the module root as cwd. Use `go -C cli` which changes directory internally without affecting the shell. Never use `cd cli` -- it poisons the cwd for all subsequent Bash calls.
 
 ```bash
-cd cli && go build -o synthorg ./main.go   # build CLI
-cd cli && go test ./...                     # run tests (fuzz targets run seed corpus only without -fuzz flag)
-cd cli && go vet ./...                      # vet
-cd cli && golangci-lint run                 # lint
-cd cli && go test -fuzz=FuzzYamlStr -fuzztime=30s ./internal/compose/  # fuzz example
+go -C cli build -o synthorg ./main.go                                  # build CLI
+go -C cli test ./...                                                   # run tests (fuzz targets run seed corpus only without -fuzz flag)
+go -C cli vet ./...                                                    # vet
+(cd cli && golangci-lint run)                                          # lint (no -C flag, use subshell)
+go -C cli test -fuzz=FuzzYamlStr -fuzztime=30s ./internal/compose/     # fuzz example
 ```
 
 ## Documentation


### PR DESCRIPTION
## Summary

- **Dev-release tag fix**: `gh release create --draft` does not create a git tag (draft releases are tagless until published). Now creates the tag explicitly via the GitHub API first (using PAT to trigger downstream Docker + CLI workflows), then creates the draft release pointing at it. Adds tag cleanup on release creation failure.
- **Dependabot coverage gap**: Added `github-actions` ecosystem entry for `.github/actions/setup-python-uv` composite action, which was missed because Dependabot only scans `.github/workflows/` by default. The composite action was stuck on `setup-uv@v7.4.0` while workflows had `v7.6.0`.
- **Go CLI command convention**: Switched from `cd cli && go <cmd>` to `go -C cli <cmd>` in CLAUDE.md and pre-pr-review skill. The `cd` approach poisons the shell cwd for all subsequent Bash calls, breaking git/uv/npm commands. `go -C cli` changes directory internally with no side effects.

## Test plan

- [ ] Merge and verify dev-release workflow creates both a git tag AND a draft release (check `gh api repos/Aureliolo/synthorg/git/matching-refs/tags/v` for the tag)
- [ ] Verify Docker + CLI workflows trigger on the new tag push
- [ ] Verify Dependabot picks up `setup-uv` in the composite action (check next daily run or trigger manually)
- [ ] Verify `go -C cli test ./...` works in pre-pr-review skill execution

Skipped agent review (CI/docs-only changes, no substantive code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)