### PR TITLE
fix: update run_affected_tests.py to use -n 8

### DIFF
--- a/scripts/run_affected_tests.py
+++ b/scripts/run_affected_tests.py
@@ -157,7 +157,7 @@ def _run_pytest(paths: list[str]) -> int:
         "-m",
         "unit",
         "-n",
-        "auto",
+        "8",
         "-q",
     ]
     result = subprocess.run(cmd, cwd=_REPO_ROOT, check=False)


### PR DESCRIPTION
## Summary

The pre-push hook script `scripts/run_affected_tests.py` had `"auto"` hardcoded as the xdist worker count (line 160), bypassing the `pyproject.toml` addopts change from #1013.

This was missed in #1013 because the value was split across two Python list elements (`"-n"`, `"auto"`) rather than a single string `"-n auto"`, so the grep search didn't catch it.

### Changes

- `scripts/run_affected_tests.py`: Change worker count from `"auto"` to `"8"`

### Why

Follow-up to #1013. Without this fix, `git push` still triggers 32 pytest workers via the pre-push hook, causing the same crashes and slowness that #1013 aimed to fix.