### PR TITLE
test: audit + clean up unit test suite (regression guard, sleeps, hypothesis, resource leaks)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,9 @@ jobs:
             --cov-report=term-missing \
             --cov-report=xml:coverage.xml \
             --cov-fail-under=80 \
-            --junitxml=junit.xml
+            --junitxml=junit.xml \
+            --durations=20 \
+            --durations-min=1.0
 
       # Codecov upload is best-effort -- CI should not fail on Codecov outages.
       # Coverage enforcement is handled by --cov-fail-under. Uses tokenless

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,16 @@ See `web/CLAUDE.md` for the full component inventory, design token rules, and po
 - **`RetryExhaustedError`** signals that all retries failed -- the engine layer catches this to trigger fallback chains
 - **Rate limiter** respects `RateLimitError.retry_after` from providers -- automatically pauses future requests
 
+## Test Regression (MANDATORY)
+
+When tests fail due to timeout, slowness, or xdist resource contention:
+- **NEVER** delete tests, skip tests, or mark them `xfail` to "fix" slowness
+- **NEVER** use `--no-verify` to bypass pre-push hooks
+- **FIRST** run: `uv run python -m pytest tests/unit/ -m unit -n 8 --durations=50 --durations-min=0.5 -q --no-header` to identify the slow tests
+- **THEN** compare against `tests/baselines/unit_timing.json` (the known-good baseline)
+- **IF** suite time exceeds `baseline * 1.3`: this is a **source code regression**, not a test bug -- fix the source code that caused the regression, not the tests
+- The `pytest_sessionfinish` hook in `tests/conftest.py` will warn loudly if a regression is detected -- trust the warning
+
 ## Testing
 
 - **Markers**: `@pytest.mark.unit`, `@pytest.mark.integration`, `@pytest.mark.e2e`, `@pytest.mark.slow`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ dev = [
     "ruff==0.15.10",
     "types-pyyaml==6.0.12.20260408",
     "bandit==1.9.4",
+    "pytest-randomly>=4.0.1",
     {include-group = "test"},
     {include-group = "docs"},
 ]
@@ -268,7 +269,7 @@ markers = [
     "slow: Slow tests (excluded from default runs)",
     "timescaledb: Integration tests that require the TimescaleDB extension (self-hosted Postgres only)",
 ]
-addopts = ["--strict-markers", "--strict-config", "-ra", "--tb=short", "--dist=worksteal", "-n=8"]
+addopts = ["--strict-markers", "--strict-config", "-ra", "--tb=short", "--dist=worksteal", "-n=8", "-p", "no:randomly"]
 filterwarnings = [
     "error",
     "ignore:Core Pydantic V1 functionality:UserWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ dev = [
     "ruff==0.15.10",
     "types-pyyaml==6.0.12.20260408",
     "bandit==1.9.4",
-    "pytest-randomly>=4.0.1",
+    "pytest-randomly==4.0.1",
     {include-group = "test"},
     {include-group = "docs"},
 ]

--- a/scripts/run_affected_tests.py
+++ b/scripts/run_affected_tests.py
@@ -167,6 +167,14 @@ def _check_timing_regression(elapsed: float, *, run_all: bool) -> bool:
     except json.JSONDecodeError, KeyError, ValueError, OSError:
         return False
     max_allowed = baseline_secs * (1 + threshold_pct / 100)
+    # Honor the same override used by the conftest guard.
+    import contextlib
+    import os
+
+    env_override = os.environ.get("UNIT_SUITE_MAX_SECONDS")
+    if env_override is not None:
+        with contextlib.suppress(ValueError):
+            max_allowed = float(env_override)
     if elapsed > max_allowed:
         pct = (elapsed - baseline_secs) / baseline_secs * 100
         border = "!" * 60

--- a/scripts/run_affected_tests.py
+++ b/scripts/run_affected_tests.py
@@ -14,9 +14,11 @@ Exit codes match pytest: 0 (passed/nothing to run), 1 (failures), etc.
 Git command failures fall back to running the full unit suite.
 """
 
+import json
 import re
 import subprocess
 import sys
+import time
 from pathlib import Path, PurePosixPath
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -147,7 +149,41 @@ def _affected_test_dirs(changed: list[str]) -> tuple[list[str], bool]:
     return test_dirs, False
 
 
-def _run_pytest(paths: list[str]) -> int:
+_BASELINE_PATH = _REPO_ROOT / "tests" / "baselines" / "unit_timing.json"
+
+
+def _check_timing_regression(elapsed: float, *, run_all: bool) -> bool:
+    """Return True if the run shows a timing regression.
+
+    Only checks full-suite runs (``run_all=True``) since affected-only
+    runs vary widely and are not comparable to the baseline.
+    """
+    if not run_all or not _BASELINE_PATH.exists():
+        return False
+    try:
+        baseline = json.loads(_BASELINE_PATH.read_text(encoding="utf-8"))
+        baseline_secs = float(baseline["unit_suite_seconds"])
+        threshold_pct = float(baseline.get("regression_threshold_pct", 30))
+    except json.JSONDecodeError, KeyError, ValueError, OSError:
+        return False
+    max_allowed = baseline_secs * (1 + threshold_pct / 100)
+    if elapsed > max_allowed:
+        pct = (elapsed - baseline_secs) / baseline_secs * 100
+        border = "!" * 60
+        print(
+            f"\n{border}\n"
+            f"REGRESSION DETECTED: suite took {elapsed:.0f}s, "
+            f"baseline is {baseline_secs:.0f}s (+{pct:.0f}%)\n"
+            f"Run A/B against origin/main before fixing anything.\n"
+            f"Do NOT delete tests or use --no-verify.\n"
+            f"{border}",
+            file=sys.stderr,
+        )
+        return True
+    return False
+
+
+def _run_pytest(paths: list[str], *, run_all: bool = False) -> int:
     """Run pytest with the given paths.
 
     Uses ``--dist loadscope`` instead of pyproject.toml's default
@@ -174,7 +210,12 @@ def _run_pytest(paths: list[str]) -> int:
         "--max-worker-restart=0",
         "-q",
     ]
+    start = time.monotonic()
     result = subprocess.run(cmd, cwd=_REPO_ROOT, check=False)
+    elapsed = time.monotonic() - start
+    if _check_timing_regression(elapsed, run_all=run_all):
+        # Regression detected -- block the push even if tests passed.
+        return max(result.returncode, 1)
     return result.returncode
 
 
@@ -184,13 +225,13 @@ def main() -> int:
         base = _merge_base()
     except _GitError as exc:
         print(f"ERROR: {exc} -- running full unit suite", file=sys.stderr)
-        return _run_pytest(["tests/unit/"])
+        return _run_pytest(["tests/unit/"], run_all=True)
 
     try:
         changed = _changed_files(base)
     except _GitError as exc:
         print(f"ERROR: {exc} -- running full unit suite", file=sys.stderr)
-        return _run_pytest(["tests/unit/"])
+        return _run_pytest(["tests/unit/"], run_all=True)
 
     # Filter to Python files only.
     py_changed = [f for f in changed if f.endswith(".py")]
@@ -202,7 +243,7 @@ def main() -> int:
 
     if run_all:
         print("Foundational module or conftest changed -- running full unit suite.")
-        return _run_pytest(["tests/unit/"])
+        return _run_pytest(["tests/unit/"], run_all=True)
 
     if not test_dirs:
         print("Changed files don't map to any test directories -- skipping.")

--- a/tests/baselines/unit_timing.json
+++ b/tests/baselines/unit_timing.json
@@ -1,7 +1,7 @@
 {
-  "unit_suite_seconds": 191,
+  "unit_suite_seconds": 185,
   "test_count": 18299,
-  "commit": "be0cf09f",
+  "commit": "fb239ba2",
   "measured_at": "2026-04-12",
   "regression_threshold_pct": 30
 }

--- a/tests/baselines/unit_timing.json
+++ b/tests/baselines/unit_timing.json
@@ -1,0 +1,7 @@
+{
+  "unit_suite_seconds": 191,
+  "test_count": 18299,
+  "commit": "be0cf09f",
+  "measured_at": "2026-04-12",
+  "regression_threshold_pct": 30
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,9 +193,16 @@ def pytest_sessionfinish(
     try:
         baseline = json.loads(_BASELINE_PATH.read_text(encoding="utf-8"))
         baseline_secs = float(baseline["unit_suite_seconds"])
+        baseline_count = int(baseline.get("test_count", 0))
         threshold_pct = float(baseline.get("regression_threshold_pct", 30))
     except json.JSONDecodeError, KeyError, ValueError, OSError:
         return  # Malformed baseline -- skip check, don't block.
+    # Only compare against baseline when running (roughly) the full
+    # suite.  Partial runs have very different timing profiles and
+    # would produce noisy false positives.
+    unit_count = sum(1 for item in session.items if item.get_closest_marker("unit"))
+    if baseline_count and unit_count < baseline_count * 0.8:
+        return
     max_allowed = baseline_secs * (1 + threshold_pct / 100)
     # Allow override for optimization work where the suite is
     # intentionally being re-measured at a new (lower) baseline.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
 """Root test configuration and shared fixtures."""
 
+import contextlib
+import json
 import logging
 import os
 import shutil
+import sys
 import time
 from collections.abc import AsyncGenerator, Iterable
 from pathlib import Path
@@ -154,6 +157,64 @@ def pytest_runtest_teardown(item: pytest.Item) -> None:
             f"a fixture is doing heavy I/O -- check setup/teardown.",
             pytrace=False,
         )
+
+
+# ── Suite-level regression guard ─────────────────────────────────
+# Compares total wall-clock time against the committed baseline in
+# tests/baselines/unit_timing.json.  Fires after every full suite
+# run (locally, in pre-push hooks, in CI).  When a regression is
+# detected, prints a loud warning so the cause is investigated
+# instead of "fixing" by deleting tests or bypassing hooks.
+_BASELINE_PATH = Path(__file__).parent / "baselines" / "unit_timing.json"
+_suite_start: float | None = None
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_sessionstart(session: pytest.Session) -> None:
+    """Record suite start time for regression detection."""
+    global _suite_start  # noqa: PLW0603
+    _suite_start = time.monotonic()
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_sessionfinish(
+    session: pytest.Session,
+    exitstatus: int,
+) -> None:
+    """Warn loudly if the unit suite regressed beyond the baseline."""
+    if _suite_start is None or _FUZZ_PROFILE_ACTIVE:
+        return
+    # Only check when running unit tests (not integration/e2e-only).
+    if not any(item.get_closest_marker("unit") for item in session.items):
+        return
+    elapsed = time.monotonic() - _suite_start
+    if not _BASELINE_PATH.exists():
+        return
+    try:
+        baseline = json.loads(_BASELINE_PATH.read_text(encoding="utf-8"))
+        baseline_secs = float(baseline["unit_suite_seconds"])
+        threshold_pct = float(baseline.get("regression_threshold_pct", 30))
+    except json.JSONDecodeError, KeyError, ValueError, OSError:
+        return  # Malformed baseline -- skip check, don't block.
+    max_allowed = baseline_secs * (1 + threshold_pct / 100)
+    # Allow override for optimization work where the suite is
+    # intentionally being re-measured at a new (lower) baseline.
+    env_override = os.environ.get("UNIT_SUITE_MAX_SECONDS")
+    if env_override is not None:
+        with contextlib.suppress(ValueError):
+            max_allowed = float(env_override)
+    if elapsed > max_allowed:
+        pct = (elapsed - baseline_secs) / baseline_secs * 100
+        border = "!" * 60
+        msg = (
+            f"\n{border}\n"
+            f"REGRESSION DETECTED: suite took {elapsed:.0f}s, "
+            f"baseline is {baseline_secs:.0f}s (+{pct:.0f}%)\n"
+            f"Run A/B against origin/main before fixing anything.\n"
+            f"Do NOT delete tests or use --no-verify.\n"
+            f"{border}\n"
+        )
+        print(msg, file=sys.stderr)  # noqa: T201
 
 
 def clear_logging_state() -> None:

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -86,32 +86,44 @@ def _lightweight_argon2_hasher() -> Any:
     _auth_mod._hasher = original
 
 
-@pytest.fixture(autouse=True)
-def _required_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture(scope="session", autouse=True)
+def _required_env_vars() -> Generator[None]:
     """Set SYNTHORG_JWT_SECRET and SYNTHORG_SETTINGS_KEY for API tests.
 
-    The backend now requires both env vars at startup (no auto-generation).
+    Session-scoped with manual env-var management (``monkeypatch`` is
+    function-scoped and cannot be used here).
     """
-    monkeypatch.setenv("SYNTHORG_JWT_SECRET", _TEST_JWT_SECRET)
-    monkeypatch.setenv("SYNTHORG_SETTINGS_KEY", _TEST_SETTINGS_KEY)
+    import os
+
+    old_jwt = os.environ.get("SYNTHORG_JWT_SECRET")
+    old_key = os.environ.get("SYNTHORG_SETTINGS_KEY")
+    os.environ["SYNTHORG_JWT_SECRET"] = _TEST_JWT_SECRET
+    os.environ["SYNTHORG_SETTINGS_KEY"] = _TEST_SETTINGS_KEY
+    yield
+    if old_jwt is None:
+        os.environ.pop("SYNTHORG_JWT_SECRET", None)
+    else:
+        os.environ["SYNTHORG_JWT_SECRET"] = old_jwt
+    if old_key is None:
+        os.environ.pop("SYNTHORG_SETTINGS_KEY", None)
+    else:
+        os.environ["SYNTHORG_SETTINGS_KEY"] = old_key
 
 
-@pytest.fixture(autouse=True)
-def _no_backup_service(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture(scope="session", autouse=True)
+def _no_backup_service() -> Generator[None]:
     """Disable the backup service in all API unit tests.
 
-    ``create_app`` auto-builds a real ``BackupService`` from config,
-    which triggers filesystem I/O (backup creation + retention
-    pruning of tar.gz archives) on every app startup and shutdown.
-    On Windows this adds 15-25 s per ``TestClient`` lifecycle due to
-    Defender scanning each archive.  Patching the factory to return
-    ``None`` eliminates this overhead.  Backup-specific behaviour is
-    tested in ``tests/unit/backup/`` with dedicated mocks.
+    Session-scoped with ``unittest.mock.patch`` (``monkeypatch`` is
+    function-scoped and cannot be used here).
     """
-    monkeypatch.setattr(
+    from unittest.mock import patch
+
+    with patch(
         "synthorg.api.app.build_backup_service",
-        lambda *_a, **_kw: None,
-    )
+        return_value=None,
+    ):
+        yield
 
 
 def make_exception_handler_app(handler: Any) -> Litestar:
@@ -221,16 +233,16 @@ def auth_service() -> AuthService:
 
 
 @pytest.fixture
-async def fake_persistence() -> FakePersistenceBackend:
+def fake_persistence() -> FakePersistenceBackend:
     backend = FakePersistenceBackend()
-    await backend.connect()
+    backend._connected = True
     return backend
 
 
 @pytest.fixture
-async def fake_message_bus() -> FakeMessageBus:
+def fake_message_bus() -> FakeMessageBus:
     bus = FakeMessageBus()
-    await bus.start()
+    bus._running = True
     return bus
 
 
@@ -246,13 +258,6 @@ def approval_store() -> ApprovalStore:
 
 @pytest.fixture
 def root_config() -> RootConfig:
-    # High rate limit so Hypothesis property tests (10k+ examples)
-    # don't hit 429.
-    #
-    # ``integrations.enabled=False`` skips ~20 integration controller
-    # route registrations (~0.7s per ``create_app``). Tests that need
-    # integration endpoints must opt-in by constructing their own
-    # ``RootConfig(integrations=IntegrationsConfig(enabled=True))``.
     from synthorg.integrations.config import IntegrationsConfig
 
     return RootConfig(
@@ -274,25 +279,21 @@ def performance_tracker() -> PerformanceTracker:
 
 @pytest.fixture
 def agent_registry() -> AgentRegistryService:
-    """Return a fresh AgentRegistryService instance."""
     return AgentRegistryService()
 
 
 @pytest.fixture
 def provider_health_tracker() -> ProviderHealthTracker:
-    """Return a fresh ProviderHealthTracker instance."""
     return ProviderHealthTracker()
 
 
 @pytest.fixture
 def tool_invocation_tracker() -> ToolInvocationTracker:
-    """Return a fresh ToolInvocationTracker instance."""
     return ToolInvocationTracker()
 
 
 @pytest.fixture
 def delegation_record_store() -> DelegationRecordStore:
-    """Return a fresh DelegationRecordStore instance."""
     return DelegationRecordStore()
 
 
@@ -300,21 +301,16 @@ def delegation_record_store() -> DelegationRecordStore:
 def fake_task_engine(
     fake_persistence: FakePersistenceBackend,
 ) -> TaskEngine:
-    """TaskEngine backed by the shared fake persistence."""
-    return TaskEngine(
-        persistence=fake_persistence,
-    )
+    return TaskEngine(persistence=fake_persistence)
 
 
 @pytest.fixture
 def audit_log() -> AuditLog:
-    """Fresh in-memory audit log."""
     return AuditLog()
 
 
 @pytest.fixture
 def trust_service() -> TrustService:
-    """Trust service with disabled strategy (no-op evaluation)."""
     return TrustService(
         strategy=DisabledTrustStrategy(),
         config=TrustConfig(),
@@ -323,7 +319,6 @@ def trust_service() -> TrustService:
 
 @pytest.fixture
 def coordination_metrics_store() -> CoordinationMetricsStore:
-    """Fresh in-memory coordination metrics store."""
     return CoordinationMetricsStore()
 
 
@@ -345,7 +340,6 @@ def test_client(  # noqa: PLR0913
     trust_service: TrustService,
     coordination_metrics_store: CoordinationMetricsStore,
 ) -> Generator[TestClient[Any]]:
-    # Pre-seed users for each role so JWT sub claims resolve
     _seed_test_users(fake_persistence, auth_service)
 
     settings_service = SettingsService(
@@ -374,7 +368,6 @@ def test_client(  # noqa: PLR0913
         coordination_metrics_store=coordination_metrics_store,
     )
     with TestClient(app) as client:
-        # Default: CEO token (most tests need write access)
         client.headers.update(make_auth_headers("ceo"))
         yield client
 

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -1,7 +1,7 @@
 """Shared fixtures for API unit tests."""
 
 import uuid
-from collections.abc import Generator
+from collections.abc import AsyncGenerator, Generator
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -233,17 +233,19 @@ def auth_service() -> AuthService:
 
 
 @pytest.fixture
-def fake_persistence() -> FakePersistenceBackend:
+async def fake_persistence() -> AsyncGenerator[FakePersistenceBackend]:
     backend = FakePersistenceBackend()
-    backend._connected = True
-    return backend
+    await backend.connect()
+    yield backend
+    await backend.disconnect()
 
 
 @pytest.fixture
-def fake_message_bus() -> FakeMessageBus:
+async def fake_message_bus() -> AsyncGenerator[FakeMessageBus]:
     bus = FakeMessageBus()
-    bus._running = True
-    return bus
+    await bus.start()
+    yield bus
+    await bus.stop()
 
 
 @pytest.fixture

--- a/tests/unit/api/fakes.py
+++ b/tests/unit/api/fakes.py
@@ -628,6 +628,10 @@ class FakeMessageBus:
         self._running = False
         self._channels: list[Channel] = []
 
+    def clear(self) -> None:
+        """Reset all in-memory state for test isolation."""
+        self._channels.clear()
+
     async def start(self) -> None:
         self._running = True
 

--- a/tests/unit/api/fakes.py
+++ b/tests/unit/api/fakes.py
@@ -631,6 +631,7 @@ class FakeMessageBus:
     def clear(self) -> None:
         """Reset all in-memory state for test isolation."""
         self._channels.clear()
+        self._running = True
 
     async def start(self) -> None:
         self._running = True

--- a/tests/unit/api/fakes_backend.py
+++ b/tests/unit/api/fakes_backend.py
@@ -277,12 +277,22 @@ class FakePersistenceBackend:
     def clear(self) -> None:
         """Reset all in-memory state for test isolation.
 
-        Preserves the connection flag so the backend remains usable
-        after clearing.  Called between tests when the app is cached
-        at module level to prevent cross-test state pollution.
+        Clears repository contents in-place so any services holding
+        references to repository objects observe the reset.  Preserves
+        object identity and the connection flag.
         """
-        self.__init__()  # type: ignore[misc]
-        self._connected = True
+        for attr_name in list(vars(self)):
+            if attr_name == "_connected":
+                continue
+            value = getattr(self, attr_name)
+            # Clear mutable containers directly.
+            if isinstance(value, (dict, list, set)):
+                value.clear()
+                continue
+            # Clear internal state of fake repository objects.
+            for inner_value in vars(value).values():
+                if isinstance(inner_value, (dict, list, set)):
+                    inner_value.clear()
 
     async def connect(self) -> None:
         self._connected = True

--- a/tests/unit/api/fakes_backend.py
+++ b/tests/unit/api/fakes_backend.py
@@ -274,6 +274,16 @@ class FakePersistenceBackend:
         self._settings: dict[str, str] = {}
         self._connected = False
 
+    def clear(self) -> None:
+        """Reset all in-memory state for test isolation.
+
+        Preserves the connection flag so the backend remains usable
+        after clearing.  Called between tests when the app is cached
+        at module level to prevent cross-test state pollution.
+        """
+        self.__init__()  # type: ignore[misc]
+        self._connected = True
+
     async def connect(self) -> None:
         self._connected = True
 

--- a/tests/unit/api/test_dto_properties.py
+++ b/tests/unit/api/test_dto_properties.py
@@ -1,7 +1,7 @@
 """Property-based tests for API DTO validation constraints."""
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 from pydantic import ValidationError
 
@@ -38,7 +38,6 @@ class TestCoordinateTaskRequestProperties:
             max_size=10,
         ),
     )
-    @settings(max_examples=100)
     def test_case_insensitive_uniqueness(
         self,
         names: list[str],
@@ -54,7 +53,6 @@ class TestCoordinateTaskRequestProperties:
             assert req.agent_names == tuple(names)
 
     @given(name=_not_blank)
-    @settings(max_examples=50)
     def test_single_agent_always_valid(self, name: str) -> None:
         req = CoordinateTaskRequest(agent_names=(name,))
         assert req.agent_names == (name,)
@@ -64,7 +62,6 @@ class TestCoordinateTaskRequestProperties:
         assert req.agent_names is None
 
     @given(name=_not_blank)
-    @settings(max_examples=50)
     def test_duplicate_same_case_rejected(self, name: str) -> None:
         with pytest.raises(ValidationError, match="Duplicate agent name"):
             CoordinateTaskRequest(agent_names=(name, name))
@@ -76,7 +73,6 @@ class TestCoordinateTaskRequestProperties:
             max_size=20,
         ),
     )
-    @settings(max_examples=50)
     def test_duplicate_different_case_rejected(self, name: str) -> None:
         with pytest.raises(ValidationError, match="Duplicate agent name"):
             CoordinateTaskRequest(
@@ -91,7 +87,6 @@ class TestCoordinateTaskRequestProperties:
         ),
         fail_fast=st.one_of(st.none(), st.booleans()),
     )
-    @settings(max_examples=50)
     def test_valid_config_roundtrip(
         self,
         max_subtasks: int,
@@ -115,7 +110,6 @@ class TestCreateApprovalRequestProperties:
         description=_not_blank,
         risk_level=_risk_levels,
     )
-    @settings(max_examples=50)
     def test_valid_request_roundtrip(
         self,
         action_type: str,
@@ -141,7 +135,6 @@ class TestCreateApprovalRequestProperties:
             max_value=_MAX_METADATA_KEYS + 5,
         ),
     )
-    @settings(max_examples=10)
     def test_too_many_metadata_keys_rejected(self, num_keys: int) -> None:
         metadata = {f"key-{i}": f"val-{i}" for i in range(num_keys)}
         with pytest.raises(
@@ -162,7 +155,6 @@ class TestCreateApprovalRequestProperties:
             max_value=_MAX_METADATA_STR_LEN + 50,
         ),
     )
-    @settings(max_examples=10)
     def test_long_metadata_key_rejected(self, key_len: int) -> None:
         long_key = "k" * key_len
         with pytest.raises(
@@ -183,7 +175,6 @@ class TestCreateApprovalRequestProperties:
             max_value=_MAX_METADATA_STR_LEN + 50,
         ),
     )
-    @settings(max_examples=10)
     def test_long_metadata_value_rejected(self, val_len: int) -> None:
         long_val = "v" * val_len
         with pytest.raises(
@@ -214,7 +205,6 @@ class TestCreateApprovalRequestProperties:
             max_size=_MAX_METADATA_KEYS,
         ),
     )
-    @settings(max_examples=50)
     def test_valid_metadata_accepted(self, metadata: dict[str, str]) -> None:
         req = CreateApprovalRequest(
             action_type="test:action",
@@ -266,7 +256,6 @@ def _error_detail_strategy() -> st.SearchStrategy[ErrorDetail]:
 
 class TestErrorDetailProperties:
     @given(detail=_error_detail_strategy())
-    @settings(max_examples=100)
     def test_roundtrip(self, detail: ErrorDetail) -> None:
         dumped = detail.model_dump()
         restored = ErrorDetail.model_validate(dumped)
@@ -276,7 +265,6 @@ class TestErrorDetailProperties:
         error_category=st.sampled_from(list(ErrorCategory)),
         retryable=st.booleans(),
     )
-    @settings(max_examples=50)
     def test_retryable_and_category_preserved(
         self,
         error_category: ErrorCategory,
@@ -350,7 +338,6 @@ def _problem_detail_strategy() -> st.SearchStrategy[ProblemDetail]:
 
 class TestProblemDetailProperties:
     @given(problem=_problem_detail_strategy())
-    @settings(max_examples=100)
     def test_roundtrip(self, problem: ProblemDetail) -> None:
         dumped = problem.model_dump()
         restored = ProblemDetail.model_validate(dumped)

--- a/tests/unit/budget/test_config_properties.py
+++ b/tests/unit/budget/test_config_properties.py
@@ -1,7 +1,7 @@
 """Property-based tests for budget configuration validation constraints."""
 
 import pytest
-from hypothesis import assume, given, settings
+from hypothesis import assume, given
 from hypothesis import strategies as st
 from pydantic import ValidationError
 
@@ -19,7 +19,6 @@ _not_blank = st.text(min_size=1, max_size=20).filter(lambda s: s.strip())
 
 class TestBudgetAlertConfigProperties:
     @given(warn=_pct, critical=_pct, hard_stop=_pct)
-    @settings(max_examples=200)
     def test_threshold_ordering_invariant(
         self,
         warn: int,
@@ -50,7 +49,6 @@ class TestBudgetAlertConfigProperties:
         .map(sorted)
         .filter(lambda xs: xs[0] < xs[1] < xs[2]),
     )
-    @settings(max_examples=100)
     def test_valid_config_roundtrip(self, data: list[int]) -> None:
         warn, critical, hard_stop = data
         cfg = BudgetAlertConfig(
@@ -68,7 +66,6 @@ class TestAutoDowngradeConfigProperties:
         enabled=st.booleans(),
         threshold=_pct,
     )
-    @settings(max_examples=50)
     def test_basic_config_roundtrip(
         self,
         enabled: bool,
@@ -80,7 +77,6 @@ class TestAutoDowngradeConfigProperties:
         assert restored == cfg
 
     @given(source=_not_blank)
-    @settings(max_examples=50)
     def test_self_downgrade_rejected(self, source: str) -> None:
         with pytest.raises(ValidationError, match="Self-downgrade"):
             AutoDowngradeConfig(
@@ -89,7 +85,6 @@ class TestAutoDowngradeConfigProperties:
             )
 
     @given(source=_not_blank, target1=_not_blank, target2=_not_blank)
-    @settings(max_examples=50)
     def test_duplicate_source_rejected(
         self,
         source: str,
@@ -111,7 +106,6 @@ class TestAutoDowngradeConfigProperties:
             max_size=5,
         ),
     )
-    @settings(max_examples=100)
     def test_valid_map_accepted_or_expected_rejection(
         self,
         pairs: list[tuple[str, str]],
@@ -158,7 +152,6 @@ class TestBudgetConfigProperties:
         ),
         reset_day=st.integers(min_value=1, max_value=28),
     )
-    @settings(max_examples=100)
     def test_budget_config_validation(
         self,
         total: float,
@@ -191,7 +184,6 @@ class TestBudgetConfigProperties:
         total=st.floats(min_value=10.0, max_value=1000.0, allow_nan=False),
         reset_day=st.integers(min_value=1, max_value=28),
     )
-    @settings(max_examples=50)
     def test_valid_budget_roundtrip(
         self,
         total: float,

--- a/tests/unit/communication/test_message_properties.py
+++ b/tests/unit/communication/test_message_properties.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 
 from synthorg.communication.enums import MessagePriority, MessageType
@@ -155,7 +155,6 @@ class TestMessageRoundtripProperties:
 
 class TestFromAliasProperties:
     @given(sender=_not_blank)
-    @settings(max_examples=50)
     def test_from_alias_works(self, sender: str) -> None:
         kwargs = _make_default_message_kwargs()
         kwargs["from"] = sender
@@ -163,7 +162,6 @@ class TestFromAliasProperties:
         assert msg.sender == sender
 
     @given(sender=_not_blank)
-    @settings(max_examples=50)
     def test_populate_by_name_works(self, sender: str) -> None:
         kwargs = _make_default_message_kwargs()
         del kwargs["from"]
@@ -237,7 +235,6 @@ class TestMetadataRoundtripProperties:
             st.floats(min_value=0.0, max_value=100.0, allow_nan=False),
         ),
     )
-    @settings(max_examples=100)
     def test_metadata_roundtrip(
         self,
         task_id: str | None,

--- a/tests/unit/config/test_loader_properties.py
+++ b/tests/unit/config/test_loader_properties.py
@@ -45,7 +45,6 @@ class TestSubstituteEnvVarsProperties:
             max_size=5,
         ),
     )
-    @settings(max_examples=100)
     def test_no_env_vars_passes_through(self, data: dict[str, Any]) -> None:
         has_env_pattern = any(
             isinstance(v, str) and "${" in v and "}" in v for v in data.values()
@@ -57,7 +56,6 @@ class TestSubstituteEnvVarsProperties:
         assert result is not data
 
     @given(text=_env_var_text)
-    @settings(max_examples=100)
     def test_arbitrary_text_with_patterns_no_crash(self, text: str) -> None:
         """Crash-safety: _substitute_env_vars must only raise ConfigValidationError."""
         data = {"key": text}
@@ -78,7 +76,6 @@ class TestSubstituteEnvVarsProperties:
             max_size=5,
         ),
     )
-    @settings(max_examples=50)
     def test_non_string_values_unchanged(self, data: dict[str, Any]) -> None:
         result = _substitute_env_vars(data)
         assert result == data
@@ -91,7 +88,7 @@ class TestSubstituteEnvVarsProperties:
 
 class TestParseYamlStringProperties:
     @given(text=_yaml_text)
-    @settings(max_examples=100, deadline=None)
+    @settings(deadline=None)
     def test_arbitrary_text_no_unhandled_exception(self, text: str) -> None:
         """Crash-safety: _parse_yaml_string must only raise ConfigParseError."""
         try:
@@ -124,7 +121,6 @@ class TestParseYamlStringProperties:
             max_size=50,
         ),
     )
-    @settings(max_examples=100)
     def test_garbled_yaml_raises_or_returns_dict(self, text: str) -> None:
         """Crash-safety: garbled input must only raise ConfigParseError."""
         try:

--- a/tests/unit/config/test_utils_properties.py
+++ b/tests/unit/config/test_utils_properties.py
@@ -4,7 +4,7 @@ import copy
 from typing import Any
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 
 from synthorg.config.utils import deep_merge, to_float
@@ -52,7 +52,6 @@ _str_key_dicts = st.dictionaries(
 
 class TestDeepMergeProperties:
     @given(a=_str_key_dicts)
-    @settings(max_examples=50)
     def test_identity_merge_with_empty(self, a: dict[str, Any]) -> None:
         result = deep_merge(a, {})
         assert result == a
@@ -60,13 +59,11 @@ class TestDeepMergeProperties:
         assert result is not a
 
     @given(a=_str_key_dicts, b=_str_key_dicts)
-    @settings(max_examples=50)
     def test_result_keys_are_union(self, a: dict[str, Any], b: dict[str, Any]) -> None:
         result = deep_merge(a, b)
         assert set(result.keys()) == set(a.keys()) | set(b.keys())
 
     @given(a=_str_key_dicts, b=_str_key_dicts)
-    @settings(max_examples=50)
     def test_inputs_are_not_mutated(self, a: dict[str, Any], b: dict[str, Any]) -> None:
         a_before = copy.deepcopy(a)
         b_before = copy.deepcopy(b)
@@ -84,7 +81,6 @@ class TestDeepMergeProperties:
         ),
         override_z=st.integers(),
     )
-    @settings(max_examples=50)
     def test_recursive_nested_merge(
         self, base: dict[str, Any], override_z: int
     ) -> None:
@@ -97,7 +93,6 @@ class TestDeepMergeProperties:
         assert result["nested"]["z"] == override_z
 
     @given(a=_str_key_dicts, b=_str_key_dicts)
-    @settings(max_examples=50)
     def test_override_values_win_for_non_dict(
         self, a: dict[str, Any], b: dict[str, Any]
     ) -> None:
@@ -112,14 +107,12 @@ class TestDeepMergeProperties:
 
 class TestToFloatProperties:
     @given(value=st.integers(min_value=-10_000, max_value=10_000))
-    @settings(max_examples=50)
     def test_integers_convert(self, value: int) -> None:
         result = to_float(value)
         assert isinstance(result, float)
         assert result == float(value)
 
     @given(value=st.floats(allow_nan=False, allow_infinity=False))
-    @settings(max_examples=50)
     def test_floats_pass_through(self, value: float) -> None:
         result = to_float(value)
         assert isinstance(result, float)
@@ -128,7 +121,6 @@ class TestToFloatProperties:
     @given(
         value=st.from_regex(r"-?\d+(\.\d+)?", fullmatch=True),
     )
-    @settings(max_examples=50)
     def test_numeric_strings_convert(self, value: str) -> None:
         result = to_float(value)
         assert isinstance(result, float)
@@ -141,13 +133,11 @@ class TestToFloatProperties:
             st.dictionaries(st.text(max_size=5), st.integers(), max_size=3),
         ),
     )
-    @settings(max_examples=50)
     def test_non_numeric_raises_value_error(self, value: object) -> None:
         with pytest.raises(ValueError, match="numeric value"):
             to_float(value)
 
     @given(value=st.text().filter(lambda s: not _is_numeric_string(s)))
-    @settings(max_examples=50)
     def test_non_numeric_strings_raise_value_error(self, value: str) -> None:
         with pytest.raises(ValueError, match="numeric value"):
             to_float(value)

--- a/tests/unit/core/test_enums_properties.py
+++ b/tests/unit/core/test_enums_properties.py
@@ -1,7 +1,7 @@
 """Property-based tests for enum comparator algebraic properties."""
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 
 from synthorg.core.enums import (
@@ -19,12 +19,10 @@ _autonomy_levels = st.sampled_from(AutonomyLevel)
 
 class TestCompareSeniorityProperties:
     @given(a=_seniority_levels)
-    @settings(max_examples=50)
     def test_reflexive_zero(self, a: SeniorityLevel) -> None:
         assert compare_seniority(a, a) == 0
 
     @given(a=_seniority_levels, b=_seniority_levels)
-    @settings(max_examples=200)
     def test_anti_symmetry(self, a: SeniorityLevel, b: SeniorityLevel) -> None:
         assert compare_seniority(a, b) == -compare_seniority(b, a)
 
@@ -33,7 +31,6 @@ class TestCompareSeniorityProperties:
         b=_seniority_levels,
         c=_seniority_levels,
     )
-    @settings(max_examples=200)
     def test_transitivity(
         self,
         a: SeniorityLevel,
@@ -49,7 +46,6 @@ class TestCompareSeniorityProperties:
             assert ac <= 0
 
     @given(a=_seniority_levels, b=_seniority_levels)
-    @settings(max_examples=100)
     def test_totality(self, a: SeniorityLevel, b: SeniorityLevel) -> None:
         result = compare_seniority(a, b)
         assert isinstance(result, int)
@@ -61,12 +57,10 @@ class TestCompareSeniorityProperties:
 
 class TestCompareAutonomyProperties:
     @given(a=_autonomy_levels)
-    @settings(max_examples=50)
     def test_reflexive_zero(self, a: AutonomyLevel) -> None:
         assert compare_autonomy(a, a) == 0
 
     @given(a=_autonomy_levels, b=_autonomy_levels)
-    @settings(max_examples=200)
     def test_anti_symmetry(self, a: AutonomyLevel, b: AutonomyLevel) -> None:
         assert compare_autonomy(a, b) == -compare_autonomy(b, a)
 
@@ -75,7 +69,6 @@ class TestCompareAutonomyProperties:
         b=_autonomy_levels,
         c=_autonomy_levels,
     )
-    @settings(max_examples=200)
     def test_transitivity(
         self,
         a: AutonomyLevel,
@@ -91,7 +84,6 @@ class TestCompareAutonomyProperties:
             assert ac <= 0
 
     @given(a=_autonomy_levels, b=_autonomy_levels)
-    @settings(max_examples=100)
     def test_totality(self, a: AutonomyLevel, b: AutonomyLevel) -> None:
         result = compare_autonomy(a, b)
         assert isinstance(result, int)

--- a/tests/unit/core/test_task_properties.py
+++ b/tests/unit/core/test_task_properties.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 from pydantic import ValidationError
 
@@ -56,7 +56,6 @@ _roundtrip_st = st.fixed_dictionaries(
 
 class TestTaskRoundtripProperties:
     @given(data=_roundtrip_st)
-    @settings(max_examples=100)
     def test_model_dump_validate_roundtrip(self, data: dict[str, Any]) -> None:
         task = Task(
             id="task-rt-001",
@@ -76,7 +75,6 @@ class TestTaskRoundtripProperties:
 
 class TestSelfDependencyProperties:
     @given(task_id=_not_blank)
-    @settings(max_examples=100)
     def test_self_dependency_always_rejected(self, task_id: str) -> None:
         with pytest.raises(ValidationError, match="cannot depend on itself"):
             Task(
@@ -93,7 +91,6 @@ class TestWithTransitionProperties:
             list(VALID_TRANSITIONS[TaskStatus.CREATED]),
         ),
     )
-    @settings(max_examples=20)
     def test_valid_transition_from_created(self, target: TaskStatus) -> None:
         task = Task(**_make_task_kwargs())
         # CREATED can only go to ASSIGNED, which requires assigned_to.
@@ -108,7 +105,6 @@ class TestWithTransitionProperties:
             lambda s: s not in VALID_TRANSITIONS[TaskStatus.CREATED],
         ),
     )
-    @settings(max_examples=50)
     def test_invalid_transition_from_created_raises(
         self,
         target: TaskStatus,

--- a/tests/unit/core/test_transitions_properties.py
+++ b/tests/unit/core/test_transitions_properties.py
@@ -1,7 +1,7 @@
 """Property-based tests for task transition validation invariants."""
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 
 from synthorg.core.enums import TaskStatus
@@ -17,7 +17,6 @@ _TRANSITION_ERR = r"Invalid task status transition|has no entry"
 
 class TestValidateTransitionProperties:
     @given(current=_all_statuses, target=_all_statuses)
-    @settings(max_examples=200)
     def test_matches_valid_transitions_map(
         self,
         current: TaskStatus,
@@ -37,7 +36,6 @@ class TestValidateTransitionProperties:
         status=st.sampled_from(list(_TERMINAL_STATES)),
         target=_all_statuses,
     )
-    @settings(max_examples=100)
     def test_terminal_states_have_no_outgoing(
         self,
         status: TaskStatus,
@@ -51,7 +49,6 @@ class TestValidateTransitionProperties:
             validate_transition(status, target)
 
     @given(current=_all_statuses)
-    @settings(max_examples=50)
     def test_every_status_has_transition_entry(
         self,
         current: TaskStatus,
@@ -63,7 +60,6 @@ class TestValidateTransitionProperties:
             lambda s: len(VALID_TRANSITIONS[s]) > 0,
         ),
     )
-    @settings(max_examples=50)
     def test_all_valid_transitions_succeed(
         self,
         current: TaskStatus,
@@ -72,7 +68,6 @@ class TestValidateTransitionProperties:
             validate_transition(current, target)
 
     @given(current=_all_statuses)
-    @settings(max_examples=50)
     def test_invalid_transitions_raise(
         self,
         current: TaskStatus,

--- a/tests/unit/core/test_types_properties.py
+++ b/tests/unit/core/test_types_properties.py
@@ -1,7 +1,7 @@
 """Property-based tests for custom type validators (NotBlankStr)."""
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 from pydantic import BaseModel, ValidationError
 
@@ -18,7 +18,6 @@ class TestNotBlankStrProperties:
     @given(
         text=st.text(min_size=1).filter(lambda s: s.strip()),
     )
-    @settings(max_examples=200)
     def test_valid_strings_accepted(self, text: str) -> None:
         model = _NotBlankModel(value=text)
         assert model.value == text
@@ -30,7 +29,6 @@ class TestNotBlankStrProperties:
             max_size=20,
         ),
     )
-    @settings(max_examples=100)
     def test_whitespace_only_rejected(self, text: str) -> None:
         with pytest.raises(ValidationError):
             _NotBlankModel(value=text)
@@ -50,7 +48,6 @@ class TestNotBlankStrProperties:
             max_size=5,
         ),
     )
-    @settings(max_examples=100)
     def test_strings_with_non_whitespace_core_accepted(
         self,
         prefix: str,

--- a/tests/unit/engine/stagnation/test_properties.py
+++ b/tests/unit/engine/stagnation/test_properties.py
@@ -1,7 +1,7 @@
 """Property-based tests for stagnation detection (Hypothesis)."""
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 
 from synthorg.engine.loop_helpers import compute_fingerprints
@@ -55,7 +55,6 @@ class TestFingerprintProperties:
         name=_tool_name,
         args=_args_strategy,
     )
-    @settings(max_examples=50)
     def test_determinism(
         self,
         name: str,
@@ -71,7 +70,6 @@ class TestFingerprintProperties:
         name=_tool_name,
         args=_args_strategy,
     )
-    @settings(max_examples=50)
     def test_format(
         self,
         name: str,
@@ -97,7 +95,6 @@ class TestDetectorProperties:
     @given(
         n_unique=st.integers(min_value=2, max_value=10),
     )
-    @settings(max_examples=100)
     async def test_unique_fingerprints_no_stagnation(
         self,
         n_unique: int,
@@ -118,7 +115,6 @@ class TestDetectorProperties:
         window_size=st.integers(min_value=2, max_value=20),
         n_turns=st.integers(min_value=5, max_value=50),
     )
-    @settings(max_examples=100)
     async def test_window_bounded(
         self,
         window_size: int,

--- a/tests/unit/engine/test_context_budget_properties.py
+++ b/tests/unit/engine/test_context_budget_properties.py
@@ -1,7 +1,7 @@
 """Property-based tests for context budget indicators."""
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 
 from synthorg.engine.context_budget import ContextBudgetIndicator
@@ -22,7 +22,6 @@ class TestContextBudgetIndicatorProperties:
         ),
         archived=st.integers(min_value=0, max_value=100),
     )
-    @settings(max_examples=200)
     def test_format_never_crashes(
         self,
         fill: int,
@@ -42,7 +41,6 @@ class TestContextBudgetIndicatorProperties:
         fill=st.integers(min_value=0, max_value=1_000_000),
         capacity=st.integers(min_value=1, max_value=1_000_000),
     )
-    @settings(max_examples=200)
     def test_fill_percent_non_negative(
         self,
         fill: int,
@@ -57,7 +55,6 @@ class TestContextBudgetIndicatorProperties:
         assert pct >= 0.0
 
     @given(fill=st.integers(min_value=0, max_value=1_000_000))
-    @settings(max_examples=200)
     def test_fill_percent_none_without_capacity(
         self,
         fill: int,
@@ -77,7 +74,6 @@ class TestEstimateConversationTokensProperties:
             max_size=50,
         ),
     )
-    @settings(max_examples=200)
     def test_estimate_non_negative(
         self,
         contents: list[str],

--- a/tests/unit/hr/performance/test_tracker_inflections.py
+++ b/tests/unit/hr/performance/test_tracker_inflections.py
@@ -130,7 +130,12 @@ class TestInflectionDetection:
         # Should not raise.
         await tracker.get_snapshot("agent-1")
         if tasks := list(tracker._background_tasks):
-            await asyncio.gather(*tasks, return_exceptions=True)
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            # Verify only the expected sink error propagated, not
+            # unexpected failures that would indicate a real bug.
+            for result in results:
+                if isinstance(result, BaseException):
+                    assert isinstance(result, RuntimeError)
 
     @pytest.mark.unit
     async def test_cache_is_updated(self) -> None:

--- a/tests/unit/hr/performance/test_tracker_inflections.py
+++ b/tests/unit/hr/performance/test_tracker_inflections.py
@@ -90,7 +90,8 @@ class TestInflectionDetection:
                 _make_task_record(days_ago=i, quality=8.0),
             )
         await tracker.get_snapshot("agent-1")
-        await asyncio.sleep(0.05)
+        if tasks := list(tracker._background_tasks):
+            await asyncio.gather(*tasks)
 
         # Force a different direction by manipulating the cache.
         for key in list(tracker._trend_direction_cache.keys()):
@@ -99,7 +100,8 @@ class TestInflectionDetection:
 
         # Second snapshot should detect the change.
         await tracker.get_snapshot("agent-1")
-        await asyncio.sleep(0.05)
+        if tasks := list(tracker._background_tasks):
+            await asyncio.gather(*tasks)
 
         # At least one inflection should have been emitted.
         if sink.emit.call_count > 0:
@@ -127,7 +129,8 @@ class TestInflectionDetection:
 
         # Should not raise.
         await tracker.get_snapshot("agent-1")
-        await asyncio.sleep(0.05)
+        if tasks := list(tracker._background_tasks):
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     @pytest.mark.unit
     async def test_cache_is_updated(self) -> None:
@@ -140,7 +143,8 @@ class TestInflectionDetection:
                 _make_task_record(days_ago=i),
             )
         await tracker.get_snapshot("agent-1")
-        await asyncio.sleep(0.05)
+        if tasks := list(tracker._background_tasks):
+            await asyncio.gather(*tasks)
 
         # Cache should have entries.
         assert len(tracker._trend_direction_cache) > 0

--- a/tests/unit/settings/test_dispatcher.py
+++ b/tests/unit/settings/test_dispatcher.py
@@ -563,8 +563,9 @@ class TestConsecutiveErrors:
                 if call_count == 4:
                     # After 3 errors, return a valid message once
                     return _envelope(_settings_message("ns", "k"))
-                # Then block (normal poll timeout)
-                await asyncio.sleep(timeout or 1.0)
+                # Then block (normal poll timeout) -- use Event
+                # instead of real sleep to avoid wall-clock delay.
+                await asyncio.Event().wait()
                 return None
 
         bus = _TransientBus()

--- a/tests/unit/tools/git/test_git_url_validator.py
+++ b/tests/unit/tools/git/test_git_url_validator.py
@@ -5,7 +5,7 @@ import ipaddress
 from unittest.mock import AsyncMock
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 from pydantic import ValidationError
 
@@ -695,7 +695,6 @@ class TestValidateCloneUrlHostProperties:
             *(st.ip_addresses(v=4, network=str(net)) for net in _ALL_BLOCKED_V4)
         ),
     )
-    @settings(max_examples=200)
     def test_blocked_ipv4_always_detected(self, ip: ipaddress.IPv4Address) -> None:
         """Every IPv4 in a blocked range is detected."""
         assert _is_blocked_ip(str(ip)) is True
@@ -709,7 +708,6 @@ class TestValidateCloneUrlHostProperties:
             )
         ),
     )
-    @settings(max_examples=200)
     def test_blocked_ipv6_always_detected(self, ip: ipaddress.IPv6Address) -> None:
         """Every IPv6 in a blocked range is detected."""
         assert _is_blocked_ip(str(ip)) is True
@@ -719,7 +717,6 @@ class TestValidateCloneUrlHostProperties:
             lambda ip: not any(ip in net for net in _ALL_BLOCKED_V4)
         ),
     )
-    @settings(max_examples=200)
     def test_non_blocked_ipv4_never_flagged(self, ip: ipaddress.IPv4Address) -> None:
         """IPv4 outside blocked ranges is never flagged."""
         assert _is_blocked_ip(str(ip)) is False
@@ -736,7 +733,6 @@ class TestValidateCloneUrlHostProperties:
             )
         ),
     )
-    @settings(max_examples=50)
     def test_non_blocked_ipv6_never_flagged(self, ip: ipaddress.IPv6Address) -> None:
         """IPv6 outside blocked ranges is never flagged.
 

--- a/tests/unit/tools/mcp/test_client.py
+++ b/tests/unit/tools/mcp/test_client.py
@@ -79,7 +79,7 @@ class TestMCPClientConnection:
         client = MCPClient(config)
 
         async def hang_forever(*_a: object, **_kw: object) -> None:
-            await asyncio.sleep(100)
+            await asyncio.Event().wait()
 
         with (
             patch.object(

--- a/uv.lock
+++ b/uv.lock
@@ -3220,7 +3220,7 @@ dev = [
     { name = "pytest-asyncio", specifier = "==1.3.0" },
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-mock", specifier = "==3.15.1" },
-    { name = "pytest-randomly", specifier = ">=4.0.1" },
+    { name = "pytest-randomly", specifier = "==4.0.1" },
     { name = "pytest-timeout", specifier = "==2.4.0" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "respx", specifier = "==0.23.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -2518,6 +2518,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-randomly"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1d/258a4bf1109258c00c35043f40433be5c16647387b6e7cd5582d638c116b/pytest_randomly-4.0.1.tar.gz", hash = "sha256:174e57bb12ac2c26f3578188490bd333f0e80620c3f47340158a86eca0593cd8", size = 14130, upload-time = "2025-09-12T15:23:00.085Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/3e/a4a9227807b56869790aad3e24472a554b585974fe7e551ea350f50897ae/pytest_randomly-4.0.1-py3-none-any.whl", hash = "sha256:e0dfad2fd4f35e07beff1e47c17fbafcf98f9bf4531fd369d9260e2f858bfcb7", size = 8304, upload-time = "2025-09-12T15:22:58.946Z" },
+]
+
+[[package]]
 name = "pytest-timeout"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3126,6 +3138,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-randomly" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "respx" },
@@ -3207,6 +3220,7 @@ dev = [
     { name = "pytest-asyncio", specifier = "==1.3.0" },
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-mock", specifier = "==3.15.1" },
+    { name = "pytest-randomly", specifier = ">=4.0.1" },
     { name = "pytest-timeout", specifier = "==2.4.0" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "respx", specifier = "==0.23.1" },


### PR DESCRIPTION
## Summary

Local regression detection system + safe test suite optimizations. Establishes the infrastructure to catch test suite regressions automatically, and applies the low-risk fixes from the audit.

## Changes

### Regression detection system (6 layers)

1. **`tests/conftest.py`** -- `pytest_sessionfinish` suite-level timing guard. Compares total wall-clock time against baseline, prints loud warning if >30% regression detected.
2. **`tests/baselines/unit_timing.json`** -- committed baseline file (185s, 18299 tests). Source of truth for regression detection.
3. **`scripts/run_affected_tests.py`** -- pre-push hook now checks timing after full-suite runs and blocks push if regression detected.
4. **`CLAUDE.md`** -- "Test Regression (MANDATORY)" section. Explicit rule: never delete tests or --no-verify when tests fail from slowness. Run --durations, compare baseline, fix source regression.
5. **`.github/workflows/ci.yml`** -- `--durations=20 --durations-min=1.0` added to CI pytest for permanent slow-test visibility.
6. **`pyproject.toml`** -- `pytest-randomly` installed (disabled by default via `-p no:randomly`). Available for isolation verification after fixture-scoping changes.

### Test optimizations

- **Real sleeps removed** -- `asyncio.sleep(0.05)` x4 in tracker inflection tests replaced with `asyncio.gather(*tasks)`. `asyncio.sleep(100)` in MCP client test replaced with `asyncio.Event().wait()`. `asyncio.sleep(timeout or 1.0)` in dispatcher test replaced with `asyncio.Event().wait()`.
- **Hypothesis profile enforcement** -- removed 75 hardcoded `@settings(max_examples=N)` decorators across 13 property test files. All now respect the global `HYPOTHESIS_PROFILE` (CI: 10 examples, dev: 1000, fuzz: 10000).
- **Resource leak teardowns** -- `fake_persistence` and `fake_message_bus` fixtures converted to generators with proper `disconnect()`/`stop()` cleanup. `clear()` methods added to `FakePersistenceBackend` and `FakeMessageBus`.
- **Session-scoped env/backup patches** -- `_required_env_vars` and `_no_backup_service` autouse fixtures converted from function-scoped monkeypatch to session-scoped direct management. Eliminates per-test monkeypatch overhead across all API tests.

## Baseline

- Before: 191s (18,299 tests)
- After: 185s (18,299 tests)
- The remaining bottleneck is `test_client` fixture setup (1.5-2.3s per controller test, ~700 tests). Filed as follow-up: #1272

## Test plan

- Full unit suite: 18,299 passed, 6 skipped
- Lint: ruff check + format clean
- Type check: mypy clean
- Pre-push hooks: all passed

Closes #1243