### PR TITLE
docs: refresh README with stronger positioning and structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,6 @@
-> [!CAUTION]
-> **MASSIVE WORK IN PROGRESS** -- SynthOrg is under active development and is **not ready for production use**.
-> APIs, configuration formats, and behavior may change without notice between releases.
-> Some features shown in the documentation are planned but not yet fully implemented.
-> Follow progress on [GitHub](https://github.com/Aureliolo/synthorg) or check the [roadmap](docs/roadmap/).
-
 <p align="center">
-  <strong>SynthOrg</strong>
-</p>
-
-<p align="center">
-  A framework for building synthetic organizations -- autonomous AI agents orchestrated as a virtual company.
+  <strong>SynthOrg</strong><br>
+  <em>Build AI teams that actually collaborate -- with roles, budgets, memory, and governance.</em>
 </p>
 
 <p align="center">
@@ -18,104 +9,55 @@
   <a href="https://github.com/Aureliolo/synthorg/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-BSL_1.1_(source_available)-blue" alt="License"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.14%2B-blue" alt="Python"></a>
   <a href="https://synthorg.io/docs"><img src="https://img.shields.io/badge/docs-synthorg.io-purple" alt="Docs"></a>
-  <a href="https://securityscorecards.dev/viewer/?uri=github.com/Aureliolo/synthorg"><img src="https://api.securityscorecards.dev/projects/github.com/Aureliolo/synthorg/badge" alt="OpenSSF Scorecard"></a>
-  <a href="https://slsa.dev"><img src="https://slsa.dev/images/gh-badge-level3.svg" alt="SLSA 3"></a>
 </p>
 
 ---
 
-## What is SynthOrg?
+SynthOrg is a Python framework for building **synthetic organizations** -- autonomous AI agents orchestrated as a virtual company. Unlike task-queue or DAG-based agent frameworks, SynthOrg models agents as members of an actual organization with roles, departments, hierarchies, persistent memory, budgets, and structured communication.
 
-SynthOrg lets you define agents with roles, personalities, budgets, and tools, then orchestrate them to collaborate on complex tasks as a virtual organization. Each agent has a defined role (CEO, developer, designer, QA), persistent memory, and access to real tools. Agents collaborate through structured communication, follow workflows, and produce real artifacts -- code, documents, designs, and more.
+Define your company in YAML. Agents collaborate through a message bus, follow workflows (Kanban, Agile sprints, or custom), track costs against budgets, and produce real artifacts. The framework is provider-agnostic (100+ LLMs via [LiteLLM](https://github.com/BerriAI/litellm)), configuration-driven ([Pydantic v2](https://docs.pydantic.dev/) models), and designed for the full autonomy spectrum -- from human approval on every action to fully autonomous operation.
 
-The framework is provider-agnostic (any LLM via LiteLLM), configuration-driven (YAML + Pydantic), and designed for the full autonomy spectrum -- from locked-down human approval of every action to fully autonomous operation.
+> **Early access.** Core subsystems are built and tested (13,000+ unit tests, 80%+ coverage). APIs may change between releases. See the [roadmap](docs/roadmap/) for what's next.
 
-## Capabilities
+## Why SynthOrg?
 
-<table>
-<tr>
-<td width="33%">
+Most agent frameworks give you **functions that call LLMs**. SynthOrg gives you a **company that thinks**.
 
-**Agent Orchestration**
-
-Define agents with roles, models, and tools. The engine handles task decomposition, routing, execution loops (ReAct, Plan-and-Execute, Hybrid, auto-selection by complexity), crash recovery (checkpoint resume), and multi-agent coordination.
-
-</td>
-<td width="33%">
-
-**Budget & Cost Management**
-
-Per-agent cost limits, auto-downgrade to cheaper models at task boundaries, spending reports, CFO-level cost optimization with anomaly detection.
-
-</td>
-<td width="33%">
-
-**Security & Trust**
-
-SecOps agent with fail-closed rule engine, progressive trust (4 strategies), configurable autonomy levels, audit logging, and approval timeout policies. Container images are cosign-signed with SLSA L3 provenance, verified by the CLI at pull time.
-
-</td>
-</tr>
-<tr>
-<td>
-
-**Memory**
-
-Per-agent and shared organizational memory with hybrid retrieval pipeline (dense + BM25 sparse with RRF fusion), tool-based and context injection strategies, non-inferable filtering, consolidation, and archival. Pluggable backends via protocol.
-
-</td>
-<td>
-
-**Communication**
-
-Message bus, hierarchical delegation with loop prevention, conflict resolution (4 strategies), and meeting protocols (round-robin, position papers, structured phases).
-
-</td>
-<td>
-
-**Tools & Integration**
-
-Built-in tools (file system, git, sandbox, code runner) plus MCP bridge for external tools. Layered sandboxing with subprocess and Docker backends.
-
-</td>
-</tr>
-</table>
+- **Roles, not functions.** Agents are CEO, engineer, designer, QA -- with personality, goals, seniority, and autonomy levels. 9 company templates and 23 personality presets get you started fast.
+- **Shared organizational memory.** Hybrid retrieval pipeline (dense + BM25 sparse with RRF fusion), tool-based and context injection strategies, consolidation, and archival. Agents remember across sessions.
+- **Cost-aware by design.** Per-agent token budgets, automatic model downgrade at task boundaries, spending reports, trend analysis, and CFO-level optimization with anomaly detection.
+- **Trust spectrum.** From locked-down (human approves every tool call) to fully autonomous -- with a fail-closed security rule engine, output scanning, progressive trust, and audit logging in between.
+- **Real workflows.** Kanban boards, Agile sprints with velocity tracking, ceremony scheduling (8 strategies), visual workflow editor, and workflow execution from graph definitions.
+- **Provider-agnostic.** Any LLM via LiteLLM -- Ollama, LM Studio, vLLM, OpenAI, Anthropic, Google, and 100+ more. Local model management with pull/delete/configure for Ollama and LM Studio.
 
 ## Quick Start
 
-### Install CLI
+### Install
 
 ```bash
 # Linux / macOS
 curl -sSfL https://synthorg.io/get/install.sh | bash
-```
 
-```powershell
 # Windows (PowerShell)
 irm https://synthorg.io/get/install.ps1 | iex
 ```
 
-### Setup & Run
+### Run
 
 ```bash
 synthorg init       # interactive setup wizard
 synthorg start      # pull images + start containers
-synthorg status     # check health
-synthorg doctor     # diagnostics if something is wrong
-synthorg config set channel dev  # opt in to pre-release builds
-synthorg wipe       # factory-reset with interactive backup and restart prompts
-synthorg cleanup    # remove old container images
 ```
 
-Open [http://localhost:3000](http://localhost:3000) after `synthorg start` -- on a fresh install, the **setup wizard** starts with an admin account (if needed), then asks you to choose **Guided Setup** (template, company, providers, agents with personality presets, theme, and review) or **Quick Setup** (company name + provider only, configure the rest later in Settings). Providers are configured before agents so model assignment is available during agent customization.
+Open [localhost:3000](http://localhost:3000) -- the **setup wizard** walks you through company config, LLM providers, agent setup with personality presets, and theme selection. Choose **Guided Setup** for the full experience or **Quick Setup** (company name + provider only, configure the rest later).
 
-### Development (from source)
+### From source
 
 ```bash
 git clone https://github.com/Aureliolo/synthorg.git
 cd synthorg
 uv sync                  # install dev + test deps
-uv sync --group docs     # install docs toolchain (zensical)
+uv sync --group docs     # install docs toolchain
 ```
 
 ### Docker Compose (manual)
@@ -123,9 +65,26 @@ uv sync --group docs     # install docs toolchain (zensical)
 ```bash
 cp docker/.env.example docker/.env
 docker compose -f docker/compose.yml up -d
-curl http://localhost:3001/api/v1/health   # verify (replace 3001 if BACKEND_PORT was changed)
-docker compose -f docker/compose.yml down  # stop
+curl http://localhost:3001/api/v1/health
 ```
+
+## What's Inside
+
+**[Agent Orchestration](docs/design/engine.md)** -- Task decomposition, 6 routing strategies, execution loops (ReAct, Plan-and-Execute, Hybrid, auto-selection by complexity), crash recovery with checkpoint resume, and multi-agent coordination.
+
+**[Budget & Cost Management](docs/design/operations.md)** -- Per-agent cost limits with hierarchical cascading, auto-downgrade to cheaper models at task boundaries, spending reports, budget forecasting, and anomaly detection.
+
+**[Security & Trust](docs/security.md)** -- SecOps agent with fail-closed rule engine, progressive trust (4 strategies), configurable autonomy levels (5 tiers), approval gates, LLM fallback evaluator, and audit logging. Container images are cosign-signed with [SLSA L3](https://slsa.dev) provenance.
+
+**[Memory](docs/design/memory.md)** -- 5 memory types (episodic, semantic, procedural, working, organizational) with hybrid retrieval, tool-based injection (agents call `search_memory` and `recall_memory` on demand), query reformulation, consolidation, and pluggable backends.
+
+**[Communication](docs/design/communication.md)** -- Message bus, hierarchical delegation with loop prevention, conflict resolution (4 strategies), and meeting protocols (round-robin, position papers, structured phases).
+
+**[Tools & MCP](docs/guides/mcp-tools.md)** -- Built-in tools (file system, git, sandbox, code runner) plus MCP bridge for external tools. Layered sandboxing with subprocess and Docker backends. SSRF prevention with configurable allowlists.
+
+**[Web Dashboard](docs/design/page-structure.md)** -- React 19 + shadcn/ui dashboard with org chart, task board, agent detail, budget tracking, provider management, workflow editor, ceremony policy settings, and setup wizard. Real-time WebSocket updates.
+
+**[CLI](https://synthorg.io/get/)** -- Go binary with init, start, stop, status, doctor, config, wipe, cleanup commands. Cosign signature and SLSA provenance verification at pull time.
 
 ## Architecture
 
@@ -141,29 +100,50 @@ graph TB
     Engine --> Budget[Budget & Cost]
     Engine --> HR[HR Engine]
     API[REST & WebSocket API] --> Engine
+    Dashboard[React Dashboard] --> API
+    CLI[Go CLI] --> API
     Observability[Observability] -.-> Engine
     Persistence[Persistence] -.-> HR
     Persistence -.-> Security
     Persistence -.-> Engine
 ```
 
+## Compare
+
+SynthOrg vs [44 agent frameworks](https://synthorg.io/compare/) across 14 dimensions -- org structure, multi-agent coordination, memory, budget tracking, security, observability, and more.
+
 ## Documentation
 
-| Section | Description |
+| Section | What's there |
 |---------|-------------|
-| [Design Specification](docs/design/index.md) | Vision, agents, communication, engine, memory, operations, brand & UX, page structure |
+| [User Guide](docs/user_guide.md) | Install, configure, run, customize |
+| [Guides](docs/guides/) | Quickstart, company config, agents, budget, security, MCP tools, deployment, logging, memory |
+| [Design Specification](docs/design/index.md) | Agents, org structure, communication, engine, memory, operations, brand & UX (12 pages) |
 | [Architecture](docs/architecture/index.md) | System overview, tech stack, decision log |
-| [API Reference](docs/rest-api.md) | REST API reference (Scalar/OpenAPI) |
-| [Library Reference](docs/api/index.md) | Auto-generated from docstrings |
-| [Security](docs/security.md) | Security architecture, hardening, CI/CD security |
-| [Developer Setup](docs/getting_started.md) | Clone, test, lint, contribute |
-| [User Guide](docs/user_guide.md) | Install, configure, run via Docker |
+| [REST API](docs/rest-api.md) | Scalar/OpenAPI reference |
+| [Library Reference](docs/api/index.md) | Auto-generated from docstrings (14 modules) |
+| [Security](docs/security.md) | Application security, container hardening, CI/CD security (8 scanners) |
+| [Licensing](docs/licensing.md) | BSL 1.1 terms, Additional Use Grant, commercial options |
+| [Roadmap](docs/roadmap/) | Current status, open questions, future vision |
 
-> **Contributors:** Start with the [Design Overview](docs/design/index.md) before implementing any feature -- it is the mandatory starting point for architecture, data models, and behavior. [`DESIGN_SPEC.md`](docs/DESIGN_SPEC.md) serves as a pointer to the full design set.
+> **Contributors:** Start with the [Design Overview](docs/design/index.md) before implementing any feature. See [`DESIGN_SPEC.md`](docs/DESIGN_SPEC.md) for the full design set.
 
-## Status
+## Security
 
-Early development. The core subsystems (agent engine, security, communication, memory, tools, budget, HR, persistence, observability) are built and unit-tested, but the project has not been run end-to-end as a cohesive product. See the [roadmap](docs/roadmap/) for what's next.
+<details>
+<summary>Badges and scanning details</summary>
+
+<p>
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/Aureliolo/synthorg"><img src="https://api.securityscorecards.dev/projects/github.com/Aureliolo/synthorg/badge" alt="OpenSSF Scorecard"></a>
+  <a href="https://slsa.dev"><img src="https://slsa.dev/images/gh-badge-level3.svg" alt="SLSA 3"></a>
+</p>
+
+- **Application:** Fail-closed rule engine, 5 autonomy tiers, output scanning, progressive trust, approval gates, audit logging
+- **Containers:** Chainguard distroless images, Trivy + Grype scanning, cosign signatures, CIS compliance
+- **CI/CD:** 8 scanners (gitleaks, CodeQL, ZAP DAST, zizmor, pip-audit, npm audit, Socket.dev, OSSF Scorecard)
+- **Supply chain:** SLSA L3 provenance on all releases, cosign keyless signing, Dependabot + dependency-review
+
+</details>
 
 ## License
 


### PR DESCRIPTION
## Summary

Refresh the README to lead with confidence instead of caveats, following patterns from top agent frameworks (CrewAI, LangGraph, Pydantic AI, OpenAI Agents SDK).

### Key changes

- **Lead with tagline** instead of CAUTION box: "Build AI teams that actually collaborate -- with roles, budgets, memory, and governance."
- **"Why SynthOrg?"** section with 6 differentiators (roles not functions, shared memory, cost-aware, trust spectrum, real workflows, provider-agnostic)
- **Early access note** replaces the scary CAUTION box -- honest but not apologetic, includes test count (13,000+) as confidence signal
- **Capabilities as linked list** instead of static HTML table -- each links to relevant docs page, includes Dashboard and CLI as first-class entries
- **Compare section** linking to synthorg.io/compare/ (44 frameworks, 14 dimensions)
- **Security badges moved** to collapsible details section (reduces badge clutter, security-conscious users still find them)
- **Architecture diagram expanded** to include Dashboard and CLI nodes
- **Documentation table expanded** with guide counts and module counts
- **GitHub topics updated** separately: added agent-framework, ai-orchestration, synthetic-organization, pydantic, mcp, litellm, react-dashboard; removed low-value scalar, api-driven, golang