### PR TITLE
refactor: evaluate nats-core + split bus/nats.py into focused modules

### DIFF
--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -124,7 +124,7 @@ All significant design and architecture decisions, organized by domain. Each ent
 
 **Eliminated:** No other Python NATS clients exist. Custom JetStream client over raw NATS protocol was not considered (substantial effort, no ecosystem benefit).
 
-**SynthOrg JetStream usage** (verified in `bus/nats.py` and `workers/claim.py`): `SYNTHORG_BUS` stream (LimitsPolicy), `SYNTHORG_TASKS` stream (WorkQueuePolicy), `SYNTHORG_BUS_CHANNELS` KV bucket, durable pull consumers with `ConsumerConfig`, stream management (`stream_info`/`add_stream`/`update_stream`), history scanning with ephemeral consumers (`DeliverPolicy.ALL`/`AckPolicy.NONE`), connection lifecycle callbacks.
+**SynthOrg JetStream usage** (verified in `bus/nats.py` facade and `workers/claim.py`): `SYNTHORG_BUS` stream (LimitsPolicy, `_nats_connection`), `SYNTHORG_TASKS` stream (WorkQueuePolicy, `claim.py`), `SYNTHORG_BUS_CHANNELS` KV bucket (`_nats_kv`), durable pull consumers with `ConsumerConfig` (`_nats_consumers`), stream management via `stream_info`/`add_stream`/`update_stream` (`_nats_connection`), history scanning with ephemeral consumers using `DeliverPolicy.ALL`/`AckPolicy.NONE` (`_nats_history`), connection lifecycle callbacks (`_nats_connection`).
 
 **Mitigation plan:** (1) File upstream PR against `nats-io/nats.py` with the one-line `inspect.iscoroutinefunction` fix (TODO: pending -- link back here once filed). (2) Keep scoped `filterwarnings` in `pyproject.toml` as workaround. (3) If upstream is unresponsive after 60 days, maintain a local monkey-patch in `bus/_nats_compat.py`. (4) Monitor `nats-core` for future JetStream support.
 

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -126,7 +126,7 @@ All significant design and architecture decisions, organized by domain. Each ent
 
 **SynthOrg JetStream usage** (verified in `bus/nats.py` and `workers/claim.py`): `SYNTHORG_BUS` stream (LimitsPolicy), `SYNTHORG_TASKS` stream (WorkQueuePolicy), `SYNTHORG_BUS_CHANNELS` KV bucket, durable pull consumers with `ConsumerConfig`, stream management (`stream_info`/`add_stream`/`update_stream`), history scanning with ephemeral consumers (`DeliverPolicy.ALL`/`AckPolicy.NONE`), connection lifecycle callbacks.
 
-**Mitigation plan:** (1) File upstream PR with the one-line `inspect.iscoroutinefunction` fix. (2) Keep scoped `filterwarnings` in `pyproject.toml` as workaround. (3) If upstream is unresponsive after 60 days, maintain a local monkey-patch in `bus/_nats_compat.py`. (4) Monitor `nats-core` for future JetStream support.
+**Mitigation plan:** (1) File upstream PR against `nats-io/nats.py` with the one-line `inspect.iscoroutinefunction` fix (TODO: pending -- link back here once filed). (2) Keep scoped `filterwarnings` in `pyproject.toml` as workaround. (3) If upstream is unresponsive after 60 days, maintain a local monkey-patch in `bus/_nats_compat.py`. (4) Monitor `nats-core` for future JetStream support.
 
 ## Overarching Pattern
 

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -111,6 +111,23 @@ All significant design and architecture decisions, organized by domain. Each ent
 | D26 | Adopt append-only writes + MVCC-style snapshot reads for `SharedKnowledgeStore`; personal memories stay sequential | Append-only provides audit trail ("what was the state before date X?"), rollback, and safe concurrent writes. MVCC snapshot reads are consistent with no locking overhead. Personal memories have no cross-agent contention so sequential writes are sufficient. Protocol extension (future PR): add `get_operation_log(fact_id)` and `snapshot_at(timestamp)` to `SharedKnowledgeStore` | CRDT (conflict-free but ~20% space overhead and resurfaces deleted facts on node divergence), event sourcing (good audit properties but requires snapshot compaction strategy), pessimistic locking (high contention under load, tail latency spikes) |
 | D27 | RL consolidation not recommended for MVP; revisit at 10k+ agent deployments | Reward function is multi-objective (readability, retrieval accuracy, synthesis fidelity, token cost) and unsolved without ~1000 annotated sessions. Failure mode is data loss -- RL model drift silently deletes memories; LLM degrades gracefully. At current scale (50--500 agents) training infra cost exceeds token savings by ~12 months. DPO fine-tuning on LLM preference data is the viable intermediate step if cost becomes a concern | Pure RL policy training (reward design is open research problem), behavioral cloning only (low gain over current LLM approach), threshold-based consolidation triggers (no quality improvement, only cost saving) |
 
+## NATS Client Library (2026-04-10)
+
+**Decision:** Stay on `nats-py` (pinned `==2.14.0`). File upstream PR to replace deprecated `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction`. Maintain scoped `filterwarnings` as workaround until upstream fix lands.
+
+**Context:** PR #1214 (distributed runtime) introduced `nats-py==2.14.0` for the JetStream message bus and task queue. Python 3.14 CI fails because `nats-py` calls `asyncio.iscoroutinefunction` in `nats/aio/client.py:476` -- deprecated in Python 3.14, slated for removal in 3.16. Upstream (`nats-io/nats.py`) has no open issue or fix in progress; classifiers top out at Python 3.13. A separate library, `nats-core`, was evaluated as a potential replacement.
+
+| Candidate | Why chosen / rejected |
+|-----------|----------------------|
+| **nats-py** (stay) | Only Python NATS client with JetStream support (streams, KV store, durable pull consumers, work-queue retention). Official `nats-io` project, Apache 2.0, asyncio-native. The `asyncio.iscoroutinefunction` deprecation is a one-line fix (`inspect.iscoroutinefunction` is a drop-in replacement, backward-compatible to Python 3.5+). All SynthOrg distributed features depend on JetStream primitives |
+| nats-core v0.1.0 | Lean, zero-dependency client (63x faster for core ops). **Does not support JetStream, KV store, pull consumers, or durable consumers** -- only core pub/sub, request/reply, and queue groups. Migration would require rewriting the entire message bus and task queue, losing persistence, durability, history, and KV-backed channel discovery. Also v0.1.0 with no API stability commitment |
+
+**Eliminated:** No other Python NATS clients exist. Custom JetStream client over raw NATS protocol was not considered (substantial effort, no ecosystem benefit).
+
+**SynthOrg JetStream usage** (verified in `bus/nats.py` and `workers/claim.py`): `SYNTHORG_BUS` stream (LimitsPolicy), `SYNTHORG_TASKS` stream (WorkQueuePolicy), `SYNTHORG_BUS_CHANNELS` KV bucket, durable pull consumers with `ConsumerConfig`, stream management (`stream_info`/`add_stream`/`update_stream`), history scanning with ephemeral consumers (`DeliverPolicy.ALL`/`AckPolicy.NONE`), connection lifecycle callbacks.
+
+**Mitigation plan:** (1) File upstream PR with the one-line `inspect.iscoroutinefunction` fix. (2) Keep scoped `filterwarnings` in `pyproject.toml` as workaround. (3) If upstream is unresponsive after 60 days, maintain a local monkey-patch in `bus/_nats_compat.py`. (4) Monitor `nats-core` for future JetStream support.
+
 ## Overarching Pattern
 
 Nearly every decision follows the same architecture: a pluggable protocol interface with one initial implementation shipped, and alternative strategies documented for future extension. This is consistent with the project's protocol-driven design philosophy.

--- a/docs/design/distributed-runtime.md
+++ b/docs/design/distributed-runtime.md
@@ -92,6 +92,10 @@ NATS JetStream wins on three dimensions that matter most for a first distributed
 
 The trade-off is that `docs/architecture/tech-stack.md` does not currently mention NATS; it lists Redis as the planned backend. This design adds NATS alongside the existing Redis-planned note rather than replacing it. Redis, RabbitMQ, and Kafka remain valid future backends under the same pluggable factory, and the CLI picker registry is designed so that adding any of them later is one struct literal plus one Python class, not a UI rewrite.
 
+#### NATS client library (2026-04-10)
+
+The project stays on `nats-py==2.14.0`. An alternative client (`nats-core` v0.1.0) was evaluated and rejected because it lacks JetStream, KV store, and durable consumer support -- all primitives this design depends on. A scoped `filterwarnings` entry in `pyproject.toml` suppresses the `asyncio.iscoroutinefunction` deprecation warning from `nats-py` on Python 3.14 until an upstream fix lands. See [docs/architecture/decisions.md](../architecture/decisions.md) for the full decision record and mitigation plan.
+
 ---
 
 ## Bus Backend Design

--- a/src/synthorg/communication/bus/__init__.py
+++ b/src/synthorg/communication/bus/__init__.py
@@ -8,6 +8,7 @@ can import it directly.
 See ``docs/design/distributed-runtime.md`` for the overall design.
 """
 
+from synthorg.communication.bus._nats_utils import redact_url
 from synthorg.communication.bus.memory import InMemoryMessageBus
 from synthorg.communication.bus_protocol import MessageBus
 from synthorg.communication.config import MessageBusConfig  # noqa: TC001
@@ -21,6 +22,7 @@ __all__ = (
     "InMemoryMessageBus",
     "MessageBus",
     "build_message_bus",
+    "redact_url",
 )
 
 

--- a/src/synthorg/communication/bus/_nats_channels.py
+++ b/src/synthorg/communication/bus/_nats_channels.py
@@ -9,7 +9,6 @@ from synthorg.communication.bus._nats_kv import (
     create_channel_in_kv,
     load_channel_from_kv,
     scan_kv_channels,
-    write_channel_to_kv,
 )
 from synthorg.communication.bus._nats_state import _NatsState  # noqa: TC001
 from synthorg.communication.bus._nats_utils import (
@@ -55,12 +54,16 @@ def durable_name(channel_name: str, subscriber_id: str) -> str:
     return f"{encode_token(channel_name)}__{encode_token(subscriber_id)}"
 
 
-async def ensure_direct_channel(
+def prepare_direct_channel(
     state: _NatsState,
     channel_name: str,
     pair: tuple[str, str],
-) -> None:
-    """Create DIRECT channel locally and in KV bucket if needed.
+) -> Channel | None:
+    """Compute the DIRECT channel state change under ``state.lock``.
+
+    Updates ``state.channels`` in-place and returns the channel to
+    persist to KV, or ``None`` if no KV write is needed. The caller
+    must perform the KV write outside the lock.
 
     Args:
         state: Shared bus state.
@@ -77,16 +80,15 @@ async def ensure_direct_channel(
             updated = current.model_copy(
                 update={"subscribers": new_subs},
             )
-            await write_channel_to_kv(state, updated)
             state.channels[channel_name] = updated
-        return
+            return updated
+        return None
 
     ch = Channel(
         name=channel_name,
         type=ChannelType.DIRECT,
         subscribers=pair,
     )
-    await write_channel_to_kv(state, ch)
     state.channels[channel_name] = ch
     logger.info(
         COMM_CHANNEL_CREATED,
@@ -94,6 +96,7 @@ async def ensure_direct_channel(
         type=str(ChannelType.DIRECT),
         backend="nats",
     )
+    return ch
 
 
 async def create_channel(state: _NatsState, ch: Channel) -> Channel:

--- a/src/synthorg/communication/bus/_nats_channels.py
+++ b/src/synthorg/communication/bus/_nats_channels.py
@@ -6,6 +6,7 @@ KV bucket for multi-process discovery.
 """
 
 from synthorg.communication.bus._nats_kv import (
+    create_channel_in_kv,
     load_channel_from_kv,
     scan_kv_channels,
     write_channel_to_kv,
@@ -98,15 +99,15 @@ async def ensure_direct_channel(
 async def create_channel(state: _NatsState, ch: Channel) -> Channel:
     """Create a new channel.
 
-    Uses an optimistic check-then-act pattern: local cache, then KV
-    bucket, then local cache again. Two processes creating the same
-    channel concurrently may both succeed at the KV write (last-write
-    wins). A future improvement could use KV CAS/revision checks for
-    cross-process atomicity.
+    Uses an atomic KV create to enforce cross-process uniqueness:
+    ``kv.create()`` fails with ``KeyWrongLastSequenceError`` if the
+    key already exists, which is translated to
+    ``ChannelAlreadyExistsError``.
 
     Raises:
         MessageBusNotRunningError: If not running.
-        ChannelAlreadyExistsError: If the channel already exists.
+        ChannelAlreadyExistsError: If the channel already exists
+            (locally or in the KV bucket).
     """
     async with state.lock:
         require_running(state)
@@ -120,34 +121,12 @@ async def create_channel(state: _NatsState, ch: Channel) -> Channel:
                 msg,
                 context={"channel": ch.name},
             )
-    kv_existing = await load_channel_from_kv(state, ch.name)
-    if kv_existing is not None:
-        async with state.lock:
-            if ch.name not in state.channels:
-                state.channels[ch.name] = kv_existing
-        logger.warning(
-            COMM_CHANNEL_ALREADY_EXISTS,
-            channel=ch.name,
-            source="kv",
-        )
-        msg = f"Channel already exists (peer-created): {ch.name}"
-        raise ChannelAlreadyExistsError(
-            msg,
-            context={"channel": ch.name},
-        )
+
+    # Atomic KV create -- raises ChannelAlreadyExistsError if a peer
+    # already created this channel, BusStreamError on transport failure.
+    await create_channel_in_kv(state, ch)
+
     async with state.lock:
-        require_running(state)
-        if ch.name in state.channels:
-            logger.warning(
-                COMM_CHANNEL_ALREADY_EXISTS,
-                channel=ch.name,
-            )
-            msg = f"Channel already exists: {ch.name}"
-            raise ChannelAlreadyExistsError(
-                msg,
-                context={"channel": ch.name},
-            )
-        await write_channel_to_kv(state, ch)
         state.channels[ch.name] = ch
     logger.info(
         COMM_CHANNEL_CREATED,

--- a/src/synthorg/communication/bus/_nats_channels.py
+++ b/src/synthorg/communication/bus/_nats_channels.py
@@ -16,6 +16,7 @@ from synthorg.communication.bus._nats_utils import (
     SUBJECT_DIRECT_TOKEN,
     encode_token,
     raise_channel_not_found,
+    require_running,
 )
 from synthorg.communication.channel import Channel
 from synthorg.communication.enums import ChannelType
@@ -60,6 +61,11 @@ async def ensure_direct_channel(
 ) -> None:
     """Create DIRECT channel locally and in KV bucket if needed.
 
+    Args:
+        state: Shared bus state.
+        channel_name: Deterministic direct-channel name (``@a:b``).
+        pair: Sorted tuple of the two participant agent IDs.
+
     Must be called under ``state.lock``.
     """
     if channel_name in state.channels:
@@ -67,10 +73,11 @@ async def ensure_direct_channel(
         pair_set = set(pair)
         if not pair_set.issubset(set(current.subscribers)):
             new_subs = tuple(sorted(set(current.subscribers) | pair_set))
-            state.channels[channel_name] = current.model_copy(
+            updated = current.model_copy(
                 update={"subscribers": new_subs},
             )
-            await write_channel_to_kv(state, state.channels[channel_name])
+            await write_channel_to_kv(state, updated)
+            state.channels[channel_name] = updated
         return
 
     ch = Channel(
@@ -78,8 +85,8 @@ async def ensure_direct_channel(
         type=ChannelType.DIRECT,
         subscribers=pair,
     )
-    state.channels[channel_name] = ch
     await write_channel_to_kv(state, ch)
+    state.channels[channel_name] = ch
     logger.info(
         COMM_CHANNEL_CREATED,
         channel=channel_name,
@@ -91,11 +98,18 @@ async def ensure_direct_channel(
 async def create_channel(state: _NatsState, ch: Channel) -> Channel:
     """Create a new channel.
 
+    Uses an optimistic check-then-act pattern: local cache, then KV
+    bucket, then local cache again. Two processes creating the same
+    channel concurrently may both succeed at the KV write (last-write
+    wins). A future improvement could use KV CAS/revision checks for
+    cross-process atomicity.
+
     Raises:
         MessageBusNotRunningError: If not running.
         ChannelAlreadyExistsError: If the channel already exists.
     """
     async with state.lock:
+        require_running(state)
         if ch.name in state.channels:
             logger.warning(
                 COMM_CHANNEL_ALREADY_EXISTS,
@@ -122,6 +136,7 @@ async def create_channel(state: _NatsState, ch: Channel) -> Channel:
             context={"channel": ch.name},
         )
     async with state.lock:
+        require_running(state)
         if ch.name in state.channels:
             logger.warning(
                 COMM_CHANNEL_ALREADY_EXISTS,
@@ -132,8 +147,8 @@ async def create_channel(state: _NatsState, ch: Channel) -> Channel:
                 msg,
                 context={"channel": ch.name},
             )
-        state.channels[ch.name] = ch
         await write_channel_to_kv(state, ch)
+        state.channels[ch.name] = ch
     logger.info(
         COMM_CHANNEL_CREATED,
         channel=ch.name,

--- a/src/synthorg/communication/bus/_nats_channels.py
+++ b/src/synthorg/communication/bus/_nats_channels.py
@@ -1,0 +1,179 @@
+"""Channel management: creation, resolution, listing, and subject helpers.
+
+Handles the mapping between SynthOrg channel names and JetStream
+subject tokens, as well as channel creation/resolution backed by the
+KV bucket for multi-process discovery.
+"""
+
+from synthorg.communication.bus._nats_kv import (
+    load_channel_from_kv,
+    scan_kv_channels,
+    write_channel_to_kv,
+)
+from synthorg.communication.bus._nats_state import _NatsState  # noqa: TC001
+from synthorg.communication.bus._nats_utils import (
+    SUBJECT_CHANNEL_TOKEN,
+    SUBJECT_DIRECT_TOKEN,
+    encode_token,
+    raise_channel_not_found,
+)
+from synthorg.communication.channel import Channel
+from synthorg.communication.enums import ChannelType
+from synthorg.communication.errors import ChannelAlreadyExistsError
+from synthorg.observability import get_logger
+from synthorg.observability.events.communication import (
+    COMM_CHANNEL_ALREADY_EXISTS,
+    COMM_CHANNEL_CREATED,
+)
+
+logger = get_logger(__name__)
+
+
+def channel_subject(prefix: str, channel_name: str) -> str:
+    """Compute the stream subject for a TOPIC/BROADCAST channel."""
+    pfx = prefix.lower()
+    return f"{pfx}.bus.{SUBJECT_CHANNEL_TOKEN}.{encode_token(channel_name)}"
+
+
+def direct_subject(prefix: str, channel_name: str) -> str:
+    """Compute the stream subject for a DIRECT channel."""
+    pfx = prefix.lower()
+    return f"{pfx}.bus.{SUBJECT_DIRECT_TOKEN}.{encode_token(channel_name)}"
+
+
+def subject_for_channel(prefix: str, ch: Channel) -> str:
+    """Pick the correct subject based on channel type."""
+    if ch.type == ChannelType.DIRECT:
+        return direct_subject(prefix, ch.name)
+    return channel_subject(prefix, ch.name)
+
+
+def durable_name(channel_name: str, subscriber_id: str) -> str:
+    """Compute a safe durable consumer name."""
+    return f"{encode_token(channel_name)}__{encode_token(subscriber_id)}"
+
+
+async def ensure_direct_channel(
+    state: _NatsState,
+    channel_name: str,
+    pair: tuple[str, str],
+) -> None:
+    """Create DIRECT channel locally and in KV bucket if needed.
+
+    Must be called under ``state.lock``.
+    """
+    if channel_name in state.channels:
+        current = state.channels[channel_name]
+        pair_set = set(pair)
+        if not pair_set.issubset(set(current.subscribers)):
+            new_subs = tuple(sorted(set(current.subscribers) | pair_set))
+            state.channels[channel_name] = current.model_copy(
+                update={"subscribers": new_subs},
+            )
+            await write_channel_to_kv(state, state.channels[channel_name])
+        return
+
+    ch = Channel(
+        name=channel_name,
+        type=ChannelType.DIRECT,
+        subscribers=pair,
+    )
+    state.channels[channel_name] = ch
+    await write_channel_to_kv(state, ch)
+    logger.info(
+        COMM_CHANNEL_CREATED,
+        channel=channel_name,
+        type=str(ChannelType.DIRECT),
+        backend="nats",
+    )
+
+
+async def create_channel(state: _NatsState, ch: Channel) -> Channel:
+    """Create a new channel.
+
+    Raises:
+        MessageBusNotRunningError: If not running.
+        ChannelAlreadyExistsError: If the channel already exists.
+    """
+    async with state.lock:
+        if ch.name in state.channels:
+            logger.warning(
+                COMM_CHANNEL_ALREADY_EXISTS,
+                channel=ch.name,
+            )
+            msg = f"Channel already exists: {ch.name}"
+            raise ChannelAlreadyExistsError(
+                msg,
+                context={"channel": ch.name},
+            )
+    kv_existing = await load_channel_from_kv(state, ch.name)
+    if kv_existing is not None:
+        async with state.lock:
+            if ch.name not in state.channels:
+                state.channels[ch.name] = kv_existing
+        logger.warning(
+            COMM_CHANNEL_ALREADY_EXISTS,
+            channel=ch.name,
+            source="kv",
+        )
+        msg = f"Channel already exists (peer-created): {ch.name}"
+        raise ChannelAlreadyExistsError(
+            msg,
+            context={"channel": ch.name},
+        )
+    async with state.lock:
+        if ch.name in state.channels:
+            logger.warning(
+                COMM_CHANNEL_ALREADY_EXISTS,
+                channel=ch.name,
+            )
+            msg = f"Channel already exists: {ch.name}"
+            raise ChannelAlreadyExistsError(
+                msg,
+                context={"channel": ch.name},
+            )
+        state.channels[ch.name] = ch
+        await write_channel_to_kv(state, ch)
+    logger.info(
+        COMM_CHANNEL_CREATED,
+        channel=ch.name,
+        type=str(ch.type),
+        backend="nats",
+    )
+    return ch
+
+
+async def resolve_channel_or_raise(
+    state: _NatsState,
+    channel_name: str,
+) -> Channel:
+    """Return a Channel from local cache or JetStream KV.
+
+    Shared by multiple public methods so a second process can observe
+    channels created by another process on the same stream.
+    """
+    async with state.lock:
+        cached = state.channels.get(channel_name)
+    if cached is not None:
+        return cached
+
+    loaded = await load_channel_from_kv(state, channel_name)
+    if loaded is None:
+        raise_channel_not_found(channel_name)
+
+    async with state.lock:
+        existing = state.channels.get(channel_name)
+        if existing is not None:
+            return existing
+        state.channels[channel_name] = loaded
+        return loaded
+
+
+async def list_channels(state: _NatsState) -> tuple[Channel, ...]:
+    """List all channels, including those created by peer processes."""
+    kv_channels = await scan_kv_channels(state)
+    async with state.lock:
+        for ch in kv_channels:
+            if ch.name not in state.channels:
+                state.channels[ch.name] = ch
+        return tuple(state.channels.values())

--- a/src/synthorg/communication/bus/_nats_connection.py
+++ b/src/synthorg/communication/bus/_nats_connection.py
@@ -189,7 +189,7 @@ async def stop(state: _NatsState) -> None:
         )
     state.in_flight_fetches.clear()
 
-    for key, sub in state.subscriptions.items():
+    for key, sub in list(state.subscriptions.items()):
         try:
             await sub.unsubscribe()
         except asyncio.CancelledError:

--- a/src/synthorg/communication/bus/_nats_connection.py
+++ b/src/synthorg/communication/bus/_nats_connection.py
@@ -1,0 +1,221 @@
+"""NATS connection lifecycle and JetStream infrastructure setup.
+
+Handles: connect, drain, stream creation, KV bucket creation, and
+graceful stop (cancel in-flight fetches, unsubscribe consumers, drain
+the client).
+"""
+
+import asyncio
+
+from synthorg.communication.bus._nats_state import _NatsState  # noqa: TC001
+from synthorg.communication.bus._nats_utils import (
+    SUBJECT_CHANNEL_TOKEN,
+    SUBJECT_DIRECT_TOKEN,
+    redact_url,
+)
+from synthorg.communication.bus.errors import (
+    BusConnectionError,
+    BusStreamError,
+)
+from synthorg.observability import get_logger
+from synthorg.observability.events.communication import (
+    COMM_BUS_CONNECTED,
+    COMM_BUS_DISCONNECTED,
+    COMM_BUS_KV_READ_FAILED,
+    COMM_BUS_RECONNECTING,
+    COMM_BUS_STOPPED,
+    COMM_BUS_STREAM_SCAN_FAILED,
+)
+
+logger = get_logger(__name__)
+
+
+async def connect(state: _NatsState) -> None:
+    """Establish the NATS connection, setting ``state.client`` and ``state.js``."""
+    import nats  # noqa: PLC0415
+    from nats.errors import NoServersError  # noqa: PLC0415
+
+    async def on_disconnected() -> None:
+        logger.warning(COMM_BUS_DISCONNECTED)
+
+    async def on_reconnected() -> None:
+        logger.info(COMM_BUS_CONNECTED, reconnect=True)
+
+    async def on_error(exc: Exception) -> None:
+        logger.warning(COMM_BUS_RECONNECTING, error=str(exc))
+
+    try:
+        state.client = await nats.connect(
+            servers=[state.nats_config.url],
+            reconnect_time_wait=state.nats_config.reconnect_time_wait_seconds,
+            max_reconnect_attempts=state.nats_config.max_reconnect_attempts,
+            connect_timeout=state.nats_config.connect_timeout_seconds,
+            user_credentials=state.nats_config.credentials_path,
+            disconnected_cb=on_disconnected,
+            reconnected_cb=on_reconnected,
+            error_cb=on_error,
+        )
+    except (TimeoutError, NoServersError, OSError) as exc:
+        redacted = redact_url(state.nats_config.url)
+        msg = f"Failed to connect to NATS at {redacted}: {exc}"
+        logger.exception(COMM_BUS_DISCONNECTED, error=msg, url=redacted)
+        raise BusConnectionError(
+            msg,
+            context={"url": redacted},
+        ) from exc
+
+    state.js = state.client.jetstream()
+    logger.info(COMM_BUS_CONNECTED, url=redact_url(state.nats_config.url))
+
+
+async def drain_partial_client(state: _NatsState) -> None:
+    """Drain a connected NATS client after a failed ``start()``.
+
+    Silently swallows drain errors because a drain failure cannot be
+    surfaced to the caller -- the original setup exception takes
+    precedence.
+    """
+    client = state.client
+    if client is None:
+        return
+    try:
+        await client.drain()
+    except Exception as exc:
+        logger.warning(
+            COMM_BUS_DISCONNECTED,
+            phase="drain_partial",
+            error=str(exc),
+        )
+    finally:
+        state.client = None
+        state.js = None
+        state.kv = None
+
+
+async def ensure_stream(state: _NatsState) -> None:
+    """Create the bus stream if it does not already exist."""
+    from nats.errors import Error as NatsError  # noqa: PLC0415
+    from nats.js.api import (  # noqa: PLC0415
+        RetentionPolicy,
+        StorageType,
+        StreamConfig,
+    )
+    from nats.js.errors import NotFoundError  # noqa: PLC0415
+
+    if state.js is None:
+        msg = "JetStream context not initialized"
+        raise BusStreamError(msg)
+
+    pfx = state.nats_config.stream_name_prefix.lower()
+    stream_config = StreamConfig(
+        name=state.stream_name,
+        subjects=[
+            f"{pfx}.bus.{SUBJECT_CHANNEL_TOKEN}.>",
+            f"{pfx}.bus.{SUBJECT_DIRECT_TOKEN}.>",
+        ],
+        retention=RetentionPolicy.LIMITS,
+        max_msgs_per_subject=(state.config.retention.max_messages_per_channel),
+        storage=StorageType.FILE,
+    )
+    try:
+        try:
+            await state.js.stream_info(state.stream_name)
+        except NotFoundError:
+            await state.js.add_stream(stream_config)
+        else:
+            await state.js.update_stream(stream_config)
+    except NatsError as exc:
+        msg = f"Failed to set up stream {state.stream_name}: {exc}"
+        logger.warning(
+            COMM_BUS_STREAM_SCAN_FAILED,
+            stream=state.stream_name,
+            error=str(exc),
+            phase="ensure_stream",
+        )
+        raise BusStreamError(
+            msg,
+            context={"stream": state.stream_name},
+        ) from exc
+
+
+async def ensure_kv_bucket(state: _NatsState) -> None:
+    """Create the KV bucket for dynamic channel registration."""
+    from nats.errors import Error as NatsError  # noqa: PLC0415
+    from nats.js.errors import BucketNotFoundError  # noqa: PLC0415
+
+    if state.js is None:
+        msg = "JetStream context not initialized"
+        raise BusStreamError(msg)
+
+    try:
+        try:
+            state.kv = await state.js.key_value(state.kv_bucket_name)
+        except BucketNotFoundError:
+            state.kv = await state.js.create_key_value(
+                bucket=state.kv_bucket_name,
+            )
+    except NatsError as exc:
+        msg = f"Failed to set up KV bucket {state.kv_bucket_name}: {exc}"
+        logger.warning(
+            COMM_BUS_KV_READ_FAILED,
+            channel="*",
+            error=str(exc),
+            phase="ensure_kv_bucket",
+        )
+        raise BusStreamError(
+            msg,
+            context={"bucket": state.kv_bucket_name},
+        ) from exc
+
+
+async def stop(state: _NatsState) -> None:
+    """Stop the bus gracefully. Idempotent.
+
+    Cancels outstanding ``receive()`` calls and closes the
+    underlying NATS connection.
+    """
+    async with state.lock:
+        if not state.running:
+            return
+        state.running = False
+    state.shutdown_event.set()
+
+    for task in list(state.in_flight_fetches):
+        task.cancel()
+    if state.in_flight_fetches:
+        await asyncio.gather(
+            *state.in_flight_fetches,
+            return_exceptions=True,
+        )
+    state.in_flight_fetches.clear()
+
+    for key, sub in state.subscriptions.items():
+        try:
+            await sub.unsubscribe()
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.warning(
+                COMM_BUS_DISCONNECTED,
+                phase="stop_unsubscribe",
+                subscription=str(key),
+                exc_info=True,
+            )
+    state.subscriptions.clear()
+
+    if state.client is not None:
+        try:
+            await state.client.drain()
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.warning(
+                COMM_BUS_DISCONNECTED,
+                phase="stop_drain",
+                exc_info=True,
+            )
+        state.client = None
+        state.js = None
+        state.kv = None
+
+    logger.info(COMM_BUS_STOPPED, backend="nats")

--- a/src/synthorg/communication/bus/_nats_consumers.py
+++ b/src/synthorg/communication/bus/_nats_consumers.py
@@ -1,0 +1,153 @@
+"""Durable pull consumer lifecycle: subscribe and unsubscribe.
+
+Each ``(channel_name, subscriber_id)`` pair maps to a durable pull
+consumer. This module handles creation and teardown of those consumers.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+from synthorg.communication.bus._nats_channels import (
+    durable_name,
+    resolve_channel_or_raise,
+    subject_for_channel,
+)
+from synthorg.communication.bus._nats_kv import write_channel_to_kv
+from synthorg.communication.bus._nats_state import _NatsState  # noqa: TC001
+from synthorg.communication.bus._nats_utils import (
+    CONSUMER_ACK_WAIT_MULTIPLIER,
+    raise_not_subscribed,
+    require_running,
+)
+from synthorg.communication.bus.errors import BusStreamError
+from synthorg.communication.channel import Channel  # noqa: TC001
+from synthorg.communication.subscription import Subscription
+from synthorg.observability import get_logger
+from synthorg.observability.events.communication import (
+    COMM_SUBSCRIPTION_CREATED,
+    COMM_SUBSCRIPTION_REMOVED,
+)
+
+logger = get_logger(__name__)
+
+
+async def create_pull_consumer(
+    state: _NatsState,
+    channel_name: str,
+    subscriber_id: str,
+    channel: Channel,
+) -> None:
+    """Create a durable pull consumer for (channel, subscriber).
+
+    Must be called under ``state.lock``.
+    """
+    from nats.js.api import ConsumerConfig  # noqa: PLC0415
+
+    if state.js is None:
+        msg = "JetStream context not initialized"
+        raise BusStreamError(msg)
+    prefix = state.nats_config.stream_name_prefix
+    subject = subject_for_channel(prefix, channel)
+    durable = durable_name(channel_name, subscriber_id)
+    consumer_config = ConsumerConfig(
+        durable_name=durable,
+        ack_wait=(
+            state.nats_config.publish_ack_wait_seconds * CONSUMER_ACK_WAIT_MULTIPLIER
+        ),
+        max_deliver=1,
+        filter_subject=subject,
+    )
+    sub = await state.js.pull_subscribe(
+        subject=subject,
+        durable=durable,
+        stream=state.stream_name,
+        config=consumer_config,
+    )
+    state.subscriptions[(channel_name, subscriber_id)] = sub
+
+
+async def subscribe(
+    state: _NatsState,
+    channel_name: str,
+    subscriber_id: str,
+) -> Subscription:
+    """Subscribe an agent to a channel via a durable pull consumer."""
+    async with state.lock:
+        require_running(state)
+    await resolve_channel_or_raise(state, channel_name)
+    async with state.lock:
+        require_running(state)
+        channel = state.channels[channel_name]
+        state.known_agents.add(subscriber_id)
+
+        key = (channel_name, subscriber_id)
+        if key not in state.subscriptions:
+            await create_pull_consumer(
+                state,
+                channel_name,
+                subscriber_id,
+                channel,
+            )
+
+        if subscriber_id not in channel.subscribers:
+            new_subs = (*channel.subscribers, subscriber_id)
+            updated = channel.model_copy(
+                update={"subscribers": new_subs},
+            )
+            state.channels[channel_name] = updated
+            await write_channel_to_kv(state, updated)
+
+    logger.info(
+        COMM_SUBSCRIPTION_CREATED,
+        channel=channel_name,
+        subscriber=subscriber_id,
+        backend="nats",
+    )
+    return Subscription(
+        channel_name=channel_name,
+        subscriber_id=subscriber_id,
+        subscribed_at=datetime.now(UTC),
+    )
+
+
+async def unsubscribe(
+    state: _NatsState,
+    channel_name: str,
+    subscriber_id: str,
+) -> None:
+    """Remove a subscription and tear down the pull consumer."""
+    async with state.lock:
+        require_running(state)
+        if channel_name not in state.channels:
+            raise_not_subscribed(channel_name, subscriber_id)
+        channel = state.channels[channel_name]
+        if subscriber_id not in channel.subscribers:
+            raise_not_subscribed(channel_name, subscriber_id)
+        new_subs = tuple(s for s in channel.subscribers if s != subscriber_id)
+        updated = channel.model_copy(
+            update={"subscribers": new_subs},
+        )
+        state.channels[channel_name] = updated
+        await write_channel_to_kv(state, updated)
+        key = (channel_name, subscriber_id)
+        sub: Any = state.subscriptions.pop(key, None)
+
+    if sub is not None:
+        try:
+            await sub.unsubscribe()
+        except Exception:
+            logger.warning(
+                COMM_SUBSCRIPTION_REMOVED,
+                channel=channel_name,
+                subscriber=subscriber_id,
+                backend="nats",
+                phase="unsubscribe_consumer_failed",
+                exc_info=True,
+            )
+
+    logger.info(
+        COMM_SUBSCRIPTION_REMOVED,
+        channel=channel_name,
+        subscriber=subscriber_id,
+        backend="nats",
+    )

--- a/src/synthorg/communication/bus/_nats_consumers.py
+++ b/src/synthorg/communication/bus/_nats_consumers.py
@@ -91,9 +91,14 @@ async def subscribe(
 
     # Store results under lock; KV write deferred to outside the lock.
     updated_channel = None
+    cleanup_sub = None
     async with state.lock:
-        if sub is not None and key not in state.subscriptions:
-            state.subscriptions[key] = sub
+        if sub is not None:
+            if key not in state.subscriptions:
+                state.subscriptions[key] = sub
+            else:
+                # Another coroutine won the race -- discard our sub.
+                cleanup_sub = sub
 
         channel = state.channels[channel_name]
         if subscriber_id not in channel.subscribers:
@@ -102,6 +107,18 @@ async def subscribe(
                 update={"subscribers": new_subs},
             )
             state.channels[channel_name] = updated_channel
+
+    if cleanup_sub is not None:
+        try:
+            await cleanup_sub.unsubscribe()
+        except Exception:
+            logger.warning(
+                COMM_SUBSCRIPTION_REMOVED,
+                channel=channel_name,
+                subscriber=subscriber_id,
+                phase="cleanup_duplicate_consumer",
+                exc_info=True,
+            )
 
     if updated_channel is not None:
         await write_channel_to_kv(state, updated_channel)

--- a/src/synthorg/communication/bus/_nats_consumers.py
+++ b/src/synthorg/communication/bus/_nats_consumers.py
@@ -36,10 +36,11 @@ async def create_pull_consumer(
     channel_name: str,
     subscriber_id: str,
     channel: Channel,
-) -> None:
+) -> Any:
     """Create a durable pull consumer for (channel, subscriber).
 
-    Must be called under ``state.lock``.
+    Returns the subscription object. Does NOT acquire ``state.lock``
+    so callers can perform the network I/O outside the lock.
     """
     from nats.js.api import ConsumerConfig  # noqa: PLC0415
 
@@ -57,13 +58,12 @@ async def create_pull_consumer(
         max_deliver=1,
         filter_subject=subject,
     )
-    sub = await state.js.pull_subscribe(
+    return await state.js.pull_subscribe(
         subject=subject,
         durable=durable,
         stream=state.stream_name,
         config=consumer_config,
     )
-    state.subscriptions[(channel_name, subscriber_id)] = sub
 
 
 async def subscribe(
@@ -75,27 +75,33 @@ async def subscribe(
     async with state.lock:
         require_running(state)
     await resolve_channel_or_raise(state, channel_name)
+
+    # Snapshot state under lock, then release for network I/O.
     async with state.lock:
         require_running(state)
         channel = state.channels[channel_name]
         state.known_agents.add(subscriber_id)
-
         key = (channel_name, subscriber_id)
-        if key not in state.subscriptions:
-            await create_pull_consumer(
-                state,
-                channel_name,
-                subscriber_id,
-                channel,
-            )
+        needs_consumer = key not in state.subscriptions
 
+    # Network I/O outside the lock so other bus operations are not blocked.
+    sub = None
+    if needs_consumer:
+        sub = await create_pull_consumer(state, channel_name, subscriber_id, channel)
+
+    # Store results under lock.
+    async with state.lock:
+        if sub is not None and key not in state.subscriptions:
+            state.subscriptions[key] = sub
+
+        channel = state.channels[channel_name]
         if subscriber_id not in channel.subscribers:
             new_subs = (*channel.subscribers, subscriber_id)
             updated = channel.model_copy(
                 update={"subscribers": new_subs},
             )
-            state.channels[channel_name] = updated
             await write_channel_to_kv(state, updated)
+            state.channels[channel_name] = updated
 
     logger.info(
         COMM_SUBSCRIPTION_CREATED,

--- a/src/synthorg/communication/bus/_nats_consumers.py
+++ b/src/synthorg/communication/bus/_nats_consumers.py
@@ -89,7 +89,8 @@ async def subscribe(
     if needs_consumer:
         sub = await create_pull_consumer(state, channel_name, subscriber_id, channel)
 
-    # Store results under lock.
+    # Store results under lock; KV write deferred to outside the lock.
+    updated_channel = None
     async with state.lock:
         if sub is not None and key not in state.subscriptions:
             state.subscriptions[key] = sub
@@ -97,11 +98,13 @@ async def subscribe(
         channel = state.channels[channel_name]
         if subscriber_id not in channel.subscribers:
             new_subs = (*channel.subscribers, subscriber_id)
-            updated = channel.model_copy(
+            updated_channel = channel.model_copy(
                 update={"subscribers": new_subs},
             )
-            await write_channel_to_kv(state, updated)
-            state.channels[channel_name] = updated
+            state.channels[channel_name] = updated_channel
+
+    if updated_channel is not None:
+        await write_channel_to_kv(state, updated_channel)
 
     logger.info(
         COMM_SUBSCRIPTION_CREATED,
@@ -134,9 +137,10 @@ async def unsubscribe(
             update={"subscribers": new_subs},
         )
         state.channels[channel_name] = updated
-        await write_channel_to_kv(state, updated)
         key = (channel_name, subscriber_id)
         sub: Any = state.subscriptions.pop(key, None)
+
+    await write_channel_to_kv(state, updated)
 
     if sub is not None:
         try:

--- a/src/synthorg/communication/bus/_nats_history.py
+++ b/src/synthorg/communication/bus/_nats_history.py
@@ -13,6 +13,7 @@ from synthorg.communication.bus._nats_channels import (
 )
 from synthorg.communication.bus._nats_publish import deserialize_message
 from synthorg.communication.bus._nats_state import _NatsState  # noqa: TC001
+from synthorg.communication.bus.errors import BusStreamError
 from synthorg.communication.message import Message  # noqa: TC001
 from synthorg.observability import get_logger
 from synthorg.observability.events.communication import (
@@ -58,7 +59,10 @@ async def create_history_scan_consumer(
             phase="subscribe",
             error=str(exc),
         )
-        return None
+        msg = f"History scan consumer creation failed for {subject}: {exc}"
+        raise BusStreamError(
+            msg, context={"stream": stream_name, "subject": subject}
+        ) from exc
 
 
 async def collect_history_batches(
@@ -83,7 +87,10 @@ async def collect_history_batches(
                 phase="fetch",
                 error=str(exc),
             )
-            return parsed_messages
+            msg = f"History batch fetch failed for {subject}: {exc}"
+            raise BusStreamError(
+                msg, context={"stream": stream_name, "subject": subject}
+            ) from exc
         if not batch:
             return parsed_messages
         for raw in batch:

--- a/src/synthorg/communication/bus/_nats_history.py
+++ b/src/synthorg/communication/bus/_nats_history.py
@@ -1,0 +1,198 @@
+"""History scanning: query JetStream for bounded message history.
+
+Uses ephemeral pull consumers with ``DeliverPolicy.ALL`` and
+``AckPolicy.NONE`` to scan a subject's history without affecting
+durable consumer state.
+"""
+
+from typing import Any
+
+from synthorg.communication.bus._nats_channels import (
+    resolve_channel_or_raise,
+    subject_for_channel,
+)
+from synthorg.communication.bus._nats_publish import deserialize_message
+from synthorg.communication.bus._nats_state import _NatsState  # noqa: TC001
+from synthorg.communication.message import Message  # noqa: TC001
+from synthorg.observability import get_logger
+from synthorg.observability.events.communication import (
+    COMM_BUS_MESSAGE_DESERIALIZE_FAILED,
+    COMM_BUS_STREAM_SCAN_FAILED,
+    COMM_HISTORY_QUERIED,
+)
+
+logger = get_logger(__name__)
+
+
+async def create_history_scan_consumer(
+    js: Any,
+    subject: str,
+    stream_name: str,
+) -> Any | None:
+    """Create the ephemeral pull consumer used by history scans."""
+    from nats.js.api import (  # noqa: PLC0415
+        AckPolicy,
+        ConsumerConfig,
+        DeliverPolicy,
+    )
+    from nats.js.errors import NotFoundError  # noqa: PLC0415
+
+    consumer_config = ConsumerConfig(
+        deliver_policy=DeliverPolicy.ALL,
+        ack_policy=AckPolicy.NONE,
+        filter_subject=subject,
+    )
+    try:
+        return await js.pull_subscribe(
+            subject=subject,
+            stream=stream_name,
+            config=consumer_config,
+        )
+    except NotFoundError:
+        return None
+    except Exception as exc:
+        logger.warning(
+            COMM_BUS_STREAM_SCAN_FAILED,
+            stream=stream_name,
+            subject=subject,
+            phase="subscribe",
+            error=str(exc),
+        )
+        return None
+
+
+async def collect_history_batches(
+    psub: Any,
+    subject: str,
+    stream_name: str,
+) -> list[Message]:
+    """Drain the history consumer into a list, stopping on idle timeout."""
+    from nats.errors import TimeoutError as NatsTimeoutError  # noqa: PLC0415
+
+    parsed_messages: list[Message] = []
+    while True:
+        try:
+            batch = await psub.fetch(batch=100, timeout=0.5)
+        except NatsTimeoutError:
+            return parsed_messages
+        except Exception as exc:
+            logger.warning(
+                COMM_BUS_STREAM_SCAN_FAILED,
+                stream=stream_name,
+                subject=subject,
+                phase="fetch",
+                error=str(exc),
+            )
+            return parsed_messages
+        if not batch:
+            return parsed_messages
+        for raw in batch:
+            parsed = try_parse_matching(raw, subject)
+            if parsed is not None:
+                parsed_messages.append(parsed)
+
+
+async def unsubscribe_history_consumer(
+    psub: Any,
+    subject: str,
+    stream_name: str,
+) -> None:
+    """Best-effort teardown for an ephemeral history consumer."""
+    try:
+        await psub.unsubscribe()
+    except Exception as exc:
+        logger.warning(
+            COMM_BUS_STREAM_SCAN_FAILED,
+            stream=stream_name,
+            subject=subject,
+            phase="unsubscribe",
+            error=str(exc),
+        )
+
+
+def try_parse_matching(raw: Any, subject: str) -> Message | None:
+    """Parse the raw message if it matches the target subject."""
+    if raw.subject != subject or raw.data is None:
+        return None
+    try:
+        return deserialize_message(raw.data)
+    except ValueError:
+        logger.warning(
+            COMM_BUS_MESSAGE_DESERIALIZE_FAILED,
+            subject=subject,
+            size=len(raw.data),
+            phase="history_scan",
+            exc_info=True,
+        )
+        return None
+
+
+async def scan_stream_for_subject(
+    state: _NatsState,
+    js: Any,
+    *,
+    subject: str,
+    max_to_return: int,
+) -> list[Message]:
+    """Collect the most recent messages on a subject, oldest-first."""
+    if js is None:
+        return []
+
+    psub = await create_history_scan_consumer(js, subject, state.stream_name)
+    if psub is None:
+        return []
+
+    try:
+        parsed_messages = await collect_history_batches(
+            psub, subject, state.stream_name
+        )
+    finally:
+        await unsubscribe_history_consumer(psub, subject, state.stream_name)
+
+    if len(parsed_messages) <= max_to_return:
+        return parsed_messages
+    return parsed_messages[-max_to_return:]
+
+
+async def get_channel_history(
+    state: _NatsState,
+    channel_name: str,
+    *,
+    limit: int | None = None,
+) -> tuple[Message, ...]:
+    """Get message history for a channel."""
+    channel = await resolve_channel_or_raise(state, channel_name)
+    async with state.lock:
+        prefix = state.nats_config.stream_name_prefix
+        subject = subject_for_channel(prefix, channel)
+        js = state.js
+
+    if limit is not None and limit <= 0:
+        logger.debug(
+            COMM_HISTORY_QUERIED,
+            channel=channel_name,
+            count=0,
+            limit=limit,
+            backend="nats",
+        )
+        return ()
+
+    max_to_return = (
+        limit if limit is not None else state.config.retention.max_messages_per_channel
+    )
+
+    messages = await scan_stream_for_subject(
+        state,
+        js,
+        subject=subject,
+        max_to_return=max_to_return,
+    )
+
+    logger.debug(
+        COMM_HISTORY_QUERIED,
+        channel=channel_name,
+        count=len(messages),
+        limit=limit,
+        backend="nats",
+    )
+    return tuple(messages)

--- a/src/synthorg/communication/bus/_nats_kv.py
+++ b/src/synthorg/communication/bus/_nats_kv.py
@@ -39,7 +39,8 @@ async def create_channel_in_kv(
     )
 
     if state.kv is None:
-        return
+        msg = "KV store unavailable -- cannot create channel"
+        raise BusStreamError(msg, context={"channel": channel.name})
     key = encode_token(channel.name)
     value = channel.model_dump_json().encode("utf-8")
     try:

--- a/src/synthorg/communication/bus/_nats_kv.py
+++ b/src/synthorg/communication/bus/_nats_kv.py
@@ -52,6 +52,12 @@ async def create_channel_in_kv(
         await state.kv.create(key, value)
     except KeyWrongLastSequenceError:
         msg = f"Channel already exists in KV: {channel.name}"
+        logger.warning(
+            COMM_BUS_KV_WRITE_FAILED,
+            channel=channel.name,
+            error=msg,
+            phase="atomic_create",
+        )
         raise ChannelAlreadyExistsError(
             msg, context={"channel": channel.name}
         ) from None

--- a/src/synthorg/communication/bus/_nats_kv.py
+++ b/src/synthorg/communication/bus/_nats_kv.py
@@ -1,0 +1,142 @@
+"""JetStream KV bucket operations for channel persistence.
+
+Handles reading, writing, and scanning the KV bucket that stores
+channel definitions so they are discoverable across processes.
+"""
+
+import json
+from typing import Any
+
+from synthorg.communication.bus._nats_state import _NatsState  # noqa: TC001
+from synthorg.communication.bus._nats_utils import decode_token, encode_token
+from synthorg.communication.channel import Channel
+from synthorg.observability import get_logger
+from synthorg.observability.events.communication import (
+    COMM_BUS_KV_READ_FAILED,
+    COMM_BUS_KV_WRITE_FAILED,
+)
+
+logger = get_logger(__name__)
+
+
+async def write_channel_to_kv(state: _NatsState, channel: Channel) -> None:
+    """Persist a Channel definition to the KV bucket."""
+    if state.kv is None:
+        return
+    key = encode_token(channel.name)
+    value = channel.model_dump_json().encode("utf-8")
+    try:
+        await state.kv.put(key, value)
+    except Exception as exc:
+        logger.warning(
+            COMM_BUS_KV_WRITE_FAILED,
+            channel=channel.name,
+            error=str(exc),
+        )
+
+
+async def load_channel_from_kv(
+    state: _NatsState,
+    channel_name: str,
+) -> Channel | None:
+    """Load a Channel definition from the KV bucket, if present."""
+    entry = await fetch_kv_entry(state, channel_name)
+    if entry is None:
+        return None
+    return decode_kv_channel(channel_name, entry)
+
+
+async def fetch_kv_entry(
+    state: _NatsState,
+    channel_name: str,
+) -> Any | None:
+    """Fetch a raw KV entry, logging transport errors and returning None."""
+    from nats.js.errors import KeyNotFoundError  # noqa: PLC0415
+
+    if state.kv is None:
+        return None
+    key = encode_token(channel_name)
+    try:
+        entry = await state.kv.get(key)
+    except KeyNotFoundError:
+        return None
+    except Exception as exc:
+        logger.warning(
+            COMM_BUS_KV_READ_FAILED,
+            channel=channel_name,
+            error=str(exc),
+        )
+        return None
+    if entry is None or entry.value is None:
+        return None
+    return entry
+
+
+def decode_kv_channel(
+    channel_name: str,
+    entry: Any,
+) -> Channel | None:
+    """Decode a KV entry into a Channel, logging parse failures."""
+    try:
+        data = json.loads(entry.value.decode("utf-8"))
+        channel = Channel.model_validate(data)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            COMM_BUS_KV_READ_FAILED,
+            channel=channel_name,
+            error=str(exc),
+        )
+        return None
+    except ValueError as exc:
+        logger.warning(
+            COMM_BUS_KV_READ_FAILED,
+            channel=channel_name,
+            error=str(exc),
+        )
+        return None
+    if channel.name != channel_name:
+        logger.warning(
+            COMM_BUS_KV_READ_FAILED,
+            channel=channel_name,
+            error=(
+                f"KV entry name mismatch: expected {channel_name!r}, "
+                f"got {channel.name!r}"
+            ),
+        )
+        return None
+    return channel
+
+
+async def scan_kv_channels(state: _NatsState) -> list[Channel]:
+    """Scan the KV bucket for all persisted channels."""
+    if state.kv is None:
+        return []
+    try:
+        keys = await state.kv.keys()
+    except Exception as exc:
+        logger.warning(
+            COMM_BUS_KV_READ_FAILED,
+            channel="*",
+            error=str(exc),
+            phase="list_channels_scan",
+        )
+        return []
+    channels: list[Channel] = []
+    for key in keys:
+        try:
+            decoded_name = decode_token(key)
+        except Exception as exc:
+            logger.warning(
+                COMM_BUS_KV_READ_FAILED,
+                channel=key,
+                error=str(exc),
+                phase="decode_token",
+            )
+            continue
+        entry = await fetch_kv_entry(state, decoded_name)
+        if entry is None:
+            continue
+        ch = decode_kv_channel(decoded_name, entry)
+        if ch is not None:
+            channels.append(ch)
+    return channels

--- a/src/synthorg/communication/bus/_nats_kv.py
+++ b/src/synthorg/communication/bus/_nats_kv.py
@@ -40,6 +40,11 @@ async def create_channel_in_kv(
 
     if state.kv is None:
         msg = "KV store unavailable -- cannot create channel"
+        logger.error(
+            COMM_BUS_KV_WRITE_FAILED,
+            channel=channel.name,
+            error=msg,
+        )
         raise BusStreamError(msg, context={"channel": channel.name})
     key = encode_token(channel.name)
     value = channel.model_dump_json().encode("utf-8")
@@ -96,7 +101,11 @@ async def fetch_kv_entry(
     state: _NatsState,
     channel_name: str,
 ) -> Any | None:
-    """Fetch a raw KV entry, logging transport errors and returning None."""
+    """Fetch a raw KV entry.
+
+    Returns ``None`` for ``KeyNotFoundError`` (genuine miss).
+    Raises ``BusStreamError`` on transport/connection errors.
+    """
     from nats.js.errors import KeyNotFoundError  # noqa: PLC0415
 
     if state.kv is None:

--- a/src/synthorg/communication/bus/_nats_kv.py
+++ b/src/synthorg/communication/bus/_nats_kv.py
@@ -12,6 +12,7 @@ from synthorg.communication.bus._nats_state import _NatsState  # noqa: TC001
 from synthorg.communication.bus._nats_utils import decode_token, encode_token
 from synthorg.communication.bus.errors import BusStreamError
 from synthorg.communication.channel import Channel
+from synthorg.communication.errors import ChannelAlreadyExistsError
 from synthorg.observability import get_logger
 from synthorg.observability.events.communication import (
     COMM_BUS_KV_READ_FAILED,
@@ -21,8 +22,50 @@ from synthorg.observability.events.communication import (
 logger = get_logger(__name__)
 
 
+async def create_channel_in_kv(
+    state: _NatsState,
+    channel: Channel,
+) -> None:
+    """Atomically create a channel entry in KV (fails if it exists).
+
+    Uses the KV ``create`` API which is an atomic create-if-not-exists.
+
+    Raises:
+        ChannelAlreadyExistsError: If the key already exists.
+        BusStreamError: If a transport error prevents the write.
+    """
+    from nats.js.errors import (  # noqa: PLC0415
+        KeyWrongLastSequenceError,
+    )
+
+    if state.kv is None:
+        return
+    key = encode_token(channel.name)
+    value = channel.model_dump_json().encode("utf-8")
+    try:
+        await state.kv.create(key, value)
+    except KeyWrongLastSequenceError:
+        msg = f"Channel already exists in KV: {channel.name}"
+        raise ChannelAlreadyExistsError(
+            msg, context={"channel": channel.name}
+        ) from None
+    except Exception as exc:
+        logger.warning(
+            COMM_BUS_KV_WRITE_FAILED,
+            channel=channel.name,
+            error=str(exc),
+        )
+        msg = f"KV create failed for channel {channel.name!r}: {exc}"
+        raise BusStreamError(msg, context={"channel": channel.name}) from exc
+
+
 async def write_channel_to_kv(state: _NatsState, channel: Channel) -> None:
-    """Persist a Channel definition to the KV bucket."""
+    """Persist a Channel definition to the KV bucket (best-effort update).
+
+    Used for subscription changes and direct channel updates where
+    local state is authoritative and KV persistence is secondary.
+    Logs failures but does not raise.
+    """
     if state.kv is None:
         return
     key = encode_token(channel.name)
@@ -118,8 +161,12 @@ async def scan_kv_channels(state: _NatsState) -> list[Channel]:
     """
     if state.kv is None:
         return []
+    from nats.js.errors import NoKeysError  # noqa: PLC0415
+
     try:
         keys = await state.kv.keys()
+    except NoKeysError:
+        return []
     except Exception as exc:
         logger.warning(
             COMM_BUS_KV_READ_FAILED,
@@ -144,11 +191,10 @@ async def scan_kv_channels(state: _NatsState) -> list[Channel]:
 
     entries = await asyncio.gather(
         *(fetch_kv_entry(state, name) for _, name in decoded_keys),
-        return_exceptions=True,
     )
     channels: list[Channel] = []
     for (_, decoded_name), entry in zip(decoded_keys, entries, strict=True):
-        if isinstance(entry, Exception) or entry is None:
+        if entry is None:
             continue
         ch = decode_kv_channel(decoded_name, entry)
         if ch is not None:

--- a/src/synthorg/communication/bus/_nats_kv.py
+++ b/src/synthorg/communication/bus/_nats_kv.py
@@ -208,11 +208,12 @@ async def scan_kv_channels(state: _NatsState) -> list[Channel]:
 
     entries = await asyncio.gather(
         *(fetch_kv_entry(state, name) for _, name in decoded_keys),
+        return_exceptions=True,
     )
     channels: list[Channel] = []
     for (_, decoded_name), entry in zip(decoded_keys, entries, strict=True):
-        if entry is None:
-            continue
+        if isinstance(entry, Exception) or entry is None:
+            continue  # Transport/decode errors already logged inside helpers.
         try:
             ch = decode_kv_channel(decoded_name, entry)
         except BusStreamError:

--- a/src/synthorg/communication/bus/_nats_kv.py
+++ b/src/synthorg/communication/bus/_nats_kv.py
@@ -4,11 +4,13 @@ Handles reading, writing, and scanning the KV bucket that stores
 channel definitions so they are discoverable across processes.
 """
 
+import asyncio
 import json
 from typing import Any
 
 from synthorg.communication.bus._nats_state import _NatsState  # noqa: TC001
 from synthorg.communication.bus._nats_utils import decode_token, encode_token
+from synthorg.communication.bus.errors import BusStreamError
 from synthorg.communication.channel import Channel
 from synthorg.observability import get_logger
 from synthorg.observability.events.communication import (
@@ -66,7 +68,8 @@ async def fetch_kv_entry(
             channel=channel_name,
             error=str(exc),
         )
-        return None
+        msg = f"KV transport error for channel {channel_name!r}: {exc}"
+        raise BusStreamError(msg, context={"channel": channel_name}) from exc
     if entry is None or entry.value is None:
         return None
     return entry
@@ -108,7 +111,11 @@ def decode_kv_channel(
 
 
 async def scan_kv_channels(state: _NatsState) -> list[Channel]:
-    """Scan the KV bucket for all persisted channels."""
+    """Scan the KV bucket for all persisted channels.
+
+    Raises:
+        BusStreamError: If the KV bucket cannot be listed.
+    """
     if state.kv is None:
         return []
     try:
@@ -120,11 +127,13 @@ async def scan_kv_channels(state: _NatsState) -> list[Channel]:
             error=str(exc),
             phase="list_channels_scan",
         )
-        return []
-    channels: list[Channel] = []
+        msg = f"KV scan failed: {exc}"
+        raise BusStreamError(msg, context={"phase": "list_channels_scan"}) from exc
+
+    decoded_keys: list[tuple[str, str]] = []
     for key in keys:
         try:
-            decoded_name = decode_token(key)
+            decoded_keys.append((key, decode_token(key)))
         except Exception as exc:
             logger.warning(
                 COMM_BUS_KV_READ_FAILED,
@@ -132,9 +141,14 @@ async def scan_kv_channels(state: _NatsState) -> list[Channel]:
                 error=str(exc),
                 phase="decode_token",
             )
-            continue
-        entry = await fetch_kv_entry(state, decoded_name)
-        if entry is None:
+
+    entries = await asyncio.gather(
+        *(fetch_kv_entry(state, name) for _, name in decoded_keys),
+        return_exceptions=True,
+    )
+    channels: list[Channel] = []
+    for (_, decoded_name), entry in zip(decoded_keys, entries, strict=True):
+        if isinstance(entry, Exception) or entry is None:
             continue
         ch = decode_kv_channel(decoded_name, entry)
         if ch is not None:

--- a/src/synthorg/communication/bus/_nats_kv.py
+++ b/src/synthorg/communication/bus/_nats_kv.py
@@ -122,8 +122,13 @@ async def fetch_kv_entry(
 def decode_kv_channel(
     channel_name: str,
     entry: Any,
-) -> Channel | None:
-    """Decode a KV entry into a Channel, logging parse failures."""
+) -> Channel:
+    """Decode a KV entry into a Channel.
+
+    Raises:
+        BusStreamError: If the entry contains invalid JSON, fails
+            schema validation, or has a mismatched channel name.
+    """
     try:
         data = json.loads(entry.value.decode("utf-8"))
         channel = Channel.model_validate(data)
@@ -133,24 +138,26 @@ def decode_kv_channel(
             channel=channel_name,
             error=str(exc),
         )
-        return None
+        msg = f"Corrupt KV entry for channel {channel_name!r}: {exc}"
+        raise BusStreamError(msg, context={"channel": channel_name}) from exc
     except ValueError as exc:
         logger.warning(
             COMM_BUS_KV_READ_FAILED,
             channel=channel_name,
             error=str(exc),
         )
-        return None
+        msg = f"Invalid KV data for channel {channel_name!r}: {exc}"
+        raise BusStreamError(msg, context={"channel": channel_name}) from exc
     if channel.name != channel_name:
+        mismatch = (
+            f"KV entry name mismatch: expected {channel_name!r}, got {channel.name!r}"
+        )
         logger.warning(
             COMM_BUS_KV_READ_FAILED,
             channel=channel_name,
-            error=(
-                f"KV entry name mismatch: expected {channel_name!r}, "
-                f"got {channel.name!r}"
-            ),
+            error=mismatch,
         )
-        return None
+        raise BusStreamError(mismatch, context={"channel": channel_name})
     return channel
 
 
@@ -197,7 +204,9 @@ async def scan_kv_channels(state: _NatsState) -> list[Channel]:
     for (_, decoded_name), entry in zip(decoded_keys, entries, strict=True):
         if entry is None:
             continue
-        ch = decode_kv_channel(decoded_name, entry)
-        if ch is not None:
-            channels.append(ch)
+        try:
+            ch = decode_kv_channel(decoded_name, entry)
+        except BusStreamError:
+            continue  # Already logged inside decode_kv_channel.
+        channels.append(ch)
     return channels

--- a/src/synthorg/communication/bus/_nats_publish.py
+++ b/src/synthorg/communication/bus/_nats_publish.py
@@ -10,10 +10,11 @@ from synthorg.communication.bus._nats_channels import (
     direct_subject as _direct_subject,
 )
 from synthorg.communication.bus._nats_channels import (
-    ensure_direct_channel,
+    prepare_direct_channel,
     resolve_channel_or_raise,
     subject_for_channel,
 )
+from synthorg.communication.bus._nats_kv import write_channel_to_kv
 from synthorg.communication.bus._nats_state import _NatsState  # noqa: TC001
 from synthorg.communication.bus._nats_utils import (
     DM_SEPARATOR,
@@ -111,9 +112,12 @@ async def send_direct(
 
     async with state.lock:
         require_running(state)
-        await ensure_direct_channel(state, channel_name, pair)
+        kv_channel = prepare_direct_channel(state, channel_name, pair)
         state.known_agents.add(sender)
         state.known_agents.add(recipient)
+
+    if kv_channel is not None:
+        await write_channel_to_kv(state, kv_channel)
 
     prefix = state.nats_config.stream_name_prefix
     subject = _direct_subject(prefix, channel_name)

--- a/src/synthorg/communication/bus/_nats_publish.py
+++ b/src/synthorg/communication/bus/_nats_publish.py
@@ -34,7 +34,7 @@ logger = get_logger(__name__)
 
 def serialize_message(message: Message) -> bytes:
     """Serialize a Message to JSON bytes for the wire."""
-    return message.model_dump_json().encode("utf-8")
+    return message.model_dump_json(by_alias=True).encode("utf-8")
 
 
 def deserialize_message(data: bytes) -> Message:

--- a/src/synthorg/communication/bus/_nats_publish.py
+++ b/src/synthorg/communication/bus/_nats_publish.py
@@ -15,7 +15,11 @@ from synthorg.communication.bus._nats_channels import (
     subject_for_channel,
 )
 from synthorg.communication.bus._nats_state import _NatsState  # noqa: TC001
-from synthorg.communication.bus._nats_utils import DM_SEPARATOR, require_running
+from synthorg.communication.bus._nats_utils import (
+    DM_SEPARATOR,
+    MAX_BUS_PAYLOAD_BYTES,
+    require_running,
+)
 from synthorg.communication.errors import MessageBusNotRunningError
 from synthorg.communication.message import Message
 from synthorg.observability import get_logger
@@ -63,6 +67,13 @@ async def publish(state: _NatsState, message: Message) -> None:
     subject = subject_for_channel(prefix, channel)
 
     payload = serialize_message(message)
+    if len(payload) > MAX_BUS_PAYLOAD_BYTES:
+        msg = (
+            f"Serialized message exceeds bus payload limit: "
+            f"{len(payload)} > {MAX_BUS_PAYLOAD_BYTES}"
+        )
+        logger.warning(COMM_SEND_DIRECT_INVALID, error=msg, channel=channel_name)
+        raise ValueError(msg)
     await publish_with_ack(state, subject, payload)
 
     logger.info(
@@ -107,6 +118,13 @@ async def send_direct(
     prefix = state.nats_config.stream_name_prefix
     subject = _direct_subject(prefix, channel_name)
     payload = serialize_message(message)
+    if len(payload) > MAX_BUS_PAYLOAD_BYTES:
+        msg = (
+            f"Serialized direct message exceeds bus payload limit: "
+            f"{len(payload)} > {MAX_BUS_PAYLOAD_BYTES}"
+        )
+        logger.warning(COMM_SEND_DIRECT_INVALID, error=msg, channel=channel_name)
+        raise ValueError(msg)
     await publish_with_ack(state, subject, payload)
 
     logger.info(

--- a/src/synthorg/communication/bus/_nats_publish.py
+++ b/src/synthorg/communication/bus/_nats_publish.py
@@ -1,0 +1,119 @@
+"""Publishing: publish to channels and send direct messages.
+
+Includes message serialization/deserialization and the JetStream
+publish-with-ack wrapper.
+"""
+
+import asyncio
+
+from synthorg.communication.bus._nats_channels import (
+    direct_subject as _direct_subject,
+)
+from synthorg.communication.bus._nats_channels import (
+    ensure_direct_channel,
+    resolve_channel_or_raise,
+    subject_for_channel,
+)
+from synthorg.communication.bus._nats_state import _NatsState  # noqa: TC001
+from synthorg.communication.bus._nats_utils import DM_SEPARATOR, require_running
+from synthorg.communication.errors import MessageBusNotRunningError
+from synthorg.communication.message import Message
+from synthorg.observability import get_logger
+from synthorg.observability.events.communication import (
+    COMM_DIRECT_SENT,
+    COMM_MESSAGE_PUBLISHED,
+    COMM_SEND_DIRECT_INVALID,
+)
+
+logger = get_logger(__name__)
+
+
+def serialize_message(message: Message) -> bytes:
+    """Serialize a Message to JSON bytes for the wire."""
+    return message.model_dump_json().encode("utf-8")
+
+
+def deserialize_message(data: bytes) -> Message:
+    """Reconstruct a Message from wire JSON bytes."""
+    return Message.model_validate_json(data.decode("utf-8"))
+
+
+async def publish_with_ack(
+    state: _NatsState,
+    subject: str,
+    payload: bytes,
+) -> None:
+    """Publish to JetStream waiting for server ack."""
+    if state.js is None:
+        msg = "JetStream context not initialized"
+        raise MessageBusNotRunningError(msg)
+    await asyncio.wait_for(
+        state.js.publish(subject, payload),
+        timeout=state.nats_config.publish_ack_wait_seconds,
+    )
+
+
+async def publish(state: _NatsState, message: Message) -> None:
+    """Publish a message to its channel via the JetStream stream."""
+    async with state.lock:
+        require_running(state)
+    channel_name = message.channel
+    channel = await resolve_channel_or_raise(state, channel_name)
+    prefix = state.nats_config.stream_name_prefix
+    subject = subject_for_channel(prefix, channel)
+
+    payload = serialize_message(message)
+    await publish_with_ack(state, subject, payload)
+
+    logger.info(
+        COMM_MESSAGE_PUBLISHED,
+        channel=channel_name,
+        message_id=str(message.id),
+        type=str(message.type),
+        backend="nats",
+    )
+
+
+async def send_direct(
+    state: _NatsState,
+    message: Message,
+    *,
+    recipient: str,
+) -> None:
+    """Send a direct message, creating the DIRECT channel lazily."""
+    sender = message.sender
+    if message.to != recipient:
+        msg = f"recipient={recipient!r} does not match message.to={message.to!r}"
+        logger.warning(COMM_SEND_DIRECT_INVALID, error=msg)
+        raise ValueError(msg)
+    for agent_id in (sender, recipient):
+        if DM_SEPARATOR in agent_id:
+            msg = (
+                f"Agent ID {agent_id!r} contains the reserved "
+                f"separator character {DM_SEPARATOR!r}"
+            )
+            logger.warning(COMM_SEND_DIRECT_INVALID, error=msg)
+            raise ValueError(msg)
+    a, b = sorted([sender, recipient])
+    pair = (a, b)
+    channel_name = f"@{pair[0]}:{pair[1]}"
+
+    async with state.lock:
+        require_running(state)
+        await ensure_direct_channel(state, channel_name, pair)
+        state.known_agents.add(sender)
+        state.known_agents.add(recipient)
+
+    prefix = state.nats_config.stream_name_prefix
+    subject = _direct_subject(prefix, channel_name)
+    payload = serialize_message(message)
+    await publish_with_ack(state, subject, payload)
+
+    logger.info(
+        COMM_DIRECT_SENT,
+        channel=channel_name,
+        sender=sender,
+        recipient=recipient,
+        message_id=str(message.id),
+        backend="nats",
+    )

--- a/src/synthorg/communication/bus/_nats_receive.py
+++ b/src/synthorg/communication/bus/_nats_receive.py
@@ -1,0 +1,299 @@
+"""Message reception: fetch loop, ack, envelope building.
+
+The core complexity of the bus -- racing fetch against shutdown,
+handling timeouts, building delivery envelopes, and acking messages.
+"""
+
+import asyncio
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+from synthorg.communication.bus._nats_channels import resolve_channel_or_raise
+from synthorg.communication.bus._nats_consumers import create_pull_consumer
+from synthorg.communication.bus._nats_publish import deserialize_message
+from synthorg.communication.bus._nats_state import _NatsState  # noqa: TC001
+from synthorg.communication.bus._nats_utils import (
+    MAX_BUS_PAYLOAD_BYTES,
+    RECEIVE_POLL_WINDOW_SECONDS,
+    cancel_if_pending,
+    raise_not_subscribed,
+    require_running,
+)
+from synthorg.communication.enums import ChannelType
+from synthorg.communication.subscription import DeliveryEnvelope
+from synthorg.observability import get_logger
+from synthorg.observability.events.communication import (
+    COMM_BUS_MESSAGE_DESERIALIZE_FAILED,
+    COMM_BUS_MESSAGE_TOO_LARGE,
+    COMM_BUS_RECEIVE_ERROR,
+    COMM_MESSAGE_DELIVERED,
+    COMM_RECEIVE_SHUTDOWN,
+)
+
+logger = get_logger(__name__)
+
+
+async def resolve_consumer(
+    state: _NatsState,
+    channel_name: str,
+    subscriber_id: str,
+) -> Any:
+    """Validate preconditions and return the durable pull consumer.
+
+    Creates the consumer lazily for BROADCAST subscribers.
+    """
+    async with state.lock:
+        require_running(state)
+    await resolve_channel_or_raise(state, channel_name)
+    async with state.lock:
+        require_running(state)
+        channel = state.channels[channel_name]
+        if (
+            channel.type != ChannelType.BROADCAST
+            and subscriber_id not in channel.subscribers
+        ):
+            raise_not_subscribed(channel_name, subscriber_id)
+        key = (channel_name, subscriber_id)
+        sub = state.subscriptions.get(key)
+        if sub is None:
+            await create_pull_consumer(
+                state,
+                channel_name,
+                subscriber_id,
+                channel,
+            )
+            sub = state.subscriptions[key]
+    return sub
+
+
+async def fetch_with_shutdown(
+    state: _NatsState,
+    sub: Any,
+    timeout: float,  # noqa: ASYNC109
+    *,
+    channel_name: str,
+    subscriber_id: str,
+) -> list[Any] | None:
+    """Fetch at most one message, racing against the shutdown event.
+
+    Returns ``None`` on shutdown, cancellation, or internal errors;
+    an empty list on clean timeout.
+    """
+    from nats.errors import TimeoutError as NatsTimeoutError  # noqa: PLC0415
+
+    fetch_task: asyncio.Task[Any] = asyncio.create_task(
+        sub.fetch(batch=1, timeout=timeout),
+    )
+    shutdown_task: asyncio.Task[Any] = asyncio.create_task(
+        state.shutdown_event.wait(),
+    )
+    state.in_flight_fetches.add(fetch_task)
+    state.in_flight_fetches.add(shutdown_task)
+
+    try:
+        done, _ = await asyncio.wait(
+            {fetch_task, shutdown_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+    except BaseException:
+        fetch_task.cancel()
+        shutdown_task.cancel()
+        raise
+    finally:
+        state.in_flight_fetches.discard(fetch_task)
+        state.in_flight_fetches.discard(shutdown_task)
+
+    await cancel_if_pending(fetch_task)
+    await cancel_if_pending(shutdown_task)
+
+    if shutdown_task in done and fetch_task not in done:
+        logger.debug(
+            COMM_RECEIVE_SHUTDOWN,
+            channel=channel_name,
+            subscriber=subscriber_id,
+        )
+        return None
+
+    try:
+        result: list[Any] = fetch_task.result()
+    except NatsTimeoutError:
+        return []
+    except asyncio.CancelledError:
+        return None
+    except Exception:
+        logger.exception(
+            COMM_BUS_RECEIVE_ERROR,
+            channel=channel_name,
+            subscriber=subscriber_id,
+        )
+        return None
+    return result
+
+
+async def try_ack(
+    msg: Any,
+    *,
+    channel_name: str,
+    subscriber_id: str,
+) -> bool:
+    """Attempt to ack a fetched JetStream message.
+
+    Returns ``True`` on success, ``False`` on failure.
+    """
+    try:
+        await msg.ack()
+    except Exception:
+        logger.exception(
+            COMM_BUS_RECEIVE_ERROR,
+            channel=channel_name,
+            subscriber=subscriber_id,
+            phase="ack",
+        )
+        return False
+    return True
+
+
+async def build_envelope(
+    msgs: list[Any] | None,
+    *,
+    channel_name: str,
+    subscriber_id: str,
+) -> DeliveryEnvelope | None:
+    """Ack the fetched message and wrap it in a DeliveryEnvelope."""
+    if not msgs:
+        return None
+
+    msg = msgs[0]
+    if len(msg.data) > MAX_BUS_PAYLOAD_BYTES:
+        logger.warning(
+            COMM_BUS_MESSAGE_TOO_LARGE,
+            channel=channel_name,
+            subscriber=subscriber_id,
+            size=len(msg.data),
+            limit=MAX_BUS_PAYLOAD_BYTES,
+        )
+        await try_ack(
+            msg,
+            channel_name=channel_name,
+            subscriber_id=subscriber_id,
+        )
+        return None
+
+    try:
+        parsed = deserialize_message(msg.data)
+    except ValueError as exc:
+        logger.warning(
+            COMM_BUS_MESSAGE_DESERIALIZE_FAILED,
+            channel=channel_name,
+            subscriber=subscriber_id,
+            size=len(msg.data),
+            error=str(exc),
+        )
+        await try_ack(
+            msg,
+            channel_name=channel_name,
+            subscriber_id=subscriber_id,
+        )
+        return None
+
+    if not await try_ack(
+        msg,
+        channel_name=channel_name,
+        subscriber_id=subscriber_id,
+    ):
+        return None
+
+    envelope = DeliveryEnvelope(
+        message=parsed,
+        channel_name=channel_name,
+        delivered_at=datetime.now(UTC),
+    )
+    logger.debug(
+        COMM_MESSAGE_DELIVERED,
+        channel=channel_name,
+        subscriber=subscriber_id,
+        message_id=str(parsed.id),
+        backend="nats",
+    )
+    return envelope
+
+
+async def receive_blocking(
+    state: _NatsState,
+    channel_name: str,
+    subscriber_id: str,
+    sub: Any,
+) -> DeliveryEnvelope | None:
+    """Block on a fetch loop until a message arrives or the bus stops."""
+    while True:
+        if state.shutdown_event.is_set():
+            return None
+        msgs = await fetch_with_shutdown(
+            state,
+            sub,
+            RECEIVE_POLL_WINDOW_SECONDS,
+            channel_name=channel_name,
+            subscriber_id=subscriber_id,
+        )
+        if msgs is None:
+            return None
+        if not msgs:
+            continue
+        envelope = await build_envelope(
+            msgs,
+            channel_name=channel_name,
+            subscriber_id=subscriber_id,
+        )
+        if envelope is not None:
+            return envelope
+
+
+async def receive_with_timeout(
+    state: _NatsState,
+    channel_name: str,
+    subscriber_id: str,
+    sub: Any,
+    timeout: float,  # noqa: ASYNC109
+) -> DeliveryEnvelope | None:
+    """Wait up to ``timeout`` seconds across one or more fetch polls."""
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0.0:
+            return None
+        if state.shutdown_event.is_set():
+            return None
+        poll = min(remaining, RECEIVE_POLL_WINDOW_SECONDS)
+        msgs = await fetch_with_shutdown(
+            state,
+            sub,
+            poll,
+            channel_name=channel_name,
+            subscriber_id=subscriber_id,
+        )
+        if msgs is None:
+            return None
+        if not msgs:
+            continue
+        envelope = await build_envelope(
+            msgs,
+            channel_name=channel_name,
+            subscriber_id=subscriber_id,
+        )
+        if envelope is not None:
+            return envelope
+
+
+async def receive(
+    state: _NatsState,
+    channel_name: str,
+    subscriber_id: str,
+    *,
+    timeout: float | None = None,  # noqa: ASYNC109
+) -> DeliveryEnvelope | None:
+    """Receive the next message from the durable consumer."""
+    sub = await resolve_consumer(state, channel_name, subscriber_id)
+    if timeout is None:
+        return await receive_blocking(state, channel_name, subscriber_id, sub)
+    return await receive_with_timeout(state, channel_name, subscriber_id, sub, timeout)

--- a/src/synthorg/communication/bus/_nats_state.py
+++ b/src/synthorg/communication/bus/_nats_state.py
@@ -1,0 +1,70 @@
+"""Shared mutable state for the JetStream message bus submodules.
+
+Each submodule receives a ``_NatsState`` instance rather than the
+full ``JetStreamMessageBus`` class, which avoids circular imports
+and makes the data dependencies between modules explicit.
+"""
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from synthorg.communication.channel import Channel  # noqa: TC001
+from synthorg.communication.config import (  # noqa: TC001
+    MessageBusConfig,
+    NatsConfig,
+)
+
+if TYPE_CHECKING:
+    from nats.aio.client import Client as NatsClient
+    from nats.js import JetStreamContext
+    from nats.js.kv import KeyValue
+
+
+@dataclass
+class _NatsState:
+    """Internal mutable state shared across JetStream bus submodules.
+
+    Created by :func:`create_state` and owned by
+    ``JetStreamMessageBus``. Submodule functions accept this as their
+    first parameter instead of the facade class.
+    """
+
+    config: MessageBusConfig
+    nats_config: NatsConfig
+
+    # Derived names (computed once at creation).
+    stream_name: str
+    kv_bucket_name: str
+
+    # NATS primitives (``None`` until connected).
+    client: NatsClient | None = None
+    js: JetStreamContext | None = None
+    kv: KeyValue | None = None
+
+    # Runtime state.
+    channels: dict[str, Channel] = field(default_factory=dict)
+    subscriptions: dict[tuple[str, str], Any] = field(default_factory=dict)
+    known_agents: set[str] = field(default_factory=set)
+    in_flight_fetches: set[asyncio.Task[Any]] = field(default_factory=set)
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    shutdown_event: asyncio.Event = field(default_factory=asyncio.Event)
+    running: bool = False
+
+
+def create_state(config: MessageBusConfig) -> _NatsState:
+    """Build a ``_NatsState`` from validated bus configuration.
+
+    The caller (``JetStreamMessageBus.__init__``) must ensure
+    ``config.nats`` is not ``None`` before calling this function.
+    """
+    nats_config = config.nats
+    if nats_config is None:  # pragma: no cover -- caller validates
+        msg = "config.nats must not be None"
+        raise ValueError(msg)
+    return _NatsState(
+        config=config,
+        nats_config=nats_config,
+        stream_name=f"{nats_config.stream_name_prefix}_BUS",
+        kv_bucket_name=f"{nats_config.stream_name_prefix}_BUS_CHANNELS",
+    )

--- a/src/synthorg/communication/bus/_nats_state.py
+++ b/src/synthorg/communication/bus/_nats_state.py
@@ -18,7 +18,10 @@ from synthorg.communication.config import (  # noqa: TC001
 if TYPE_CHECKING:
     from nats.aio.client import Client as NatsClient
     from nats.js import JetStreamContext
+    from nats.js.client import JetStreamContext as _JSCtx
     from nats.js.kv import KeyValue
+
+    PullSubscription = _JSCtx.PullSubscription
 
 
 @dataclass
@@ -44,7 +47,7 @@ class _NatsState:
 
     # Runtime state.
     channels: dict[str, Channel] = field(default_factory=dict)
-    subscriptions: dict[tuple[str, str], Any] = field(default_factory=dict)
+    subscriptions: dict[tuple[str, str], PullSubscription] = field(default_factory=dict)
     known_agents: set[str] = field(default_factory=set)
     in_flight_fetches: set[asyncio.Task[Any]] = field(default_factory=set)
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)

--- a/src/synthorg/communication/bus/_nats_state.py
+++ b/src/synthorg/communication/bus/_nats_state.py
@@ -18,10 +18,11 @@ from synthorg.communication.config import (  # noqa: TC001
 if TYPE_CHECKING:
     from nats.aio.client import Client as NatsClient
     from nats.js import JetStreamContext
-    from nats.js.client import JetStreamContext as _JSCtx
     from nats.js.kv import KeyValue
 
-    PullSubscription = _JSCtx.PullSubscription
+    # PullSubscription is a nested class on JetStreamContext, not a
+    # module-level export, so it cannot be imported directly.
+    PullSubscription = JetStreamContext.PullSubscription
 
 
 @dataclass

--- a/src/synthorg/communication/bus/_nats_utils.py
+++ b/src/synthorg/communication/bus/_nats_utils.py
@@ -1,8 +1,12 @@
-"""Pure utility functions and constants for the NATS bus submodules.
+"""Utility functions and constants for the NATS bus submodules.
 
-All functions in this module are free of NATS state -- they operate on
-primitive values or asyncio tasks. Imported directly by higher-level
-submodules and by external code such as ``workers/claim.py``.
+Most functions in this module are pure (encoding, URL redaction,
+task cancellation) and operate on primitive values or asyncio tasks.
+The exception is :func:`require_running`, which accepts a
+``_NatsState`` instance to validate bus liveness.
+
+``redact_url`` is re-exported via ``synthorg.communication.bus`` for
+use by external code such as ``workers/claim.py``.
 """
 
 import asyncio

--- a/src/synthorg/communication/bus/_nats_utils.py
+++ b/src/synthorg/communication/bus/_nats_utils.py
@@ -1,0 +1,174 @@
+"""Pure utility functions and constants for the NATS bus submodules.
+
+All functions in this module are free of NATS state -- they operate on
+primitive values or asyncio tasks. Higher-level submodules import from
+here; the public ``nats.py`` facade re-exports ``redact_url`` under
+its legacy ``_redact_url`` name for ``workers/claim.py``.
+"""
+
+import asyncio
+import base64
+from typing import Any, Final, NoReturn
+from urllib.parse import urlparse
+
+from synthorg.communication.bus._nats_state import _NatsState  # noqa: TC001
+from synthorg.communication.errors import (
+    ChannelNotFoundError,
+    MessageBusNotRunningError,
+    NotSubscribedError,
+)
+from synthorg.observability import get_logger
+from synthorg.observability.events.communication import (
+    COMM_BUS_NOT_RUNNING,
+    COMM_BUS_RECEIVE_ERROR,
+    COMM_CHANNEL_NOT_FOUND,
+    COMM_SUBSCRIPTION_NOT_FOUND,
+)
+
+logger = get_logger(__name__)
+
+# ---- constants --------------------------------------------------------
+
+DM_SEPARATOR = ":"
+"""Separator used in deterministic direct-channel names (matches in-memory)."""
+
+SUBJECT_CHANNEL_TOKEN: Final[str] = "channel"  # noqa: S105
+SUBJECT_DIRECT_TOKEN: Final[str] = "direct"  # noqa: S105
+
+MAX_BUS_PAYLOAD_BYTES: Final[int] = 4 * 1024 * 1024
+"""Maximum bus message payload size (4 MB) accepted from JetStream.
+
+Messages include parts that can carry text/data blobs, so the limit
+is higher than the task-claim limit but still bounded to prevent a
+single malformed publisher from exhausting worker memory during
+deserialization.
+"""
+
+RECEIVE_POLL_WINDOW_SECONDS: Final[float] = 60.0
+"""Maximum seconds a single JetStream fetch waits before looping.
+
+``receive()`` uses this value as the upper bound on a single
+``_fetch_with_shutdown`` call. A ``timeout=None`` caller loops over
+these polls until a message arrives or the bus shuts down; a
+bounded ``timeout`` decrements the remaining budget by this window
+each iteration. Keeps per-fetch server-side state bounded while
+still matching the in-memory bus's "block indefinitely" contract.
+"""
+
+CONSUMER_ACK_WAIT_MULTIPLIER: Final[float] = 6.0
+"""Multiplier on ``publish_ack_wait_seconds`` for per-subscriber consumer ack_wait.
+
+A subscriber's durable pull consumer gets an ack deadline that is
+several times longer than the publisher's ack wait: publish acks are a
+server-side fire-and-forget acknowledgement, while the subscriber's
+ack deadline must span receive + application processing + the
+possibility of redelivery before being considered in-flight. The 6x
+factor mirrors typical JetStream guidance for interactive workloads
+and is surfaced here as a named constant so tests and operators can
+reason about it without grepping for a raw literal.
+"""
+
+
+# ---- helpers ----------------------------------------------------------
+
+
+def redact_url(url: str) -> str:
+    """Strip credentials from a NATS URL for safe logging.
+
+    ``nats://user:pass@host:port`` -> ``nats://***@host:port``.
+    Non-URL strings pass through unchanged (best effort).
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return url
+    if not parsed.hostname:
+        return url
+    authority = parsed.hostname
+    if parsed.port is not None:
+        authority = f"{authority}:{parsed.port}"
+    has_creds = parsed.username is not None or parsed.password is not None
+    if has_creds:
+        authority = f"***@{authority}"
+    scheme = parsed.scheme or "nats"
+    rest = parsed.path or ""
+    return f"{scheme}://{authority}{rest}"
+
+
+def raise_channel_not_found(channel_name: str) -> NoReturn:
+    """Log and raise :class:`ChannelNotFoundError`."""
+    logger.warning(COMM_CHANNEL_NOT_FOUND, channel=channel_name)
+    msg = f"Channel not found: {channel_name}"
+    raise ChannelNotFoundError(msg, context={"channel": channel_name})
+
+
+def raise_not_subscribed(
+    channel_name: str,
+    subscriber_id: str,
+) -> NoReturn:
+    """Log and raise :class:`NotSubscribedError`."""
+    logger.warning(
+        COMM_SUBSCRIPTION_NOT_FOUND,
+        channel=channel_name,
+        subscriber=subscriber_id,
+    )
+    msg = f"Not subscribed to {channel_name}"
+    raise NotSubscribedError(
+        msg,
+        context={
+            "channel": channel_name,
+            "subscriber": subscriber_id,
+        },
+    )
+
+
+async def cancel_if_pending(task: asyncio.Task[Any]) -> None:
+    """Cancel a task, await completion, and suppress CancelledError.
+
+    Any exception other than ``CancelledError`` is logged at WARNING
+    and re-raised so the caller can decide whether recovery is
+    possible.
+    """
+    if task.done():
+        return
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        logger.warning(
+            COMM_BUS_RECEIVE_ERROR,
+            phase="cancel_pending_task",
+            task_repr=repr(task),
+            exc_info=True,
+        )
+        raise
+
+
+def encode_token(name: str) -> str:
+    """Encode an arbitrary string into a NATS-subject-safe token.
+
+    JetStream subject tokens may contain alphanumerics, ``-``, and
+    ``_`` but not ``#``, ``@``, ``:``, ``.`` or other separators used
+    in SynthOrg channel names. Base32 (lowercase, no padding) gives a
+    deterministic, collision-free, case-insensitive encoding using
+    only safe characters.
+    """
+    raw = name.encode("utf-8")
+    return base64.b32encode(raw).decode("ascii").rstrip("=").lower()
+
+
+def decode_token(token: str) -> str:
+    """Reverse of :func:`encode_token`."""
+    padding = "=" * ((-len(token)) % 8)
+    raw = base64.b32decode((token.upper() + padding).encode("ascii"))
+    return raw.decode("utf-8")
+
+
+def require_running(state: _NatsState) -> None:
+    """Raise if the bus is not running."""
+    if not state.running:
+        logger.warning(COMM_BUS_NOT_RUNNING)
+        msg = "Message bus is not running"
+        raise MessageBusNotRunningError(msg)

--- a/src/synthorg/communication/bus/_nats_utils.py
+++ b/src/synthorg/communication/bus/_nats_utils.py
@@ -1,9 +1,8 @@
 """Pure utility functions and constants for the NATS bus submodules.
 
 All functions in this module are free of NATS state -- they operate on
-primitive values or asyncio tasks. Higher-level submodules import from
-here; the public ``nats.py`` facade re-exports ``redact_url`` under
-its legacy ``_redact_url`` name for ``workers/claim.py``.
+primitive values or asyncio tasks. Imported directly by higher-level
+submodules and by external code such as ``workers/claim.py``.
 """
 
 import asyncio

--- a/src/synthorg/communication/bus/nats.py
+++ b/src/synthorg/communication/bus/nats.py
@@ -1,18 +1,16 @@
 """NATS JetStream message bus backend.
 
-First distributed :class:`MessageBus` backend for SynthOrg. Maps the
-pull-model protocol in ``bus_protocol.py`` onto JetStream primitives:
+Thin facade over focused submodules. Delegates all logic to:
 
-- A single stream ``<prefix>_BUS`` with ``LimitsPolicy`` retention and
-  ``MaxMsgsPerSubject = config.retention.max_messages_per_channel``
-  preserves the bounded-history semantic natively.
-- Each ``(channel_name, subscriber_id)`` pair maps to a durable pull
-  consumer. ``receive(timeout=t)`` becomes
-  ``consumer.fetch(batch=1, timeout=t)``.
-- Lazily-created DIRECT channels are registered in a JetStream KV
-  bucket so they are discoverable across processes.
-- Ack is immediate on successful fetch, matching in-memory
-  "dequeue-and-go" semantics.
+- ``_nats_connection``: connect, drain, stream/KV setup, stop
+- ``_nats_channels``: channel creation, resolution, listing, subjects
+- ``_nats_consumers``: subscribe, unsubscribe, pull consumer lifecycle
+- ``_nats_kv``: KV bucket read/write/scan
+- ``_nats_publish``: publish, send_direct, serialization
+- ``_nats_receive``: receive loop, fetch, ack, envelope building
+- ``_nats_history``: history scanning with ephemeral consumers
+- ``_nats_state``: shared mutable state dataclass
+- ``_nats_utils``: pure utilities and constants
 
 See ``docs/design/distributed-runtime.md`` for the full design.
 
@@ -21,77 +19,28 @@ synthorg[distributed]``). Importing this module raises
 ``ImportError`` if the package is not installed.
 """
 
-import asyncio
-import json
-import time
-from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
-
-from synthorg.communication.bus._nats_utils import (
-    CONSUMER_ACK_WAIT_MULTIPLIER,
-    DM_SEPARATOR,
-    MAX_BUS_PAYLOAD_BYTES,
-    RECEIVE_POLL_WINDOW_SECONDS,
-    SUBJECT_CHANNEL_TOKEN,
-    SUBJECT_DIRECT_TOKEN,
-    cancel_if_pending,
-    decode_token,
-    encode_token,
-    raise_channel_not_found,
-    raise_not_subscribed,
-    redact_url,
-)
-from synthorg.communication.bus.errors import (
-    BusConnectionError,
-    BusStreamError,
-)
+from synthorg.communication.bus import _nats_channels as _ch
+from synthorg.communication.bus import _nats_connection as _conn
+from synthorg.communication.bus import _nats_consumers as _cons
+from synthorg.communication.bus import _nats_history as _hist
+from synthorg.communication.bus import _nats_publish as _pub
+from synthorg.communication.bus import _nats_receive as _recv
+from synthorg.communication.bus._nats_state import create_state
+from synthorg.communication.bus._nats_utils import require_running
 from synthorg.communication.channel import Channel
-from synthorg.communication.config import (  # noqa: TC001
-    MessageBusConfig,
-    NatsConfig,
-)
+from synthorg.communication.config import MessageBusConfig  # noqa: TC001
 from synthorg.communication.enums import ChannelType
-from synthorg.communication.errors import (
-    ChannelAlreadyExistsError,
-    MessageBusAlreadyRunningError,
-    MessageBusNotRunningError,
-)
-from synthorg.communication.message import Message
-from synthorg.communication.subscription import (
+from synthorg.communication.errors import MessageBusAlreadyRunningError
+from synthorg.communication.message import Message  # noqa: TC001
+from synthorg.communication.subscription import (  # noqa: TC001
     DeliveryEnvelope,
     Subscription,
 )
 from synthorg.observability import get_logger
 from synthorg.observability.events.communication import (
     COMM_BUS_ALREADY_RUNNING,
-    COMM_BUS_CONNECTED,
-    COMM_BUS_DISCONNECTED,
-    COMM_BUS_KV_READ_FAILED,
-    COMM_BUS_KV_WRITE_FAILED,
-    COMM_BUS_MESSAGE_DESERIALIZE_FAILED,
-    COMM_BUS_MESSAGE_TOO_LARGE,
-    COMM_BUS_NOT_RUNNING,
-    COMM_BUS_RECEIVE_ERROR,
-    COMM_BUS_RECONNECTING,
     COMM_BUS_STARTED,
-    COMM_BUS_STOPPED,
-    COMM_BUS_STREAM_SCAN_FAILED,
-    COMM_CHANNEL_ALREADY_EXISTS,
-    COMM_CHANNEL_CREATED,
-    COMM_DIRECT_SENT,
-    COMM_HISTORY_QUERIED,
-    COMM_MESSAGE_DELIVERED,
-    COMM_MESSAGE_PUBLISHED,
-    COMM_RECEIVE_SHUTDOWN,
-    COMM_SEND_DIRECT_INVALID,
-    COMM_SUBSCRIPTION_CREATED,
-    COMM_SUBSCRIPTION_REMOVED,
 )
-
-if TYPE_CHECKING:
-    from nats.aio.client import Client as NatsClient
-    from nats.js import JetStreamContext
-    from nats.js.kv import KeyValue
 
 logger = get_logger(__name__)
 
@@ -126,340 +75,56 @@ class JetStreamMessageBus:
                 "Install with 'pip install synthorg[distributed]'."
             )
             raise ImportError(msg) from exc
-        self._config: MessageBusConfig = config
-        self._nats_config: NatsConfig = config.nats
-        self._lock = asyncio.Lock()
-        self._channels: dict[str, Channel] = {}
-        self._subscriptions: dict[tuple[str, str], Any] = {}
-        self._known_agents: set[str] = set()
-        self._in_flight_fetches: set[asyncio.Task[Any]] = set()
-        self._running = False
-        self._shutdown_event = asyncio.Event()
-        self._client: NatsClient | None = None
-        self._js: JetStreamContext | None = None
-        self._kv: KeyValue | None = None
-
-    @property
-    def _stream_name(self) -> str:
-        """Name of the bus stream (derived from prefix)."""
-        return f"{self._nats_config.stream_name_prefix}_BUS"
-
-    @property
-    def _kv_bucket_name(self) -> str:
-        """Name of the KV bucket for dynamic channel registration."""
-        return f"{self._nats_config.stream_name_prefix}_BUS_CHANNELS"
+        self._state = create_state(config)
 
     @property
     def is_running(self) -> bool:
         """Whether the bus is currently running."""
-        return self._running
+        return self._state.running
 
     async def start(self) -> None:
-        """Connect to NATS, create the stream, and register pre-configured channels.
-
-        If stream/KV setup fails after ``_connect()`` succeeds, drain
-        the partially-initialised client before the exception
-        propagates so the caller does not leak a live NATS connection.
+        """Connect to NATS, create the stream, and register channels.
 
         Raises:
             MessageBusAlreadyRunningError: If already running.
             BusConnectionError: If connection to NATS fails.
             BusStreamError: If stream or KV bucket setup fails.
         """
-        async with self._lock:
-            if self._running:
+        state = self._state
+        async with state.lock:
+            if state.running:
                 msg = "Message bus is already running"
                 logger.warning(COMM_BUS_ALREADY_RUNNING)
                 raise MessageBusAlreadyRunningError(msg)
 
             try:
-                await self._connect()
-                await self._ensure_stream()
-                await self._ensure_kv_bucket()
+                await _conn.connect(state)
+                await _conn.ensure_stream(state)
+                await _conn.ensure_kv_bucket(state)
             except BaseException:
-                await self._drain_partial_client()
+                await _conn.drain_partial_client(state)
                 raise
 
-            for name in self._config.channels:
+            for name in state.config.channels:
                 ch = Channel(name=name, type=ChannelType.TOPIC)
-                self._channels[name] = ch
+                state.channels[name] = ch
 
-            self._running = True
-            self._shutdown_event.clear()
+            state.running = True
+            state.shutdown_event.clear()
 
         logger.info(
             COMM_BUS_STARTED,
-            channels_created=len(self._config.channels),
+            channels_created=len(state.config.channels),
             backend="nats",
         )
-
-    async def _drain_partial_client(self) -> None:
-        """Drain a connected NATS client after a failed ``start()``.
-
-        Called from ``start()`` when the stream or KV bucket setup
-        raises. Silently swallows drain errors because a drain failure
-        cannot be surfaced to the caller -- the original setup
-        exception takes precedence -- and the process is about to
-        unwind anyway.
-        """
-        client = self._client
-        if client is None:
-            return
-        try:
-            await client.drain()
-        except Exception as exc:
-            logger.warning(
-                COMM_BUS_DISCONNECTED,
-                phase="drain_partial",
-                error=str(exc),
-            )
-        finally:
-            self._client = None
-            self._js = None
-            self._kv = None
-
-    async def _connect(self) -> None:
-        """Establish the NATS connection."""
-        import nats  # noqa: PLC0415
-        from nats.errors import NoServersError  # noqa: PLC0415
-
-        async def on_disconnected() -> None:
-            logger.warning(COMM_BUS_DISCONNECTED)
-
-        async def on_reconnected() -> None:
-            logger.info(COMM_BUS_CONNECTED, reconnect=True)
-
-        async def on_error(exc: Exception) -> None:
-            logger.warning(COMM_BUS_RECONNECTING, error=str(exc))
-
-        try:
-            self._client = await nats.connect(
-                servers=[self._nats_config.url],
-                reconnect_time_wait=self._nats_config.reconnect_time_wait_seconds,
-                max_reconnect_attempts=self._nats_config.max_reconnect_attempts,
-                connect_timeout=self._nats_config.connect_timeout_seconds,
-                user_credentials=self._nats_config.credentials_path,
-                disconnected_cb=on_disconnected,
-                reconnected_cb=on_reconnected,
-                error_cb=on_error,
-            )
-        except (TimeoutError, NoServersError, OSError) as exc:
-            redacted = redact_url(self._nats_config.url)
-            msg = f"Failed to connect to NATS at {redacted}: {exc}"
-            logger.exception(COMM_BUS_DISCONNECTED, error=msg, url=redacted)
-            raise BusConnectionError(
-                msg,
-                context={"url": redacted},
-            ) from exc
-
-        self._js = self._client.jetstream()
-        logger.info(COMM_BUS_CONNECTED, url=redact_url(self._nats_config.url))
-
-    async def _ensure_stream(self) -> None:
-        """Create the bus stream if it does not already exist."""
-        from nats.errors import Error as NatsError  # noqa: PLC0415
-        from nats.js.api import (  # noqa: PLC0415
-            RetentionPolicy,
-            StorageType,
-            StreamConfig,
-        )
-        from nats.js.errors import NotFoundError  # noqa: PLC0415
-
-        if self._js is None:
-            msg = "JetStream context not initialized"
-            raise BusStreamError(msg)
-
-        pfx = self._nats_config.stream_name_prefix.lower()
-        stream_config = StreamConfig(
-            name=self._stream_name,
-            subjects=[
-                f"{pfx}.bus.{SUBJECT_CHANNEL_TOKEN}.>",
-                f"{pfx}.bus.{SUBJECT_DIRECT_TOKEN}.>",
-            ],
-            retention=RetentionPolicy.LIMITS,
-            max_msgs_per_subject=(self._config.retention.max_messages_per_channel),
-            storage=StorageType.FILE,
-        )
-        try:
-            try:
-                await self._js.stream_info(self._stream_name)
-            except NotFoundError:
-                await self._js.add_stream(stream_config)
-            else:
-                await self._js.update_stream(stream_config)
-        except NatsError as exc:
-            msg = f"Failed to set up stream {self._stream_name}: {exc}"
-            logger.warning(
-                COMM_BUS_STREAM_SCAN_FAILED,
-                stream=self._stream_name,
-                error=str(exc),
-                phase="ensure_stream",
-            )
-            raise BusStreamError(
-                msg,
-                context={"stream": self._stream_name},
-            ) from exc
-
-    async def _ensure_kv_bucket(self) -> None:
-        """Create the KV bucket for dynamic channel registration."""
-        from nats.errors import Error as NatsError  # noqa: PLC0415
-        from nats.js.errors import BucketNotFoundError  # noqa: PLC0415
-
-        if self._js is None:
-            msg = "JetStream context not initialized"
-            raise BusStreamError(msg)
-
-        try:
-            try:
-                self._kv = await self._js.key_value(self._kv_bucket_name)
-            except BucketNotFoundError:
-                self._kv = await self._js.create_key_value(
-                    bucket=self._kv_bucket_name,
-                )
-        except NatsError as exc:
-            msg = f"Failed to set up KV bucket {self._kv_bucket_name}: {exc}"
-            logger.warning(
-                COMM_BUS_KV_READ_FAILED,
-                channel="*",
-                error=str(exc),
-                phase="ensure_kv_bucket",
-            )
-            raise BusStreamError(
-                msg,
-                context={"bucket": self._kv_bucket_name},
-            ) from exc
 
     async def stop(self) -> None:
-        """Stop the bus gracefully. Idempotent.
-
-        Cancels outstanding ``receive()`` calls and closes the
-        underlying NATS connection.
-        """
-        async with self._lock:
-            if not self._running:
-                return
-            self._running = False
-        self._shutdown_event.set()
-
-        for task in list(self._in_flight_fetches):
-            task.cancel()
-        if self._in_flight_fetches:
-            await asyncio.gather(
-                *self._in_flight_fetches,
-                return_exceptions=True,
-            )
-        self._in_flight_fetches.clear()
-
-        for key, sub in self._subscriptions.items():
-            try:
-                await sub.unsubscribe()
-            except asyncio.CancelledError:
-                pass
-            except Exception:
-                logger.warning(
-                    COMM_BUS_DISCONNECTED,
-                    phase="stop_unsubscribe",
-                    subscription=str(key),
-                    exc_info=True,
-                )
-        self._subscriptions.clear()
-
-        if self._client is not None:
-            try:
-                await self._client.drain()
-            except asyncio.CancelledError:
-                pass
-            except Exception:
-                logger.warning(
-                    COMM_BUS_DISCONNECTED,
-                    phase="stop_drain",
-                    exc_info=True,
-                )
-            self._client = None
-            self._js = None
-            self._kv = None
-
-        logger.info(COMM_BUS_STOPPED, backend="nats")
-
-    def _require_running(self) -> None:
-        """Raise if the bus is not running."""
-        if not self._running:
-            logger.warning(COMM_BUS_NOT_RUNNING)
-            msg = "Message bus is not running"
-            raise MessageBusNotRunningError(msg)
-
-    def _channel_subject(self, channel_name: str) -> str:
-        """Compute the stream subject for a TOPIC/BROADCAST channel."""
-        pfx = self._nats_config.stream_name_prefix.lower()
-        return f"{pfx}.bus.{SUBJECT_CHANNEL_TOKEN}.{encode_token(channel_name)}"
-
-    def _direct_subject(self, channel_name: str) -> str:
-        """Compute the stream subject for a DIRECT channel."""
-        pfx = self._nats_config.stream_name_prefix.lower()
-        return f"{pfx}.bus.{SUBJECT_DIRECT_TOKEN}.{encode_token(channel_name)}"
-
-    def _subject_for_channel(self, channel: Channel) -> str:
-        """Pick the correct subject based on channel type."""
-        if channel.type == ChannelType.DIRECT:
-            return self._direct_subject(channel.name)
-        return self._channel_subject(channel.name)
-
-    @staticmethod
-    def _durable_name(channel_name: str, subscriber_id: str) -> str:
-        """Compute a safe durable consumer name."""
-        return f"{encode_token(channel_name)}__{encode_token(subscriber_id)}"
+        """Stop the bus gracefully. Idempotent."""
+        await _conn.stop(self._state)
 
     async def publish(self, message: Message) -> None:
-        """Publish a message to its channel via the JetStream stream.
-
-        Uses ``_resolve_channel_or_raise`` so a publisher in a
-        different process than the channel creator can publish without
-        calling ``get_channel()`` first, matching the multi-process
-        contract already established for subscribe/receive/history.
-
-        Args:
-            message: The message to publish.
-
-        Raises:
-            MessageBusNotRunningError: If not running.
-            ChannelNotFoundError: If the channel does not exist.
-        """
-        async with self._lock:
-            self._require_running()
-        channel_name = message.channel
-        channel = await self._resolve_channel_or_raise(channel_name)
-        subject = self._subject_for_channel(channel)
-
-        payload = self._serialize_message(message)
-        await self._publish_with_ack(subject, payload)
-
-        logger.info(
-            COMM_MESSAGE_PUBLISHED,
-            channel=channel_name,
-            message_id=str(message.id),
-            type=str(message.type),
-            backend="nats",
-        )
-
-    async def _publish_with_ack(self, subject: str, payload: bytes) -> None:
-        """Publish to JetStream waiting for server ack."""
-        if self._js is None:
-            msg = "JetStream context not initialized"
-            raise MessageBusNotRunningError(msg)
-        await asyncio.wait_for(
-            self._js.publish(subject, payload),
-            timeout=self._nats_config.publish_ack_wait_seconds,
-        )
-
-    @staticmethod
-    def _serialize_message(message: Message) -> bytes:
-        """Serialize a Message to JSON bytes for the wire."""
-        return message.model_dump_json().encode("utf-8")
-
-    @staticmethod
-    def _deserialize_message(data: bytes) -> Message:
-        """Reconstruct a Message from wire JSON bytes."""
-        return Message.model_validate_json(data.decode("utf-8"))
+        """Publish a message to its channel via JetStream."""
+        await _pub.publish(self._state, message)
 
     async def send_direct(
         self,
@@ -467,317 +132,24 @@ class JetStreamMessageBus:
         *,
         recipient: str,
     ) -> None:
-        """Send a direct message, creating the DIRECT channel lazily.
-
-        Args:
-            message: The message to send.
-            recipient: Recipient agent ID.
-
-        Raises:
-            MessageBusNotRunningError: If not running.
-            ValueError: If recipient does not match ``message.to`` or
-                if agent IDs contain the separator character.
-        """
-        sender = message.sender
-        if message.to != recipient:
-            msg = f"recipient={recipient!r} does not match message.to={message.to!r}"
-            logger.warning(COMM_SEND_DIRECT_INVALID, error=msg)
-            raise ValueError(msg)
-        for agent_id in (sender, recipient):
-            if DM_SEPARATOR in agent_id:
-                msg = (
-                    f"Agent ID {agent_id!r} contains the reserved "
-                    f"separator character {DM_SEPARATOR!r}"
-                )
-                logger.warning(COMM_SEND_DIRECT_INVALID, error=msg)
-                raise ValueError(msg)
-        a, b = sorted([sender, recipient])
-        pair = (a, b)
-        channel_name = f"@{pair[0]}:{pair[1]}"
-
-        async with self._lock:
-            self._require_running()
-            await self._ensure_direct_channel(channel_name, pair)
-            self._known_agents.add(sender)
-            self._known_agents.add(recipient)
-
-        subject = self._direct_subject(channel_name)
-        payload = self._serialize_message(message)
-        await self._publish_with_ack(subject, payload)
-
-        logger.info(
-            COMM_DIRECT_SENT,
-            channel=channel_name,
-            sender=sender,
-            recipient=recipient,
-            message_id=str(message.id),
-            backend="nats",
-        )
-
-    async def _ensure_direct_channel(
-        self,
-        channel_name: str,
-        pair: tuple[str, str],
-    ) -> None:
-        """Create DIRECT channel locally and in KV bucket if needed.
-
-        Must be called under ``self._lock``.
-        """
-        if channel_name in self._channels:
-            current = self._channels[channel_name]
-            pair_set = set(pair)
-            if not pair_set.issubset(set(current.subscribers)):
-                new_subs = tuple(sorted(set(current.subscribers) | pair_set))
-                self._channels[channel_name] = current.model_copy(
-                    update={"subscribers": new_subs},
-                )
-                await self._write_channel_to_kv(self._channels[channel_name])
-            return
-
-        ch = Channel(
-            name=channel_name,
-            type=ChannelType.DIRECT,
-            subscribers=pair,
-        )
-        self._channels[channel_name] = ch
-        await self._write_channel_to_kv(ch)
-        logger.info(
-            COMM_CHANNEL_CREATED,
-            channel=channel_name,
-            type=str(ChannelType.DIRECT),
-            backend="nats",
-        )
-
-    async def _write_channel_to_kv(self, channel: Channel) -> None:
-        """Persist a Channel definition to the KV bucket."""
-        if self._kv is None:
-            return
-        key = encode_token(channel.name)
-        value = channel.model_dump_json().encode("utf-8")
-        try:
-            await self._kv.put(key, value)
-        except Exception as exc:
-            logger.warning(
-                COMM_BUS_KV_WRITE_FAILED,
-                channel=channel.name,
-                error=str(exc),
-            )
-
-    async def _load_channel_from_kv(self, channel_name: str) -> Channel | None:
-        """Load a Channel definition from the KV bucket, if present."""
-        entry = await self._fetch_kv_entry(channel_name)
-        if entry is None:
-            return None
-        return self._decode_kv_channel(channel_name, entry)
-
-    async def _fetch_kv_entry(self, channel_name: str) -> Any | None:
-        """Fetch a raw KV entry, logging transport errors and returning None."""
-        from nats.js.errors import KeyNotFoundError  # noqa: PLC0415
-
-        if self._kv is None:
-            return None
-        key = encode_token(channel_name)
-        try:
-            entry = await self._kv.get(key)
-        except KeyNotFoundError:
-            return None
-        except Exception as exc:
-            logger.warning(
-                COMM_BUS_KV_READ_FAILED,
-                channel=channel_name,
-                error=str(exc),
-            )
-            return None
-        if entry is None or entry.value is None:
-            return None
-        return entry
-
-    def _decode_kv_channel(
-        self,
-        channel_name: str,
-        entry: Any,
-    ) -> Channel | None:
-        """Decode a KV entry into a Channel, logging parse failures."""
-        try:
-            data = json.loads(entry.value.decode("utf-8"))
-            channel = Channel.model_validate(data)
-        except json.JSONDecodeError as exc:
-            logger.warning(
-                COMM_BUS_KV_READ_FAILED,
-                channel=channel_name,
-                error=str(exc),
-            )
-            return None
-        except ValueError as exc:
-            logger.warning(
-                COMM_BUS_KV_READ_FAILED,
-                channel=channel_name,
-                error=str(exc),
-            )
-            return None
-        if channel.name != channel_name:
-            logger.warning(
-                COMM_BUS_KV_READ_FAILED,
-                channel=channel_name,
-                error=(
-                    f"KV entry name mismatch: expected {channel_name!r}, "
-                    f"got {channel.name!r}"
-                ),
-            )
-            return None
-        return channel
+        """Send a direct message, creating the DIRECT channel lazily."""
+        await _pub.send_direct(self._state, message, recipient=recipient)
 
     async def subscribe(
         self,
         channel_name: str,
         subscriber_id: str,
     ) -> Subscription:
-        """Subscribe an agent to a channel via a durable pull consumer.
-
-        Idempotent: returns a fresh Subscription on repeated calls and
-        does not recreate the underlying consumer.
-
-        Args:
-            channel_name: Channel to subscribe to.
-            subscriber_id: Agent ID.
-
-        Returns:
-            The subscription record.
-
-        Raises:
-            MessageBusNotRunningError: If not running.
-            ChannelNotFoundError: If the channel does not exist.
-        """
-        async with self._lock:
-            self._require_running()
-        # Resolve through the shared KV-backed resolver so multi-process
-        # subscribers can see channels registered by another process.
-        await self._resolve_channel_or_raise(channel_name)
-        async with self._lock:
-            self._require_running()
-            channel = self._channels[channel_name]
-            self._known_agents.add(subscriber_id)
-
-            key = (channel_name, subscriber_id)
-            if key not in self._subscriptions:
-                # Create the durable consumer BEFORE mutating the
-                # subscriber list so a consumer-creation failure does
-                # not leave a ghost subscriber in the cache/KV that
-                # no consumer backs.
-                await self._create_pull_consumer(
-                    channel_name,
-                    subscriber_id,
-                    channel,
-                )
-
-            if subscriber_id not in channel.subscribers:
-                new_subs = (*channel.subscribers, subscriber_id)
-                updated = channel.model_copy(
-                    update={"subscribers": new_subs},
-                )
-                self._channels[channel_name] = updated
-                await self._write_channel_to_kv(updated)
-
-        logger.info(
-            COMM_SUBSCRIPTION_CREATED,
-            channel=channel_name,
-            subscriber=subscriber_id,
-            backend="nats",
-        )
-        return Subscription(
-            channel_name=channel_name,
-            subscriber_id=subscriber_id,
-            subscribed_at=datetime.now(UTC),
-        )
-
-    async def _create_pull_consumer(
-        self,
-        channel_name: str,
-        subscriber_id: str,
-        channel: Channel,
-    ) -> None:
-        """Create a durable pull consumer for (channel, subscriber).
-
-        Must be called under ``self._lock``. Passes an explicit
-        :class:`ConsumerConfig` so the ack deadline and max-deliver
-        semantics documented in the Distributed Runtime design page
-        are applied consistently rather than relying on JetStream
-        server defaults.
-        """
-        from nats.js.api import ConsumerConfig  # noqa: PLC0415
-
-        if self._js is None:
-            msg = "JetStream context not initialized"
-            raise BusStreamError(msg)
-        subject = self._subject_for_channel(channel)
-        durable = self._durable_name(channel_name, subscriber_id)
-        consumer_config = ConsumerConfig(
-            durable_name=durable,
-            ack_wait=(
-                self._nats_config.publish_ack_wait_seconds
-                * CONSUMER_ACK_WAIT_MULTIPLIER
-            ),
-            max_deliver=1,
-            filter_subject=subject,
-        )
-        sub = await self._js.pull_subscribe(
-            subject=subject,
-            durable=durable,
-            stream=self._stream_name,
-            config=consumer_config,
-        )
-        self._subscriptions[(channel_name, subscriber_id)] = sub
+        """Subscribe an agent to a channel via a durable pull consumer."""
+        return await _cons.subscribe(self._state, channel_name, subscriber_id)
 
     async def unsubscribe(
         self,
         channel_name: str,
         subscriber_id: str,
     ) -> None:
-        """Remove a subscription and tear down the pull consumer.
-
-        Args:
-            channel_name: Channel to unsubscribe from.
-            subscriber_id: Agent ID.
-
-        Raises:
-            MessageBusNotRunningError: If not running.
-            NotSubscribedError: If not currently subscribed.
-        """
-        async with self._lock:
-            self._require_running()
-            if channel_name not in self._channels:
-                raise_not_subscribed(channel_name, subscriber_id)
-            channel = self._channels[channel_name]
-            if subscriber_id not in channel.subscribers:
-                raise_not_subscribed(channel_name, subscriber_id)
-            new_subs = tuple(s for s in channel.subscribers if s != subscriber_id)
-            updated = channel.model_copy(
-                update={"subscribers": new_subs},
-            )
-            self._channels[channel_name] = updated
-            await self._write_channel_to_kv(updated)
-            key = (channel_name, subscriber_id)
-            sub = self._subscriptions.pop(key, None)
-
-        if sub is not None:
-            try:
-                await sub.unsubscribe()
-            except Exception:
-                logger.warning(
-                    COMM_SUBSCRIPTION_REMOVED,
-                    channel=channel_name,
-                    subscriber=subscriber_id,
-                    backend="nats",
-                    phase="unsubscribe_consumer_failed",
-                    exc_info=True,
-                )
-
-        logger.info(
-            COMM_SUBSCRIPTION_REMOVED,
-            channel=channel_name,
-            subscriber=subscriber_id,
-            backend="nats",
-        )
+        """Remove a subscription and tear down the pull consumer."""
+        await _cons.unsubscribe(self._state, channel_name, subscriber_id)
 
     async def receive(
         self,
@@ -786,473 +158,27 @@ class JetStreamMessageBus:
         *,
         timeout: float | None = None,  # noqa: ASYNC109
     ) -> DeliveryEnvelope | None:
-        """Receive the next message from the durable consumer.
-
-        Args:
-            channel_name: Channel to receive from.
-            subscriber_id: Agent ID.
-            timeout: Seconds to wait for a message. ``None`` means
-                "block indefinitely until a message arrives or the bus
-                is shut down", matching the in-memory bus contract;
-                a positive value caps the total wait.
-
-        Returns:
-            A delivery envelope, or ``None`` on timeout or shutdown.
-
-        Raises:
-            MessageBusNotRunningError: If not running.
-            ChannelNotFoundError: If the channel does not exist.
-            NotSubscribedError: If the subscriber is not subscribed
-                (for TOPIC and DIRECT channels).
-        """
-        sub = await self._resolve_consumer(channel_name, subscriber_id)
-        # A single 60s fetch would return ``None`` the moment the
-        # server reports "no messages", which violates the "block
-        # until shutdown" semantics when the caller passed
-        # ``timeout=None``. Loop the fetch in that case so an empty
-        # poll becomes a retry rather than a premature ``None``; the
-        # shutdown event still wins via ``_fetch_with_shutdown``.
-        if timeout is None:
-            return await self._receive_blocking(channel_name, subscriber_id, sub)
-        return await self._receive_with_timeout(
-            channel_name, subscriber_id, sub, timeout
+        """Receive the next message from the durable consumer."""
+        return await _recv.receive(
+            self._state,
+            channel_name,
+            subscriber_id,
+            timeout=timeout,
         )
-
-    async def _receive_blocking(
-        self,
-        channel_name: str,
-        subscriber_id: str,
-        sub: Any,
-    ) -> DeliveryEnvelope | None:
-        """Block on a fetch loop until a message arrives or the bus stops."""
-        while True:
-            if self._shutdown_event.is_set():
-                return None
-            msgs = await self._fetch_with_shutdown(
-                sub,
-                RECEIVE_POLL_WINDOW_SECONDS,
-                channel_name=channel_name,
-                subscriber_id=subscriber_id,
-            )
-            if msgs is None:
-                return None
-            if not msgs:
-                continue
-            envelope = await self._build_envelope(
-                msgs,
-                channel_name=channel_name,
-                subscriber_id=subscriber_id,
-            )
-            # _build_envelope returns None when the fetched message was
-            # oversized, malformed, or couldn't be acked. Those
-            # conditions are per-message -- the next message in the
-            # stream may be perfectly valid, so keep waiting instead of
-            # returning None and ending the caller's receive loop.
-            if envelope is not None:
-                return envelope
-
-    async def _receive_with_timeout(
-        self,
-        channel_name: str,
-        subscriber_id: str,
-        sub: Any,
-        timeout: float,  # noqa: ASYNC109
-    ) -> DeliveryEnvelope | None:
-        """Wait up to ``timeout`` seconds across one or more fetch polls.
-
-        Uses an absolute ``time.monotonic()`` deadline so the budget
-        reflects real elapsed time. Subtracting the poll window from
-        a running counter would double-count when a fetch returns
-        before the window expires or when ``_build_envelope`` drops a
-        message (the dropped-message path doesn't consume wall time
-        proportional to the poll window).
-        """
-        deadline = time.monotonic() + timeout
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0.0:
-                return None
-            if self._shutdown_event.is_set():
-                return None
-            poll = min(remaining, RECEIVE_POLL_WINDOW_SECONDS)
-            msgs = await self._fetch_with_shutdown(
-                sub,
-                poll,
-                channel_name=channel_name,
-                subscriber_id=subscriber_id,
-            )
-            if msgs is None:
-                return None
-            if not msgs:
-                continue
-            envelope = await self._build_envelope(
-                msgs,
-                channel_name=channel_name,
-                subscriber_id=subscriber_id,
-            )
-            if envelope is not None:
-                return envelope
-
-    async def _resolve_consumer(
-        self,
-        channel_name: str,
-        subscriber_id: str,
-    ) -> Any:
-        """Validate preconditions and return the durable pull consumer.
-
-        Creates the consumer lazily for BROADCAST subscribers that
-        have not called ``subscribe()`` explicitly. Resolves the
-        channel through ``_resolve_channel_or_raise`` so a receiver
-        in a different process than the publisher can still pull
-        messages without first calling ``get_channel()``.
-        """
-        async with self._lock:
-            self._require_running()
-        await self._resolve_channel_or_raise(channel_name)
-        async with self._lock:
-            self._require_running()
-            channel = self._channels[channel_name]
-            if (
-                channel.type != ChannelType.BROADCAST
-                and subscriber_id not in channel.subscribers
-            ):
-                raise_not_subscribed(channel_name, subscriber_id)
-            key = (channel_name, subscriber_id)
-            sub = self._subscriptions.get(key)
-            if sub is None:
-                await self._create_pull_consumer(
-                    channel_name,
-                    subscriber_id,
-                    channel,
-                )
-                sub = self._subscriptions[key]
-        return sub
-
-    async def _fetch_with_shutdown(
-        self,
-        sub: Any,
-        timeout: float,  # noqa: ASYNC109
-        *,
-        channel_name: str,
-        subscriber_id: str,
-    ) -> list[Any] | None:
-        """Fetch at most one message, racing against the shutdown event.
-
-        Returns ``None`` on shutdown, timeout, cancellation, or
-        internal NATS errors; returns an empty list only if the fetch
-        succeeded with no messages (shouldn't happen for batch=1 but
-        handled defensively).
-        """
-        from nats.errors import TimeoutError as NatsTimeoutError  # noqa: PLC0415
-
-        fetch_task: asyncio.Task[Any] = asyncio.create_task(
-            sub.fetch(batch=1, timeout=timeout),
-        )
-        shutdown_task: asyncio.Task[Any] = asyncio.create_task(
-            self._shutdown_event.wait(),
-        )
-        self._in_flight_fetches.add(fetch_task)
-        self._in_flight_fetches.add(shutdown_task)
-
-        try:
-            done, _ = await asyncio.wait(
-                {fetch_task, shutdown_task},
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-        except BaseException:
-            fetch_task.cancel()
-            shutdown_task.cancel()
-            raise
-        finally:
-            self._in_flight_fetches.discard(fetch_task)
-            self._in_flight_fetches.discard(shutdown_task)
-
-        await cancel_if_pending(fetch_task)
-        await cancel_if_pending(shutdown_task)
-
-        if shutdown_task in done and fetch_task not in done:
-            logger.debug(
-                COMM_RECEIVE_SHUTDOWN,
-                channel=channel_name,
-                subscriber=subscriber_id,
-            )
-            return None
-
-        try:
-            result: list[Any] = fetch_task.result()
-        except NatsTimeoutError:
-            return []
-        except asyncio.CancelledError:
-            return None
-        except Exception:
-            logger.exception(
-                COMM_BUS_RECEIVE_ERROR,
-                channel=channel_name,
-                subscriber=subscriber_id,
-            )
-            return None
-        return result
-
-    async def _try_ack(
-        self,
-        msg: Any,
-        *,
-        channel_name: str,
-        subscriber_id: str,
-    ) -> bool:
-        """Attempt to ack a fetched JetStream message.
-
-        Returns ``True`` on success, ``False`` on failure. Failures
-        are logged with context so the caller can return ``None``
-        instead of handing the message to the application and letting
-        JetStream redeliver it under the same durable consumer.
-        """
-        try:
-            await msg.ack()
-        except Exception:
-            logger.exception(
-                COMM_BUS_RECEIVE_ERROR,
-                channel=channel_name,
-                subscriber=subscriber_id,
-                phase="ack",
-            )
-            return False
-        return True
-
-    async def _build_envelope(
-        self,
-        msgs: list[Any] | None,
-        *,
-        channel_name: str,
-        subscriber_id: str,
-    ) -> DeliveryEnvelope | None:
-        """Ack the fetched message and wrap it in a DeliveryEnvelope."""
-        if not msgs:
-            return None
-
-        msg = msgs[0]
-        if len(msg.data) > MAX_BUS_PAYLOAD_BYTES:
-            logger.warning(
-                COMM_BUS_MESSAGE_TOO_LARGE,
-                channel=channel_name,
-                subscriber=subscriber_id,
-                size=len(msg.data),
-                limit=MAX_BUS_PAYLOAD_BYTES,
-            )
-            # Ack the oversized payload so JetStream does not
-            # redeliver it. Even if the ack fails we have already
-            # decided not to surface the message, so swallowing the
-            # error here is safe -- the worker sees the same outcome
-            # either way.
-            await self._try_ack(
-                msg,
-                channel_name=channel_name,
-                subscriber_id=subscriber_id,
-            )
-            return None
-
-        try:
-            parsed = self._deserialize_message(msg.data)
-        except ValueError as exc:
-            logger.warning(
-                COMM_BUS_MESSAGE_DESERIALIZE_FAILED,
-                channel=channel_name,
-                subscriber=subscriber_id,
-                size=len(msg.data),
-                error=str(exc),
-            )
-            # Same reasoning as the oversized branch: the message is
-            # unusable regardless of whether ack succeeds.
-            await self._try_ack(
-                msg,
-                channel_name=channel_name,
-                subscriber_id=subscriber_id,
-            )
-            return None
-
-        if not await self._try_ack(
-            msg,
-            channel_name=channel_name,
-            subscriber_id=subscriber_id,
-        ):
-            # Returning the envelope after a failed ack would let
-            # JetStream redeliver this exact message and cause the
-            # caller to process it twice. Drop it instead.
-            return None
-
-        envelope = DeliveryEnvelope(
-            message=parsed,
-            channel_name=channel_name,
-            delivered_at=datetime.now(UTC),
-        )
-        logger.debug(
-            COMM_MESSAGE_DELIVERED,
-            channel=channel_name,
-            subscriber=subscriber_id,
-            message_id=str(parsed.id),
-            backend="nats",
-        )
-        return envelope
 
     async def create_channel(self, channel: Channel) -> Channel:
-        """Create a new channel.
-
-        Args:
-            channel: Channel definition to create.
-
-        Returns:
-            The created channel.
-
-        Raises:
-            MessageBusNotRunningError: If not running.
-            ChannelAlreadyExistsError: If the channel already exists.
-        """
-        async with self._lock:
-            self._require_running()
-            if channel.name in self._channels:
-                logger.warning(
-                    COMM_CHANNEL_ALREADY_EXISTS,
-                    channel=channel.name,
-                )
-                msg = f"Channel already exists: {channel.name}"
-                raise ChannelAlreadyExistsError(
-                    msg,
-                    context={"channel": channel.name},
-                )
-        # Check the distributed KV store so a peer process that
-        # already created this channel is detected before we overwrite
-        # its definition with our local copy.
-        kv_existing = await self._load_channel_from_kv(channel.name)
-        if kv_existing is not None:
-            async with self._lock:
-                if channel.name not in self._channels:
-                    self._channels[channel.name] = kv_existing
-            logger.warning(
-                COMM_CHANNEL_ALREADY_EXISTS,
-                channel=channel.name,
-                source="kv",
-            )
-            msg = f"Channel already exists (peer-created): {channel.name}"
-            raise ChannelAlreadyExistsError(
-                msg,
-                context={"channel": channel.name},
-            )
-        async with self._lock:
-            # Re-check local cache after the KV round-trip in case a
-            # concurrent local call created the channel while we were
-            # checking KV.
-            if channel.name in self._channels:
-                logger.warning(
-                    COMM_CHANNEL_ALREADY_EXISTS,
-                    channel=channel.name,
-                )
-                msg = f"Channel already exists: {channel.name}"
-                raise ChannelAlreadyExistsError(
-                    msg,
-                    context={"channel": channel.name},
-                )
-            self._channels[channel.name] = channel
-            await self._write_channel_to_kv(channel)
-        logger.info(
-            COMM_CHANNEL_CREATED,
-            channel=channel.name,
-            type=str(channel.type),
-            backend="nats",
-        )
-        return channel
+        """Create a new channel."""
+        async with self._state.lock:
+            require_running(self._state)
+        return await _ch.create_channel(self._state, channel)
 
     async def get_channel(self, channel_name: str) -> Channel:
-        """Get a channel by name.
-
-        Args:
-            channel_name: Name of the channel.
-
-        Returns:
-            The channel.
-
-        Raises:
-            ChannelNotFoundError: If the channel does not exist.
-        """
-        return await self._resolve_channel_or_raise(channel_name)
-
-    async def _resolve_channel_or_raise(self, channel_name: str) -> Channel:
-        """Return a Channel from the local cache or the JetStream KV.
-
-        Shared by ``get_channel``, ``subscribe``, ``receive`` and
-        ``get_channel_history`` so a second process can observe
-        channels created by another process on the same stream
-        without having to call ``get_channel()`` first. The KV lookup
-        happens outside the lock to avoid blocking other bus
-        operations during the round-trip; the result is inserted
-        under the lock to keep the cache consistent.
-        """
-        async with self._lock:
-            cached = self._channels.get(channel_name)
-        if cached is not None:
-            return cached
-
-        loaded = await self._load_channel_from_kv(channel_name)
-        if loaded is None:
-            raise_channel_not_found(channel_name)
-
-        async with self._lock:
-            existing = self._channels.get(channel_name)
-            if existing is not None:
-                return existing
-            self._channels[channel_name] = loaded
-            return loaded
+        """Get a channel by name."""
+        return await _ch.resolve_channel_or_raise(self._state, channel_name)
 
     async def list_channels(self) -> tuple[Channel, ...]:
-        """List all channels, including those created by peer processes.
-
-        Merges KV-stored channels with the local cache so callers get
-        a complete view of the bus regardless of which process created
-        each channel. KV read errors are logged and treated as
-        non-fatal so the caller still gets the local cache.
-
-        Returns:
-            All registered channels (local + KV-discovered).
-        """
-        kv_channels = await self._scan_kv_channels()
-        async with self._lock:
-            for ch in kv_channels:
-                if ch.name not in self._channels:
-                    self._channels[ch.name] = ch
-            return tuple(self._channels.values())
-
-    async def _scan_kv_channels(self) -> list[Channel]:
-        """Scan the KV bucket for all persisted channels."""
-        if self._kv is None:
-            return []
-        try:
-            keys = await self._kv.keys()
-        except Exception as exc:
-            logger.warning(
-                COMM_BUS_KV_READ_FAILED,
-                channel="*",
-                error=str(exc),
-                phase="list_channels_scan",
-            )
-            return []
-        channels: list[Channel] = []
-        for key in keys:
-            try:
-                decoded_name = decode_token(key)
-            except Exception as exc:
-                logger.warning(
-                    COMM_BUS_KV_READ_FAILED,
-                    channel=key,
-                    error=str(exc),
-                    phase="decode_token",
-                )
-                continue
-            entry = await self._fetch_kv_entry(decoded_name)
-            if entry is None:
-                continue
-            ch = self._decode_kv_channel(decoded_name, entry)
-            if ch is not None:
-                channels.append(ch)
-        return channels
+        """List all channels, including those from peer processes."""
+        return await _ch.list_channels(self._state)
 
     async def get_channel_history(
         self,
@@ -1260,197 +186,5 @@ class JetStreamMessageBus:
         *,
         limit: int | None = None,
     ) -> tuple[Message, ...]:
-        """Get message history for a channel.
-
-        Queries JetStream for the most recent messages on the
-        channel's subject. Uses ``_resolve_channel_or_raise`` so
-        callers in a different process than the publisher can still
-        inspect history without having to call ``get_channel()`` first.
-
-        Args:
-            channel_name: Channel to query.
-            limit: Maximum number of most recent messages to return.
-                ``None`` returns all retained messages (up to
-                ``max_messages_per_channel``). ``<= 0`` returns
-                an empty tuple.
-
-        Returns:
-            Messages in chronological order.
-
-        Raises:
-            ChannelNotFoundError: If the channel does not exist.
-        """
-        channel = await self._resolve_channel_or_raise(channel_name)
-        async with self._lock:
-            subject = self._subject_for_channel(channel)
-            js = self._js
-
-        if limit is not None and limit <= 0:
-            logger.debug(
-                COMM_HISTORY_QUERIED,
-                channel=channel_name,
-                count=0,
-                limit=limit,
-                backend="nats",
-            )
-            return ()
-
-        max_to_return = (
-            limit
-            if limit is not None
-            else self._config.retention.max_messages_per_channel
-        )
-
-        messages = await self._scan_stream_for_subject(
-            js,
-            subject=subject,
-            max_to_return=max_to_return,
-        )
-
-        logger.debug(
-            COMM_HISTORY_QUERIED,
-            channel=channel_name,
-            count=len(messages),
-            limit=limit,
-            backend="nats",
-        )
-        return tuple(messages)
-
-    async def _scan_stream_for_subject(
-        self,
-        js: Any,
-        *,
-        subject: str,
-        max_to_return: int,
-    ) -> list[Message]:
-        """Collect the most recent messages on a subject, oldest-first.
-
-        Uses an ephemeral pull consumer with ``filter_subject`` so the
-        NATS server does the subject filtering server-side and the
-        client fetches in batches instead of walking the stream one
-        sequence at a time. Retention is bounded by
-        ``max_messages_per_channel``, so fetching every match for a
-        single subject and slicing the tail is cheap and correct.
-
-        Falls back to an empty list on any transport error so the
-        history API degrades gracefully rather than propagating a
-        backend exception to the caller.
-        """
-        if js is None:
-            return []
-
-        psub = await self._create_history_scan_consumer(js, subject)
-        if psub is None:
-            return []
-
-        try:
-            parsed_messages = await self._collect_history_batches(psub, subject)
-        finally:
-            await self._unsubscribe_history_consumer(psub, subject)
-
-        if len(parsed_messages) <= max_to_return:
-            return parsed_messages
-        return parsed_messages[-max_to_return:]
-
-    async def _create_history_scan_consumer(
-        self,
-        js: Any,
-        subject: str,
-    ) -> Any | None:
-        """Create the ephemeral pull consumer used by history scans."""
-        from nats.js.api import (  # noqa: PLC0415
-            AckPolicy,
-            ConsumerConfig,
-            DeliverPolicy,
-        )
-        from nats.js.errors import NotFoundError  # noqa: PLC0415
-
-        consumer_config = ConsumerConfig(
-            deliver_policy=DeliverPolicy.ALL,
-            ack_policy=AckPolicy.NONE,
-            filter_subject=subject,
-        )
-        try:
-            return await js.pull_subscribe(
-                subject=subject,
-                stream=self._stream_name,
-                config=consumer_config,
-            )
-        except NotFoundError:
-            return None
-        except Exception as exc:
-            logger.warning(
-                COMM_BUS_STREAM_SCAN_FAILED,
-                stream=self._stream_name,
-                subject=subject,
-                phase="subscribe",
-                error=str(exc),
-            )
-            return None
-
-    async def _collect_history_batches(
-        self,
-        psub: Any,
-        subject: str,
-    ) -> list[Message]:
-        """Drain the history consumer into a list, stopping on idle timeout."""
-        from nats.errors import TimeoutError as NatsTimeoutError  # noqa: PLC0415
-
-        parsed_messages: list[Message] = []
-        while True:
-            try:
-                batch = await psub.fetch(batch=100, timeout=0.5)
-            except NatsTimeoutError:
-                return parsed_messages
-            except Exception as exc:
-                logger.warning(
-                    COMM_BUS_STREAM_SCAN_FAILED,
-                    stream=self._stream_name,
-                    subject=subject,
-                    phase="fetch",
-                    error=str(exc),
-                )
-                return parsed_messages
-            if not batch:
-                return parsed_messages
-            for raw in batch:
-                parsed = self._try_parse_matching(raw, subject)
-                if parsed is not None:
-                    parsed_messages.append(parsed)
-
-    async def _unsubscribe_history_consumer(
-        self,
-        psub: Any,
-        subject: str,
-    ) -> None:
-        """Best-effort teardown for an ephemeral history consumer."""
-        try:
-            await psub.unsubscribe()
-        except Exception as exc:
-            logger.warning(
-                COMM_BUS_STREAM_SCAN_FAILED,
-                stream=self._stream_name,
-                subject=subject,
-                phase="unsubscribe",
-                error=str(exc),
-            )
-
-    def _try_parse_matching(
-        self,
-        raw: Any,
-        subject: str,
-    ) -> Message | None:
-        """Parse the raw message if it matches the target subject."""
-        if raw.subject != subject or raw.data is None:
-            return None
-        try:
-            return self._deserialize_message(raw.data)
-        except ValueError:
-            logger.warning(
-                COMM_BUS_MESSAGE_DESERIALIZE_FAILED,
-                subject=subject,
-                size=len(raw.data),
-                phase="history_scan",
-                exc_info=True,
-            )
-            return None
+        """Get message history for a channel."""
+        return await _hist.get_channel_history(self._state, channel_name, limit=limit)

--- a/src/synthorg/communication/bus/nats.py
+++ b/src/synthorg/communication/bus/nats.py
@@ -22,13 +22,25 @@ synthorg[distributed]``). Importing this module raises
 """
 
 import asyncio
-import base64
 import json
 import time
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, Final, NoReturn
-from urllib.parse import urlparse
+from typing import TYPE_CHECKING, Any
 
+from synthorg.communication.bus._nats_utils import (
+    CONSUMER_ACK_WAIT_MULTIPLIER,
+    DM_SEPARATOR,
+    MAX_BUS_PAYLOAD_BYTES,
+    RECEIVE_POLL_WINDOW_SECONDS,
+    SUBJECT_CHANNEL_TOKEN,
+    SUBJECT_DIRECT_TOKEN,
+    cancel_if_pending,
+    decode_token,
+    encode_token,
+    raise_channel_not_found,
+    raise_not_subscribed,
+    redact_url,
+)
 from synthorg.communication.bus.errors import (
     BusConnectionError,
     BusStreamError,
@@ -41,10 +53,8 @@ from synthorg.communication.config import (  # noqa: TC001
 from synthorg.communication.enums import ChannelType
 from synthorg.communication.errors import (
     ChannelAlreadyExistsError,
-    ChannelNotFoundError,
     MessageBusAlreadyRunningError,
     MessageBusNotRunningError,
-    NotSubscribedError,
 )
 from synthorg.communication.message import Message
 from synthorg.communication.subscription import (
@@ -68,7 +78,6 @@ from synthorg.observability.events.communication import (
     COMM_BUS_STREAM_SCAN_FAILED,
     COMM_CHANNEL_ALREADY_EXISTS,
     COMM_CHANNEL_CREATED,
-    COMM_CHANNEL_NOT_FOUND,
     COMM_DIRECT_SENT,
     COMM_HISTORY_QUERIED,
     COMM_MESSAGE_DELIVERED,
@@ -76,7 +85,6 @@ from synthorg.observability.events.communication import (
     COMM_RECEIVE_SHUTDOWN,
     COMM_SEND_DIRECT_INVALID,
     COMM_SUBSCRIPTION_CREATED,
-    COMM_SUBSCRIPTION_NOT_FOUND,
     COMM_SUBSCRIPTION_REMOVED,
 )
 
@@ -86,140 +94,6 @@ if TYPE_CHECKING:
     from nats.js.kv import KeyValue
 
 logger = get_logger(__name__)
-
-_DM_SEPARATOR = ":"
-"""Separator used in deterministic direct-channel names (matches in-memory)."""
-
-_SUBJECT_CHANNEL_TOKEN: Final[str] = "channel"  # noqa: S105
-_SUBJECT_DIRECT_TOKEN: Final[str] = "direct"  # noqa: S105
-
-_MAX_BUS_PAYLOAD_BYTES: Final[int] = 4 * 1024 * 1024
-"""Maximum bus message payload size (4 MB) accepted from JetStream.
-
-Messages include parts that can carry text/data blobs, so the limit
-is higher than the task-claim limit but still bounded to prevent a
-single malformed publisher from exhausting worker memory during
-deserialization.
-"""
-
-_RECEIVE_POLL_WINDOW_SECONDS: Final[float] = 60.0
-"""Maximum seconds a single JetStream fetch waits before looping.
-
-``receive()`` uses this value as the upper bound on a single
-``_fetch_with_shutdown`` call. A ``timeout=None`` caller loops over
-these polls until a message arrives or the bus shuts down; a
-bounded ``timeout`` decrements the remaining budget by this window
-each iteration. Keeps per-fetch server-side state bounded while
-still matching the in-memory bus's "block indefinitely" contract.
-"""
-
-_CONSUMER_ACK_WAIT_MULTIPLIER: Final[float] = 6.0
-"""Multiplier on ``publish_ack_wait_seconds`` for per-subscriber consumer ack_wait.
-
-A subscriber's durable pull consumer gets an ack deadline that is
-several times longer than the publisher's ack wait: publish acks are a
-server-side fire-and-forget acknowledgement, while the subscriber's
-ack deadline must span receive + application processing + the
-possibility of redelivery before being considered in-flight. The 6x
-factor mirrors typical JetStream guidance for interactive workloads
-and is surfaced here as a named constant so tests and operators can
-reason about it without grepping for a raw literal.
-"""
-
-
-def _redact_url(url: str) -> str:
-    """Strip credentials from a NATS URL for safe logging.
-
-    ``nats://user:pass@host:port`` -> ``nats://***@host:port``.
-    Non-URL strings pass through unchanged (best effort).
-    """
-    try:
-        parsed = urlparse(url)
-    except ValueError:
-        return url
-    if not parsed.hostname:
-        return url
-    authority = parsed.hostname
-    if parsed.port is not None:
-        authority = f"{authority}:{parsed.port}"
-    has_creds = parsed.username is not None or parsed.password is not None
-    if has_creds:
-        authority = f"***@{authority}"
-    scheme = parsed.scheme or "nats"
-    rest = parsed.path or ""
-    return f"{scheme}://{authority}{rest}"
-
-
-def _raise_channel_not_found(channel_name: str) -> NoReturn:
-    """Log and raise :class:`ChannelNotFoundError`."""
-    logger.warning(COMM_CHANNEL_NOT_FOUND, channel=channel_name)
-    msg = f"Channel not found: {channel_name}"
-    raise ChannelNotFoundError(msg, context={"channel": channel_name})
-
-
-def _raise_not_subscribed(
-    channel_name: str,
-    subscriber_id: str,
-) -> NoReturn:
-    """Log and raise :class:`NotSubscribedError`."""
-    logger.warning(
-        COMM_SUBSCRIPTION_NOT_FOUND,
-        channel=channel_name,
-        subscriber=subscriber_id,
-    )
-    msg = f"Not subscribed to {channel_name}"
-    raise NotSubscribedError(
-        msg,
-        context={
-            "channel": channel_name,
-            "subscriber": subscriber_id,
-        },
-    )
-
-
-async def _cancel_if_pending(task: asyncio.Task[Any]) -> None:
-    """Cancel a task, await completion, and suppress the expected CancelledError.
-
-    Any exception other than ``CancelledError`` is logged at WARNING
-    and re-raised so the caller can decide whether recovery is
-    possible. The previous ``contextlib.suppress(Exception)`` masked
-    genuine errors like transport failures during in-flight fetches.
-    """
-    if task.done():
-        return
-    task.cancel()
-    try:
-        await task
-    except asyncio.CancelledError:
-        pass
-    except Exception:
-        logger.warning(
-            COMM_BUS_RECEIVE_ERROR,
-            phase="cancel_pending_task",
-            task_repr=repr(task),
-            exc_info=True,
-        )
-        raise
-
-
-def _encode_token(name: str) -> str:
-    """Encode an arbitrary string into a NATS-subject-safe token.
-
-    JetStream subject tokens may contain alphanumerics, ``-``, and
-    ``_`` but not ``#``, ``@``, ``:``, ``.`` or other separators used
-    in SynthOrg channel names. Base32 (lowercase, no padding) gives a
-    deterministic, collision-free, case-insensitive encoding using
-    only safe characters.
-    """
-    raw = name.encode("utf-8")
-    return base64.b32encode(raw).decode("ascii").rstrip("=").lower()
-
-
-def _decode_token(token: str) -> str:
-    """Reverse of :func:`_encode_token`."""
-    padding = "=" * ((-len(token)) % 8)
-    raw = base64.b32decode((token.upper() + padding).encode("ascii"))
-    return raw.decode("utf-8")
 
 
 class JetStreamMessageBus:
@@ -370,7 +244,7 @@ class JetStreamMessageBus:
                 error_cb=on_error,
             )
         except (TimeoutError, NoServersError, OSError) as exc:
-            redacted = _redact_url(self._nats_config.url)
+            redacted = redact_url(self._nats_config.url)
             msg = f"Failed to connect to NATS at {redacted}: {exc}"
             logger.exception(COMM_BUS_DISCONNECTED, error=msg, url=redacted)
             raise BusConnectionError(
@@ -379,7 +253,7 @@ class JetStreamMessageBus:
             ) from exc
 
         self._js = self._client.jetstream()
-        logger.info(COMM_BUS_CONNECTED, url=_redact_url(self._nats_config.url))
+        logger.info(COMM_BUS_CONNECTED, url=redact_url(self._nats_config.url))
 
     async def _ensure_stream(self) -> None:
         """Create the bus stream if it does not already exist."""
@@ -399,8 +273,8 @@ class JetStreamMessageBus:
         stream_config = StreamConfig(
             name=self._stream_name,
             subjects=[
-                f"{pfx}.bus.{_SUBJECT_CHANNEL_TOKEN}.>",
-                f"{pfx}.bus.{_SUBJECT_DIRECT_TOKEN}.>",
+                f"{pfx}.bus.{SUBJECT_CHANNEL_TOKEN}.>",
+                f"{pfx}.bus.{SUBJECT_DIRECT_TOKEN}.>",
             ],
             retention=RetentionPolicy.LIMITS,
             max_msgs_per_subject=(self._config.retention.max_messages_per_channel),
@@ -517,12 +391,12 @@ class JetStreamMessageBus:
     def _channel_subject(self, channel_name: str) -> str:
         """Compute the stream subject for a TOPIC/BROADCAST channel."""
         pfx = self._nats_config.stream_name_prefix.lower()
-        return f"{pfx}.bus.{_SUBJECT_CHANNEL_TOKEN}.{_encode_token(channel_name)}"
+        return f"{pfx}.bus.{SUBJECT_CHANNEL_TOKEN}.{encode_token(channel_name)}"
 
     def _direct_subject(self, channel_name: str) -> str:
         """Compute the stream subject for a DIRECT channel."""
         pfx = self._nats_config.stream_name_prefix.lower()
-        return f"{pfx}.bus.{_SUBJECT_DIRECT_TOKEN}.{_encode_token(channel_name)}"
+        return f"{pfx}.bus.{SUBJECT_DIRECT_TOKEN}.{encode_token(channel_name)}"
 
     def _subject_for_channel(self, channel: Channel) -> str:
         """Pick the correct subject based on channel type."""
@@ -533,7 +407,7 @@ class JetStreamMessageBus:
     @staticmethod
     def _durable_name(channel_name: str, subscriber_id: str) -> str:
         """Compute a safe durable consumer name."""
-        return f"{_encode_token(channel_name)}__{_encode_token(subscriber_id)}"
+        return f"{encode_token(channel_name)}__{encode_token(subscriber_id)}"
 
     async def publish(self, message: Message) -> None:
         """Publish a message to its channel via the JetStream stream.
@@ -610,10 +484,10 @@ class JetStreamMessageBus:
             logger.warning(COMM_SEND_DIRECT_INVALID, error=msg)
             raise ValueError(msg)
         for agent_id in (sender, recipient):
-            if _DM_SEPARATOR in agent_id:
+            if DM_SEPARATOR in agent_id:
                 msg = (
                     f"Agent ID {agent_id!r} contains the reserved "
-                    f"separator character {_DM_SEPARATOR!r}"
+                    f"separator character {DM_SEPARATOR!r}"
                 )
                 logger.warning(COMM_SEND_DIRECT_INVALID, error=msg)
                 raise ValueError(msg)
@@ -678,7 +552,7 @@ class JetStreamMessageBus:
         """Persist a Channel definition to the KV bucket."""
         if self._kv is None:
             return
-        key = _encode_token(channel.name)
+        key = encode_token(channel.name)
         value = channel.model_dump_json().encode("utf-8")
         try:
             await self._kv.put(key, value)
@@ -702,7 +576,7 @@ class JetStreamMessageBus:
 
         if self._kv is None:
             return None
-        key = _encode_token(channel_name)
+        key = encode_token(channel_name)
         try:
             entry = await self._kv.get(key)
         except KeyNotFoundError:
@@ -841,7 +715,7 @@ class JetStreamMessageBus:
             durable_name=durable,
             ack_wait=(
                 self._nats_config.publish_ack_wait_seconds
-                * _CONSUMER_ACK_WAIT_MULTIPLIER
+                * CONSUMER_ACK_WAIT_MULTIPLIER
             ),
             max_deliver=1,
             filter_subject=subject,
@@ -872,10 +746,10 @@ class JetStreamMessageBus:
         async with self._lock:
             self._require_running()
             if channel_name not in self._channels:
-                _raise_not_subscribed(channel_name, subscriber_id)
+                raise_not_subscribed(channel_name, subscriber_id)
             channel = self._channels[channel_name]
             if subscriber_id not in channel.subscribers:
-                _raise_not_subscribed(channel_name, subscriber_id)
+                raise_not_subscribed(channel_name, subscriber_id)
             new_subs = tuple(s for s in channel.subscribers if s != subscriber_id)
             updated = channel.model_copy(
                 update={"subscribers": new_subs},
@@ -956,7 +830,7 @@ class JetStreamMessageBus:
                 return None
             msgs = await self._fetch_with_shutdown(
                 sub,
-                _RECEIVE_POLL_WINDOW_SECONDS,
+                RECEIVE_POLL_WINDOW_SECONDS,
                 channel_name=channel_name,
                 subscriber_id=subscriber_id,
             )
@@ -1000,7 +874,7 @@ class JetStreamMessageBus:
                 return None
             if self._shutdown_event.is_set():
                 return None
-            poll = min(remaining, _RECEIVE_POLL_WINDOW_SECONDS)
+            poll = min(remaining, RECEIVE_POLL_WINDOW_SECONDS)
             msgs = await self._fetch_with_shutdown(
                 sub,
                 poll,
@@ -1042,7 +916,7 @@ class JetStreamMessageBus:
                 channel.type != ChannelType.BROADCAST
                 and subscriber_id not in channel.subscribers
             ):
-                _raise_not_subscribed(channel_name, subscriber_id)
+                raise_not_subscribed(channel_name, subscriber_id)
             key = (channel_name, subscriber_id)
             sub = self._subscriptions.get(key)
             if sub is None:
@@ -1093,8 +967,8 @@ class JetStreamMessageBus:
             self._in_flight_fetches.discard(fetch_task)
             self._in_flight_fetches.discard(shutdown_task)
 
-        await _cancel_if_pending(fetch_task)
-        await _cancel_if_pending(shutdown_task)
+        await cancel_if_pending(fetch_task)
+        await cancel_if_pending(shutdown_task)
 
         if shutdown_task in done and fetch_task not in done:
             logger.debug(
@@ -1157,13 +1031,13 @@ class JetStreamMessageBus:
             return None
 
         msg = msgs[0]
-        if len(msg.data) > _MAX_BUS_PAYLOAD_BYTES:
+        if len(msg.data) > MAX_BUS_PAYLOAD_BYTES:
             logger.warning(
                 COMM_BUS_MESSAGE_TOO_LARGE,
                 channel=channel_name,
                 subscriber=subscriber_id,
                 size=len(msg.data),
-                limit=_MAX_BUS_PAYLOAD_BYTES,
+                limit=MAX_BUS_PAYLOAD_BYTES,
             )
             # Ack the oversized payload so JetStream does not
             # redeliver it. Even if the ack fails we have already
@@ -1319,7 +1193,7 @@ class JetStreamMessageBus:
 
         loaded = await self._load_channel_from_kv(channel_name)
         if loaded is None:
-            _raise_channel_not_found(channel_name)
+            raise_channel_not_found(channel_name)
 
         async with self._lock:
             existing = self._channels.get(channel_name)
@@ -1363,7 +1237,7 @@ class JetStreamMessageBus:
         channels: list[Channel] = []
         for key in keys:
             try:
-                decoded_name = _decode_token(key)
+                decoded_name = decode_token(key)
             except Exception as exc:
                 logger.warning(
                     COMM_BUS_KV_READ_FAILED,

--- a/src/synthorg/observability/events/workers.py
+++ b/src/synthorg/observability/events/workers.py
@@ -30,6 +30,7 @@ WORKERS_DISPATCHER_PUBLISH_EXHAUSTED: Final[str] = (
 WORKERS_DISPATCHER_CLAIM_ENQUEUED: Final[str] = "workers.dispatcher.claim_enqueued"
 
 # Task queue client
+WORKERS_TASK_QUEUE_CONNECT_FAILED: Final[str] = "workers.task_queue.connect_failed"
 WORKERS_TASK_QUEUE_UNSUBSCRIBE_FAILED: Final[str] = (
     "workers.task_queue.unsubscribe_failed"
 )

--- a/src/synthorg/workers/claim.py
+++ b/src/synthorg/workers/claim.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any, Final
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 
-from synthorg.communication.bus._nats_utils import redact_url
+from synthorg.communication.bus import redact_url
 from synthorg.communication.bus.errors import (
     BusConnectionError,
     BusStreamError,
@@ -25,6 +25,7 @@ from synthorg.observability import get_logger
 from synthorg.observability.events.workers import (
     WORKERS_TASK_QUEUE_ACK_MALFORMED_FAILED,
     WORKERS_TASK_QUEUE_CLAIM_PARSE_FAILED,
+    WORKERS_TASK_QUEUE_CONNECT_FAILED,
     WORKERS_TASK_QUEUE_DRAIN_FAILED,
     WORKERS_TASK_QUEUE_UNSUBSCRIBE_FAILED,
 )
@@ -214,6 +215,11 @@ class JetStreamTaskQueue:
         except (TimeoutError, NoServersError, OSError) as exc:
             safe_url = redact_url(self._nats_config.url)
             msg = f"Failed to connect to NATS at {safe_url} for task queue: {exc}"
+            logger.exception(
+                WORKERS_TASK_QUEUE_CONNECT_FAILED,
+                url=safe_url,
+                error=str(exc),
+            )
             raise BusConnectionError(
                 msg,
                 context={"url": safe_url},

--- a/src/synthorg/workers/claim.py
+++ b/src/synthorg/workers/claim.py
@@ -15,11 +15,11 @@ from typing import TYPE_CHECKING, Any, Final
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 
+from synthorg.communication.bus._nats_utils import redact_url
 from synthorg.communication.bus.errors import (
     BusConnectionError,
     BusStreamError,
 )
-from synthorg.communication.bus.nats import _redact_url
 from synthorg.core.types import NotBlankStr  # noqa: TC001
 from synthorg.observability import get_logger
 from synthorg.observability.events.workers import (
@@ -212,7 +212,7 @@ class JetStreamTaskQueue:
                 user_credentials=self._nats_config.credentials_path,
             )
         except (TimeoutError, NoServersError, OSError) as exc:
-            safe_url = _redact_url(self._nats_config.url)
+            safe_url = redact_url(self._nats_config.url)
             msg = f"Failed to connect to NATS at {safe_url} for task queue: {exc}"
             raise BusConnectionError(
                 msg,

--- a/tests/unit/communication/test_bus_nats_helpers.py
+++ b/tests/unit/communication/test_bus_nats_helpers.py
@@ -1,4 +1,4 @@
-"""Unit tests for bus/nats.py top-level helpers.
+"""Unit tests for NATS bus utility helpers.
 
 These helpers are pure functions (subject encoding, URL redaction,
 task cancellation) that can be exercised without a live NATS
@@ -11,11 +11,11 @@ import asyncio
 
 import pytest
 
-from synthorg.communication.bus.nats import (
-    _cancel_if_pending,
-    _decode_token,
-    _encode_token,
-    _redact_url,
+from synthorg.communication.bus._nats_utils import (
+    cancel_if_pending,
+    decode_token,
+    encode_token,
+    redact_url,
 )
 
 
@@ -32,7 +32,7 @@ class TestEncodeToken:
         ],
     )
     def test_round_trip_simple(self, original: str) -> None:
-        assert _decode_token(_encode_token(original)) == original
+        assert decode_token(encode_token(original)) == original
 
     @pytest.mark.unit
     @pytest.mark.parametrize(
@@ -45,12 +45,12 @@ class TestEncodeToken:
         ],
     )
     def test_round_trip_with_special_characters(self, original: str) -> None:
-        assert _decode_token(_encode_token(original)) == original
+        assert decode_token(encode_token(original)) == original
 
     @pytest.mark.unit
     def test_encoding_is_deterministic(self) -> None:
-        first = _encode_token("#general")
-        second = _encode_token("#general")
+        first = encode_token("#general")
+        second = encode_token("#general")
         assert first == second
 
     @pytest.mark.unit
@@ -60,7 +60,7 @@ class TestEncodeToken:
         Lowercase base32 uses ``a-z`` plus digits ``2-7``, which are
         all safe NATS subject tokens.
         """
-        token = _encode_token("#engineering")
+        token = encode_token("#engineering")
         allowed = set("abcdefghijklmnopqrstuvwxyz234567")
         for char in token:
             assert char in allowed, f"unexpected char {char!r} in token"
@@ -68,8 +68,8 @@ class TestEncodeToken:
     @pytest.mark.unit
     def test_encoding_distinguishes_channels(self) -> None:
         """Different channel names must encode to different tokens."""
-        assert _encode_token("#a") != _encode_token("#b")
-        assert _encode_token("@agent-a:agent-b") != _encode_token("@agent-b:agent-a")
+        assert encode_token("#a") != encode_token("#b")
+        assert encode_token("@agent-a:agent-b") != encode_token("@agent-b:agent-a")
 
 
 class TestRedactUrl:
@@ -77,29 +77,29 @@ class TestRedactUrl:
 
     @pytest.mark.unit
     def test_passthrough_without_credentials(self) -> None:
-        assert _redact_url("nats://localhost:4222") == "nats://localhost:4222"
+        assert redact_url("nats://localhost:4222") == "nats://localhost:4222"
 
     @pytest.mark.unit
     def test_strips_username_password(self) -> None:
-        redacted = _redact_url("nats://admin:secret@nats-prod:4222")
+        redacted = redact_url("nats://admin:secret@nats-prod:4222")
         assert "secret" not in redacted
         assert "admin" not in redacted
         assert "***@nats-prod:4222" in redacted
 
     @pytest.mark.unit
     def test_strips_username_only(self) -> None:
-        redacted = _redact_url("nats://admin@nats-prod:4222")
+        redacted = redact_url("nats://admin@nats-prod:4222")
         assert "admin" not in redacted
         assert "***@nats-prod:4222" in redacted
 
     @pytest.mark.unit
     def test_preserves_scheme(self) -> None:
-        assert _redact_url("tls://host:4222").startswith("tls://")
+        assert redact_url("tls://host:4222").startswith("tls://")
 
     @pytest.mark.unit
     def test_invalid_url_passes_through(self) -> None:
         # Non-URL strings shouldn't crash; return the input unchanged.
-        assert _redact_url("not a url") == "not a url"
+        assert redact_url("not a url") == "not a url"
 
 
 class TestCancelIfPending:
@@ -113,7 +113,7 @@ class TestCancelIfPending:
         task = asyncio.create_task(noop())
         await task
         # Already done -- should return without touching the task.
-        await _cancel_if_pending(task)
+        await cancel_if_pending(task)
         assert task.done()
 
     @pytest.mark.unit
@@ -130,7 +130,7 @@ class TestCancelIfPending:
         # so the cancel is guaranteed to race a pending task rather
         # than one that is still queued in the event loop.
         await started.wait()
-        await _cancel_if_pending(task)
+        await cancel_if_pending(task)
         assert task.cancelled()
 
     @pytest.mark.unit
@@ -144,5 +144,5 @@ class TestCancelIfPending:
         task = asyncio.create_task(wait_forever())
         await started.wait()
         # Should not raise.
-        await _cancel_if_pending(task)
+        await cancel_if_pending(task)
         assert task.cancelled()

--- a/tests/unit/communication/test_bus_nats_helpers.py
+++ b/tests/unit/communication/test_bus_nats_helpers.py
@@ -2,9 +2,8 @@
 
 These helpers are pure functions (subject encoding, URL redaction,
 task cancellation) that can be exercised without a live NATS
-connection. Importing the module requires ``nats-py`` to be
-installed, so these tests assume the ``distributed`` extra is
-present in the dev/test environment.
+connection. The ``_nats_utils`` module does not import ``nats-py``
+at runtime, so these tests work without the ``distributed`` extra.
 """
 
 import asyncio
@@ -73,7 +72,7 @@ class TestEncodeToken:
 
 
 class TestRedactUrl:
-    """``_redact_url`` strips credentials before logging a NATS URL."""
+    """``redact_url`` strips credentials before logging a NATS URL."""
 
     @pytest.mark.unit
     def test_passthrough_without_credentials(self) -> None:
@@ -103,7 +102,7 @@ class TestRedactUrl:
 
 
 class TestCancelIfPending:
-    """``_cancel_if_pending`` cancels a task and swallows cancellation."""
+    """``cancel_if_pending`` cancels a task and swallows cancellation."""
 
     @pytest.mark.unit
     async def test_noop_on_completed_task(self) -> None:


### PR DESCRIPTION
## Summary

Two related issues addressed in dependency order:

### #1217: nats-core evaluation

- Evaluated `nats-core` v0.1.0 as a replacement for `nats-py==2.14.0` (Python 3.14 `asyncio.iscoroutinefunction` deprecation)
- **Verdict: stay on nats-py** -- nats-core lacks JetStream, KV store, and durable consumers (all features SynthOrg depends on)
- Decision recorded in `docs/architecture/decisions.md` with mitigation plan (upstream PR + existing filterwarnings workaround)

### #1221: split bus/nats.py into focused modules

Refactored the monolithic `bus/nats.py` (1582 lines) into 9 focused internal submodules + a thin facade:

| Module | Lines | Responsibility |
|--------|-------|----------------|
| `nats.py` (facade) | 190 | Thin wrapper delegating to submodules |
| `_nats_receive.py` | 299 | Receive loop, fetch, ack, envelope |
| `_nats_connection.py` | 221 | Connect, drain, stream/KV setup, stop |
| `_nats_history.py` | 198 | History scanning with ephemeral consumers |
| `_nats_channels.py` | 179 | Channel create/get/list/resolve + subjects |
| `_nats_utils.py` | 174 | Pure utilities + constants |
| `_nats_consumers.py` | 153 | Subscribe/unsubscribe, pull consumers |
| `_nats_kv.py` | 142 | KV bucket read/write/scan |
| `_nats_publish.py` | 119 | Publish, send_direct, serialize |
| `_nats_state.py` | 70 | Shared state dataclass |

Architecture: `_NatsState` dataclass bundles shared mutable state. Submodule functions accept `state: _NatsState`. Facade creates state in `__init__` and delegates.

## Test plan

- 1017 communication unit tests pass (including updated helper tests)
- 17,791 total tests pass (8 pre-existing integration failures unrelated to bus changes)
- mypy strict: 0 issues across 15 source files
- ruff check + format: clean
- All files under 300 lines (well under 800 limit)
- Public API unchanged (`JetStreamMessageBus` -- same 13 methods)
- No new public surface (all submodules `_`-prefixed)

## Review coverage

Pre-reviewed by 6 agents: docs-consistency, python-reviewer, code-reviewer, conventions-enforcer, async-concurrency-reviewer, issue-resolution-verifier. 1 finding addressed (stale docstring).

Closes #1217
Closes #1221
