### PR TITLE
chore: tune ZAP DAST scan -- auth, timeouts, rules, report artifacts

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -62,18 +62,20 @@ jobs:
       # aud=synthorg-backend) that the Go CLI uses.  The system user is
       # bootstrapped at backend startup and skips pwd_sig validation --
       # the JWT HMAC signature is the sole auth gate.
+      # See: src/synthorg/api/auth/middleware.py _resolve_jwt_user()
       - name: Generate DAST JWT
         id: jwt
         run: |
           TOKEN=$(docker compose -f docker/compose.yml exec -T backend \
             python -c "
-          import os, jwt, datetime
+          import os, jwt, datetime, uuid
           secret = os.environ['SYNTHORG_JWT_SECRET']
           payload = {
               'sub': 'system',
               'iss': 'synthorg-cli',
               'aud': 'synthorg-backend',
               'role': 'system',
+              'jti': uuid.uuid4().hex,
               'iat': datetime.datetime.now(datetime.timezone.utc),
               'exp': datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=2),
           }
@@ -108,6 +110,16 @@ jobs:
                 -config scanner.maxRuleDurationInMins=5
                 -config scanner.maxScanDurationInMins=30"
           rules_file_name: .github/zap-rules.tsv
+
+      - name: Upload ZAP reports
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: zap-reports
+          path: |
+            report.json
+            report.html
+          retention-days: 30
 
       - name: Stop backend
         if: always()

--- a/.github/zap-rules.tsv
+++ b/.github/zap-rules.tsv
@@ -1,4 +1,4 @@
-# ZAP DAST rules -- see docs/security.md "DAST Tuning" for rationale.
+# ZAP DAST rules -- this file is the source of truth for current rule actions.
 # Format: rule_id<TAB>action<TAB>description (description is informational only).
 # Valid actions: PASS, IGNORE, INFO, WARN, FAIL.
 #
@@ -7,6 +7,10 @@
 90020	FAIL	Remote OS Command Injection
 40046	FAIL	Server Side Request Forgery
 90023	FAIL	XML External Entity (XXE)
+40012	FAIL	Cross Site Scripting (Reflected)
+40014	FAIL	Cross Site Scripting (Persistent)
+6	FAIL	Path Traversal
+90024	FAIL	Generic Remote Code Execution
 #
 # --- Triaged false positives / informational noise ---
 100001	IGNORE	Unexpected Content-Type was returned


### PR DESCRIPTION
## Summary

Tunes the weekly ZAP DAST scan for better coverage, performance, and signal-to-noise ratio.

## Changes

- **JWT authentication**: Generate a system-user JWT (same identity as Go CLI) before scanning so ZAP can hit authenticated endpoints. Previously every protected route returned 401/403.
- **Timeout controls**: `-T 20` (startup/passive cap), `maxRuleDurationInMins=5`, `maxScanDurationInMins=30` prevent runaway scans.
- **Performance**: `threadPerHost=5` (up from 2) for faster localhost scanning.
- **Report artifacts**: `-J report.json -r report.html` for machine-parseable and human-readable outputs.
- **Critical rules promoted to FAIL**: SQL injection (40018), OS command injection (90020), SSRF (40046), XXE (90023) -- prepares for eventual `fail_action: true`.
- **Triaged noise suppressed**: Changed 10049 from WARN to IGNORE, added 10104 (User Agent Fuzzer) as IGNORE. Once all alerts are IGNORE'd, the ZAP action auto-closes #760.

## Test plan

- CI-only changes (workflow + rules TSV) -- no application code affected
- Next weekly DAST run (or manual `workflow_dispatch`) validates the config
- Can verify JWT generation by triggering the workflow manually after merge

## Review

Quick mode (CI config only, no substantive code changes).

Closes #1096