### PR TITLE
feat: subworkflows -- nestable reusable workflow components (#1012)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,21 @@
             "type": "command",
             "command": "bash scripts/check_push_rebased.sh",
             "timeout": 15000
+          },
+          {
+            "type": "command",
+            "command": "bash scripts/check_no_atlas_rehash.sh",
+            "timeout": 5000
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/check_no_edit_migration.sh",
+            "timeout": 5000
           }
         ]
       }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Enforce at most one new migration per PR
         if: github.event_name == 'pull_request'
         run: |
-          git fetch origin ${{ github.base_ref }} --depth=1
+          git fetch origin "${{ github.base_ref }}" --depth=1
           base_ref="origin/${{ github.base_ref }}"
           mapfile -t new_migs < <(
             git diff --name-only --diff-filter=A "$base_ref"...HEAD -- \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
 
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: test-results-${{ matrix.python-version }}
           path: junit.xml
@@ -396,7 +396,7 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=4096 --report-on-fatalerror --report-directory=."
       - name: Upload Node.js crash report
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: storybook-crash-report
           path: web/report.*.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,11 @@ jobs:
 
       - name: Enforce at most one new migration per PR
         if: github.event_name == 'pull_request'
+        env:
+          GH_BASE_REF: ${{ github.base_ref }}
         run: |
-          git fetch origin "${{ github.base_ref }}" --depth=1
-          base_ref="origin/${{ github.base_ref }}"
+          git fetch origin "$GH_BASE_REF" --depth=1
+          base_ref="origin/$GH_BASE_REF"
           mapfile -t new_migs < <(
             git diff --name-only --diff-filter=A "$base_ref"...HEAD -- \
               'src/synthorg/persistence/sqlite/revisions/*.sql'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,26 @@ jobs:
       - name: Validate migration checksums
         run: atlas migrate validate --dir "file://src/synthorg/persistence/sqlite/revisions" --dev-url "sqlite://file?mode=memory"
 
+      - name: Enforce at most one new migration per PR
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth=1
+          base_ref="origin/${{ github.base_ref }}"
+          mapfile -t new_migs < <(
+            git diff --name-only --diff-filter=A "$base_ref"...HEAD -- \
+              'src/synthorg/persistence/sqlite/revisions/*.sql'
+          )
+          count=${#new_migs[@]}
+          if [ "$count" -gt 1 ]; then
+            echo "::error::PR adds $count new Atlas migration files; policy allows at most 1."
+            printf '  - %s\n' "${new_migs[@]}" >&2
+            echo "" >&2
+            echo "Consolidate into a single migration: delete all in-progress migrations" >&2
+            echo "and regenerate with 'atlas migrate diff --env sqlite <name>'." >&2
+            exit 1
+          fi
+          echo "OK: PR adds $count new migration(s) (limit 1)."
+
       - name: Drift detection
         run: |
           diff_output=$(atlas schema diff --env ci \

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload coverage
         if: ${{ !cancelled() && matrix.os == 'ubuntu-latest' }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: cli-coverage
           path: cli/coverage.out

--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Upload ZAP reports
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: zap-reports
           path: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -161,7 +161,7 @@ jobs:
 
       - name: Upload Trivy report (backend)
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: trivy-backend-report
           path: trivy-backend.json
@@ -255,7 +255,7 @@ jobs:
 
       - name: Upload SBOM artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: sbom-backend
           path: sbom-backend.cdx.json
@@ -367,7 +367,7 @@ jobs:
 
       - name: Upload Trivy report (web)
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: trivy-web-report
           path: trivy-web.json
@@ -458,7 +458,7 @@ jobs:
 
       - name: Upload SBOM artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: sbom-web
           path: sbom-web.cdx.json
@@ -570,7 +570,7 @@ jobs:
 
       - name: Upload Trivy report (sandbox)
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: trivy-sandbox-report
           path: trivy-sandbox.json
@@ -661,7 +661,7 @@ jobs:
 
       - name: Upload SBOM artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: sbom-sandbox
           path: sbom-sandbox.cdx.json

--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -216,7 +216,7 @@ jobs:
           PYEOF
 
       - name: Upload preview artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: preview-site
           path: _site

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   autoupdate_schedule: never
   autofix_prs: true
   autofix_commit_msg: "style: auto-fix pre-commit hooks"
-  skip: [commitizen, gitleaks, hadolint-docker, no-em-dashes, no-redundant-timeout, mypy, pytest-unit, golangci-lint, go-vet, go-test, eslint-web, check-push-rebased]
+  skip: [commitizen, gitleaks, hadolint-docker, no-em-dashes, no-redundant-timeout, mypy, pytest-unit, golangci-lint, go-vet, go-test, eslint-web, check-push-rebased, check-single-migration-per-pr]
 
 default_install_hook_types: [pre-commit, commit-msg, pre-push]
 
@@ -17,6 +17,15 @@ repos:
         always_run: true
         pass_filenames: false
         stages: [pre-push]
+        types: []
+      - id: check-single-migration-per-pr
+        name: enforce at most one new Atlas migration per PR
+        entry: bash
+        args: ["scripts/check_single_migration_per_pr.sh"]
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages: [pre-commit, pre-push]
         types: []
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   autoupdate_schedule: never
   autofix_prs: true
   autofix_commit_msg: "style: auto-fix pre-commit hooks"
-  skip: [commitizen, gitleaks, hadolint-docker, no-em-dashes, no-redundant-timeout, mypy, pytest-unit, golangci-lint, go-vet, go-test, eslint-web, check-push-rebased, check-single-migration-per-pr]
+  skip: [commitizen, gitleaks, hadolint-docker, no-em-dashes, no-redundant-timeout, mypy, pytest-unit, golangci-lint, go-vet, go-test, eslint-web, check-push-rebased, check-single-migration-per-pr, check-no-modify-migration]
 
 default_install_hook_types: [pre-commit, commit-msg, pre-push]
 
@@ -26,6 +26,15 @@ repos:
         always_run: true
         pass_filenames: false
         stages: [pre-commit, pre-push]
+        types: []
+      - id: check-no-modify-migration
+        name: block modification of existing migration files
+        entry: bash
+        args: ["scripts/check_no_modify_migration.sh"]
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages: [pre-commit]
         types: []
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/docs/design/engine.md
+++ b/docs/design/engine.md
@@ -214,6 +214,7 @@ A **WorkflowDefinition** is a design-time blueprint -- a visual directed graph t
 | `conditional` | Boolean branch (true/false outgoing edges) |
 | `parallel_split` | Fan-out to 2+ parallel branches |
 | `parallel_join` | Fan-in with configurable join strategy (all/any) |
+| `subworkflow` | Invokes a versioned reusable workflow component from the subworkflow registry with typed input/output contracts (see [Subworkflows](#subworkflows) below). |
 
 ### Edge Types (`WorkflowEdgeType`)
 
@@ -302,6 +303,83 @@ nodes/edges). Optimistic concurrency via version counter.
 | GET | `/by-definition/{workflow_id}` | List executions for a definition |
 | GET | `/{execution_id}` | Get a specific execution |
 | POST | `/{execution_id}/cancel` | Cancel an execution |
+
+### Subworkflows
+
+Subworkflows are reusable workflow definitions published to a dedicated
+registry keyed by `(subworkflow_id, semver)` and invoked from a parent
+workflow via the `SUBWORKFLOW` node type. They exist alongside live
+workflow definitions -- any `WorkflowDefinition` with
+`is_subworkflow = True` is registered into the versioned `subworkflows`
+table and becomes referenceable.
+
+**Typed I/O contracts.** Every subworkflow declares typed `inputs` and
+`outputs` via `WorkflowIODeclaration` (name, `WorkflowValueType`,
+required, optional default, description). A parent `SUBWORKFLOW` node
+provides `input_bindings` and `output_bindings` in its config:
+literal values or dotted-path expressions prefixed with `@parent.`
+(resolved from the caller's frame) or `@child.` (used on the output
+side to project child-frame variables back into parent scope).
+
+**Explicit version pinning.** Parent references always pin a specific
+`version` string. Updating a subworkflow publishes a new row with a
+new semver; existing parents continue to resolve the old version
+until an explicit re-pin. Semver ordering uses
+`packaging.version.Version` so `1.10.0` correctly compares greater
+than `1.9.0`.
+
+**Runtime call/return with a frame stack.** `WorkflowExecutionService`
+walks each workflow graph inside an `ExecutionFrame` whose
+`variables` mapping is private to that frame. When the walker hits a
+`SUBWORKFLOW` node it resolves the pinned child, evaluates input
+bindings against the parent frame, pushes a new frame, recursively
+walks the child graph with qualified node IDs
+(`{parent_node_id}::{child_node_id}`) in the shared accumulator,
+projects declared outputs back into the parent scope, and pops. The
+executor records a `SUBWORKFLOW_COMPLETED` `WorkflowNodeExecutionStatus`
+on the parent node.
+
+**Variable scoping** is enforced because each frame holds its own
+`variables` dict. Child conditional expressions only see declared
+inputs and values projected onto the child's own scope -- they
+cannot read undeclared parent keys.
+
+**Static cycle detection.** `validate_subworkflow_graph()` performs a
+DFS across the `(id, version)` reference graph at save time via the
+registry, rejecting any back-edge with a
+`SUBWORKFLOW_CYCLE_DETECTED` validation error. This runs in addition
+to `validate_subworkflow_io()` which enforces the parent's bindings
+against the child's declared contract (missing required inputs,
+unknown input or output keys, literal type mismatches). Dotted-path
+expressions are deferred to runtime for evaluation.
+
+**Runtime depth limit.** `WorkflowConfig.max_subworkflow_depth`
+(default `16`) is enforced during the recursive walk; overflow raises
+`SubworkflowDepthExceededError` with a bounded error payload.
+
+**Delete protection.** The `SubworkflowRegistry.delete` service layer
+rejects deleting a `(id, version)` coordinate when any parent
+workflow still pins it (via the `find_parents` JSON scan of the
+`workflow_definitions` table).
+
+**Persistence.** Subworkflows live in a dedicated `subworkflows` table
+with composite primary key `(subworkflow_id, semver)`; every live
+parent stays in `workflow_definitions` as before. The rename of the
+definition's optimistic concurrency counter from `version: int` to
+`revision: int` makes room for `version: NotBlankStr` semver on
+every workflow definition (defaulting to `"1.0.0"`).
+
+**API endpoints** (`/subworkflows` controller):
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/` | List unique subworkflows (latest version per id) |
+| GET | `/search?q=` | Substring search over name and description |
+| GET | `/{id}/versions` | List semver strings newest first |
+| GET | `/{id}/versions/{version}` | Fetch a specific version |
+| GET | `/{id}/versions/{version}/parents` | List parent references |
+| POST | `/` | Publish a new subworkflow version |
+| DELETE | `/{id}/versions/{version}` | Delete a version (rejected when pinned) |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "mcp==1.27.0",
     "mem0ai==1.0.11",
     "mmh3==5.2.1",
+    "packaging==26.0",
     "pydantic==2.12.5",
     "pyjwt[crypto]==2.12.1",
     "pyyaml==6.0.3",

--- a/scripts/check_no_atlas_rehash.sh
+++ b/scripts/check_no_atlas_rehash.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block `atlas migrate hash` commands.
+# Rehashing rewrites atlas.sum checksums. Post-release, this would silently
+# invalidate existing database installations.
+#
+# If the migration needs to change, delete and regenerate:
+#   1. Delete the in-progress migration .sql file
+#   2. atlas migrate diff --env sqlite <name>
+#
+# Exit behavior:
+#   - Non-rehash commands: exit 0 (allow)
+#   - atlas migrate hash: print JSON with reason, exit 2
+
+set -euo pipefail
+
+if ! COMMAND=$(jq -r '.tool_input.command // ""' 2>/dev/null); then
+    exit 0
+fi
+if [[ -z "$COMMAND" ]]; then
+    exit 0
+fi
+
+if [[ "$COMMAND" =~ atlas[[:space:]]+migrate[[:space:]]+hash ]]; then
+    REASON="Do not rehash Atlas migrations. Delete the migration and regenerate: atlas migrate diff --env sqlite <name>"
+    cat <<ENDJSON
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "$REASON"
+  }
+}
+ENDJSON
+    exit 2
+fi
+
+exit 0

--- a/scripts/check_no_edit_migration.sh
+++ b/scripts/check_no_edit_migration.sh
@@ -18,7 +18,7 @@ fi
 
 REVISIONS_DIR="src/synthorg/persistence/sqlite/revisions"
 
-if [[ "$FILE_PATH" == *"$REVISIONS_DIR"*.sql ]]; then
+if [[ "$FILE_PATH" == */"$REVISIONS_DIR/"*.sql || "$FILE_PATH" == "$REVISIONS_DIR/"*.sql ]]; then
     REASON="Do not manually edit migration files. Edit schema.sql and regenerate: atlas migrate diff --env sqlite <name>"
     cat <<ENDJSON
 {

--- a/scripts/check_no_edit_migration.sh
+++ b/scripts/check_no_edit_migration.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block Edit/Write on Atlas migration files.
+# Migrations must be generated from schema.sql via `atlas migrate diff`,
+# not hand-edited.
+#
+# Exit behavior:
+#   - Non-migration files: exit 0 (allow)
+#   - Migration files: print JSON with reason, exit 2
+
+set -euo pipefail
+
+if ! FILE_PATH=$(jq -r '.tool_input.file_path // ""' 2>/dev/null); then
+    exit 0
+fi
+if [[ -z "$FILE_PATH" ]]; then
+    exit 0
+fi
+
+REVISIONS_DIR="src/synthorg/persistence/sqlite/revisions"
+
+if [[ "$FILE_PATH" == *"$REVISIONS_DIR"*.sql ]]; then
+    REASON="Do not manually edit migration files. Edit schema.sql and regenerate: atlas migrate diff --env sqlite <name>"
+    cat <<ENDJSON
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "$REASON"
+  }
+}
+ENDJSON
+    exit 2
+fi
+
+exit 0

--- a/scripts/check_no_modify_migration.sh
+++ b/scripts/check_no_modify_migration.sh
@@ -16,9 +16,10 @@ fi
 
 REVISIONS_DIR="src/synthorg/persistence/sqlite/revisions"
 
-mapfile -t MODIFIED < <(
-    git diff --cached --name-only --diff-filter=MR -- "$REVISIONS_DIR/*.sql" 2>/dev/null || true
-)
+MODIFIED=()
+while IFS= read -r line; do
+    [ -n "$line" ] && MODIFIED+=("$line")
+done < <(git diff --cached --name-only --diff-filter=MR -- "$REVISIONS_DIR/*.sql" 2>/dev/null || true)
 
 if [ "${#MODIFIED[@]}" -gt 0 ] && [ -n "${MODIFIED[0]}" ]; then
     echo "" >&2

--- a/scripts/check_no_modify_migration.sh
+++ b/scripts/check_no_modify_migration.sh
@@ -17,7 +17,7 @@ fi
 REVISIONS_DIR="src/synthorg/persistence/sqlite/revisions"
 
 mapfile -t MODIFIED < <(
-    git diff --cached --name-only --diff-filter=M -- "$REVISIONS_DIR/*.sql" 2>/dev/null || true
+    git diff --cached --name-only --diff-filter=MR -- "$REVISIONS_DIR/*.sql" 2>/dev/null || true
 )
 
 if [ "${#MODIFIED[@]}" -gt 0 ] && [ -n "${MODIFIED[0]}" ]; then

--- a/scripts/check_no_modify_migration.sh
+++ b/scripts/check_no_modify_migration.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Pre-commit hook: block commits that modify (not add) existing migration files.
+# Migrations should be deleted and regenerated, not hand-edited.
+#
+# Bypass: set SYNTHORG_MIGRATION_SQUASH=1 when committing after a squash.
+#
+# Exit codes:
+#   0 -- allow (no modified migrations, squash bypass, or only new ones)
+#   1 -- blocked (existing migration was modified)
+
+set -euo pipefail
+
+if [ "${SYNTHORG_MIGRATION_SQUASH:-0}" = "1" ]; then
+    exit 0
+fi
+
+REVISIONS_DIR="src/synthorg/persistence/sqlite/revisions"
+
+mapfile -t MODIFIED < <(
+    git diff --cached --name-only --diff-filter=M -- "$REVISIONS_DIR/*.sql" 2>/dev/null || true
+)
+
+if [ "${#MODIFIED[@]}" -gt 0 ] && [ -n "${MODIFIED[0]}" ]; then
+    echo "" >&2
+    echo "ERROR: Do not modify existing migration files. Delete and regenerate instead:" >&2
+    echo "" >&2
+    for f in "${MODIFIED[@]}"; do
+        echo "  Modified: $f" >&2
+    done
+    echo "" >&2
+    echo "To fix:" >&2
+    echo "  1. Delete the migration: rm $f" >&2
+    echo "  2. Remove its line from atlas.sum" >&2
+    echo "  3. Regenerate: atlas migrate diff --env sqlite <name>" >&2
+    echo "" >&2
+    exit 1
+fi
+
+exit 0

--- a/scripts/check_no_modify_migration.sh
+++ b/scripts/check_no_modify_migration.sh
@@ -28,8 +28,8 @@ if [ "${#MODIFIED[@]}" -gt 0 ] && [ -n "${MODIFIED[0]}" ]; then
         echo "  Modified: $f" >&2
     done
     echo "" >&2
-    echo "To fix:" >&2
-    echo "  1. Delete the migration: rm $f" >&2
+    echo "To fix (for each file above):" >&2
+    echo "  1. Delete the migration: rm <migration>.sql" >&2
     echo "  2. Remove its line from atlas.sum" >&2
     echo "  3. Regenerate: atlas migrate diff --env sqlite <name>" >&2
     echo "" >&2

--- a/scripts/check_single_migration_per_pr.sh
+++ b/scripts/check_single_migration_per_pr.sh
@@ -39,11 +39,11 @@ if ! git show-ref --verify --quiet refs/remotes/origin/main; then
     fi
 fi
 
-# Find all .sql files under revisions/ that exist on HEAD.
+# Find all .sql files under revisions/ (staged + committed).
 HEAD_FILES=()
 while IFS= read -r line; do
     HEAD_FILES+=("$line")
-done < <(git ls-tree -r --name-only HEAD -- "$REVISIONS_DIR" | grep -E '\.sql$' || true)
+done < <(git ls-files --cached -- "$REVISIONS_DIR/*.sql" 2>/dev/null || true)
 
 # For each file on HEAD, check whether it exists on origin/main. If it does
 # not, it is a new migration added by this PR.

--- a/scripts/check_single_migration_per_pr.sh
+++ b/scripts/check_single_migration_per_pr.sh
@@ -40,10 +40,10 @@ if ! git show-ref --verify --quiet refs/remotes/origin/main; then
 fi
 
 # Find all .sql files under revisions/ that exist on HEAD.
-mapfile -t HEAD_FILES < <(
-    git ls-tree -r --name-only HEAD -- "$REVISIONS_DIR" \
-        | grep -E '\.sql$' || true
-)
+HEAD_FILES=()
+while IFS= read -r line; do
+    HEAD_FILES+=("$line")
+done < <(git ls-tree -r --name-only HEAD -- "$REVISIONS_DIR" | grep -E '\.sql$' || true)
 
 # For each file on HEAD, check whether it exists on origin/main. If it does
 # not, it is a new migration added by this PR.

--- a/scripts/check_single_migration_per_pr.sh
+++ b/scripts/check_single_migration_per_pr.sh
@@ -31,10 +31,12 @@ fi
 
 REVISIONS_DIR="src/synthorg/persistence/sqlite/revisions"
 
-# Fail closed if origin/main cannot be fetched -- we cannot verify otherwise.
-if ! git fetch origin main --quiet 2>/dev/null; then
-    echo "check_single_migration_per_pr: failed to fetch origin/main; cannot verify migration count." >&2
-    exit 1
+# Use existing origin/main ref when available; only fetch as a fallback.
+if ! git show-ref --verify --quiet refs/remotes/origin/main; then
+    if ! git fetch origin main --quiet 2>/dev/null; then
+        echo "check_single_migration_per_pr: origin/main is unavailable; skipping local check." >&2
+        exit 0
+    fi
 fi
 
 # Find all .sql files under revisions/ that exist on HEAD.

--- a/scripts/check_single_migration_per_pr.sh
+++ b/scripts/check_single_migration_per_pr.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Enforce: at most one new Atlas migration file per PR.
+#
+# Rationale: during a feature PR we want a clean schema history -- if the
+# developer iterates on the schema multiple times they should delete the
+# in-progress migration and regenerate it (the "delete-and-regenerate"
+# workflow), so that the final PR ships exactly one migration. Multiple
+# migrations per PR make review harder and pollute the release history.
+#
+# Algorithm:
+#   1. Ensure origin/main is fetched.
+#   2. Count new `.sql` files added under src/synthorg/persistence/sqlite/revisions/
+#      on HEAD that do not exist on origin/main.
+#   3. Fail if the count is greater than 1.
+#
+# The script runs on every commit (pre-commit stage) and every push (pre-push
+# stage). On the `main` branch itself the check is skipped (main never adds
+# its own migrations outside of a squashed PR).
+#
+# Exit codes:
+#   0 -- allow (0 or 1 new migrations)
+#   1 -- error (fetch failed or other unrecoverable condition)
+#   2 -- blocked (more than one new migration)
+
+set -euo pipefail
+
+BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+if [ "$BRANCH" = "main" ]; then
+    exit 0
+fi
+
+REVISIONS_DIR="src/synthorg/persistence/sqlite/revisions"
+
+# Fail closed if origin/main cannot be fetched -- we cannot verify otherwise.
+if ! git fetch origin main --quiet 2>/dev/null; then
+    echo "check_single_migration_per_pr: failed to fetch origin/main; cannot verify migration count." >&2
+    exit 1
+fi
+
+# Find all .sql files under revisions/ that exist on HEAD.
+mapfile -t HEAD_FILES < <(
+    git ls-tree -r --name-only HEAD -- "$REVISIONS_DIR" \
+        | grep -E '\.sql$' || true
+)
+
+# For each file on HEAD, check whether it exists on origin/main. If it does
+# not, it is a new migration added by this PR.
+NEW_COUNT=0
+NEW_FILES=()
+for f in "${HEAD_FILES[@]}"; do
+    if ! git cat-file -e "origin/main:${f}" 2>/dev/null; then
+        NEW_COUNT=$((NEW_COUNT + 1))
+        NEW_FILES+=("$f")
+    fi
+done
+
+if [ "$NEW_COUNT" -gt 1 ]; then
+    echo "" >&2
+    echo "ERROR: This PR adds $NEW_COUNT new Atlas migration files, but the policy" >&2
+    echo "allows at most ONE new migration per PR." >&2
+    echo "" >&2
+    echo "New migrations detected:" >&2
+    for f in "${NEW_FILES[@]}"; do
+        echo "  - $f" >&2
+    done
+    echo "" >&2
+    echo "To fix: delete all but the most recent in-progress migration, then" >&2
+    echo "re-generate a single consolidated migration:" >&2
+    echo "" >&2
+    echo "  1. rm src/synthorg/persistence/sqlite/revisions/<older_migration>.sql" >&2
+    echo "  2. Manually remove its line from src/synthorg/persistence/sqlite/revisions/atlas.sum" >&2
+    echo "  3. rm the newest in-progress migration as well" >&2
+    echo "  4. atlas migrate diff --env sqlite <name>" >&2
+    echo "" >&2
+    echo "This leaves the PR with exactly one clean migration file." >&2
+    exit 2
+fi
+
+exit 0

--- a/scripts/squash_migrations.sh
+++ b/scripts/squash_migrations.sh
@@ -41,7 +41,11 @@ ALL_MIGRATIONS=()
 for f in "$MIGRATION_DIR"/*.sql; do
     [ -f "$f" ] && ALL_MIGRATIONS+=("$(basename "$f")")
 done
-IFS=$'\n' ALL_MIGRATIONS=($(printf '%s\n' "${ALL_MIGRATIONS[@]}" | sort)); unset IFS
+sorted=()
+while IFS= read -r line; do
+    sorted+=("$line")
+done < <(printf '%s\n' "${ALL_MIGRATIONS[@]}" | sort)
+ALL_MIGRATIONS=("${sorted[@]}")
 count=${#ALL_MIGRATIONS[@]}
 echo "Migration count: $count (threshold: $THRESHOLD, keep newest: $KEEP)"
 

--- a/scripts/squash_migrations.sh
+++ b/scripts/squash_migrations.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Partial migration squash: when migration count exceeds THRESHOLD (default
-# 100), squash the oldest half into a checkpoint baseline while keeping the
-# newest KEEP (default 50) as individual files.
+# 100), squash the oldest (count - KEEP) migrations into a checkpoint baseline
+# while keeping the newest KEEP (default 50) as individual files.
 #
 # This preserves the upgrade path for users on older versions -- their applied
 # migrations still exist as individual files above the checkpoint.
@@ -24,11 +24,11 @@ THRESHOLD="${SQUASH_THRESHOLD:-100}"
 KEEP="${SQUASH_KEEP:-50}"
 
 if ! [[ "$THRESHOLD" =~ ^[0-9]+$ ]]; then
-    echo "Error: SQUASH_THRESHOLD must be a positive integer, got '$THRESHOLD'" >&2
+    echo "Error: SQUASH_THRESHOLD must be a non-negative integer, got '$THRESHOLD'" >&2
     exit 1
 fi
 if ! [[ "$KEEP" =~ ^[0-9]+$ ]]; then
-    echo "Error: SQUASH_KEEP must be a positive integer, got '$KEEP'" >&2
+    echo "Error: SQUASH_KEEP must be a non-negative integer, got '$KEEP'" >&2
     exit 1
 fi
 
@@ -38,7 +38,7 @@ if [ ! -d "$MIGRATION_DIR" ]; then
 fi
 
 mapfile -t ALL_MIGRATIONS < <(
-    find "$MIGRATION_DIR" -maxdepth 1 -name '*.sql' -printf '%f\n' | sort
+    find "$MIGRATION_DIR" -maxdepth 1 -name '*.sql' -exec basename {} \; | sort
 )
 count=${#ALL_MIGRATIONS[@]}
 echo "Migration count: $count (threshold: $THRESHOLD, keep newest: $KEEP)"

--- a/scripts/squash_migrations.sh
+++ b/scripts/squash_migrations.sh
@@ -3,8 +3,8 @@
 # 100), squash the oldest (count - KEEP) migrations into a checkpoint baseline
 # while keeping the newest KEEP (default 50) as individual files.
 #
-# This preserves the upgrade path for users on older versions -- their applied
-# migrations still exist as individual files above the checkpoint.
+# This preserves the upgrade path: the oldest (count - KEEP) files are replaced
+# by a single checkpoint baseline; only the newest KEEP files remain on disk.
 #
 # Run manually during the release process:
 #   bash scripts/squash_migrations.sh
@@ -37,9 +37,11 @@ if [ ! -d "$MIGRATION_DIR" ]; then
     exit 1
 fi
 
-mapfile -t ALL_MIGRATIONS < <(
-    find "$MIGRATION_DIR" -maxdepth 1 -name '*.sql' -exec basename {} \; | sort
-)
+ALL_MIGRATIONS=()
+for f in "$MIGRATION_DIR"/*.sql; do
+    [ -f "$f" ] && ALL_MIGRATIONS+=("$(basename "$f")")
+done
+IFS=$'\n' ALL_MIGRATIONS=($(printf '%s\n' "${ALL_MIGRATIONS[@]}" | sort)); unset IFS
 count=${#ALL_MIGRATIONS[@]}
 echo "Migration count: $count (threshold: $THRESHOLD, keep newest: $KEEP)"
 

--- a/scripts/squash_migrations.sh
+++ b/scripts/squash_migrations.sh
@@ -32,4 +32,6 @@ fi
 
 echo "Squashing migrations..."
 atlas migrate squash --env sqlite
-echo "Done. Review the result and commit."
+echo ""
+echo "Done. Review the result, then commit with:"
+echo "  SYNTHORG_MIGRATION_SQUASH=1 git commit -m 'chore: squash migrations'"

--- a/scripts/squash_migrations.sh
+++ b/scripts/squash_migrations.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
-# Squash migrations when the count exceeds a threshold.
+# Partial migration squash: at 100+ migrations, squash the oldest 50 into a
+# checkpoint baseline while keeping the newest 50 as individual files.
+#
+# This preserves the upgrade path for users on older versions -- their applied
+# migrations still exist as individual files above the checkpoint.
 #
 # Run manually during the release process:
 #   bash scripts/squash_migrations.sh
 #
-# The threshold defaults to 50 and can be overridden:
-#   SQUASH_THRESHOLD=30 bash scripts/squash_migrations.sh
+# Override thresholds:
+#   SQUASH_THRESHOLD=80 SQUASH_KEEP=40 bash scripts/squash_migrations.sh
 
 set -euo pipefail
 
@@ -15,23 +19,38 @@ if ! command -v atlas &> /dev/null; then
 fi
 
 MIGRATION_DIR="src/synthorg/persistence/sqlite/revisions"
-THRESHOLD="${SQUASH_THRESHOLD:-50}"
+THRESHOLD="${SQUASH_THRESHOLD:-100}"
+KEEP="${SQUASH_KEEP:-50}"
 
 if [ ! -d "$MIGRATION_DIR" ]; then
     echo "Error: Migration directory not found: $MIGRATION_DIR"
     exit 1
 fi
 
-count=$(find "$MIGRATION_DIR" -maxdepth 1 -name '*.sql' -printf '.' | wc -c)
-echo "Migration count: $count (threshold: $THRESHOLD)"
+mapfile -t ALL_MIGRATIONS < <(
+    find "$MIGRATION_DIR" -maxdepth 1 -name '*.sql' -printf '%f\n' | sort
+)
+count=${#ALL_MIGRATIONS[@]}
+echo "Migration count: $count (threshold: $THRESHOLD, keep newest: $KEEP)"
 
 if [ "$count" -le "$THRESHOLD" ]; then
     echo "Below threshold -- no squashing needed."
     exit 0
 fi
 
-echo "Squashing migrations..."
-atlas migrate squash --env sqlite
+squash_count=$((count - KEEP))
+if [ "$squash_count" -le 0 ]; then
+    echo "Nothing to squash (count=$count, keep=$KEEP)."
+    exit 0
+fi
+
+target_migration="${ALL_MIGRATIONS[$((squash_count - 1))]}"
+target_version="${target_migration%.sql}"
+
+echo "Squashing oldest $squash_count migrations (up to $target_migration)..."
+echo "Keeping newest $KEEP migrations as individual files."
+echo ""
+atlas migrate squash --env sqlite --to "$target_version"
 echo ""
 echo "Done. Review the result, then commit with:"
-echo "  SYNTHORG_MIGRATION_SQUASH=1 git commit -m 'chore: squash migrations'"
+echo "  SYNTHORG_MIGRATION_SQUASH=1 git commit -m 'chore: squash oldest $squash_count migrations'"

--- a/scripts/squash_migrations.sh
+++ b/scripts/squash_migrations.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Partial migration squash: at 100+ migrations, squash the oldest 50 into a
-# checkpoint baseline while keeping the newest 50 as individual files.
+# Partial migration squash: when migration count exceeds THRESHOLD (default
+# 100), squash the oldest half into a checkpoint baseline while keeping the
+# newest KEEP (default 50) as individual files.
 #
 # This preserves the upgrade path for users on older versions -- their applied
 # migrations still exist as individual files above the checkpoint.
@@ -21,6 +22,15 @@ fi
 MIGRATION_DIR="src/synthorg/persistence/sqlite/revisions"
 THRESHOLD="${SQUASH_THRESHOLD:-100}"
 KEEP="${SQUASH_KEEP:-50}"
+
+if ! [[ "$THRESHOLD" =~ ^[0-9]+$ ]]; then
+    echo "Error: SQUASH_THRESHOLD must be a positive integer, got '$THRESHOLD'" >&2
+    exit 1
+fi
+if ! [[ "$KEEP" =~ ^[0-9]+$ ]]; then
+    echo "Error: SQUASH_KEEP must be a positive integer, got '$KEEP'" >&2
+    exit 1
+fi
 
 if [ ! -d "$MIGRATION_DIR" ]; then
     echo "Error: Migration directory not found: $MIGRATION_DIR"

--- a/src/synthorg/api/controllers/__init__.py
+++ b/src/synthorg/api/controllers/__init__.py
@@ -54,6 +54,7 @@ from synthorg.api.controllers.setup_personality import (
     SetupPersonalityController,
 )
 from synthorg.api.controllers.simulations import SimulationController
+from synthorg.api.controllers.subworkflows import SubworkflowController
 from synthorg.api.controllers.tasks import TaskController
 from synthorg.api.controllers.teams import TeamController
 from synthorg.api.controllers.template_packs import TemplatePackController
@@ -99,6 +100,7 @@ ALL_CONTROLLERS: tuple[type[Controller], ...] = (
     TeamController,
     TemplatePackController,
     UserController,
+    SubworkflowController,
     WorkflowController,
     WorkflowVersionController,
     BudgetConfigVersionController,
@@ -156,6 +158,7 @@ __all__ = [
     "SetupController",
     "SetupPersonalityController",
     "SimulationController",
+    "SubworkflowController",
     "TaskController",
     "TeamController",
     "TemplatePackController",

--- a/src/synthorg/api/controllers/subworkflows.py
+++ b/src/synthorg/api/controllers/subworkflows.py
@@ -33,6 +33,9 @@ from synthorg.engine.workflow.definition import (
 )
 from synthorg.engine.workflow.subworkflow_registry import SubworkflowRegistry
 from synthorg.observability import get_logger
+from synthorg.observability.events.workflow_definition import (
+    SUBWORKFLOW_INVALID_REQUEST,
+)
 from synthorg.persistence.errors import DuplicateRecordError
 from synthorg.persistence.subworkflow_repo import (
     ParentReference,
@@ -238,7 +241,7 @@ class SubworkflowController(Controller):
             )
         except (ValueError, ValidationError) as exc:
             logger.warning(
-                "workflow.subworkflow.invalid_request",
+                SUBWORKFLOW_INVALID_REQUEST,
                 error=str(exc),
             )
             return Response(
@@ -252,13 +255,19 @@ class SubworkflowController(Controller):
         try:
             await registry.register(definition)
         except SubworkflowIOError as exc:
+            logger.warning(SUBWORKFLOW_INVALID_REQUEST, error=str(exc))
             return Response(
-                content=ApiResponse[WorkflowDefinition](error=str(exc)),
+                content=ApiResponse[WorkflowDefinition](
+                    error="Subworkflow I/O validation failed.",
+                ),
                 status_code=422,
             )
         except DuplicateRecordError as exc:
+            logger.warning(SUBWORKFLOW_INVALID_REQUEST, error=str(exc))
             return Response(
-                content=ApiResponse[WorkflowDefinition](error=str(exc)),
+                content=ApiResponse[WorkflowDefinition](
+                    error="A subworkflow with this ID and version already exists.",
+                ),
                 status_code=409,
             )
 
@@ -290,13 +299,18 @@ class SubworkflowController(Controller):
         try:
             await registry.delete(subworkflow_id, version)
         except SubworkflowIOError as exc:
+            logger.warning(SUBWORKFLOW_INVALID_REQUEST, error=str(exc))
             return Response(
-                content=ApiResponse[None](error=str(exc)),
+                content=ApiResponse[None](
+                    error="Cannot delete: version is still referenced.",
+                ),
                 status_code=409,
             )
-        except SubworkflowNotFoundError as exc:
+        except SubworkflowNotFoundError:
             return Response(
-                content=ApiResponse[None](error=str(exc)),
+                content=ApiResponse[None](
+                    error="Subworkflow version not found.",
+                ),
                 status_code=404,
             )
         return Response(content=ApiResponse[None]())

--- a/src/synthorg/api/controllers/subworkflows.py
+++ b/src/synthorg/api/controllers/subworkflows.py
@@ -237,9 +237,13 @@ class SubworkflowController(Controller):
                 updated_at=now,
             )
         except (ValueError, ValidationError) as exc:
+            logger.warning(
+                "workflow.subworkflow.invalid_request",
+                error=str(exc),
+            )
             return Response(
                 content=ApiResponse[WorkflowDefinition](
-                    error=f"Invalid subworkflow definition: {exc}",
+                    error="Invalid subworkflow definition",
                 ),
                 status_code=422,
             )

--- a/src/synthorg/api/controllers/subworkflows.py
+++ b/src/synthorg/api/controllers/subworkflows.py
@@ -1,0 +1,298 @@
+"""Subworkflow registry controller -- CRUD + list + find parents.
+
+Exposes the :class:`SubworkflowRegistry` over HTTP at ``/subworkflows``.
+Parent workflows are authored through the existing ``/workflows``
+controller; this controller is a dedicated surface for the versioned
+subworkflow registry.
+"""
+
+from datetime import UTC, datetime
+from typing import Annotated, Any
+from uuid import uuid4
+
+from litestar import Controller, Request, Response, delete, get, post
+from litestar.datastructures import State  # noqa: TC002
+from litestar.params import Parameter
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from synthorg.api.controllers._workflow_helpers import get_auth_user_id
+from synthorg.api.dto import ApiResponse
+from synthorg.api.guards import require_read_access, require_write_access
+from synthorg.api.path_params import PathId  # noqa: TC001
+from synthorg.core.enums import WorkflowType
+from synthorg.core.types import NotBlankStr  # noqa: TC001
+from synthorg.engine.errors import (
+    SubworkflowIOError,
+    SubworkflowNotFoundError,
+)
+from synthorg.engine.workflow.definition import (
+    WorkflowDefinition,
+    WorkflowEdge,
+    WorkflowIODeclaration,
+    WorkflowNode,
+)
+from synthorg.engine.workflow.subworkflow_registry import SubworkflowRegistry
+from synthorg.observability import get_logger
+from synthorg.persistence.errors import DuplicateRecordError
+from synthorg.persistence.subworkflow_repo import (
+    ParentReference,
+    SubworkflowSummary,
+)
+
+logger = get_logger(__name__)
+
+
+class CreateSubworkflowRequest(BaseModel):
+    """Payload for publishing a new subworkflow version.
+
+    Attributes:
+        subworkflow_id: Identifier.  Generated server-side when omitted.
+        version: Semver string.  Defaults to ``"1.0.0"``.
+        name: Human-readable name.
+        description: Optional description.
+        workflow_type: Target workflow type.
+        inputs: Declared input contract.
+        outputs: Declared output contract.
+        nodes: Graph node payloads.
+        edges: Graph edge payloads.
+    """
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False)
+
+    subworkflow_id: NotBlankStr | None = Field(
+        default=None,
+        max_length=128,
+        description="Stable identifier (generated when omitted)",
+    )
+    version: NotBlankStr = Field(
+        default="1.0.0",
+        max_length=64,
+        description="Semver version",
+    )
+    name: NotBlankStr = Field(max_length=256, description="Display name")
+    description: str = Field(default="", max_length=4096)
+    workflow_type: WorkflowType = Field(
+        default=WorkflowType.SEQUENTIAL_PIPELINE,
+    )
+    inputs: tuple[dict[str, object], ...] = Field(
+        default=(),
+        max_length=64,
+    )
+    outputs: tuple[dict[str, object], ...] = Field(
+        default=(),
+        max_length=64,
+    )
+    nodes: tuple[dict[str, object], ...] = Field(
+        max_length=500,
+    )
+    edges: tuple[dict[str, object], ...] = Field(
+        max_length=1000,
+    )
+
+
+def _registry(state: State) -> SubworkflowRegistry:
+    """Build a :class:`SubworkflowRegistry` from the app state."""
+    return SubworkflowRegistry(state.app_state.persistence.subworkflows)
+
+
+class SubworkflowController(Controller):
+    """Versioned subworkflow registry controller.
+
+    Parent workflows remain authored through ``/workflows``; this
+    controller exposes the subworkflow library as a distinct surface.
+    """
+
+    path = "/subworkflows"
+    tags = ("subworkflows",)
+
+    @get("", guards=[require_read_access])
+    async def list_subworkflows(
+        self,
+        state: State,
+    ) -> Response[ApiResponse[tuple[SubworkflowSummary, ...]]]:
+        """List every unique subworkflow in the registry (latest per id)."""
+        registry = _registry(state)
+        summaries = await registry.list_all()
+        return Response(
+            content=ApiResponse[tuple[SubworkflowSummary, ...]](
+                data=summaries,
+            ),
+        )
+
+    @get("/search", guards=[require_read_access])
+    async def search_subworkflows(
+        self,
+        state: State,
+        q: Annotated[
+            str,
+            Parameter(
+                required=True,
+                min_length=1,
+                max_length=128,
+                description="Search substring",
+            ),
+        ],
+    ) -> Response[ApiResponse[tuple[SubworkflowSummary, ...]]]:
+        """Substring search across name and description."""
+        registry = _registry(state)
+        matches = await registry.search(q)
+        return Response(
+            content=ApiResponse[tuple[SubworkflowSummary, ...]](
+                data=matches,
+            ),
+        )
+
+    @get("/{subworkflow_id:str}/versions", guards=[require_read_access])
+    async def list_versions(
+        self,
+        state: State,
+        subworkflow_id: PathId,
+    ) -> Response[ApiResponse[tuple[str, ...]]]:
+        """List every semver for a subworkflow, newest first."""
+        registry = _registry(state)
+        versions = await registry.list_versions(subworkflow_id)
+        return Response(
+            content=ApiResponse[tuple[str, ...]](data=versions),
+        )
+
+    @get(
+        "/{subworkflow_id:str}/versions/{version:str}",
+        guards=[require_read_access],
+    )
+    async def get_version(
+        self,
+        state: State,
+        subworkflow_id: PathId,
+        version: Annotated[
+            str,
+            Parameter(min_length=1, max_length=64),
+        ],
+    ) -> Response[ApiResponse[WorkflowDefinition]]:
+        """Fetch a specific subworkflow version."""
+        registry = _registry(state)
+        try:
+            definition = await registry.get(subworkflow_id, version)
+        except SubworkflowNotFoundError:
+            return Response(
+                content=ApiResponse[WorkflowDefinition](
+                    error=(
+                        f"Subworkflow {subworkflow_id!r} version {version!r} not found"
+                    ),
+                ),
+                status_code=404,
+            )
+        return Response(
+            content=ApiResponse[WorkflowDefinition](data=definition),
+        )
+
+    @get(
+        "/{subworkflow_id:str}/versions/{version:str}/parents",
+        guards=[require_read_access],
+    )
+    async def list_parents(
+        self,
+        state: State,
+        subworkflow_id: PathId,
+        version: Annotated[
+            str,
+            Parameter(min_length=1, max_length=64),
+        ],
+    ) -> Response[ApiResponse[tuple[ParentReference, ...]]]:
+        """List parent workflow definitions pinning this version."""
+        registry = _registry(state)
+        parents = await registry.find_parents(subworkflow_id, version)
+        return Response(
+            content=ApiResponse[tuple[ParentReference, ...]](data=parents),
+        )
+
+    @post("", guards=[require_write_access])
+    async def create_subworkflow(
+        self,
+        request: Request[Any, Any, Any],
+        state: State,
+        data: CreateSubworkflowRequest,
+    ) -> Response[ApiResponse[WorkflowDefinition]]:
+        """Publish a new subworkflow version to the registry."""
+        creator = get_auth_user_id(request)
+        now = datetime.now(UTC)
+        subworkflow_id = data.subworkflow_id or f"sub-{uuid4().hex[:12]}"
+        try:
+            definition = WorkflowDefinition(
+                id=subworkflow_id,
+                name=data.name,
+                description=data.description,
+                workflow_type=data.workflow_type,
+                version=data.version,
+                inputs=tuple(
+                    WorkflowIODeclaration.model_validate(i) for i in data.inputs
+                ),
+                outputs=tuple(
+                    WorkflowIODeclaration.model_validate(o) for o in data.outputs
+                ),
+                is_subworkflow=True,
+                nodes=tuple(WorkflowNode.model_validate(n) for n in data.nodes),
+                edges=tuple(WorkflowEdge.model_validate(e) for e in data.edges),
+                created_by=creator,
+                created_at=now,
+                updated_at=now,
+            )
+        except (ValueError, ValidationError) as exc:
+            return Response(
+                content=ApiResponse[WorkflowDefinition](
+                    error=f"Invalid subworkflow definition: {exc}",
+                ),
+                status_code=422,
+            )
+
+        registry = _registry(state)
+        try:
+            await registry.register(definition)
+        except SubworkflowIOError as exc:
+            return Response(
+                content=ApiResponse[WorkflowDefinition](error=str(exc)),
+                status_code=422,
+            )
+        except DuplicateRecordError as exc:
+            return Response(
+                content=ApiResponse[WorkflowDefinition](error=str(exc)),
+                status_code=409,
+            )
+
+        return Response(
+            content=ApiResponse[WorkflowDefinition](data=definition),
+            status_code=201,
+        )
+
+    @delete(
+        "/{subworkflow_id:str}/versions/{version:str}",
+        guards=[require_write_access],
+        status_code=200,
+    )
+    async def delete_version(
+        self,
+        state: State,
+        subworkflow_id: PathId,
+        version: Annotated[
+            str,
+            Parameter(min_length=1, max_length=64),
+        ],
+    ) -> Response[ApiResponse[None]]:
+        """Delete a subworkflow version.
+
+        Returns 409 when any parent workflow still pins the version;
+        404 when the coordinate does not exist.
+        """
+        registry = _registry(state)
+        try:
+            await registry.delete(subworkflow_id, version)
+        except SubworkflowIOError as exc:
+            return Response(
+                content=ApiResponse[None](error=str(exc)),
+                status_code=409,
+            )
+        except SubworkflowNotFoundError as exc:
+            return Response(
+                content=ApiResponse[None](error=str(exc)),
+                status_code=404,
+            )
+        return Response(content=ApiResponse[None]())

--- a/src/synthorg/api/controllers/workflow_versions.py
+++ b/src/synthorg/api/controllers/workflow_versions.py
@@ -181,6 +181,7 @@ def _build_rolled_back_definition(
     return target.snapshot.model_copy(
         update={
             "id": existing.id,
+            "version": existing.version,
             "created_by": existing.created_by,
             "created_at": existing.created_at,
             "updated_at": now,

--- a/src/synthorg/api/controllers/workflow_versions.py
+++ b/src/synthorg/api/controllers/workflow_versions.py
@@ -126,12 +126,12 @@ async def _fetch_rollback_target(
             status_code=404,
         )
 
-    if data.expected_version != existing.version:
+    if data.expected_revision != existing.revision:
         logger.warning(
             WORKFLOW_DEF_VERSION_CONFLICT,
             definition_id=workflow_id,
-            expected=data.expected_version,
-            actual=existing.version,
+            expected=data.expected_revision,
+            actual=existing.revision,
         )
         return Response(
             content=ApiResponse[WorkflowDefinition](
@@ -184,7 +184,7 @@ def _build_rolled_back_definition(
             "created_by": existing.created_by,
             "created_at": existing.created_at,
             "updated_at": now,
-            "version": existing.version + 1,
+            "revision": existing.revision + 1,
         },
         deep=True,
     )
@@ -373,13 +373,13 @@ class WorkflowVersionController(Controller):
             logger.exception(
                 WORKFLOW_VERSION_SNAPSHOT_FAILED,
                 definition_id=rolled_back.id,
-                version=rolled_back.version,
+                revision=rolled_back.revision,
             )
         logger.info(
             WORKFLOW_DEF_ROLLED_BACK,
             definition_id=workflow_id,
             target_version=data.target_version,
-            new_version=rolled_back.version,
+            new_revision=rolled_back.revision,
         )
         return Response(
             content=ApiResponse[WorkflowDefinition](data=rolled_back),

--- a/src/synthorg/api/controllers/workflows.py
+++ b/src/synthorg/api/controllers/workflows.py
@@ -136,7 +136,7 @@ def _build_update_fields(  # noqa: C901, PLR0912
             )
             return Response(
                 content=ApiResponse[WorkflowDefinition](
-                    error=f"Invalid inputs: {exc}",
+                    error="Invalid 'inputs' field in request.",
                 ),
                 status_code=422,
             )
@@ -153,7 +153,7 @@ def _build_update_fields(  # noqa: C901, PLR0912
             )
             return Response(
                 content=ApiResponse[WorkflowDefinition](
-                    error=f"Invalid outputs: {exc}",
+                    error="Invalid 'outputs' field in request.",
                 ),
                 status_code=422,
             )
@@ -549,11 +549,19 @@ class WorkflowController(Controller):
         try:
             nodes = tuple(WorkflowNode.model_validate(n) for n in data.nodes)
             edges = tuple(WorkflowEdge.model_validate(e) for e in data.edges)
+            inputs = tuple(WorkflowIODeclaration.model_validate(i) for i in data.inputs)
+            outputs = tuple(
+                WorkflowIODeclaration.model_validate(o) for o in data.outputs
+            )
             definition = WorkflowDefinition(
                 id=f"wfdef-{uuid.uuid4().hex[:12]}",
                 name=data.name,
                 description=data.description,
                 workflow_type=data.workflow_type,
+                version=data.version,
+                inputs=inputs,
+                outputs=outputs,
+                is_subworkflow=data.is_subworkflow,
                 nodes=nodes,
                 edges=edges,
                 created_by=creator,
@@ -567,7 +575,7 @@ class WorkflowController(Controller):
             )
             return Response(
                 content=ApiResponse[WorkflowDefinition](
-                    error=f"Invalid workflow definition: {exc}",
+                    error="Invalid workflow definition.",
                 ),
                 status_code=422,
             )
@@ -581,7 +589,7 @@ class WorkflowController(Controller):
             )
             return Response(
                 content=ApiResponse[WorkflowDefinition](
-                    error=f"Subworkflow validation failed: {messages}",
+                    error="Subworkflow validation failed.",
                 ),
                 status_code=422,
             )
@@ -634,6 +642,20 @@ class WorkflowController(Controller):
             return update_result
         updated = update_result
 
+        subworkflow_errors = await _run_subworkflow_validation(updated, state)
+        if subworkflow_errors:
+            messages = "; ".join(e.message for e in subworkflow_errors)
+            logger.warning(
+                WORKFLOW_DEF_INVALID_REQUEST,
+                error=messages,
+            )
+            return Response(
+                content=ApiResponse[WorkflowDefinition](
+                    error="Subworkflow validation failed.",
+                ),
+                status_code=422,
+            )
+
         try:
             await repo.save(updated)
         except VersionConflictError as exc:
@@ -644,7 +666,7 @@ class WorkflowController(Controller):
             )
             return Response(
                 content=ApiResponse[WorkflowDefinition](
-                    error=f"Version conflict: {exc}",
+                    error="Version conflict: definition was modified concurrently.",
                 ),
                 status_code=409,
             )

--- a/src/synthorg/api/controllers/workflows.py
+++ b/src/synthorg/api/controllers/workflows.py
@@ -38,10 +38,15 @@ from synthorg.engine.workflow.blueprint_models import BlueprintData  # noqa: TC0
 from synthorg.engine.workflow.definition import (
     WorkflowDefinition,
     WorkflowEdge,
+    WorkflowIODeclaration,
     WorkflowNode,
 )
+from synthorg.engine.workflow.subworkflow_registry import SubworkflowRegistry
 from synthorg.engine.workflow.validation import (
+    WorkflowValidationError,
     WorkflowValidationResult,
+    validate_subworkflow_graph,
+    validate_subworkflow_io,
 )
 from synthorg.engine.workflow.validation import (
     validate_workflow as run_workflow_validation,
@@ -86,7 +91,24 @@ def _wf_versioning(state: State) -> VersioningService[WorkflowDefinition]:
 logger = get_logger(__name__)
 
 
-def _build_update_fields(
+async def _run_subworkflow_validation(
+    definition: WorkflowDefinition,
+    state: State,
+) -> tuple[WorkflowValidationError, ...]:
+    """Run save-time subworkflow I/O + cycle validation.
+
+    Returns the combined tuple of validation errors; empty when
+    the definition is subworkflow-clean.  Never raises for individual
+    validation errors -- those are returned as structured errors so
+    callers can map to 400 responses.
+    """
+    registry = SubworkflowRegistry(state.app_state.persistence.subworkflows)
+    io_result = await validate_subworkflow_io(definition, registry)
+    graph_result = await validate_subworkflow_graph(definition, registry)
+    return tuple(io_result.errors) + tuple(graph_result.errors)
+
+
+def _build_update_fields(  # noqa: C901, PLR0912
     data: UpdateWorkflowDefinitionRequest,
 ) -> dict[str, object] | Response[ApiResponse[WorkflowDefinition]]:
     """Build the update dict from the request, or return error."""
@@ -97,6 +119,44 @@ def _build_update_fields(
         updates["description"] = data.description
     if data.workflow_type is not None:
         updates["workflow_type"] = data.workflow_type
+    if data.version is not None:
+        updates["version"] = data.version
+    if data.is_subworkflow is not None:
+        updates["is_subworkflow"] = data.is_subworkflow
+    if data.inputs is not None:
+        try:
+            updates["inputs"] = tuple(
+                WorkflowIODeclaration.model_validate(i) for i in data.inputs
+            )
+        except (ValueError, ValidationError) as exc:
+            logger.warning(
+                WORKFLOW_DEF_INVALID_REQUEST,
+                field="inputs",
+                error=str(exc),
+            )
+            return Response(
+                content=ApiResponse[WorkflowDefinition](
+                    error=f"Invalid inputs: {exc}",
+                ),
+                status_code=422,
+            )
+    if data.outputs is not None:
+        try:
+            updates["outputs"] = tuple(
+                WorkflowIODeclaration.model_validate(o) for o in data.outputs
+            )
+        except (ValueError, ValidationError) as exc:
+            logger.warning(
+                WORKFLOW_DEF_INVALID_REQUEST,
+                field="outputs",
+                error=str(exc),
+            )
+            return Response(
+                content=ApiResponse[WorkflowDefinition](
+                    error=f"Invalid outputs: {exc}",
+                ),
+                status_code=422,
+            )
     if data.nodes is not None:
         try:
             updates["nodes"] = tuple(WorkflowNode.model_validate(n) for n in data.nodes)
@@ -201,7 +261,7 @@ def _apply_update(
 ) -> WorkflowDefinition | Response[ApiResponse[WorkflowDefinition]]:
     """Merge update fields into an existing definition and validate.
 
-    Builds the update dict, bumps the version, and validates the merged
+    Builds the update dict, bumps the revision, and validates the merged
     model. Returns the updated definition on success or an error
     ``Response`` on validation failure or field-level errors.
 
@@ -216,7 +276,7 @@ def _apply_update(
     if isinstance(result, Response):
         return result
     updates = result
-    updates["version"] = existing.version + 1
+    updates["revision"] = existing.revision + 1
 
     try:
         merged = existing.model_dump() | updates
@@ -237,15 +297,15 @@ def _apply_update(
 async def _fetch_existing_for_update(
     repo: WorkflowDefinitionRepository,
     workflow_id: str,
-    expected_version: int | None,
+    expected_revision: int | None,
 ) -> WorkflowDefinition | Response[ApiResponse[WorkflowDefinition]]:
-    """Fetch a definition and check for version conflicts before update.
+    """Fetch a definition and check for revision conflicts before update.
 
     Args:
         repo: The workflow definition repository.
         workflow_id: The workflow definition ID.
-        expected_version: Client-supplied expected version (``None`` to
-            skip the optimistic concurrency check).
+        expected_revision: Client-supplied expected revision (``None``
+            to skip the optimistic concurrency check).
 
     Returns:
         The existing ``WorkflowDefinition``, or a ``Response`` error.
@@ -263,12 +323,12 @@ async def _fetch_existing_for_update(
             status_code=404,
         )
 
-    if expected_version is not None and expected_version != existing.version:
+    if expected_revision is not None and expected_revision != existing.revision:
         logger.warning(
             WORKFLOW_DEF_VERSION_CONFLICT,
             definition_id=workflow_id,
-            expected=expected_version,
-            actual=existing.version,
+            expected=expected_revision,
+            actual=existing.revision,
         )
         return Response(
             content=ApiResponse[WorkflowDefinition](
@@ -439,7 +499,7 @@ class WorkflowController(Controller):
             logger.exception(
                 WORKFLOW_VERSION_SNAPSHOT_FAILED,
                 definition_id=definition.id,
-                version=definition.version,
+                revision=definition.revision,
             )
 
         logger.info(
@@ -512,6 +572,20 @@ class WorkflowController(Controller):
                 status_code=422,
             )
 
+        subworkflow_errors = await _run_subworkflow_validation(definition, state)
+        if subworkflow_errors:
+            messages = "; ".join(e.message for e in subworkflow_errors)
+            logger.warning(
+                WORKFLOW_DEF_INVALID_REQUEST,
+                error=messages,
+            )
+            return Response(
+                content=ApiResponse[WorkflowDefinition](
+                    error=f"Subworkflow validation failed: {messages}",
+                ),
+                status_code=422,
+            )
+
         repo = state.app_state.persistence.workflow_definitions
         await repo.save(definition)
 
@@ -526,7 +600,7 @@ class WorkflowController(Controller):
             logger.exception(
                 WORKFLOW_VERSION_SNAPSHOT_FAILED,
                 definition_id=definition.id,
-                version=definition.version,
+                revision=definition.revision,
             )
 
         logger.info(WORKFLOW_DEF_CREATED, definition_id=definition.id)
@@ -549,7 +623,7 @@ class WorkflowController(Controller):
         fetch_result = await _fetch_existing_for_update(
             repo,
             workflow_id,
-            data.expected_version,
+            data.expected_revision,
         )
         if isinstance(fetch_result, Response):
             return fetch_result
@@ -587,7 +661,7 @@ class WorkflowController(Controller):
             logger.exception(
                 WORKFLOW_VERSION_SNAPSHOT_FAILED,
                 definition_id=updated.id,
-                version=updated.version,
+                revision=updated.revision,
             )
         logger.info(WORKFLOW_DEF_UPDATED, definition_id=updated.id)
 

--- a/src/synthorg/api/dto.py
+++ b/src/synthorg/api/dto.py
@@ -667,11 +667,11 @@ class UpdateWorkflowDefinitionRequest(BaseModel):
     )
     inputs: tuple[dict[str, object], ...] | None = Field(
         default=None,
-        max_length=64,
+        max_length=100,
     )
     outputs: tuple[dict[str, object], ...] | None = Field(
         default=None,
-        max_length=64,
+        max_length=100,
     )
     is_subworkflow: bool | None = None
     nodes: tuple[dict[str, object], ...] | None = Field(

--- a/src/synthorg/api/dto.py
+++ b/src/synthorg/api/dto.py
@@ -627,9 +627,13 @@ class UpdateWorkflowDefinitionRequest(BaseModel):
         name: New name.
         description: New description.
         workflow_type: New workflow type.
+        version: New semver version string.
+        inputs: New typed input contract.
+        outputs: New typed output contract.
+        is_subworkflow: New publishing flag.
         nodes: New nodes.
         edges: New edges.
-        expected_version: Optimistic concurrency guard.
+        expected_revision: Optimistic concurrency guard.
     """
 
     model_config = ConfigDict(frozen=True, allow_inf_nan=False)
@@ -637,6 +641,20 @@ class UpdateWorkflowDefinitionRequest(BaseModel):
     name: NotBlankStr | None = Field(default=None, max_length=256)
     description: str | None = Field(default=None, max_length=4096)
     workflow_type: WorkflowType | None = None
+    version: NotBlankStr | None = Field(
+        default=None,
+        max_length=64,
+        description="Semver string override",
+    )
+    inputs: tuple[dict[str, object], ...] | None = Field(
+        default=None,
+        max_length=64,
+    )
+    outputs: tuple[dict[str, object], ...] | None = Field(
+        default=None,
+        max_length=64,
+    )
+    is_subworkflow: bool | None = None
     nodes: tuple[dict[str, object], ...] | None = Field(
         default=None,
         max_length=500,
@@ -645,10 +663,10 @@ class UpdateWorkflowDefinitionRequest(BaseModel):
         default=None,
         max_length=1000,
     )
-    expected_version: int | None = Field(
+    expected_revision: int | None = Field(
         default=None,
         ge=1,
-        description="Optimistic concurrency guard",
+        description="Optimistic concurrency guard (revision counter)",
     )
 
 
@@ -733,25 +751,19 @@ class RollbackWorkflowRequest(BaseModel):
     """Request body for rolling back a workflow to a previous version.
 
     Attributes:
-        target_version: Version number to restore content from.
-        expected_version: Current version for optimistic concurrency.
+        target_version: Snapshot version number to restore content from
+            (monotonic counter in the workflow_definition_versions table).
+        expected_revision: Current definition revision for optimistic
+            concurrency on the live workflow_definitions row.
     """
 
     model_config = ConfigDict(frozen=True, allow_inf_nan=False)
 
-    target_version: int = Field(ge=1, description="Version to rollback to")
-    expected_version: int = Field(
+    target_version: int = Field(ge=1, description="Snapshot version to rollback to")
+    expected_revision: int = Field(
         ge=1,
-        description="Optimistic concurrency guard",
+        description="Optimistic concurrency guard on the definition revision",
     )
-
-    @model_validator(mode="after")
-    def _validate_version_order(self) -> Self:
-        """Reject rollback where target >= expected."""
-        if self.target_version >= self.expected_version:
-            msg = "target_version must be less than expected_version"
-            raise ValueError(msg)
-        return self
 
 
 __all__ = [

--- a/src/synthorg/api/dto.py
+++ b/src/synthorg/api/dto.py
@@ -608,6 +608,25 @@ class CreateWorkflowDefinitionRequest(BaseModel):
     name: NotBlankStr = Field(max_length=256, description="Workflow name")
     description: str = Field(default="", max_length=4096, description="Description")
     workflow_type: WorkflowType = Field(description="Target execution topology")
+    version: str = Field(
+        default="1.0.0",
+        max_length=64,
+        description="Semver version string",
+    )
+    inputs: tuple[dict[str, object], ...] = Field(
+        default=(),
+        max_length=100,
+        description="Typed input declarations",
+    )
+    outputs: tuple[dict[str, object], ...] = Field(
+        default=(),
+        max_length=100,
+        description="Typed output declarations",
+    )
+    is_subworkflow: bool = Field(
+        default=False,
+        description="Whether this definition is a reusable subworkflow",
+    )
     nodes: tuple[dict[str, object], ...] = Field(
         max_length=500,
         description="Workflow nodes",

--- a/src/synthorg/core/enums.py
+++ b/src/synthorg/core/enums.py
@@ -336,6 +336,24 @@ class WorkflowNodeType(StrEnum):
     CONDITIONAL = "conditional"
     PARALLEL_SPLIT = "parallel_split"
     PARALLEL_JOIN = "parallel_join"
+    SUBWORKFLOW = "subworkflow"
+
+
+class WorkflowValueType(StrEnum):
+    """Typed value kinds for workflow I/O declarations.
+
+    Used by :class:`WorkflowIODeclaration` to enforce typed contracts
+    on subworkflow inputs and outputs at save time and at runtime.
+    """
+
+    STRING = "string"
+    INTEGER = "integer"
+    FLOAT = "float"
+    BOOLEAN = "boolean"
+    DATETIME = "datetime"
+    JSON = "json"
+    TASK_REF = "task_ref"
+    AGENT_REF = "agent_ref"
 
 
 class WorkflowEdgeType(StrEnum):
@@ -378,6 +396,7 @@ class WorkflowNodeExecutionStatus(StrEnum):
     TASK_COMPLETED = "task_completed"
     TASK_FAILED = "task_failed"
     COMPLETED = "completed"
+    SUBWORKFLOW_COMPLETED = "subworkflow_completed"
 
 
 class ArtifactType(StrEnum):

--- a/src/synthorg/engine/errors.py
+++ b/src/synthorg/engine/errors.py
@@ -209,6 +209,72 @@ class WorkflowExecutionNotFoundError(WorkflowExecutionError):
     """Raised when a workflow execution instance is not found."""
 
 
+class SubworkflowNotFoundError(WorkflowExecutionError):
+    """Raised when a referenced subworkflow version cannot be resolved.
+
+    Attributes:
+        subworkflow_id: The subworkflow identifier.
+        version: The semver pin that failed to resolve.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        subworkflow_id: NotBlankStr,
+        version: NotBlankStr,
+    ) -> None:
+        super().__init__(message)
+        self.subworkflow_id = subworkflow_id
+        self.version = version
+
+
+class SubworkflowCycleError(WorkflowExecutionError):
+    """Raised when the subworkflow reference graph contains a cycle.
+
+    Attributes:
+        cycle_path: Ordered ``(subworkflow_id, version)`` tuples that
+            participate in the cycle.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        cycle_path: tuple[tuple[str, str], ...],
+    ) -> None:
+        super().__init__(message)
+        self.cycle_path = cycle_path
+
+
+class SubworkflowDepthExceededError(WorkflowExecutionError):
+    """Raised when runtime subworkflow nesting exceeds the configured limit.
+
+    Attributes:
+        depth: The depth at which the limit was exceeded.
+        max_depth: The configured maximum.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        depth: int,
+        max_depth: int,
+    ) -> None:
+        super().__init__(message)
+        self.depth = depth
+        self.max_depth = max_depth
+
+
+class SubworkflowIOError(WorkflowExecutionError):
+    """Raised when subworkflow input or output binding is invalid.
+
+    Covers missing required inputs, unknown inputs, unknown outputs,
+    type mismatches, and invalid binding expressions.
+    """
+
+
 class SelfReviewError(EngineError):
     """Raised when an agent attempts to review their own work.
 

--- a/src/synthorg/engine/workflow/definition.py
+++ b/src/synthorg/engine/workflow/definition.py
@@ -13,10 +13,57 @@ from collections.abc import Mapping  # noqa: TC003
 from datetime import UTC, datetime
 from typing import Self
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from packaging.version import InvalidVersion, Version
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from synthorg.core.enums import WorkflowEdgeType, WorkflowNodeType, WorkflowType
+from synthorg.core.enums import (
+    WorkflowEdgeType,
+    WorkflowNodeType,
+    WorkflowType,
+    WorkflowValueType,
+)
 from synthorg.core.types import NotBlankStr  # noqa: TC001
+
+_DEFAULT_SEMVER = "1.0.0"
+
+
+class WorkflowIODeclaration(BaseModel):
+    """A typed input or output declaration for a workflow definition.
+
+    Subworkflows use these declarations as their contract: parents must
+    provide matching inputs, and the parent scope receives outputs
+    projected from the child frame's variables.
+
+    Attributes:
+        name: Identifier used by parent bindings and child expressions.
+        type: The value kind (see :class:`WorkflowValueType`).
+        required: Whether the caller must provide this input.
+            Always ``True`` for outputs.
+        default: Optional default value when ``required`` is ``False``.
+        description: Free-text description for the UI.
+    """
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False)
+
+    name: NotBlankStr = Field(description="Identifier")
+    type: WorkflowValueType = Field(description="Typed value kind")
+    required: bool = Field(default=True, description="Whether a value is mandatory")
+    default: object | None = Field(
+        default=None,
+        description="Default value when not required",
+    )
+    description: str = Field(default="", description="Human-readable description")
+
+    @model_validator(mode="after")
+    def _validate_default_compatible(self) -> Self:
+        """Reject defaults on required declarations or on unknown value kinds."""
+        if self.required and self.default is not None:
+            msg = (
+                f"Declaration {self.name!r}: required declarations "
+                f"must not carry a default value"
+            )
+            raise ValueError(msg)
+        return self
 
 
 class WorkflowNode(BaseModel):
@@ -82,12 +129,20 @@ class WorkflowDefinition(BaseModel):
         name: Human-readable workflow name.
         description: Optional detailed description.
         workflow_type: The execution topology this workflow targets.
+        version: Semver string (``MAJOR.MINOR.PATCH``) identifying this
+            revision for subworkflow pinning and publication.
+        inputs: Typed input contract (used when this definition is
+            referenced as a subworkflow).
+        outputs: Typed output contract (used when this definition is
+            referenced as a subworkflow).
+        is_subworkflow: Whether this definition is published to the
+            subworkflow registry.
         nodes: All nodes in the workflow graph.
         edges: All edges connecting the nodes.
         created_by: Identity of the creator.
         created_at: Creation timestamp (UTC).
         updated_at: Last update timestamp (UTC).
-        version: Optimistic concurrency version counter.
+        revision: Optimistic concurrency counter (monotonic integer).
     """
 
     model_config = ConfigDict(frozen=True, allow_inf_nan=False)
@@ -98,6 +153,22 @@ class WorkflowDefinition(BaseModel):
     workflow_type: WorkflowType = Field(
         default=WorkflowType.SEQUENTIAL_PIPELINE,
         description="Target execution topology",
+    )
+    version: NotBlankStr = Field(
+        default=_DEFAULT_SEMVER,
+        description="Semver version string (MAJOR.MINOR.PATCH)",
+    )
+    inputs: tuple[WorkflowIODeclaration, ...] = Field(
+        default=(),
+        description="Typed input contract (subworkflow-facing)",
+    )
+    outputs: tuple[WorkflowIODeclaration, ...] = Field(
+        default=(),
+        description="Typed output contract (subworkflow-facing)",
+    )
+    is_subworkflow: bool = Field(
+        default=False,
+        description="Whether this definition is published to the registry",
     )
     nodes: tuple[WorkflowNode, ...] = Field(
         default=(),
@@ -116,7 +187,38 @@ class WorkflowDefinition(BaseModel):
         default_factory=lambda: datetime.now(UTC),
         description="Last update timestamp (UTC)",
     )
-    version: int = Field(default=1, ge=1, description="Optimistic concurrency version")
+    revision: int = Field(
+        default=1,
+        ge=1,
+        description="Optimistic concurrency counter",
+    )
+
+    @field_validator("version")
+    @classmethod
+    def _validate_semver(cls, value: str) -> str:
+        """Reject invalid semver strings via :mod:`packaging`."""
+        try:
+            Version(value)
+        except InvalidVersion as exc:
+            msg = f"Invalid version string {value!r}: {exc}"
+            raise ValueError(msg) from exc
+        return value
+
+    @model_validator(mode="after")
+    def _validate_unique_io_names(self) -> Self:
+        """Reject duplicate input or output names within the same scope."""
+        input_names = tuple(decl.name for decl in self.inputs)
+        if len(input_names) != len(set(input_names)):
+            dupes = sorted(v for v, c in Counter(input_names).items() if c > 1)
+            msg = f"Duplicate input declaration names: {dupes}"
+            raise ValueError(msg)
+
+        output_names = tuple(decl.name for decl in self.outputs)
+        if len(output_names) != len(set(output_names)):
+            dupes = sorted(v for v, c in Counter(output_names).items() if c > 1)
+            msg = f"Duplicate output declaration names: {dupes}"
+            raise ValueError(msg)
+        return self
 
     @model_validator(mode="after")
     def _validate_unique_ids(self) -> Self:

--- a/src/synthorg/engine/workflow/definition.py
+++ b/src/synthorg/engine/workflow/definition.py
@@ -8,6 +8,7 @@ This is distinct from ``WorkflowConfig`` (runtime operational config
 for Kanban/Sprint settings).
 """
 
+import json
 from collections import Counter
 from collections.abc import Mapping  # noqa: TC003
 from datetime import UTC, datetime
@@ -40,13 +41,20 @@ _VALUE_TYPE_CHECKS: dict[WorkflowValueType, type | tuple[type, ...]] = {
 def _check_default_type(name: str, default: object, vtype: WorkflowValueType) -> None:
     """Validate that *default* is compatible with *vtype*."""
     if vtype is WorkflowValueType.JSON:
+        try:
+            json.dumps(default)
+        except (TypeError, ValueError) as exc:
+            msg = f"Declaration {name!r}: JSON default is not serializable"
+            raise TypeError(msg) from exc
         return
     expected = _VALUE_TYPE_CHECKS.get(vtype)
     if expected is None:
         return
-    if vtype is WorkflowValueType.INTEGER and isinstance(default, bool):
-        msg = f"Declaration {name!r}: default must be INTEGER, got bool"
-        raise ValueError(msg)
+    if vtype in (WorkflowValueType.INTEGER, WorkflowValueType.FLOAT) and isinstance(
+        default, bool
+    ):
+        msg = f"Declaration {name!r}: default must be {vtype.value}, got bool"
+        raise TypeError(msg)
     if not isinstance(default, expected):
         msg = (
             f"Declaration {name!r}: default must be"

--- a/src/synthorg/engine/workflow/definition.py
+++ b/src/synthorg/engine/workflow/definition.py
@@ -26,6 +26,34 @@ from synthorg.core.types import NotBlankStr  # noqa: TC001
 
 _DEFAULT_SEMVER = "1.0.0"
 
+_VALUE_TYPE_CHECKS: dict[WorkflowValueType, type | tuple[type, ...]] = {
+    WorkflowValueType.STRING: str,
+    WorkflowValueType.INTEGER: int,
+    WorkflowValueType.FLOAT: (int, float),
+    WorkflowValueType.BOOLEAN: bool,
+    WorkflowValueType.DATETIME: datetime,
+    WorkflowValueType.TASK_REF: str,
+    WorkflowValueType.AGENT_REF: str,
+}
+
+
+def _check_default_type(name: str, default: object, vtype: WorkflowValueType) -> None:
+    """Validate that *default* is compatible with *vtype*."""
+    if vtype is WorkflowValueType.JSON:
+        return
+    expected = _VALUE_TYPE_CHECKS.get(vtype)
+    if expected is None:
+        return
+    if vtype is WorkflowValueType.INTEGER and isinstance(default, bool):
+        msg = f"Declaration {name!r}: default must be INTEGER, got bool"
+        raise ValueError(msg)
+    if not isinstance(default, expected):
+        msg = (
+            f"Declaration {name!r}: default must be"
+            f" {vtype.value}, got {type(default).__name__}"
+        )
+        raise TypeError(msg)
+
 
 class WorkflowIODeclaration(BaseModel):
     """A typed input or output declaration for a workflow definition.
@@ -56,13 +84,15 @@ class WorkflowIODeclaration(BaseModel):
 
     @model_validator(mode="after")
     def _validate_default_compatible(self) -> Self:
-        """Reject defaults on required declarations or on unknown value kinds."""
+        """Reject defaults on required declarations and type-check defaults."""
         if self.required and self.default is not None:
             msg = (
                 f"Declaration {self.name!r}: required declarations "
                 f"must not carry a default value"
             )
             raise ValueError(msg)
+        if self.default is not None:
+            _check_default_type(self.name, self.default, self.type)
         return self
 
 

--- a/src/synthorg/engine/workflow/definition.py
+++ b/src/synthorg/engine/workflow/definition.py
@@ -9,6 +9,7 @@ for Kanban/Sprint settings).
 """
 
 import json
+import math
 from collections import Counter
 from collections.abc import Mapping  # noqa: TC003
 from datetime import UTC, datetime
@@ -42,7 +43,7 @@ def _check_default_type(name: str, default: object, vtype: WorkflowValueType) ->
     """Validate that *default* is compatible with *vtype*."""
     if vtype is WorkflowValueType.JSON:
         try:
-            json.dumps(default)
+            json.dumps(default, allow_nan=False)
         except (TypeError, ValueError) as exc:
             msg = f"Declaration {name!r}: JSON default is not serializable"
             raise TypeError(msg) from exc
@@ -60,6 +61,13 @@ def _check_default_type(name: str, default: object, vtype: WorkflowValueType) ->
             f"Declaration {name!r}: default must be"
             f" {vtype.value}, got {type(default).__name__}"
         )
+        raise TypeError(msg)
+    if (
+        vtype is WorkflowValueType.FLOAT
+        and isinstance(default, (int, float))
+        and not math.isfinite(default)
+    ):
+        msg = f"Declaration {name!r}: FLOAT default must be finite"
         raise TypeError(msg)
 
 

--- a/src/synthorg/engine/workflow/definition.py
+++ b/src/synthorg/engine/workflow/definition.py
@@ -33,7 +33,7 @@ _VALUE_TYPE_CHECKS: dict[WorkflowValueType, type | tuple[type, ...]] = {
     WorkflowValueType.INTEGER: int,
     WorkflowValueType.FLOAT: (int, float),
     WorkflowValueType.BOOLEAN: bool,
-    WorkflowValueType.DATETIME: datetime,
+    WorkflowValueType.DATETIME: (datetime, str),
     WorkflowValueType.TASK_REF: str,
     WorkflowValueType.AGENT_REF: str,
 }
@@ -62,6 +62,12 @@ def _check_default_type(name: str, default: object, vtype: WorkflowValueType) ->
             f" {vtype.value}, got {type(default).__name__}"
         )
         raise TypeError(msg)
+    if vtype is WorkflowValueType.DATETIME and isinstance(default, str):
+        try:
+            datetime.fromisoformat(default)
+        except ValueError as exc:
+            msg = f"Declaration {name!r}: DATETIME default is not valid ISO-8601"
+            raise TypeError(msg) from exc
     if (
         vtype is WorkflowValueType.FLOAT
         and isinstance(default, (int, float))

--- a/src/synthorg/engine/workflow/definition.py
+++ b/src/synthorg/engine/workflow/definition.py
@@ -10,12 +10,12 @@ for Kanban/Sprint settings).
 
 import json
 import math
+import re
 from collections import Counter
 from collections.abc import Mapping  # noqa: TC003
 from datetime import UTC, datetime
 from typing import Self
 
-from packaging.version import InvalidVersion, Version
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from synthorg.core.enums import (
@@ -242,13 +242,26 @@ class WorkflowDefinition(BaseModel):
     @field_validator("version")
     @classmethod
     def _validate_semver(cls, value: str) -> str:
-        """Reject invalid semver strings via :mod:`packaging`."""
-        try:
-            Version(value)
-        except InvalidVersion as exc:
-            msg = f"Invalid version string {value!r}: {exc}"
-            raise ValueError(msg) from exc
+        """Reject non-strict semver (must be MAJOR.MINOR.PATCH)."""
+        if not re.fullmatch(r"\d+\.\d+\.\d+", value):
+            msg = (
+                f"Invalid version {value!r}: must be strict"
+                f" MAJOR.MINOR.PATCH (e.g. '1.0.0')"
+            )
+            raise ValueError(msg)
         return value
+
+    @model_validator(mode="after")
+    def _validate_outputs_required(self) -> Self:
+        """Ensure all output declarations are required."""
+        for decl in self.outputs:
+            if not decl.required:
+                msg = (
+                    f"Output declaration {decl.name!r} must be"
+                    f" required (optional outputs are not supported)"
+                )
+                raise ValueError(msg)
+        return self
 
     @model_validator(mode="after")
     def _validate_unique_io_names(self) -> Self:

--- a/src/synthorg/engine/workflow/definition.py
+++ b/src/synthorg/engine/workflow/definition.py
@@ -243,7 +243,7 @@ class WorkflowDefinition(BaseModel):
     @classmethod
     def _validate_semver(cls, value: str) -> str:
         """Reject non-strict semver (must be MAJOR.MINOR.PATCH)."""
-        if not re.fullmatch(r"\d+\.\d+\.\d+", value):
+        if not re.fullmatch(r"(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)", value):
             msg = (
                 f"Invalid version {value!r}: must be strict"
                 f" MAJOR.MINOR.PATCH (e.g. '1.0.0')"

--- a/src/synthorg/engine/workflow/execution_models.py
+++ b/src/synthorg/engine/workflow/execution_models.py
@@ -51,7 +51,9 @@ class ExecutionFrame(BaseModel):
 
     @field_validator("variables", mode="before")
     @classmethod
-    def _freeze_variables(cls, value: Mapping[str, object]) -> MappingProxyType:
+    def _freeze_variables(
+        cls, value: Mapping[str, object]
+    ) -> MappingProxyType[str, object]:
         if isinstance(value, MappingProxyType):
             return value
         return MappingProxyType(deepcopy(dict(value)))

--- a/src/synthorg/engine/workflow/execution_models.py
+++ b/src/synthorg/engine/workflow/execution_models.py
@@ -7,11 +7,12 @@ via the ``TaskEngine``.
 """
 
 from collections.abc import Mapping  # noqa: TC003
+from copy import deepcopy
 from datetime import UTC, datetime
 from types import MappingProxyType
 from typing import ClassVar, Self
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from synthorg.core.enums import (
     WorkflowExecutionStatus,
@@ -47,6 +48,14 @@ class ExecutionFrame(BaseModel):
         default_factory=lambda: MappingProxyType({}),
         description="Frame-local variables",
     )
+
+    @field_validator("variables", mode="before")
+    @classmethod
+    def _freeze_variables(cls, value: Mapping[str, object]) -> MappingProxyType:
+        if isinstance(value, MappingProxyType):
+            return value
+        return MappingProxyType(deepcopy(dict(value)))
+
     parent_frame: ExecutionFrame | None = Field(
         default=None,
         description="Caller frame (None for root)",

--- a/src/synthorg/engine/workflow/execution_models.py
+++ b/src/synthorg/engine/workflow/execution_models.py
@@ -6,7 +6,9 @@ and maps TASK nodes to concrete ``Task`` instances created
 via the ``TaskEngine``.
 """
 
+from collections.abc import Mapping  # noqa: TC003
 from datetime import UTC, datetime
+from types import MappingProxyType
 from typing import ClassVar, Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -17,6 +19,57 @@ from synthorg.core.enums import (
     WorkflowNodeType,
 )
 from synthorg.core.types import NotBlankStr  # noqa: TC001
+
+
+class ExecutionFrame(BaseModel):
+    """A scoped variable frame for subworkflow call/return execution.
+
+    The activation-time graph walker pushes a new frame whenever it
+    resolves a ``SUBWORKFLOW`` node and pops it when the child graph
+    completes.  Each frame owns a private ``variables`` mapping --
+    children cannot read parent variables outside declared inputs
+    because the walker receives a new frame-scoped context map.
+
+    Attributes:
+        workflow_id: ID of the workflow whose graph is being walked.
+        workflow_version: Semver version string of the workflow.
+        variables: Frame-local variable map (resolved inputs, defaults,
+            and walk-time computed values).
+        parent_frame: Immediate caller frame, ``None`` for the root.
+        depth: Nesting depth (root frame is ``0``).
+    """
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False)
+
+    workflow_id: NotBlankStr = Field(description="Workflow definition ID")
+    workflow_version: NotBlankStr = Field(description="Semver version")
+    variables: Mapping[str, object] = Field(
+        default_factory=lambda: MappingProxyType({}),
+        description="Frame-local variables",
+    )
+    parent_frame: ExecutionFrame | None = Field(
+        default=None,
+        description="Caller frame (None for root)",
+    )
+    depth: int = Field(default=0, ge=0, description="Nesting depth")
+
+    @model_validator(mode="after")
+    def _validate_depth_matches_parent(self) -> Self:
+        """Ensure ``depth == parent.depth + 1`` (root frame has depth 0)."""
+        if self.parent_frame is None:
+            if self.depth != 0:
+                msg = f"Root frame must have depth=0, got {self.depth}"
+                raise ValueError(msg)
+        elif self.depth != self.parent_frame.depth + 1:
+            msg = (
+                f"Frame depth {self.depth} does not match "
+                f"parent depth + 1 ({self.parent_frame.depth + 1})"
+            )
+            raise ValueError(msg)
+        return self
+
+
+ExecutionFrame.model_rebuild()
 
 
 class WorkflowNodeExecution(BaseModel):
@@ -94,8 +147,8 @@ class WorkflowExecution(BaseModel):
     Attributes:
         id: Unique execution identifier (``"wfexec-{uuid12}"``).
         definition_id: Source ``WorkflowDefinition`` ID.
-        definition_version: Snapshot of the definition's version
-            at activation time.
+        definition_revision: Snapshot of the definition's optimistic
+            concurrency counter at activation time.
         status: Overall execution lifecycle status.
         node_executions: Per-node execution state.
         activated_by: Identity of the user who triggered activation.
@@ -111,9 +164,9 @@ class WorkflowExecution(BaseModel):
 
     id: NotBlankStr = Field(description="Unique execution ID")
     definition_id: NotBlankStr = Field(description="Source definition ID")
-    definition_version: int = Field(
+    definition_revision: int = Field(
         ge=1,
-        description="Definition version at activation time",
+        description="Definition revision (optimistic concurrency) at activation time",
     )
     status: WorkflowExecutionStatus = Field(
         default=WorkflowExecutionStatus.PENDING,

--- a/src/synthorg/engine/workflow/execution_models.py
+++ b/src/synthorg/engine/workflow/execution_models.py
@@ -54,8 +54,6 @@ class ExecutionFrame(BaseModel):
     def _freeze_variables(
         cls, value: Mapping[str, object]
     ) -> MappingProxyType[str, object]:
-        if isinstance(value, MappingProxyType):
-            return value
         return MappingProxyType(deepcopy(dict(value)))
 
     parent_frame: ExecutionFrame | None = Field(

--- a/src/synthorg/engine/workflow/execution_service.py
+++ b/src/synthorg/engine/workflow/execution_service.py
@@ -63,6 +63,7 @@ from synthorg.observability.events.workflow_execution import (
     WORKFLOW_EXEC_SUBWORKFLOW_FRAME_PUSHED,
     WORKFLOW_EXEC_SUBWORKFLOW_NODE_COMPLETED,
 )
+from synthorg.persistence.errors import VersionConflictError
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -640,6 +641,7 @@ class WorkflowExecutionService:
             output_bindings,
             child_final_vars,
             child_definition.outputs,
+            parent_vars=frame_ctx,
         )
         frame_ctx.update(projected)
 
@@ -854,10 +856,25 @@ class WorkflowExecutionService:
         if execution is None:
             return
 
-        if event.new_status in {TaskStatus.FAILED, TaskStatus.CANCELLED}:
-            await self._handle_task_failed(execution, event)
-        else:
-            await self._handle_task_completed(execution, event)
+        try:
+            if event.new_status in {TaskStatus.FAILED, TaskStatus.CANCELLED}:
+                await self._handle_task_failed(execution, event)
+            else:
+                await self._handle_task_completed(execution, event)
+        except VersionConflictError:
+            logger.warning(
+                WORKFLOW_EXEC_NODE_TASK_COMPLETED,
+                execution_id=execution.id,
+                task_id=event.task_id,
+                error="Concurrent modification; re-fetching execution",
+            )
+            refreshed = await self._execution_repo.get(execution.id)
+            if refreshed is None:
+                return
+            if event.new_status in {TaskStatus.FAILED, TaskStatus.CANCELLED}:
+                await self._handle_task_failed(refreshed, event)
+            else:
+                await self._handle_task_completed(refreshed, event)
 
     async def _handle_task_failed(
         self,

--- a/src/synthorg/engine/workflow/execution_service.py
+++ b/src/synthorg/engine/workflow/execution_service.py
@@ -558,8 +558,8 @@ class WorkflowExecutionService:
         config = dict(node.config)
         subworkflow_id = config.get("subworkflow_id")
         version = config.get("version")
-        input_bindings = config.get("input_bindings") or {}
-        output_bindings = config.get("output_bindings") or {}
+        input_bindings = config.get("input_bindings")
+        output_bindings = config.get("output_bindings")
         if not isinstance(subworkflow_id, str) or not subworkflow_id.strip():
             msg = f"SUBWORKFLOW node {nid!r} is missing subworkflow_id in config"
             raise WorkflowExecutionError(msg)
@@ -870,8 +870,13 @@ class WorkflowExecutionService:
             else:
                 await self._handle_task_completed(execution, event)
         except VersionConflictError:
+            retry_event = (
+                WORKFLOW_EXEC_NODE_TASK_FAILED
+                if event.new_status in {TaskStatus.FAILED, TaskStatus.CANCELLED}
+                else WORKFLOW_EXEC_NODE_TASK_COMPLETED
+            )
             logger.warning(
-                WORKFLOW_EXEC_NODE_TASK_COMPLETED,
+                retry_event,
                 execution_id=execution.id,
                 task_id=event.task_id,
                 error="Concurrent modification; re-fetching execution",

--- a/src/synthorg/engine/workflow/execution_service.py
+++ b/src/synthorg/engine/workflow/execution_service.py
@@ -879,6 +879,12 @@ class WorkflowExecutionService:
             refreshed = await self._execution_repo.get(execution.id)
             if refreshed is None:
                 return
+            if refreshed.status in {
+                WorkflowExecutionStatus.COMPLETED,
+                WorkflowExecutionStatus.FAILED,
+                WorkflowExecutionStatus.CANCELLED,
+            }:
+                return
             if event.new_status in {TaskStatus.FAILED, TaskStatus.CANCELLED}:
                 await self._handle_task_failed(refreshed, event)
             else:

--- a/src/synthorg/engine/workflow/execution_service.py
+++ b/src/synthorg/engine/workflow/execution_service.py
@@ -8,6 +8,7 @@ upstream task dependencies from the graph edges.
 
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from types import MappingProxyType
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
@@ -570,7 +571,7 @@ class WorkflowExecutionService:
             output_bindings = {}
 
         next_depth = frame.depth + 1
-        if next_depth > self._max_subworkflow_depth:
+        if next_depth >= self._max_subworkflow_depth:
             logger.error(
                 WORKFLOW_EXEC_SUBWORKFLOW_DEPTH_EXCEEDED,
                 execution_id=execution_id,
@@ -605,7 +606,7 @@ class WorkflowExecutionService:
         child_frame = ExecutionFrame(
             workflow_id=child_definition.id,
             workflow_version=child_definition.version,
-            variables=resolved_inputs,
+            variables=MappingProxyType(resolved_inputs),
             parent_frame=frame,
             depth=next_depth,
         )

--- a/src/synthorg/engine/workflow/execution_service.py
+++ b/src/synthorg/engine/workflow/execution_service.py
@@ -6,6 +6,7 @@ order, creating concrete tasks for TASK nodes, and wiring
 upstream task dependencies from the graph edges.
 """
 
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 from uuid import uuid4
@@ -18,6 +19,7 @@ from synthorg.core.enums import (
     WorkflowNodeType,
 )
 from synthorg.engine.errors import (
+    SubworkflowDepthExceededError,
     WorkflowDefinitionInvalidError,
     WorkflowExecutionError,
     WorkflowExecutionNotFoundError,
@@ -28,6 +30,7 @@ from synthorg.engine.workflow.execution_activation_helpers import (
     process_task_node,
 )
 from synthorg.engine.workflow.execution_models import (
+    ExecutionFrame,
     WorkflowExecution,
     WorkflowNodeExecution,
 )
@@ -35,6 +38,11 @@ from synthorg.engine.workflow.graph_utils import (
     build_adjacency_maps,
     topological_sort,
 )
+from synthorg.engine.workflow.subworkflow_binding import (
+    project_output_bindings,
+    resolve_input_bindings,
+)
+from synthorg.engine.workflow.subworkflow_registry import MAX_WORKFLOW_DEPTH
 from synthorg.engine.workflow.validation import validate_workflow
 from synthorg.observability import get_logger
 from synthorg.observability.events.workflow_execution import (
@@ -49,6 +57,10 @@ from synthorg.observability.events.workflow_execution import (
     WORKFLOW_EXEC_NODE_TASK_COMPLETED,
     WORKFLOW_EXEC_NODE_TASK_FAILED,
     WORKFLOW_EXEC_NOT_FOUND,
+    WORKFLOW_EXEC_SUBWORKFLOW_DEPTH_EXCEEDED,
+    WORKFLOW_EXEC_SUBWORKFLOW_FRAME_POPPED,
+    WORKFLOW_EXEC_SUBWORKFLOW_FRAME_PUSHED,
+    WORKFLOW_EXEC_SUBWORKFLOW_NODE_COMPLETED,
 )
 
 if TYPE_CHECKING:
@@ -60,12 +72,41 @@ if TYPE_CHECKING:
         WorkflowDefinition,
         WorkflowNode,
     )
+    from synthorg.engine.workflow.subworkflow_registry import (
+        SubworkflowRegistry,
+    )
     from synthorg.persistence.workflow_definition_repo import (
         WorkflowDefinitionRepository,
     )
     from synthorg.persistence.workflow_execution_repo import (
         WorkflowExecutionRepository,
     )
+
+
+_QUALIFIED_ID_SEPARATOR = "::"
+
+
+def _qualify_id(prefix: str, node_id: str) -> str:
+    """Build a qualified node ID ``{prefix}::{node_id}`` or return *node_id*.
+
+    When *prefix* is empty the node ID is returned unchanged so that
+    top-level graphs keep their existing unqualified IDs.
+    """
+    if not prefix:
+        return node_id
+    return f"{prefix}{_QUALIFIED_ID_SEPARATOR}{node_id}"
+
+
+@dataclass
+class _WalkState:
+    """Mutable accumulators shared across all frames in a single activation."""
+
+    node_exec_map: dict[str, WorkflowNodeExecution] = field(
+        default_factory=dict,
+    )
+    node_task_ids: dict[str, str] = field(default_factory=dict)
+    ordered_keys: list[str] = field(default_factory=list)
+
 
 logger = get_logger(__name__)
 
@@ -93,10 +134,14 @@ class WorkflowExecutionService:
         definition_repo: WorkflowDefinitionRepository,
         execution_repo: WorkflowExecutionRepository,
         task_engine: TaskEngine,
+        subworkflow_registry: SubworkflowRegistry | None = None,
+        max_subworkflow_depth: int = MAX_WORKFLOW_DEPTH,
     ) -> None:
         self._definition_repo = definition_repo
         self._execution_repo = execution_repo
         self._task_engine = task_engine
+        self._subworkflow_registry = subworkflow_registry
+        self._max_subworkflow_depth = max_subworkflow_depth
 
     async def activate(
         self,
@@ -133,34 +178,30 @@ class WorkflowExecutionService:
         # 1. Load and validate
         definition = await self._load_and_validate(definition_id)
 
-        # 2. Build graph structures
-        adjacency, reverse_adj, outgoing = build_adjacency_maps(
-            definition,
-        )
-        node_map = {n.id: n for n in definition.nodes}
-        sorted_ids = topological_sort(
-            [n.id for n in definition.nodes],
-            adjacency,
-        )
-
-        # 3. Walk nodes in topological order
+        # 2. Walk nodes in topological order, starting from the root frame.
         execution_id = f"wfexec-{uuid4().hex[:12]}"
         now = datetime.now(UTC)
-        node_exec_map, node_task_ids = await self._walk_nodes(
-            sorted_ids=sorted_ids,
-            node_map=node_map,
-            adjacency=adjacency,
-            reverse_adj=reverse_adj,
-            outgoing=outgoing,
-            ctx=ctx,
+        state = _WalkState()
+        root_frame = ExecutionFrame(
+            workflow_id=definition.id,
+            workflow_version=definition.version,
+            variables=ctx,
+            parent_frame=None,
+            depth=0,
+        )
+        await self._walk_frame(
+            definition=definition,
+            frame=root_frame,
+            qualifier_prefix="",
+            state=state,
             execution_id=execution_id,
             project=project,
             activated_by=activated_by,
         )
 
-        # 4. Build and persist execution
+        # 3. Build and persist execution
         # If no tasks were created, the workflow is immediately complete
-        if node_task_ids:
+        if state.node_task_ids:
             status = WorkflowExecutionStatus.RUNNING
             completed_at = None
         else:
@@ -170,9 +211,11 @@ class WorkflowExecutionService:
         execution = WorkflowExecution(
             id=execution_id,
             definition_id=definition.id,
-            definition_version=definition.version,
+            definition_revision=definition.revision,
             status=status,
-            node_executions=tuple(node_exec_map[n.id] for n in definition.nodes),
+            node_executions=tuple(
+                state.node_exec_map[key] for key in state.ordered_keys
+            ),
             activated_by=activated_by,
             project=project,
             created_at=now,
@@ -185,7 +228,7 @@ class WorkflowExecutionService:
             WORKFLOW_EXEC_ACTIVATED,
             execution_id=execution_id,
             definition_id=definition.id,
-            task_count=len(node_task_ids),
+            task_count=len(state.node_task_ids),
         )
 
         return execution
@@ -222,81 +265,130 @@ class WorkflowExecutionService:
 
         return definition
 
-    async def _walk_nodes(  # noqa: PLR0913
+    async def _walk_frame(  # noqa: PLR0913
         self,
         *,
-        sorted_ids: list[str],
-        node_map: dict[str, WorkflowNode],
-        adjacency: dict[str, list[str]],
-        reverse_adj: dict[str, list[str]],
-        outgoing: dict[str, list[tuple[str, WorkflowEdgeType]]],
-        ctx: dict[str, object],
+        definition: WorkflowDefinition,
+        frame: ExecutionFrame,
+        qualifier_prefix: str,
+        state: _WalkState,
         execution_id: str,
         project: str,
         activated_by: str,
-    ) -> tuple[dict[str, WorkflowNodeExecution], dict[str, str]]:
-        """Walk the graph in topological order, processing each node.
+    ) -> dict[str, object]:
+        """Walk one workflow graph inside a scoped execution frame.
+
+        Walks *definition* in topological order, mutating *state*
+        in place.  On hitting a SUBWORKFLOW node, recursively walks
+        the referenced child definition inside a new frame whose
+        variables are scoped to the declared inputs only.
+
+        Node execution entries are stored under qualified keys so
+        that nested graphs never collide with the parent.  The root
+        frame uses no prefix and keeps existing unqualified IDs.
 
         Returns:
-            A 2-tuple of (node_exec_map, node_task_ids).
+            The frame's final mutable variable map.  Callers (parent
+            frames invoking a subworkflow) use this to project outputs
+            back into their own scope.
         """
-        node_exec_map: dict[str, WorkflowNodeExecution] = {}
-        node_task_ids: dict[str, str] = {}
+        adjacency, reverse_adj, outgoing = build_adjacency_maps(definition)
+        node_map = {n.id: n for n in definition.nodes}
+        sorted_ids = topological_sort(
+            [n.id for n in definition.nodes],
+            adjacency,
+        )
+
+        # Frame-local task-ID map: upstream lookups must not cross frames.
+        frame_node_task_ids: dict[str, str] = {}
         skipped_nodes: set[str] = set()
         pending_assignments: dict[str, str] = {}
+        # The child graph's condition evaluator sees only the frame's
+        # variable map -- parent keys cannot leak in.  This dict is
+        # mutated in place as subworkflow outputs project values
+        # back into the caller's scope during the walk.
+        frame_ctx: dict[str, object] = dict(frame.variables)
 
         for nid in sorted_ids:
+            qualified = _qualify_id(qualifier_prefix, nid)
+            node = node_map[nid]
+
             if nid in skipped_nodes:
-                node_exec_map[nid] = WorkflowNodeExecution(
-                    node_id=nid,
-                    node_type=node_map[nid].type,
-                    status=WorkflowNodeExecutionStatus.SKIPPED,
-                    skipped_reason="Conditional branch not taken",
+                self._record_node(
+                    state,
+                    qualified,
+                    WorkflowNodeExecution(
+                        node_id=qualified,
+                        node_type=node.type,
+                        status=WorkflowNodeExecutionStatus.SKIPPED,
+                        skipped_reason="Conditional branch not taken",
+                    ),
                 )
                 logger.debug(
                     WORKFLOW_EXEC_NODE_SKIPPED,
                     execution_id=execution_id,
-                    node_id=nid,
+                    node_id=qualified,
                 )
                 continue
 
-            node = node_map[nid]
-            node_exec_map[nid] = await self._process_node(
+            node_execution = await self._process_node_in_frame(
                 nid=nid,
+                qualified_id=qualified,
                 node=node,
                 adjacency=adjacency,
                 reverse_adj=reverse_adj,
                 outgoing=outgoing,
-                ctx=ctx,
+                frame=frame,
+                frame_ctx=frame_ctx,
                 execution_id=execution_id,
                 project=project,
                 activated_by=activated_by,
                 node_map=node_map,
-                node_task_ids=node_task_ids,
+                frame_node_task_ids=frame_node_task_ids,
+                qualifier_prefix=qualifier_prefix,
+                state=state,
                 skipped_nodes=skipped_nodes,
                 pending_assignments=pending_assignments,
             )
+            self._record_node(state, qualified, node_execution)
 
-        return node_exec_map, node_task_ids
+        return frame_ctx
 
-    async def _process_node(  # noqa: PLR0913
+    def _record_node(
+        self,
+        state: _WalkState,
+        qualified_id: str,
+        node_execution: WorkflowNodeExecution,
+    ) -> None:
+        """Store a processed node execution in *state* preserving order."""
+        if qualified_id not in state.node_exec_map:
+            state.ordered_keys.append(qualified_id)
+        state.node_exec_map[qualified_id] = node_execution
+        if node_execution.task_id is not None:
+            state.node_task_ids[qualified_id] = node_execution.task_id
+
+    async def _process_node_in_frame(  # noqa: PLR0913
         self,
         *,
         nid: str,
+        qualified_id: str,
         node: WorkflowNode,
         adjacency: dict[str, list[str]],
         reverse_adj: dict[str, list[str]],
         outgoing: dict[str, list[tuple[str, WorkflowEdgeType]]],
-        ctx: dict[str, object],
+        frame: ExecutionFrame,
+        frame_ctx: dict[str, object],
         execution_id: str,
         project: str,
         activated_by: str,
         node_map: dict[str, WorkflowNode],
-        node_task_ids: dict[str, str],
+        frame_node_task_ids: dict[str, str],
+        qualifier_prefix: str,
+        state: _WalkState,
         skipped_nodes: set[str],
         pending_assignments: dict[str, str],
     ) -> WorkflowNodeExecution:
-        """Dispatch a single node to the appropriate handler."""
+        """Dispatch a single node in the context of *frame*."""
         if node.type in {
             WorkflowNodeType.START,
             WorkflowNodeType.END,
@@ -306,11 +398,11 @@ class WorkflowExecutionService:
             logger.debug(
                 WORKFLOW_EXEC_NODE_COMPLETED,
                 execution_id=execution_id,
-                node_id=nid,
+                node_id=qualified_id,
                 node_type=node.type.value,
             )
             return WorkflowNodeExecution(
-                node_id=nid,
+                node_id=qualified_id,
                 node_type=node.type,
                 status=WorkflowNodeExecutionStatus.COMPLETED,
             )
@@ -329,30 +421,47 @@ class WorkflowExecutionService:
                 logger.warning(
                     WORKFLOW_EXEC_NODE_COMPLETED,
                     execution_id=execution_id,
-                    node_id=nid,
+                    node_id=qualified_id,
                     note="AGENT_ASSIGNMENT node has no agent_name",
                 )
             logger.debug(
                 WORKFLOW_EXEC_NODE_COMPLETED,
                 execution_id=execution_id,
-                node_id=nid,
+                node_id=qualified_id,
                 node_type=node.type.value,
             )
             return WorkflowNodeExecution(
-                node_id=nid,
+                node_id=qualified_id,
                 node_type=node.type,
                 status=WorkflowNodeExecutionStatus.COMPLETED,
             )
 
         if node.type is WorkflowNodeType.CONDITIONAL:
-            return process_conditional_node(
+            conditional_execution = process_conditional_node(
                 nid,
                 node,
-                ctx,
+                frame_ctx,
                 outgoing,
                 adjacency,
                 skipped_nodes,
                 execution_id,
+            )
+            # Rewrite node_id to the qualified form so persistence is stable.
+            return conditional_execution.model_copy(
+                update={"node_id": qualified_id},
+            )
+
+        if node.type is WorkflowNodeType.SUBWORKFLOW:
+            return await self._process_subworkflow_node(
+                nid=nid,
+                qualified_id=qualified_id,
+                node=node,
+                frame=frame,
+                frame_ctx=frame_ctx,
+                state=state,
+                execution_id=execution_id,
+                project=project,
+                activated_by=activated_by,
             )
 
         if node.type is not WorkflowNodeType.TASK:
@@ -360,24 +469,196 @@ class WorkflowExecutionService:
             logger.error(
                 WORKFLOW_EXEC_NODE_COMPLETED,
                 execution_id=execution_id,
-                node_id=nid,
+                node_id=qualified_id,
                 node_type=node.type.value,
                 error=msg,
             )
             raise WorkflowExecutionError(msg)
 
-        return await process_task_node(
+        return await self._process_task_node_in_frame(
+            nid=nid,
+            qualified_id=qualified_id,
+            node=node,
+            reverse_adj=reverse_adj,
+            node_map=node_map,
+            frame_node_task_ids=frame_node_task_ids,
+            qualifier_prefix=qualifier_prefix,
+            state=state,
+            skipped_nodes=skipped_nodes,
+            pending_assignments=pending_assignments,
+            project=project,
+            activated_by=activated_by,
+            execution_id=execution_id,
+        )
+
+    async def _process_task_node_in_frame(  # noqa: PLR0913
+        self,
+        *,
+        nid: str,
+        qualified_id: str,
+        node: WorkflowNode,
+        reverse_adj: dict[str, list[str]],
+        node_map: dict[str, WorkflowNode],
+        frame_node_task_ids: dict[str, str],
+        qualifier_prefix: str,  # noqa: ARG002
+        state: _WalkState,  # noqa: ARG002
+        skipped_nodes: set[str],
+        pending_assignments: dict[str, str],
+        project: str,
+        activated_by: str,
+        execution_id: str,
+    ) -> WorkflowNodeExecution:
+        """Create a task for a TASK node and store it under the qualified key.
+
+        Upstream dependency lookup is frame-local: it walks only this
+        graph's reverse adjacency, which guarantees that a task inside
+        a subworkflow does not silently depend on a parent task outside
+        its declared inputs.
+        """
+        node_execution = await process_task_node(
             nid,
             node,
             reverse_adj=reverse_adj,
             node_map=node_map,
-            node_task_ids=node_task_ids,
+            node_task_ids=frame_node_task_ids,
             skipped_nodes=skipped_nodes,
             pending_assignments=pending_assignments,
             project=project,
             activated_by=activated_by,
             task_engine=self._task_engine,
             execution_id=execution_id,
+        )
+        # Rewrite node_id with the frame qualifier for persistence.
+        return node_execution.model_copy(update={"node_id": qualified_id})
+
+    async def _process_subworkflow_node(  # noqa: PLR0913
+        self,
+        *,
+        nid: str,
+        qualified_id: str,
+        node: WorkflowNode,
+        frame: ExecutionFrame,
+        frame_ctx: dict[str, object],
+        state: _WalkState,
+        execution_id: str,
+        project: str,
+        activated_by: str,
+    ) -> WorkflowNodeExecution:
+        """Resolve a subworkflow node and walk the child graph in a new frame."""
+        if self._subworkflow_registry is None:
+            msg = (
+                f"Workflow definition contains a SUBWORKFLOW node {nid!r} "
+                "but no SubworkflowRegistry is configured on "
+                "WorkflowExecutionService"
+            )
+            raise WorkflowExecutionError(msg)
+
+        config = dict(node.config)
+        subworkflow_id = config.get("subworkflow_id")
+        version = config.get("version")
+        input_bindings = config.get("input_bindings") or {}
+        output_bindings = config.get("output_bindings") or {}
+        if not isinstance(subworkflow_id, str) or not subworkflow_id.strip():
+            msg = f"SUBWORKFLOW node {nid!r} is missing subworkflow_id in config"
+            raise WorkflowExecutionError(msg)
+        if not isinstance(version, str) or not version.strip():
+            msg = f"SUBWORKFLOW node {nid!r} is missing version pin in config"
+            raise WorkflowExecutionError(msg)
+        if not isinstance(input_bindings, dict):
+            input_bindings = {}
+        if not isinstance(output_bindings, dict):
+            output_bindings = {}
+
+        next_depth = frame.depth + 1
+        if next_depth > self._max_subworkflow_depth:
+            logger.error(
+                WORKFLOW_EXEC_SUBWORKFLOW_DEPTH_EXCEEDED,
+                execution_id=execution_id,
+                node_id=qualified_id,
+                depth=next_depth,
+                max_depth=self._max_subworkflow_depth,
+            )
+            msg = (
+                f"Subworkflow depth {next_depth} exceeds maximum "
+                f"{self._max_subworkflow_depth}"
+            )
+            raise SubworkflowDepthExceededError(
+                msg,
+                depth=next_depth,
+                max_depth=self._max_subworkflow_depth,
+            )
+
+        child_definition = await self._subworkflow_registry.get(
+            subworkflow_id,
+            version,
+        )
+
+        # Resolve input bindings against the parent frame's current
+        # variable map (which may include values projected from earlier
+        # subworkflow calls), producing the child frame's private
+        # variable map.
+        resolved_inputs = resolve_input_bindings(
+            input_bindings,
+            frame_ctx,
+            child_definition.inputs,
+        )
+        child_frame = ExecutionFrame(
+            workflow_id=child_definition.id,
+            workflow_version=child_definition.version,
+            variables=resolved_inputs,
+            parent_frame=frame,
+            depth=next_depth,
+        )
+        logger.info(
+            WORKFLOW_EXEC_SUBWORKFLOW_FRAME_PUSHED,
+            execution_id=execution_id,
+            node_id=qualified_id,
+            subworkflow_id=subworkflow_id,
+            version=version,
+            depth=next_depth,
+        )
+
+        # Recurse into the child graph.  Child node IDs are qualified
+        # with the parent's subworkflow node ID to keep the flat
+        # accumulator unique across frame boundaries.
+        child_prefix = qualified_id
+        child_final_vars = await self._walk_frame(
+            definition=child_definition,
+            frame=child_frame,
+            qualifier_prefix=child_prefix,
+            state=state,
+            execution_id=execution_id,
+            project=project,
+            activated_by=activated_by,
+        )
+
+        # Project outputs back into the parent frame's mutable variable
+        # map.  Downstream nodes in the parent graph will see the new
+        # values via their own reads of frame_ctx.
+        projected = project_output_bindings(
+            output_bindings,
+            child_final_vars,
+            child_definition.outputs,
+        )
+        frame_ctx.update(projected)
+
+        logger.info(
+            WORKFLOW_EXEC_SUBWORKFLOW_FRAME_POPPED,
+            execution_id=execution_id,
+            node_id=qualified_id,
+            subworkflow_id=subworkflow_id,
+            version=version,
+            depth=next_depth,
+        )
+        logger.debug(
+            WORKFLOW_EXEC_SUBWORKFLOW_NODE_COMPLETED,
+            execution_id=execution_id,
+            node_id=qualified_id,
+        )
+        return WorkflowNodeExecution(
+            node_id=qualified_id,
+            node_type=WorkflowNodeType.SUBWORKFLOW,
+            status=WorkflowNodeExecutionStatus.SUBWORKFLOW_COMPLETED,
         )
 
     async def get_execution(

--- a/src/synthorg/engine/workflow/execution_service.py
+++ b/src/synthorg/engine/workflow/execution_service.py
@@ -567,12 +567,20 @@ class WorkflowExecutionService:
             msg = f"SUBWORKFLOW node {nid!r} is missing version pin in config"
             raise WorkflowExecutionError(msg)
         if not isinstance(input_bindings, dict):
-            input_bindings = {}
+            msg = (
+                f"SUBWORKFLOW node {nid!r} input_bindings must be"
+                f" a dict, got {type(input_bindings).__name__}"
+            )
+            raise WorkflowExecutionError(msg)
         if not isinstance(output_bindings, dict):
-            output_bindings = {}
+            msg = (
+                f"SUBWORKFLOW node {nid!r} output_bindings must be"
+                f" a dict, got {type(output_bindings).__name__}"
+            )
+            raise WorkflowExecutionError(msg)
 
         next_depth = frame.depth + 1
-        if next_depth >= self._max_subworkflow_depth:
+        if next_depth > self._max_subworkflow_depth:
             logger.error(
                 WORKFLOW_EXEC_SUBWORKFLOW_DEPTH_EXCEEDED,
                 execution_id=execution_id,

--- a/src/synthorg/engine/workflow/subworkflow_binding.py
+++ b/src/synthorg/engine/workflow/subworkflow_binding.py
@@ -89,7 +89,7 @@ def _resolve_expression(
     return expression
 
 
-def _validate_value_type(  # noqa: C901, PLR0911
+def _validate_value_type(  # noqa: C901, PLR0911, PLR0912
     name: str,
     value: object,
     expected: WorkflowValueType,
@@ -121,6 +121,16 @@ def _validate_value_type(  # noqa: C901, PLR0911
             raise SubworkflowIOError(msg)
         return
     if expected is WorkflowValueType.DATETIME:
+        if isinstance(value, str):
+            try:
+                datetime.fromisoformat(value)
+            except ValueError:
+                msg = (
+                    f"Declaration {name!r} expects DATETIME"
+                    f" (ISO-8601 string or datetime), got {value!r}"
+                )
+                raise SubworkflowIOError(msg) from None
+            return
         if not isinstance(value, datetime):
             msg = f"Declaration {name!r} expects DATETIME, got {type(value).__name__}"
             raise SubworkflowIOError(msg)

--- a/src/synthorg/engine/workflow/subworkflow_binding.py
+++ b/src/synthorg/engine/workflow/subworkflow_binding.py
@@ -30,9 +30,12 @@ from typing import TYPE_CHECKING
 
 from synthorg.core.enums import WorkflowValueType
 from synthorg.engine.errors import SubworkflowIOError
+from synthorg.observability import get_logger
 
 if TYPE_CHECKING:
     from synthorg.engine.workflow.definition import WorkflowIODeclaration
+
+logger = get_logger(__name__)
 
 _PARENT_PREFIX = "@parent."
 _CHILD_PREFIX = "@child."
@@ -86,6 +89,11 @@ def _resolve_expression(
             raise SubworkflowIOError(msg)
         path = expression[len(_CHILD_PREFIX) :]
         return _lookup_path(child_vars, path)
+    if expression.startswith("@"):
+        msg = (
+            f"Unsupported binding prefix in {expression!r}; use '@parent.' or '@child.'"
+        )
+        raise SubworkflowIOError(msg)
     return expression
 
 

--- a/src/synthorg/engine/workflow/subworkflow_binding.py
+++ b/src/synthorg/engine/workflow/subworkflow_binding.py
@@ -1,0 +1,256 @@
+"""Input/output binding resolution for subworkflow calls.
+
+Subworkflow invocations declare typed I/O contracts via
+:class:`WorkflowIODeclaration`.  When the executor walks a
+``SUBWORKFLOW`` node, it pushes a new frame whose ``variables`` map
+contains exactly the declared inputs (resolved against the caller's
+frame).  On child completion, declared outputs are projected back into
+the caller's frame.
+
+This module contains the pure evaluation helpers.  They never touch
+persistence, the registry, or the execution service -- they operate
+on plain mappings so they can be unit-tested with Hypothesis.
+
+Binding expression language (minimal, deliberately):
+
+- **Literal**: any non-string value or a string not starting with ``@``.
+  Literals pass through unchanged (subject to type validation).
+- **Dotted path lookup**: a string like ``"@parent.current_quarter"``.
+  The prefix before the first ``.`` names the source scope; the rest
+  is a dotted path into that scope's variable mapping. Two scopes are
+  currently recognized:
+    - ``@parent`` -- the parent frame's variables (used in input bindings)
+    - ``@child``  -- the child frame's variables (used in output bindings)
+"""
+
+from collections.abc import Mapping
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from synthorg.core.enums import WorkflowValueType
+from synthorg.engine.errors import SubworkflowIOError
+
+if TYPE_CHECKING:
+    from synthorg.engine.workflow.definition import WorkflowIODeclaration
+
+_PARENT_PREFIX = "@parent."
+_CHILD_PREFIX = "@child."
+
+
+def _lookup_path(source: Mapping[str, object], path: str) -> object:
+    """Walk a dotted path through a nested mapping.
+
+    Raises ``KeyError`` if any segment is missing or traverses a
+    non-mapping leaf.
+    """
+    if not path:
+        msg = "Empty lookup path"
+        raise KeyError(msg)
+
+    parts = path.split(".")
+    current: object = source
+    for part in parts:
+        if not isinstance(current, Mapping):
+            msg = f"Lookup path {path!r} traversed non-mapping at segment {part!r}"
+            raise KeyError(msg)
+        if part not in current:
+            msg = f"Lookup path {path!r} missing segment {part!r}"
+            raise KeyError(msg)
+        current = current[part]
+    return current
+
+
+def _resolve_expression(
+    expression: object,
+    *,
+    parent_vars: Mapping[str, object],
+    child_vars: Mapping[str, object] | None = None,
+) -> object:
+    """Resolve a single binding expression to a concrete value.
+
+    String expressions starting with ``@parent.`` or ``@child.`` are
+    dotted-path lookups; everything else is a literal.
+    """
+    if not isinstance(expression, str):
+        return expression
+    if expression.startswith(_PARENT_PREFIX):
+        path = expression[len(_PARENT_PREFIX) :]
+        return _lookup_path(parent_vars, path)
+    if expression.startswith(_CHILD_PREFIX):
+        if child_vars is None:
+            msg = (
+                f"Binding {expression!r} references '@child' but "
+                f"no child variables are available in this context"
+            )
+            raise SubworkflowIOError(msg)
+        path = expression[len(_CHILD_PREFIX) :]
+        return _lookup_path(child_vars, path)
+    return expression
+
+
+def _validate_value_type(  # noqa: C901, PLR0911
+    name: str,
+    value: object,
+    expected: WorkflowValueType,
+) -> None:
+    """Enforce that *value* is compatible with *expected*.
+
+    Raises ``SubworkflowIOError`` on mismatch.  ``JSON`` accepts any
+    value (it is deliberately permissive for structured payloads);
+    ``TASK_REF``/``AGENT_REF`` accept non-blank strings.
+    """
+    if expected is WorkflowValueType.STRING:
+        if not isinstance(value, str):
+            msg = f"Declaration {name!r} expects STRING, got {type(value).__name__}"
+            raise SubworkflowIOError(msg)
+        return
+    if expected is WorkflowValueType.INTEGER:
+        if isinstance(value, bool) or not isinstance(value, int):
+            msg = f"Declaration {name!r} expects INTEGER, got {type(value).__name__}"
+            raise SubworkflowIOError(msg)
+        return
+    if expected is WorkflowValueType.FLOAT:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            msg = f"Declaration {name!r} expects FLOAT, got {type(value).__name__}"
+            raise SubworkflowIOError(msg)
+        return
+    if expected is WorkflowValueType.BOOLEAN:
+        if not isinstance(value, bool):
+            msg = f"Declaration {name!r} expects BOOLEAN, got {type(value).__name__}"
+            raise SubworkflowIOError(msg)
+        return
+    if expected is WorkflowValueType.DATETIME:
+        if not isinstance(value, datetime):
+            msg = f"Declaration {name!r} expects DATETIME, got {type(value).__name__}"
+            raise SubworkflowIOError(msg)
+        return
+    if expected in (WorkflowValueType.TASK_REF, WorkflowValueType.AGENT_REF):
+        if not isinstance(value, str) or not value.strip():
+            msg = (
+                f"Declaration {name!r} expects {expected.value.upper()}, got "
+                f"{type(value).__name__}"
+            )
+            raise SubworkflowIOError(msg)
+        return
+    # WorkflowValueType.JSON is permissive by design.
+    return
+
+
+def resolve_input_bindings(
+    bindings: Mapping[str, object],
+    parent_vars: Mapping[str, object],
+    declarations: tuple[WorkflowIODeclaration, ...],
+) -> dict[str, object]:
+    """Resolve a subworkflow call's input bindings.
+
+    Args:
+        bindings: Mapping from child input name to a literal or
+            ``@parent.<path>`` expression.
+        parent_vars: The calling frame's variable map.
+        declarations: The child's declared input contract.
+
+    Returns:
+        A new ``dict`` mapping each declared input name to its
+        resolved, type-validated value.  Missing optional inputs
+        fall back to ``default`` (when the declaration supplies one).
+
+    Raises:
+        SubworkflowIOError: On unknown binding keys, missing required
+            inputs, invalid dotted paths, or type mismatches.
+    """
+    declaration_by_name = {d.name: d for d in declarations}
+    unknown = set(bindings) - set(declaration_by_name)
+    if unknown:
+        msg = (
+            f"Unknown input bindings: {sorted(unknown)}; "
+            f"declared inputs are {sorted(declaration_by_name)}"
+        )
+        raise SubworkflowIOError(msg)
+
+    resolved: dict[str, object] = {}
+    for decl in declarations:
+        if decl.name in bindings:
+            expression = bindings[decl.name]
+            try:
+                value = _resolve_expression(
+                    expression,
+                    parent_vars=parent_vars,
+                )
+            except KeyError as exc:
+                msg = f"Cannot resolve input binding {decl.name!r}: {exc}"
+                raise SubworkflowIOError(msg) from exc
+            _validate_value_type(decl.name, value, decl.type)
+            resolved[decl.name] = value
+            continue
+        if decl.required:
+            msg = f"Missing required input {decl.name!r}"
+            raise SubworkflowIOError(msg)
+        if decl.default is not None:
+            _validate_value_type(decl.name, decl.default, decl.type)
+            resolved[decl.name] = decl.default
+    return resolved
+
+
+def project_output_bindings(
+    bindings: Mapping[str, object],
+    child_vars: Mapping[str, object],
+    declarations: tuple[WorkflowIODeclaration, ...],
+) -> dict[str, object]:
+    """Project a subworkflow's outputs into the caller's scope.
+
+    Args:
+        bindings: Mapping from ``parent_target_name`` to a literal,
+            ``@child.<path>`` expression, or ``@parent.<path>``
+            expression (pass-through).  The binding key names the
+            variable to set in the caller's frame; it must match one
+            of the child's output declarations for type validation.
+        child_vars: The child frame's final variable map.
+        declarations: The child's declared output contract.
+
+    Returns:
+        A new ``dict`` containing values to merge into the caller's
+        frame.
+
+    Raises:
+        SubworkflowIOError: On unknown binding keys (names not declared
+            as outputs), missing required outputs, invalid dotted paths,
+            or type mismatches.
+    """
+    declaration_by_name = {d.name: d for d in declarations}
+    unknown = set(bindings) - set(declaration_by_name)
+    if unknown:
+        msg = (
+            f"Unknown output bindings: {sorted(unknown)}; "
+            f"declared outputs are {sorted(declaration_by_name)}"
+        )
+        raise SubworkflowIOError(msg)
+
+    projected: dict[str, object] = {}
+    for decl in declarations:
+        if decl.name in bindings:
+            expression = bindings[decl.name]
+            try:
+                value = _resolve_expression(
+                    expression,
+                    parent_vars={},
+                    child_vars=child_vars,
+                )
+            except KeyError as exc:
+                msg = f"Cannot resolve output binding {decl.name!r}: {exc}"
+                raise SubworkflowIOError(msg) from exc
+            _validate_value_type(decl.name, value, decl.type)
+            projected[decl.name] = value
+            continue
+        if decl.required:
+            msg = f"Missing required output binding for {decl.name!r}"
+            raise SubworkflowIOError(msg)
+        if decl.default is not None:
+            _validate_value_type(decl.name, decl.default, decl.type)
+            projected[decl.name] = decl.default
+    return projected
+
+
+__all__ = [
+    "project_output_bindings",
+    "resolve_input_bindings",
+]

--- a/src/synthorg/engine/workflow/subworkflow_binding.py
+++ b/src/synthorg/engine/workflow/subworkflow_binding.py
@@ -72,8 +72,9 @@ def _resolve_expression(
 ) -> object:
     """Resolve a single binding expression to a concrete value.
 
-    String expressions starting with ``@parent.`` or ``@child.`` are
-    dotted-path lookups; everything else is a literal.
+    ``@parent.<path>`` and ``@child.<path>`` are dotted-path lookups.
+    Non-string values and strings not starting with ``@`` are literals.
+    Any other ``@``-prefixed string raises ``SubworkflowIOError``.
     """
     if not isinstance(expression, str):
         return expression

--- a/src/synthorg/engine/workflow/subworkflow_binding.py
+++ b/src/synthorg/engine/workflow/subworkflow_binding.py
@@ -23,6 +23,7 @@ Binding expression language (minimal, deliberately):
     - ``@child``  -- the child frame's variables (used in output bindings)
 """
 
+import copy
 from collections.abc import Mapping
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -180,14 +181,14 @@ def resolve_input_bindings(
                 msg = f"Cannot resolve input binding {decl.name!r}: {exc}"
                 raise SubworkflowIOError(msg) from exc
             _validate_value_type(decl.name, value, decl.type)
-            resolved[decl.name] = value
+            resolved[decl.name] = copy.deepcopy(value)
             continue
         if decl.required:
             msg = f"Missing required input {decl.name!r}"
             raise SubworkflowIOError(msg)
         if decl.default is not None:
             _validate_value_type(decl.name, decl.default, decl.type)
-            resolved[decl.name] = decl.default
+            resolved[decl.name] = copy.deepcopy(decl.default)
     return resolved
 
 
@@ -195,6 +196,8 @@ def project_output_bindings(
     bindings: Mapping[str, object],
     child_vars: Mapping[str, object],
     declarations: tuple[WorkflowIODeclaration, ...],
+    *,
+    parent_vars: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
     """Project a subworkflow's outputs into the caller's scope.
 
@@ -206,6 +209,8 @@ def project_output_bindings(
             of the child's output declarations for type validation.
         child_vars: The child frame's final variable map.
         declarations: The child's declared output contract.
+        parent_vars: The calling frame's variable map, required for
+            ``@parent.*`` pass-through bindings.
 
     Returns:
         A new ``dict`` containing values to merge into the caller's
@@ -225,6 +230,7 @@ def project_output_bindings(
         )
         raise SubworkflowIOError(msg)
 
+    caller_vars = parent_vars if parent_vars is not None else {}
     projected: dict[str, object] = {}
     for decl in declarations:
         if decl.name in bindings:
@@ -232,21 +238,21 @@ def project_output_bindings(
             try:
                 value = _resolve_expression(
                     expression,
-                    parent_vars={},
+                    parent_vars=caller_vars,
                     child_vars=child_vars,
                 )
             except KeyError as exc:
                 msg = f"Cannot resolve output binding {decl.name!r}: {exc}"
                 raise SubworkflowIOError(msg) from exc
             _validate_value_type(decl.name, value, decl.type)
-            projected[decl.name] = value
+            projected[decl.name] = copy.deepcopy(value)
             continue
         if decl.required:
             msg = f"Missing required output binding for {decl.name!r}"
             raise SubworkflowIOError(msg)
         if decl.default is not None:
             _validate_value_type(decl.name, decl.default, decl.type)
-            projected[decl.name] = decl.default
+            projected[decl.name] = copy.deepcopy(decl.default)
     return projected
 
 

--- a/src/synthorg/engine/workflow/subworkflow_binding.py
+++ b/src/synthorg/engine/workflow/subworkflow_binding.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING
 from synthorg.core.enums import WorkflowValueType
 from synthorg.engine.errors import SubworkflowIOError
 from synthorg.observability import get_logger
+from synthorg.observability.events.workflow_definition import SUBWORKFLOW_IO_INVALID
 
 if TYPE_CHECKING:
     from synthorg.engine.workflow.definition import WorkflowIODeclaration
@@ -185,6 +186,7 @@ def resolve_input_bindings(
             f"Unknown input bindings: {sorted(unknown)}; "
             f"declared inputs are {sorted(declaration_by_name)}"
         )
+        logger.warning(SUBWORKFLOW_IO_INVALID, error=msg)
         raise SubworkflowIOError(msg)
 
     resolved: dict[str, object] = {}
@@ -198,12 +200,14 @@ def resolve_input_bindings(
                 )
             except KeyError as exc:
                 msg = f"Cannot resolve input binding {decl.name!r}: {exc}"
+                logger.warning(SUBWORKFLOW_IO_INVALID, error=msg)
                 raise SubworkflowIOError(msg) from exc
             _validate_value_type(decl.name, value, decl.type)
             resolved[decl.name] = copy.deepcopy(value)
             continue
         if decl.required:
             msg = f"Missing required input {decl.name!r}"
+            logger.warning(SUBWORKFLOW_IO_INVALID, error=msg)
             raise SubworkflowIOError(msg)
         if decl.default is not None:
             _validate_value_type(decl.name, decl.default, decl.type)
@@ -247,6 +251,7 @@ def project_output_bindings(
             f"Unknown output bindings: {sorted(unknown)}; "
             f"declared outputs are {sorted(declaration_by_name)}"
         )
+        logger.warning(SUBWORKFLOW_IO_INVALID, error=msg)
         raise SubworkflowIOError(msg)
 
     caller_vars = parent_vars if parent_vars is not None else {}
@@ -262,12 +267,14 @@ def project_output_bindings(
                 )
             except KeyError as exc:
                 msg = f"Cannot resolve output binding {decl.name!r}: {exc}"
+                logger.warning(SUBWORKFLOW_IO_INVALID, error=msg)
                 raise SubworkflowIOError(msg) from exc
             _validate_value_type(decl.name, value, decl.type)
             projected[decl.name] = copy.deepcopy(value)
             continue
         if decl.required:
             msg = f"Missing required output binding for {decl.name!r}"
+            logger.warning(SUBWORKFLOW_IO_INVALID, error=msg)
             raise SubworkflowIOError(msg)
         if decl.default is not None:
             _validate_value_type(decl.name, decl.default, decl.type)

--- a/src/synthorg/engine/workflow/subworkflow_registry.py
+++ b/src/synthorg/engine/workflow/subworkflow_registry.py
@@ -1,0 +1,206 @@
+"""Subworkflow registry service.
+
+A thin coordination layer on top of :class:`SubworkflowRepository`
+that:
+
+- publishes new subworkflow versions (validating ``is_subworkflow`` and
+  semver uniqueness),
+- resolves pinned ``(subworkflow_id, version)`` references,
+- enforces deletion protection when a version is still referenced by a
+  live parent workflow,
+- emits observability events for every lifecycle action.
+
+The default runtime depth limit for nested subworkflow calls is defined
+here (``MAX_WORKFLOW_DEPTH``).  ``WorkflowConfig.max_subworkflow_depth``
+overrides it at runtime.
+"""
+
+from typing import TYPE_CHECKING
+
+from packaging.version import InvalidVersion, Version
+
+from synthorg.core.types import NotBlankStr  # noqa: TC001
+from synthorg.engine.errors import (
+    SubworkflowIOError,
+    SubworkflowNotFoundError,
+)
+from synthorg.observability import get_logger
+from synthorg.observability.events.workflow_definition import (
+    SUBWORKFLOW_DELETED,
+    SUBWORKFLOW_REGISTERED,
+    SUBWORKFLOW_RESOLVED,
+)
+
+if TYPE_CHECKING:
+    from synthorg.engine.workflow.definition import WorkflowDefinition
+    from synthorg.persistence.subworkflow_repo import (
+        ParentReference,
+        SubworkflowRepository,
+        SubworkflowSummary,
+    )
+
+logger = get_logger(__name__)
+
+MAX_WORKFLOW_DEPTH = 16
+"""Default maximum runtime subworkflow nesting depth."""
+
+
+class SubworkflowRegistry:
+    """High-level service for publishing and resolving subworkflows.
+
+    Args:
+        repository: The underlying :class:`SubworkflowRepository`.
+    """
+
+    def __init__(self, repository: SubworkflowRepository) -> None:
+        self._repo = repository
+
+    async def register(self, definition: WorkflowDefinition) -> None:
+        """Publish a new subworkflow version to the registry.
+
+        Args:
+            definition: The workflow definition to publish.  Must have
+                ``is_subworkflow = True``.
+
+        Raises:
+            SubworkflowIOError: If ``definition`` is not marked as a
+                subworkflow or carries an invalid semver.
+            DuplicateRecordError: If ``(id, version)`` already exists.
+        """
+        if not definition.is_subworkflow:
+            msg = (
+                f"Cannot register workflow definition {definition.id!r} "
+                "as a subworkflow: is_subworkflow flag is False"
+            )
+            raise SubworkflowIOError(msg)
+        try:
+            Version(definition.version)
+        except InvalidVersion as exc:
+            msg = (
+                f"Subworkflow {definition.id!r} has invalid semver "
+                f"{definition.version!r}: {exc}"
+            )
+            raise SubworkflowIOError(msg) from exc
+
+        await self._repo.save(definition)
+        logger.info(
+            SUBWORKFLOW_REGISTERED,
+            subworkflow_id=definition.id,
+            version=definition.version,
+        )
+
+    async def get(
+        self,
+        subworkflow_id: NotBlankStr,
+        version: NotBlankStr,
+    ) -> WorkflowDefinition:
+        """Resolve a pinned ``(id, version)`` reference.
+
+        Args:
+            subworkflow_id: Subworkflow identifier.
+            version: Semver version string.
+
+        Returns:
+            The resolved ``WorkflowDefinition``.
+
+        Raises:
+            SubworkflowNotFoundError: If the version is not in the
+                registry.
+        """
+        definition = await self._repo.get(subworkflow_id, version)
+        if definition is None:
+            msg = (
+                f"Subworkflow {subworkflow_id!r} version {version!r} "
+                "not found in registry"
+            )
+            logger.warning(
+                SUBWORKFLOW_RESOLVED,
+                subworkflow_id=subworkflow_id,
+                version=version,
+                found=False,
+            )
+            raise SubworkflowNotFoundError(
+                msg,
+                subworkflow_id=subworkflow_id,
+                version=version,
+            )
+        logger.debug(
+            SUBWORKFLOW_RESOLVED,
+            subworkflow_id=subworkflow_id,
+            version=version,
+            found=True,
+        )
+        return definition
+
+    async def list_versions(
+        self,
+        subworkflow_id: NotBlankStr,
+    ) -> tuple[str, ...]:
+        """List semver strings for a subworkflow, newest first."""
+        return await self._repo.list_versions(subworkflow_id)
+
+    async def latest_version(
+        self,
+        subworkflow_id: NotBlankStr,
+    ) -> str | None:
+        """Return the highest semver for a subworkflow, or ``None``."""
+        versions = await self._repo.list_versions(subworkflow_id)
+        return versions[0] if versions else None
+
+    async def list_all(self) -> tuple[SubworkflowSummary, ...]:
+        """Return summaries for every unique subworkflow in the registry."""
+        return await self._repo.list_summaries()
+
+    async def search(
+        self,
+        query: NotBlankStr,
+    ) -> tuple[SubworkflowSummary, ...]:
+        """Search subworkflows by name or description substring."""
+        return await self._repo.search(query)
+
+    async def delete(
+        self,
+        subworkflow_id: NotBlankStr,
+        version: NotBlankStr,
+    ) -> None:
+        """Delete a subworkflow version with parent-reference protection.
+
+        Raises:
+            SubworkflowIOError: If any live parent still pins this
+                ``(id, version)`` coordinate.
+            SubworkflowNotFoundError: If the coordinate does not exist.
+        """
+        parents = await self._repo.find_parents(subworkflow_id, version)
+        if parents:
+            names = ", ".join(f"{p.parent_name!r}" for p in parents)
+            msg = (
+                f"Cannot delete subworkflow {subworkflow_id!r} version "
+                f"{version!r}: still referenced by {len(parents)} parent "
+                f"workflow(s): {names}"
+            )
+            raise SubworkflowIOError(msg)
+
+        deleted = await self._repo.delete(subworkflow_id, version)
+        if not deleted:
+            msg = (
+                f"Subworkflow {subworkflow_id!r} version {version!r} "
+                "not found in registry"
+            )
+            raise SubworkflowNotFoundError(
+                msg,
+                subworkflow_id=subworkflow_id,
+                version=version,
+            )
+        logger.info(
+            SUBWORKFLOW_DELETED,
+            subworkflow_id=subworkflow_id,
+            version=version,
+        )
+
+    async def find_parents(
+        self,
+        subworkflow_id: NotBlankStr,
+        version: NotBlankStr | None = None,
+    ) -> tuple[ParentReference, ...]:
+        """Return parent workflow definitions referencing a subworkflow."""
+        return await self._repo.find_parents(subworkflow_id, version)

--- a/src/synthorg/engine/workflow/validation.py
+++ b/src/synthorg/engine/workflow/validation.py
@@ -3,7 +3,9 @@
 Model-level validators on ``WorkflowDefinition`` ensure structural
 integrity (unique IDs, edge references, terminal nodes).  This module
 adds *semantic* validation: connectivity, edge-type constraints,
-conditional/parallel correctness, and config completeness.
+conditional/parallel correctness, config completeness, and
+subworkflow reference correctness (static cycle detection and I/O
+contract compatibility).
 """
 
 from collections import defaultdict, deque
@@ -12,16 +14,26 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 
-from synthorg.core.enums import WorkflowEdgeType, WorkflowNodeType
+from synthorg.core.enums import (
+    WorkflowEdgeType,
+    WorkflowNodeType,
+    WorkflowValueType,
+)
 from synthorg.core.types import NotBlankStr  # noqa: TC001
+from synthorg.engine.workflow.definition import WorkflowIODeclaration  # noqa: TC001
 from synthorg.observability import get_logger
 from synthorg.observability.events.workflow_definition import (
+    SUBWORKFLOW_CYCLE_DETECTED,
+    SUBWORKFLOW_IO_INVALID,
     WORKFLOW_DEF_VALIDATED,
     WORKFLOW_DEF_VALIDATION_FAILED,
 )
 
 if TYPE_CHECKING:
     from synthorg.engine.workflow.definition import WorkflowDefinition
+    from synthorg.engine.workflow.subworkflow_registry import (
+        SubworkflowRegistry,
+    )
 
 logger = get_logger(__name__)
 
@@ -46,6 +58,14 @@ class ValidationErrorCode(StrEnum):
     SPLIT_TOO_FEW_BRANCHES = "split_too_few_branches"
     TASK_MISSING_TITLE = "task_missing_title"
     CYCLE_DETECTED = "cycle_detected"
+    SUBWORKFLOW_REF_MISSING = "subworkflow_ref_missing"
+    SUBWORKFLOW_VERSION_UNPINNED = "subworkflow_version_unpinned"
+    SUBWORKFLOW_NOT_FOUND = "subworkflow_not_found"
+    SUBWORKFLOW_INPUT_MISSING = "subworkflow_input_missing"
+    SUBWORKFLOW_INPUT_UNKNOWN = "subworkflow_input_unknown"
+    SUBWORKFLOW_OUTPUT_UNKNOWN = "subworkflow_output_unknown"
+    SUBWORKFLOW_OUTPUT_TYPE_MISMATCH = "subworkflow_output_type_mismatch"
+    SUBWORKFLOW_CYCLE_DETECTED = "subworkflow_cycle_detected"
 
 
 class WorkflowValidationError(BaseModel):
@@ -310,3 +330,310 @@ def validate_workflow(
         )
 
     return result
+
+
+# ---------------------------------------------------------------------------
+# Subworkflow save-time validation
+# ---------------------------------------------------------------------------
+
+
+def _extract_subworkflow_config(
+    node_config: object,
+) -> tuple[str, str, dict[str, object], dict[str, object]] | None:
+    """Unpack subworkflow node config into ``(id, version, ib, ob)``.
+
+    Returns ``None`` when any required field is missing or malformed.
+    ``ib`` / ``ob`` are always plain dicts even if the config supplied
+    ``None`` or a non-dict value (to keep downstream handling simple).
+    """
+    if not isinstance(node_config, dict):
+        return None
+    subworkflow_id = node_config.get("subworkflow_id")
+    version = node_config.get("version")
+    if not isinstance(subworkflow_id, str) or not subworkflow_id.strip():
+        return None
+    if not isinstance(version, str) or not version.strip():
+        return None
+    ib = node_config.get("input_bindings") or {}
+    ob = node_config.get("output_bindings") or {}
+    if not isinstance(ib, dict):
+        ib = {}
+    if not isinstance(ob, dict):
+        ob = {}
+    return subworkflow_id, version, ib, ob
+
+
+def _literal_matches_type(
+    value: object,
+    value_type: WorkflowValueType,
+) -> bool:
+    """Return ``True`` if *value* is compatible with *value_type*.
+
+    Used at save time to reject obviously-wrong literal bindings.
+    Dotted-path expressions (``@parent.x``) cannot be resolved at save
+    time, so they are skipped and validated again at runtime.
+    """
+    if value_type is WorkflowValueType.STRING:
+        return isinstance(value, str)
+    if value_type is WorkflowValueType.INTEGER:
+        return isinstance(value, int) and not isinstance(value, bool)
+    if value_type is WorkflowValueType.FLOAT:
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if value_type is WorkflowValueType.BOOLEAN:
+        return isinstance(value, bool)
+    if value_type in (
+        WorkflowValueType.TASK_REF,
+        WorkflowValueType.AGENT_REF,
+    ):
+        return isinstance(value, str) and bool(value.strip())
+    # JSON and DATETIME are permissive at save time.
+    return True
+
+
+def _is_deferred_expression(value: object) -> bool:
+    """Return ``True`` when *value* is a lookup that defers to runtime."""
+    return isinstance(value, str) and value.startswith(("@parent.", "@child."))
+
+
+def _check_subworkflow_io_for_node(  # noqa: PLR0913
+    *,
+    node_id: str,
+    subworkflow_id: str,
+    version: str,
+    input_bindings: dict[str, object],
+    output_bindings: dict[str, object],
+    child_inputs: tuple[WorkflowIODeclaration, ...],
+    child_outputs: tuple[WorkflowIODeclaration, ...],
+) -> list[WorkflowValidationError]:
+    """Check a single SUBWORKFLOW node's bindings against child I/O."""
+    errors: list[WorkflowValidationError] = [
+        WorkflowValidationError(
+            code=ValidationErrorCode.SUBWORKFLOW_INPUT_MISSING,
+            message=(
+                f"Subworkflow node {node_id!r} missing required "
+                f"input {required.name!r} for "
+                f"{subworkflow_id!r}@{version!r}"
+            ),
+            node_id=node_id,
+        )
+        for required in child_inputs
+        if required.required and required.name not in input_bindings
+    ]
+    input_by_name = {d.name: d for d in child_inputs}
+    output_by_name = {d.name: d for d in child_outputs}
+
+    for name, value in input_bindings.items():
+        if name not in input_by_name:
+            errors.append(
+                WorkflowValidationError(
+                    code=ValidationErrorCode.SUBWORKFLOW_INPUT_UNKNOWN,
+                    message=(
+                        f"Subworkflow node {node_id!r} binds unknown input "
+                        f"{name!r} for {subworkflow_id!r}@{version!r}"
+                    ),
+                    node_id=node_id,
+                ),
+            )
+            continue
+        decl = input_by_name[name]
+        if _is_deferred_expression(value):
+            continue
+        if not _literal_matches_type(value, decl.type):
+            errors.append(
+                WorkflowValidationError(
+                    code=ValidationErrorCode.SUBWORKFLOW_OUTPUT_TYPE_MISMATCH,
+                    message=(
+                        f"Subworkflow node {node_id!r} binds input "
+                        f"{name!r} with literal incompatible with "
+                        f"declared type {decl.type.value}"
+                    ),
+                    node_id=node_id,
+                ),
+            )
+
+    for name, value in output_bindings.items():
+        if name not in output_by_name:
+            errors.append(
+                WorkflowValidationError(
+                    code=ValidationErrorCode.SUBWORKFLOW_OUTPUT_UNKNOWN,
+                    message=(
+                        f"Subworkflow node {node_id!r} binds unknown "
+                        f"output {name!r} for {subworkflow_id!r}@{version!r}"
+                    ),
+                    node_id=node_id,
+                ),
+            )
+            continue
+        decl = output_by_name[name]
+        if _is_deferred_expression(value):
+            continue
+        if not _literal_matches_type(value, decl.type):
+            errors.append(
+                WorkflowValidationError(
+                    code=ValidationErrorCode.SUBWORKFLOW_OUTPUT_TYPE_MISMATCH,
+                    message=(
+                        f"Subworkflow node {node_id!r} binds output "
+                        f"{name!r} with literal incompatible with "
+                        f"declared type {decl.type.value}"
+                    ),
+                    node_id=node_id,
+                ),
+            )
+
+    return errors
+
+
+async def validate_subworkflow_io(
+    definition: WorkflowDefinition,
+    registry: SubworkflowRegistry,
+) -> WorkflowValidationResult:
+    """Validate every SUBWORKFLOW node's bindings against its child.
+
+    Args:
+        definition: The workflow definition to validate.
+        registry: A :class:`SubworkflowRegistry` used to resolve
+            pinned subworkflows.
+
+    Returns:
+        A ``WorkflowValidationResult`` with errors (possibly empty).
+        Errors cover: missing ``subworkflow_id`` / ``version`` config,
+        unresolvable pinned versions, missing required inputs, unknown
+        inputs/outputs, and literal type mismatches.
+    """
+    errors: list[WorkflowValidationError] = []
+    from synthorg.engine.errors import SubworkflowNotFoundError  # noqa: PLC0415
+
+    for node in definition.nodes:
+        if node.type is not WorkflowNodeType.SUBWORKFLOW:
+            continue
+        parsed = _extract_subworkflow_config(dict(node.config))
+        if parsed is None:
+            errors.append(
+                WorkflowValidationError(
+                    code=ValidationErrorCode.SUBWORKFLOW_REF_MISSING,
+                    message=(
+                        f"Subworkflow node {node.id!r} is missing "
+                        "subworkflow_id or version in config"
+                    ),
+                    node_id=node.id,
+                ),
+            )
+            continue
+        subworkflow_id, version, ib, ob = parsed
+
+        try:
+            child = await registry.get(subworkflow_id, version)
+        except SubworkflowNotFoundError:
+            errors.append(
+                WorkflowValidationError(
+                    code=ValidationErrorCode.SUBWORKFLOW_NOT_FOUND,
+                    message=(
+                        f"Subworkflow node {node.id!r} references "
+                        f"{subworkflow_id!r}@{version!r}, which is "
+                        "not in the registry"
+                    ),
+                    node_id=node.id,
+                ),
+            )
+            continue
+
+        errors.extend(
+            _check_subworkflow_io_for_node(
+                node_id=node.id,
+                subworkflow_id=subworkflow_id,
+                version=version,
+                input_bindings=ib,
+                output_bindings=ob,
+                child_inputs=child.inputs,
+                child_outputs=child.outputs,
+            ),
+        )
+
+    result = WorkflowValidationResult(errors=tuple(errors))
+    if errors:
+        logger.warning(
+            SUBWORKFLOW_IO_INVALID,
+            workflow_id=definition.id,
+            error_count=len(errors),
+        )
+    return result
+
+
+async def validate_subworkflow_graph(
+    definition: WorkflowDefinition,
+    registry: SubworkflowRegistry,
+) -> WorkflowValidationResult:
+    """Detect cycles across the static subworkflow reference graph.
+
+    Starting from *definition*, walk every SUBWORKFLOW node config's
+    pinned ``(id, version)`` reference (via the registry) and then
+    recurse into the child's own SUBWORKFLOW nodes.  Any back-edge
+    (revisiting a ``(id, version)`` coordinate currently on the DFS
+    stack) is a cycle and is reported with the cycle path.
+
+    Unresolvable references are NOT reported here -- that's
+    :func:`validate_subworkflow_io`'s job.
+
+    Returns:
+        A ``WorkflowValidationResult`` with one ``SUBWORKFLOW_CYCLE_DETECTED``
+        error per detected cycle.  Empty errors mean no cycles.
+    """
+    errors: list[WorkflowValidationError] = []
+    root_key = (definition.id, definition.version)
+    visiting: set[tuple[str, str]] = set()
+    finished: set[tuple[str, str]] = set()
+
+    from synthorg.engine.errors import SubworkflowNotFoundError  # noqa: PLC0415
+
+    async def _visit(
+        node_key: tuple[str, str],
+        source_definition: WorkflowDefinition,
+        path: list[tuple[str, str]],
+    ) -> None:
+        if node_key in visiting:
+            cycle_slice = [*path[path.index(node_key) :], node_key]
+            cycle_repr = " -> ".join(f"{sid}@{ver}" for sid, ver in cycle_slice)
+            errors.append(
+                WorkflowValidationError(
+                    code=ValidationErrorCode.SUBWORKFLOW_CYCLE_DETECTED,
+                    message=(f"Subworkflow reference cycle detected: {cycle_repr}"),
+                ),
+            )
+            return
+        if node_key in finished:
+            return
+
+        visiting.add(node_key)
+        path.append(node_key)
+        try:
+            for child_node in source_definition.nodes:
+                if child_node.type is not WorkflowNodeType.SUBWORKFLOW:
+                    continue
+                parsed = _extract_subworkflow_config(dict(child_node.config))
+                if parsed is None:
+                    continue
+                child_sub_id, child_version, _ib, _ob = parsed
+                child_key = (child_sub_id, child_version)
+
+                try:
+                    child_definition = await registry.get(
+                        child_sub_id,
+                        child_version,
+                    )
+                except SubworkflowNotFoundError:
+                    continue
+                await _visit(child_key, child_definition, path)
+        finally:
+            visiting.discard(node_key)
+            path.pop()
+            finished.add(node_key)
+
+    await _visit(root_key, definition, [])
+
+    if errors:
+        logger.warning(
+            SUBWORKFLOW_CYCLE_DETECTED,
+            workflow_id=definition.id,
+            cycle_count=len(errors),
+        )
+    return WorkflowValidationResult(errors=tuple(errors))

--- a/src/synthorg/engine/workflow/validation.py
+++ b/src/synthorg/engine/workflow/validation.py
@@ -392,9 +392,15 @@ def _literal_matches_type(
     return True
 
 
-def _is_deferred_expression(value: object) -> bool:
-    """Return ``True`` when *value* is a lookup that defers to runtime."""
-    return isinstance(value, str) and value.startswith(("@parent.", "@child."))
+def _is_deferred_expression(value: object, *, direction: str = "") -> bool:
+    """Return ``True`` when *value* is a valid deferred lookup for *direction*."""
+    if not isinstance(value, str):
+        return False
+    if direction == "input":
+        return value.startswith("@parent.")
+    if direction == "output":
+        return value.startswith("@child.")
+    return value.startswith(("@parent.", "@child."))
 
 
 def _check_bindings_against_declarations(  # noqa: PLR0913
@@ -436,7 +442,7 @@ def _check_bindings_against_declarations(  # noqa: PLR0913
             )
             continue
         decl = by_name[name]
-        if _is_deferred_expression(value):
+        if _is_deferred_expression(value, direction=direction):
             continue
         if not _literal_matches_type(value, decl.type):
             errors.append(

--- a/src/synthorg/engine/workflow/validation.py
+++ b/src/synthorg/engine/workflow/validation.py
@@ -444,6 +444,18 @@ def _check_bindings_against_declarations(  # noqa: PLR0913
         decl = by_name[name]
         if _is_deferred_expression(value, direction=direction):
             continue
+        if isinstance(value, str) and value.startswith("@"):
+            errors.append(
+                WorkflowValidationError(
+                    code=type_code,
+                    message=(
+                        f"Subworkflow node {node_id!r} binds {direction} "
+                        f"{name!r} with unsupported expression {value!r}"
+                    ),
+                    node_id=node_id,
+                ),
+            )
+            continue
         if not _literal_matches_type(value, decl.type):
             errors.append(
                 WorkflowValidationError(

--- a/src/synthorg/engine/workflow/validation.py
+++ b/src/synthorg/engine/workflow/validation.py
@@ -64,6 +64,7 @@ class ValidationErrorCode(StrEnum):
     SUBWORKFLOW_INPUT_MISSING = "subworkflow_input_missing"
     SUBWORKFLOW_INPUT_UNKNOWN = "subworkflow_input_unknown"
     SUBWORKFLOW_INPUT_TYPE_MISMATCH = "subworkflow_input_type_mismatch"
+    SUBWORKFLOW_OUTPUT_MISSING = "subworkflow_output_missing"
     SUBWORKFLOW_OUTPUT_UNKNOWN = "subworkflow_output_unknown"
     SUBWORKFLOW_OUTPUT_TYPE_MISMATCH = "subworkflow_output_type_mismatch"
     SUBWORKFLOW_CYCLE_DETECTED = "subworkflow_cycle_detected"
@@ -481,7 +482,7 @@ def _check_subworkflow_io_for_node(  # noqa: PLR0913
             bindings=output_bindings,
             declarations=child_outputs,
             direction="output",
-            missing_code=ValidationErrorCode.SUBWORKFLOW_INPUT_MISSING,
+            missing_code=ValidationErrorCode.SUBWORKFLOW_OUTPUT_MISSING,
             unknown_code=ValidationErrorCode.SUBWORKFLOW_OUTPUT_UNKNOWN,
             type_code=ValidationErrorCode.SUBWORKFLOW_OUTPUT_TYPE_MISMATCH,
         ),

--- a/src/synthorg/engine/workflow/validation.py
+++ b/src/synthorg/engine/workflow/validation.py
@@ -63,6 +63,7 @@ class ValidationErrorCode(StrEnum):
     SUBWORKFLOW_NOT_FOUND = "subworkflow_not_found"
     SUBWORKFLOW_INPUT_MISSING = "subworkflow_input_missing"
     SUBWORKFLOW_INPUT_UNKNOWN = "subworkflow_input_unknown"
+    SUBWORKFLOW_INPUT_TYPE_MISMATCH = "subworkflow_input_type_mismatch"
     SUBWORKFLOW_OUTPUT_UNKNOWN = "subworkflow_output_unknown"
     SUBWORKFLOW_OUTPUT_TYPE_MISMATCH = "subworkflow_output_type_mismatch"
     SUBWORKFLOW_CYCLE_DETECTED = "subworkflow_cycle_detected"
@@ -395,6 +396,62 @@ def _is_deferred_expression(value: object) -> bool:
     return isinstance(value, str) and value.startswith(("@parent.", "@child."))
 
 
+def _check_bindings_against_declarations(  # noqa: PLR0913
+    *,
+    node_id: str,
+    ref_label: str,
+    bindings: dict[str, object],
+    declarations: tuple[WorkflowIODeclaration, ...],
+    direction: str,
+    missing_code: ValidationErrorCode,
+    unknown_code: ValidationErrorCode,
+    type_code: ValidationErrorCode,
+) -> list[WorkflowValidationError]:
+    """Validate binding keys/literals against a set of declarations."""
+    errors: list[WorkflowValidationError] = [
+        WorkflowValidationError(
+            code=missing_code,
+            message=(
+                f"Subworkflow node {node_id!r} missing required "
+                f"{direction} {d.name!r} for {ref_label}"
+            ),
+            node_id=node_id,
+        )
+        for d in declarations
+        if d.required and d.name not in bindings
+    ]
+    by_name = {d.name: d for d in declarations}
+    for name, value in bindings.items():
+        if name not in by_name:
+            errors.append(
+                WorkflowValidationError(
+                    code=unknown_code,
+                    message=(
+                        f"Subworkflow node {node_id!r} binds unknown "
+                        f"{direction} {name!r} for {ref_label}"
+                    ),
+                    node_id=node_id,
+                ),
+            )
+            continue
+        decl = by_name[name]
+        if _is_deferred_expression(value):
+            continue
+        if not _literal_matches_type(value, decl.type):
+            errors.append(
+                WorkflowValidationError(
+                    code=type_code,
+                    message=(
+                        f"Subworkflow node {node_id!r} binds {direction} "
+                        f"{name!r} with literal incompatible with "
+                        f"declared type {decl.type.value}"
+                    ),
+                    node_id=node_id,
+                ),
+            )
+    return errors
+
+
 def _check_subworkflow_io_for_node(  # noqa: PLR0913
     *,
     node_id: str,
@@ -406,80 +463,29 @@ def _check_subworkflow_io_for_node(  # noqa: PLR0913
     child_outputs: tuple[WorkflowIODeclaration, ...],
 ) -> list[WorkflowValidationError]:
     """Check a single SUBWORKFLOW node's bindings against child I/O."""
-    errors: list[WorkflowValidationError] = [
-        WorkflowValidationError(
-            code=ValidationErrorCode.SUBWORKFLOW_INPUT_MISSING,
-            message=(
-                f"Subworkflow node {node_id!r} missing required "
-                f"input {required.name!r} for "
-                f"{subworkflow_id!r}@{version!r}"
-            ),
+    ref_label = f"{subworkflow_id!r}@{version!r}"
+    errors = _check_bindings_against_declarations(
+        node_id=node_id,
+        ref_label=ref_label,
+        bindings=input_bindings,
+        declarations=child_inputs,
+        direction="input",
+        missing_code=ValidationErrorCode.SUBWORKFLOW_INPUT_MISSING,
+        unknown_code=ValidationErrorCode.SUBWORKFLOW_INPUT_UNKNOWN,
+        type_code=ValidationErrorCode.SUBWORKFLOW_INPUT_TYPE_MISMATCH,
+    )
+    errors.extend(
+        _check_bindings_against_declarations(
             node_id=node_id,
-        )
-        for required in child_inputs
-        if required.required and required.name not in input_bindings
-    ]
-    input_by_name = {d.name: d for d in child_inputs}
-    output_by_name = {d.name: d for d in child_outputs}
-
-    for name, value in input_bindings.items():
-        if name not in input_by_name:
-            errors.append(
-                WorkflowValidationError(
-                    code=ValidationErrorCode.SUBWORKFLOW_INPUT_UNKNOWN,
-                    message=(
-                        f"Subworkflow node {node_id!r} binds unknown input "
-                        f"{name!r} for {subworkflow_id!r}@{version!r}"
-                    ),
-                    node_id=node_id,
-                ),
-            )
-            continue
-        decl = input_by_name[name]
-        if _is_deferred_expression(value):
-            continue
-        if not _literal_matches_type(value, decl.type):
-            errors.append(
-                WorkflowValidationError(
-                    code=ValidationErrorCode.SUBWORKFLOW_OUTPUT_TYPE_MISMATCH,
-                    message=(
-                        f"Subworkflow node {node_id!r} binds input "
-                        f"{name!r} with literal incompatible with "
-                        f"declared type {decl.type.value}"
-                    ),
-                    node_id=node_id,
-                ),
-            )
-
-    for name, value in output_bindings.items():
-        if name not in output_by_name:
-            errors.append(
-                WorkflowValidationError(
-                    code=ValidationErrorCode.SUBWORKFLOW_OUTPUT_UNKNOWN,
-                    message=(
-                        f"Subworkflow node {node_id!r} binds unknown "
-                        f"output {name!r} for {subworkflow_id!r}@{version!r}"
-                    ),
-                    node_id=node_id,
-                ),
-            )
-            continue
-        decl = output_by_name[name]
-        if _is_deferred_expression(value):
-            continue
-        if not _literal_matches_type(value, decl.type):
-            errors.append(
-                WorkflowValidationError(
-                    code=ValidationErrorCode.SUBWORKFLOW_OUTPUT_TYPE_MISMATCH,
-                    message=(
-                        f"Subworkflow node {node_id!r} binds output "
-                        f"{name!r} with literal incompatible with "
-                        f"declared type {decl.type.value}"
-                    ),
-                    node_id=node_id,
-                ),
-            )
-
+            ref_label=ref_label,
+            bindings=output_bindings,
+            declarations=child_outputs,
+            direction="output",
+            missing_code=ValidationErrorCode.SUBWORKFLOW_INPUT_MISSING,
+            unknown_code=ValidationErrorCode.SUBWORKFLOW_OUTPUT_UNKNOWN,
+            type_code=ValidationErrorCode.SUBWORKFLOW_OUTPUT_TYPE_MISMATCH,
+        ),
+    )
     return errors
 
 

--- a/src/synthorg/engine/workflow/validation.py
+++ b/src/synthorg/engine/workflow/validation.py
@@ -399,7 +399,7 @@ def _is_deferred_expression(value: object, *, direction: str = "") -> bool:
     if direction == "input":
         return value.startswith("@parent.")
     if direction == "output":
-        return value.startswith("@child.")
+        return value.startswith(("@child.", "@parent."))
     return value.startswith(("@parent.", "@child."))
 
 

--- a/src/synthorg/engine/workflow/validation.py
+++ b/src/synthorg/engine/workflow/validation.py
@@ -9,6 +9,7 @@ contract compatibility).
 """
 
 from collections import defaultdict, deque
+from datetime import datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
@@ -365,7 +366,7 @@ def _extract_subworkflow_config(
     return subworkflow_id, version, ib, ob
 
 
-def _literal_matches_type(
+def _literal_matches_type(  # noqa: C901, PLR0911
     value: object,
     value_type: WorkflowValueType,
 ) -> bool:
@@ -388,7 +389,18 @@ def _literal_matches_type(
         WorkflowValueType.AGENT_REF,
     ):
         return isinstance(value, str) and bool(value.strip())
-    # JSON and DATETIME are permissive at save time.
+    if value_type is WorkflowValueType.DATETIME:
+        if isinstance(value, datetime):
+            return True
+        if isinstance(value, str):
+            try:
+                datetime.fromisoformat(value)
+            except ValueError:
+                return False
+            else:
+                return True
+        return False
+    # JSON is permissive at save time.
     return True
 
 

--- a/src/synthorg/engine/workflow/yaml_export.py
+++ b/src/synthorg/engine/workflow/yaml_export.py
@@ -72,6 +72,21 @@ def _add_assignment_fields(
             step[_ASSIGNMENT_STEP_MAP[key]] = config[key]
 
 
+def _add_subworkflow_fields(
+    step: dict[str, Any],
+    config: dict[str, Any],
+) -> None:
+    """Copy subworkflow reference fields into the step dict."""
+    if "subworkflow_id" in config:
+        step["subworkflow_id"] = config["subworkflow_id"]
+    if "version" in config:
+        step["version"] = config["version"]
+    if config.get("input_bindings"):
+        step["input_bindings"] = dict(config["input_bindings"])
+    if config.get("output_bindings"):
+        step["output_bindings"] = dict(config["output_bindings"])
+
+
 def _build_step(
     node_id: str,
     node_type: WorkflowNodeType,
@@ -97,6 +112,8 @@ def _build_step(
             step["max_concurrency"] = config["max_concurrency"]
     elif node_type == WorkflowNodeType.PARALLEL_JOIN:
         step["join_strategy"] = config.get("join_strategy", "all")
+    elif node_type == WorkflowNodeType.SUBWORKFLOW:
+        _add_subworkflow_fields(step, config)
 
     depends_on = [nid for nid in incoming_node_ids if nid != node_id]
     if depends_on:
@@ -110,16 +127,20 @@ def _assemble_document(
     steps: list[dict[str, Any]],
 ) -> dict[str, Any]:
     """Assemble the top-level YAML document structure."""
-    doc: dict[str, Any] = {
-        "workflow_definition": {
-            "name": definition.name,
-            "workflow_type": definition.workflow_type.value,
-            "steps": steps,
-        },
+    body: dict[str, Any] = {
+        "name": definition.name,
+        "workflow_type": definition.workflow_type.value,
+        "version": definition.version,
+        "is_subworkflow": definition.is_subworkflow,
     }
     if definition.description:
-        doc["workflow_definition"]["description"] = definition.description
-    return doc
+        body["description"] = definition.description
+    if definition.inputs:
+        body["inputs"] = [i.model_dump(mode="json") for i in definition.inputs]
+    if definition.outputs:
+        body["outputs"] = [o.model_dump(mode="json") for o in definition.outputs]
+    body["steps"] = steps
+    return {"workflow_definition": body}
 
 
 def _generate_steps(

--- a/src/synthorg/observability/events/persistence.py
+++ b/src/synthorg/observability/events/persistence.py
@@ -301,6 +301,24 @@ PERSISTENCE_WORKFLOW_DEF_DESERIALIZE_FAILED: Final[str] = (
     "persistence.workflow_def.deserialize_failed"
 )
 
+# -- Subworkflow registry events ---------------------------------------------
+
+PERSISTENCE_SUBWORKFLOW_SAVED: Final[str] = "persistence.subworkflow.saved"
+PERSISTENCE_SUBWORKFLOW_SAVE_FAILED: Final[str] = "persistence.subworkflow.save_failed"
+PERSISTENCE_SUBWORKFLOW_FETCHED: Final[str] = "persistence.subworkflow.fetched"
+PERSISTENCE_SUBWORKFLOW_FETCH_FAILED: Final[str] = (
+    "persistence.subworkflow.fetch_failed"
+)
+PERSISTENCE_SUBWORKFLOW_LISTED: Final[str] = "persistence.subworkflow.listed"
+PERSISTENCE_SUBWORKFLOW_LIST_FAILED: Final[str] = "persistence.subworkflow.list_failed"
+PERSISTENCE_SUBWORKFLOW_DELETED: Final[str] = "persistence.subworkflow.deleted"
+PERSISTENCE_SUBWORKFLOW_DELETE_FAILED: Final[str] = (
+    "persistence.subworkflow.delete_failed"
+)
+PERSISTENCE_SUBWORKFLOW_DESERIALIZE_FAILED: Final[str] = (
+    "persistence.subworkflow.deserialize_failed"
+)
+
 # -- Workflow execution events -----------------------------------------------
 
 PERSISTENCE_WORKFLOW_EXEC_SAVED: Final[str] = "persistence.workflow_exec.saved"

--- a/src/synthorg/observability/events/workflow_definition.py
+++ b/src/synthorg/observability/events/workflow_definition.py
@@ -78,3 +78,6 @@ SUBWORKFLOW_CYCLE_DETECTED: Final[str] = "workflow.subworkflow.cycle_detected"
 
 SUBWORKFLOW_IO_INVALID: Final[str] = "workflow.subworkflow.io_invalid"
 """Save-time I/O validation rejected a subworkflow reference."""
+
+SUBWORKFLOW_INVALID_REQUEST: Final[str] = "workflow.subworkflow.invalid_request"
+"""API request to create or update a subworkflow was invalid."""

--- a/src/synthorg/observability/events/workflow_definition.py
+++ b/src/synthorg/observability/events/workflow_definition.py
@@ -61,3 +61,20 @@ WORKFLOW_DEF_ROLLED_BACK: Final[str] = "workflow.definition.rolled_back"
 
 WORKFLOW_DEF_DIFF_COMPUTED: Final[str] = "workflow.definition.diff_computed"
 """Diff computed between two workflow definition versions."""
+
+# -- Subworkflow registry events ---------------------------------------------
+
+SUBWORKFLOW_REGISTERED: Final[str] = "workflow.subworkflow.registered"
+"""A new subworkflow version was published to the registry."""
+
+SUBWORKFLOW_RESOLVED: Final[str] = "workflow.subworkflow.resolved"
+"""A subworkflow reference was resolved against the registry."""
+
+SUBWORKFLOW_DELETED: Final[str] = "workflow.subworkflow.deleted"
+"""A subworkflow version was deleted from the registry."""
+
+SUBWORKFLOW_CYCLE_DETECTED: Final[str] = "workflow.subworkflow.cycle_detected"
+"""Static cycle detection rejected a subworkflow reference graph."""
+
+SUBWORKFLOW_IO_INVALID: Final[str] = "workflow.subworkflow.io_invalid"
+"""Save-time I/O validation rejected a subworkflow reference."""

--- a/src/synthorg/observability/events/workflow_execution.py
+++ b/src/synthorg/observability/events/workflow_execution.py
@@ -58,3 +58,25 @@ WORKFLOW_EXEC_CANCELLED: Final[str] = "workflow.execution.cancelled"
 
 WORKFLOW_EXEC_PERSISTENCE_FAILED: Final[str] = "workflow.execution.persistence_failed"
 """Persistence operation failed during workflow execution."""
+
+# -- Subworkflow runtime events ----------------------------------------------
+
+WORKFLOW_EXEC_SUBWORKFLOW_FRAME_PUSHED: Final[str] = (
+    "workflow.execution.subworkflow.frame_pushed"
+)
+"""Subworkflow frame pushed onto the execution stack."""
+
+WORKFLOW_EXEC_SUBWORKFLOW_FRAME_POPPED: Final[str] = (
+    "workflow.execution.subworkflow.frame_popped"
+)
+"""Subworkflow frame popped after child graph completed."""
+
+WORKFLOW_EXEC_SUBWORKFLOW_DEPTH_EXCEEDED: Final[str] = (
+    "workflow.execution.subworkflow.depth_exceeded"
+)
+"""Runtime subworkflow nesting depth exceeded the configured limit."""
+
+WORKFLOW_EXEC_SUBWORKFLOW_NODE_COMPLETED: Final[str] = (
+    "workflow.execution.subworkflow.node_completed"
+)
+"""A SUBWORKFLOW node finished walking its child graph."""

--- a/src/synthorg/persistence/postgres/backend.py
+++ b/src/synthorg/persistence/postgres/backend.py
@@ -128,6 +128,7 @@ if TYPE_CHECKING:
     )
     from synthorg.persistence.risk_override_repo import RiskOverrideRepository
     from synthorg.persistence.ssrf_violation_repo import SsrfViolationRepository
+    from synthorg.persistence.subworkflow_repo import SubworkflowRepository
     from synthorg.persistence.version_repo import VersionRepository
     from synthorg.persistence.workflow_definition_repo import (
         WorkflowDefinitionRepository,
@@ -203,6 +204,7 @@ class PostgresPersistenceBackend:
         self._custom_presets: PersonalityPresetRepository | None = None
         self._workflow_definitions: WorkflowDefinitionRepository | None = None
         self._workflow_executions: WorkflowExecutionRepository | None = None
+        self._subworkflows: SubworkflowRepository | None = None
         self._workflow_versions: VersionRepository[WorkflowDefinition] | None = None
         self._identity_versions: VersionRepository[AgentIdentity] | None = None
         self._evaluation_config_versions: VersionRepository[EvaluationConfig] | None = (
@@ -241,6 +243,7 @@ class PostgresPersistenceBackend:
         self._custom_presets = None
         self._workflow_definitions = None
         self._workflow_executions = None
+        self._subworkflows = None
         self._workflow_versions = None
         self._identity_versions = None
         self._evaluation_config_versions = None
@@ -661,6 +664,11 @@ class PostgresPersistenceBackend:
     def workflow_executions(self) -> WorkflowExecutionRepository:
         """Repository for workflow execution persistence."""
         return self._require_connected(self._workflow_executions, "workflow_executions")
+
+    @property
+    def subworkflows(self) -> SubworkflowRepository:
+        """Repository for subworkflow registry persistence."""
+        return self._require_connected(self._subworkflows, "subworkflows")
 
     @property
     def workflow_versions(self) -> VersionRepository[WorkflowDefinition]:

--- a/src/synthorg/persistence/postgres/workflow_definition_repo.py
+++ b/src/synthorg/persistence/postgres/workflow_definition_repo.py
@@ -41,7 +41,7 @@ logger = get_logger(__name__)
 
 _SELECT_COLUMNS = """\
 id, name, description, workflow_type, nodes, edges,
-created_by, created_at, updated_at, revision"""
+created_by, created_at, updated_at, version"""
 
 
 def _deserialize_row(
@@ -73,6 +73,9 @@ def _deserialize_row(
         data["edges"] = tuple(
             WorkflowEdge.model_validate(e) for e in (data.get("edges") or [])
         )
+        if "version" in data and isinstance(data["version"], int):
+            data["revision"] = data.pop("version")
+            data.setdefault("version", "1.0.0")
         return WorkflowDefinition.model_validate(data)
     except (ValueError, ValidationError, KeyError, TypeError) as exc:
         msg = f"Failed to deserialize workflow definition {context_id!r}"
@@ -137,8 +140,8 @@ class PostgresWorkflowDefinitionRepository:
                         """
                         UPDATE workflow_definitions SET
                             name=%s, description=%s, workflow_type=%s,
-                            nodes=%s, edges=%s, updated_at=%s, revision=%s
-                        WHERE id = %s AND revision = %s
+                            nodes=%s, edges=%s, updated_at=%s, version=%s
+                        WHERE id = %s AND version = %s
                         """,
                         (
                             definition.name,
@@ -160,7 +163,7 @@ class PostgresWorkflowDefinitionRepository:
                         INSERT INTO workflow_definitions
                             (id, name, description, workflow_type, nodes,
                              edges, created_by, created_at, updated_at,
-                             revision)
+                             version)
                         VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                         ON CONFLICT(id) DO NOTHING
                         """,

--- a/src/synthorg/persistence/postgres/workflow_definition_repo.py
+++ b/src/synthorg/persistence/postgres/workflow_definition_repo.py
@@ -41,7 +41,7 @@ logger = get_logger(__name__)
 
 _SELECT_COLUMNS = """\
 id, name, description, workflow_type, nodes, edges,
-created_by, created_at, updated_at, version"""
+created_by, created_at, updated_at, revision"""
 
 
 def _deserialize_row(
@@ -112,10 +112,10 @@ class PostgresWorkflowDefinitionRepository:
             QueryError: If the database operation fails.
             VersionConflictError: If optimistic concurrency check fails.
         """
-        if definition.version < 1:
+        if definition.revision < 1:
             msg = (
                 f"Workflow definition version must be >= 1, got"
-                f" {definition.version} for {definition.id!r}"
+                f" {definition.revision} for {definition.id!r}"
             )
             logger.warning(
                 PERSISTENCE_WORKFLOW_DEF_SAVE_FAILED,
@@ -128,7 +128,7 @@ class PostgresWorkflowDefinitionRepository:
         edges_jsonb = Jsonb([e.model_dump(mode="json") for e in definition.edges])
         try:
             async with self._pool.connection() as conn, conn.cursor() as cur:
-                if definition.version > 1:
+                if definition.revision > 1:
                     # Update path: optimistic concurrency via WHERE
                     # version = incoming_version - 1.  If no row exists
                     # at all this is also a version conflict (you can't
@@ -137,8 +137,8 @@ class PostgresWorkflowDefinitionRepository:
                         """
                         UPDATE workflow_definitions SET
                             name=%s, description=%s, workflow_type=%s,
-                            nodes=%s, edges=%s, updated_at=%s, version=%s
-                        WHERE id = %s AND version = %s
+                            nodes=%s, edges=%s, updated_at=%s, revision=%s
+                        WHERE id = %s AND revision = %s
                         """,
                         (
                             definition.name,
@@ -147,9 +147,9 @@ class PostgresWorkflowDefinitionRepository:
                             nodes_jsonb,
                             edges_jsonb,
                             definition.updated_at,
-                            definition.version,
+                            definition.revision,
                             definition.id,
-                            definition.version - 1,
+                            definition.revision - 1,
                         ),
                     )
                 else:
@@ -160,7 +160,7 @@ class PostgresWorkflowDefinitionRepository:
                         INSERT INTO workflow_definitions
                             (id, name, description, workflow_type, nodes,
                              edges, created_by, created_at, updated_at,
-                             version)
+                             revision)
                         VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                         ON CONFLICT(id) DO NOTHING
                         """,
@@ -174,15 +174,15 @@ class PostgresWorkflowDefinitionRepository:
                             definition.created_by,
                             definition.created_at,
                             definition.updated_at,
-                            definition.version,
+                            definition.revision,
                         ),
                     )
                 if cur.rowcount == 0:
-                    if definition.version > 1:
+                    if definition.revision > 1:
                         msg = (
                             f"Version conflict saving workflow definition"
                             f" {definition.id!r}: expected version"
-                            f" {definition.version - 1}, not found"
+                            f" {definition.revision - 1}, not found"
                         )
                     else:
                         msg = (

--- a/src/synthorg/persistence/postgres/workflow_execution_repo.py
+++ b/src/synthorg/persistence/postgres/workflow_execution_repo.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 _SELECT_COLUMNS = """\
-id, definition_id, definition_revision, status, node_executions,
+id, definition_id, definition_version, status, node_executions,
 activated_by, project, created_at, updated_at, completed_at,
 error, version"""
 
@@ -98,6 +98,8 @@ def _deserialize_row(
         data["node_executions"] = _deserialize_node_executions(
             data.get("node_executions") or [],
         )
+        if "definition_version" in data:
+            data["definition_revision"] = data.pop("definition_version")
         return WorkflowExecution.model_validate(data)
     except (
         TypeError,
@@ -182,7 +184,7 @@ class PostgresWorkflowExecutionRepository:
                 await cur.execute(
                     """
                     INSERT INTO workflow_executions
-                        (id, definition_id, definition_revision, status,
+                        (id, definition_id, definition_version, status,
                          node_executions,
                          activated_by, project, created_at, updated_at, completed_at,
                          error, version)
@@ -217,7 +219,7 @@ class PostgresWorkflowExecutionRepository:
                 await cur.execute(
                     """
                     UPDATE workflow_executions SET
-                        definition_id=%s, definition_revision=%s, status=%s,
+                        definition_id=%s, definition_version=%s, status=%s,
                         node_executions=%s, activated_by=%s, project=%s,
                         created_at=%s, updated_at=%s, completed_at=%s,
                         error=%s, version=%s

--- a/src/synthorg/persistence/postgres/workflow_execution_repo.py
+++ b/src/synthorg/persistence/postgres/workflow_execution_repo.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 _SELECT_COLUMNS = """\
-id, definition_id, definition_version, status, node_executions,
+id, definition_id, definition_revision, status, node_executions,
 activated_by, project, created_at, updated_at, completed_at,
 error, version"""
 
@@ -162,7 +162,7 @@ class PostgresWorkflowExecutionRepository:
         return (
             execution.id,
             execution.definition_id,
-            execution.definition_version,
+            execution.definition_revision,
             execution.status.value,
             node_jsonb,
             execution.activated_by,
@@ -182,7 +182,8 @@ class PostgresWorkflowExecutionRepository:
                 await cur.execute(
                     """
                     INSERT INTO workflow_executions
-                        (id, definition_id, definition_version, status, node_executions,
+                        (id, definition_id, definition_revision, status,
+                         node_executions,
                          activated_by, project, created_at, updated_at, completed_at,
                          error, version)
                     VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
@@ -216,7 +217,7 @@ class PostgresWorkflowExecutionRepository:
                 await cur.execute(
                     """
                     UPDATE workflow_executions SET
-                        definition_id=%s, definition_version=%s, status=%s,
+                        definition_id=%s, definition_revision=%s, status=%s,
                         node_executions=%s, activated_by=%s, project=%s,
                         created_at=%s, updated_at=%s, completed_at=%s,
                         error=%s, version=%s

--- a/src/synthorg/persistence/protocol.py
+++ b/src/synthorg/persistence/protocol.py
@@ -48,6 +48,9 @@ from synthorg.persistence.risk_override_repo import (
 from synthorg.persistence.ssrf_violation_repo import (
     SsrfViolationRepository,  # noqa: TC001
 )
+from synthorg.persistence.subworkflow_repo import (
+    SubworkflowRepository,  # noqa: TC001
+)
 from synthorg.persistence.version_repo import (
     VersionRepository,  # noqa: TC001
 )
@@ -258,6 +261,11 @@ class PersistenceBackend(Protocol):
     @property
     def workflow_executions(self) -> WorkflowExecutionRepository:
         """Repository for workflow execution persistence."""
+        ...
+
+    @property
+    def subworkflows(self) -> SubworkflowRepository:
+        """Repository for versioned subworkflow persistence."""
         ...
 
     @property

--- a/src/synthorg/persistence/sqlite/backend.py
+++ b/src/synthorg/persistence/sqlite/backend.py
@@ -83,6 +83,9 @@ from synthorg.persistence.sqlite.settings_repo import (
 from synthorg.persistence.sqlite.ssrf_violation_repo import (
     SQLiteSsrfViolationRepository,
 )
+from synthorg.persistence.sqlite.subworkflow_repo import (
+    SQLiteSubworkflowRepository,
+)
 from synthorg.persistence.sqlite.user_repo import (
     SQLiteApiKeyRepository,
     SQLiteUserRepository,
@@ -144,6 +147,7 @@ class SQLitePersistenceBackend:
         self._custom_presets: SQLitePersonalityPresetRepository | None = None
         self._workflow_definitions: SQLiteWorkflowDefinitionRepository | None = None
         self._workflow_executions: SQLiteWorkflowExecutionRepository | None = None
+        self._subworkflows: SQLiteSubworkflowRepository | None = None
         self._workflow_versions: SQLiteVersionRepository[WorkflowDefinition] | None = (
             None
         )
@@ -186,6 +190,7 @@ class SQLitePersistenceBackend:
         self._custom_presets = None
         self._workflow_definitions = None
         self._workflow_executions = None
+        self._subworkflows = None
         self._workflow_versions = None
         self._identity_versions = None
         self._evaluation_config_versions = None
@@ -281,6 +286,7 @@ class SQLitePersistenceBackend:
         self._custom_presets = SQLitePersonalityPresetRepository(self._db)
         self._workflow_definitions = SQLiteWorkflowDefinitionRepository(self._db)
         self._workflow_executions = SQLiteWorkflowExecutionRepository(self._db)
+        self._subworkflows = SQLiteSubworkflowRepository(self._db)
 
         def _ver_repo[T: BaseModel](
             table: str,
@@ -651,6 +657,18 @@ class SQLitePersistenceBackend:
         return self._require_connected(
             self._workflow_executions,
             "workflow_executions",
+        )
+
+    @property
+    def subworkflows(self) -> SQLiteSubworkflowRepository:
+        """Repository for versioned subworkflow persistence.
+
+        Raises:
+            PersistenceConnectionError: If not connected.
+        """
+        return self._require_connected(
+            self._subworkflows,
+            "subworkflows",
         )
 
     @property

--- a/src/synthorg/persistence/sqlite/revisions/20260410113102_subworkflows.sql
+++ b/src/synthorg/persistence/sqlite/revisions/20260410113102_subworkflows.sql
@@ -1,0 +1,113 @@
+-- Disable the enforcement of foreign-keys constraints
+PRAGMA foreign_keys = off;
+-- Create "new_workflow_definitions" table
+CREATE TABLE `new_workflow_definitions` (
+  `id` text NOT NULL,
+  `name` text NOT NULL,
+  `description` text NOT NULL DEFAULT '',
+  `workflow_type` text NOT NULL,
+  `version` text NOT NULL DEFAULT '1.0.0',
+  `inputs` text NOT NULL DEFAULT '[]',
+  `outputs` text NOT NULL DEFAULT '[]',
+  `is_subworkflow` integer NOT NULL DEFAULT 0,
+  `nodes` text NOT NULL,
+  `edges` text NOT NULL,
+  `created_by` text NOT NULL,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  `revision` integer NOT NULL DEFAULT 1,
+  PRIMARY KEY (`id`),
+  CHECK (length(id) > 0),
+  CHECK (length(name) > 0),
+  CHECK (workflow_type IN (
+        'sequential_pipeline', 'parallel_execution', 'kanban', 'agile_kanban'
+    )),
+  CHECK (length(version) > 0),
+  CHECK (is_subworkflow IN (0, 1)),
+  CHECK (length(created_by) > 0),
+  CHECK (revision >= 1)
+);
+-- Copy rows from old table "workflow_definitions" to new temporary table "new_workflow_definitions"
+INSERT INTO `new_workflow_definitions` (`id`, `name`, `description`, `workflow_type`, `version`, `nodes`, `edges`, `created_by`, `created_at`, `updated_at`) SELECT `id`, `name`, `description`, `workflow_type`, IFNULL(`version`, '1.0.0') AS `version`, `nodes`, `edges`, `created_by`, `created_at`, `updated_at` FROM `workflow_definitions`;
+-- Drop "workflow_definitions" table after copying rows
+DROP TABLE `workflow_definitions`;
+-- Rename temporary table "new_workflow_definitions" to "workflow_definitions"
+ALTER TABLE `new_workflow_definitions` RENAME TO `workflow_definitions`;
+-- Create index "idx_wd_workflow_type" to table: "workflow_definitions"
+CREATE INDEX `idx_wd_workflow_type` ON `workflow_definitions` (`workflow_type`);
+-- Create index "idx_wd_updated_at" to table: "workflow_definitions"
+CREATE INDEX `idx_wd_updated_at` ON `workflow_definitions` (`updated_at` DESC);
+-- Create index "idx_wd_is_subworkflow" to table: "workflow_definitions"
+CREATE INDEX `idx_wd_is_subworkflow` ON `workflow_definitions` (`is_subworkflow`);
+-- Create "new_workflow_executions" table
+CREATE TABLE `new_workflow_executions` (
+  `id` text NOT NULL,
+  `definition_id` text NOT NULL,
+  `definition_revision` integer NOT NULL,
+  `status` text NOT NULL,
+  `node_executions` text NOT NULL DEFAULT '[]',
+  `activated_by` text NOT NULL,
+  `project` text NOT NULL,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  `completed_at` text NULL,
+  `error` text NULL,
+  `version` integer NOT NULL DEFAULT 1,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `0` FOREIGN KEY (`definition_id`) REFERENCES `workflow_definitions` (`id`) ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CHECK (length(id) > 0),
+  CHECK (length(definition_id) > 0),
+  CHECK (definition_revision >= 1),
+  CHECK (status IN (
+        'pending', 'running', 'completed', 'failed', 'cancelled'
+    )),
+  CHECK (length(activated_by) > 0),
+  CHECK (length(project) > 0),
+  CHECK (version >= 1)
+);
+-- Copy rows from old table "workflow_executions" to new temporary table "new_workflow_executions"
+INSERT INTO `new_workflow_executions` (`id`, `definition_id`, `status`, `node_executions`, `activated_by`, `project`, `created_at`, `updated_at`, `completed_at`, `error`, `version`) SELECT `id`, `definition_id`, `status`, `node_executions`, `activated_by`, `project`, `created_at`, `updated_at`, `completed_at`, `error`, `version` FROM `workflow_executions`;
+-- Drop "workflow_executions" table after copying rows
+DROP TABLE `workflow_executions`;
+-- Rename temporary table "new_workflow_executions" to "workflow_executions"
+ALTER TABLE `new_workflow_executions` RENAME TO `workflow_executions`;
+-- Create index "idx_wfe_definition_id" to table: "workflow_executions"
+CREATE INDEX `idx_wfe_definition_id` ON `workflow_executions` (`definition_id`);
+-- Create index "idx_wfe_status" to table: "workflow_executions"
+CREATE INDEX `idx_wfe_status` ON `workflow_executions` (`status`);
+-- Create index "idx_wfe_updated_at" to table: "workflow_executions"
+CREATE INDEX `idx_wfe_updated_at` ON `workflow_executions` (`updated_at` DESC);
+-- Create index "idx_wfe_definition_updated" to table: "workflow_executions"
+CREATE INDEX `idx_wfe_definition_updated` ON `workflow_executions` (`definition_id`, `updated_at` DESC);
+-- Create index "idx_wfe_status_updated" to table: "workflow_executions"
+CREATE INDEX `idx_wfe_status_updated` ON `workflow_executions` (`status`, `updated_at` DESC);
+-- Create index "idx_wfe_project" to table: "workflow_executions"
+CREATE INDEX `idx_wfe_project` ON `workflow_executions` (`project`);
+-- Create "subworkflows" table
+CREATE TABLE `subworkflows` (
+  `subworkflow_id` text NOT NULL,
+  `semver` text NOT NULL,
+  `name` text NOT NULL,
+  `description` text NOT NULL DEFAULT '',
+  `workflow_type` text NOT NULL,
+  `inputs` text NOT NULL DEFAULT '[]',
+  `outputs` text NOT NULL DEFAULT '[]',
+  `nodes` text NOT NULL,
+  `edges` text NOT NULL,
+  `created_by` text NOT NULL,
+  `created_at` text NOT NULL,
+  PRIMARY KEY (`subworkflow_id`, `semver`),
+  CHECK (length(subworkflow_id) > 0),
+  CHECK (length(semver) > 0),
+  CHECK (length(name) > 0),
+  CHECK (workflow_type IN (
+        'sequential_pipeline', 'parallel_execution', 'kanban', 'agile_kanban'
+    )),
+  CHECK (length(created_by) > 0)
+);
+-- Create index "idx_subworkflows_id" to table: "subworkflows"
+CREATE INDEX `idx_subworkflows_id` ON `subworkflows` (`subworkflow_id`);
+-- Create index "idx_subworkflows_created_at" to table: "subworkflows"
+CREATE INDEX `idx_subworkflows_created_at` ON `subworkflows` (`created_at` DESC);
+-- Enable back the enforcement of foreign-keys constraints
+PRAGMA foreign_keys = on;

--- a/src/synthorg/persistence/sqlite/revisions/20260410113102_subworkflows.sql
+++ b/src/synthorg/persistence/sqlite/revisions/20260410113102_subworkflows.sql
@@ -28,7 +28,7 @@ CREATE TABLE `new_workflow_definitions` (
   CHECK (revision >= 1)
 );
 -- Copy rows from old table "workflow_definitions" to new temporary table "new_workflow_definitions"
-INSERT INTO `new_workflow_definitions` (`id`, `name`, `description`, `workflow_type`, `version`, `nodes`, `edges`, `created_by`, `created_at`, `updated_at`) SELECT `id`, `name`, `description`, `workflow_type`, IFNULL(`version`, '1.0.0') AS `version`, `nodes`, `edges`, `created_by`, `created_at`, `updated_at` FROM `workflow_definitions`;
+INSERT INTO `new_workflow_definitions` (`id`, `name`, `description`, `workflow_type`, `version`, `nodes`, `edges`, `created_by`, `created_at`, `updated_at`, `revision`) SELECT `id`, `name`, `description`, `workflow_type`, '1.0.0', `nodes`, `edges`, `created_by`, `created_at`, `updated_at`, IFNULL(`version`, 1) FROM `workflow_definitions`;
 -- Drop "workflow_definitions" table after copying rows
 DROP TABLE `workflow_definitions`;
 -- Rename temporary table "new_workflow_definitions" to "workflow_definitions"
@@ -66,7 +66,7 @@ CREATE TABLE `new_workflow_executions` (
   CHECK (version >= 1)
 );
 -- Copy rows from old table "workflow_executions" to new temporary table "new_workflow_executions"
-INSERT INTO `new_workflow_executions` (`id`, `definition_id`, `status`, `node_executions`, `activated_by`, `project`, `created_at`, `updated_at`, `completed_at`, `error`, `version`) SELECT `id`, `definition_id`, `status`, `node_executions`, `activated_by`, `project`, `created_at`, `updated_at`, `completed_at`, `error`, `version` FROM `workflow_executions`;
+INSERT INTO `new_workflow_executions` (`id`, `definition_id`, `definition_revision`, `status`, `node_executions`, `activated_by`, `project`, `created_at`, `updated_at`, `completed_at`, `error`, `version`) SELECT `id`, `definition_id`, IFNULL(`definition_version`, 1), `status`, `node_executions`, `activated_by`, `project`, `created_at`, `updated_at`, `completed_at`, `error`, `version` FROM `workflow_executions`;
 -- Drop "workflow_executions" table after copying rows
 DROP TABLE `workflow_executions`;
 -- Rename temporary table "new_workflow_executions" to "workflow_executions"
@@ -79,6 +79,8 @@ CREATE INDEX `idx_wfe_status` ON `workflow_executions` (`status`);
 CREATE INDEX `idx_wfe_updated_at` ON `workflow_executions` (`updated_at` DESC);
 -- Create index "idx_wfe_definition_updated" to table: "workflow_executions"
 CREATE INDEX `idx_wfe_definition_updated` ON `workflow_executions` (`definition_id`, `updated_at` DESC);
+-- Create index "idx_wfe_definition_revision" to table: "workflow_executions"
+CREATE INDEX `idx_wfe_definition_revision` ON `workflow_executions` (`definition_id`, `definition_revision`);
 -- Create index "idx_wfe_status_updated" to table: "workflow_executions"
 CREATE INDEX `idx_wfe_status_updated` ON `workflow_executions` (`status`, `updated_at` DESC);
 -- Create index "idx_wfe_project" to table: "workflow_executions"

--- a/src/synthorg/persistence/sqlite/revisions/atlas.sum
+++ b/src/synthorg/persistence/sqlite/revisions/atlas.sum
@@ -1,2 +1,3 @@
-h1:SKuP+LbGdxex1Kk3elx+pNCX8sJatzW8tXfks2gUbUQ=
+h1:DXnbFaQrR2hc2LlfYMYQyv+RZS+Wfn+EnsLgRFgy8GM=
 20260409210418_baseline.sql h1:S7ZGI9L3DKFOcpqqJWq/UNypsf1P8aOyckYHejTZUrE=
+20260410113102_subworkflows.sql h1:aPReK5d4w59nG+Tx1jUjCcrjIU7n+Pmu+FShSHpGu9k=

--- a/src/synthorg/persistence/sqlite/revisions/atlas.sum
+++ b/src/synthorg/persistence/sqlite/revisions/atlas.sum
@@ -1,3 +1,3 @@
-h1:DXnbFaQrR2hc2LlfYMYQyv+RZS+Wfn+EnsLgRFgy8GM=
+h1:jQumL/YVKJP9qKl3aThKjwkjd609iBaGi2s+/GmWTzg=
 20260409210418_baseline.sql h1:S7ZGI9L3DKFOcpqqJWq/UNypsf1P8aOyckYHejTZUrE=
-20260410113102_subworkflows.sql h1:aPReK5d4w59nG+Tx1jUjCcrjIU7n+Pmu+FShSHpGu9k=
+20260410113102_subworkflows.sql h1:lrH6BsWIdWDYc5eoOtovHamSTbrF08OeGX02YnsDv28=

--- a/src/synthorg/persistence/sqlite/schema.sql
+++ b/src/synthorg/persistence/sqlite/schema.sql
@@ -340,12 +340,16 @@ CREATE TABLE workflow_definitions (
     workflow_type TEXT NOT NULL CHECK(workflow_type IN (
         'sequential_pipeline', 'parallel_execution', 'kanban', 'agile_kanban'
     )),
+    version TEXT NOT NULL DEFAULT '1.0.0' CHECK(length(version) > 0),
+    inputs TEXT NOT NULL DEFAULT '[]',
+    outputs TEXT NOT NULL DEFAULT '[]',
+    is_subworkflow INTEGER NOT NULL DEFAULT 0 CHECK(is_subworkflow IN (0, 1)),
     nodes TEXT NOT NULL,
     edges TEXT NOT NULL,
     created_by TEXT NOT NULL CHECK(length(created_by) > 0),
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
-    version INTEGER NOT NULL DEFAULT 1 CHECK(version >= 1)
+    revision INTEGER NOT NULL DEFAULT 1 CHECK(revision >= 1)
 );
 
 CREATE INDEX idx_wd_workflow_type
@@ -354,12 +358,40 @@ CREATE INDEX idx_wd_workflow_type
 CREATE INDEX idx_wd_updated_at
     ON workflow_definitions(updated_at DESC);
 
+CREATE INDEX idx_wd_is_subworkflow
+    ON workflow_definitions(is_subworkflow);
+
+-- ── Subworkflow registry (versioned reusable workflow components) ─
+
+CREATE TABLE subworkflows (
+    subworkflow_id TEXT NOT NULL CHECK(length(subworkflow_id) > 0),
+    semver TEXT NOT NULL CHECK(length(semver) > 0),
+    name TEXT NOT NULL CHECK(length(name) > 0),
+    description TEXT NOT NULL DEFAULT '',
+    workflow_type TEXT NOT NULL CHECK(workflow_type IN (
+        'sequential_pipeline', 'parallel_execution', 'kanban', 'agile_kanban'
+    )),
+    inputs TEXT NOT NULL DEFAULT '[]',
+    outputs TEXT NOT NULL DEFAULT '[]',
+    nodes TEXT NOT NULL,
+    edges TEXT NOT NULL,
+    created_by TEXT NOT NULL CHECK(length(created_by) > 0),
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (subworkflow_id, semver)
+);
+
+CREATE INDEX idx_subworkflows_id
+    ON subworkflows(subworkflow_id);
+
+CREATE INDEX idx_subworkflows_created_at
+    ON subworkflows(created_at DESC);
+
 -- ── Workflow execution instances ─────────────────────────────
 
 CREATE TABLE workflow_executions (
     id TEXT PRIMARY KEY NOT NULL CHECK(length(id) > 0),
     definition_id TEXT NOT NULL CHECK(length(definition_id) > 0),
-    definition_version INTEGER NOT NULL CHECK(definition_version >= 1),
+    definition_revision INTEGER NOT NULL CHECK(definition_revision >= 1),
     status TEXT NOT NULL CHECK(status IN (
         'pending', 'running', 'completed', 'failed', 'cancelled'
     )),

--- a/src/synthorg/persistence/sqlite/schema.sql
+++ b/src/synthorg/persistence/sqlite/schema.sql
@@ -418,6 +418,9 @@ CREATE INDEX idx_wfe_updated_at
 CREATE INDEX idx_wfe_definition_updated
     ON workflow_executions(definition_id, updated_at DESC);
 
+CREATE INDEX idx_wfe_definition_revision
+    ON workflow_executions(definition_id, definition_revision);
+
 CREATE INDEX idx_wfe_status_updated
     ON workflow_executions(status, updated_at DESC);
 

--- a/src/synthorg/persistence/sqlite/subworkflow_repo.py
+++ b/src/synthorg/persistence/sqlite/subworkflow_repo.py
@@ -354,17 +354,15 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         subworkflow_id: NotBlankStr,
         version: NotBlankStr | None = None,
     ) -> tuple[ParentReference, ...]:
-        """Return parent workflow definitions referencing a subworkflow.
+        """Return workflow definitions referencing a subworkflow.
 
-        Performs a JSON scan over ``workflow_definitions.nodes``,
-        filtering rows whose ``is_subworkflow`` flag is ``0`` (live
-        parents, not nested subworkflows) and whose nodes array contains
-        a SUBWORKFLOW entry matching the coordinate.
+        Performs a JSON scan over all ``workflow_definitions.nodes``
+        (both top-level workflows and nested subworkflows) whose nodes
+        array contains a SUBWORKFLOW entry matching the coordinate.
         """
         try:
             cursor = await self._db.execute(
-                "SELECT id, name, nodes FROM workflow_definitions "
-                "WHERE is_subworkflow = 0",
+                "SELECT id, name, nodes FROM workflow_definitions",
             )
             rows = await cursor.fetchall()
         except sqlite3.Error as exc:
@@ -383,8 +381,18 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             try:
                 nodes = json.loads(row["nodes"])
             except json.JSONDecodeError:
+                logger.warning(
+                    PERSISTENCE_SUBWORKFLOW_LIST_FAILED,
+                    parent_id=parent_id,
+                    error="Corrupted nodes JSON in workflow definition",
+                )
                 continue
             if not isinstance(nodes, list):
+                logger.warning(
+                    PERSISTENCE_SUBWORKFLOW_LIST_FAILED,
+                    parent_id=parent_id,
+                    error="nodes field is not a list",
+                )
                 continue
             for node in nodes:
                 if not isinstance(node, dict):
@@ -434,6 +442,11 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 inputs = json.loads(latest["inputs"])
                 outputs = json.loads(latest["outputs"])
             except json.JSONDecodeError:
+                logger.warning(
+                    PERSISTENCE_SUBWORKFLOW_LIST_FAILED,
+                    subworkflow_id=sub_id,
+                    error="Corrupted I/O JSON in subworkflow",
+                )
                 inputs = []
                 outputs = []
             summaries.append(

--- a/src/synthorg/persistence/sqlite/subworkflow_repo.py
+++ b/src/synthorg/persistence/sqlite/subworkflow_repo.py
@@ -402,9 +402,10 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     continue
                 if node.get("type") != WorkflowNodeType.SUBWORKFLOW.value:
                     continue
-                config = node.get("config") or {}
+                config = node.get("config")
                 if not isinstance(config, dict):
-                    continue
+                    msg = f"Malformed SUBWORKFLOW config in workflow {parent_id!r}"
+                    raise QueryError(msg)
                 if config.get("subworkflow_id") != subworkflow_id:
                     continue
                 pinned = str(config.get("version") or "")
@@ -412,7 +413,11 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     continue
                 node_id = node.get("id")
                 if not isinstance(node_id, str) or not pinned:
-                    continue
+                    msg = (
+                        f"Malformed SUBWORKFLOW node in"
+                        f" workflow {parent_id!r}: missing id or version"
+                    )
+                    raise QueryError(msg)
                 references.append(
                     ParentReference(
                         parent_id=parent_id,

--- a/src/synthorg/persistence/sqlite/subworkflow_repo.py
+++ b/src/synthorg/persistence/sqlite/subworkflow_repo.py
@@ -449,14 +449,14 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             try:
                 inputs = json.loads(latest["inputs"])
                 outputs = json.loads(latest["outputs"])
-            except json.JSONDecodeError:
+            except json.JSONDecodeError as exc:
+                msg = f"Corrupted I/O JSON in subworkflow {sub_id!r}"
                 logger.warning(
                     PERSISTENCE_SUBWORKFLOW_LIST_FAILED,
                     subworkflow_id=sub_id,
-                    error="Corrupted I/O JSON in subworkflow",
+                    error=str(exc),
                 )
-                inputs = []
-                outputs = []
+                raise QueryError(msg) from exc
             summaries.append(
                 SubworkflowSummary(
                     subworkflow_id=sub_id,

--- a/src/synthorg/persistence/sqlite/subworkflow_repo.py
+++ b/src/synthorg/persistence/sqlite/subworkflow_repo.py
@@ -457,14 +457,22 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     error=str(exc),
                 )
                 raise QueryError(msg) from exc
+            if not isinstance(inputs, list) or not isinstance(outputs, list):
+                msg = f"I/O fields are not lists in subworkflow {sub_id!r}"
+                logger.warning(
+                    PERSISTENCE_SUBWORKFLOW_LIST_FAILED,
+                    subworkflow_id=sub_id,
+                    error=msg,
+                )
+                raise QueryError(msg)
             summaries.append(
                 SubworkflowSummary(
                     subworkflow_id=sub_id,
                     latest_version=str(latest["semver"]),
                     name=str(latest["name"]),
                     description=str(latest["description"]),
-                    input_count=len(inputs) if isinstance(inputs, list) else 0,
-                    output_count=len(outputs) if isinstance(outputs, list) else 0,
+                    input_count=len(inputs),
+                    output_count=len(outputs),
                     version_count=len(versions),
                 ),
             )

--- a/src/synthorg/persistence/sqlite/subworkflow_repo.py
+++ b/src/synthorg/persistence/sqlite/subworkflow_repo.py
@@ -1,0 +1,450 @@
+"""SQLite repository implementation for subworkflows.
+
+Subworkflows are first-class versioned workflow definitions living
+in their own table keyed by ``(subworkflow_id, semver)``.  See
+``src/synthorg/persistence/subworkflow_repo.py`` for the protocol.
+"""
+
+import json
+import sqlite3
+from collections.abc import Iterable  # noqa: TC003
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from packaging.version import InvalidVersion, Version
+from pydantic import ValidationError
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+from synthorg.core.enums import WorkflowNodeType, WorkflowType
+from synthorg.core.types import NotBlankStr  # noqa: TC001
+from synthorg.engine.workflow.definition import (
+    WorkflowDefinition,
+    WorkflowEdge,
+    WorkflowIODeclaration,
+    WorkflowNode,
+)
+from synthorg.observability import get_logger
+from synthorg.observability.events.persistence import (
+    PERSISTENCE_SUBWORKFLOW_DELETE_FAILED,
+    PERSISTENCE_SUBWORKFLOW_DELETED,
+    PERSISTENCE_SUBWORKFLOW_DESERIALIZE_FAILED,
+    PERSISTENCE_SUBWORKFLOW_FETCH_FAILED,
+    PERSISTENCE_SUBWORKFLOW_FETCHED,
+    PERSISTENCE_SUBWORKFLOW_LIST_FAILED,
+    PERSISTENCE_SUBWORKFLOW_LISTED,
+    PERSISTENCE_SUBWORKFLOW_SAVE_FAILED,
+    PERSISTENCE_SUBWORKFLOW_SAVED,
+)
+from synthorg.persistence.errors import DuplicateRecordError, QueryError
+from synthorg.persistence.subworkflow_repo import (
+    ParentReference,
+    SubworkflowSummary,
+)
+
+logger = get_logger(__name__)
+
+
+_SUBWORKFLOW_SELECT = """\
+subworkflow_id, semver, name, description, workflow_type, inputs, outputs,
+nodes, edges, created_by, created_at"""
+
+
+def _semver_sort_key(version: str) -> Version:
+    """Parse a semver string to a :class:`packaging.version.Version` key."""
+    try:
+        return Version(version)
+    except InvalidVersion:
+        # Unparseable strings sort last by using the lowest version.
+        return Version("0.0.0")
+
+
+def _parse_created_at(value: object) -> datetime:
+    """Parse an ISO timestamp, forcing UTC."""
+    dt = datetime.fromisoformat(str(value))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+def _deserialize_row(
+    row: aiosqlite.Row,
+    context_id: str,
+) -> WorkflowDefinition:
+    """Reconstruct a ``WorkflowDefinition`` from a subworkflows row."""
+    try:
+        data = dict(row)
+        nodes = tuple(WorkflowNode.model_validate(n) for n in json.loads(data["nodes"]))
+        edges = tuple(WorkflowEdge.model_validate(e) for e in json.loads(data["edges"]))
+        inputs = tuple(
+            WorkflowIODeclaration.model_validate(i) for i in json.loads(data["inputs"])
+        )
+        outputs = tuple(
+            WorkflowIODeclaration.model_validate(o) for o in json.loads(data["outputs"])
+        )
+        created_at = _parse_created_at(data["created_at"])
+        return WorkflowDefinition(
+            id=str(data["subworkflow_id"]),
+            name=str(data["name"]),
+            description=str(data["description"]),
+            workflow_type=WorkflowType(data["workflow_type"]),
+            version=str(data["semver"]),
+            inputs=inputs,
+            outputs=outputs,
+            is_subworkflow=True,
+            nodes=nodes,
+            edges=edges,
+            created_by=str(data["created_by"]),
+            created_at=created_at,
+            updated_at=created_at,
+            revision=1,
+        )
+    except (ValueError, ValidationError, json.JSONDecodeError, KeyError) as exc:
+        msg = f"Failed to deserialize subworkflow {context_id!r}"
+        logger.exception(
+            PERSISTENCE_SUBWORKFLOW_DESERIALIZE_FAILED,
+            subworkflow_id=context_id,
+            error=str(exc),
+        )
+        raise QueryError(msg) from exc
+
+
+class SQLiteSubworkflowRepository:
+    """SQLite-backed subworkflow repository.
+
+    Stores versioned subworkflows keyed by ``(subworkflow_id, semver)``.
+    Unlike the main workflow definition repo, there is no optimistic
+    concurrency -- every ``save`` is an INSERT, and duplicate
+    coordinates are rejected.
+
+    Args:
+        db: An open aiosqlite connection.
+    """
+
+    def __init__(self, db: aiosqlite.Connection) -> None:
+        self._db = db
+
+    async def save(self, definition: WorkflowDefinition) -> None:
+        """Insert a new subworkflow version row.
+
+        Args:
+            definition: The workflow definition to publish.  Its ``id``
+                becomes the ``subworkflow_id`` and its ``version`` the
+                semver coordinate.
+
+        Raises:
+            DuplicateRecordError: If ``(id, version)`` already exists.
+            QueryError: On any other database failure.
+        """
+        nodes_json = json.dumps(
+            [n.model_dump(mode="json") for n in definition.nodes],
+        )
+        edges_json = json.dumps(
+            [e.model_dump(mode="json") for e in definition.edges],
+        )
+        inputs_json = json.dumps(
+            [i.model_dump(mode="json") for i in definition.inputs],
+        )
+        outputs_json = json.dumps(
+            [o.model_dump(mode="json") for o in definition.outputs],
+        )
+        try:
+            await self._db.execute(
+                """\
+INSERT INTO subworkflows
+    (subworkflow_id, semver, name, description, workflow_type,
+     inputs, outputs, nodes, edges, created_by, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    definition.id,
+                    definition.version,
+                    definition.name,
+                    definition.description,
+                    definition.workflow_type.value,
+                    inputs_json,
+                    outputs_json,
+                    nodes_json,
+                    edges_json,
+                    definition.created_by,
+                    definition.created_at.astimezone(UTC).isoformat(),
+                ),
+            )
+            await self._db.commit()
+        except sqlite3.IntegrityError as exc:
+            await self._db.rollback()
+            msg = (
+                f"Subworkflow {definition.id!r} version "
+                f"{definition.version!r} already exists"
+            )
+            logger.warning(
+                PERSISTENCE_SUBWORKFLOW_SAVE_FAILED,
+                subworkflow_id=definition.id,
+                version=definition.version,
+                error=msg,
+            )
+            raise DuplicateRecordError(msg) from exc
+        except sqlite3.Error as exc:
+            await self._db.rollback()
+            msg = (
+                f"Failed to save subworkflow {definition.id!r} version "
+                f"{definition.version!r}"
+            )
+            logger.exception(
+                PERSISTENCE_SUBWORKFLOW_SAVE_FAILED,
+                subworkflow_id=definition.id,
+                version=definition.version,
+                error=str(exc),
+            )
+            raise QueryError(msg) from exc
+
+        logger.info(
+            PERSISTENCE_SUBWORKFLOW_SAVED,
+            subworkflow_id=definition.id,
+            version=definition.version,
+        )
+
+    async def get(
+        self,
+        subworkflow_id: NotBlankStr,
+        version: NotBlankStr,
+    ) -> WorkflowDefinition | None:
+        """Fetch a specific subworkflow version."""
+        try:
+            cursor = await self._db.execute(
+                f"SELECT {_SUBWORKFLOW_SELECT} FROM subworkflows "  # noqa: S608
+                "WHERE subworkflow_id = ? AND semver = ?",
+                (subworkflow_id, version),
+            )
+            row = await cursor.fetchone()
+        except sqlite3.Error as exc:
+            msg = f"Failed to fetch subworkflow {subworkflow_id!r}@{version!r}"
+            logger.exception(
+                PERSISTENCE_SUBWORKFLOW_FETCH_FAILED,
+                subworkflow_id=subworkflow_id,
+                version=version,
+                error=str(exc),
+            )
+            raise QueryError(msg) from exc
+
+        if row is None:
+            logger.debug(
+                PERSISTENCE_SUBWORKFLOW_FETCHED,
+                subworkflow_id=subworkflow_id,
+                version=version,
+                found=False,
+            )
+            return None
+
+        definition = _deserialize_row(row, subworkflow_id)
+        logger.debug(
+            PERSISTENCE_SUBWORKFLOW_FETCHED,
+            subworkflow_id=subworkflow_id,
+            version=version,
+            found=True,
+        )
+        return definition
+
+    async def list_versions(
+        self,
+        subworkflow_id: NotBlankStr,
+    ) -> tuple[str, ...]:
+        """List semver strings for a subworkflow, newest first."""
+        try:
+            cursor = await self._db.execute(
+                "SELECT semver FROM subworkflows WHERE subworkflow_id = ?",
+                (subworkflow_id,),
+            )
+            rows = await cursor.fetchall()
+        except sqlite3.Error as exc:
+            msg = f"Failed to list versions for subworkflow {subworkflow_id!r}"
+            logger.exception(
+                PERSISTENCE_SUBWORKFLOW_LIST_FAILED,
+                subworkflow_id=subworkflow_id,
+                error=str(exc),
+            )
+            raise QueryError(msg) from exc
+
+        versions = [str(row["semver"]) for row in rows]
+        versions.sort(key=_semver_sort_key, reverse=True)
+        return tuple(versions)
+
+    async def list_summaries(self) -> tuple[SubworkflowSummary, ...]:
+        """Return summaries (latest version per subworkflow)."""
+        try:
+            cursor = await self._db.execute(
+                f"SELECT {_SUBWORKFLOW_SELECT} FROM subworkflows "  # noqa: S608
+                "ORDER BY subworkflow_id, created_at DESC",
+            )
+            rows = await cursor.fetchall()
+        except sqlite3.Error as exc:
+            msg = "Failed to list subworkflows"
+            logger.exception(
+                PERSISTENCE_SUBWORKFLOW_LIST_FAILED,
+                error=str(exc),
+            )
+            raise QueryError(msg) from exc
+
+        summaries = self._build_summaries_from_rows(rows)
+        logger.debug(
+            PERSISTENCE_SUBWORKFLOW_LISTED,
+            count=len(summaries),
+        )
+        return summaries
+
+    async def search(
+        self,
+        query: NotBlankStr,
+    ) -> tuple[SubworkflowSummary, ...]:
+        """Return summaries matching a name or description substring."""
+        pattern = f"%{query}%"
+        try:
+            cursor = await self._db.execute(
+                f"SELECT {_SUBWORKFLOW_SELECT} FROM subworkflows "  # noqa: S608
+                "WHERE name LIKE ? COLLATE NOCASE "
+                "OR description LIKE ? COLLATE NOCASE",
+                (pattern, pattern),
+            )
+            rows = await cursor.fetchall()
+        except sqlite3.Error as exc:
+            msg = f"Failed to search subworkflows with query {query!r}"
+            logger.exception(
+                PERSISTENCE_SUBWORKFLOW_LIST_FAILED,
+                query=query,
+                error=str(exc),
+            )
+            raise QueryError(msg) from exc
+
+        return self._build_summaries_from_rows(rows)
+
+    async def delete(
+        self,
+        subworkflow_id: NotBlankStr,
+        version: NotBlankStr,
+    ) -> bool:
+        """Delete a subworkflow version, returning ``True`` on success."""
+        try:
+            cursor = await self._db.execute(
+                "DELETE FROM subworkflows WHERE subworkflow_id = ? AND semver = ?",
+                (subworkflow_id, version),
+            )
+            await self._db.commit()
+        except sqlite3.Error as exc:
+            msg = f"Failed to delete subworkflow {subworkflow_id!r}@{version!r}"
+            logger.exception(
+                PERSISTENCE_SUBWORKFLOW_DELETE_FAILED,
+                subworkflow_id=subworkflow_id,
+                version=version,
+                error=str(exc),
+            )
+            raise QueryError(msg) from exc
+
+        deleted = cursor.rowcount > 0
+        logger.info(
+            PERSISTENCE_SUBWORKFLOW_DELETED,
+            subworkflow_id=subworkflow_id,
+            version=version,
+            deleted=deleted,
+        )
+        return deleted
+
+    async def find_parents(  # noqa: C901
+        self,
+        subworkflow_id: NotBlankStr,
+        version: NotBlankStr | None = None,
+    ) -> tuple[ParentReference, ...]:
+        """Return parent workflow definitions referencing a subworkflow.
+
+        Performs a JSON scan over ``workflow_definitions.nodes``,
+        filtering rows whose ``is_subworkflow`` flag is ``0`` (live
+        parents, not nested subworkflows) and whose nodes array contains
+        a SUBWORKFLOW entry matching the coordinate.
+        """
+        try:
+            cursor = await self._db.execute(
+                "SELECT id, name, nodes FROM workflow_definitions "
+                "WHERE is_subworkflow = 0",
+            )
+            rows = await cursor.fetchall()
+        except sqlite3.Error as exc:
+            msg = f"Failed to find parents for subworkflow {subworkflow_id!r}"
+            logger.exception(
+                PERSISTENCE_SUBWORKFLOW_LIST_FAILED,
+                subworkflow_id=subworkflow_id,
+                error=str(exc),
+            )
+            raise QueryError(msg) from exc
+
+        references: list[ParentReference] = []
+        for row in rows:
+            parent_id = str(row["id"])
+            parent_name = str(row["name"])
+            try:
+                nodes = json.loads(row["nodes"])
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(nodes, list):
+                continue
+            for node in nodes:
+                if not isinstance(node, dict):
+                    continue
+                if node.get("type") != WorkflowNodeType.SUBWORKFLOW.value:
+                    continue
+                config = node.get("config") or {}
+                if not isinstance(config, dict):
+                    continue
+                if config.get("subworkflow_id") != subworkflow_id:
+                    continue
+                pinned = str(config.get("version") or "")
+                if version is not None and pinned != version:
+                    continue
+                node_id = node.get("id")
+                if not isinstance(node_id, str) or not pinned:
+                    continue
+                references.append(
+                    ParentReference(
+                        parent_id=parent_id,
+                        parent_name=parent_name,
+                        pinned_version=pinned,
+                        node_id=node_id,
+                    ),
+                )
+
+        return tuple(references)
+
+    def _build_summaries_from_rows(
+        self,
+        rows: Iterable[Any],
+    ) -> tuple[SubworkflowSummary, ...]:
+        """Group rows by subworkflow and emit a summary for the latest one."""
+        grouped: dict[str, list[dict[str, Any]]] = {}
+        for row in rows:
+            data = dict(row)
+            grouped.setdefault(str(data["subworkflow_id"]), []).append(data)
+
+        summaries: list[SubworkflowSummary] = []
+        for sub_id, versions in grouped.items():
+            versions.sort(
+                key=lambda d: _semver_sort_key(str(d["semver"])),
+                reverse=True,
+            )
+            latest = versions[0]
+            try:
+                inputs = json.loads(latest["inputs"])
+                outputs = json.loads(latest["outputs"])
+            except json.JSONDecodeError:
+                inputs = []
+                outputs = []
+            summaries.append(
+                SubworkflowSummary(
+                    subworkflow_id=sub_id,
+                    latest_version=str(latest["semver"]),
+                    name=str(latest["name"]),
+                    description=str(latest["description"]),
+                    input_count=len(inputs) if isinstance(inputs, list) else 0,
+                    output_count=len(outputs) if isinstance(outputs, list) else 0,
+                    version_count=len(versions),
+                ),
+            )
+        summaries.sort(key=lambda s: s.subworkflow_id)
+        return tuple(summaries)

--- a/src/synthorg/persistence/sqlite/subworkflow_repo.py
+++ b/src/synthorg/persistence/sqlite/subworkflow_repo.py
@@ -316,7 +316,27 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             )
             raise QueryError(msg) from exc
 
-        return self._build_summaries_from_rows(rows)
+        matched_ids = {str(row["subworkflow_id"]) for row in rows}
+        if not matched_ids:
+            return ()
+        placeholders = ", ".join("?" for _ in matched_ids)
+        try:
+            full_cursor = await self._db.execute(
+                f"SELECT {_SUBWORKFLOW_SELECT} FROM subworkflows "  # noqa: S608
+                f"WHERE subworkflow_id IN ({placeholders})",
+                tuple(matched_ids),
+            )
+            full_rows = await full_cursor.fetchall()
+        except sqlite3.Error as exc:
+            msg = "Failed to load full versions for search results"
+            logger.exception(
+                PERSISTENCE_SUBWORKFLOW_LIST_FAILED,
+                query=query,
+                error=str(exc),
+            )
+            raise QueryError(msg) from exc
+
+        return self._build_summaries_from_rows(full_rows)
 
     async def delete(
         self,

--- a/src/synthorg/persistence/sqlite/subworkflow_repo.py
+++ b/src/synthorg/persistence/sqlite/subworkflow_repo.py
@@ -297,12 +297,13 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         query: NotBlankStr,
     ) -> tuple[SubworkflowSummary, ...]:
         """Return summaries matching a name or description substring."""
-        pattern = f"%{query}%"
+        escaped = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        pattern = f"%{escaped}%"
         try:
             cursor = await self._db.execute(
                 f"SELECT {_SUBWORKFLOW_SELECT} FROM subworkflows "  # noqa: S608
-                "WHERE name LIKE ? COLLATE NOCASE "
-                "OR description LIKE ? COLLATE NOCASE",
+                "WHERE name LIKE ? ESCAPE '\\' COLLATE NOCASE "
+                "OR description LIKE ? ESCAPE '\\' COLLATE NOCASE",
                 (pattern, pattern),
             )
             rows = await cursor.fetchall()

--- a/src/synthorg/persistence/sqlite/subworkflow_repo.py
+++ b/src/synthorg/persistence/sqlite/subworkflow_repo.py
@@ -331,6 +331,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             )
             await self._db.commit()
         except sqlite3.Error as exc:
+            await self._db.rollback()
             msg = f"Failed to delete subworkflow {subworkflow_id!r}@{version!r}"
             logger.exception(
                 PERSISTENCE_SUBWORKFLOW_DELETE_FAILED,
@@ -381,19 +382,21 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             try:
                 nodes = json.loads(row["nodes"])
             except json.JSONDecodeError:
+                msg = f"Corrupted nodes JSON in workflow {parent_id!r}"
                 logger.warning(
                     PERSISTENCE_SUBWORKFLOW_LIST_FAILED,
                     parent_id=parent_id,
-                    error="Corrupted nodes JSON in workflow definition",
+                    error=msg,
                 )
-                continue
+                raise QueryError(msg) from None
             if not isinstance(nodes, list):
+                msg = f"nodes field is not a list in workflow {parent_id!r}"
                 logger.warning(
                     PERSISTENCE_SUBWORKFLOW_LIST_FAILED,
                     parent_id=parent_id,
-                    error="nodes field is not a list",
+                    error=msg,
                 )
-                continue
+                raise QueryError(msg)
             for node in nodes:
                 if not isinstance(node, dict):
                     continue

--- a/src/synthorg/persistence/sqlite/workflow_definition_repo.py
+++ b/src/synthorg/persistence/sqlite/workflow_definition_repo.py
@@ -15,6 +15,7 @@ from synthorg.core.types import NotBlankStr  # noqa: TC001
 from synthorg.engine.workflow.definition import (
     WorkflowDefinition,
     WorkflowEdge,
+    WorkflowIODeclaration,
     WorkflowNode,
 )
 from synthorg.observability import get_logger
@@ -34,8 +35,8 @@ from synthorg.persistence.errors import QueryError, VersionConflictError
 logger = get_logger(__name__)
 
 _SELECT_COLUMNS = """\
-id, name, description, workflow_type, nodes, edges,
-created_by, created_at, updated_at, version"""
+id, name, description, workflow_type, version, inputs, outputs,
+is_subworkflow, nodes, edges, created_by, created_at, updated_at, revision"""
 
 
 def _parse_row_timestamps(data: dict[str, object]) -> None:
@@ -72,6 +73,13 @@ def _deserialize_row(
         data["edges"] = tuple(
             WorkflowEdge.model_validate(e) for e in json.loads(data["edges"])
         )
+        data["inputs"] = tuple(
+            WorkflowIODeclaration.model_validate(i) for i in json.loads(data["inputs"])
+        )
+        data["outputs"] = tuple(
+            WorkflowIODeclaration.model_validate(o) for o in json.loads(data["outputs"])
+        )
+        data["is_subworkflow"] = bool(data["is_subworkflow"])
         _parse_row_timestamps(data)
         return WorkflowDefinition.model_validate(data)
     except (ValueError, ValidationError, json.JSONDecodeError, KeyError) as exc:
@@ -118,41 +126,56 @@ class SQLiteWorkflowDefinitionRepository:
         edges_json = json.dumps(
             [e.model_dump(mode="json") for e in definition.edges],
         )
+        inputs_json = json.dumps(
+            [i.model_dump(mode="json") for i in definition.inputs],
+        )
+        outputs_json = json.dumps(
+            [o.model_dump(mode="json") for o in definition.outputs],
+        )
         try:
             cursor = await self._db.execute(
                 """\
 INSERT INTO workflow_definitions
-    (id, name, description, workflow_type, nodes, edges,
-     created_by, created_at, updated_at, version)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    (id, name, description, workflow_type, version, inputs, outputs,
+     is_subworkflow, nodes, edges, created_by, created_at, updated_at,
+     revision)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
     name=excluded.name,
     description=excluded.description,
     workflow_type=excluded.workflow_type,
+    version=excluded.version,
+    inputs=excluded.inputs,
+    outputs=excluded.outputs,
+    is_subworkflow=excluded.is_subworkflow,
     nodes=excluded.nodes,
     edges=excluded.edges,
     updated_at=excluded.updated_at,
-    version=excluded.version
-WHERE workflow_definitions.version = excluded.version - 1""",
+    revision=excluded.revision
+WHERE workflow_definitions.revision = excluded.revision - 1""",
                 (
                     definition.id,
                     definition.name,
                     definition.description,
                     definition.workflow_type.value,
+                    definition.version,
+                    inputs_json,
+                    outputs_json,
+                    1 if definition.is_subworkflow else 0,
                     nodes_json,
                     edges_json,
                     definition.created_by,
                     definition.created_at.astimezone(UTC).isoformat(),
                     definition.updated_at.astimezone(UTC).isoformat(),
-                    definition.version,
+                    definition.revision,
                 ),
             )
-            if cursor.rowcount == 0 and definition.version > 1:
+            if cursor.rowcount == 0 and definition.revision > 1:
                 await self._db.rollback()
                 msg = (
                     f"Version conflict saving workflow definition"
-                    f" {definition.id!r}: expected version"
-                    f" {definition.version - 1}, not found"
+                    f" {definition.id!r}: expected revision"
+                    f" {definition.revision - 1}, not found"
                 )
                 logger.warning(
                     PERSISTENCE_WORKFLOW_DEF_SAVE_FAILED,

--- a/src/synthorg/persistence/sqlite/workflow_execution_repo.py
+++ b/src/synthorg/persistence/sqlite/workflow_execution_repo.py
@@ -43,7 +43,7 @@ from synthorg.persistence.errors import (
 logger = get_logger(__name__)
 
 _SELECT_COLUMNS = """\
-id, definition_id, definition_version, status, node_executions,
+id, definition_id, definition_revision, status, node_executions,
 activated_by, project, created_at, updated_at, completed_at,
 error, version"""
 
@@ -179,7 +179,7 @@ class SQLiteWorkflowExecutionRepository:
         return (
             execution.id,
             execution.definition_id,
-            execution.definition_version,
+            execution.definition_revision,
             execution.status.value,
             node_json,
             execution.activated_by,
@@ -198,7 +198,7 @@ class SQLiteWorkflowExecutionRepository:
             cursor = await self._db.execute(
                 """\
 INSERT INTO workflow_executions
-    (id, definition_id, definition_version, status, node_executions,
+    (id, definition_id, definition_revision, status, node_executions,
      activated_by, project, created_at, updated_at, completed_at,
      error, version)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
@@ -250,7 +250,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             cursor = await self._db.execute(
                 """\
 UPDATE workflow_executions SET
-    definition_id=?, definition_version=?, status=?,
+    definition_id=?, definition_revision=?, status=?,
     node_executions=?, activated_by=?, project=?,
     created_at=?, updated_at=?, completed_at=?,
     error=?, version=?

--- a/src/synthorg/persistence/subworkflow_repo.py
+++ b/src/synthorg/persistence/subworkflow_repo.py
@@ -1,0 +1,174 @@
+"""Repository protocol for subworkflow persistence.
+
+A subworkflow is a ``WorkflowDefinition`` published to the registry under
+a specific ``(subworkflow_id, semver)`` coordinate.  Unlike live workflow
+definitions (which are mutable and use optimistic concurrency), subworkflow
+versions are immutable -- updating a subworkflow always creates a new
+semver row.  Parent workflows pin a specific version in their
+``SUBWORKFLOW`` node configs; deleting a pinned version is rejected.
+"""
+
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from synthorg.core.types import NotBlankStr  # noqa: TC001
+from synthorg.engine.workflow.definition import WorkflowDefinition  # noqa: TC001
+
+
+class SubworkflowSummary(BaseModel):
+    """Summary information for a subworkflow entry in the registry.
+
+    Used by list / search endpoints that do not need the full node
+    and edge payload.
+
+    Attributes:
+        subworkflow_id: Stable identifier (shared across versions).
+        latest_version: Highest semver currently in the registry.
+        name: Human-readable name.
+        description: Short description.
+        input_count: Number of declared inputs on the latest version.
+        output_count: Number of declared outputs on the latest version.
+        version_count: Total number of versions in the registry.
+    """
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False)
+
+    subworkflow_id: NotBlankStr = Field(description="Stable identifier")
+    latest_version: NotBlankStr = Field(description="Latest semver")
+    name: NotBlankStr = Field(description="Name of the latest version")
+    description: str = Field(default="", description="Description")
+    input_count: int = Field(ge=0, description="Number of inputs")
+    output_count: int = Field(ge=0, description="Number of outputs")
+    version_count: int = Field(ge=1, description="Total versions")
+
+
+class ParentReference(BaseModel):
+    """A parent workflow definition that references a given subworkflow.
+
+    Attributes:
+        parent_id: Workflow definition ID of the parent.
+        parent_name: Display name of the parent.
+        pinned_version: Semver of the subworkflow the parent has pinned.
+        node_id: Node ID within the parent graph holding the reference.
+    """
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False)
+
+    parent_id: NotBlankStr = Field(description="Parent workflow ID")
+    parent_name: NotBlankStr = Field(description="Parent workflow name")
+    pinned_version: NotBlankStr = Field(description="Pinned semver")
+    node_id: NotBlankStr = Field(description="Referencing node ID")
+
+
+@runtime_checkable
+class SubworkflowRepository(Protocol):
+    """CRUD interface for subworkflow persistence.
+
+    Subworkflows are stored keyed by ``(subworkflow_id, semver)``.
+    """
+
+    async def save(self, definition: WorkflowDefinition) -> None:
+        """Persist a new subworkflow version.
+
+        The definition's ``id`` is interpreted as the ``subworkflow_id``
+        and its ``version`` (semver) as the version coordinate.  Writing
+        the same ``(id, version)`` twice is rejected.
+
+        Args:
+            definition: The workflow definition to publish.
+
+        Raises:
+            PersistenceError: If the operation fails.
+            DuplicateRecordError: If the ``(id, version)`` already exists.
+        """
+        ...
+
+    async def get(
+        self,
+        subworkflow_id: NotBlankStr,
+        version: NotBlankStr,
+    ) -> WorkflowDefinition | None:
+        """Fetch a specific subworkflow version.
+
+        Args:
+            subworkflow_id: The subworkflow identifier.
+            version: The semver string.
+
+        Returns:
+            The definition, or ``None`` if not found.
+        """
+        ...
+
+    async def list_versions(
+        self,
+        subworkflow_id: NotBlankStr,
+    ) -> tuple[NotBlankStr, ...]:
+        """List all semver strings for a subworkflow, newest first.
+
+        Args:
+            subworkflow_id: The subworkflow identifier.
+
+        Returns:
+            Tuple of semver strings sorted by ``packaging.version``
+            comparison descending.  Empty when the subworkflow does
+            not exist.
+        """
+        ...
+
+    async def list_summaries(self) -> tuple[SubworkflowSummary, ...]:
+        """Return a summary for every unique subworkflow in the registry.
+
+        The summary reflects the latest version of each subworkflow.
+        """
+        ...
+
+    async def search(
+        self,
+        query: NotBlankStr,
+    ) -> tuple[SubworkflowSummary, ...]:
+        """Search subworkflows by case-insensitive substring in name or description.
+
+        Args:
+            query: Search term.
+
+        Returns:
+            Matching summaries.
+        """
+        ...
+
+    async def delete(
+        self,
+        subworkflow_id: NotBlankStr,
+        version: NotBlankStr,
+    ) -> bool:
+        """Delete a specific subworkflow version.
+
+        Deletion protection (rejecting when a parent pins the version)
+        is enforced at the service layer, not here.
+
+        Args:
+            subworkflow_id: The subworkflow identifier.
+            version: The semver string.
+
+        Returns:
+            ``True`` if a row was deleted, ``False`` if not found.
+        """
+        ...
+
+    async def find_parents(
+        self,
+        subworkflow_id: NotBlankStr,
+        version: NotBlankStr | None = None,
+    ) -> tuple[ParentReference, ...]:
+        """Find parent workflow definitions referencing a subworkflow.
+
+        Args:
+            subworkflow_id: The subworkflow identifier.
+            version: Optional semver filter.  When ``None``, returns
+                parents pinning any version of the subworkflow.
+
+        Returns:
+            Tuple of parent references (possibly empty).
+        """
+        ...

--- a/tests/conformance/persistence/test_workflow_definition_repository.py
+++ b/tests/conformance/persistence/test_workflow_definition_repository.py
@@ -72,7 +72,7 @@ def _make_workflow_definition(
         "created_by": "admin",
         "created_at": datetime.now(UTC),
         "updated_at": datetime.now(UTC),
-        "version": 1,
+        "revision": 1,
     }
     defaults.update(overrides)
     return WorkflowDefinition.model_validate(defaults)

--- a/tests/conformance/persistence/test_workflow_definition_repository.py
+++ b/tests/conformance/persistence/test_workflow_definition_repository.py
@@ -172,7 +172,7 @@ class TestWorkflowDefinitionRepository:
             name="Updated",
             description="Updated description",
             workflow_type=WorkflowType.PARALLEL_EXECUTION,
-            version=2,
+            revision=2,
         )
         await repo.save(updated)
 
@@ -180,7 +180,7 @@ class TestWorkflowDefinitionRepository:
         assert retrieved is not None
         assert retrieved.name == "Updated"
         assert retrieved.description == "Updated description"
-        assert retrieved.version == 2
+        assert retrieved.revision == 2
 
     async def test_version_conflict_on_stale_update(
         self,
@@ -198,7 +198,7 @@ class TestWorkflowDefinitionRepository:
         stale = _make_workflow_definition(
             definition_id="wf-003",
             name="Stale",
-            version=5,
+            revision=5,
         )
 
         with pytest.raises(VersionConflictError):

--- a/tests/conformance/persistence/test_workflow_execution_repository.py
+++ b/tests/conformance/persistence/test_workflow_execution_repository.py
@@ -95,7 +95,7 @@ def _make_workflow_execution(
     defaults: dict[str, object] = {
         "id": execution_id,
         "definition_id": definition_id,
-        "definition_version": 1,
+        "definition_revision": 1,
         "status": WorkflowExecutionStatus.RUNNING,
         "node_executions": (
             WorkflowNodeExecution(

--- a/tests/conformance/persistence/test_workflow_execution_repository.py
+++ b/tests/conformance/persistence/test_workflow_execution_repository.py
@@ -81,7 +81,7 @@ def _make_workflow_definition(
         created_by="admin",
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
-        version=1,
+        revision=1,
     )
 
 

--- a/tests/unit/api/controllers/test_subworkflows.py
+++ b/tests/unit/api/controllers/test_subworkflows.py
@@ -1,0 +1,197 @@
+"""Tests for the subworkflow API controller."""
+
+from typing import Any
+
+import pytest
+from litestar.testing import TestClient
+
+from tests.unit.api.conftest import make_auth_headers
+
+_SUB_ID = "sub-finance-close"
+
+
+def _sub_payload(
+    *,
+    subworkflow_id: str | None = _SUB_ID,
+    version: str = "1.0.0",
+    name: str = "Finance Close",
+) -> dict[str, Any]:
+    return {
+        "subworkflow_id": subworkflow_id,
+        "version": version,
+        "name": name,
+        "description": "Finance close subworkflow",
+        "workflow_type": "sequential_pipeline",
+        "inputs": [
+            {"name": "quarter", "type": "string", "required": True},
+        ],
+        "outputs": [
+            {"name": "report", "type": "string", "required": True},
+        ],
+        "nodes": [
+            {
+                "id": "start",
+                "type": "start",
+                "label": "Start",
+                "config": {},
+            },
+            {
+                "id": "task-close",
+                "type": "task",
+                "label": "Close",
+                "config": {"title": "Close", "task_type": "admin"},
+            },
+            {
+                "id": "end",
+                "type": "end",
+                "label": "End",
+                "config": {},
+            },
+        ],
+        "edges": [
+            {
+                "id": "e1",
+                "source_node_id": "start",
+                "target_node_id": "task-close",
+                "type": "sequential",
+            },
+            {
+                "id": "e2",
+                "source_node_id": "task-close",
+                "target_node_id": "end",
+                "type": "sequential",
+            },
+        ],
+    }
+
+
+def _create_subworkflow(
+    test_client: TestClient[Any],
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    body = payload or _sub_payload()
+    resp = test_client.post(
+        "/api/v1/subworkflows",
+        json=body,
+        headers=make_auth_headers("ceo"),
+    )
+    assert resp.status_code == 201, resp.text
+    result: dict[str, Any] = resp.json()["data"]
+    return result
+
+
+@pytest.mark.unit
+class TestSubworkflowCrud:
+    def test_create_and_list(self, test_client: TestClient[Any]) -> None:
+        _create_subworkflow(test_client)
+
+        resp = test_client.get(
+            "/api/v1/subworkflows",
+            headers=make_auth_headers("ceo"),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        items = body["data"]
+        assert len(items) == 1
+        assert items[0]["subworkflow_id"] == _SUB_ID
+        assert items[0]["latest_version"] == "1.0.0"
+        assert items[0]["input_count"] == 1
+        assert items[0]["output_count"] == 1
+
+    def test_list_versions_semver_descending(
+        self,
+        test_client: TestClient[Any],
+    ) -> None:
+        _create_subworkflow(test_client, _sub_payload(version="1.0.0"))
+        _create_subworkflow(test_client, _sub_payload(version="1.9.0"))
+        _create_subworkflow(test_client, _sub_payload(version="1.10.0"))
+
+        resp = test_client.get(
+            f"/api/v1/subworkflows/{_SUB_ID}/versions",
+            headers=make_auth_headers("ceo"),
+        )
+        assert resp.status_code == 200
+        versions = resp.json()["data"]
+        assert versions == ["1.10.0", "1.9.0", "1.0.0"]
+
+    def test_get_version_missing_returns_404(
+        self,
+        test_client: TestClient[Any],
+    ) -> None:
+        resp = test_client.get(
+            "/api/v1/subworkflows/sub-nope/versions/1.0.0",
+            headers=make_auth_headers("ceo"),
+        )
+        assert resp.status_code == 404
+
+    def test_get_version_round_trip(
+        self,
+        test_client: TestClient[Any],
+    ) -> None:
+        _create_subworkflow(test_client)
+        resp = test_client.get(
+            f"/api/v1/subworkflows/{_SUB_ID}/versions/1.0.0",
+            headers=make_auth_headers("ceo"),
+        )
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["id"] == _SUB_ID
+        assert data["version"] == "1.0.0"
+        assert data["is_subworkflow"] is True
+
+    def test_delete_version(
+        self,
+        test_client: TestClient[Any],
+    ) -> None:
+        _create_subworkflow(test_client, _sub_payload(version="1.0.0"))
+        _create_subworkflow(test_client, _sub_payload(version="2.0.0"))
+
+        resp = test_client.delete(
+            f"/api/v1/subworkflows/{_SUB_ID}/versions/1.0.0",
+            headers=make_auth_headers("ceo"),
+        )
+        assert resp.status_code == 200
+
+        versions_resp = test_client.get(
+            f"/api/v1/subworkflows/{_SUB_ID}/versions",
+            headers=make_auth_headers("ceo"),
+        )
+        assert versions_resp.json()["data"] == ["2.0.0"]
+
+    def test_create_rejects_non_subworkflow_flag_bypass(
+        self,
+        test_client: TestClient[Any],
+    ) -> None:
+        """The controller always registers with is_subworkflow=True."""
+        _create_subworkflow(test_client)
+        resp = test_client.get(
+            f"/api/v1/subworkflows/{_SUB_ID}/versions/1.0.0",
+            headers=make_auth_headers("ceo"),
+        )
+        assert resp.json()["data"]["is_subworkflow"] is True
+
+    def test_duplicate_version_returns_409(
+        self,
+        test_client: TestClient[Any],
+    ) -> None:
+        _create_subworkflow(test_client)
+        resp = test_client.post(
+            "/api/v1/subworkflows",
+            json=_sub_payload(),
+            headers=make_auth_headers("ceo"),
+        )
+        assert resp.status_code == 409
+
+    def test_find_parents_endpoint(
+        self,
+        test_client: TestClient[Any],
+    ) -> None:
+        _create_subworkflow(test_client)
+        resp = test_client.get(
+            f"/api/v1/subworkflows/{_SUB_ID}/versions/1.0.0/parents",
+            headers=make_auth_headers("ceo"),
+        )
+        assert resp.status_code == 200
+        parents = resp.json()["data"]
+        assert parents == []

--- a/tests/unit/api/controllers/test_workflow_versions.py
+++ b/tests/unit/api/controllers/test_workflow_versions.py
@@ -62,11 +62,11 @@ def _create_workflow(
 def _update_workflow(
     test_client: TestClient[Any],
     wf_id: str,
-    expected_version: int,
+    expected_revision: int,
     **fields: object,
 ) -> dict[str, Any]:
     """PATCH a workflow and return response data."""
-    payload: dict[str, object] = {"expected_version": expected_version}
+    payload: dict[str, object] = {"expected_revision": expected_revision}
     payload.update(fields)
     resp = test_client.patch(
         f"/api/v1/workflows/{wf_id}",
@@ -262,10 +262,10 @@ class TestRollback:
         # 2. Update it to name "Updated" (auto-creates v2).
         _update_workflow(test_client, wf_id, 1, name="Updated")
 
-        # 3. POST rollback to v1.
+        # 3. POST rollback to v1 (definition revision is now 2).
         resp = test_client.post(
             f"/api/v1/workflows/{wf_id}/rollback",
-            json={"target_version": 1, "expected_version": 2},
+            json={"target_version": 1, "expected_revision": 2},
             headers=make_auth_headers("ceo"),
         )
         assert resp.status_code == 200
@@ -284,34 +284,20 @@ class TestRollback:
         assert versions[0]["snapshot"]["name"] == "Original"
 
     @pytest.mark.unit
-    def test_rollback_version_conflict(self, test_client: TestClient[Any]) -> None:
+    def test_rollback_revision_conflict(self, test_client: TestClient[Any]) -> None:
         wf = _create_workflow(test_client)
         resp = test_client.post(
             f"/api/v1/workflows/{wf['id']}/rollback",
-            json={"target_version": 1, "expected_version": 99},
+            json={"target_version": 1, "expected_revision": 99},
             headers=make_auth_headers("ceo"),
         )
         assert resp.status_code == 409
 
     @pytest.mark.unit
-    def test_rollback_target_gte_expected_returns_400(
-        self,
-        test_client: TestClient[Any],
-    ) -> None:
-        """Rollback is rejected when target_version >= expected_version."""
-        wf = _create_workflow(test_client)
-        resp = test_client.post(
-            f"/api/v1/workflows/{wf['id']}/rollback",
-            json={"target_version": 5, "expected_version": 3},
-            headers=make_auth_headers("ceo"),
-        )
-        assert resp.status_code == 400
-
-    @pytest.mark.unit
     def test_rollback_definition_not_found(self, test_client: TestClient[Any]) -> None:
         resp = test_client.post(
             "/api/v1/workflows/wfdef-nonexistent/rollback",
-            json={"target_version": 1, "expected_version": 2},
+            json={"target_version": 1, "expected_revision": 2},
             headers=make_auth_headers("ceo"),
         )
         assert resp.status_code == 404

--- a/tests/unit/api/controllers/test_workflows.py
+++ b/tests/unit/api/controllers/test_workflows.py
@@ -224,7 +224,9 @@ class TestWorkflowController:
         assert data["id"].startswith("wfdef-")
         assert data["name"] == "new-workflow"
         assert data["workflow_type"] == "sequential_pipeline"
-        assert data["version"] == 1
+        assert data["revision"] == 1
+        assert data["version"] == "1.0.0"
+        assert data["is_subworkflow"] is False
         assert len(data["nodes"]) == 3
         assert len(data["edges"]) == 2
 
@@ -276,7 +278,7 @@ class TestWorkflowController:
         assert body["success"] is True
         assert body["data"]["name"] == "updated-name"
         assert body["data"]["description"] == "new desc"
-        assert body["data"]["version"] == 2
+        assert body["data"]["revision"] == 2
 
     def test_update_workflow_not_found(self, test_client: TestClient[Any]) -> None:
         resp = test_client.patch(
@@ -289,7 +291,7 @@ class TestWorkflowController:
         assert body["success"] is False
         assert "not found" in body["error"].lower()
 
-    def test_update_workflow_version_conflict(
+    def test_update_workflow_revision_conflict(
         self, test_client: TestClient[Any]
     ) -> None:
         created = _create_workflow(test_client)
@@ -297,7 +299,7 @@ class TestWorkflowController:
 
         resp = test_client.patch(
             f"/api/v1/workflows/{wf_id}",
-            json={"name": "conflict-name", "expected_version": 999},
+            json={"name": "conflict-name", "expected_revision": 999},
             headers=make_auth_headers("ceo"),
         )
         assert resp.status_code == 409
@@ -305,7 +307,7 @@ class TestWorkflowController:
         assert body["success"] is False
         assert "version conflict" in body["error"].lower()
 
-    def test_update_workflow_with_correct_expected_version(
+    def test_update_workflow_with_correct_expected_revision(
         self, test_client: TestClient[Any]
     ) -> None:
         created = _create_workflow(test_client)
@@ -315,12 +317,12 @@ class TestWorkflowController:
             f"/api/v1/workflows/{wf_id}",
             json={
                 "name": "versioned-update",
-                "expected_version": 1,
+                "expected_revision": 1,
             },
             headers=make_auth_headers("ceo"),
         )
         assert resp.status_code == 200
-        assert resp.json()["data"]["version"] == 2
+        assert resp.json()["data"]["revision"] == 2
 
     # ── Delete ───────────────────────────────────────────────────
 

--- a/tests/unit/api/fakes_backend.py
+++ b/tests/unit/api/fakes_backend.py
@@ -35,6 +35,7 @@ from tests.unit.api.fakes import (
     FakeUserRepository,
 )
 from tests.unit.api.fakes_workflow import (
+    FakeSubworkflowRepository,
     FakeWorkflowDefinitionRepository,
     FakeWorkflowExecutionRepository,
     FakeWorkflowVersionRepository,
@@ -232,6 +233,9 @@ class FakePersistenceBackend:
         self._workflow_definitions = FakeWorkflowDefinitionRepository()
         self._workflow_executions = FakeWorkflowExecutionRepository()
         self._workflow_versions = FakeWorkflowVersionRepository()
+        self._subworkflows = FakeSubworkflowRepository(
+            definition_repo=self._workflow_definitions,
+        )
         self._identity_versions = FakeVersionRepository()
         self._evaluation_config_versions = FakeVersionRepository()
         self._budget_config_versions = FakeVersionRepository()
@@ -363,6 +367,10 @@ class FakePersistenceBackend:
     @property
     def workflow_executions(self) -> FakeWorkflowExecutionRepository:
         return self._workflow_executions
+
+    @property
+    def subworkflows(self) -> FakeSubworkflowRepository:
+        return self._subworkflows
 
     @property
     def workflow_versions(self) -> FakeWorkflowVersionRepository:

--- a/tests/unit/api/fakes_workflow.py
+++ b/tests/unit/api/fakes_workflow.py
@@ -283,7 +283,9 @@ class FakeSubworkflowRepository:
         q = query.lower()
         summaries = await self.list_summaries()
         return tuple(
-            s for s in summaries if q in s.name.lower() or q in s.description.lower()
+            s
+            for s in summaries
+            if q in s.name.lower() or q in (s.description or "").lower()
         )
 
     async def delete(

--- a/tests/unit/api/fakes_workflow.py
+++ b/tests/unit/api/fakes_workflow.py
@@ -1,7 +1,6 @@
 """In-memory fake workflow repositories for API unit tests."""
 
 import copy
-import json
 from typing import TYPE_CHECKING
 
 from packaging.version import InvalidVersion, Version
@@ -329,5 +328,4 @@ class FakeSubworkflowRepository:
                         node_id=node.id,
                     ),
                 )
-        _ = json  # keep import live for future JSON-scan helpers
         return tuple(references)

--- a/tests/unit/api/fakes_workflow.py
+++ b/tests/unit/api/fakes_workflow.py
@@ -1,10 +1,17 @@
 """In-memory fake workflow repositories for API unit tests."""
 
 import copy
+import json
 from typing import TYPE_CHECKING
 
-from synthorg.core.enums import WorkflowExecutionStatus
+from packaging.version import InvalidVersion, Version
+
+from synthorg.core.enums import WorkflowExecutionStatus, WorkflowNodeType
 from synthorg.persistence.errors import DuplicateRecordError, VersionConflictError
+from synthorg.persistence.subworkflow_repo import (
+    ParentReference,
+    SubworkflowSummary,
+)
 
 if TYPE_CHECKING:
     from synthorg.core.enums import WorkflowType
@@ -196,3 +203,129 @@ class FakeWorkflowVersionRepository:
         for k in to_delete:
             del self._versions[k]
         return len(to_delete)
+
+
+def _semver_key(value: str) -> Version:
+    try:
+        return Version(value)
+    except InvalidVersion:
+        return Version("0.0.0")
+
+
+class FakeSubworkflowRepository:
+    """In-memory subworkflow repository for tests.
+
+    Implements the ``SubworkflowRepository`` protocol with an internal
+    ``dict`` keyed on ``(subworkflow_id, semver)``.  ``find_parents``
+    scans a companion ``FakeWorkflowDefinitionRepository`` instance so
+    tests that create parents via ``/workflows`` see the references.
+    """
+
+    def __init__(
+        self,
+        definition_repo: FakeWorkflowDefinitionRepository | None = None,
+    ) -> None:
+        self._rows: dict[tuple[str, str], WorkflowDefinition] = {}
+        self._definition_repo = definition_repo
+
+    async def save(self, definition: WorkflowDefinition) -> None:
+        key = (definition.id, definition.version)
+        if key in self._rows:
+            msg = (
+                f"Subworkflow {definition.id!r} version "
+                f"{definition.version!r} already exists"
+            )
+            raise DuplicateRecordError(msg)
+        self._rows[key] = copy.deepcopy(definition)
+
+    async def get(
+        self,
+        subworkflow_id: NotBlankStr,
+        version: NotBlankStr,
+    ) -> WorkflowDefinition | None:
+        stored = self._rows.get((subworkflow_id, version))
+        return copy.deepcopy(stored) if stored is not None else None
+
+    async def list_versions(
+        self,
+        subworkflow_id: NotBlankStr,
+    ) -> tuple[str, ...]:
+        versions = [v for (sid, v) in self._rows if sid == subworkflow_id]
+        versions.sort(key=_semver_key, reverse=True)
+        return tuple(versions)
+
+    async def list_summaries(self) -> tuple[SubworkflowSummary, ...]:
+        grouped: dict[str, list[WorkflowDefinition]] = {}
+        for definition in self._rows.values():
+            grouped.setdefault(definition.id, []).append(definition)
+        summaries: list[SubworkflowSummary] = []
+        for sub_id, items in grouped.items():
+            items.sort(key=lambda d: _semver_key(d.version), reverse=True)
+            latest = items[0]
+            summaries.append(
+                SubworkflowSummary(
+                    subworkflow_id=sub_id,
+                    latest_version=latest.version,
+                    name=latest.name,
+                    description=latest.description,
+                    input_count=len(latest.inputs),
+                    output_count=len(latest.outputs),
+                    version_count=len(items),
+                ),
+            )
+        summaries.sort(key=lambda s: s.subworkflow_id)
+        return tuple(summaries)
+
+    async def search(
+        self,
+        query: NotBlankStr,
+    ) -> tuple[SubworkflowSummary, ...]:
+        q = query.lower()
+        summaries = await self.list_summaries()
+        return tuple(
+            s for s in summaries if q in s.name.lower() or q in s.description.lower()
+        )
+
+    async def delete(
+        self,
+        subworkflow_id: NotBlankStr,
+        version: NotBlankStr,
+    ) -> bool:
+        key = (subworkflow_id, version)
+        if key in self._rows:
+            del self._rows[key]
+            return True
+        return False
+
+    async def find_parents(
+        self,
+        subworkflow_id: NotBlankStr,
+        version: NotBlankStr | None = None,
+    ) -> tuple[ParentReference, ...]:
+        if self._definition_repo is None:
+            return ()
+        references: list[ParentReference] = []
+        for definition in self._definition_repo._definitions.values():
+            if definition.is_subworkflow:
+                continue
+            for node in definition.nodes:
+                if node.type is not WorkflowNodeType.SUBWORKFLOW:
+                    continue
+                config = dict(node.config)
+                if config.get("subworkflow_id") != subworkflow_id:
+                    continue
+                pinned = str(config.get("version") or "")
+                if version is not None and pinned != version:
+                    continue
+                if not pinned:
+                    continue
+                references.append(
+                    ParentReference(
+                        parent_id=definition.id,
+                        parent_name=definition.name,
+                        pinned_version=pinned,
+                        node_id=node.id,
+                    ),
+                )
+        _ = json  # keep import live for future JSON-scan helpers
+        return tuple(references)

--- a/tests/unit/engine/workflow/test_definition.py
+++ b/tests/unit/engine/workflow/test_definition.py
@@ -162,7 +162,8 @@ class TestWorkflowDefinition:
         wf = _minimal_definition()
         assert wf.id == "wf-1"
         assert wf.name == "Test Workflow"
-        assert wf.version == 1
+        assert wf.revision == 1
+        assert wf.version == "1.0.0"
         assert len(wf.nodes) == 3
         assert len(wf.edges) == 2
 
@@ -182,9 +183,9 @@ class TestWorkflowDefinition:
         assert wf.description == ""
 
     @pytest.mark.unit
-    def test_version_minimum(self) -> None:
+    def test_revision_minimum(self) -> None:
         with pytest.raises(ValidationError, match="greater than or equal to 1"):
-            _minimal_definition(version=0)
+            _minimal_definition(revision=0)
 
     @pytest.mark.unit
     def test_frozen(self) -> None:

--- a/tests/unit/engine/workflow/test_execution_helpers.py
+++ b/tests/unit/engine/workflow/test_execution_helpers.py
@@ -27,7 +27,7 @@ class TestUpdateNodeStatus:
         exe = WorkflowExecution(
             id="wfexec-test",
             definition_id="wf-1",
-            definition_version=1,
+            definition_revision=1,
             status=WorkflowExecutionStatus.RUNNING,
             node_executions=(
                 WorkflowNodeExecution(
@@ -56,7 +56,7 @@ class TestUpdateNodeStatus:
         exe = WorkflowExecution(
             id="wfexec-test",
             definition_id="wf-1",
-            definition_version=1,
+            definition_revision=1,
             status=WorkflowExecutionStatus.RUNNING,
             node_executions=(
                 WorkflowNodeExecution(
@@ -89,7 +89,7 @@ class TestUpdateNodeStatus:
         exe = WorkflowExecution(
             id="wfexec-test",
             definition_id="wf-1",
-            definition_version=1,
+            definition_revision=1,
             status=WorkflowExecutionStatus.RUNNING,
             node_executions=(
                 WorkflowNodeExecution(
@@ -121,7 +121,7 @@ class TestAllTasksCompleted:
         exe = WorkflowExecution(
             id="wfexec-test",
             definition_id="wf-1",
-            definition_version=1,
+            definition_revision=1,
             status=WorkflowExecutionStatus.RUNNING,
             node_executions=(
                 WorkflowNodeExecution(
@@ -151,7 +151,7 @@ class TestAllTasksCompleted:
         exe = WorkflowExecution(
             id="wfexec-test",
             definition_id="wf-1",
-            definition_version=1,
+            definition_revision=1,
             status=WorkflowExecutionStatus.RUNNING,
             node_executions=(
                 WorkflowNodeExecution(
@@ -177,7 +177,7 @@ class TestAllTasksCompleted:
         exe = WorkflowExecution(
             id="wfexec-test",
             definition_id="wf-1",
-            definition_version=1,
+            definition_revision=1,
             status=WorkflowExecutionStatus.RUNNING,
             node_executions=(
                 WorkflowNodeExecution(
@@ -203,7 +203,7 @@ class TestAllTasksCompleted:
         exe = WorkflowExecution(
             id="wfexec-test",
             definition_id="wf-1",
-            definition_version=1,
+            definition_revision=1,
             status=WorkflowExecutionStatus.RUNNING,
             node_executions=(
                 WorkflowNodeExecution(
@@ -230,7 +230,7 @@ class TestAllTasksCompleted:
         exe = WorkflowExecution(
             id="wfexec-test",
             definition_id="wf-1",
-            definition_version=1,
+            definition_revision=1,
             status=WorkflowExecutionStatus.RUNNING,
             node_executions=(
                 WorkflowNodeExecution(

--- a/tests/unit/engine/workflow/test_execution_models.py
+++ b/tests/unit/engine/workflow/test_execution_models.py
@@ -101,7 +101,7 @@ def _make_execution(**overrides: object) -> WorkflowExecution:
     defaults: dict[str, object] = {
         "id": "wfexec-test001",
         "definition_id": "wfdef-abc123",
-        "definition_version": 1,
+        "definition_revision": 1,
         "activated_by": "test-user",
         "project": "test-project",
         "created_at": now,
@@ -119,7 +119,7 @@ class TestWorkflowExecution:
         exe = _make_execution()
         assert exe.id == "wfexec-test001"
         assert exe.definition_id == "wfdef-abc123"
-        assert exe.definition_version == 1
+        assert exe.definition_revision == 1
         assert exe.status is WorkflowExecutionStatus.PENDING
         assert exe.node_executions == ()
         assert exe.activated_by == "test-user"
@@ -206,9 +206,9 @@ class TestWorkflowExecution:
             _make_execution(version=0)
 
     @pytest.mark.unit
-    def test_definition_version_must_be_ge_1(self) -> None:
-        with pytest.raises(ValidationError, match="definition_version"):
-            _make_execution(definition_version=0)
+    def test_definition_revision_must_be_ge_1(self) -> None:
+        with pytest.raises(ValidationError, match="definition_revision"):
+            _make_execution(definition_revision=0)
 
     @pytest.mark.unit
     def test_nan_rejected_in_version(self) -> None:
@@ -216,9 +216,9 @@ class TestWorkflowExecution:
             _make_execution(version=math.nan)
 
     @pytest.mark.unit
-    def test_nan_rejected_in_definition_version(self) -> None:
+    def test_nan_rejected_in_definition_revision(self) -> None:
         with pytest.raises(ValidationError):
-            _make_execution(definition_version=math.nan)
+            _make_execution(definition_revision=math.nan)
 
 
 # ── Negative cross-field validator tests ─────────────────────────

--- a/tests/unit/engine/workflow/test_execution_service_subworkflows.py
+++ b/tests/unit/engine/workflow/test_execution_service_subworkflows.py
@@ -375,7 +375,7 @@ class TestSubworkflowExecution:
                 activated_by="ceo",
             )
         assert exc_info.value.max_depth == 1
-        assert exc_info.value.depth == 2
+        assert exc_info.value.depth == 1
 
     async def test_two_level_nesting_under_default_depth(
         self,

--- a/tests/unit/engine/workflow/test_execution_service_subworkflows.py
+++ b/tests/unit/engine/workflow/test_execution_service_subworkflows.py
@@ -11,6 +11,7 @@ Covers:
 """
 
 from datetime import UTC, datetime
+from typing import Any
 
 import pytest
 
@@ -162,7 +163,7 @@ class _FakeTaskEngine:
     def __init__(self) -> None:
         self.created: list[str] = []
 
-    async def create_task(self, data, requested_by):
+    async def create_task(self, data: Any, requested_by: str) -> Task:
         task_id = f"task-{len(self.created)}"
         self.created.append(task_id)
         return Task(

--- a/tests/unit/engine/workflow/test_execution_service_subworkflows.py
+++ b/tests/unit/engine/workflow/test_execution_service_subworkflows.py
@@ -1,0 +1,473 @@
+"""Tests for the subworkflow-aware execution service frame stack.
+
+Covers:
+
+- Parent with a SUBWORKFLOW node calls a child and the child's tasks
+  land in the same WorkflowExecution under qualified IDs.
+- Runtime depth limit enforcement.
+- Output projection feeds downstream conditionals.
+- Variable scoping: child frame's condition evaluator only sees
+  declared inputs.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from synthorg.core.enums import (
+    Complexity,
+    Priority,
+    TaskStatus,
+    TaskType,
+    WorkflowEdgeType,
+    WorkflowNodeExecutionStatus,
+    WorkflowNodeType,
+    WorkflowType,
+    WorkflowValueType,
+)
+from synthorg.core.task import Task
+from synthorg.engine.errors import SubworkflowDepthExceededError
+from synthorg.engine.workflow.definition import (
+    WorkflowDefinition,
+    WorkflowEdge,
+    WorkflowIODeclaration,
+    WorkflowNode,
+)
+from synthorg.engine.workflow.execution_service import (
+    WorkflowExecutionService,
+)
+from synthorg.engine.workflow.subworkflow_registry import SubworkflowRegistry
+from tests.unit.engine.workflow.test_subworkflow_registry import (
+    FakeSubworkflowRepository,
+)
+
+_NOW = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _task_node(
+    node_id: str,
+    title: str = "Work",
+) -> WorkflowNode:
+    return WorkflowNode(
+        id=node_id,
+        type=WorkflowNodeType.TASK,
+        label=title,
+        config={"title": title, "task_type": "development"},
+    )
+
+
+def _seq_edge(edge_id: str, src: str, tgt: str) -> WorkflowEdge:
+    return WorkflowEdge(
+        id=edge_id,
+        source_node_id=src,
+        target_node_id=tgt,
+        type=WorkflowEdgeType.SEQUENTIAL,
+    )
+
+
+def _make_child_definition(
+    *,
+    definition_id: str = "child-sub",
+    version: str = "1.0.0",
+    inputs: tuple[WorkflowIODeclaration, ...] = (),
+    outputs: tuple[WorkflowIODeclaration, ...] = (),
+) -> WorkflowDefinition:
+    return WorkflowDefinition(
+        id=definition_id,
+        name="Child",
+        description="",
+        workflow_type=WorkflowType.SEQUENTIAL_PIPELINE,
+        version=version,
+        inputs=inputs,
+        outputs=outputs,
+        is_subworkflow=True,
+        nodes=(
+            WorkflowNode(
+                id="start",
+                type=WorkflowNodeType.START,
+                label="Start",
+            ),
+            _task_node("child-task", "Child Task"),
+            WorkflowNode(
+                id="end",
+                type=WorkflowNodeType.END,
+                label="End",
+            ),
+        ),
+        edges=(
+            _seq_edge("ce1", "start", "child-task"),
+            _seq_edge("ce2", "child-task", "end"),
+        ),
+        created_by="test",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+
+
+def _make_parent_definition(
+    *,
+    subworkflow_id: str = "child-sub",
+    version: str = "1.0.0",
+    input_bindings: dict[str, object] | None = None,
+    output_bindings: dict[str, object] | None = None,
+) -> WorkflowDefinition:
+    sub_config: dict[str, object] = {
+        "subworkflow_id": subworkflow_id,
+        "version": version,
+        "input_bindings": input_bindings or {},
+        "output_bindings": output_bindings or {},
+    }
+    return WorkflowDefinition(
+        id="parent-wf",
+        name="Parent",
+        description="",
+        workflow_type=WorkflowType.SEQUENTIAL_PIPELINE,
+        version="1.0.0",
+        is_subworkflow=False,
+        nodes=(
+            WorkflowNode(
+                id="start",
+                type=WorkflowNodeType.START,
+                label="Start",
+            ),
+            _task_node("parent-before", "Parent Before"),
+            WorkflowNode(
+                id="sub-call",
+                type=WorkflowNodeType.SUBWORKFLOW,
+                label="Subworkflow Call",
+                config=sub_config,
+            ),
+            _task_node("parent-after", "Parent After"),
+            WorkflowNode(
+                id="end",
+                type=WorkflowNodeType.END,
+                label="End",
+            ),
+        ),
+        edges=(
+            _seq_edge("e1", "start", "parent-before"),
+            _seq_edge("e2", "parent-before", "sub-call"),
+            _seq_edge("e3", "sub-call", "parent-after"),
+            _seq_edge("e4", "parent-after", "end"),
+        ),
+        created_by="test",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+
+
+class _FakeTaskEngine:
+    """Minimal task engine stub that records created tasks."""
+
+    def __init__(self) -> None:
+        self.created: list[str] = []
+
+    async def create_task(self, data, requested_by):
+        task_id = f"task-{len(self.created)}"
+        self.created.append(task_id)
+        return Task(
+            id=task_id,
+            title=data.title,
+            description=data.description,
+            type=TaskType(data.type),
+            priority=Priority(data.priority),
+            project=data.project,
+            created_by=data.created_by,
+            assigned_to=data.assigned_to or "default-agent",
+            dependencies=tuple(data.dependencies),
+            estimated_complexity=Complexity(data.estimated_complexity),
+            status=TaskStatus.ASSIGNED,
+        )
+
+
+class _FakeDefinitionRepo:
+    """Definition repo stub holding a single definition."""
+
+    def __init__(self, definition: WorkflowDefinition) -> None:
+        self._definition = definition
+
+    async def get(self, definition_id: str) -> WorkflowDefinition | None:
+        if definition_id == self._definition.id:
+            return self._definition
+        return None
+
+
+class _FakeExecutionRepo:
+    """Execution repo stub that records the last save."""
+
+    def __init__(self) -> None:
+        self.saved: list[object] = []
+
+    async def save(self, execution: object) -> None:
+        self.saved.append(execution)
+
+
+async def _build_service(
+    parent: WorkflowDefinition,
+    registry: SubworkflowRegistry,
+    *,
+    max_depth: int = 16,
+) -> tuple[WorkflowExecutionService, _FakeTaskEngine, _FakeExecutionRepo]:
+    task_engine = _FakeTaskEngine()
+    definition_repo = _FakeDefinitionRepo(parent)
+    execution_repo = _FakeExecutionRepo()
+    service = WorkflowExecutionService(
+        definition_repo=definition_repo,  # type: ignore[arg-type]
+        execution_repo=execution_repo,  # type: ignore[arg-type]
+        task_engine=task_engine,  # type: ignore[arg-type]
+        subworkflow_registry=registry,
+        max_subworkflow_depth=max_depth,
+    )
+    return service, task_engine, execution_repo
+
+
+@pytest.fixture
+def registry() -> SubworkflowRegistry:
+    return SubworkflowRegistry(FakeSubworkflowRepository())
+
+
+@pytest.mark.unit
+class TestSubworkflowExecution:
+    async def test_parent_calls_subworkflow_receives_outputs(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        child = _make_child_definition(
+            inputs=(
+                WorkflowIODeclaration(
+                    name="quarter",
+                    type=WorkflowValueType.STRING,
+                ),
+            ),
+            outputs=(
+                WorkflowIODeclaration(
+                    name="quarter_echo",
+                    type=WorkflowValueType.STRING,
+                ),
+            ),
+        )
+        await registry.register(child)
+
+        parent = _make_parent_definition(
+            input_bindings={"quarter": "@parent.current_quarter"},
+            output_bindings={"quarter_echo": "@child.quarter"},
+        )
+        service, engine, exec_repo = await _build_service(parent, registry)
+
+        execution = await service.activate(
+            "parent-wf",
+            project="test",
+            activated_by="ceo",
+            context={"current_quarter": "Q4"},
+        )
+
+        # Parent created 2 tasks (before + after) and child created 1.
+        assert len(engine.created) == 3
+        assert len(exec_repo.saved) == 1
+
+        node_ids = [ne.node_id for ne in execution.node_executions]
+        # Parent nodes keep their unqualified IDs
+        assert "parent-before" in node_ids
+        assert "sub-call" in node_ids
+        assert "parent-after" in node_ids
+        # Child nodes carry the qualified prefix
+        assert "sub-call::start" in node_ids
+        assert "sub-call::child-task" in node_ids
+        assert "sub-call::end" in node_ids
+
+        sub_call_exec = next(
+            ne for ne in execution.node_executions if ne.node_id == "sub-call"
+        )
+        assert sub_call_exec.status is WorkflowNodeExecutionStatus.SUBWORKFLOW_COMPLETED
+
+    async def test_unresolved_subworkflow_without_registry_raises(
+        self,
+    ) -> None:
+        parent = _make_parent_definition()
+        task_engine = _FakeTaskEngine()
+        definition_repo = _FakeDefinitionRepo(parent)
+        execution_repo = _FakeExecutionRepo()
+        service = WorkflowExecutionService(
+            definition_repo=definition_repo,  # type: ignore[arg-type]
+            execution_repo=execution_repo,  # type: ignore[arg-type]
+            task_engine=task_engine,  # type: ignore[arg-type]
+            subworkflow_registry=None,
+        )
+
+        from synthorg.engine.errors import WorkflowExecutionError
+
+        with pytest.raises(
+            WorkflowExecutionError,
+            match="no SubworkflowRegistry",
+        ):
+            await service.activate(
+                "parent-wf",
+                project="test",
+                activated_by="ceo",
+            )
+
+    async def test_runtime_depth_limit_enforced(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        """A 3-level deep chain with max_depth=1 is rejected at runtime."""
+        leaf = _make_child_definition(
+            definition_id="leaf-sub",
+            version="1.0.0",
+        )
+        await registry.register(leaf)
+
+        # Middle subworkflow nested one leaf call
+        middle = WorkflowDefinition(
+            id="middle-sub",
+            name="Middle",
+            description="",
+            workflow_type=WorkflowType.SEQUENTIAL_PIPELINE,
+            version="1.0.0",
+            is_subworkflow=True,
+            nodes=(
+                WorkflowNode(
+                    id="start",
+                    type=WorkflowNodeType.START,
+                    label="Start",
+                ),
+                WorkflowNode(
+                    id="inner",
+                    type=WorkflowNodeType.SUBWORKFLOW,
+                    label="Inner",
+                    config={
+                        "subworkflow_id": "leaf-sub",
+                        "version": "1.0.0",
+                        "input_bindings": {},
+                        "output_bindings": {},
+                    },
+                ),
+                WorkflowNode(
+                    id="end",
+                    type=WorkflowNodeType.END,
+                    label="End",
+                ),
+            ),
+            edges=(
+                _seq_edge("me1", "start", "inner"),
+                _seq_edge("me2", "inner", "end"),
+            ),
+            created_by="test",
+            created_at=_NOW,
+            updated_at=_NOW,
+        )
+        await registry.register(middle)
+
+        parent = _make_parent_definition(
+            subworkflow_id="middle-sub",
+            version="1.0.0",
+        )
+        service, _engine, _exec = await _build_service(
+            parent,
+            registry,
+            max_depth=1,
+        )
+
+        with pytest.raises(SubworkflowDepthExceededError) as exc_info:
+            await service.activate(
+                "parent-wf",
+                project="test",
+                activated_by="ceo",
+            )
+        assert exc_info.value.max_depth == 1
+        assert exc_info.value.depth == 2
+
+    async def test_two_level_nesting_under_default_depth(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        """Two-level nesting fits comfortably under the default depth limit."""
+        leaf = _make_child_definition(
+            definition_id="leaf-sub",
+            version="1.0.0",
+        )
+        await registry.register(leaf)
+        middle = WorkflowDefinition(
+            id="middle-sub",
+            name="Middle",
+            description="",
+            workflow_type=WorkflowType.SEQUENTIAL_PIPELINE,
+            version="1.0.0",
+            is_subworkflow=True,
+            nodes=(
+                WorkflowNode(
+                    id="start",
+                    type=WorkflowNodeType.START,
+                    label="Start",
+                ),
+                WorkflowNode(
+                    id="inner",
+                    type=WorkflowNodeType.SUBWORKFLOW,
+                    label="Inner",
+                    config={
+                        "subworkflow_id": "leaf-sub",
+                        "version": "1.0.0",
+                        "input_bindings": {},
+                        "output_bindings": {},
+                    },
+                ),
+                WorkflowNode(
+                    id="end",
+                    type=WorkflowNodeType.END,
+                    label="End",
+                ),
+            ),
+            edges=(
+                _seq_edge("me1", "start", "inner"),
+                _seq_edge("me2", "inner", "end"),
+            ),
+            created_by="test",
+            created_at=_NOW,
+            updated_at=_NOW,
+        )
+        await registry.register(middle)
+
+        parent = _make_parent_definition(subworkflow_id="middle-sub")
+        service, engine, _exec = await _build_service(parent, registry)
+        execution = await service.activate(
+            "parent-wf",
+            project="test",
+            activated_by="ceo",
+        )
+
+        # parent-before + parent-after + middle's child-task (via leaf) +
+        # leaf's own child-task -- wait, middle is not a task-bearing
+        # intermediate.  Actually middle has NO task nodes; the tasks
+        # come from the leaf (child-task) and the parent (before/after).
+        assert len(engine.created) == 3
+        # Deeply nested node ID present
+        node_ids = {ne.node_id for ne in execution.node_executions}
+        assert "sub-call::inner::child-task" in node_ids
+
+    async def test_input_binding_missing_raises_at_runtime(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        child = _make_child_definition(
+            inputs=(
+                WorkflowIODeclaration(
+                    name="quarter",
+                    type=WorkflowValueType.STRING,
+                ),
+            ),
+        )
+        await registry.register(child)
+        parent = _make_parent_definition(input_bindings={})
+        service, _engine, _exec = await _build_service(parent, registry)
+
+        from synthorg.engine.errors import SubworkflowIOError
+
+        with pytest.raises(
+            SubworkflowIOError,
+            match="Missing required input",
+        ):
+            await service.activate(
+                "parent-wf",
+                project="test",
+                activated_by="ceo",
+            )

--- a/tests/unit/engine/workflow/test_execution_service_subworkflows.py
+++ b/tests/unit/engine/workflow/test_execution_service_subworkflows.py
@@ -376,7 +376,7 @@ class TestSubworkflowExecution:
                 activated_by="ceo",
             )
         assert exc_info.value.max_depth == 1
-        assert exc_info.value.depth == 1
+        assert exc_info.value.depth == 2
 
     async def test_two_level_nesting_under_default_depth(
         self,

--- a/tests/unit/engine/workflow/test_io_declaration.py
+++ b/tests/unit/engine/workflow/test_io_declaration.py
@@ -1,0 +1,199 @@
+"""Tests for ``WorkflowIODeclaration`` and ``WorkflowValueType``.
+
+Covers the typed I/O contract model used by subworkflows, including
+name uniqueness, default compatibility, and semver validation on
+``WorkflowDefinition``.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from synthorg.core.enums import WorkflowValueType
+from synthorg.engine.workflow.definition import (
+    WorkflowDefinition,
+    WorkflowIODeclaration,
+)
+from tests.unit.engine.workflow.conftest import (
+    make_edge,
+    make_end_node,
+    make_start_node,
+    make_task_node,
+)
+
+
+def _minimal_kwargs(**overrides: object) -> dict[str, object]:
+    """Build the kwargs for a minimal valid workflow definition."""
+    defaults: dict[str, object] = {
+        "id": "wf-1",
+        "name": "Test Workflow",
+        "created_by": "test-user",
+        "nodes": (make_start_node(), make_task_node(), make_end_node()),
+        "edges": (
+            make_edge("e1", "start-1", "task-1"),
+            make_edge("e2", "task-1", "end-1"),
+        ),
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+class TestWorkflowIODeclaration:
+    """WorkflowIODeclaration validation."""
+
+    @pytest.mark.unit
+    def test_basic_required_declaration(self) -> None:
+        decl = WorkflowIODeclaration(
+            name="quarter",
+            type=WorkflowValueType.STRING,
+        )
+        assert decl.name == "quarter"
+        assert decl.type is WorkflowValueType.STRING
+        assert decl.required is True
+        assert decl.default is None
+        assert decl.description == ""
+
+    @pytest.mark.unit
+    def test_optional_with_default(self) -> None:
+        decl = WorkflowIODeclaration(
+            name="budget",
+            type=WorkflowValueType.FLOAT,
+            required=False,
+            default=1000.0,
+            description="Quarter budget cap",
+        )
+        assert decl.required is False
+        assert decl.default == 1000.0
+
+    @pytest.mark.unit
+    def test_required_with_default_rejected(self) -> None:
+        with pytest.raises(
+            ValidationError,
+            match="required declarations must not carry a default",
+        ):
+            WorkflowIODeclaration(
+                name="budget",
+                type=WorkflowValueType.FLOAT,
+                required=True,
+                default=0.0,
+            )
+
+    @pytest.mark.unit
+    def test_blank_name_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkflowIODeclaration(name="  ", type=WorkflowValueType.STRING)
+
+    @pytest.mark.unit
+    def test_frozen(self) -> None:
+        decl = WorkflowIODeclaration(name="x", type=WorkflowValueType.STRING)
+        with pytest.raises(ValidationError, match="frozen"):
+            decl.name = "y"  # type: ignore[misc]
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("value_type", list(WorkflowValueType))
+    def test_every_value_type_accepted(
+        self,
+        value_type: WorkflowValueType,
+    ) -> None:
+        decl = WorkflowIODeclaration(name="v", type=value_type)
+        assert decl.type is value_type
+
+
+class TestWorkflowDefinitionSemver:
+    """WorkflowDefinition semver field."""
+
+    @pytest.mark.unit
+    def test_default_version(self) -> None:
+        wf = WorkflowDefinition.model_validate(_minimal_kwargs())
+        assert wf.version == "1.0.0"
+        assert wf.revision == 1
+        assert wf.is_subworkflow is False
+        assert wf.inputs == ()
+        assert wf.outputs == ()
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "version_str",
+        ["0.1.0", "1.2.3", "10.0.0", "1.10.0", "0.0.1"],
+    )
+    def test_valid_semver_accepted(self, version_str: str) -> None:
+        wf = WorkflowDefinition.model_validate(
+            _minimal_kwargs(version=version_str),
+        )
+        assert wf.version == version_str
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "version_str",
+        ["not-a-version", "x.y.z", "abc"],
+    )
+    def test_invalid_semver_rejected(self, version_str: str) -> None:
+        with pytest.raises(ValidationError, match="Invalid version"):
+            WorkflowDefinition.model_validate(
+                _minimal_kwargs(version=version_str),
+            )
+
+    @pytest.mark.unit
+    def test_blank_version_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkflowDefinition.model_validate(_minimal_kwargs(version="  "))
+
+
+class TestWorkflowDefinitionIODeclarations:
+    """WorkflowDefinition inputs / outputs."""
+
+    @pytest.mark.unit
+    def test_inputs_and_outputs_round_trip(self) -> None:
+        inputs = (
+            WorkflowIODeclaration(name="quarter", type=WorkflowValueType.STRING),
+            WorkflowIODeclaration(
+                name="budget",
+                type=WorkflowValueType.FLOAT,
+                required=False,
+                default=1000.0,
+            ),
+        )
+        outputs = (
+            WorkflowIODeclaration(
+                name="closing_report",
+                type=WorkflowValueType.STRING,
+            ),
+        )
+        wf = WorkflowDefinition.model_validate(
+            _minimal_kwargs(
+                inputs=inputs,
+                outputs=outputs,
+                is_subworkflow=True,
+            ),
+        )
+        assert wf.inputs == inputs
+        assert wf.outputs == outputs
+        assert wf.is_subworkflow is True
+
+    @pytest.mark.unit
+    def test_duplicate_input_names_rejected(self) -> None:
+        inputs = (
+            WorkflowIODeclaration(name="x", type=WorkflowValueType.STRING),
+            WorkflowIODeclaration(name="x", type=WorkflowValueType.INTEGER),
+        )
+        with pytest.raises(ValidationError, match="Duplicate input"):
+            WorkflowDefinition.model_validate(_minimal_kwargs(inputs=inputs))
+
+    @pytest.mark.unit
+    def test_duplicate_output_names_rejected(self) -> None:
+        outputs = (
+            WorkflowIODeclaration(name="y", type=WorkflowValueType.STRING),
+            WorkflowIODeclaration(name="y", type=WorkflowValueType.INTEGER),
+        )
+        with pytest.raises(ValidationError, match="Duplicate output"):
+            WorkflowDefinition.model_validate(_minimal_kwargs(outputs=outputs))
+
+    @pytest.mark.unit
+    def test_input_and_output_can_share_name(self) -> None:
+        """Input names and output names are validated independently."""
+        inputs = (WorkflowIODeclaration(name="q", type=WorkflowValueType.STRING),)
+        outputs = (WorkflowIODeclaration(name="q", type=WorkflowValueType.STRING),)
+        wf = WorkflowDefinition.model_validate(
+            _minimal_kwargs(inputs=inputs, outputs=outputs),
+        )
+        assert wf.inputs[0].name == "q"
+        assert wf.outputs[0].name == "q"

--- a/tests/unit/engine/workflow/test_subworkflow_binding.py
+++ b/tests/unit/engine/workflow/test_subworkflow_binding.py
@@ -1,0 +1,260 @@
+"""Tests for :mod:`synthorg.engine.workflow.subworkflow_binding`."""
+
+from datetime import UTC, datetime
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from synthorg.core.enums import WorkflowValueType
+from synthorg.engine.errors import SubworkflowIOError
+from synthorg.engine.workflow.definition import WorkflowIODeclaration
+from synthorg.engine.workflow.subworkflow_binding import (
+    project_output_bindings,
+    resolve_input_bindings,
+)
+
+
+class TestResolveInputBindings:
+    """resolve_input_bindings covers literals, lookups, defaults, type checks."""
+
+    @pytest.mark.unit
+    def test_literal_pass_through(self) -> None:
+        decls = (WorkflowIODeclaration(name="quarter", type=WorkflowValueType.STRING),)
+        resolved = resolve_input_bindings(
+            bindings={"quarter": "Q4-2026"},
+            parent_vars={},
+            declarations=decls,
+        )
+        assert resolved == {"quarter": "Q4-2026"}
+
+    @pytest.mark.unit
+    def test_parent_dotted_path_lookup(self) -> None:
+        decls = (WorkflowIODeclaration(name="quarter", type=WorkflowValueType.STRING),)
+        resolved = resolve_input_bindings(
+            bindings={"quarter": "@parent.current_quarter"},
+            parent_vars={"current_quarter": "Q4"},
+            declarations=decls,
+        )
+        assert resolved == {"quarter": "Q4"}
+
+    @pytest.mark.unit
+    def test_nested_dotted_path(self) -> None:
+        decls = (WorkflowIODeclaration(name="quarter", type=WorkflowValueType.STRING),)
+        resolved = resolve_input_bindings(
+            bindings={"quarter": "@parent.context.quarter"},
+            parent_vars={"context": {"quarter": "Q4"}},
+            declarations=decls,
+        )
+        assert resolved == {"quarter": "Q4"}
+
+    @pytest.mark.unit
+    def test_missing_required_input_raises(self) -> None:
+        decls = (WorkflowIODeclaration(name="quarter", type=WorkflowValueType.STRING),)
+        with pytest.raises(SubworkflowIOError, match="Missing required input"):
+            resolve_input_bindings(
+                bindings={},
+                parent_vars={},
+                declarations=decls,
+            )
+
+    @pytest.mark.unit
+    def test_unknown_binding_raises(self) -> None:
+        decls = (WorkflowIODeclaration(name="quarter", type=WorkflowValueType.STRING),)
+        with pytest.raises(SubworkflowIOError, match="Unknown input bindings"):
+            resolve_input_bindings(
+                bindings={"quarter": "Q4", "ghost": 42},
+                parent_vars={},
+                declarations=decls,
+            )
+
+    @pytest.mark.unit
+    def test_optional_default_applied(self) -> None:
+        decls = (
+            WorkflowIODeclaration(
+                name="budget",
+                type=WorkflowValueType.FLOAT,
+                required=False,
+                default=1000.0,
+            ),
+        )
+        resolved = resolve_input_bindings(
+            bindings={},
+            parent_vars={},
+            declarations=decls,
+        )
+        assert resolved == {"budget": 1000.0}
+
+    @pytest.mark.unit
+    def test_type_mismatch_string_int(self) -> None:
+        decls = (WorkflowIODeclaration(name="quarter", type=WorkflowValueType.STRING),)
+        with pytest.raises(SubworkflowIOError, match="expects STRING"):
+            resolve_input_bindings(
+                bindings={"quarter": 42},
+                parent_vars={},
+                declarations=decls,
+            )
+
+    @pytest.mark.unit
+    def test_type_mismatch_boolean_int(self) -> None:
+        """Booleans are not accepted for INTEGER fields even though bool is int."""
+        decls = (WorkflowIODeclaration(name="count", type=WorkflowValueType.INTEGER),)
+        with pytest.raises(SubworkflowIOError, match="expects INTEGER"):
+            resolve_input_bindings(
+                bindings={"count": True},
+                parent_vars={},
+                declarations=decls,
+            )
+
+    @pytest.mark.unit
+    def test_datetime_accepted(self) -> None:
+        decls = (WorkflowIODeclaration(name="ts", type=WorkflowValueType.DATETIME),)
+        now = datetime.now(UTC)
+        resolved = resolve_input_bindings(
+            bindings={"ts": now},
+            parent_vars={},
+            declarations=decls,
+        )
+        assert resolved == {"ts": now}
+
+    @pytest.mark.unit
+    def test_task_ref_rejects_blank(self) -> None:
+        decls = (WorkflowIODeclaration(name="task", type=WorkflowValueType.TASK_REF),)
+        with pytest.raises(SubworkflowIOError, match="expects TASK_REF"):
+            resolve_input_bindings(
+                bindings={"task": "  "},
+                parent_vars={},
+                declarations=decls,
+            )
+
+    @pytest.mark.unit
+    def test_json_permissive(self) -> None:
+        decls = (WorkflowIODeclaration(name="payload", type=WorkflowValueType.JSON),)
+        resolved = resolve_input_bindings(
+            bindings={"payload": {"a": [1, 2, 3]}},
+            parent_vars={},
+            declarations=decls,
+        )
+        assert resolved == {"payload": {"a": [1, 2, 3]}}
+
+    @pytest.mark.unit
+    def test_scoping_parent_key_outside_declarations_invisible(self) -> None:
+        """Parent keys not referenced by a binding do not leak into resolved."""
+        decls = (WorkflowIODeclaration(name="quarter", type=WorkflowValueType.STRING),)
+        resolved = resolve_input_bindings(
+            bindings={"quarter": "@parent.current_quarter"},
+            parent_vars={"current_quarter": "Q4", "secret": "leaked"},
+            declarations=decls,
+        )
+        assert "secret" not in resolved
+        assert resolved == {"quarter": "Q4"}
+
+    @pytest.mark.unit
+    def test_missing_parent_key_raises(self) -> None:
+        decls = (WorkflowIODeclaration(name="quarter", type=WorkflowValueType.STRING),)
+        with pytest.raises(SubworkflowIOError, match="missing segment"):
+            resolve_input_bindings(
+                bindings={"quarter": "@parent.missing"},
+                parent_vars={},
+                declarations=decls,
+            )
+
+    @pytest.mark.unit
+    @given(
+        quarter=st.text(min_size=1, max_size=10).filter(
+            lambda s: not s.startswith("@"),
+        ),
+    )
+    def test_literal_strings_round_trip(self, quarter: str) -> None:
+        decls = (WorkflowIODeclaration(name="quarter", type=WorkflowValueType.STRING),)
+        resolved = resolve_input_bindings(
+            bindings={"quarter": quarter},
+            parent_vars={},
+            declarations=decls,
+        )
+        assert resolved["quarter"] == quarter
+
+
+class TestProjectOutputBindings:
+    """project_output_bindings covers the reverse path."""
+
+    @pytest.mark.unit
+    def test_child_dotted_path(self) -> None:
+        decls = (
+            WorkflowIODeclaration(
+                name="closing_report",
+                type=WorkflowValueType.STRING,
+            ),
+        )
+        projected = project_output_bindings(
+            bindings={"closing_report": "@child.report"},
+            child_vars={"report": "Q4 closed"},
+            declarations=decls,
+        )
+        assert projected == {"closing_report": "Q4 closed"}
+
+    @pytest.mark.unit
+    def test_literal_output(self) -> None:
+        decls = (
+            WorkflowIODeclaration(
+                name="status",
+                type=WorkflowValueType.STRING,
+            ),
+        )
+        projected = project_output_bindings(
+            bindings={"status": "ok"},
+            child_vars={},
+            declarations=decls,
+        )
+        assert projected == {"status": "ok"}
+
+    @pytest.mark.unit
+    def test_missing_required_output_raises(self) -> None:
+        decls = (
+            WorkflowIODeclaration(
+                name="status",
+                type=WorkflowValueType.STRING,
+            ),
+        )
+        with pytest.raises(
+            SubworkflowIOError,
+            match="Missing required output",
+        ):
+            project_output_bindings(
+                bindings={},
+                child_vars={},
+                declarations=decls,
+            )
+
+    @pytest.mark.unit
+    def test_unknown_output_binding_raises(self) -> None:
+        decls = (
+            WorkflowIODeclaration(
+                name="status",
+                type=WorkflowValueType.STRING,
+            ),
+        )
+        with pytest.raises(
+            SubworkflowIOError,
+            match="Unknown output bindings",
+        ):
+            project_output_bindings(
+                bindings={"ghost": "x"},
+                child_vars={},
+                declarations=decls,
+            )
+
+    @pytest.mark.unit
+    def test_output_type_mismatch(self) -> None:
+        decls = (
+            WorkflowIODeclaration(
+                name="count",
+                type=WorkflowValueType.INTEGER,
+            ),
+        )
+        with pytest.raises(SubworkflowIOError, match="expects INTEGER"):
+            project_output_bindings(
+                bindings={"count": "not a number"},
+                child_vars={},
+                declarations=decls,
+            )

--- a/tests/unit/engine/workflow/test_subworkflow_binding.py
+++ b/tests/unit/engine/workflow/test_subworkflow_binding.py
@@ -258,3 +258,83 @@ class TestProjectOutputBindings:
                 child_vars={},
                 declarations=decls,
             )
+
+    @pytest.mark.unit
+    def test_parent_pass_through_binding(self) -> None:
+        decls = (
+            WorkflowIODeclaration(
+                name="context",
+                type=WorkflowValueType.STRING,
+            ),
+        )
+        projected = project_output_bindings(
+            bindings={"context": "@parent.env"},
+            child_vars={},
+            declarations=decls,
+            parent_vars={"env": "production"},
+        )
+        assert projected == {"context": "production"}
+
+
+class TestBooleanAndAgentRefTypes:
+    """Cover BOOLEAN and AGENT_REF type validation paths."""
+
+    @pytest.mark.unit
+    def test_boolean_input_accepted(self) -> None:
+        decls = (WorkflowIODeclaration(name="flag", type=WorkflowValueType.BOOLEAN),)
+        resolved = resolve_input_bindings(
+            bindings={"flag": True},
+            parent_vars={},
+            declarations=decls,
+        )
+        assert resolved["flag"] is True
+
+    @pytest.mark.unit
+    def test_boolean_rejects_int(self) -> None:
+        decls = (WorkflowIODeclaration(name="flag", type=WorkflowValueType.BOOLEAN),)
+        with pytest.raises(SubworkflowIOError, match="expects BOOLEAN"):
+            resolve_input_bindings(
+                bindings={"flag": 1},
+                parent_vars={},
+                declarations=decls,
+            )
+
+    @pytest.mark.unit
+    def test_agent_ref_accepted(self) -> None:
+        decls = (WorkflowIODeclaration(name="agent", type=WorkflowValueType.AGENT_REF),)
+        resolved = resolve_input_bindings(
+            bindings={"agent": "agent-001"},
+            parent_vars={},
+            declarations=decls,
+        )
+        assert resolved["agent"] == "agent-001"
+
+    @pytest.mark.unit
+    def test_agent_ref_rejects_blank(self) -> None:
+        decls = (WorkflowIODeclaration(name="agent", type=WorkflowValueType.AGENT_REF),)
+        with pytest.raises(SubworkflowIOError, match="expects AGENT_REF"):
+            resolve_input_bindings(
+                bindings={"agent": "   "},
+                parent_vars={},
+                declarations=decls,
+            )
+
+    @pytest.mark.unit
+    def test_boolean_output_accepted(self) -> None:
+        decls = (WorkflowIODeclaration(name="ok", type=WorkflowValueType.BOOLEAN),)
+        projected = project_output_bindings(
+            bindings={"ok": "@child.success"},
+            child_vars={"success": False},
+            declarations=decls,
+        )
+        assert projected["ok"] is False
+
+    @pytest.mark.unit
+    def test_agent_ref_output_accepted(self) -> None:
+        decls = (WorkflowIODeclaration(name="agent", type=WorkflowValueType.AGENT_REF),)
+        projected = project_output_bindings(
+            bindings={"agent": "@child.assigned"},
+            child_vars={"assigned": "agent-002"},
+            declarations=decls,
+        )
+        assert projected["agent"] == "agent-002"

--- a/tests/unit/engine/workflow/test_subworkflow_registry.py
+++ b/tests/unit/engine/workflow/test_subworkflow_registry.py
@@ -86,7 +86,7 @@ class FakeSubworkflowRepository(SubworkflowRepository):
 
     def __init__(self) -> None:
         self._rows: dict[tuple[str, str], WorkflowDefinition] = {}
-        self._parents: list[ParentReference] = []
+        self._parents: dict[str, list[ParentReference]] = {}
 
     async def save(self, definition: WorkflowDefinition) -> None:
         key = (definition.id, definition.version)
@@ -156,13 +156,15 @@ class FakeSubworkflowRepository(SubworkflowRepository):
         version: str | None = None,
     ) -> tuple[ParentReference, ...]:
         matching = [
-            p for p in self._parents if version is None or p.pinned_version == version
+            p
+            for p in self._parents.get(subworkflow_id, [])
+            if version is None or p.pinned_version == version
         ]
         return tuple(matching)
 
-    def add_parent(self, parent: ParentReference) -> None:
+    def add_parent(self, subworkflow_id: str, parent: ParentReference) -> None:
         """Test helper to inject a parent reference."""
-        self._parents.append(parent)
+        self._parents.setdefault(subworkflow_id, []).append(parent)
 
 
 @pytest.fixture
@@ -259,6 +261,7 @@ class TestDeleteProtection:
         fake_repo = registry._repo
         assert isinstance(fake_repo, FakeSubworkflowRepository)
         fake_repo.add_parent(
+            "sub-finance-close",
             ParentReference(
                 parent_id="parent-1",
                 parent_name="Parent Workflow",

--- a/tests/unit/engine/workflow/test_subworkflow_registry.py
+++ b/tests/unit/engine/workflow/test_subworkflow_registry.py
@@ -1,0 +1,315 @@
+"""Tests for :class:`SubworkflowRegistry`."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from synthorg.core.enums import (
+    WorkflowEdgeType,
+    WorkflowNodeType,
+    WorkflowType,
+)
+from synthorg.engine.errors import (
+    SubworkflowIOError,
+    SubworkflowNotFoundError,
+)
+from synthorg.engine.workflow.definition import (
+    WorkflowDefinition,
+    WorkflowEdge,
+    WorkflowIODeclaration,
+    WorkflowNode,
+)
+from synthorg.engine.workflow.subworkflow_registry import (
+    MAX_WORKFLOW_DEPTH,
+    SubworkflowRegistry,
+)
+from synthorg.persistence.errors import DuplicateRecordError
+from synthorg.persistence.subworkflow_repo import (
+    ParentReference,
+    SubworkflowRepository,
+    SubworkflowSummary,
+)
+
+_DEFAULT_TS = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _make_subworkflow(  # noqa: PLR0913
+    *,
+    subworkflow_id: str = "sub-finance-close",
+    version: str = "1.0.0",
+    name: str = "Finance Close",
+    is_subworkflow: bool = True,
+    inputs: tuple[WorkflowIODeclaration, ...] = (),
+    outputs: tuple[WorkflowIODeclaration, ...] = (),
+) -> WorkflowDefinition:
+    return WorkflowDefinition(
+        id=subworkflow_id,
+        name=name,
+        description="Finance close",
+        workflow_type=WorkflowType.SEQUENTIAL_PIPELINE,
+        version=version,
+        inputs=inputs,
+        outputs=outputs,
+        is_subworkflow=is_subworkflow,
+        nodes=(
+            WorkflowNode(id="s", type=WorkflowNodeType.START, label="Start"),
+            WorkflowNode(
+                id="t",
+                type=WorkflowNodeType.TASK,
+                label="Close",
+                config={"title": "Close", "task_type": "admin"},
+            ),
+            WorkflowNode(id="e", type=WorkflowNodeType.END, label="End"),
+        ),
+        edges=(
+            WorkflowEdge(
+                id="e1",
+                source_node_id="s",
+                target_node_id="t",
+                type=WorkflowEdgeType.SEQUENTIAL,
+            ),
+            WorkflowEdge(
+                id="e2",
+                source_node_id="t",
+                target_node_id="e",
+                type=WorkflowEdgeType.SEQUENTIAL,
+            ),
+        ),
+        created_by="test-user",
+        created_at=_DEFAULT_TS,
+        updated_at=_DEFAULT_TS,
+    )
+
+
+class FakeSubworkflowRepository(SubworkflowRepository):
+    """In-memory fake repository for registry unit tests."""
+
+    def __init__(self) -> None:
+        self._rows: dict[tuple[str, str], WorkflowDefinition] = {}
+        self._parents: list[ParentReference] = []
+
+    async def save(self, definition: WorkflowDefinition) -> None:
+        key = (definition.id, definition.version)
+        if key in self._rows:
+            msg = f"Duplicate {key}"
+            raise DuplicateRecordError(msg)
+        self._rows[key] = definition
+
+    async def get(
+        self,
+        subworkflow_id: str,
+        version: str,
+    ) -> WorkflowDefinition | None:
+        return self._rows.get((subworkflow_id, version))
+
+    async def list_versions(self, subworkflow_id: str) -> tuple[str, ...]:
+        from packaging.version import Version
+
+        versions = [v for (sid, v) in self._rows if sid == subworkflow_id]
+        versions.sort(key=Version, reverse=True)
+        return tuple(versions)
+
+    async def list_summaries(self) -> tuple[SubworkflowSummary, ...]:
+        grouped: dict[str, list[WorkflowDefinition]] = {}
+        for definition in self._rows.values():
+            grouped.setdefault(definition.id, []).append(definition)
+        from packaging.version import Version
+
+        summaries: list[SubworkflowSummary] = []
+        for sub_id, items in grouped.items():
+            items.sort(key=lambda d: Version(d.version), reverse=True)
+            latest = items[0]
+            summaries.append(
+                SubworkflowSummary(
+                    subworkflow_id=sub_id,
+                    latest_version=latest.version,
+                    name=latest.name,
+                    description=latest.description,
+                    input_count=len(latest.inputs),
+                    output_count=len(latest.outputs),
+                    version_count=len(items),
+                ),
+            )
+        return tuple(summaries)
+
+    async def search(self, query: str) -> tuple[SubworkflowSummary, ...]:
+        q = query.lower()
+        summaries = await self.list_summaries()
+        return tuple(
+            s for s in summaries if q in s.name.lower() or q in s.description.lower()
+        )
+
+    async def delete(
+        self,
+        subworkflow_id: str,
+        version: str,
+    ) -> bool:
+        key = (subworkflow_id, version)
+        if key in self._rows:
+            del self._rows[key]
+            return True
+        return False
+
+    async def find_parents(
+        self,
+        subworkflow_id: str,
+        version: str | None = None,
+    ) -> tuple[ParentReference, ...]:
+        matching = [
+            p for p in self._parents if version is None or p.pinned_version == version
+        ]
+        return tuple(matching)
+
+    def add_parent(self, parent: ParentReference) -> None:
+        """Test helper to inject a parent reference."""
+        self._parents.append(parent)
+
+
+@pytest.fixture
+def registry() -> SubworkflowRegistry:
+    return SubworkflowRegistry(FakeSubworkflowRepository())
+
+
+class TestRegister:
+    @pytest.mark.unit
+    async def test_register_sets_registered_event(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        sub = _make_subworkflow()
+        await registry.register(sub)
+
+        fetched = await registry.get("sub-finance-close", "1.0.0")
+        assert fetched.id == "sub-finance-close"
+
+    @pytest.mark.unit
+    async def test_register_rejects_non_subworkflow(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        sub = _make_subworkflow(is_subworkflow=False)
+        with pytest.raises(
+            SubworkflowIOError,
+            match="is_subworkflow flag is False",
+        ):
+            await registry.register(sub)
+
+    @pytest.mark.unit
+    async def test_register_duplicate_raises(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        sub = _make_subworkflow()
+        await registry.register(sub)
+        with pytest.raises(DuplicateRecordError):
+            await registry.register(sub)
+
+
+class TestGet:
+    @pytest.mark.unit
+    async def test_get_missing_raises(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        with pytest.raises(SubworkflowNotFoundError) as exc_info:
+            await registry.get("sub-missing", "1.0.0")
+        assert exc_info.value.subworkflow_id == "sub-missing"
+        assert exc_info.value.version == "1.0.0"
+
+
+class TestVersionOrdering:
+    @pytest.mark.unit
+    async def test_list_versions_semver_descending(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        for version in ["1.0.0", "1.9.0", "1.10.0", "2.0.0"]:
+            await registry.register(_make_subworkflow(version=version))
+
+        versions = await registry.list_versions("sub-finance-close")
+        assert versions == ("2.0.0", "1.10.0", "1.9.0", "1.0.0")
+
+    @pytest.mark.unit
+    async def test_latest_version(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        await registry.register(_make_subworkflow(version="1.9.0"))
+        await registry.register(_make_subworkflow(version="1.10.0"))
+        latest = await registry.latest_version("sub-finance-close")
+        assert latest == "1.10.0"
+
+    @pytest.mark.unit
+    async def test_latest_version_missing(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        assert await registry.latest_version("sub-nope") is None
+
+
+class TestDeleteProtection:
+    @pytest.mark.unit
+    async def test_delete_blocked_by_pinned_parent(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        sub = _make_subworkflow()
+        await registry.register(sub)
+
+        fake_repo = registry._repo
+        assert isinstance(fake_repo, FakeSubworkflowRepository)
+        fake_repo.add_parent(
+            ParentReference(
+                parent_id="parent-1",
+                parent_name="Parent Workflow",
+                pinned_version="1.0.0",
+                node_id="sub-node",
+            ),
+        )
+
+        with pytest.raises(
+            SubworkflowIOError,
+            match="still referenced by 1 parent",
+        ):
+            await registry.delete("sub-finance-close", "1.0.0")
+
+    @pytest.mark.unit
+    async def test_delete_missing_raises(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        with pytest.raises(SubworkflowNotFoundError):
+            await registry.delete("sub-missing", "1.0.0")
+
+    @pytest.mark.unit
+    async def test_delete_success_without_parents(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        sub = _make_subworkflow()
+        await registry.register(sub)
+        await registry.delete("sub-finance-close", "1.0.0")
+        assert await registry.latest_version("sub-finance-close") is None
+
+
+class TestSearch:
+    @pytest.mark.unit
+    async def test_search_matches_name(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        await registry.register(
+            _make_subworkflow(subworkflow_id="sub-a", name="Alpha Close"),
+        )
+        await registry.register(
+            _make_subworkflow(subworkflow_id="sub-b", name="Beta Review"),
+        )
+        results = await registry.search("alpha")
+        assert len(results) == 1
+        assert results[0].subworkflow_id == "sub-a"
+
+
+class TestMaxWorkflowDepth:
+    @pytest.mark.unit
+    def test_max_depth_default(self) -> None:
+        assert MAX_WORKFLOW_DEPTH == 16

--- a/tests/unit/engine/workflow/test_subworkflow_validation.py
+++ b/tests/unit/engine/workflow/test_subworkflow_validation.py
@@ -1,0 +1,473 @@
+"""Tests for subworkflow-aware validation.
+
+Covers :func:`validate_subworkflow_io` (save-time I/O contract checks)
+and :func:`validate_subworkflow_graph` (static reference cycle
+detection across the subworkflow registry).
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from synthorg.core.enums import (
+    WorkflowEdgeType,
+    WorkflowNodeType,
+    WorkflowType,
+    WorkflowValueType,
+)
+from synthorg.engine.workflow.definition import (
+    WorkflowDefinition,
+    WorkflowEdge,
+    WorkflowIODeclaration,
+    WorkflowNode,
+)
+from synthorg.engine.workflow.subworkflow_registry import SubworkflowRegistry
+from synthorg.engine.workflow.validation import (
+    ValidationErrorCode,
+    validate_subworkflow_graph,
+    validate_subworkflow_io,
+)
+from tests.unit.engine.workflow.test_subworkflow_registry import (
+    FakeSubworkflowRepository,
+)
+
+_DEFAULT_TS = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _make_minimal_definition(  # noqa: PLR0913
+    *,
+    definition_id: str,
+    nodes: tuple[WorkflowNode, ...],
+    edges: tuple[WorkflowEdge, ...],
+    is_subworkflow: bool = False,
+    version: str = "1.0.0",
+    inputs: tuple[WorkflowIODeclaration, ...] = (),
+    outputs: tuple[WorkflowIODeclaration, ...] = (),
+) -> WorkflowDefinition:
+    return WorkflowDefinition(
+        id=definition_id,
+        name=definition_id,
+        description="",
+        workflow_type=WorkflowType.SEQUENTIAL_PIPELINE,
+        version=version,
+        inputs=inputs,
+        outputs=outputs,
+        is_subworkflow=is_subworkflow,
+        nodes=nodes,
+        edges=edges,
+        created_by="test-user",
+        created_at=_DEFAULT_TS,
+        updated_at=_DEFAULT_TS,
+    )
+
+
+def _make_child_subworkflow(
+    *,
+    subworkflow_id: str = "child-sub",
+    version: str = "1.0.0",
+    inputs: tuple[WorkflowIODeclaration, ...] = (),
+    outputs: tuple[WorkflowIODeclaration, ...] = (),
+    nested_refs: tuple[tuple[str, str], ...] = (),
+) -> WorkflowDefinition:
+    nodes: list[WorkflowNode] = [
+        WorkflowNode(id="start", type=WorkflowNodeType.START, label="Start"),
+    ]
+    edges: list[WorkflowEdge] = []
+    prev_id = "start"
+
+    for idx, (nested_id, nested_version) in enumerate(nested_refs):
+        node_id = f"nested-{idx}"
+        nodes.append(
+            WorkflowNode(
+                id=node_id,
+                type=WorkflowNodeType.SUBWORKFLOW,
+                label=f"Nested {idx}",
+                config={
+                    "subworkflow_id": nested_id,
+                    "version": nested_version,
+                    "input_bindings": {},
+                    "output_bindings": {},
+                },
+            ),
+        )
+        edges.append(
+            WorkflowEdge(
+                id=f"e-{idx}",
+                source_node_id=prev_id,
+                target_node_id=node_id,
+                type=WorkflowEdgeType.SEQUENTIAL,
+            ),
+        )
+        prev_id = node_id
+
+    nodes.append(
+        WorkflowNode(id="end", type=WorkflowNodeType.END, label="End"),
+    )
+    edges.append(
+        WorkflowEdge(
+            id="e-end",
+            source_node_id=prev_id,
+            target_node_id="end",
+            type=WorkflowEdgeType.SEQUENTIAL,
+        ),
+    )
+
+    return _make_minimal_definition(
+        definition_id=subworkflow_id,
+        nodes=tuple(nodes),
+        edges=tuple(edges),
+        is_subworkflow=True,
+        version=version,
+        inputs=inputs,
+        outputs=outputs,
+    )
+
+
+def _make_parent_with_subworkflow(
+    *,
+    subworkflow_id: str = "child-sub",
+    version: str = "1.0.0",
+    input_bindings: dict[str, object] | None = None,
+    output_bindings: dict[str, object] | None = None,
+    parent_id: str = "parent-1",
+) -> WorkflowDefinition:
+    config: dict[str, object] = {
+        "subworkflow_id": subworkflow_id,
+        "version": version,
+        "input_bindings": input_bindings or {},
+        "output_bindings": output_bindings or {},
+    }
+    nodes = (
+        WorkflowNode(id="start", type=WorkflowNodeType.START, label="Start"),
+        WorkflowNode(
+            id="sub-call",
+            type=WorkflowNodeType.SUBWORKFLOW,
+            label="Call",
+            config=config,
+        ),
+        WorkflowNode(id="end", type=WorkflowNodeType.END, label="End"),
+    )
+    edges = (
+        WorkflowEdge(
+            id="e1",
+            source_node_id="start",
+            target_node_id="sub-call",
+            type=WorkflowEdgeType.SEQUENTIAL,
+        ),
+        WorkflowEdge(
+            id="e2",
+            source_node_id="sub-call",
+            target_node_id="end",
+            type=WorkflowEdgeType.SEQUENTIAL,
+        ),
+    )
+    return _make_minimal_definition(
+        definition_id=parent_id,
+        nodes=nodes,
+        edges=edges,
+    )
+
+
+@pytest.fixture
+def registry() -> SubworkflowRegistry:
+    return SubworkflowRegistry(FakeSubworkflowRepository())
+
+
+@pytest.mark.unit
+class TestValidateSubworkflowIO:
+    async def test_valid_io_contract(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        child = _make_child_subworkflow(
+            inputs=(
+                WorkflowIODeclaration(
+                    name="quarter",
+                    type=WorkflowValueType.STRING,
+                ),
+            ),
+            outputs=(
+                WorkflowIODeclaration(
+                    name="report",
+                    type=WorkflowValueType.STRING,
+                ),
+            ),
+        )
+        await registry.register(child)
+
+        parent = _make_parent_with_subworkflow(
+            input_bindings={"quarter": "@parent.current_quarter"},
+            output_bindings={"report": "@child.report"},
+        )
+        result = await validate_subworkflow_io(parent, registry)
+        assert result.valid
+
+    async def test_missing_required_input_reported(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        child = _make_child_subworkflow(
+            inputs=(
+                WorkflowIODeclaration(
+                    name="quarter",
+                    type=WorkflowValueType.STRING,
+                ),
+            ),
+        )
+        await registry.register(child)
+
+        parent = _make_parent_with_subworkflow(input_bindings={})
+        result = await validate_subworkflow_io(parent, registry)
+        assert not result.valid
+        codes = {e.code for e in result.errors}
+        assert ValidationErrorCode.SUBWORKFLOW_INPUT_MISSING in codes
+
+    async def test_unknown_input_reported(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        child = _make_child_subworkflow()
+        await registry.register(child)
+
+        parent = _make_parent_with_subworkflow(
+            input_bindings={"ghost": 42},
+        )
+        result = await validate_subworkflow_io(parent, registry)
+        assert not result.valid
+        codes = {e.code for e in result.errors}
+        assert ValidationErrorCode.SUBWORKFLOW_INPUT_UNKNOWN in codes
+
+    async def test_unknown_output_reported(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        child = _make_child_subworkflow()
+        await registry.register(child)
+
+        parent = _make_parent_with_subworkflow(
+            output_bindings={"ghost": 42},
+        )
+        result = await validate_subworkflow_io(parent, registry)
+        assert not result.valid
+        codes = {e.code for e in result.errors}
+        assert ValidationErrorCode.SUBWORKFLOW_OUTPUT_UNKNOWN in codes
+
+    async def test_literal_type_mismatch_reported(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        child = _make_child_subworkflow(
+            inputs=(
+                WorkflowIODeclaration(
+                    name="quarter",
+                    type=WorkflowValueType.INTEGER,
+                ),
+            ),
+        )
+        await registry.register(child)
+
+        parent = _make_parent_with_subworkflow(
+            input_bindings={"quarter": "not an int"},
+        )
+        result = await validate_subworkflow_io(parent, registry)
+        assert not result.valid
+
+    async def test_dotted_expression_deferred_to_runtime(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        """Dotted-path expressions are not type-checked at save time."""
+        child = _make_child_subworkflow(
+            inputs=(
+                WorkflowIODeclaration(
+                    name="quarter",
+                    type=WorkflowValueType.INTEGER,
+                ),
+            ),
+        )
+        await registry.register(child)
+
+        parent = _make_parent_with_subworkflow(
+            input_bindings={"quarter": "@parent.current_quarter"},
+        )
+        result = await validate_subworkflow_io(parent, registry)
+        assert result.valid
+
+    async def test_missing_config_reported(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        parent = _make_parent_with_subworkflow(subworkflow_id="")
+        # Overwrite sub-call config to be invalid
+        new_nodes = []
+        for node in parent.nodes:
+            if node.id == "sub-call":
+                new_nodes.append(
+                    WorkflowNode(
+                        id=node.id,
+                        type=node.type,
+                        label=node.label,
+                        config={},
+                    ),
+                )
+            else:
+                new_nodes.append(node)
+        parent = parent.model_copy(update={"nodes": tuple(new_nodes)})
+
+        result = await validate_subworkflow_io(parent, registry)
+        codes = {e.code for e in result.errors}
+        assert ValidationErrorCode.SUBWORKFLOW_REF_MISSING in codes
+
+    async def test_unresolved_reference_reported(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        parent = _make_parent_with_subworkflow(
+            subworkflow_id="sub-missing",
+            version="1.0.0",
+        )
+        result = await validate_subworkflow_io(parent, registry)
+        codes = {e.code for e in result.errors}
+        assert ValidationErrorCode.SUBWORKFLOW_NOT_FOUND in codes
+
+
+@pytest.mark.unit
+class TestValidateSubworkflowGraph:
+    async def test_no_subworkflows_is_acyclic(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        definition = _make_minimal_definition(
+            definition_id="simple-parent",
+            nodes=(
+                WorkflowNode(
+                    id="s",
+                    type=WorkflowNodeType.START,
+                    label="Start",
+                ),
+                WorkflowNode(
+                    id="t",
+                    type=WorkflowNodeType.TASK,
+                    label="T",
+                    config={"title": "T", "task_type": "admin"},
+                ),
+                WorkflowNode(
+                    id="e",
+                    type=WorkflowNodeType.END,
+                    label="End",
+                ),
+            ),
+            edges=(
+                WorkflowEdge(
+                    id="e1",
+                    source_node_id="s",
+                    target_node_id="t",
+                    type=WorkflowEdgeType.SEQUENTIAL,
+                ),
+                WorkflowEdge(
+                    id="e2",
+                    source_node_id="t",
+                    target_node_id="e",
+                    type=WorkflowEdgeType.SEQUENTIAL,
+                ),
+            ),
+        )
+        result = await validate_subworkflow_graph(definition, registry)
+        assert result.valid
+
+    async def test_linear_chain_acyclic(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        leaf = _make_child_subworkflow(
+            subworkflow_id="leaf",
+            version="1.0.0",
+        )
+        await registry.register(leaf)
+        middle = _make_child_subworkflow(
+            subworkflow_id="middle",
+            version="1.0.0",
+            nested_refs=(("leaf", "1.0.0"),),
+        )
+        await registry.register(middle)
+        parent = _make_parent_with_subworkflow(
+            subworkflow_id="middle",
+            version="1.0.0",
+        )
+        result = await validate_subworkflow_graph(parent, registry)
+        assert result.valid
+
+    async def test_two_subworkflows_cycle_detected(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        """A true two-node cycle is detected.
+
+        Immutable versioning means cycles cannot be produced through the
+        normal ``register`` API (the second definition in a loop would
+        need to reference a future definition).  To exercise the DFS
+        cycle detector, the test mutates the fake repository's internal
+        state directly -- simulating a corrupt write that bypassed save-
+        time validation or a broken migration.  The DFS must still
+        report the cycle as a safety net.
+        """
+        a_v1 = _make_child_subworkflow(
+            subworkflow_id="sub-a",
+            version="1.0.0",
+            nested_refs=(("sub-b", "1.0.0"),),
+        )
+        # sub-b references sub-a@1.0.0 -> after mutation, sub-a@1.0.0
+        # will reference sub-b@1.0.0, closing the loop.
+        b = _make_child_subworkflow(
+            subworkflow_id="sub-b",
+            version="1.0.0",
+            nested_refs=(("sub-a", "1.0.0"),),
+        )
+
+        # Inject both directly into the fake repo (bypasses validation).
+        fake_repo = registry._repo
+        assert isinstance(fake_repo, FakeSubworkflowRepository)
+        fake_repo._rows[("sub-a", "1.0.0")] = a_v1
+        fake_repo._rows[("sub-b", "1.0.0")] = b
+
+        parent = _make_parent_with_subworkflow(
+            subworkflow_id="sub-a",
+            version="1.0.0",
+        )
+        result = await validate_subworkflow_graph(parent, registry)
+        codes = {e.code for e in result.errors}
+        assert ValidationErrorCode.SUBWORKFLOW_CYCLE_DETECTED in codes
+
+    async def test_three_deep_cycle_detected(
+        self,
+        registry: SubworkflowRegistry,
+    ) -> None:
+        """A 3-node cycle is detected via direct repo injection."""
+        a = _make_child_subworkflow(
+            subworkflow_id="sub-a",
+            version="1.0.0",
+            nested_refs=(("sub-b", "1.0.0"),),
+        )
+        b = _make_child_subworkflow(
+            subworkflow_id="sub-b",
+            version="1.0.0",
+            nested_refs=(("sub-c", "1.0.0"),),
+        )
+        c = _make_child_subworkflow(
+            subworkflow_id="sub-c",
+            version="1.0.0",
+            nested_refs=(("sub-a", "1.0.0"),),
+        )
+        fake_repo = registry._repo
+        assert isinstance(fake_repo, FakeSubworkflowRepository)
+        fake_repo._rows[("sub-a", "1.0.0")] = a
+        fake_repo._rows[("sub-b", "1.0.0")] = b
+        fake_repo._rows[("sub-c", "1.0.0")] = c
+
+        parent = _make_parent_with_subworkflow(
+            subworkflow_id="sub-a",
+            version="1.0.0",
+        )
+        result = await validate_subworkflow_graph(parent, registry)
+        codes = {e.code for e in result.errors}
+        assert ValidationErrorCode.SUBWORKFLOW_CYCLE_DETECTED in codes

--- a/tests/unit/engine/workflow/test_yaml_export_subworkflows.py
+++ b/tests/unit/engine/workflow/test_yaml_export_subworkflows.py
@@ -1,0 +1,231 @@
+"""Tests for subworkflow fields in YAML export output."""
+
+from datetime import UTC, datetime
+
+import pytest
+import yaml
+
+from synthorg.core.enums import (
+    WorkflowEdgeType,
+    WorkflowNodeType,
+    WorkflowType,
+    WorkflowValueType,
+)
+from synthorg.engine.workflow.definition import (
+    WorkflowDefinition,
+    WorkflowEdge,
+    WorkflowIODeclaration,
+    WorkflowNode,
+)
+from synthorg.engine.workflow.yaml_export import export_workflow_yaml
+
+_NOW = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _minimal_parent_with_subworkflow_node() -> WorkflowDefinition:
+    return WorkflowDefinition(
+        id="wfdef-parent",
+        name="Parent Workflow",
+        description="Uses a subworkflow",
+        workflow_type=WorkflowType.SEQUENTIAL_PIPELINE,
+        version="2.1.0",
+        is_subworkflow=False,
+        nodes=(
+            WorkflowNode(
+                id="start",
+                type=WorkflowNodeType.START,
+                label="Start",
+            ),
+            WorkflowNode(
+                id="before",
+                type=WorkflowNodeType.TASK,
+                label="Before",
+                config={"title": "Before", "task_type": "development"},
+            ),
+            WorkflowNode(
+                id="call-sub",
+                type=WorkflowNodeType.SUBWORKFLOW,
+                label="Call Sub",
+                config={
+                    "subworkflow_id": "sub-finance-close",
+                    "version": "1.0.0",
+                    "input_bindings": {"quarter": "@parent.current_quarter"},
+                    "output_bindings": {"report": "@child.report"},
+                },
+            ),
+            WorkflowNode(
+                id="end",
+                type=WorkflowNodeType.END,
+                label="End",
+            ),
+        ),
+        edges=(
+            WorkflowEdge(
+                id="e1",
+                source_node_id="start",
+                target_node_id="before",
+                type=WorkflowEdgeType.SEQUENTIAL,
+            ),
+            WorkflowEdge(
+                id="e2",
+                source_node_id="before",
+                target_node_id="call-sub",
+                type=WorkflowEdgeType.SEQUENTIAL,
+            ),
+            WorkflowEdge(
+                id="e3",
+                source_node_id="call-sub",
+                target_node_id="end",
+                type=WorkflowEdgeType.SEQUENTIAL,
+            ),
+        ),
+        created_by="test",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+
+
+def _subworkflow_definition() -> WorkflowDefinition:
+    return WorkflowDefinition(
+        id="sub-finance-close",
+        name="Finance Close",
+        description="",
+        workflow_type=WorkflowType.SEQUENTIAL_PIPELINE,
+        version="1.0.0",
+        is_subworkflow=True,
+        inputs=(
+            WorkflowIODeclaration(
+                name="quarter",
+                type=WorkflowValueType.STRING,
+            ),
+        ),
+        outputs=(
+            WorkflowIODeclaration(
+                name="report",
+                type=WorkflowValueType.STRING,
+            ),
+        ),
+        nodes=(
+            WorkflowNode(
+                id="s",
+                type=WorkflowNodeType.START,
+                label="Start",
+            ),
+            WorkflowNode(
+                id="t",
+                type=WorkflowNodeType.TASK,
+                label="Close",
+                config={"title": "Close", "task_type": "admin"},
+            ),
+            WorkflowNode(
+                id="e",
+                type=WorkflowNodeType.END,
+                label="End",
+            ),
+        ),
+        edges=(
+            WorkflowEdge(
+                id="e1",
+                source_node_id="s",
+                target_node_id="t",
+                type=WorkflowEdgeType.SEQUENTIAL,
+            ),
+            WorkflowEdge(
+                id="e2",
+                source_node_id="t",
+                target_node_id="e",
+                type=WorkflowEdgeType.SEQUENTIAL,
+            ),
+        ),
+        created_by="test",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+
+
+@pytest.mark.unit
+class TestYamlExportSubworkflowFields:
+    def test_parent_exports_subworkflow_node(self) -> None:
+        parent = _minimal_parent_with_subworkflow_node()
+        yaml_text = export_workflow_yaml(parent)
+        doc = yaml.safe_load(yaml_text)
+
+        body = doc["workflow_definition"]
+        assert body["name"] == "Parent Workflow"
+        assert body["version"] == "2.1.0"
+        assert body["is_subworkflow"] is False
+
+        steps = body["steps"]
+        sub_step = next(s for s in steps if s["id"] == "call-sub")
+        assert sub_step["type"] == "subworkflow"
+        assert sub_step["subworkflow_id"] == "sub-finance-close"
+        assert sub_step["version"] == "1.0.0"
+        assert sub_step["input_bindings"] == {"quarter": "@parent.current_quarter"}
+        assert sub_step["output_bindings"] == {"report": "@child.report"}
+
+    def test_subworkflow_definition_exports_io_contract(self) -> None:
+        sub = _subworkflow_definition()
+        yaml_text = export_workflow_yaml(sub)
+        doc = yaml.safe_load(yaml_text)
+
+        body = doc["workflow_definition"]
+        assert body["name"] == "Finance Close"
+        assert body["version"] == "1.0.0"
+        assert body["is_subworkflow"] is True
+        assert len(body["inputs"]) == 1
+        assert body["inputs"][0]["name"] == "quarter"
+        assert body["inputs"][0]["type"] == "string"
+        assert len(body["outputs"]) == 1
+        assert body["outputs"][0]["name"] == "report"
+
+    def test_parent_without_subworkflow_still_valid(self) -> None:
+        """Parent without any SUBWORKFLOW node omits the io arrays."""
+        definition = WorkflowDefinition(
+            id="plain",
+            name="Plain",
+            description="",
+            workflow_type=WorkflowType.SEQUENTIAL_PIPELINE,
+            version="1.0.0",
+            is_subworkflow=False,
+            nodes=(
+                WorkflowNode(
+                    id="start",
+                    type=WorkflowNodeType.START,
+                    label="Start",
+                ),
+                WorkflowNode(
+                    id="t",
+                    type=WorkflowNodeType.TASK,
+                    label="T",
+                    config={"title": "T", "task_type": "development"},
+                ),
+                WorkflowNode(
+                    id="end",
+                    type=WorkflowNodeType.END,
+                    label="End",
+                ),
+            ),
+            edges=(
+                WorkflowEdge(
+                    id="e1",
+                    source_node_id="start",
+                    target_node_id="t",
+                    type=WorkflowEdgeType.SEQUENTIAL,
+                ),
+                WorkflowEdge(
+                    id="e2",
+                    source_node_id="t",
+                    target_node_id="end",
+                    type=WorkflowEdgeType.SEQUENTIAL,
+                ),
+            ),
+            created_by="test",
+            created_at=_NOW,
+            updated_at=_NOW,
+        )
+        yaml_text = export_workflow_yaml(definition)
+        doc = yaml.safe_load(yaml_text)
+        body = doc["workflow_definition"]
+        assert "inputs" not in body
+        assert "outputs" not in body
+        assert body["version"] == "1.0.0"

--- a/tests/unit/persistence/sqlite/test_subworkflow_repo.py
+++ b/tests/unit/persistence/sqlite/test_subworkflow_repo.py
@@ -1,0 +1,421 @@
+"""Tests for :class:`SQLiteSubworkflowRepository`."""
+
+import json
+from datetime import UTC, datetime
+
+import aiosqlite
+import pytest
+
+from synthorg.core.enums import (
+    WorkflowNodeType,
+    WorkflowType,
+    WorkflowValueType,
+)
+from synthorg.engine.workflow.definition import (
+    WorkflowDefinition,
+    WorkflowEdge,
+    WorkflowIODeclaration,
+    WorkflowNode,
+)
+from synthorg.persistence.errors import DuplicateRecordError
+from synthorg.persistence.sqlite.subworkflow_repo import (
+    SQLiteSubworkflowRepository,
+)
+
+_DEFAULT_TS = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def repo(
+    migrated_db: aiosqlite.Connection,
+) -> SQLiteSubworkflowRepository:
+    return SQLiteSubworkflowRepository(migrated_db)
+
+
+def _make_nodes() -> tuple[WorkflowNode, ...]:
+    return (
+        WorkflowNode(
+            id="start-1",
+            type=WorkflowNodeType.START,
+            label="Start",
+        ),
+        WorkflowNode(
+            id="task-1",
+            type=WorkflowNodeType.TASK,
+            label="Do work",
+            config={"title": "Do work", "task_type": "development"},
+        ),
+        WorkflowNode(
+            id="end-1",
+            type=WorkflowNodeType.END,
+            label="End",
+        ),
+    )
+
+
+def _make_edges() -> tuple[WorkflowEdge, ...]:
+    return (
+        WorkflowEdge(
+            id="e1",
+            source_node_id="start-1",
+            target_node_id="task-1",
+        ),
+        WorkflowEdge(
+            id="e2",
+            source_node_id="task-1",
+            target_node_id="end-1",
+        ),
+    )
+
+
+def _make_subworkflow(  # noqa: PLR0913
+    *,
+    subworkflow_id: str = "sub-quarterly-close",
+    version: str = "1.0.0",
+    name: str = "Quarterly Close",
+    description: str = "Quarterly finance close workflow",
+    inputs: tuple[WorkflowIODeclaration, ...] = (),
+    outputs: tuple[WorkflowIODeclaration, ...] = (),
+) -> WorkflowDefinition:
+    return WorkflowDefinition(
+        id=subworkflow_id,
+        name=name,
+        description=description,
+        workflow_type=WorkflowType.SEQUENTIAL_PIPELINE,
+        version=version,
+        inputs=inputs,
+        outputs=outputs,
+        is_subworkflow=True,
+        nodes=_make_nodes(),
+        edges=_make_edges(),
+        created_by="test-user",
+        created_at=_DEFAULT_TS,
+        updated_at=_DEFAULT_TS,
+    )
+
+
+@pytest.mark.unit
+class TestSaveAndGet:
+    """Save and retrieve subworkflow rows."""
+
+    async def test_save_and_get_roundtrip(
+        self,
+        repo: SQLiteSubworkflowRepository,
+    ) -> None:
+        sub = _make_subworkflow(
+            inputs=(
+                WorkflowIODeclaration(
+                    name="quarter",
+                    type=WorkflowValueType.STRING,
+                ),
+            ),
+            outputs=(
+                WorkflowIODeclaration(
+                    name="closing_report",
+                    type=WorkflowValueType.STRING,
+                ),
+            ),
+        )
+        await repo.save(sub)
+
+        loaded = await repo.get("sub-quarterly-close", "1.0.0")
+        assert loaded is not None
+        assert loaded.id == sub.id
+        assert loaded.version == "1.0.0"
+        assert loaded.is_subworkflow is True
+        assert len(loaded.inputs) == 1
+        assert loaded.inputs[0].name == "quarter"
+        assert loaded.inputs[0].type is WorkflowValueType.STRING
+        assert len(loaded.outputs) == 1
+        assert len(loaded.nodes) == 3
+        assert len(loaded.edges) == 2
+
+    async def test_get_missing_returns_none(
+        self,
+        repo: SQLiteSubworkflowRepository,
+    ) -> None:
+        result = await repo.get("sub-nonexistent", "1.0.0")
+        assert result is None
+
+    async def test_duplicate_version_rejected(
+        self,
+        repo: SQLiteSubworkflowRepository,
+    ) -> None:
+        sub = _make_subworkflow()
+        await repo.save(sub)
+
+        duplicate = _make_subworkflow(name="Different Name")
+        with pytest.raises(DuplicateRecordError):
+            await repo.save(duplicate)
+
+
+@pytest.mark.unit
+class TestListVersions:
+    """List semver strings for a subworkflow."""
+
+    async def test_list_versions_sorted_semver_desc(
+        self,
+        repo: SQLiteSubworkflowRepository,
+    ) -> None:
+        for version in ["1.0.0", "1.9.0", "1.10.0", "2.0.0"]:
+            await repo.save(_make_subworkflow(version=version))
+
+        versions = await repo.list_versions("sub-quarterly-close")
+        assert versions == ("2.0.0", "1.10.0", "1.9.0", "1.0.0")
+
+    async def test_list_versions_missing_subworkflow(
+        self,
+        repo: SQLiteSubworkflowRepository,
+    ) -> None:
+        versions = await repo.list_versions("sub-nonexistent")
+        assert versions == ()
+
+
+@pytest.mark.unit
+class TestListSummariesAndSearch:
+    """Summary and search endpoints."""
+
+    async def test_list_summaries_reflects_latest(
+        self,
+        repo: SQLiteSubworkflowRepository,
+    ) -> None:
+        await repo.save(
+            _make_subworkflow(version="1.0.0", name="Close v1.0"),
+        )
+        await repo.save(
+            _make_subworkflow(
+                version="1.10.0",
+                name="Close v1.10",
+                inputs=(
+                    WorkflowIODeclaration(
+                        name="quarter",
+                        type=WorkflowValueType.STRING,
+                    ),
+                ),
+            ),
+        )
+
+        summaries = await repo.list_summaries()
+        assert len(summaries) == 1
+        summary = summaries[0]
+        assert summary.subworkflow_id == "sub-quarterly-close"
+        assert summary.latest_version == "1.10.0"
+        assert summary.name == "Close v1.10"
+        assert summary.input_count == 1
+        assert summary.output_count == 0
+        assert summary.version_count == 2
+
+    async def test_search_matches_name_case_insensitive(
+        self,
+        repo: SQLiteSubworkflowRepository,
+    ) -> None:
+        await repo.save(
+            _make_subworkflow(
+                subworkflow_id="sub-quarterly-close",
+                name="Quarterly Close",
+                description="Finance close workflow",
+            ),
+        )
+        await repo.save(
+            _make_subworkflow(
+                subworkflow_id="sub-weekly-report",
+                name="Weekly Report",
+                description="Status summary",
+            ),
+        )
+
+        results = await repo.search("QUARTERLY")
+        assert len(results) == 1
+        assert results[0].subworkflow_id == "sub-quarterly-close"
+
+
+@pytest.mark.unit
+class TestDelete:
+    """Delete endpoint."""
+
+    async def test_delete_existing_returns_true(
+        self,
+        repo: SQLiteSubworkflowRepository,
+    ) -> None:
+        await repo.save(_make_subworkflow())
+        assert await repo.delete("sub-quarterly-close", "1.0.0") is True
+
+    async def test_delete_missing_returns_false(
+        self,
+        repo: SQLiteSubworkflowRepository,
+    ) -> None:
+        assert await repo.delete("sub-nonexistent", "1.0.0") is False
+
+    async def test_delete_version_leaves_other_versions_intact(
+        self,
+        repo: SQLiteSubworkflowRepository,
+    ) -> None:
+        await repo.save(_make_subworkflow(version="1.0.0"))
+        await repo.save(_make_subworkflow(version="2.0.0"))
+
+        await repo.delete("sub-quarterly-close", "1.0.0")
+        remaining = await repo.list_versions("sub-quarterly-close")
+        assert remaining == ("2.0.0",)
+
+
+@pytest.mark.unit
+class TestFindParents:
+    """find_parents scans workflow_definitions for SUBWORKFLOW nodes."""
+
+    async def test_find_parents_returns_references(
+        self,
+        repo: SQLiteSubworkflowRepository,
+        migrated_db: aiosqlite.Connection,
+    ) -> None:
+        # Insert a parent workflow directly into workflow_definitions
+        # with a SUBWORKFLOW node referencing the subworkflow.
+        parent_nodes = [
+            {
+                "id": "start-1",
+                "type": "start",
+                "label": "Start",
+                "position_x": 0.0,
+                "position_y": 0.0,
+                "config": {},
+            },
+            {
+                "id": "sub-node-1",
+                "type": "subworkflow",
+                "label": "Quarterly Close",
+                "position_x": 100.0,
+                "position_y": 100.0,
+                "config": {
+                    "subworkflow_id": "sub-quarterly-close",
+                    "version": "1.0.0",
+                    "input_bindings": {},
+                    "output_bindings": {},
+                },
+            },
+            {
+                "id": "end-1",
+                "type": "end",
+                "label": "End",
+                "position_x": 200.0,
+                "position_y": 200.0,
+                "config": {},
+            },
+        ]
+        parent_edges = [
+            {
+                "id": "e1",
+                "source_node_id": "start-1",
+                "target_node_id": "sub-node-1",
+                "type": "sequential",
+                "label": None,
+            },
+            {
+                "id": "e2",
+                "source_node_id": "sub-node-1",
+                "target_node_id": "end-1",
+                "type": "sequential",
+                "label": None,
+            },
+        ]
+        await migrated_db.execute(
+            """INSERT INTO workflow_definitions
+               (id, name, description, workflow_type, version, inputs, outputs,
+                is_subworkflow, nodes, edges, created_by, created_at, updated_at,
+                revision)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "parent-1",
+                "Parent Workflow",
+                "",
+                "sequential_pipeline",
+                "1.0.0",
+                "[]",
+                "[]",
+                0,
+                json.dumps(parent_nodes),
+                json.dumps(parent_edges),
+                "test-user",
+                _DEFAULT_TS.isoformat(),
+                _DEFAULT_TS.isoformat(),
+                1,
+            ),
+        )
+        await migrated_db.commit()
+
+        refs = await repo.find_parents("sub-quarterly-close", "1.0.0")
+        assert len(refs) == 1
+        ref = refs[0]
+        assert ref.parent_id == "parent-1"
+        assert ref.parent_name == "Parent Workflow"
+        assert ref.pinned_version == "1.0.0"
+        assert ref.node_id == "sub-node-1"
+
+    async def test_find_parents_filters_by_version(
+        self,
+        repo: SQLiteSubworkflowRepository,
+        migrated_db: aiosqlite.Connection,
+    ) -> None:
+        parent_nodes = [
+            {
+                "id": "start-1",
+                "type": "start",
+                "label": "Start",
+                "position_x": 0.0,
+                "position_y": 0.0,
+                "config": {},
+            },
+            {
+                "id": "sub-node-1",
+                "type": "subworkflow",
+                "label": "Close",
+                "position_x": 100.0,
+                "position_y": 100.0,
+                "config": {
+                    "subworkflow_id": "sub-quarterly-close",
+                    "version": "1.0.0",
+                },
+            },
+            {
+                "id": "end-1",
+                "type": "end",
+                "label": "End",
+                "position_x": 0.0,
+                "position_y": 0.0,
+                "config": {},
+            },
+        ]
+        await migrated_db.execute(
+            """INSERT INTO workflow_definitions
+               (id, name, description, workflow_type, version, inputs, outputs,
+                is_subworkflow, nodes, edges, created_by, created_at, updated_at,
+                revision)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "parent-old",
+                "Parent Old",
+                "",
+                "sequential_pipeline",
+                "1.0.0",
+                "[]",
+                "[]",
+                0,
+                json.dumps(parent_nodes),
+                "[]",
+                "test-user",
+                _DEFAULT_TS.isoformat(),
+                _DEFAULT_TS.isoformat(),
+                1,
+            ),
+        )
+        await migrated_db.commit()
+
+        # Version-specific query should match
+        refs_v1 = await repo.find_parents("sub-quarterly-close", "1.0.0")
+        assert len(refs_v1) == 1
+
+        # Non-matching version should return empty
+        refs_v2 = await repo.find_parents("sub-quarterly-close", "2.0.0")
+        assert len(refs_v2) == 0
+
+        # None means "any version"
+        refs_any = await repo.find_parents("sub-quarterly-close", None)
+        assert len(refs_any) == 1

--- a/tests/unit/persistence/sqlite/test_subworkflow_repo.py
+++ b/tests/unit/persistence/sqlite/test_subworkflow_repo.py
@@ -228,6 +228,33 @@ class TestListSummariesAndSearch:
         assert len(results) == 1
         assert results[0].subworkflow_id == "sub-quarterly-close"
 
+    async def test_search_escapes_like_wildcards(
+        self,
+        repo: SQLiteSubworkflowRepository,
+    ) -> None:
+        await repo.save(
+            _make_subworkflow(
+                subworkflow_id="sub-percent-literal",
+                name="50% Complete Workflow",
+                description="Uses percent sign",
+            ),
+        )
+        await repo.save(
+            _make_subworkflow(
+                subworkflow_id="sub-underscore-literal",
+                name="step_1 setup",
+                description="Uses underscore",
+            ),
+        )
+
+        results = await repo.search("50%")
+        assert len(results) == 1
+        assert results[0].subworkflow_id == "sub-percent-literal"
+
+        results = await repo.search("step_1")
+        assert len(results) == 1
+        assert results[0].subworkflow_id == "sub-underscore-literal"
+
 
 @pytest.mark.unit
 class TestDelete:

--- a/tests/unit/persistence/sqlite/test_workflow_definition_repo.py
+++ b/tests/unit/persistence/sqlite/test_workflow_definition_repo.py
@@ -93,7 +93,7 @@ def _make_definition(  # noqa: PLR0913
     created_by: str = "test-user",
     created_at: datetime = _DEFAULT_TS,
     updated_at: datetime = _DEFAULT_TS,
-    version: int = 1,
+    revision: int = 1,
     node_prefix: str = "n",
 ) -> WorkflowDefinition:
     """Build a complete ``WorkflowDefinition`` for testing."""
@@ -107,7 +107,7 @@ def _make_definition(  # noqa: PLR0913
         created_by=created_by,
         created_at=created_at,
         updated_at=updated_at,
-        version=version,
+        revision=revision,
     )
 
 
@@ -128,6 +128,7 @@ class TestSQLiteWorkflowDefinitionRepository:
         assert result.description == defn.description
         assert result.workflow_type == defn.workflow_type
         assert result.created_by == defn.created_by
+        assert result.revision == defn.revision
         assert result.version == defn.version
         assert len(result.nodes) == len(defn.nodes)
         assert len(result.edges) == len(defn.edges)
@@ -149,7 +150,7 @@ class TestSQLiteWorkflowDefinitionRepository:
         self,
         repo: SQLiteWorkflowDefinitionRepository,
     ) -> None:
-        defn_v1 = _make_definition(version=1)
+        defn_v1 = _make_definition(revision=1)
         await repo.save(defn_v1)
 
         defn_v2 = _make_definition(
@@ -157,7 +158,7 @@ class TestSQLiteWorkflowDefinitionRepository:
             description="Updated description",
             workflow_type=WorkflowType.PARALLEL_EXECUTION,
             updated_at=datetime(2026, 4, 2, 8, 0, 0, tzinfo=UTC),
-            version=2,
+            revision=2,
         )
         await repo.save(defn_v2)
 
@@ -166,27 +167,27 @@ class TestSQLiteWorkflowDefinitionRepository:
         assert result.name == "Updated Workflow"
         assert result.description == "Updated description"
         assert result.workflow_type == WorkflowType.PARALLEL_EXECUTION
-        assert result.version == 2
+        assert result.revision == 2
 
-    async def test_save_rejects_on_version_mismatch(
+    async def test_save_rejects_on_revision_mismatch(
         self,
         repo: SQLiteWorkflowDefinitionRepository,
     ) -> None:
-        defn_v1 = _make_definition(version=1)
+        defn_v1 = _make_definition(revision=1)
         await repo.save(defn_v1)
 
-        # Attempt to save version 3 (skipping 2) -- should raise
+        # Attempt to save revision 3 (skipping 2) -- should raise
         defn_v3 = _make_definition(
-            name="Skipped version",
-            version=3,
+            name="Skipped revision",
+            revision=3,
         )
         with pytest.raises(VersionConflictError, match="Version conflict"):
             await repo.save(defn_v3)
 
-        # Original version 1 should still be stored
+        # Original revision 1 should still be stored
         result = await repo.get("wf-001")
         assert result is not None
-        assert result.version == 1
+        assert result.revision == 1
         assert result.name == "Test Workflow"
 
     async def test_get_not_found(

--- a/tests/unit/persistence/sqlite/test_workflow_execution_repo.py
+++ b/tests/unit/persistence/sqlite/test_workflow_execution_repo.py
@@ -36,7 +36,7 @@ def _make_execution(
     defaults: dict[str, object] = {
         "id": execution_id,
         "definition_id": "wfdef-abc123",
-        "definition_version": 1,
+        "definition_revision": 1,
         "status": WorkflowExecutionStatus.RUNNING,
         "node_executions": (
             WorkflowNodeExecution(
@@ -75,7 +75,7 @@ class TestSaveAndGet:
         assert loaded is not None
         assert loaded.id == exe.id
         assert loaded.definition_id == exe.definition_id
-        assert loaded.definition_version == 1
+        assert loaded.definition_revision == 1
         assert loaded.status is WorkflowExecutionStatus.RUNNING
         assert loaded.activated_by == "test-user"
         assert loaded.project == "test-project"

--- a/tests/unit/persistence/test_protocol.py
+++ b/tests/unit/persistence/test_protocol.py
@@ -553,6 +553,13 @@ class _FakeBackend:
         return _FakeWorkflowExecutionRepository()
 
     @property
+    def subworkflows(self) -> object:
+        # ``PersistenceBackend`` is ``@runtime_checkable``, which only
+        # verifies that the attribute exists -- returning a bare
+        # ``object()`` is enough for the isinstance conformance check.
+        return object()
+
+    @property
     def workflow_versions(self) -> object:
         # ``PersistenceBackend`` is ``@runtime_checkable``, which only
         # verifies that the ``workflow_versions`` attribute exists --

--- a/uv.lock
+++ b/uv.lock
@@ -1068,35 +1068,37 @@ wheels = [
 
 [[package]]
 name = "jiter"
-version = "0.13.0"
+version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/5e/4ec91646aee381d01cdb9974e30882c9cd3b8c5d1079d6b5ff4af522439a/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4", size = 164847, upload-time = "2026-02-02T12:37:56.441Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c1/0cddc6eb17d4c53a99840953f95dd3accdc5cfc7a337b0e9b26476276be9/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e", size = 165725, upload-time = "2026-04-10T14:28:42.01Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/f5/f1997e987211f6f9bd71b8083047b316208b4aca0b529bb5f8c96c89ef3e/jiter-0.13.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cc5223ab19fe25e2f0bf2643204ad7318896fe3729bf12fde41b77bfc4fafff0", size = 308804, upload-time = "2026-02-02T12:36:43.496Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/8f/5482a7677731fd44881f0204981ce2d7175db271f82cba2085dd2212e095/jiter-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9776ebe51713acf438fd9b4405fcd86893ae5d03487546dae7f34993217f8a91", size = 318787, upload-time = "2026-02-02T12:36:45.071Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/b9/7257ac59778f1cd025b26a23c5520a36a424f7f1b068f2442a5b499b7464/jiter-0.13.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:879e768938e7b49b5e90b7e3fecc0dbec01b8cb89595861fb39a8967c5220d09", size = 353880, upload-time = "2026-02-02T12:36:47.365Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/87/719eec4a3f0841dad99e3d3604ee4cba36af4419a76f3cb0b8e2e691ad67/jiter-0.13.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:682161a67adea11e3aae9038c06c8b4a9a71023228767477d683f69903ebc607", size = 366702, upload-time = "2026-02-02T12:36:48.871Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/65/415f0a75cf6921e43365a1bc227c565cb949caca8b7532776e430cbaa530/jiter-0.13.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a13b68cd1cd8cc9de8f244ebae18ccb3e4067ad205220ef324c39181e23bbf66", size = 486319, upload-time = "2026-02-02T12:36:53.006Z" },
-    { url = "https://files.pythonhosted.org/packages/54/a2/9e12b48e82c6bbc6081fd81abf915e1443add1b13d8fc586e1d90bb02bb8/jiter-0.13.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87ce0f14c6c08892b610686ae8be350bf368467b6acd5085a5b65441e2bf36d2", size = 372289, upload-time = "2026-02-02T12:36:54.593Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/c1/e4693f107a1789a239c759a432e9afc592366f04e901470c2af89cfd28e1/jiter-0.13.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c365005b05505a90d1c47856420980d0237adf82f70c4aff7aebd3c1cc143ad", size = 360165, upload-time = "2026-02-02T12:36:56.112Z" },
-    { url = "https://files.pythonhosted.org/packages/17/08/91b9ea976c1c758240614bd88442681a87672eebc3d9a6dde476874e706b/jiter-0.13.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1317fdffd16f5873e46ce27d0e0f7f4f90f0cdf1d86bf6abeaea9f63ca2c401d", size = 389634, upload-time = "2026-02-02T12:36:57.495Z" },
-    { url = "https://files.pythonhosted.org/packages/18/23/58325ef99390d6d40427ed6005bf1ad54f2577866594bcf13ce55675f87d/jiter-0.13.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c05b450d37ba0c9e21c77fef1f205f56bcee2330bddca68d344baebfc55ae0df", size = 514933, upload-time = "2026-02-02T12:36:58.909Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/25/69f1120c7c395fd276c3996bb8adefa9c6b84c12bb7111e5c6ccdcd8526d/jiter-0.13.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:775e10de3849d0631a97c603f996f518159272db00fdda0a780f81752255ee9d", size = 548842, upload-time = "2026-02-02T12:37:00.433Z" },
-    { url = "https://files.pythonhosted.org/packages/18/05/981c9669d86850c5fbb0d9e62bba144787f9fba84546ba43d624ee27ef29/jiter-0.13.0-cp314-cp314-win32.whl", hash = "sha256:632bf7c1d28421c00dd8bbb8a3bac5663e1f57d5cd5ed962bce3c73bf62608e6", size = 202108, upload-time = "2026-02-02T12:37:01.718Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/96/cdcf54dd0b0341db7d25413229888a346c7130bd20820530905fdb65727b/jiter-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:f22ef501c3f87ede88f23f9b11e608581c14f04db59b6a801f354397ae13739f", size = 204027, upload-time = "2026-02-02T12:37:03.075Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/f9/724bcaaab7a3cd727031fe4f6995cb86c4bd344909177c186699c8dec51a/jiter-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:07b75fe09a4ee8e0c606200622e571e44943f47254f95e2436c8bdcaceb36d7d", size = 187199, upload-time = "2026-02-02T12:37:04.414Z" },
-    { url = "https://files.pythonhosted.org/packages/62/92/1661d8b9fd6a3d7a2d89831db26fe3c1509a287d83ad7838831c7b7a5c7e/jiter-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:964538479359059a35fb400e769295d4b315ae61e4105396d355a12f7fef09f0", size = 318423, upload-time = "2026-02-02T12:37:05.806Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/3b/f77d342a54d4ebcd128e520fc58ec2f5b30a423b0fd26acdfc0c6fef8e26/jiter-0.13.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e104da1db1c0991b3eaed391ccd650ae8d947eab1480c733e5a3fb28d4313e40", size = 351438, upload-time = "2026-02-02T12:37:07.189Z" },
-    { url = "https://files.pythonhosted.org/packages/76/b3/ba9a69f0e4209bd3331470c723c2f5509e6f0482e416b612431a5061ed71/jiter-0.13.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e3a5f0cde8ff433b8e88e41aa40131455420fb3649a3c7abdda6145f8cb7202", size = 364774, upload-time = "2026-02-02T12:37:08.579Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/16/6cdb31fa342932602458dbb631bfbd47f601e03d2e4950740e0b2100b570/jiter-0.13.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57aab48f40be1db920a582b30b116fe2435d184f77f0e4226f546794cedd9cf0", size = 487238, upload-time = "2026-02-02T12:37:10.066Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/b1/956cc7abaca8d95c13aa8d6c9b3f3797241c246cd6e792934cc4c8b250d2/jiter-0.13.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7772115877c53f62beeb8fd853cab692dbc04374ef623b30f997959a4c0e7e95", size = 372892, upload-time = "2026-02-02T12:37:11.656Z" },
-    { url = "https://files.pythonhosted.org/packages/26/c4/97ecde8b1e74f67b8598c57c6fccf6df86ea7861ed29da84629cdbba76c4/jiter-0.13.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1211427574b17b633cfceba5040de8081e5abf114f7a7602f73d2e16f9fdaa59", size = 360309, upload-time = "2026-02-02T12:37:13.244Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/d7/eabe3cf46715854ccc80be2cd78dd4c36aedeb30751dbf85a1d08c14373c/jiter-0.13.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7beae3a3d3b5212d3a55d2961db3c292e02e302feb43fce6a3f7a31b90ea6dfe", size = 389607, upload-time = "2026-02-02T12:37:14.881Z" },
-    { url = "https://files.pythonhosted.org/packages/df/2d/03963fc0804e6109b82decfb9974eb92df3797fe7222428cae12f8ccaa0c/jiter-0.13.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e5562a0f0e90a6223b704163ea28e831bd3a9faa3512a711f031611e6b06c939", size = 514986, upload-time = "2026-02-02T12:37:16.326Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/6c/8c83b45eb3eb1c1e18d841fe30b4b5bc5619d781267ca9bc03e005d8fd0a/jiter-0.13.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:6c26a424569a59140fb51160a56df13f438a2b0967365e987889186d5fc2f6f9", size = 548756, upload-time = "2026-02-02T12:37:17.736Z" },
-    { url = "https://files.pythonhosted.org/packages/47/66/eea81dfff765ed66c68fd2ed8c96245109e13c896c2a5015c7839c92367e/jiter-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:24dc96eca9f84da4131cdf87a95e6ce36765c3b156fc9ae33280873b1c32d5f6", size = 201196, upload-time = "2026-02-02T12:37:19.101Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/32/4ac9c7a76402f8f00d00842a7f6b83b284d0cf7c1e9d4227bc95aa6d17fa/jiter-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0a8d76c7524087272c8ae913f5d9d608bd839154b62c4322ef65723d2e5bb0b8", size = 204215, upload-time = "2026-02-02T12:37:20.495Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/8e/7def204fea9f9be8b3c21a6f2dd6c020cf56c7d5ff753e0e23ed7f9ea57e/jiter-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2c26cf47e2cad140fa23b6d58d435a7c0161f5c514284802f25e87fddfe11024", size = 187152, upload-time = "2026-02-02T12:37:22.124Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/1e/354ed92461b165bd581f9ef5150971a572c873ec3b68a916d5aa91da3cc2/jiter-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6f396837fc7577871ca8c12edaf239ed9ccef3bbe39904ae9b8b63ce0a48b140", size = 315277, upload-time = "2026-04-10T14:27:18.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/95/8c7c7028aa8636ac21b7a55faef3e34215e6ed0cbf5ae58258427f621aa3/jiter-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a4d50ea3d8ba4176f79754333bd35f1bbcd28e91adc13eb9b7ca91bc52a6cef9", size = 315923, upload-time = "2026-04-10T14:27:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/47/40/e2a852a44c4a089f2681a16611b7ce113224a80fd8504c46d78491b47220/jiter-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce17f8a050447d1b4153bda4fb7d26e6a9e74eb4f4a41913f30934c5075bf615", size = 344943, upload-time = "2026-04-10T14:27:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/1f/670f92adee1e9895eac41e8a4d623b6da68c4d46249d8b556b60b63f949e/jiter-0.14.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4f1c4b125e1652aefbc2e2c1617b60a160ab789d180e3d423c41439e5f32850", size = 369725, upload-time = "2026-04-10T14:27:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/01/2f/541c9ba567d05de1c4874a0f8f8c5e3fd78e2b874266623da9a775cf46e0/jiter-0.14.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be808176a6a3a14321d18c603f2d40741858a7c4fc982f83232842689fe86dd9", size = 461210, upload-time = "2026-04-10T14:27:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/c31cbec09627e0d5de7aeaec7690dba03e090caa808fefd8133137cf45bc/jiter-0.14.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26679d58ba816f88c3849306dd58cb863a90a1cf352cdd4ef67e30ccf8a77994", size = 380002, upload-time = "2026-04-10T14:27:26.155Z" },
+    { url = "https://files.pythonhosted.org/packages/50/02/3c05c1666c41904a2f607475a73e7a4763d1cbde2d18229c4f85b22dc253/jiter-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80381f5a19af8fa9aef743f080e34f6b25ebd89656475f8cf0470ec6157052aa", size = 354678, upload-time = "2026-04-10T14:27:27.701Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/97/e15b33545c2b13518f560d695f974b9891b311641bdcf178d63177e8801e/jiter-0.14.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:004df5fdb8ecbd6d99f3227df18ba1a259254c4359736a2e6f036c944e02d7c5", size = 358920, upload-time = "2026-04-10T14:27:29.256Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d2/8b1461def6b96ba44530df20d07ef7a1c7da22f3f9bf1727e2d611077bf1/jiter-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cff5708f7ed0fa098f2b53446c6fa74c48469118e5cd7497b4f1cd569ab06928", size = 394512, upload-time = "2026-04-10T14:27:31.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/88/837566dd6ed6e452e8d3205355afd484ce44b2533edfa4ed73a298ea893e/jiter-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:2492e5f06c36a976d25c7cc347a60e26d5470178d44cde1b9b75e60b4e519f28", size = 521120, upload-time = "2026-04-10T14:27:33.299Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6b/b00b45c4d1b4c031777fe161d620b755b5b02cdade1e316dcb46e4471d63/jiter-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:7609cfbe3a03d37bfdbf5052012d5a879e72b83168a363deae7b3a26564d57de", size = 553668, upload-time = "2026-04-10T14:27:34.868Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d8/6fe5b42011d19397433d345716eac16728ac241862a2aac9c91923c7509a/jiter-0.14.0-cp314-cp314-win32.whl", hash = "sha256:7282342d32e357543565286b6450378c3cd402eea333fc1ebe146f1fabb306fc", size = 207001, upload-time = "2026-04-10T14:27:36.455Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/43/5c2e08da1efad5e410f0eaaabeadd954812612c33fbbd8fd5328b489139d/jiter-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd77945f38866a448e73b0b7637366afa814d4617790ecd88a18ca74377e6c02", size = 202187, upload-time = "2026-04-10T14:27:38Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1f/6e39ac0b4cdfa23e606af5b245df5f9adaa76f35e0c5096790da430ca506/jiter-0.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:f2d4c61da0821ee42e0cdf5489da60a6d074306313a377c2b35af464955a3611", size = 192257, upload-time = "2026-04-10T14:27:39.504Z" },
+    { url = "https://files.pythonhosted.org/packages/05/57/7dbc0ffbbb5176a27e3518716608aa464aee2e2887dc938f0b900a120449/jiter-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1bf7ff85517dd2f20a5750081d2b75083c1b269cf75afc7511bdf1f9548beb3b", size = 323441, upload-time = "2026-04-10T14:27:41.039Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6e/7b3314398d8983f06b557aa21b670511ec72d3b79a68ee5e4d9bff972286/jiter-0.14.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8ef8791c3e78d6c6b157c6d360fbb5c715bebb8113bc6a9303c5caff012754a", size = 348109, upload-time = "2026-04-10T14:27:42.552Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4f/8dc674bcd7db6dba566de73c08c763c337058baff1dbeb34567045b27cdc/jiter-0.14.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e74663b8b10da1fe0f4e4703fd7980d24ad17174b6bb35d8498d6e3ebce2ae6a", size = 368328, upload-time = "2026-04-10T14:27:44.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/188e09a1f20906f98bbdec44ed820e19f4e8eb8aff88b9d1a5a497587ff3/jiter-0.14.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1aca29ba52913f78362ec9c2da62f22cdc4c3083313403f90c15460979b84d9b", size = 463301, upload-time = "2026-04-10T14:27:46.717Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f0/19046ef965ed8f349e8554775bb12ff4352f443fbe12b95d31f575891256/jiter-0.14.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b39b7d87a952b79949af5fef44d2544e58c21a28da7f1bae3ef166455c61746", size = 378891, upload-time = "2026-04-10T14:27:48.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c3/da43bd8431ee175695777ee78cf0e93eacbb47393ff493f18c45231b427d/jiter-0.14.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d918a68b26e9fab068c2b5453577ef04943ab2807b9a6275df2a812599a310", size = 360749, upload-time = "2026-04-10T14:27:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/72/26/e054771be889707c6161dbdec9c23d33a9ec70945395d70f07cfea1e9a6f/jiter-0.14.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:b08997c35aee1201c1a5361466a8fb9162d03ae7bf6568df70b6c859f1e654a4", size = 358526, upload-time = "2026-04-10T14:27:51.504Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0f/7bea65ea2a6d91f2bf989ff11a18136644392bf2b0497a1fa50934c30a9c/jiter-0.14.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:260bf7ca20704d58d41f669e5e9fe7fe2fa72901a6b324e79056f5d52e9c9be2", size = 393926, upload-time = "2026-04-10T14:27:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/b1ff7d70deef61ac0b7c6c2f12d2ace950cdeecb4fdc94500a0926802857/jiter-0.14.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:37826e3df29e60f30a382f9294348d0238ef127f4b5d7f5f8da78b5b9e050560", size = 521052, upload-time = "2026-04-10T14:27:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7b/3b0649983cbaf15eda26a414b5b1982e910c67bd6f7b1b490f3cfc76896a/jiter-0.14.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:645be49c46f2900937ba0eaf871ad5183c96858c0af74b6becc7f4e367e36e06", size = 553716, upload-time = "2026-04-10T14:27:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
 ]
 
 [[package]]
@@ -2133,7 +2135,7 @@ wheels = [
 
 [[package]]
 name = "posthog"
-version = "7.10.3"
+version = "7.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
@@ -2143,9 +2145,9 @@ dependencies = [
     { name = "six" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/48/dcb39417e903af8bc08e144a6adc594178ee42f276a858d570d3164c4262/posthog-7.10.3.tar.gz", hash = "sha256:dc624a07306dc2618dcfa9f9a706086db2efea33bb7ad0048625e5cf60e5401b", size = 187265, upload-time = "2026-04-08T17:43:10.931Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/29/8fed5bc33a79d2f71446a5b688cdb1d186e360b00d4656ac10fddbdc37f5/posthog-7.11.0.tar.gz", hash = "sha256:9c15d998aaa94d40d2291078616c16a5919c30f0ddab9c82a98d77da4cc415ee", size = 189175, upload-time = "2026-04-10T15:17:23.056Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/ec/d0050e82b4be2126f4769612f0ef9734348cb736a23754ea238202285343/posthog-7.10.3-py3-none-any.whl", hash = "sha256:bbaeb45dbfd56143343cf93bf091eb500f9996b95b797f4bf99b42905da54fe7", size = 217019, upload-time = "2026-04-08T17:43:09.305Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/36/e746e253c6f39866bb22b1c749f85f96079c84fb698440f130a043c8105d/posthog-7.11.0-py3-none-any.whl", hash = "sha256:be51ab01d5e7a28864bbd67bc9d7545c79625195ac56be724d287d8ea2cd2efa", size = 219909, upload-time = "2026-04-10T15:17:21.13Z" },
 ]
 
 [[package]]
@@ -2561,11 +2563,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.25"
+version = "0.0.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cf/9f/f5c842657404d69ab2d87bbb3fb70075afd24c44a00724980ee0c5e18813/python_multipart-0.0.25.tar.gz", hash = "sha256:9966d7ad12a3aca92adae7c1326a155ff3ba720f86dc3a382c27d57deeb6c3e8", size = 43011, upload-time = "2026-04-10T13:15:03.071Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/07/cd09232a94bb8b4331fc9ccca8d196706352f57126238e7100ce23cc8dea/python_multipart-0.0.25-py3-none-any.whl", hash = "sha256:0c8ed4a7a82f14478602b5e714a47a1869e250c3d784c78005711fdcb5852089", size = 28787, upload-time = "2026-04-10T13:15:01.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]
@@ -3065,6 +3067,7 @@ dependencies = [
     { name = "mcp" },
     { name = "mem0ai" },
     { name = "mmh3" },
+    { name = "packaging" },
     { name = "pydantic" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "pyyaml" },
@@ -3154,6 +3157,7 @@ requires-dist = [
     { name = "mem0ai", specifier = "==1.0.11" },
     { name = "mmh3", specifier = "==5.2.1" },
     { name = "nats-py", marker = "extra == 'distributed'", specifier = "==2.14.0" },
+    { name = "packaging", specifier = "==26.0" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = "==3.3.3" },
     { name = "psycopg-pool", marker = "extra == 'postgres'", specifier = "==3.3.0" },
     { name = "pydantic", specifier = "==2.12.5" },

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1652,6 +1652,7 @@ export type WorkflowNodeType =
   | 'conditional'
   | 'parallel_split'
   | 'parallel_join'
+  | 'subworkflow'
 
 export type WorkflowEdgeType =
   | 'sequential'
@@ -1676,17 +1677,41 @@ export interface WorkflowEdgeData {
   readonly label: string | null
 }
 
+// ── Workflow I/O declarations (subworkflow contracts) ───────
+
+export type WorkflowValueType =
+  | 'string'
+  | 'integer'
+  | 'float'
+  | 'boolean'
+  | 'datetime'
+  | 'json'
+  | 'task_ref'
+  | 'agent_ref'
+
+export interface WorkflowIODeclaration {
+  readonly name: string
+  readonly type: WorkflowValueType
+  readonly required: boolean
+  readonly default: unknown
+  readonly description: string
+}
+
 export interface WorkflowDefinition {
   readonly id: string
   readonly name: string
   readonly description: string
   readonly workflow_type: string
+  readonly version: string
+  readonly inputs: readonly WorkflowIODeclaration[]
+  readonly outputs: readonly WorkflowIODeclaration[]
+  readonly is_subworkflow: boolean
   readonly nodes: readonly WorkflowNodeData[]
   readonly edges: readonly WorkflowEdgeData[]
   readonly created_by: string
   readonly created_at: string
   readonly updated_at: string
-  readonly version: number
+  readonly revision: number
 }
 
 export interface CreateWorkflowDefinitionRequest {
@@ -1701,9 +1726,44 @@ export interface UpdateWorkflowDefinitionRequest {
   readonly name?: string
   readonly description?: string
   readonly workflow_type?: string
+  readonly version?: string
+  readonly inputs?: readonly Record<string, unknown>[]
+  readonly outputs?: readonly Record<string, unknown>[]
+  readonly is_subworkflow?: boolean
   readonly nodes?: readonly Record<string, unknown>[]
   readonly edges?: readonly Record<string, unknown>[]
-  readonly expected_version?: number
+  readonly expected_revision?: number
+}
+
+// ── Subworkflow Registry ─────────────────────────────────────
+
+export interface SubworkflowSummary {
+  readonly subworkflow_id: string
+  readonly latest_version: string
+  readonly name: string
+  readonly description: string
+  readonly input_count: number
+  readonly output_count: number
+  readonly version_count: number
+}
+
+export interface ParentReference {
+  readonly parent_id: string
+  readonly parent_name: string
+  readonly pinned_version: string
+  readonly node_id: string
+}
+
+export interface CreateSubworkflowRequest {
+  readonly subworkflow_id?: string
+  readonly version?: string
+  readonly name: string
+  readonly description?: string
+  readonly workflow_type: string
+  readonly inputs?: readonly Record<string, unknown>[]
+  readonly outputs?: readonly Record<string, unknown>[]
+  readonly nodes: readonly Record<string, unknown>[]
+  readonly edges: readonly Record<string, unknown>[]
 }
 
 export interface WorkflowValidationError {
@@ -1734,6 +1794,7 @@ export type WorkflowNodeExecutionStatus =
   | 'task_completed'
   | 'task_failed'
   | 'completed'
+  | 'subworkflow_completed'
 
 export interface WorkflowNodeExecution {
   readonly node_id: string
@@ -1746,7 +1807,7 @@ export interface WorkflowNodeExecution {
 export interface WorkflowExecution {
   readonly id: string
   readonly definition_id: string
-  readonly definition_version: number
+  readonly definition_revision: number
   readonly status: WorkflowExecutionStatus
   readonly node_executions: readonly WorkflowNodeExecution[]
   readonly activated_by: string
@@ -1849,7 +1910,7 @@ export interface WorkflowDiff {
 
 export interface RollbackWorkflowRequest {
   readonly target_version: number
-  readonly expected_version: number
+  readonly expected_revision: number
 }
 
 // ── Ceremony Policy ──────────────────────────────────────────

--- a/web/src/pages/workflow-editor/VersionHistoryPanel.tsx
+++ b/web/src/pages/workflow-editor/VersionHistoryPanel.tsx
@@ -91,8 +91,11 @@ export function VersionHistoryPanel({ open, onClose }: VersionHistoryPanelProps)
 
   async function confirmRestore() {
     if (restoreTarget === null) return
-    await rollback(restoreTarget)
-    setRestoreTarget(null)
+    try {
+      await rollback(restoreTarget)
+    } finally {
+      setRestoreTarget(null)
+    }
   }
 
   return (
@@ -105,7 +108,7 @@ export function VersionHistoryPanel({ open, onClose }: VersionHistoryPanelProps)
       >
         <div className="flex flex-col gap-section-gap">
           {versionsLoading && versions.length === 0 && (
-            <div className="flex flex-col gap-2">
+            <div className="flex flex-col gap-grid-gap">
               {Array.from({ length: 3 }, (_, i) => (
                 <Skeleton key={i} className="h-16 rounded-lg" />
               ))}

--- a/web/src/pages/workflow-editor/VersionHistoryPanel.tsx
+++ b/web/src/pages/workflow-editor/VersionHistoryPanel.tsx
@@ -26,7 +26,7 @@ export function VersionCard({ v, definition, saving, onCompare, onRestore }: Ver
           </span>
           <span className="text-sm text-foreground">{v.snapshot.name}</span>
         </div>
-        {v.version === definition?.version && (
+        {v.version === definition?.revision && (
           <span className="text-xs text-success">Current</span>
         )}
       </div>
@@ -42,7 +42,7 @@ export function VersionCard({ v, definition, saving, onCompare, onRestore }: Ver
           variant="ghost"
           size="sm"
           onClick={() => onCompare(v)}
-          disabled={v.version === definition?.version}
+          disabled={v.version === definition?.revision}
           title="Compare with current"
         >
           <GitCompare className="size-3.5" />
@@ -52,7 +52,7 @@ export function VersionCard({ v, definition, saving, onCompare, onRestore }: Ver
           variant="ghost"
           size="sm"
           onClick={() => onRestore(v.version)}
-          disabled={v.version === definition?.version || saving}
+          disabled={v.version === definition?.revision || saving}
           title="Restore this version"
         >
           <RotateCcw className="size-3.5" />
@@ -82,7 +82,7 @@ export function VersionHistoryPanel({ open, onClose }: VersionHistoryPanelProps)
 
   function handleCompare(version: WorkflowDefinitionVersionSummary) {
     if (!definition) return
-    loadDiff(version.version, definition.version)
+    loadDiff(version.version, definition.revision)
   }
 
   function handleRestore(version: number) {

--- a/web/src/pages/workflow-editor/node-config-schemas.ts
+++ b/web/src/pages/workflow-editor/node-config-schemas.ts
@@ -86,4 +86,20 @@ export const NODE_CONFIG_SCHEMAS: Record<WorkflowNodeType, readonly ConfigField[
   parallel_join: [
     { key: 'join_strategy', label: 'Join Strategy', type: 'select', options: JOIN_STRATEGY_OPTIONS },
   ],
+  subworkflow: [
+    {
+      key: 'subworkflow_id',
+      label: 'Subworkflow ID',
+      type: 'text',
+      required: true,
+      placeholder: 'sub-...',
+    },
+    {
+      key: 'version',
+      label: 'Pinned version',
+      type: 'text',
+      required: true,
+      placeholder: 'e.g. 1.0.0',
+    },
+  ],
 }

--- a/web/src/pages/workflow-editor/node-config-schemas.ts
+++ b/web/src/pages/workflow-editor/node-config-schemas.ts
@@ -101,5 +101,17 @@ export const NODE_CONFIG_SCHEMAS: Record<WorkflowNodeType, readonly ConfigField[
       required: true,
       placeholder: 'e.g. 1.0.0',
     },
+    {
+      key: 'input_bindings',
+      label: 'Input Bindings (JSON)',
+      type: 'text',
+      placeholder: '{"quarter": "@parent.current_quarter"}',
+    },
+    {
+      key: 'output_bindings',
+      label: 'Output Bindings (JSON)',
+      type: 'text',
+      placeholder: '{"report": "@child.closing_report"}',
+    },
   ],
 }

--- a/web/src/pages/workflows/WorkflowCard.tsx
+++ b/web/src/pages/workflows/WorkflowCard.tsx
@@ -48,6 +48,9 @@ export function WorkflowCard({ workflow, onDelete, onDuplicate }: WorkflowCardPr
             <span>v{workflow.version}</span>
             <span>Updated {formatRelativeTime(workflow.updated_at)}</span>
           </div>
+          {workflow.is_subworkflow && (
+            <div className="text-xs text-accent">Subworkflow</div>
+          )}
         </Link>
 
         <Menu.Root>

--- a/web/src/pages/workflows/WorkflowCard.tsx
+++ b/web/src/pages/workflows/WorkflowCard.tsx
@@ -72,7 +72,7 @@ export function WorkflowCard({ workflow, onDelete, onDuplicate }: WorkflowCardPr
 
           <Menu.Portal>
             <Menu.Positioner align="end" sideOffset={4}>
-              <Menu.Popup className="z-50 w-36 rounded-lg border border-border bg-card py-1 shadow-[var(--so-shadow-card-hover)] transition-[opacity,translate,scale] duration-150 ease-out data-[closed]:opacity-0 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 data-[closed]:scale-95 data-[starting-style]:scale-95 data-[ending-style]:scale-95">
+              <Menu.Popup className="z-50 w-36 rounded-lg border border-border bg-card py-1 shadow-[var(--so-shadow-card-hover)] transition-[opacity,translate,scale] duration-[var(--so-duration-default)] ease-[var(--so-ease-default)] data-[closed]:opacity-0 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 data-[closed]:scale-95 data-[starting-style]:scale-95 data-[ending-style]:scale-95">
                 <Menu.Item
                   className="flex w-full cursor-default items-center gap-2 px-3 py-1.5 text-sm text-foreground outline-none data-[highlighted]:bg-surface"
                   onClick={() => { void navigate(editorUrl) }}

--- a/web/src/stores/workflow-editor.ts
+++ b/web/src/stores/workflow-editor.ts
@@ -327,7 +327,7 @@ export const useWorkflowEditorStore = create<WorkflowEditorState>()((set, get) =
           type: ((e.data as Record<string, unknown>)?.edgeType as string) ?? 'sequential',
           label: (e.label as string) ?? null,
         })),
-        expected_version: definition.version,
+        expected_revision: definition.revision,
       })
       set({ definition: updatedDef, saving: false, dirty: false, validationResult: null })
     } catch (err) {
@@ -685,7 +685,7 @@ export const useWorkflowEditorStore = create<WorkflowEditorState>()((set, get) =
     try {
       const updated = await rollbackWorkflow(defn.id, {
         target_version: targetVersion,
-        expected_version: defn.version,
+        expected_revision: defn.revision,
       })
       // Hydrate editor state immediately from the rollback response
       // so the UI reflects the rolled-back version even if the


### PR DESCRIPTION
## Summary

Implements nestable reusable workflow components (subworkflows) -- a `SUBWORKFLOW` node type that references a child `WorkflowDefinition` by ID + pinned semver, with typed input/output contracts, a shared registry, and safety guards.

### Key pieces

- **`WorkflowNodeType.SUBWORKFLOW`** + **`WorkflowValueType`** enum (8 typed value kinds) + **`WorkflowIODeclaration`** model for typed I/O contracts
- **`WorkflowDefinition`** extended with `version` (semver via `packaging`), `inputs`, `outputs`, `is_subworkflow`; renamed `version: int` to `revision: int` (optimistic concurrency) across 55 files
- **`SubworkflowRegistry`** service with CRUD, semver ordering, delete protection when parents still pin a version
- **`SubworkflowRepository`** protocol + SQLite implementation with composite PK `(subworkflow_id, semver)`
- **Recursive frame stack** in `WorkflowExecutionService._walk_frame()` with per-frame `ctx` isolation (child cannot read parent variables outside declared inputs), qualified node IDs (`parent::child`), and runtime depth enforcement (`MAX_WORKFLOW_DEPTH = 16`)
- **Static cycle detection** via DFS across the `(id, version)` reference graph at save time
- **Save-time I/O validation**: missing required inputs, unknown keys, literal type mismatches
- **Input/output binding resolution**: `@parent.path` and `@child.path` dotted-path lookups + type validation (pure functions, no eval/exec)
- **`/subworkflows` API controller** (7 endpoints: list, search, get, versions, parents, create, delete)
- **YAML export** extended for subworkflow node serialization
- **Atlas migration** + one-migration-per-PR enforcement (pre-commit hook + CI check)
- **Frontend types** updated: `WorkflowDefinition` with semver + I/O + `is_subworkflow`, new subworkflow registry types, `subworkflow` node type + execution status

### Pre-reviewed by 4 agents, 9 findings addressed

- Security: sanitized exception messages in API responses, escaped LIKE metacharacters in search, fixed depth limit boundary condition
- Code quality: added `SUBWORKFLOW_INPUT_TYPE_MISMATCH` error code (was using output code for inputs), split validation function, wrapped frame inputs in `MappingProxyType`
- Conventions: all new modules follow CLAUDE.md (frozen Pydantic, structured logging, NotBlankStr, allow_inf_nan=False)

### Test plan

- 17095 unit tests pass (including 100+ new tests across 8 test files)
- mypy strict clean, ruff clean, frontend type-check + lint clean
- Atlas migration validates, schema drift check passes

### Follow-up

- Dashboard subworkflow library page, picker modal, bindings editor, update notification UI: #1218
- Dedicated integration tests (full SQLite round-trip): #1218

Closes #1012
