### PR TITLE
chore(ci): audit and update GitHub Actions from v0.6.6 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,15 +187,16 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: junit.xml
           fail_ci_if_error: false
+          report_type: test_results
 
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results-${{ matrix.python-version }}
           path: junit.xml
@@ -396,7 +397,7 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=4096 --report-on-fatalerror --report-directory=."
       - name: Upload Node.js crash report
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: storybook-crash-report
           path: web/report.*.json

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload coverage
         if: ${{ !cancelled() && matrix.os == 'ubuntu-latest' }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cli-coverage
           path: cli/coverage.out

--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Upload ZAP reports
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: zap-reports
           path: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,6 +73,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        with:
+          cache-binary: false
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
@@ -96,7 +98,7 @@ jobs:
 
       # Build locally first, scan, then push only if scans pass
       - name: Build image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: docker/backend/Dockerfile
@@ -161,7 +163,7 @@ jobs:
 
       - name: Upload Trivy report (backend)
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: trivy-backend-report
           path: trivy-backend.json
@@ -202,7 +204,7 @@ jobs:
       - name: Push image
         if: github.event_name != 'pull_request'
         id: push
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: docker/backend/Dockerfile
@@ -255,7 +257,7 @@ jobs:
 
       - name: Upload SBOM artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-backend
           path: sbom-backend.cdx.json
@@ -280,6 +282,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        with:
+          cache-binary: false
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
@@ -303,7 +307,7 @@ jobs:
 
       # Build locally first, scan, then push only if scans pass
       - name: Build image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: docker/web/Dockerfile
@@ -367,7 +371,7 @@ jobs:
 
       - name: Upload Trivy report (web)
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: trivy-web-report
           path: trivy-web.json
@@ -405,7 +409,7 @@ jobs:
       - name: Push image
         if: github.event_name != 'pull_request'
         id: push
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: docker/web/Dockerfile
@@ -458,7 +462,7 @@ jobs:
 
       - name: Upload SBOM artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-web
           path: sbom-web.cdx.json
@@ -483,6 +487,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        with:
+          cache-binary: false
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
@@ -506,7 +512,7 @@ jobs:
 
       # Build locally first, scan, then push only if scans pass
       - name: Build image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: docker/sandbox/Dockerfile
@@ -570,7 +576,7 @@ jobs:
 
       - name: Upload Trivy report (sandbox)
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: trivy-sandbox-report
           path: trivy-sandbox.json
@@ -608,7 +614,7 @@ jobs:
       - name: Push image
         if: github.event_name != 'pull_request'
         id: push
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: docker/sandbox/Dockerfile
@@ -661,7 +667,7 @@ jobs:
 
       - name: Upload SBOM artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-sandbox
           path: sbom-sandbox.cdx.json

--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -216,7 +216,7 @@ jobs:
           PYEOF
 
       - name: Upload preview artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: preview-site
           path: _site

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -114,7 +114,7 @@ jobs:
           # Zensical output is already at _site/docs/ from the build step
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: _site
 


### PR DESCRIPTION
## Summary

Full CI audit of all GitHub Actions workflows from the v0.6.6 release. Reviewed all 14 workflow runs, verified all 27 third-party actions against latest releases.

### Changes

- **F1**: Migrate deprecated `codecov/test-results-action` (Node.js 20) to `codecov/codecov-action@v6.0.0` with `report_type: test_results` (ci.yml)
- **F2**: Update `actions/upload-pages-artifact` v4 to v5.0.0 -- resolves Node.js 20 transitive deprecation (pages.yml)
- **F3**: Update `docker/build-push-action` v7.0.0 to v7.1.0 (docker.yml, 6 occurrences)
- **F4**: Update `actions/upload-artifact` v7.0.0 to v7.0.1 (ci.yml, docker.yml, dast.yml, pages-preview.yml, cli.yml -- 11 occurrences)
- **F5**: Add `cache-binary: false` to `docker/setup-buildx-action` -- suppresses Node.js 20 warning from bundled `actions/cache@v4.2.4` (docker.yml, 3 occurrences)
- **F6**: Remove `codecov/test-results-action@*` from repo actions allowlist (via API, not in diff)

### Upstream issues (cannot fix, latest versions)

- `googleapis/release-please-action@v4.4.0` -- Node.js 20
- `golangci/golangci-lint-action@v9.2.0` -- punycode deprecation
- `actions/deploy-pages@v5.0.0` -- punycode deprecation

### Benign warnings (no action needed)

- UV cache race condition (parallel jobs)
- Trivy vendor severity messages
- Docker build npm transitive dep warnings
- Litestar Pydantic V1 compat warning

### Test plan

- CI green (workflow syntax validated by GitHub Actions on push)
- All old SHAs verified gone via grep
- Actions allowlist updated (21 to 20 entries)

Closes #1224