### PR TITLE
fix: use git tag for dev release container image tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -635,7 +635,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
-          VERSION: ${{ needs.version.outputs.app_version }}
           BACKEND_DIGEST: ${{ needs.build-backend.outputs.digest }}
           WEB_DIGEST: ${{ needs.build-web.outputs.digest }}
           SANDBOX_DIGEST: ${{ needs.build-sandbox.outputs.digest }}
@@ -643,8 +642,8 @@ jobs:
           set -euo pipefail
 
           # Validate required inputs
-          if [ -z "$VERSION" ] || [ -z "$BACKEND_DIGEST" ] || [ -z "$WEB_DIGEST" ] || [ -z "$SANDBOX_DIGEST" ]; then
-            echo "::error::Missing required values: VERSION='$VERSION' BACKEND_DIGEST='$BACKEND_DIGEST' WEB_DIGEST='$WEB_DIGEST' SANDBOX_DIGEST='$SANDBOX_DIGEST'"
+          if [ -z "$TAG" ] || [ -z "$BACKEND_DIGEST" ] || [ -z "$WEB_DIGEST" ] || [ -z "$SANDBOX_DIGEST" ]; then
+            echo "::error::Missing required values: TAG='$TAG' BACKEND_DIGEST='$BACKEND_DIGEST' WEB_DIGEST='$WEB_DIGEST' SANDBOX_DIGEST='$SANDBOX_DIGEST'"
             exit 1
           fi
 
@@ -709,8 +708,8 @@ jobs:
           CONTAINER_SBOM_DATA -->
           BLOCK
           )
-          # Substitute placeholders
-          IMAGES=${IMAGES//VERSION_PH/$VERSION}
+          # Substitute placeholders (strip leading 'v' from tag for image tags)
+          IMAGES=${IMAGES//VERSION_PH/${TAG#v}}
           IMAGES=${IMAGES//BACKEND_DIGEST_PH/$BACKEND_DIGEST}
           IMAGES=${IMAGES//WEB_DIGEST_PH/$WEB_DIGEST}
           IMAGES=${IMAGES//SANDBOX_DIGEST_PH/$SANDBOX_DIGEST}


### PR DESCRIPTION
## Summary

- **Fix**: Dev release notes showed the stable version (e.g., `:0.4.7`) in container pull commands instead of the dev version (e.g., `:0.4.8-dev.4`)
- **Root cause**: The `VERSION` env var in docker.yml's "Append container images to release" step used `app_version` from `pyproject.toml`, which always contains the stable version
- **Fix**: Derive the image tag from the git tag (`github.ref_name`) with `v` prefix stripped. For stable releases the result is identical; for dev releases it now correctly shows the dev version

Note: The actual Docker images were always tagged correctly -- only the release notes pull commands were wrong.

## Test plan

- [ ] Verify stable release `v0.4.7` still produces `:0.4.7` in pull commands (tag `v0.4.7` -> `${TAG#v}` = `0.4.7`)
- [ ] Verify dev release `v0.4.8-dev.4` now produces `:0.4.8-dev.4` in pull commands (tag `v0.4.8-dev.4` -> `${TAG#v}` = `0.4.8-dev.4`)
- [ ] Next dev release on main confirms correct image tags in release notes

## Review coverage

Quick mode (CI-only change, no agents needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)