### PR TITLE
fix: use subordinate_id/supervisor_id in HierarchyResolver

### DIFF
--- a/src/synthorg/communication/delegation/hierarchy.py
+++ b/src/synthorg/communication/delegation/hierarchy.py
@@ -19,8 +19,9 @@ class HierarchyResolver:
     Built from three sources, in priority order:
 
     1. Explicit ``ReportingLine`` entries (most specific) -- uses
-       ``subordinate_key``/``supervisor_key`` (which prefer ``_id``
-       fields when set) and overrides team-derived relationships.
+       ``subordinate_key``/``supervisor_key`` (which resolve to the
+       ``_id`` field when set, falling back to the name) and overrides
+       team-derived relationships.
     2. ``Team.lead`` for team members
     3. ``Department.head`` for team leads without explicit reporting
        (skipped when head is ``None``)
@@ -141,10 +142,11 @@ class HierarchyResolver:
         """Get the direct supervisor of an agent.
 
         Args:
-            agent_name: Agent name to look up.
+            agent_name: Agent name or ID (matching the key used by
+                ``ReportingLine`` entries).
 
         Returns:
-            Supervisor name or None if the agent is at the top.
+            Supervisor name/ID or ``None`` if the agent is at the top.
         """
         return self._supervisor_of.get(agent_name)
 
@@ -155,10 +157,10 @@ class HierarchyResolver:
         """Get all direct reports of an agent.
 
         Args:
-            agent_name: Supervisor agent name.
+            agent_name: Supervisor agent name or ID.
 
         Returns:
-            Tuple of direct report agent names.
+            Tuple of direct report agent names/IDs.
         """
         return self._reports_of.get(agent_name, ())
 
@@ -170,8 +172,8 @@ class HierarchyResolver:
         """Check if subordinate directly reports to supervisor.
 
         Args:
-            supervisor: Supervisor agent name.
-            subordinate: Potential subordinate agent name.
+            supervisor: Supervisor agent name or ID.
+            subordinate: Potential subordinate agent name or ID.
 
         Returns:
             True if subordinate is a direct report.
@@ -188,8 +190,8 @@ class HierarchyResolver:
         Walks up the hierarchy from subordinate to root.
 
         Args:
-            supervisor: Supervisor agent name.
-            subordinate: Potential subordinate agent name.
+            supervisor: Supervisor agent name or ID.
+            subordinate: Potential subordinate agent name or ID.
 
         Returns:
             True if subordinate is below supervisor at any depth.
@@ -205,11 +207,11 @@ class HierarchyResolver:
         """Get all ancestors from agent up to root.
 
         Args:
-            agent_name: Agent to start from.
+            agent_name: Agent name or ID to start from.
 
         Returns:
-            Tuple of ancestor names, bottom-up (immediate supervisor
-            first, root last).
+            Tuple of ancestor names/IDs, bottom-up (immediate
+            supervisor first, root last).
         """
         ancestors: list[str] = []
         current = agent_name
@@ -230,11 +232,11 @@ class HierarchyResolver:
         agent, that agent is returned directly.
 
         Args:
-            agent_a: First agent name.
-            agent_b: Second agent name.
+            agent_a: First agent name or ID.
+            agent_b: Second agent name or ID.
 
         Returns:
-            Name of the lowest common manager, or None if no
+            Name/ID of the lowest common manager, or ``None`` if no
             common manager exists.
         """
         if agent_a == agent_b:
@@ -264,8 +266,10 @@ class HierarchyResolver:
         """Get hierarchy levels between two agents.
 
         Args:
-            from_agent: Higher-level agent (potential supervisor).
-            to_agent: Lower-level agent (potential subordinate).
+            from_agent: Higher-level agent name or ID (potential
+                supervisor).
+            to_agent: Lower-level agent name or ID (potential
+                subordinate).
 
         Returns:
             Number of hierarchy levels between them, or None if

--- a/src/synthorg/core/company.py
+++ b/src/synthorg/core/company.py
@@ -69,7 +69,11 @@ class ReportingLine(BaseModel):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def subordinate_key(self) -> str:
-        """Identity key: subordinate_id when set, else subordinate."""
+        """Hierarchy lookup key: ``subordinate_id`` when set, else ``subordinate``.
+
+        Unlike ``_identity_key()``, returns the raw value without
+        case-folding or namespace tagging.
+        """
         if self.subordinate_id is not None:
             return self.subordinate_id
         return self.subordinate
@@ -77,7 +81,11 @@ class ReportingLine(BaseModel):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def supervisor_key(self) -> str:
-        """Identity key: supervisor_id when set, else supervisor."""
+        """Hierarchy lookup key: ``supervisor_id`` when set, else ``supervisor``.
+
+        Unlike ``_identity_key()``, returns the raw value without
+        case-folding or namespace tagging.
+        """
         if self.supervisor_id is not None:
             return self.supervisor_id
         return self.supervisor

--- a/tests/unit/communication/delegation/test_hierarchy.py
+++ b/tests/unit/communication/delegation/test_hierarchy.py
@@ -454,6 +454,8 @@ class TestReportingLinesWithIds:
         assert resolver.get_supervisor("backend-senior") == "architect"
         assert resolver.get_supervisor("backend-mid") == "architect"
         assert resolver.get_supervisor("backend-junior") == "architect"
+        # Raw role name is NOT registered as a key when IDs are used
+        assert resolver.get_supervisor("Backend Developer") is None
 
         reports = resolver.get_direct_reports("architect")
         assert "backend-senior" in reports
@@ -504,8 +506,8 @@ class TestReportingLinesWithIds:
 
     def test_reporting_line_with_id_overrides_team_structure(self) -> None:
         """Explicit line with matching ID overrides team-inferred."""
-        # Use member name "alice" distinct from subordinate_id "alice"
-        # to prove the key transformation actually matters
+        # Team member "alice" matches subordinate_id "alice" -- the
+        # explicit reporting line overrides the team-inferred lead
         dept = Department(
             name="Engineering",
             head="cto",
@@ -530,6 +532,8 @@ class TestReportingLinesWithIds:
 
         # alice should report to cto via explicit line, not backend_lead
         assert resolver.get_supervisor("alice") == "cto"
+        assert "alice" in resolver.get_direct_reports("cto")
+        assert "alice" not in resolver.get_direct_reports("backend_lead")
 
     def test_chain_walking_with_id_keys(self) -> None:
         """get_ancestors and is_subordinate work with ID-based keys."""
@@ -566,6 +570,50 @@ class TestReportingLinesWithIds:
             )
             == 2
         )
+
+    def test_lowest_common_manager_with_id_keys(self) -> None:
+        """get_lowest_common_manager works with ID-based keys."""
+        dept = Department(
+            name="Engineering",
+            budget_percent=50.0,
+            teams=(),
+            reporting_lines=(
+                ReportingLine(
+                    subordinate="Developer",
+                    subordinate_id="dev-a",
+                    supervisor="architect",
+                ),
+                ReportingLine(
+                    subordinate="Developer",
+                    subordinate_id="dev-b",
+                    supervisor="architect",
+                ),
+            ),
+        )
+        company = _make_company(departments=(dept,))
+        resolver = HierarchyResolver(company)
+
+        assert resolver.get_lowest_common_manager("dev-a", "dev-b") == "architect"
+
+    def test_head_id_not_used_by_resolver(self) -> None:
+        """head_id on Department does NOT affect hierarchy resolution.
+
+        The resolver uses ``dept.head`` (name) for team-lead-to-head
+        links.  This test documents that ``head_id`` is ignored.
+        """
+        dept = Department(
+            name="Engineering",
+            head="Team Lead",
+            head_id="lead-001",
+            budget_percent=50.0,
+            teams=(Team(name="backend", lead="dev", members=()),),
+        )
+        company = _make_company(departments=(dept,))
+        resolver = HierarchyResolver(company)
+
+        # Resolver uses the name, not the ID
+        assert resolver.get_supervisor("dev") == "Team Lead"
+        assert resolver.get_supervisor("dev") != "lead-001"
 
     def test_no_id_backward_compatible(self) -> None:
         """Reporting lines without IDs still work as before."""

--- a/tests/unit/core/test_company_reporting.py
+++ b/tests/unit/core/test_company_reporting.py
@@ -144,6 +144,23 @@ class TestReportingLine:
         r = ReportingLine(subordinate="dev", supervisor="lead")
         assert r.supervisor_key == "lead"
 
+    def test_computed_keys_in_model_dump_roundtrip(self) -> None:
+        """Computed keys appear in model_dump and survive round-trip."""
+        r = ReportingLine(
+            subordinate="Backend Developer",
+            subordinate_id="backend-senior",
+            supervisor="Team Lead",
+            supervisor_id="lead-001",
+        )
+        data = r.model_dump()
+        assert data["subordinate_key"] == "backend-senior"
+        assert data["supervisor_key"] == "lead-001"
+
+        # Round-trip: computed fields are ignored on input
+        r2 = ReportingLine.model_validate(data)
+        assert r2.subordinate_key == "backend-senior"
+        assert r2.supervisor_key == "lead-001"
+
     @pytest.mark.parametrize(
         ("field", "value", "match"),
         [


### PR DESCRIPTION
## Summary

- Add `subordinate_key`/`supervisor_key` `@computed_field` properties to `ReportingLine` that return `subordinate_id`/`supervisor_id` when set, falling back to the role name
- Update `HierarchyResolver.__init__` to use these properties as dict keys in the explicit reporting lines loop, so agents sharing a role name but with different IDs are properly distinguished
- Add 11 tests: 4 for computed properties, 7 for hierarchy resolution with IDs (disambiguation, chain-walking, cycle detection, override, backward compatibility)

## Test plan

- [x] `uv run python -m pytest tests/unit/core/test_company_reporting.py tests/unit/communication/delegation/test_hierarchy.py -n auto -v` -- all 91 tests pass
- [x] `uv run mypy src/ tests/` -- clean
- [x] `uv run ruff check src/ tests/` -- clean
- [x] Full test suite: 10,382 passed, 93.68% coverage
- [x] Pre-reviewed by 9 agents (code-reviewer, python-reviewer, test-analyzer, type-design, logging-audit, resilience-audit, conventions-enforcer, docs-consistency, issue-verifier), 4 findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #746