### PR TITLE
chore: add no-bash-file-writes rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ See `web/CLAUDE.md` for the full component inventory, design token rules, and po
 ## Shell Usage
 
 - **NEVER use `cd` in Bash commands** -- the working directory is already set to the project root. Use absolute paths or run commands directly. Do NOT prefix commands with `cd C:/Users/Aurelio/synthorg &&`.
-- **NEVER use Bash to write or modify files** -- use the Write or Edit tools. This includes but is not limited to `cat >`, `cat << EOF`, `echo >`, `echo >>`, `sed -i`, `python -c`, and `tee`. This applies to all files (plan files, config files, source code) and all subagents.
+- **NEVER use Bash to write or modify files** -- use the Write or Edit tools. Do not use `cat >`, `cat << EOF`, `echo >`, `echo >>`, `sed -i`, `python -c "open(...).write(...)"`, or `tee` to create or modify files (read-only/inspection uses like piping to stdout are fine). This applies to all files (plan files, config files, source code) and all subagents.
 
 ## Code Conventions
 


### PR DESCRIPTION
## Summary
- Add shell usage rule prohibiting Bash-based file writes (`cat > file`, `echo >`, `python -c`, `tee`) in favor of Write/Edit tools
- Targets subagent behavior -- agents were bypassing permission checks by writing files via Bash

## Test plan
- [x] Pre-commit hooks pass
- [ ] Verify subagents respect the rule in subsequent sessions

**Review coverage:** Quick mode (docs-only change, no agents run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)