### PR TITLE
perf: preload JetBrains Mono font, remove unused api.github.com preconnect

### DIFF
--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -45,10 +45,10 @@ const recaptchaSiteKey = import.meta.env.PUBLIC_RECAPTCHA_SITE_KEY || "6LdQkossA
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImageUrl} />
-    <link rel="preconnect" href="https://api.github.com" crossorigin />
     <!-- Self-hosted fonts (eliminates CLS and Google Fonts network dependency) -->
     <link rel="preload" href="/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/fonts/geist-latin.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="/fonts/jetbrains-mono-latin.woff2" as="font" type="font/woff2" crossorigin />
   </head>
   <body class="bg-[#0F1219] text-white font-['Inter',sans-serif] antialiased">
     <main>


### PR DESCRIPTION
Two small Lighthouse fixes for synthorg.io landing page:

1. **Preload JetBrains Mono font** -- breaks the HTML->CSS->font waterfall chain. Lighthouse shows this font at the end of the critical path (509ms). Preloading parallelizes the fetch with CSS loading (~290ms estimated LCP savings).

2. **Remove unused preconnect to api.github.com** -- the GitHub star button iframe handles its own connection to api.github.com. The preconnect was flagged as unused by Lighthouse because the timing is misaligned (preconnect fires early, button script loads late, connection closes before use).

## Changes

- `site/src/layouts/Base.astro`: added `<link rel="preload">` for jetbrains-mono-latin.woff2, removed `<link rel="preconnect">` for api.github.com

## Test Plan

- Lighthouse audit on synthorg.io after deploy -- verify font no longer appears in critical path chain
- Visual check: fonts render correctly, no FOUT regression