### PR TITLE
fix: block python pre-release tags in dependabot ignore rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -165,7 +165,7 @@ updates:
     ignore:
       - dependency-name: chainguard/python
       - dependency-name: python
-        versions: [">=3.15"]
+        versions: ["3.15.*", "3.16.*"]
     labels:
       - dependencies
       - type:chore
@@ -187,7 +187,7 @@ updates:
       - Aureliolo
     ignore:
       - dependency-name: python
-        versions: [">=3.15"]
+        versions: ["3.15.*", "3.16.*"]
     labels:
       - dependencies
       - type:chore
@@ -209,7 +209,7 @@ updates:
       - Aureliolo
     ignore:
       - dependency-name: python
-        versions: [">=3.15"]
+        versions: ["3.15.*", "3.16.*"]
     labels:
       - dependencies
       - type:chore


### PR DESCRIPTION
## Summary

Dependabot kept opening PRs to bump the Docker `python` image from `3.14.3-slim` to `3.15.0a8-slim` (closed as #1201, #1202, #1203) even though all three docker blocks in `.github/dependabot.yml` had an ignore rule for `python >=3.15`.

**Root cause:** Dependabot's Docker ecosystem uses Gem::Version-style semver comparison, and pre-release tags like `3.15.0a8` sort **below** the `3.15.0` release. So `>=3.15` evaluated to `false` against the alpha and the ignore rule silently failed to fire.

**Fix:** Switch the `python` ignore rule in all three docker blocks (`/docker/backend`, `/docker/web`, `/docker/sandbox`) from `[">=3.15"]` to `["3.15.*", "3.16.*"]`. Wildcard tag matching is unambiguous and handles alpha/beta/rc pre-releases too. Python 3.14 patch bumps (`3.14.4`, `3.14.5`, ...) continue to flow through as intended.

## Test plan

- `.github/dependabot.yml` still parses as valid YAML (pre-commit `check yaml` hook passed on commit).
- Next Dependabot run on `/docker/*` should no longer propose `3.15.*` bumps.
- Manual monitoring over the next 24h to confirm no new Python 3.15 PRs appear.

## Review coverage

Quick mode pre-PR review (config-only change, no agents run).
