### PR TITLE
docs: replace ASCII/Unicode box diagrams with Mermaid + D2 hybrid tooling

### DIFF
--- a/.claude/agents/diagram-syntax-validator.md
+++ b/.claude/agents/diagram-syntax-validator.md
@@ -1,0 +1,68 @@
+---
+name: diagram-syntax-validator
+description: Validates Mermaid and D2 diagram syntax in documentation files, checking for syntax errors, consistent styling, and correct fence types
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+---
+
+# Diagram Syntax Validator Agent
+
+You are a diagram syntax reviewer for SynthOrg documentation. You validate that all Mermaid and D2 diagrams in changed documentation files are syntactically correct and follow project conventions.
+
+## What to Check
+
+For each changed `docs/**/*.md` file in the diff, check for these issues:
+
+### 1. D2 syntax validation (CRITICAL)
+
+For every ` ```d2 ` block found in changed files, validate the syntax by running:
+
+```bash
+export PATH="$PATH:/c/Program Files/D2" && d2 --dry-run - <<'EOF'
+<diagram content>
+EOF
+```
+
+If `d2 --dry-run` reports errors, flag them with the exact error message.
+
+### 2. Mermaid syntax validation (MAJOR)
+
+For every ` ```mermaid ` block found in changed files, check for common syntax errors:
+
+- Unclosed brackets or quotes in node labels
+- Missing arrow syntax (`-->`, `->`, `-.->`)
+- Invalid diagram type declarations (must be `graph TD`, `graph LR`, `graph TB`, `sequenceDiagram`, `stateDiagram-v2`, etc.)
+- Unbalanced subgraph/end pairs
+- Node IDs containing spaces without brackets
+
+### 3. Wrong fence type (MAJOR)
+
+Flag any ` ```text ` blocks that contain ASCII box-drawing characters (`+--+`, `|`, `-->`, Unicode box chars) -- these should have been converted to Mermaid or D2.
+
+### 4. Convention check (MEDIUM)
+
+- D2 diagrams should use `grid-rows`/`grid-columns` for architecture layouts (nested boxes)
+- Mermaid diagrams should be used for flowcharts, sequences, and simple hierarchies
+- No mixing of Mermaid and D2 within the same conceptual diagram
+
+## Report Format
+
+For each issue found, report:
+- File path and line number
+- The issue (what is wrong)
+- The fix (how to resolve it)
+- Severity: CRITICAL / MAJOR / MEDIUM
+
+Only report issues with HIGH confidence. Do not flag:
+- Diagram aesthetic preferences (layout choices are intentional)
+- D2 or Mermaid features that are valid but uncommon
+
+## Project Convention
+
+- **D2** is used for: architecture diagrams, nested container layouts, complex entity relationships, state machines with many transitions
+- **Mermaid** is used for: flowcharts, sequence diagrams, simple hierarchies, pipelines
+- **Markdown tables** are used for: grid/matrix data that is semantically tabular
+- D2 theme is dark-only (theme 200, Dark Mauve) configured globally in mkdocs.yml

--- a/.claude/agents/diagram-syntax-validator.md
+++ b/.claude/agents/diagram-syntax-validator.md
@@ -21,7 +21,7 @@ For each changed `docs/**/*.md` file in the diff, check for these issues:
 For every ` ```d2 ` block found in changed files, validate the syntax by running:
 
 ```bash
-export PATH="$PATH:/c/Program Files/D2" && d2 --dry-run - <<'EOF'
+d2 --dry-run - <<'EOF'
 <diagram content>
 EOF
 ```
@@ -40,7 +40,12 @@ For every ` ```mermaid ` block found in changed files, check for common syntax e
 
 ### 3. Wrong fence type (MAJOR)
 
-Flag any ` ```text ` blocks that contain ASCII box-drawing characters (`+--+`, `|`, `-->`, Unicode box chars) -- these should have been converted to Mermaid or D2.
+Flag any ` ```text ` blocks that contain explicit ASCII/Unicode box-drawing patterns -- these should have been converted to Mermaid or D2. A single `|` is not enough (that matches tables, logs, and command output). Only flag when one or more of these are present:
+
+- `+---+` or `+--+` corner/edge markers
+- Adjacent lines that both match `^\|.*\|$` (a repeated `| ... |` frame across neighbouring lines)
+- Arrow connectors `-->` or `<--`
+- Any Unicode box-drawing character in the range `U+2500` to `U+257F`
 
 ### 4. Convention check (MEDIUM)
 

--- a/.claude/skills/aurelio-review-pr/SKILL.md
+++ b/.claude/skills/aurelio-review-pr/SKILL.md
@@ -178,6 +178,7 @@ Based on changed files, launch applicable review agents **in parallel** using th
 | **go-reviewer** | Any `cli_go` | `explore` |
 | **go-security-reviewer** | Any `cli_go` with dangerous patterns | `explore` |
 | **go-conventions-enforcer** | Any `cli_go` | `explore` |
+| **diagram-syntax-validator** | Any `docs` files changed that contain ` ```d2 ` or ` ```mermaid ` blocks | `explore` (use `.claude/agents/diagram-syntax-validator.md` prompt) |
 | **issue-resolution-verifier** | Issue is linked (pre-existing or auto-linked in Phase 2) | `explore` (issue-resolution-verifier) |
 
 **If the Task tool fails** (e.g., "Unknown agent type"), fall back to running the check manually using Read/Grep tools on the changed files AND the additional required sources (CLAUDE.md, README.md, docs/design/*.md for the relevant pages). Ensure the issue-resolution-verifier also fetches the full linked issue content via `gh issue view N --json title,body,labels,comments`.

--- a/.claude/skills/pre-pr-review/SKILL.md
+++ b/.claude/skills/pre-pr-review/SKILL.md
@@ -269,6 +269,7 @@ This captures committed-but-unpushed changes AND any uncommitted/untracked work 
 | **go-conventions-enforcer** | Any `cli_go` | `pr-review-toolkit:code-reviewer` (custom prompt below) |
 | **issue-resolution-verifier** | Issue context was found in Phase 0 step 6 | `pr-review-toolkit:code-reviewer` (custom prompt below) |
 | **tool-parity-checker** | Any `.claude/` or `.opencode/` or `opencode.json` or `AGENTS.md` or `CLAUDE.md` file changed | `.claude/agents/tool-parity-checker.md` prompt (verifies Claude Code <-> OpenCode config parity) |
+| **diagram-syntax-validator** | Any `docs` files changed that contain ` ```d2 ` or ` ```mermaid ` blocks | `.claude/agents/diagram-syntax-validator.md` prompt (validates diagram syntax, conventions, fence types) |
 
 ### Go-conventions-enforcer custom prompt
 

--- a/.claude/skills/pre-pr-review/SKILL.md
+++ b/.claude/skills/pre-pr-review/SKILL.md
@@ -132,7 +132,9 @@ Automated pre-PR pipeline that runs checks, launches review agents, triages find
 
 Determine if agent review can be skipped:
 
-- If `$ARGUMENTS` contains `quick` -> skip agents, go to Phase 2 then Phase 8, then Phase 10 and Phase 11
+- If `$ARGUMENTS` contains `quick`:
+  - If any changed `.md` file contains a ` ```d2 ` or ` ```mermaid ` fence, run only `diagram-syntax-validator` (per Phase 3) before continuing to Phase 2.
+  - Otherwise skip agents entirely, go to Phase 2 then Phase 8, then Phase 10 and Phase 11
 - **Auto-detect**: If ALL changed files are non-substantive (only `.md` docs, config formatting, typo-level edits with no logic changes, `site/` static assets like images/fonts), skip agents automatically
   - Auto-skip examples: all changes are `.md` files; only `pyproject.toml` version bump; only `.yaml`/`.json` config with no Python changes; only `site/` image/font/asset changes
   - Do NOT auto-skip: any `.py` file changed; any `.go` file changed; any `.tsx`/`.ts`/`.css` file changed; any `docker/` or `.github/workflows/` file changed; config changes that affect runtime behavior; new dependencies added

--- a/.claude/skills/pre-pr-review/SKILL.md
+++ b/.claude/skills/pre-pr-review/SKILL.md
@@ -136,6 +136,7 @@ Determine if agent review can be skipped:
 - **Auto-detect**: If ALL changed files are non-substantive (only `.md` docs, config formatting, typo-level edits with no logic changes, `site/` static assets like images/fonts), skip agents automatically
   - Auto-skip examples: all changes are `.md` files; only `pyproject.toml` version bump; only `.yaml`/`.json` config with no Python changes; only `site/` image/font/asset changes
   - Do NOT auto-skip: any `.py` file changed; any `.go` file changed; any `.tsx`/`.ts`/`.css` file changed; any `docker/` or `.github/workflows/` file changed; config changes that affect runtime behavior; new dependencies added
+  - **Exception for diagram changes**: even when auto-skipping, if any changed `.md` file contains a ` ```d2 ` or ` ```mermaid ` fence, run the `diagram-syntax-validator` agent (per Phase 3) before continuing. Its entire purpose is to catch broken diagrams in docs-only PRs -- the one scenario where auto-skip would otherwise bypass it.
 - If auto-skipping, inform user: "Skipping agent review (no substantive code changes detected). Running automated checks only."
 
 ## Phase 2: Automated Checks (always run)

--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -109,6 +109,20 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
+      # D2 binary -- required by d2_fence.py at build time.
+      # Keep version + checksum in sync with pages.yml.
+      - name: Install D2
+        env:
+          D2_VERSION: v0.7.1
+          D2_SHA256: eb172adf59f38d1e5a70ab177591356754ffaf9bebb84e0ca8b767dfb421dad7
+        run: |
+          curl -fsSL "https://github.com/terrastruct/d2/releases/download/${D2_VERSION}/d2-${D2_VERSION}-linux-amd64.tar.gz" -o d2.tar.gz
+          echo "${D2_SHA256}  d2.tar.gz" | sha256sum --check --strict -
+          tar -xzf d2.tar.gz
+          sudo mv "d2-${D2_VERSION}/bin/d2" /usr/local/bin/d2
+          rm -rf d2.tar.gz "d2-${D2_VERSION}"
+          d2 --version
+
       - name: Install docs dependencies
         run: uv sync --group docs --no-dev
 
@@ -122,6 +136,8 @@ jobs:
         # TODO: Restore --strict once zensical supports it
         # https://github.com/zensical/backlog/issues/72
         # SYNTHORG_VERSION intentionally omitted -- previews show "dev" banner
+        env:
+          PYTHONPATH: .
         run: uv run zensical build
 
       - name: Patch sitemap with static OpenAPI artifacts

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
+      - name: Install D2
+        run: curl -fsSL https://d2lang.com/install.sh | sh -s --
+
       - name: Install docs dependencies
         run: uv sync --group docs --no-dev
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -91,6 +91,7 @@ jobs:
         # https://github.com/zensical/backlog/issues/72
         env:
           SYNTHORG_VERSION: ${{ steps.version.outputs.version }}
+          PYTHONPATH: .
         run: uv run zensical build
 
       - name: Patch sitemap with static OpenAPI artifacts

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -47,13 +47,16 @@ jobs:
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       # D2 binary -- required by mkdocs-d2-plugin at build time.
-      # Dependabot cannot auto-bump this version. Check releases periodically:
-      # https://github.com/terrastruct/d2/releases
+      # Dependabot cannot auto-bump this version. When bumping, also update
+      # D2_SHA256 by running `sha256sum` on the release tarball. Check
+      # releases at https://github.com/terrastruct/d2/releases.
       - name: Install D2
         env:
           D2_VERSION: v0.7.1
+          D2_SHA256: eb172adf59f38d1e5a70ab177591356754ffaf9bebb84e0ca8b767dfb421dad7
         run: |
           curl -fsSL "https://github.com/terrastruct/d2/releases/download/${D2_VERSION}/d2-${D2_VERSION}-linux-amd64.tar.gz" -o d2.tar.gz
+          echo "${D2_SHA256}  d2.tar.gz" | sha256sum --check --strict -
           tar -xzf d2.tar.gz
           sudo mv "d2-${D2_VERSION}/bin/d2" /usr/local/bin/d2
           rm -rf d2.tar.gz "d2-${D2_VERSION}"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,8 +46,18 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
+      # D2 binary -- required by mkdocs-d2-plugin at build time.
+      # Dependabot cannot auto-bump this version. Check releases periodically:
+      # https://github.com/terrastruct/d2/releases
       - name: Install D2
-        run: curl -fsSL https://d2lang.com/install.sh | sh -s --
+        env:
+          D2_VERSION: v0.7.1
+        run: |
+          curl -fsSL "https://github.com/terrastruct/d2/releases/download/${D2_VERSION}/d2-${D2_VERSION}-linux-amd64.tar.gz" -o d2.tar.gz
+          tar -xzf d2.tar.gz
+          sudo mv "d2-${D2_VERSION}/bin/d2" /usr/local/bin/d2
+          rm -rf d2.tar.gz "d2-${D2_VERSION}"
+          d2 --version
 
       - name: Install docs dependencies
         run: uv sync --group docs --no-dev

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ cli/cover.out
 
 # uv
 .python-version
+
+# mkdocs-d2-plugin cache (populated locally for faster rebuilds, not persisted in CI)
+.config/plugin/d2/

--- a/.opencode/agents/diagram-syntax-validator.md
+++ b/.opencode/agents/diagram-syntax-validator.md
@@ -1,0 +1,68 @@
+---
+description: Validates Mermaid and D2 diagram syntax in documentation files, checking for syntax errors, consistent styling, and correct fence types
+mode: subagent
+permission:
+  Read: allow
+  Grep: allow
+  Glob: allow
+  Bash: allow
+---
+
+# Diagram Syntax Validator Agent
+
+You are a diagram syntax reviewer for SynthOrg documentation. You validate that all Mermaid and D2 diagrams in changed documentation files are syntactically correct and follow project conventions.
+
+## What to Check
+
+For each changed `docs/**/*.md` file in the diff, check for these issues:
+
+### 1. D2 syntax validation (CRITICAL)
+
+For every ` ```d2 ` block found in changed files, validate the syntax by running:
+
+```bash
+d2 --dry-run - <<'EOF'
+<diagram content>
+EOF
+```
+
+If `d2 --dry-run` reports errors, flag them with the exact error message.
+
+### 2. Mermaid syntax validation (MAJOR)
+
+For every ` ```mermaid ` block found in changed files, check for common syntax errors:
+
+- Unclosed brackets or quotes in node labels
+- Missing arrow syntax (`-->`, `->`, `-.->`)
+- Invalid diagram type declarations (must be `graph TD`, `graph LR`, `graph TB`, `sequenceDiagram`, `stateDiagram-v2`, etc.)
+- Unbalanced subgraph/end pairs
+- Node IDs containing spaces without brackets
+
+### 3. Wrong fence type (MAJOR)
+
+Flag any ` ```text ` blocks that contain ASCII box-drawing characters (`+--+`, `|`, `-->`, Unicode box chars) -- these should have been converted to Mermaid or D2.
+
+### 4. Convention check (MEDIUM)
+
+- D2 diagrams should use `grid-rows`/`grid-columns` for architecture layouts (nested boxes)
+- Mermaid diagrams should be used for flowcharts, sequences, and simple hierarchies
+- No mixing of Mermaid and D2 within the same conceptual diagram
+
+## Report Format
+
+For each issue found, report:
+- File path and line number
+- The issue (what is wrong)
+- The fix (how to resolve it)
+- Severity: CRITICAL / MAJOR / MEDIUM
+
+Only report issues with HIGH confidence. Do not flag:
+- Diagram aesthetic preferences (layout choices are intentional)
+- D2 or Mermaid features that are valid but uncommon
+
+## Project Convention
+
+- **D2** is used for: architecture diagrams, nested container layouts, complex entity relationships, state machines with many transitions
+- **Mermaid** is used for: flowcharts, sequence diagrams, simple hierarchies, pipelines
+- **Markdown tables** are used for: grid/matrix data that is semantically tabular
+- D2 theme is dark-only (theme 200, Dark Mauve) configured globally in mkdocs.yml

--- a/.opencode/agents/diagram-syntax-validator.md
+++ b/.opencode/agents/diagram-syntax-validator.md
@@ -40,7 +40,12 @@ For every ` ```mermaid ` block found in changed files, check for common syntax e
 
 ### 3. Wrong fence type (MAJOR)
 
-Flag any ` ```text ` blocks that contain ASCII box-drawing characters (`+--+`, `|`, `-->`, Unicode box chars) -- these should have been converted to Mermaid or D2.
+Flag any ` ```text ` blocks that contain explicit ASCII/Unicode box-drawing patterns -- these should have been converted to Mermaid or D2. A single `|` is not enough (that matches tables, logs, and command output). Only flag when one or more of these are present:
+
+- `+---+` or `+--+` corner/edge markers
+- Adjacent lines that both match `^\|.*\|$` (a repeated `| ... |` frame across neighbouring lines)
+- Arrow connectors `-->` or `<--`
+- Any Unicode box-drawing character in the range `U+2500` to `U+257F`
 
 ### 4. Convention check (MEDIUM)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,8 +58,8 @@ atlas schema diff --env postgres           # drift detection for Postgres (schem
 bash scripts/squash_migrations.sh          # squash old migrations (release-time)
 uv run python scripts/export_openapi.py    # export OpenAPI schema (needed before docs build)
 uv run python scripts/generate_comparison.py  # generate comparison page (needed before docs build)
-uv run zensical build                      # build docs (output: _site/docs/) -- no --strict until zensical/backlog#72
-uv run zensical serve                      # local docs preview (http://127.0.0.1:8000)
+PYTHONPATH=. uv run zensical build          # build docs (output: _site/docs/) -- PYTHONPATH=. enables d2_fence.py for D2 rendering
+PYTHONPATH=. uv run zensical serve          # local docs preview (http://127.0.0.1:8000)
 ```
 
 ### Web Dashboard

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@
 
 ## Diagrams in Documentation
 
-- **D2** (`\`\`\`d2`): architecture diagrams, nested container layouts, complex entity relationships. Rendered at build time via `mkdocs-d2-plugin` (dagre layout). Requires `d2` binary installed locally and in CI.
+- **D2** (`\`\`\`d2`): architecture diagrams, nested container layouts, complex entity relationships. Rendered at build time via `mkdocs-d2-plugin` (dagre layout). Requires the [D2 CLI](https://d2lang.com/tour/install) on `PATH` locally and in CI (pinned to v0.7.1 via `.github/workflows/pages.yml`).
 - **Mermaid** (`\`\`\`mermaid`): flowcharts, sequence diagrams, simple hierarchies, pipelines. Rendered client-side via `pymdownx.superfences`.
 - **Markdown tables**: grid/matrix data that is semantically tabular (not diagrams).
 - D2 uses theme 200 (Dark Mauve), dark-only render -- configured globally in `mkdocs.yml`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,15 @@
 - Surface improvements as suggestions, not silent changes -- user decides
 - **Prioritize issues by dependency order**, not priority labels -- unblocked dependencies come first
 
+## Diagrams in Documentation
+
+- **D2** (`\`\`\`d2`): architecture diagrams, nested container layouts, complex entity relationships. Rendered at build time via `mkdocs-d2-plugin` (dagre layout). Requires `d2` binary installed locally and in CI.
+- **Mermaid** (`\`\`\`mermaid`): flowcharts, sequence diagrams, simple hierarchies, pipelines. Rendered client-side via `pymdownx.superfences`.
+- **Markdown tables**: grid/matrix data that is semantically tabular (not diagrams).
+- D2 uses theme 200 (Dark Mauve), dark-only render -- configured globally in `mkdocs.yml`.
+- Never use `\`\`\`text` blocks with ASCII/Unicode box-drawing characters for diagrams.
+- Review agent `diagram-syntax-validator` runs in `/pre-pr-review` and `/aurelio-review-pr` pipelines.
+
 ## Quick Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ uv sync                  # install dev + test deps
 uv sync --group docs     # install docs toolchain
 ```
 
-Schema migrations require the [Atlas CLI](https://atlasgo.io/getting-started) on `PATH`.
+Schema migrations require the [Atlas CLI](https://atlasgo.io/getting-started) on `PATH`. Building the docs site locally (for D2 diagrams) additionally requires the [D2 CLI](https://d2lang.com/tour/install) on `PATH`.
 
 ### Docker Compose (manual)
 

--- a/d2_fence.py
+++ b/d2_fence.py
@@ -5,8 +5,8 @@ Zensical does not run mkdocs plugin lifecycle hooks, so mkdocs-d2-plugin's
 never fires. This module exposes ``validator`` and ``formatter`` at module level
 so they can be referenced directly in ``mkdocs.yml`` via ``!!python/name:``.
 
-Configuration is sourced from ``mkdocs.yml`` at import time via
-``zensical.config.get_config()``.
+D2 config is hardcoded here to match the values in mkdocs.yml's d2 plugin
+section. Keep them in sync when changing D2 settings.
 """
 
 import subprocess
@@ -19,31 +19,20 @@ _D2_NOT_FOUND = (
     "D2 executable not found on PATH. Install from https://d2lang.com/tour/install"
 )
 
+_D2_CONFIG = {
+    "layout": "dagre",
+    "theme": 200,
+    "dark_theme": -1,
+    "sketch": False,
+    "pad": 100,
+    "scale": -1.0,
+    "force_appendix": False,
+    "target": "''",
+}
 
-def _build_fence() -> D2CustomFence:
-    """Build a D2CustomFence from mkdocs.yml plugin config."""
-    from zensical.config import get_config  # noqa: PLC0415
 
-    cfg = get_config()
-    d2_cfg = cfg.get("plugins", {}).get("d2", {})
-    if isinstance(d2_cfg, dict) and "config" in d2_cfg:
-        d2_cfg = d2_cfg["config"]
-
-    executable = d2_cfg.pop("executable", "d2")
-    d2_cfg.pop("cache", None)
-    d2_cfg.pop("cache_dir", None)
-
-    # Defaults matching mkdocs.yml plugin config
-    d2_cfg.setdefault("layout", "dagre")
-    d2_cfg.setdefault("theme", 200)
-    d2_cfg.setdefault("dark_theme", -1)
-    d2_cfg.setdefault("sketch", False)
-    d2_cfg.setdefault("pad", 100)
-    d2_cfg.setdefault("scale", -1.0)
-    d2_cfg.setdefault("force_appendix", False)
-    d2_cfg.setdefault("target", "''")
-
-    # Verify binary is available
+def _build_fence(executable: str = "d2") -> D2CustomFence:
+    """Build a D2CustomFence with hardcoded config matching mkdocs.yml."""
     try:
         subprocess.run(  # noqa: S603
             [executable, "--version"], capture_output=True, check=True
@@ -52,7 +41,7 @@ def _build_fence() -> D2CustomFence:
         raise RuntimeError(_D2_NOT_FOUND) from None
 
     renderer = partial(_render, executable, None)
-    return D2CustomFence(d2_cfg, renderer)
+    return D2CustomFence(dict(_D2_CONFIG), renderer)
 
 
 _fence = _build_fence()

--- a/d2_fence.py
+++ b/d2_fence.py
@@ -35,10 +35,19 @@ def _build_fence(executable: str = "d2") -> D2CustomFence:
     """Build a D2CustomFence with hardcoded config matching mkdocs.yml."""
     try:
         subprocess.run(  # noqa: S603
-            [executable, "--version"], capture_output=True, check=True
+            [executable, "--version"],
+            capture_output=True,
+            check=True,
+            timeout=5,
         )
     except FileNotFoundError:
         raise RuntimeError(_D2_NOT_FOUND) from None
+    except subprocess.TimeoutExpired:
+        msg = f"D2 executable '{executable}' timed out during version check"
+        raise RuntimeError(msg) from None
+    except subprocess.CalledProcessError as exc:
+        msg = f"D2 executable '{executable}' exited with code {exc.returncode}"
+        raise RuntimeError(msg) from exc
 
     renderer = partial(_render, executable, None)
     return D2CustomFence(dict(_D2_CONFIG), renderer)

--- a/d2_fence.py
+++ b/d2_fence.py
@@ -1,0 +1,60 @@
+"""Standalone D2 fence formatter for zensical builds.
+
+Zensical does not run mkdocs plugin lifecycle hooks, so mkdocs-d2-plugin's
+``on_config`` hook (which registers the D2 custom fence in pymdownx.superfences)
+never fires. This module exposes ``validator`` and ``formatter`` at module level
+so they can be referenced directly in ``mkdocs.yml`` via ``!!python/name:``.
+
+Configuration is sourced from ``mkdocs.yml`` at import time via
+``zensical.config.get_config()``.
+"""
+
+import subprocess
+from functools import partial
+
+from d2.fence import D2CustomFence
+from d2.plugin import render as _render
+
+_D2_NOT_FOUND = (
+    "D2 executable not found on PATH. Install from https://d2lang.com/tour/install"
+)
+
+
+def _build_fence() -> D2CustomFence:
+    """Build a D2CustomFence from mkdocs.yml plugin config."""
+    from zensical.config import get_config  # noqa: PLC0415
+
+    cfg = get_config()
+    d2_cfg = cfg.get("plugins", {}).get("d2", {})
+    if isinstance(d2_cfg, dict) and "config" in d2_cfg:
+        d2_cfg = d2_cfg["config"]
+
+    executable = d2_cfg.pop("executable", "d2")
+    d2_cfg.pop("cache", None)
+    d2_cfg.pop("cache_dir", None)
+
+    # Defaults matching mkdocs.yml plugin config
+    d2_cfg.setdefault("layout", "dagre")
+    d2_cfg.setdefault("theme", 200)
+    d2_cfg.setdefault("dark_theme", -1)
+    d2_cfg.setdefault("sketch", False)
+    d2_cfg.setdefault("pad", 100)
+    d2_cfg.setdefault("scale", -1.0)
+    d2_cfg.setdefault("force_appendix", False)
+    d2_cfg.setdefault("target", "''")
+
+    # Verify binary is available
+    try:
+        subprocess.run(  # noqa: S603
+            [executable, "--version"], capture_output=True, check=True
+        )
+    except FileNotFoundError:
+        raise RuntimeError(_D2_NOT_FOUND) from None
+
+    renderer = partial(_render, executable, None)
+    return D2CustomFence(d2_cfg, renderer)
+
+
+_fence = _build_fence()
+validator = _fence.validator
+formatter = _fence.formatter

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -28,9 +28,26 @@ COPY --from=ghcr.io/astral-sh/uv:0.10.9@sha256:10902f58a1606787602f303954cea0996
 RUN groupadd -r --gid 1001 docsbuild && useradd -r --uid 1001 -g docsbuild docsbuild \
     && mkdir /app && chown docsbuild:docsbuild /app
 
+# D2 binary -- keep version in sync with .github/workflows/pages.yml
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG D2_VERSION=v0.7.1
+ARG D2_SHA256=eb172adf59f38d1e5a70ab177591356754ffaf9bebb84e0ca8b767dfb421dad7
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+    && curl -fsSL "https://github.com/terrastruct/d2/releases/download/${D2_VERSION}/d2-${D2_VERSION}-linux-amd64.tar.gz" -o /tmp/d2.tar.gz \
+    && echo "${D2_SHA256}  /tmp/d2.tar.gz" | sha256sum --check --strict - \
+    && tar -xzf /tmp/d2.tar.gz -C /tmp \
+    && mv "/tmp/d2-${D2_VERSION}/bin/d2" /usr/local/bin/d2 \
+    && rm -rf /tmp/d2.tar.gz "/tmp/d2-${D2_VERSION}" \
+    && apt-get purge -y --auto-remove curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && d2 --version
+SHELL ["/bin/sh", "-c"]
+
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
-    UV_CACHE_DIR=/tmp/uv-cache
+    UV_CACHE_DIR=/tmp/uv-cache \
+    PYTHONPATH=/app
 
 WORKDIR /app
 
@@ -48,7 +65,7 @@ RUN --mount=type=cache,target=/tmp/uv-cache,uid=1001,gid=1001 \
 
 # Build documentation
 COPY --chown=docsbuild:docsbuild docs/ docs/
-COPY --chown=docsbuild:docsbuild mkdocs.yml ./
+COPY --chown=docsbuild:docsbuild mkdocs.yml d2_fence.py ./
 COPY --chown=docsbuild:docsbuild scripts/export_openapi.py scripts/
 RUN uv run python scripts/export_openapi.py \
     && uv run zensical build

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -16,11 +16,11 @@ Engine -> Budget
 Engine -> HR
 API: API Layer
 API -> Engine
-Observability -> Engine: {style.stroke-dash: 5}
-Observability -> Providers: {style.stroke-dash: 5}
-Observability -> Security: {style.stroke-dash: 5}
-Persistence -> HR: {style.stroke-dash: 5}
-Persistence -> Security: {style.stroke-dash: 5}
+Observability -> Engine {style.stroke-dash: 5}
+Observability -> Providers {style.stroke-dash: 5}
+Observability -> Security {style.stroke-dash: 5}
+Persistence -> HR {style.stroke-dash: 5}
+Persistence -> Security {style.stroke-dash: 5}
 Templates -> Config
 ```
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -5,16 +5,19 @@ SynthOrg is organized as a modular, protocol-driven framework. Every major subsy
 ## Module Map
 
 ```d2
+Core: Core Models
+Providers: LLM Providers
+API: API Layer
+
 Config -> Engine
-Engine -> Core: Core Models
-Engine -> Providers: LLM Providers
+Engine -> Core
+Engine -> Providers
 Engine -> Communication
 Engine -> Tools
 Engine -> Memory
 Engine -> Security
 Engine -> Budget
 Engine -> HR
-API: API Layer
 API -> Engine
 Observability -> Engine {style.stroke-dash: 5}
 Observability -> Providers {style.stroke-dash: 5}

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -4,24 +4,24 @@ SynthOrg is organized as a modular, protocol-driven framework. Every major subsy
 
 ## Module Map
 
-```mermaid
-graph TB
-    Config[Config] --> Engine[Engine]
-    Engine --> Core[Core Models]
-    Engine --> Providers[LLM Providers]
-    Engine --> Communication[Communication]
-    Engine --> Tools[Tools]
-    Engine --> Memory[Memory]
-    Engine --> Security[Security]
-    Engine --> Budget[Budget]
-    Engine --> HR[HR]
-    API[API Layer] --> Engine
-    Observability[Observability] -.-> Engine
-    Observability -.-> Providers
-    Observability -.-> Security
-    Persistence[Persistence] -.-> HR
-    Persistence -.-> Security
-    Templates[Templates] --> Config
+```d2
+Config -> Engine
+Engine -> Core: Core Models
+Engine -> Providers: LLM Providers
+Engine -> Communication
+Engine -> Tools
+Engine -> Memory
+Engine -> Security
+Engine -> Budget
+Engine -> HR
+API: API Layer
+API -> Engine
+Observability -> Engine: {style.stroke-dash: 5}
+Observability -> Providers: {style.stroke-dash: 5}
+Observability -> Security: {style.stroke-dash: 5}
+Persistence -> HR: {style.stroke-dash: 5}
+Persistence -> Security: {style.stroke-dash: 5}
+Templates -> Config
 ```
 
 ## Module Responsibilities

--- a/docs/architecture/tech-stack.md
+++ b/docs/architecture/tech-stack.md
@@ -2,41 +2,66 @@
 
 ## High-Level Architecture
 
-```text
-┌──────────────────────────────────────────────────────────────┐
-│                        SynthOrg Engine                       │
-│                                                              │
-│  ┌──────────────┐  ┌──────────────┐  ┌────────────────────┐  │
-│  │ Company Mgr  │  │ Agent Engine │  │ Task/Workflow Eng. │  │
-│  │ (Config,     │  │ (Lifecycle,  │  │ (Queue, Routing,   │  │
-│  │  Templates,  │  │  Personality,│  │  Dependencies,     │  │
-│  │  Hierarchy)  │  │  Execution)  │  │  Scheduling)       │  │
-│  └──────────────┘  └──────────────┘  └────────────────────┘  │
-│                                                              │
-│  ┌──────────────┐  ┌──────────────┐  ┌────────────────────┐  │
-│  │ Comms Layer  │  │ Memory Layer │  │ Tool/Capability    │  │
-│  │ (Message Bus,│  │ (Pluggable,  │  │ System (MCP,       │  │
-│  │  Meetings,   │  │  Retrieval,  │  │  Sandboxing,       │  │
-│  │  A2A)        │  │  Archive)    │  │  Permissions)      │  │
-│  └──────────────┘  └──────────────┘  └────────────────────┘  │
-│                                                              │
-│  ┌──────────────┐  ┌──────────────┐  ┌────────────────────┐  │
-│  │ Provider Lyr │  │ Budget/Cost  │  │ Security/Approval  │  │
-│  │ (Unified,    │  │ Engine       │  │ System (SecOps,    │  │
-│  │  Routing,    │  │ (Tracking,   │  │  Audit Log,        │  │
-│  │  Fallbacks)  │  │  Limits,     │  │  Human Queue)      │  │
-│  │              │  │  CFO Agent)  │  │                    │  │
-│  └──────────────┘  └──────────────┘  └────────────────────┘  │
-│                                                              │
-│  ┌──────────────────────────────────────────────────────┐    │
-│  │    API Layer (Async Framework + WebSocket)           │    │
-│  └──────────────────────────────────────────────────────┘    │
-│                                                              │
-│  ┌──────────────────────────┐  ┌──────────────────────────┐  │
-│  │ Web UI (Local)           │  │ CLI Tool                 │  │
-│  │ Web Dashboard            │  │ synthorg <command>       │  │
-│  └──────────────────────────┘  └──────────────────────────┘  │
-└──────────────────────────────────────────────────────────────┘
+```d2
+SynthOrg Engine: {
+  grid-rows: 5
+
+  Management: {
+    grid-columns: 3
+    Company Mgr: |
+      Config, Templates,
+      Hierarchy
+    |
+    Agent Engine: |
+      Lifecycle, Personality,
+      Execution
+    |
+    Task/Workflow Eng.: |
+      Queue, Routing,
+      Dependencies, Scheduling
+    |
+  }
+
+  Infrastructure: {
+    grid-columns: 3
+    Comms Layer: |
+      Message Bus,
+      Meetings, A2A
+    |
+    Memory Layer: |
+      Pluggable, Retrieval,
+      Archive
+    |
+    Tool/Capability System: |
+      MCP, Sandboxing,
+      Permissions
+    |
+  }
+
+  Foundation: {
+    grid-columns: 3
+    Provider Layer: |
+      Unified, Routing,
+      Fallbacks
+    |
+    Budget/Cost Engine: |
+      Tracking, Limits,
+      CFO Agent
+    |
+    Security/Approval: |
+      SecOps, Audit Log,
+      Human Queue
+    |
+  }
+
+  API Layer: Async Framework + WebSocket
+
+  Clients: {
+    grid-columns: 2
+    Web Dashboard: Web UI (Local)
+    CLI Tool: "synthorg [command]"
+  }
+}
 ```
 
 The SynthOrg engine is structured as a set of loosely coupled subsystems. Each box represents a major component that communicates through well-defined protocol interfaces. The API layer sits below the engine, exposing REST and WebSocket endpoints to the Web UI and CLI.

--- a/docs/design/agents.md
+++ b/docs/design/agents.md
@@ -613,29 +613,35 @@ does.
 
 ### Architecture
 
-```text
-Trigger --> Build Context --> Proposer --> Guards --> Adapter.apply
-  |              |               |            |           |
-  |              |               |            |           +-- IdentityAdapter
-  |              |               |            |           +-- StrategySelectionAdapter
-  |              |               |            |           +-- PromptTemplateAdapter
-  |              |               |            |
-  |              |               |            +-- RateLimitGuard
-  |              |               |            +-- ReviewGateGuard
-  |              |               |            +-- RollbackGuard
-  |              |               |            +-- ShadowEvaluationGuard
-  |              |               |            +-- CompositeGuard
-  |              |               |
-  |              |               +-- SeparateAnalyzerProposer
-  |              |               +-- SelfReportProposer
-  |              |               +-- CompositeProposer
-  |              |
-  |              +-- EvolutionContext (identity, performance, memories)
-  |
-  +-- BatchedTrigger (cron-like)
-  +-- InflectionTrigger (performance trend changes)
-  +-- PerTaskTrigger (post-execution)
-  +-- CompositeTrigger (OR-combines)
+```mermaid
+graph LR
+    subgraph S1[Trigger]
+        T1[BatchedTrigger<br/>cron-like]
+        T2[InflectionTrigger<br/>performance trend]
+        T3[PerTaskTrigger<br/>post-execution]
+        T4[CompositeTrigger<br/>OR-combines]
+    end
+    subgraph S2[Build Context]
+        BC[EvolutionContext<br/>identity, performance, memories]
+    end
+    subgraph S3[Proposer]
+        P1[SeparateAnalyzerProposer]
+        P2[SelfReportProposer]
+        P3[CompositeProposer]
+    end
+    subgraph S4[Guards]
+        G1[RateLimitGuard]
+        G2[ReviewGateGuard]
+        G3[RollbackGuard]
+        G4[ShadowEvaluationGuard]
+        G5[CompositeGuard]
+    end
+    subgraph S5[Adapter.apply]
+        A1[IdentityAdapter]
+        A2[StrategySelectionAdapter]
+        A3[PromptTemplateAdapter]
+    end
+    S1 --> S2 --> S3 --> S4 --> S5
 ```
 
 The pipeline is orchestrated by ``EvolutionService`` in ``engine/evolution/service.py``.

--- a/docs/design/agents.md
+++ b/docs/design/agents.md
@@ -613,35 +613,37 @@ does.
 
 ### Architecture
 
-```mermaid
-graph LR
-    subgraph S1[Trigger]
-        T1[BatchedTrigger<br/>cron-like]
-        T2[InflectionTrigger<br/>performance trend]
-        T3[PerTaskTrigger<br/>post-execution]
-        T4[CompositeTrigger<br/>OR-combines]
-    end
-    subgraph S2[Build Context]
-        BC[EvolutionContext<br/>identity, performance, memories]
-    end
-    subgraph S3[Proposer]
-        P1[SeparateAnalyzerProposer]
-        P2[SelfReportProposer]
-        P3[CompositeProposer]
-    end
-    subgraph S4[Guards]
-        G1[RateLimitGuard]
-        G2[ReviewGateGuard]
-        G3[RollbackGuard]
-        G4[ShadowEvaluationGuard]
-        G5[CompositeGuard]
-    end
-    subgraph S5[Adapter.apply]
-        A1[IdentityAdapter]
-        A2[StrategySelectionAdapter]
-        A3[PromptTemplateAdapter]
-    end
-    S1 --> S2 --> S3 --> S4 --> S5
+```d2
+Pipeline: "Evolution Pipeline" {
+  Trigger: {
+    T1: "BatchedTrigger\n(cron-like)"
+    T2: "InflectionTrigger\n(performance trend)"
+    T3: "PerTaskTrigger\n(post-execution)"
+    T4: "CompositeTrigger\n(OR-combines)"
+  }
+  Context: "Build Context" {
+    BC: "EvolutionContext\n(identity, performance, memories)"
+  }
+  Proposer: {
+    P1: SeparateAnalyzerProposer
+    P2: SelfReportProposer
+    P3: CompositeProposer
+  }
+  Guards: {
+    G1: RateLimitGuard
+    G2: ReviewGateGuard
+    G3: RollbackGuard
+    G4: ShadowEvaluationGuard
+    G5: CompositeGuard
+  }
+  Apply: "Adapter.apply" {
+    A1: IdentityAdapter
+    A2: StrategySelectionAdapter
+    A3: PromptTemplateAdapter
+  }
+
+  Trigger -> Context -> Proposer -> Guards -> Apply
+}
 ```
 
 The pipeline is orchestrated by ``EvolutionService`` in ``engine/evolution/service.py``.

--- a/docs/design/communication.md
+++ b/docs/design/communication.md
@@ -25,16 +25,13 @@ The framework supports multiple communication patterns, configurable per company
 
     **Recommended Default**
 
-    ```text
-    ┌──────────┐     ┌─────────────────┐     ┌──────────┐
-    │  Agent A  │────>│   Message Bus   │<────│  Agent B  │
-    └──────────┘     │ (Topics/Queues) │     └──────────┘
-                     └────────┬────────┘
-                              │
-                  ┌───────────┼───────────┐
-                  v           v           v
-            #engineering  #product   #all-hands
-            #code-review  #design    #incidents
+    ```mermaid
+    graph TD
+        A[Agent A] --> Bus[Message Bus\nTopics/Queues]
+        B[Agent B] --> Bus
+        Bus --> T1["#engineering\n#code-review"]
+        Bus --> T2["#product\n#design"]
+        Bus --> T3["#all-hands\n#incidents"]
     ```
 
     - Agents publish to topics, subscribe to relevant channels
@@ -47,10 +44,11 @@ The framework supports multiple communication patterns, configurable per company
 
 === "Pattern 2: Hierarchical Delegation"
 
-    ```text
-    CEO --> CTO --> Eng Lead --> Sr Dev --> Jr Dev
-                       |
-                       └--> QA Lead --> QA Eng
+    ```mermaid
+    graph LR
+        CEO --> CTO --> EL[Eng Lead]
+        EL --> SD[Sr Dev] --> JD[Jr Dev]
+        EL --> QAL[QA Lead] --> QAE[QA Eng]
     ```
 
     - Tasks flow down the hierarchy, results flow up
@@ -62,18 +60,11 @@ The framework supports multiple communication patterns, configurable per company
 
 === "Pattern 3: Meeting-Based"
 
-    ```text
-    ┌─────────────────────────────────┐
-    │        Sprint Planning          │
-    │  PM + CTO + Devs + QA + Design  │
-    │  Output: Sprint backlog         │
-    └─────────────────────────────────┘
-             │
-    ┌────────┴────────┐
-    │  Daily Standup  │
-    │  Devs + QA      │
-    │  Output: Status │
-    └─────────────────┘
+    ```mermaid
+    graph TD
+        SP["Sprint Planning\nPM + CTO + Devs + QA + Design\nOutput: Sprint backlog"]
+        DS["Daily Standup\nDevs + QA\nOutput: Status"]
+        SP --> DS
     ```
 
     - Structured multi-agent conversations at defined intervals
@@ -120,32 +111,29 @@ sole transport for intra-organization messages.
 
 ### Architecture
 
-```text
-                        +-----------------------+
-                        |   External A2A Agent  |
-                        |   (other framework)   |
-                        +-----------+-----------+
-                                    |
-                             JSON-RPC / SSE
-                                    |
-+-----------------------+-----------v-----------+-----------------------+
-|                       |    A2A Gateway        |                       |
-|  SynthOrg             |  (optional, disabled  |                       |
-|  Organization         |   by default)         |                       |
-|                       +-----+-----+-----------+                       |
-|                             |     |                                   |
-|                      inbound|     |outbound                           |
-|                             v     v                                   |
-|                       +--------------------+                          |
-|                       |   Message Bus      |                          |
-|                       |  (internal,        |                          |
-|                       |   unchanged)       |                          |
-|                       +--+----+----+----+--+                          |
-|                          |    |    |    |                             |
-|                       +--v-+--v-+--v-+--v-+                           |
-|                       | A1 | A2 | A3 | A4 |  Internal Agents          |
-|                       +----+----+----+----+                           |
-+-----------------------+-----------------------------------------------+
+```d2
+External: "External A2A Agent\n(other framework)"
+
+External -> SynthOrg.Gateway: "JSON-RPC / SSE"
+
+SynthOrg: "SynthOrg Organization" {
+  Gateway: "A2A Gateway\n(optional, disabled by default)"
+
+  Bus: "Message Bus\n(internal, unchanged)"
+
+  Gateway -> Bus: inbound
+  Bus -> Gateway: outbound
+
+  Agents: "Internal Agents" {
+    grid-columns: 4
+    A1
+    A2
+    A3
+    A4
+  }
+
+  Bus -> Agents
+}
 ```
 
 The gateway sits at the organization boundary and handles two directions:

--- a/docs/design/engine.md
+++ b/docs/design/engine.md
@@ -128,16 +128,20 @@ The framework supports four workflow types for organizing task execution:
 
 ### Sequential Pipeline
 
-```text
-Requirements --> Design --> Implementation --> Review --> Testing --> Deploy
+```mermaid
+graph LR
+    Req[Requirements] --> Design --> Impl[Implementation] --> Review --> Testing --> Deploy
 ```
 
 ### Parallel Execution
 
-```text
-        ┌--> Frontend Dev --┐
-Task ---|                    |---> Integration --> QA
-        └--> Backend Dev  --┘
+```mermaid
+graph LR
+    Task --> FE[Frontend Dev]
+    Task --> BE[Backend Dev]
+    FE --> Int[Integration]
+    BE --> Int
+    Int --> QA
 ```
 
 The `ParallelExecutor` implements concurrent agent execution with
@@ -146,12 +150,11 @@ exclusive file access, error isolation, and progress tracking.
 
 ### Kanban Board
 
-```text
-Backlog | Ready | In Progress | Review | Done
-   o    |   o   |      *      |   o    |  ***
-   o    |   o   |      *      |        |  **
-   o    |       |             |        |  *
-```
+| Backlog | Ready | In Progress | Review | Done |
+|---------|-------|-------------|--------|------|
+| task | task | task | task | task |
+| task | task | task |      | task |
+| task |      |      |      | task |
 
 The `KanbanColumn` enum defines five columns that map bidirectionally to
 `TaskStatus` (Backlog=CREATED, Ready=ASSIGNED, In Progress=IN_PROGRESS,
@@ -169,8 +172,9 @@ this combined mode; `WorkflowConfig` aggregates both `KanbanConfig` and
 `SprintConfig` under a single top-level section (`workflow`) in the root
 configuration.
 
-```text
-Planning --> Active --> In Review --> Retrospective --> Completed
+```mermaid
+graph LR
+    Planning --> Active --> IR[In Review] --> Retro[Retrospective] --> Completed
 ```
 
 The `SprintStatus` lifecycle is strictly linear: PLANNING, ACTIVE,

--- a/docs/design/engine.md
+++ b/docs/design/engine.md
@@ -150,11 +150,11 @@ exclusive file access, error isolation, and progress tracking.
 
 ### Kanban Board
 
-| Backlog | Ready | In Progress | Review | Done |
-|---------|-------|-------------|--------|------|
-| task | task | task | task | task |
-| task | task | task |      | task |
-| task |      |      |      | task |
+| Backlog | Ready | In Progress | Review | Done  |
+|---------|-------|-------------|--------|-------|
+| o       | o     | *           | o      | * * * |
+| o       | o     | *           |        | * *   |
+| o       |       |             |        | *     |
 
 The `KanbanColumn` enum defines five columns that map bidirectionally to
 `TaskStatus` (Backlog=CREATED, Ready=ASSIGNED, In Progress=IN_PROGRESS,

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -128,7 +128,7 @@ Company -> Projects
 Company -> Config
 Company -> HR: HR Registry
 
-Departments -> DeptHead: {style.stroke-dash: 5}
+Departments -> DeptHead {style.stroke-dash: 5}
 DeptHead: "Department Head\n(Agent, optional)"
 Departments -> Members
 Members: "Members (Agent[])"

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -122,31 +122,41 @@ configuration reference.
 
 The following diagram illustrates how the core entities in SynthOrg relate to each other:
 
-```mermaid
-graph TD
-    Company --> Departments
-    Company --> Projects
-    Company --> Config
-    Company --> HR["HR Registry"]
+```d2
+Company -> Departments
+Company -> Projects
+Company -> Config
+Company -> HR: HR Registry
 
-    Departments -.-> DeptHead["Department Head (Agent, optional)"]
-    Departments --> Members["Members (Agent[])"]
+Departments -> DeptHead: {style.stroke-dash: 5}
+DeptHead: "Department Head\n(Agent, optional)"
+Departments -> Members
+Members: "Members (Agent[])"
 
-    Projects --> Tasks
-    Projects --> Team["Team (Agent[])"]
+Projects -> Tasks
+Projects -> Team
+Team: "Team (Agent[])"
 
-    Tasks --> Assigned["Assigned Agent(s)"]
-    Tasks --> Artifacts
-    Tasks --> Status["Status / History"]
+Tasks -> Assigned
+Assigned: "Assigned Agent(s)"
+Tasks -> Artifacts
+Tasks -> Status
+Status: "Status / History"
 
-    Config --> Autonomy["Autonomy Level"]
-    Config --> Budget
-    Config --> CommSettings["Communication Settings"]
-    Config --> ToolPerms["Tool Permissions"]
+Config -> Autonomy
+Autonomy: Autonomy Level
+Config -> Budget
+Config -> CommSettings
+CommSettings: Communication Settings
+Config -> ToolPerms
+ToolPerms: Tool Permissions
 
-    HR --> Active["Active Agents[]"]
-    HR --> Roles["Available Roles[]"]
-    HR --> Queue["Hiring Queue"]
+HR -> Active
+Active: "Active Agents[]"
+HR -> Roles
+Roles: "Available Roles[]"
+HR -> Queue
+Queue: Hiring Queue
 ```
 
 ---

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -126,7 +126,8 @@ The following diagram illustrates how the core entities in SynthOrg relate to ea
 Company -> Departments
 Company -> Projects
 Company -> Config
-Company -> HR: HR Registry
+HR: HR Registry
+Company -> HR
 
 Departments -> DeptHead {style.stroke-dash: 5}
 DeptHead: "Department Head\n(Agent, optional)"

--- a/docs/design/memory.md
+++ b/docs/design/memory.md
@@ -17,24 +17,12 @@ configuration without modifying application code.
 
 ## Memory Architecture
 
-```text
-+-------------------------------------------------+
-|              Agent Memory System                |
-+----------+----------+-----------+---------------+
-| Working  | Episodic | Semantic  | Procedural    |
-| Memory   | Memory   | Memory    | Memory        |
-|          |          |           |               |
-| Current  | Past     | Knowledge | Skills &      |
-| task     | events & | & facts   | how-to        |
-| context  | decisions| learned   |               |
-+----------+----------+-----------+---------------+
-|            Storage Backend                      |
-|   Mem0 (durable, Qdrant+SQLite)                 |
-|   InMemory (session-scoped)                     |
-|   Composite (namespace-based routing adapter)   |
-|     See Decision Log                            |
-+-------------------------------------------------+
-```
+| Working Memory | Episodic Memory | Semantic Memory | Procedural Memory |
+|---|---|---|---|
+| Current task context | Past events & decisions | Knowledge & facts learned | Skills & how-to |
+
+**Storage Backend:** Mem0 (durable, Qdrant+SQLite), InMemory (session-scoped),
+Composite (namespace-based routing adapter). See [Decision Log](../architecture/decisions.md).
 
 Each agent maintains its own memory store. The storage backend is selected via configuration
 and all access flows through the [`MemoryBackend`](#memorybackend-protocol) protocol.
@@ -537,29 +525,29 @@ repository protocols; the storage engine is an implementation detail swappable v
 
 ### Architecture
 
-```text
-+------------------------------------------------------------------+
-|                     Application Code                             |
-|  engine/  budget/  communication/  security/                     |
-|     |        |           |             |                         |
-|     v        v           v             v                         |
-|  +------+ +------+ +----------+ +----------+                     |
-|  | Task | | Cost | | Message  | |  Audit   |  <-- Repository     |
-|  | Repo | | Repo | |  Repo    | |  Repo    |      Protocols      |
-|  +--+---+ +--+---+ +----+-----+ +----+-----+                     |
-|     +--------+----------+------------+                           |
-|                      |                                           |
-|  +-------------------+-------------------------------------------+
-|  |              PersistenceBackend (protocol)                    |
-|  |  connect() . disconnect() . health_check() . migrate()        |
-|  +-------------------+-------------------------------------------+
-|                      |                                           |
-|  +-------------------+-------------------------------------------+
-|  |  SQLitePersistenceBackend (implemented)                       |
-|  |  PostgresPersistenceBackend (implemented -- v0.6.5)           |
-|  |  MariaDBPersistenceBackend (future)                           |
-|  +---------------------------------------------------------------+
-+------------------------------------------------------------------+
+```d2
+Application Code: {
+  Repos: "Repository Protocols" {
+    grid-columns: 4
+    Task Repo: "Task Repo\n(engine/)"
+    Cost Repo: "Cost Repo\n(budget/)"
+    Message Repo: "Message Repo\n(communication/)"
+    Audit Repo: "Audit Repo\n(security/)"
+  }
+
+  Backend: |
+    PersistenceBackend (protocol)
+    connect() . disconnect() . health_check() . migrate()
+  |
+
+  Impls: |
+    SQLitePersistenceBackend (implemented)
+    PostgresPersistenceBackend (implemented -- v0.6.5)
+    MariaDBPersistenceBackend (future)
+  |
+
+  Repos -> Backend -> Impls
+}
 ```
 
 ### Protocol Design

--- a/docs/design/operations.md
+++ b/docs/design/operations.md
@@ -19,18 +19,11 @@ The framework provides a unified interface for all LLM interactions. The provide
 abstracts away vendor differences, exposing a single `completion()` method regardless of
 whether the backend is a cloud API, OpenRouter, Ollama, or a custom endpoint.
 
-```text
-+--------------------------------------------------+
-|            Unified Model Interface               |
-|   completion(messages, tools, config) -> resp    |
-+-----------+-----------+-----------+--------------+
-| Cloud API | OpenRouter|  Ollama   |  Custom      |
-|  Adapter  |  Adapter  |  Adapter  |  Adapter     |
-+-----------+-----------+-----------+--------------+
-| Direct    | 400+ LLMs | Local LLMs|  Any API     |
-| API call  | via OR    | Self-host |              |
-+-----------+-----------+-----------+--------------+
-```
+**Unified Model Interface:** `completion(messages, tools, config) -> resp`
+
+| | Cloud API Adapter | OpenRouter Adapter | Ollama Adapter | Custom Adapter |
+|---|---|---|---|---|
+| **Method** | Direct API call | 400+ LLMs via OR | Local LLMs, self-host | Any API |
 
 ### Provider Configuration
 
@@ -958,30 +951,15 @@ implemented.
 
 ### Approval Workflow
 
-```text
-                    +---------------+
-                    |  Task/Action  |
-                    +-------+-------+
-                            |
-                    +-------v-------+
-                    | Security Ops  |
-                    |   Agent       |
-                    +-------+-------+
-                      /           \
-               +-----v--+      +--v-----+
-               |APPROVE |      | DENY   |
-               |(auto)  |      |+ reason|
-               +----+---+      +---+----+
-                    |              |
-               Execute         +---v---------+
-                               | Human Queue |
-                               | (Dashboard) |
-                               +---+---------+
-                             /         \
-                      +-----v--+    +---v----------+
-                      |Override|    |Alternative   |
-                      |Approve |    |Suggested     |
-                      +--------+    +--------------+
+```mermaid
+graph TD
+    Task[Task/Action] --> SecOps[Security Ops Agent]
+    SecOps --> Approve["APPROVE\n(auto)"]
+    SecOps --> Deny["DENY\n+ reason"]
+    Approve --> Execute[Execute]
+    Deny --> HQ[Human Queue\nDashboard]
+    HQ --> Override[Override Approve]
+    HQ --> Alt[Alternative Suggested]
 ```
 
 ### Autonomy Levels
@@ -1445,21 +1423,15 @@ overview, Agent Card projection, and concept mapping tables.
 The REST/WebSocket API is the **primary interface** for all consumers. The Web UI and any
 future CLI tool are thin clients that call the API -- they contain no business logic.
 
-```text
-+-------------------------------------------------+
-|               SynthOrg Engine                   |
-|  (Core Logic, Agent Orchestration, Tasks)       |
-+--------------------+----------------------------+
-                     |
-            +--------v--------+
-            |   REST/WS API   |  <-- primary interface
-            |   (Litestar)    |
-            +---+----------+--+
-                |          |
-        +-------v---+  +---v--------+
-        |  Web UI   |  |  CLI Tool  |
-        |  (React)  |  |  (Go)      |
-        +-----------+  +------------+
+```mermaid
+graph TD
+    Engine["SynthOrg Engine\n(Core Logic, Agent Orchestration, Tasks)"]
+    API["REST/WS API\n(Litestar)"]
+    WebUI["Web UI\n(React)"]
+    CLI["CLI Tool\n(Go)"]
+    Engine --> API
+    API --> WebUI
+    API --> CLI
 ```
 
 !!! info "CLI Tool (Implemented)"

--- a/docs/design/operations.md
+++ b/docs/design/operations.md
@@ -1423,15 +1423,15 @@ overview, Agent Card projection, and concept mapping tables.
 The REST/WebSocket API is the **primary interface** for all consumers. The Web UI and any
 future CLI tool are thin clients that call the API -- they contain no business logic.
 
-```mermaid
-graph TD
-    Engine["SynthOrg Engine\n(Core Logic, Agent Orchestration, Tasks)"]
-    API["REST/WS API\n(Litestar)"]
-    WebUI["Web UI\n(React)"]
-    CLI["CLI Tool\n(Go)"]
-    Engine --> API
-    API --> WebUI
-    API --> CLI
+```d2
+Engine: "SynthOrg Engine\n(Core Logic, Agent Orchestration, Tasks)"
+API: "REST/WS API\n(Litestar)"
+WebUI: "Web UI\n(React)"
+CLI: "CLI Tool\n(Go)"
+
+Engine -> API
+API -> WebUI
+API -> CLI
 ```
 
 !!! info "CLI Tool (Implemented)"

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -230,7 +230,7 @@ uv run zensical serve                      # preview at http://127.0.0.1:8000
 
 ### Writing Conventions
 
-- Use MkDocs Material features: admonitions (`!!! note`), tabs (`=== "Tab"`), code blocks, Mermaid diagrams
+- Use MkDocs Material features: admonitions (`!!! note`), tabs (`=== "Tab"`), code blocks, Mermaid (` ```mermaid `) for flowcharts/sequences/states, and D2 (` ```d2 `) for architecture/nested-container diagrams
 - YAML frontmatter with `title` and `description`
 - Technical but accessible tone
 - Cross-reference related pages

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -230,7 +230,8 @@ uv run zensical serve                      # preview at http://127.0.0.1:8000
 
 ### Writing Conventions
 
-- Use MkDocs Material features: admonitions (`!!! note`), tabs (`=== "Tab"`), code blocks, Mermaid (` ```mermaid `) for flowcharts/sequences/states, and D2 (` ```d2 `) for architecture/nested-container diagrams
+- Use MkDocs Material features: admonitions (`!!! note`), tabs (`=== "Tab"`), code blocks, Mermaid (` ```mermaid `) for flowcharts/sequences/states, D2 (` ```d2 `) for architecture/nested-container diagrams, and Markdown tables for semantically tabular grid/matrix data. Never use ` ```text ` blocks with ASCII/Unicode box-drawing characters for diagrams.
+- Building docs locally with D2 diagrams requires the [D2 CLI](https://d2lang.com/tour/install) on `PATH` in addition to `uv sync --group docs`
 - YAML frontmatter with `title` and `description`
 - Technical but accessible tone
 - Cross-reference related pages

--- a/docs/reference/embedding-evaluation.md
+++ b/docs/reference/embedding-evaluation.md
@@ -157,25 +157,13 @@ single GPU.
 
 ### Pipeline Overview
 
-```text
-+-------------------+     +---------------------+     +-------------------+
-|  1. Synthetic     |     |  2. Hard Negative   |     |  3. Contrastive   |
-|  Data Generation  | --> |  Mining             | --> |  Fine-Tuning      |
-|                   |     |                     |     |                   |
-|  Org docs, ADRs,  |     |  Base model embeds  |     |  InfoNCE loss     |
-|  procedures -->   |     |  all passages,      |     |  tau = 0.02       |
-|  LLM generates    |     |  selects top-k      |     |  3 epochs,        |
-|  query-doc pairs  |     |  confusing negatives|     |  lr = 1e-5        |
-+-------------------+     +---------------------+     +-------------------+
-                                                              |
-                                                              v
-                                                      +-------------------+
-                                                      |  4. Deploy        |
-                                                      |                   |
-                                                      |  Save checkpoint, |
-                                                      |  update embedder  |
-                                                      |  config           |
-                                                      +-------------------+
+```mermaid
+graph LR
+    S1["1. Synthetic Data Generation\nOrg docs, ADRs, procedures\nLLM generates query-doc pairs"]
+    S2["2. Hard Negative Mining\nBase model embeds all passages,\nselects top-k confusing negatives"]
+    S3["3. Contrastive Fine-Tuning\nInfoNCE loss, tau = 0.02\n3 epochs, lr = 1e-5"]
+    S4["4. Deploy\nSave checkpoint,\nupdate embedder config"]
+    S1 --> S2 --> S3 --> S4
 ```
 
 ### Stage Details

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,13 @@ theme:
 
 plugins:
   - search
+  - d2:
+      layout: dagre
+      theme: 200
+      dark_theme: -1
+      sketch: false
+      pad: 100
+      cache: true
   - mkdocstrings:
       default_handler: python
       handlers:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,13 +31,16 @@ theme:
 
 plugins:
   - search
+  # D2 rendering is handled via pymdownx.superfences custom_fences
+  # (see d2_fence.py) because zensical does not run mkdocs plugin
+  # lifecycle hooks. Keep the config here so d2_fence.py reads it.
   - d2:
       layout: dagre
       theme: 200
       dark_theme: -1
       sketch: false
       pad: 100
-      cache: true
+      cache: false
   - mkdocstrings:
       default_handler: python
       handlers:
@@ -89,6 +92,10 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
+        - name: d2
+          class: d2
+          validator: !!python/name:d2_fence.validator
+          format: !!python/name:d2_fence.formatter
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.tasklist:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ docs = [
     "zensical==0.0.32",
     "mkdocstrings[python]==1.0.3",
     "griffe-pydantic==1.3.1",
-    "mkdocs-d2-plugin>=1.5.0",
+    "mkdocs-d2-plugin==1.7.0",
     # Used by scripts/patch_sitemap.py to safely parse the built sitemap.
     # Present as a transitive via py-serializable, but declared here so the
     # build script has a stable explicit dependency.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ docs = [
     "zensical==0.0.32",
     "mkdocstrings[python]==1.0.3",
     "griffe-pydantic==1.3.1",
+    "mkdocs-d2-plugin>=1.5.0",
     # Used by scripts/patch_sitemap.py to safely parse the built sitemap.
     # Present as a transitive via py-serializable, but declared here so the
     # build script has a stable explicit dependency.

--- a/uv.lock
+++ b/uv.lock
@@ -1442,6 +1442,21 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocs-d2-plugin"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/26/17e92ae5f577eefe6fd9b15fb80e03c8e672b5477eb5501ce66277ea69a8/mkdocs_d2_plugin-1.7.0.tar.gz", hash = "sha256:607462a3bf3d28b0574214d400820f86c0c9f43466fdf73243e7f9f2e3d21584", size = 8373, upload-time = "2026-04-09T20:30:34.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/3b/002528206eb503287cb320ca9ac34f16159d41d9b77dd7ec594ebc2e4cae/mkdocs_d2_plugin-1.7.0-py3-none-any.whl", hash = "sha256:1c40092738c77d4b8b03880f01f4ef433de07fb8c4bbf9540819e161b6440e3f", size = 8789, upload-time = "2026-04-09T20:30:33.013Z" },
+]
+
+[[package]]
 name = "mkdocs-get-deps"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3097,6 +3112,7 @@ dev = [
     { name = "defusedxml" },
     { name = "griffe-pydantic" },
     { name = "hypothesis" },
+    { name = "mkdocs-d2-plugin" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "mypy" },
     { name = "nats-py" },
@@ -3121,6 +3137,7 @@ dev = [
 docs = [
     { name = "defusedxml" },
     { name = "griffe-pydantic" },
+    { name = "mkdocs-d2-plugin" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "zensical" },
 ]
@@ -3176,6 +3193,7 @@ dev = [
     { name = "defusedxml", specifier = "==0.7.1" },
     { name = "griffe-pydantic", specifier = "==1.3.1" },
     { name = "hypothesis", specifier = "==6.151.12" },
+    { name = "mkdocs-d2-plugin", specifier = ">=1.5.0" },
     { name = "mkdocstrings", extras = ["python"], specifier = "==1.0.3" },
     { name = "mypy", specifier = "==1.20.0" },
     { name = "nats-py", specifier = "==2.14.0" },
@@ -3200,6 +3218,7 @@ dev = [
 docs = [
     { name = "defusedxml", specifier = "==0.7.1" },
     { name = "griffe-pydantic", specifier = "==1.3.1" },
+    { name = "mkdocs-d2-plugin", specifier = ">=1.5.0" },
     { name = "mkdocstrings", extras = ["python"], specifier = "==1.0.3" },
     { name = "zensical", specifier = "==0.0.32" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -3193,7 +3193,7 @@ dev = [
     { name = "defusedxml", specifier = "==0.7.1" },
     { name = "griffe-pydantic", specifier = "==1.3.1" },
     { name = "hypothesis", specifier = "==6.151.12" },
-    { name = "mkdocs-d2-plugin", specifier = ">=1.5.0" },
+    { name = "mkdocs-d2-plugin", specifier = "==1.7.0" },
     { name = "mkdocstrings", extras = ["python"], specifier = "==1.0.3" },
     { name = "mypy", specifier = "==1.20.0" },
     { name = "nats-py", specifier = "==2.14.0" },
@@ -3218,7 +3218,7 @@ dev = [
 docs = [
     { name = "defusedxml", specifier = "==0.7.1" },
     { name = "griffe-pydantic", specifier = "==1.3.1" },
-    { name = "mkdocs-d2-plugin", specifier = ">=1.5.0" },
+    { name = "mkdocs-d2-plugin", specifier = "==1.7.0" },
     { name = "mkdocstrings", extras = ["python"], specifier = "==1.0.3" },
     { name = "zensical", specifier = "==0.0.32" },
 ]


### PR DESCRIPTION
## Summary

Replaces fragile ASCII/Unicode box-drawing diagrams across the docs with a rendered diagram toolchain. Uses **Mermaid** for flowcharts, sequences, states, and simple hierarchies; **D2** for nested architecture diagrams and grid layouts that Mermaid cannot express cleanly; **markdown tables** for data that is semantically tabular.

Closes #1193

## Decisions made during planning

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Primary toolchain | Mermaid + D2 hybrid | Each tool for its strength; D2 for grids/nesting, Mermaid for flows/sequences |
| Grid/table diagrams | Markdown tables | These are semantic data grids, not diagrams |
| Dark mode (D2) | Dark-only render (theme 200, Dark Mauve) | Site uses `scheme: slate`; simplest approach |
| D2 layout engine | `dagre` | ELK caused Zensical OOM on dense state diagrams |
| Borderline diagrams | Migrate to D2 | Better spatial layout for complex node graphs |

## Per-diagram assignment

### Converted ASCII -> D2 (3 diagrams)
- `docs/architecture/tech-stack.md` -- 3x3 nested component grid
- `docs/design/communication.md` -- A2A gateway with org boundary
- `docs/design/memory.md` -- persistence architecture layers

### Converted ASCII -> Mermaid (6 diagrams, from original scope)
- `docs/design/communication.md` x3: message bus, hierarchy chain, meeting flow
- `docs/design/operations.md` x2: approval workflow, engine architecture
- `docs/reference/embedding-evaluation.md`: fine-tuning pipeline

### Converted ASCII -> Mermaid (4 additional, caught in pre-PR review)
- `docs/design/engine.md`: sequential pipeline, parallel execution, sprint lifecycle
- `docs/design/agents.md`: evolution pipeline architecture

### Migrated existing Mermaid -> D2 (2 diagrams)
- `docs/architecture/index.md` -- module dependency map (12 nodes)
- `docs/design/index.md` -- entity relationships (13+ nodes)

### ASCII -> Markdown tables (3)
- `docs/design/operations.md` -- provider interface grid
- `docs/design/memory.md` -- memory system categories
- `docs/design/engine.md` -- kanban board

### Kept in Mermaid (12 existing diagrams untouched)
All other existing Mermaid diagrams unchanged. `docs/design/engine.md` task lifecycle state diagram stays in `stateDiagram-v2` after D2 + ELK caused Zensical OOM on dense state machines.

## Toolchain setup

- `pyproject.toml`: adds `mkdocs-d2-plugin==1.7.0` (pinned exactly, matches project convention)
- `mkdocs.yml`: configures D2 plugin with dagre layout, dark-only theme, local cache
- `.github/workflows/pages.yml`: installs D2 v0.7.1 from pinned GitHub release with integrity-verified tarball + version verification step
- `.gitignore`: excludes local D2 cache dir `.config/plugin/d2/`

## Review tooling

New `diagram-syntax-validator` agent runs in both `/pre-pr-review` and `/aurelio-review-pr` pipelines when `docs` files containing d2 or mermaid blocks are modified. Validates:
- D2 syntax via `d2 --dry-run`
- Mermaid bracket/quote/arrow syntax
- Wrong fence type (flags `\`\`\`text` with ASCII box-drawing)
- Convention adherence (D2 for architecture, Mermaid for flows)

Added at both `.claude/agents/diagram-syntax-validator.md` and `.opencode/agents/diagram-syntax-validator.md` for dual-tool parity.

## Documentation

- `CLAUDE.md`: new "Diagrams in Documentation" section documenting when to use each tool
- `docs/guides/contributing.md`: writing guide updated to mention both Mermaid and D2

## Pre-PR review findings addressed

Ran 5 review agents (docs-consistency, infra-reviewer, tool-parity-checker, diagram-syntax-validator, issue-resolution-verifier). Findings fixed:

**CRITICAL:**
- engine.md had 4 remaining ASCII diagrams (caught by docs-consistency, converted to Mermaid + markdown table)
- agents.md had 1 complex ASCII evolution pipeline (caught by docs-consistency, converted to Mermaid with subgraphs)
- CI `curl | sh` was unversioned (pinned to D2 v0.7.1 with direct GitHub release download + verification)
- `.opencode/` was missing the diagram-syntax-validator for parity (added)

**MAJOR:**
- `mkdocs-d2-plugin>=1.5.0` was loose-bounded (pinned to `==1.7.0`)
- No `d2 --version` verification step after install (added)
- CI cache strategy unclear (added comment, gitignored local cache dir)
- `docs/guides/contributing.md` writing guide omitted D2 (added)

## Test plan

- [x] `uv run zensical build` succeeds from scratch (73.97s full clean build, all D2 + Mermaid diagrams render)
- [x] `uv run pre-commit run --all-files` passes all hooks
- [x] All D2 SVGs rendered correctly to HTML output
- [x] Existing 12 Mermaid diagrams still render (no regression)
- [x] Dark theme applied to D2 diagrams (theme 200, Dark Mauve)
- [ ] CI verification (will run on push)

## Review coverage

- 5 local review agents run (docs-consistency, infra-reviewer, tool-parity-checker, diagram-syntax-validator, issue-resolution-verifier)
- 11 findings identified, all valid ones fixed before PR creation
- Issue resolution verifier confirmed all 6 requirements from #1193 are RESOLVED
