### PR TITLE
feat(engine): brain/hands/session decoupling + stateless session recovery

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -668,7 +668,7 @@ jobs:
         run: |
           printf 'version: %s\n' "$APP_VERSION" > /tmp/melange-vars.yaml
           melange build docker/web/melange.yaml \
-            --arch amd64,arm64 \
+            --arch x86_64,aarch64 \
             --source-dir . \
             --signing-key melange.rsa \
             --out-dir packages/ \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -667,12 +667,17 @@ jobs:
           APP_VERSION: ${{ needs.version.outputs.app_version }}
         run: |
           printf 'version: %s\n' "$APP_VERSION" > /tmp/melange-vars.yaml
-          melange build docker/web/melange.yaml \
-            --arch x86_64,aarch64 \
-            --source-dir . \
-            --signing-key melange.rsa \
-            --out-dir packages/ \
-            --vars-file /tmp/melange-vars.yaml
+          # Build arches sequentially -- melange v0.49.0 bubblewrap
+          # runner has a bind-mount race when building multiple arches
+          # in parallel, causing web/dist/ to be invisible in one guest.
+          for arch in x86_64 aarch64; do
+            melange build docker/web/melange.yaml \
+              --arch "$arch" \
+              --source-dir . \
+              --signing-key melange.rsa \
+              --out-dir packages/ \
+              --vars-file /tmp/melange-vars.yaml
+          done
 
       - name: Upload packages artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -743,7 +743,7 @@ jobs:
       - name: Trivy scan
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
-          input: web.tar
+          image-ref: ${{ steps.scan-ref.outputs.ref }}
           format: json
           output: trivy-web.json
           exit-code: "0"

--- a/docs/design/engine.md
+++ b/docs/design/engine.md
@@ -116,6 +116,7 @@ task:
   parent_task_id: null           # parent task ID when created via delegation
   delegation_chain: []           # ordered agent IDs of delegators (root first)
   middleware_override: null       # per-task middleware chain override (null = company default)
+  metadata: {}                    # arbitrary key-value metadata (pipeline tracking, labels)
 ```
 
 `task_structure` and `coordination_topology` are described in
@@ -1238,6 +1239,26 @@ Strategies that only have an error string (`FailAndReassignStrategy`, `Checkpoin
     progress and adapt.  Richer reconciliation (e.g. workspace change
     detection) is planned for a future iteration.
 
+=== "Lightweight Alternative: Session Replay"
+
+    `Session.replay()` (`engine/session.py`) provides a lighter-weight
+    alternative to full checkpoint/resume.  It reconstructs `AgentContext`
+    from the observability event log rather than from a persisted checkpoint
+    snapshot.
+
+    - **Read-only reconstruction**: replays turn count, accumulated cost, and
+      task status -- but not full conversation history (events do not store
+      message content).
+    - **No persistence dependency**: relies on whichever observability sink
+      the operator configured (structlog file, OTLP backend, Postgres).
+    - **Best-effort**: `ReplayResult.replay_completeness` (0.0--1.0) indicates
+      how much state was recovered.
+    - **Use case**: recovery after brain failure when checkpoint persistence
+      is not configured or the checkpoint is stale.
+
+    See [Brain / Hands / Session](#brain--hands--session) for the full
+    architecture.
+
 ---
 
 ## Graceful Shutdown Protocol
@@ -1758,6 +1779,38 @@ Per-task: `Task.middleware_override` replaces the company-level chain when set.
 ### Error Semantics
 
 Middleware exceptions propagate to the classification pipeline. `ClassificationResult.action` decides: retry, escalate, or fail. No silent swallowing.
+
+---
+
+## Brain / Hands / Session
+
+*Vocabulary adopted from the [Anthropic managed-agents engineering post](https://www.anthropic.com/engineering/managed-agents).  See also: #1261.*
+
+The engine's architecture maps onto three decoupled planes.  Each plane has a distinct responsibility, failure mode, and persistence story.
+
+| Plane | SynthOrg Modules | Purpose |
+|-------|-----------------|---------|
+| **Brain** | `engine/harness.py`, `AgentContext`, loop protocol (`ReactLoop`, `PlanExecuteLoop`, `HybridLoop`) | Inference loop, middleware, decision-making.  Stateless between turns -- all state lives in the immutable `AgentContext`. |
+| **Hands** | `ToolInvoker`, `tools/sandbox/`, `SandboxCredentialManager`, auth proxy | Tool execution, side effects, credential scope.  Credentials flow exclusively through the sandbox credential proxy -- never through the agent context or turn records. |
+| **Session** | `observability/events/`, `engine/session.py` (`Session.replay`), checkpoint/resume | Durable event history, replay, audit.  Every significant action emits a structured event; the event stream is the session's source of truth. |
+
+### Resilience Property
+
+The brain can fail (crash, OOM, timeout) without losing session state.  Because every turn emits structured events (`execution.context.turn`, `execution.task.transition`, etc.) to the configured observability sinks, a new brain instance can reconstruct the execution context via `Session.replay(execution_id)`.
+
+`Session.replay()` walks the event log for a given execution and reconstructs `AgentContext` (turn count, accumulated cost, task status).  It is a **best-effort** read-only reconstruction -- conversation message content is not stored in events, so the replayed context has synthetic placeholder messages.  The `ReplayResult.replay_completeness` field (0.0--1.0) indicates how much state was recovered, scored by event coverage (engine start, context creation, turn contiguity, cost data, task transitions).
+
+This is lighter-weight than full checkpoint/resume (`checkpoint/resume.py`), which persists complete `AgentContext` snapshots and supports mid-execution suspend/resume with full message history.  Use session replay for recovery after brain failure; use checkpoint/resume for deliberate pause/resume of long-running tasks.
+
+### Credential Isolation Boundary
+
+Credentials never enter the brain or session planes.  Three enforcement points:
+
+1. **Task metadata validator** (`engine/_validation.py::validate_task_metadata`) -- rejects `Task.metadata` keys matching credential patterns (token, secret, api_key, password, bearer) at the engine input boundary before execution starts.
+2. **Sandbox credential manager** (`tools/sandbox/credential_manager.py`) -- strips credential-like environment variables before they enter sandbox containers.
+3. **Auth proxy** (`tools/sandbox/auth_proxy.py`) -- injects authentication headers at tool execution time via a local HTTP proxy, so credentials never transit through the agent context.
+
+See also: [Operations > Security > Credential Isolation Boundary](operations.md#credential-isolation-boundary).
 
 ---
 

--- a/docs/design/engine.md
+++ b/docs/design/engine.md
@@ -1790,7 +1790,7 @@ The engine's architecture maps onto three decoupled planes.  Each plane has a di
 
 | Plane | SynthOrg Modules | Purpose |
 |-------|-----------------|---------|
-| **Brain** | `engine/harness.py`, `AgentContext`, loop protocol (`ReactLoop`, `PlanExecuteLoop`, `HybridLoop`) | Inference loop, middleware, decision-making.  Stateless between turns -- all state lives in the immutable `AgentContext`. |
+| **Brain** | `engine/agent_engine.py`, `AgentContext`, loop protocol (`ReactLoop`, `PlanExecuteLoop`, `HybridLoop`) | Inference loop, middleware, decision-making.  Stateless between turns -- all state lives in the immutable `AgentContext`. |
 | **Hands** | `ToolInvoker`, `tools/sandbox/`, `SandboxCredentialManager`, auth proxy | Tool execution, side effects, credential scope.  Credentials flow exclusively through the sandbox credential proxy -- never through the agent context or turn records. |
 | **Session** | `observability/events/`, `engine/session.py` (`Session.replay`), checkpoint/resume | Durable event history, replay, audit.  Every significant action emits a structured event; the event stream is the session's source of truth. |
 

--- a/docs/design/engine.md
+++ b/docs/design/engine.md
@@ -1246,9 +1246,10 @@ Strategies that only have an error string (`FailAndReassignStrategy`, `Checkpoin
     from the observability event log rather than from a persisted checkpoint
     snapshot.
 
-    - **Read-only reconstruction**: replays turn count, accumulated cost, and
-      task status -- but not full conversation history (events do not store
-      message content).
+    - **Read-only reconstruction**: replays turn count, accumulated cost,
+      and task status transitions -- but not full conversation history
+      (events do not store message content; turns are represented as
+      placeholder messages).
     - **No persistence dependency**: relies on whichever observability sink
       the operator configured (structlog file, OTLP backend, Postgres).
     - **Best-effort**: `ReplayResult.replay_completeness` (0.0--1.0) indicates

--- a/docs/design/operations.md
+++ b/docs/design/operations.md
@@ -1145,7 +1145,7 @@ Credentials flow exclusively through the **hands** plane (tool execution) via th
 
 Three enforcement points maintain this boundary:
 
-1. **Task metadata validator** -- `engine/_validation.py::validate_task_metadata()` runs at the engine input boundary before execution begins.  It rejects any `Task.metadata` key matching credential patterns (`token`, `secret`, `api_key`, `password`, `bearer`) with an `EXECUTION_CREDENTIAL_ISOLATION_VIOLATION` error event (`execution.credential_isolation.violation`) and raises `ExecutionStateError`.
+1. **Task metadata validator** -- `engine/_validation.py::validate_task_metadata()` runs at the engine input boundary before execution begins.  It recursively scans all dict keys in `Task.metadata` (including nested dicts and dicts inside lists), rejecting any key matching credential patterns (`token`, `secret`, `api_key`, `password`, `bearer`) with an `EXECUTION_CREDENTIAL_ISOLATION_VIOLATION` error event (`execution.credential_isolation.violation`) and raises `ExecutionStateError`.
 2. **Sandbox credential manager** -- `tools/sandbox/credential_manager.py::SandboxCredentialManager` strips 14 credential-like patterns from environment variable overrides before they enter sandbox containers.  Stripped keys are logged via `SANDBOX_CREDENTIAL_STRIPPED`.
 3. **Auth proxy (planned)** -- `tools/sandbox/auth_proxy.py::SandboxAuthProxy` is the planned enforcement point for outbound header injection.  Once implemented, it will intercept outgoing HTTP requests from sandbox containers and inject authentication headers from SynthOrg's provider store at execution time, so credentials never enter the container.
 

--- a/docs/design/operations.md
+++ b/docs/design/operations.md
@@ -1145,9 +1145,9 @@ Credentials flow exclusively through the **hands** plane (tool execution) via th
 
 Three enforcement points maintain this boundary:
 
-1. **Task metadata validator** -- `engine/_validation.py::validate_task_metadata()` runs at the engine input boundary before execution begins.  It rejects any `Task.metadata` key matching credential patterns (`token`, `secret`, `api_key`, `password`, `bearer`) with a `CREDENTIAL_ISOLATION_VIOLATION` error event and raises `ExecutionStateError`.
+1. **Task metadata validator** -- `engine/_validation.py::validate_task_metadata()` runs at the engine input boundary before execution begins.  It rejects any `Task.metadata` key matching credential patterns (`token`, `secret`, `api_key`, `password`, `bearer`) with an `EXECUTION_CREDENTIAL_ISOLATION_VIOLATION` error event (`execution.credential_isolation.violation`) and raises `ExecutionStateError`.
 2. **Sandbox credential manager** -- `tools/sandbox/credential_manager.py::SandboxCredentialManager` strips 14 credential-like patterns from environment variable overrides before they enter sandbox containers.  Stripped keys are logged via `SANDBOX_CREDENTIAL_STRIPPED`.
-3. **Auth proxy** -- `tools/sandbox/auth_proxy.py::AuthProxy` (design intent) intercepts outgoing HTTP requests from sandbox containers and injects authentication headers from SynthOrg's provider store at execution time.  Credentials never enter the container.
+3. **Auth proxy (planned)** -- `tools/sandbox/auth_proxy.py::SandboxAuthProxy` is the planned enforcement point for outbound header injection.  Once implemented, it will intercept outgoing HTTP requests from sandbox containers and inject authentication headers from SynthOrg's provider store at execution time, so credentials never enter the container.
 
 See also: [Engine > Brain / Hands / Session](engine.md#brain--hands--session).
 

--- a/docs/design/operations.md
+++ b/docs/design/operations.md
@@ -1139,6 +1139,18 @@ a dedicated append-only store avoids coupling audit integrity to memory
 consolidation heuristics and makes tamper-evident review trivial (any record
 ever written stays written, verbatim).
 
+### Credential Isolation Boundary
+
+Credentials flow exclusively through the **hands** plane (tool execution) via the sandbox credential proxy (`tools/sandbox/`).  They never enter the **brain** plane (`AgentContext`, turn records, conversation history) or the **session** plane (observability events, replay).
+
+Three enforcement points maintain this boundary:
+
+1. **Task metadata validator** -- `engine/_validation.py::validate_task_metadata()` runs at the engine input boundary before execution begins.  It rejects any `Task.metadata` key matching credential patterns (`token`, `secret`, `api_key`, `password`, `bearer`) with a `CREDENTIAL_ISOLATION_VIOLATION` error event and raises `ExecutionStateError`.
+2. **Sandbox credential manager** -- `tools/sandbox/credential_manager.py::SandboxCredentialManager` strips 14 credential-like patterns from environment variable overrides before they enter sandbox containers.  Stripped keys are logged via `SANDBOX_CREDENTIAL_STRIPPED`.
+3. **Auth proxy** -- `tools/sandbox/auth_proxy.py::AuthProxy` (design intent) intercepts outgoing HTTP requests from sandbox containers and injects authentication headers from SynthOrg's provider store at execution time.  Credentials never enter the container.
+
+See also: [Engine > Brain / Hands / Session](engine.md#brain--hands--session).
+
 ### Approval Timeout Policy
 
 When an action requires human approval (per autonomy level), the agent must wait. The

--- a/src/synthorg/core/company.py
+++ b/src/synthorg/core/company.py
@@ -493,6 +493,9 @@ class CompanyConfig(BaseModel):
         communication_pattern: Default communication pattern name.
         tool_access_default: Default tool access for all agents.
         middleware: Agent and coordination middleware configuration.
+        session_replay_on_start: When ``True``, replay the previous
+            session from the event log on agent start (requires an
+            ``EventReader`` and ``resume_execution_id``).
     """
 
     model_config = ConfigDict(frozen=True, allow_inf_nan=False)
@@ -522,6 +525,10 @@ class CompanyConfig(BaseModel):
     middleware: MiddlewareConfig = Field(
         default_factory=MiddlewareConfig,
         description="Agent and coordination middleware configuration",
+    )
+    session_replay_on_start: bool = Field(
+        default=False,
+        description="Replay session from event log on agent start",
     )
 
 

--- a/src/synthorg/core/task.py
+++ b/src/synthorg/core/task.py
@@ -1,5 +1,6 @@
 """Task domain model and acceptance criteria."""
 
+import copy
 from collections import Counter
 from datetime import datetime
 from typing import Any, Self
@@ -79,6 +80,9 @@ class Task(BaseModel):
             execution (defaults to ``AUTO``).
         middleware_override: Per-task middleware chain override
             (``None`` uses company default chain).
+        metadata: Arbitrary key-value metadata for pipeline tracking,
+            labels, and operator-defined context.  Deep-copied at
+            construction to prevent external mutation.
     """
 
     model_config = ConfigDict(frozen=True, allow_inf_nan=False)
@@ -165,6 +169,16 @@ class Task(BaseModel):
         default=None,
         description=("Per-task middleware chain override (None = use company default)"),
     )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Arbitrary key-value metadata for pipeline tracking and labels",
+    )
+
+    @model_validator(mode="after")
+    def _deepcopy_metadata(self) -> Self:
+        """Defensive copy so callers cannot mutate the frozen model."""
+        object.__setattr__(self, "metadata", copy.deepcopy(self.metadata))
+        return self
 
     @model_validator(mode="after")
     def _validate_deadline_format(self) -> Self:

--- a/src/synthorg/engine/_validation.py
+++ b/src/synthorg/engine/_validation.py
@@ -4,12 +4,14 @@ Pure validation functions extracted from :mod:`agent_engine` to keep
 the main orchestrator under the 800-line limit.
 """
 
-from typing import TYPE_CHECKING
+import re
+from typing import TYPE_CHECKING, Final
 
 from synthorg.core.enums import AgentStatus, TaskStatus
 from synthorg.engine.errors import ExecutionStateError
 from synthorg.observability import get_logger
 from synthorg.observability.events.execution import (
+    EXECUTION_CREDENTIAL_ISOLATION_VIOLATION,
     EXECUTION_ENGINE_INVALID_INPUT,
 )
 
@@ -18,6 +20,14 @@ if TYPE_CHECKING:
     from synthorg.core.task import Task
 
 logger = get_logger(__name__)
+
+_CREDENTIAL_KEY_PATTERNS: Final[tuple[re.Pattern[str], ...]] = (
+    re.compile(r"(?i)token"),
+    re.compile(r"(?i)secret"),
+    re.compile(r"(?i)api[_-]?key"),
+    re.compile(r"(?i)password"),
+    re.compile(r"(?i)bearer"),
+)
 
 _EXECUTABLE_STATUSES = frozenset(
     {TaskStatus.ASSIGNED, TaskStatus.IN_PROGRESS},
@@ -28,6 +38,47 @@ CREATED tasks lack an assignee; terminal statuses (COMPLETED, CANCELLED),
 BLOCKED, IN_REVIEW, FAILED, and INTERRUPTED are not executable.  FAILED
 and INTERRUPTED tasks must be reassigned (-> ASSIGNED) before re-execution.
 """
+
+
+def validate_task_metadata(
+    task: Task,
+    agent_id: str,
+    task_id: str,
+) -> None:
+    """Reject task metadata keys that match credential patterns.
+
+    Credentials must flow exclusively through the sandbox credential
+    proxy, never through task metadata into the agent context.
+
+    Args:
+        task: The task to validate.
+        agent_id: Agent identifier for logging.
+        task_id: Task identifier for logging.
+
+    Raises:
+        ExecutionStateError: If any metadata key matches a credential
+            pattern.
+    """
+    if not task.metadata:
+        return
+    violations = sorted(
+        key
+        for key in task.metadata
+        if any(p.search(key) for p in _CREDENTIAL_KEY_PATTERNS)
+    )
+    if violations:
+        msg = (
+            f"Task {task_id!r} metadata contains credential-like keys: "
+            f"{violations}; credentials must flow through the sandbox "
+            f"credential proxy, not task metadata"
+        )
+        logger.error(
+            EXECUTION_CREDENTIAL_ISOLATION_VIOLATION,
+            agent_id=agent_id,
+            task_id=task_id,
+            violating_keys=violations,
+        )
+        raise ExecutionStateError(msg)
 
 
 def validate_run_inputs(

--- a/src/synthorg/engine/_validation.py
+++ b/src/synthorg/engine/_validation.py
@@ -40,6 +40,29 @@ and INTERRUPTED tasks must be reassigned (-> ASSIGNED) before re-execution.
 """
 
 
+def _collect_credential_keys(
+    data: object,
+    prefix: str,
+    violations: list[str],
+) -> None:
+    """Recursively scan dict keys for credential patterns."""
+    if isinstance(data, dict):
+        for key in data:
+            if not isinstance(key, str):
+                continue
+            path = f"{prefix}.{key}" if prefix else key
+            if any(p.search(key) for p in _CREDENTIAL_KEY_PATTERNS):
+                violations.append(path)
+            _collect_credential_keys(data[key], path, violations)
+    elif isinstance(data, list | tuple):
+        for i, item in enumerate(data):
+            _collect_credential_keys(
+                item,
+                f"{prefix}[{i}]",
+                violations,
+            )
+
+
 def validate_task_metadata(
     task: Task,
     agent_id: str,
@@ -47,8 +70,9 @@ def validate_task_metadata(
 ) -> None:
     """Reject task metadata keys that match credential patterns.
 
-    Credentials must flow exclusively through the sandbox credential
-    proxy, never through task metadata into the agent context.
+    Recursively scans all dict keys in ``task.metadata`` (including
+    nested dicts and dicts inside lists) so credentials cannot hide
+    inside nested structures.
 
     Args:
         task: The task to validate.
@@ -61,11 +85,9 @@ def validate_task_metadata(
     """
     if not task.metadata:
         return
-    violations = sorted(
-        key
-        for key in task.metadata
-        if any(p.search(key) for p in _CREDENTIAL_KEY_PATTERNS)
-    )
+    violations: list[str] = []
+    _collect_credential_keys(task.metadata, "", violations)
+    violations.sort()
     if violations:
         msg = (
             f"Task {task_id!r} metadata contains credential-like keys: "

--- a/src/synthorg/engine/agent_engine.py
+++ b/src/synthorg/engine/agent_engine.py
@@ -23,6 +23,7 @@ from synthorg.engine._validation import (
     validate_agent,
     validate_run_inputs,
     validate_task,
+    validate_task_metadata,
 )
 from synthorg.engine.approval_gate import ApprovalGate
 from synthorg.engine.checkpoint.models import CheckpointConfig
@@ -101,6 +102,9 @@ from synthorg.observability.events.prompt import (
     PROMPT_PERSONALITY_TRIMMED,
     PROMPT_TOKEN_RATIO_HIGH,
 )
+from synthorg.observability.events.session import (
+    SESSION_REPLAY_LOW_COMPLETENESS,
+)
 from synthorg.providers.enums import MessageRole
 from synthorg.providers.errors import DriverNotRegisteredError
 from synthorg.providers.models import ChatMessage
@@ -137,6 +141,7 @@ if TYPE_CHECKING:
     )
     from synthorg.engine.middleware.protocol import AgentMiddlewareChain
     from synthorg.engine.plan_models import PlanExecuteConfig
+    from synthorg.engine.session import EventReader
     from synthorg.engine.stagnation.protocol import StagnationDetector
     from synthorg.engine.task_engine import TaskEngine
     from synthorg.memory.injection import MemoryInjectionStrategy
@@ -166,6 +171,9 @@ logger = get_logger(__name__)
 
 _PROMPT_TOKEN_RATIO_THRESHOLD: float = 0.3
 """Prompt-to-total token ratio above which a warning is emitted."""
+
+_REPLAY_LOW_COMPLETENESS_THRESHOLD: float = 0.5
+"""Log a warning when session replay completeness is below this."""
 
 _DEFAULT_RECOVERY_STRATEGY = FailAndReassignStrategy()
 
@@ -315,6 +323,10 @@ class AgentEngine:
         audit_log: Optional audit log for recording security
             evaluations and tool invocation verdicts.  When ``None``,
             a fresh :class:`AuditLog` is created internally.
+        event_reader: Optional event reader for session replay.
+            When provided alongside ``resume_execution_id`` in
+            :meth:`run`, enables stateless recovery from a crashed
+            execution via :meth:`Session.replay`.
     """
 
     def __init__(  # noqa: PLR0913, PLR0915
@@ -356,8 +368,10 @@ class AgentEngine:
         audit_log: AuditLog | None = None,
         project_repo: ProjectRepository | None = None,
         agent_middleware_chain: AgentMiddlewareChain | None = None,
+        event_reader: EventReader | None = None,
     ) -> None:
         self._agent_middleware_chain = agent_middleware_chain
+        self._event_reader = event_reader
         if execution_loop is not None and auto_loop_config is not None:
             msg = "execution_loop and auto_loop_config are mutually exclusive"
             logger.warning(
@@ -496,7 +510,7 @@ class AgentEngine:
             raise ExecutionStateError(msg)
         return await self._coordinator.coordinate(context)
 
-    async def run(  # noqa: PLR0913
+    async def run(  # noqa: PLR0913, C901
         self,
         *,
         identity: AgentIdentity,
@@ -506,6 +520,7 @@ class AgentEngine:
         memory_messages: tuple[ChatMessage, ...] = (),
         timeout_seconds: float | None = None,
         effective_autonomy: EffectiveAutonomy | None = None,
+        resume_execution_id: str | None = None,
     ) -> AgentRunResult:
         """Execute an agent on a task.
 
@@ -526,6 +541,7 @@ class AgentEngine:
         )
         validate_agent(identity, agent_id)
         validate_task(task, agent_id, task_id)
+        validate_task_metadata(task, agent_id, task_id)
 
         with correlation_scope(agent_id=agent_id, task_id=task_id):
             start = time.monotonic()
@@ -578,6 +594,30 @@ class AgentEngine:
                         reason="project_repo_not_configured",
                     )
 
+                # Session replay: reconstruct context from event log
+                # when resuming a previous (crashed) execution.
+                replay_ctx: AgentContext | None = None
+                if resume_execution_id is not None and self._event_reader is not None:
+                    from synthorg.engine.session import Session  # noqa: PLC0415
+
+                    replay_result = await Session.replay(
+                        execution_id=resume_execution_id,
+                        event_reader=self._event_reader,
+                        identity=identity,
+                        task=task,
+                        max_turns=max_turns,
+                    )
+                    if (
+                        replay_result.replay_completeness
+                        < _REPLAY_LOW_COMPLETENESS_THRESHOLD
+                    ):
+                        logger.warning(
+                            SESSION_REPLAY_LOW_COMPLETENESS,
+                            execution_id=resume_execution_id,
+                            replay_completeness=replay_result.replay_completeness,
+                        )
+                    replay_ctx = replay_result.context
+
                 tool_invoker = self._make_tool_invoker(
                     identity,
                     task_id=task_id,
@@ -593,6 +633,8 @@ class AgentEngine:
                     tool_invoker=tool_invoker,
                     effective_autonomy=effective_autonomy,
                 )
+                if replay_ctx is not None:
+                    ctx = replay_ctx
                 return await self._execute(
                     identity=identity,
                     task=task,

--- a/src/synthorg/engine/agent_engine.py
+++ b/src/synthorg/engine/agent_engine.py
@@ -640,9 +640,12 @@ class AgentEngine:
                 if replay_ctx is not None:
                     # Merge replayed execution state into the prepared
                     # context so system prompt, memory messages, and
-                    # task instruction are preserved.
+                    # task instruction are preserved.  Also restore
+                    # the original execution lineage (ID + start time).
                     ctx = ctx.model_copy(
                         update={
+                            "execution_id": replay_ctx.execution_id,
+                            "started_at": replay_ctx.started_at,
                             "conversation": (
                                 *ctx.conversation,
                                 *replay_ctx.conversation,

--- a/src/synthorg/engine/agent_engine.py
+++ b/src/synthorg/engine/agent_engine.py
@@ -596,12 +596,12 @@ class AgentEngine:
 
                 # Session replay: reconstruct context from event log
                 # when resuming a previous (crashed) execution.
+                # NOTE: CompanyConfig.session_replay_on_start gates this
+                # at the middleware layer (Issue A). The engine trusts
+                # that the caller only passes resume_execution_id when
+                # the flag is enabled.
                 replay_ctx: AgentContext | None = None
-                if (
-                    identity.company_config.session_replay_on_start
-                    and resume_execution_id is not None
-                    and self._event_reader is not None
-                ):
+                if resume_execution_id is not None and self._event_reader is not None:
                     from synthorg.engine.session import Session  # noqa: PLC0415
 
                     replay_result = await Session.replay(

--- a/src/synthorg/engine/agent_engine.py
+++ b/src/synthorg/engine/agent_engine.py
@@ -597,7 +597,11 @@ class AgentEngine:
                 # Session replay: reconstruct context from event log
                 # when resuming a previous (crashed) execution.
                 replay_ctx: AgentContext | None = None
-                if resume_execution_id is not None and self._event_reader is not None:
+                if (
+                    identity.company_config.session_replay_on_start
+                    and resume_execution_id is not None
+                    and self._event_reader is not None
+                ):
                     from synthorg.engine.session import Session  # noqa: PLC0415
 
                     replay_result = await Session.replay(
@@ -634,7 +638,22 @@ class AgentEngine:
                     effective_autonomy=effective_autonomy,
                 )
                 if replay_ctx is not None:
-                    ctx = replay_ctx
+                    # Merge replayed execution state into the prepared
+                    # context so system prompt, memory messages, and
+                    # task instruction are preserved.
+                    ctx = ctx.model_copy(
+                        update={
+                            "conversation": (
+                                *ctx.conversation,
+                                *replay_ctx.conversation,
+                            ),
+                            "accumulated_cost": replay_ctx.accumulated_cost,
+                            "turn_count": replay_ctx.turn_count,
+                            "task_execution": (
+                                replay_ctx.task_execution or ctx.task_execution
+                            ),
+                        },
+                    )
                 return await self._execute(
                     identity=identity,
                     task=task,

--- a/src/synthorg/engine/session.py
+++ b/src/synthorg/engine/session.py
@@ -77,7 +77,7 @@ class SessionEvent(BaseModel):
     )
 
     @model_validator(mode="after")
-    def _deepcopy_data(self) -> SessionEvent:
+    def _deepcopy_data(self) -> Self:
         """Defensive copy so callers cannot mutate the frozen model."""
         object.__setattr__(self, "data", copy.deepcopy(self.data))
         return self

--- a/src/synthorg/engine/session.py
+++ b/src/synthorg/engine/session.py
@@ -196,7 +196,19 @@ class Session:
             )
             raise
 
-        if not events:
+        # Filter out events that don't belong to this execution
+        # (defense-in-depth against buggy EventReader implementations).
+        valid_events = tuple(e for e in events if e.execution_id == execution_id)
+        if len(valid_events) < len(events):
+            logger.warning(
+                SESSION_REPLAY_ERROR,
+                execution_id=execution_id,
+                reason="event_reader returned events for other executions",
+                expected=len(events),
+                kept=len(valid_events),
+            )
+
+        if not valid_events:
             logger.info(
                 SESSION_REPLAY_NO_EVENTS,
                 execution_id=execution_id,
@@ -206,7 +218,6 @@ class Session:
                 task=task,
                 max_turns=max_turns,
             )
-            # Preserve original execution lineage even with no events.
             ctx = ctx.model_copy(update={"execution_id": execution_id})
             return ReplayResult(
                 context=ctx,
@@ -215,7 +226,7 @@ class Session:
                 events_total=0,
             )
 
-        sorted_events = sorted(events, key=lambda e: e.timestamp)
+        sorted_events = sorted(valid_events, key=lambda e: e.timestamp)
         return _replay_from_events(
             sorted_events=sorted_events,
             identity=identity,
@@ -312,6 +323,7 @@ def _replay_from_events(
     # Tracking for completeness scoring.
     found_engine_start = False
     found_context_created = False
+    seen_turns: set[int] = set()
     turn_numbers: list[int] = []
     total_cost = 0.0
     found_transition = False
@@ -329,7 +341,12 @@ def _replay_from_events(
                 found_context_created = True
 
             elif name == EXECUTION_CONTEXT_TURN:
+                # Parse turn number before applying to skip duplicates.
+                raw_turn = event.data.get("turn")
+                if raw_turn is not None and int(raw_turn) in seen_turns:
+                    continue
                 ctx, turn, cost_usd = _apply_turn_event(ctx, event)
+                seen_turns.add(turn)
                 turn_numbers.append(turn)
                 total_cost += cost_usd
 

--- a/src/synthorg/engine/session.py
+++ b/src/synthorg/engine/session.py
@@ -1,0 +1,342 @@
+"""Stateless session replay from observability event log.
+
+Reconstructs an ``AgentContext`` from the structured event stream
+recorded during a previous execution.  This is a lighter-weight
+alternative to full checkpoint/resume: read-only reconstruction
+that enables brain-failure recovery without persistence dependencies.
+
+Terminology follows the Anthropic managed-agents engineering post:
+
+- **Brain**: inference loop (``harness.py``, ``AgentContext``, loop protocol)
+- **Hands**: tool execution (``ToolInvoker``, ``tools/sandbox/``, credential proxy)
+- **Session**: durable event history (``observability/events/``, replay)
+"""
+
+import copy
+from typing import Any, Protocol, runtime_checkable
+
+from pydantic import (
+    AwareDatetime,
+    BaseModel,
+    ConfigDict,
+    Field,
+    model_validator,
+)
+
+from synthorg.core.agent import AgentIdentity  # noqa: TC001
+from synthorg.core.task import Task  # noqa: TC001
+from synthorg.core.types import NotBlankStr  # noqa: TC001
+from synthorg.engine.context import DEFAULT_MAX_TURNS, AgentContext
+from synthorg.observability import get_logger
+from synthorg.observability.events.execution import (
+    EXECUTION_CONTEXT_CREATED,
+    EXECUTION_CONTEXT_TURN,
+    EXECUTION_ENGINE_START,
+    EXECUTION_TASK_TRANSITION,
+)
+from synthorg.observability.events.session import (
+    SESSION_REPLAY_COMPLETE,
+    SESSION_REPLAY_ERROR,
+    SESSION_REPLAY_NO_EVENTS,
+    SESSION_REPLAY_PARTIAL,
+    SESSION_REPLAY_START,
+)
+from synthorg.providers.enums import MessageRole
+from synthorg.providers.models import ChatMessage, TokenUsage
+
+logger = get_logger(__name__)
+
+_COMPLETENESS_THRESHOLD: float = 0.85
+"""Replay completeness at or above which the replay is considered full."""
+
+
+# ── Models ────────────────────────────────────────────────────────
+
+
+class SessionEvent(BaseModel):
+    """A single event from the observability event log.
+
+    Attributes:
+        event_name: Dotted event constant (e.g. ``"execution.context.turn"``).
+        timestamp: When the event was recorded.
+        execution_id: Execution run this event belongs to.
+        data: Structured event payload (deep-copied at construction).
+    """
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False)
+
+    event_name: str = Field(description="Dotted event constant")
+    timestamp: AwareDatetime = Field(description="Event timestamp")
+    execution_id: NotBlankStr = Field(
+        description="Execution run this event belongs to",
+    )
+    data: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Structured event payload",
+    )
+
+    @model_validator(mode="after")
+    def _deepcopy_data(self) -> SessionEvent:
+        """Defensive copy so callers cannot mutate the frozen model."""
+        object.__setattr__(self, "data", copy.deepcopy(self.data))
+        return self
+
+
+class ReplayResult(BaseModel):
+    """Result of a session replay attempt.
+
+    Attributes:
+        context: Reconstructed agent context (may be partial).
+        replay_completeness: Fraction of expected state recovered
+            (0.0 = nothing, 1.0 = everything).
+        events_processed: Number of events consumed during replay.
+        events_total: Total events found for this execution.
+    """
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False)
+
+    context: AgentContext = Field(
+        description="Reconstructed agent context",
+    )
+    replay_completeness: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="Fraction of expected state recovered",
+    )
+    events_processed: int = Field(
+        ge=0,
+        description="Events consumed during replay",
+    )
+    events_total: int = Field(
+        ge=0,
+        description="Total events found for this execution",
+    )
+
+
+# ── Protocol ──────────────────────────────────────────────────────
+
+
+@runtime_checkable
+class EventReader(Protocol):
+    """Read observability events by execution ID.
+
+    Concrete implementations may read from structured log files,
+    OTLP backends, or the Postgres ``observability_events`` table.
+    """
+
+    async def read_events(
+        self,
+        execution_id: str,
+    ) -> tuple[SessionEvent, ...]:
+        """Return events for the given execution, ordered by timestamp."""
+        ...
+
+
+# ── Session replay ────────────────────────────────────────────────
+
+
+class Session:
+    """Stateless session replay from the observability event log.
+
+    Provides ``replay()`` to reconstruct an ``AgentContext`` from
+    the event stream of a previous (possibly crashed) execution.
+    """
+
+    @staticmethod
+    async def replay(
+        *,
+        execution_id: str,
+        event_reader: EventReader,
+        identity: AgentIdentity,
+        task: Task | None = None,
+        max_turns: int = DEFAULT_MAX_TURNS,
+    ) -> ReplayResult:
+        """Reconstruct an ``AgentContext`` from the event log.
+
+        Best-effort: if the event stream is incomplete, returns a
+        partial context with ``replay_completeness < 1.0``.
+
+        Args:
+            execution_id: The execution to replay.
+            event_reader: Source of observability events.
+            identity: Agent identity for the reconstructed context.
+            task: Optional task to bind to the context.
+            max_turns: Maximum turns for the reconstructed context.
+
+        Returns:
+            ``ReplayResult`` with the reconstructed context and
+            completeness score.
+        """
+        logger.info(
+            SESSION_REPLAY_START,
+            execution_id=execution_id,
+            agent_id=str(identity.id),
+        )
+
+        try:
+            events = await event_reader.read_events(execution_id)
+        except Exception:
+            logger.exception(
+                SESSION_REPLAY_ERROR,
+                execution_id=execution_id,
+                reason="failed to read events",
+            )
+            raise
+
+        if not events:
+            logger.info(
+                SESSION_REPLAY_NO_EVENTS,
+                execution_id=execution_id,
+            )
+            ctx = AgentContext.from_identity(
+                identity,
+                task=task,
+                max_turns=max_turns,
+            )
+            return ReplayResult(
+                context=ctx,
+                replay_completeness=0.0,
+                events_processed=0,
+                events_total=0,
+            )
+
+        sorted_events = sorted(events, key=lambda e: e.timestamp)
+        return _replay_from_events(
+            sorted_events=sorted_events,
+            identity=identity,
+            task=task,
+            max_turns=max_turns,
+            execution_id=execution_id,
+        )
+
+
+# ── Internal replay logic ─────────────────────────────────────────
+
+
+def _replay_from_events(
+    *,
+    sorted_events: list[SessionEvent],
+    identity: AgentIdentity,
+    task: Task | None,
+    max_turns: int,
+    execution_id: str,
+) -> ReplayResult:
+    """Walk sorted events and reconstruct AgentContext."""
+    ctx = AgentContext.from_identity(
+        identity,
+        task=task,
+        max_turns=max_turns,
+    )
+
+    # Tracking for completeness scoring.
+    found_engine_start = False
+    found_context_created = False
+    turn_numbers: list[int] = []
+    total_cost = 0.0
+    found_transition = False
+    processed = 0
+
+    for event in sorted_events:
+        try:
+            processed += 1
+            name = event.event_name
+
+            if name == EXECUTION_ENGINE_START:
+                found_engine_start = True
+
+            elif name == EXECUTION_CONTEXT_CREATED:
+                found_context_created = True
+
+            elif name == EXECUTION_CONTEXT_TURN:
+                turn = event.data.get("turn", 0)
+                cost_usd = float(event.data.get("cost_usd", 0.0))
+                turn_numbers.append(int(turn))
+                total_cost += cost_usd
+
+                usage = TokenUsage(
+                    input_tokens=0,
+                    output_tokens=0,
+                    cost_usd=cost_usd,
+                )
+                replay_msg = ChatMessage(
+                    role=MessageRole.ASSISTANT,
+                    content=f"[replayed turn {turn}]",
+                )
+                ctx = ctx.with_turn_completed(usage, replay_msg)
+
+            elif name == EXECUTION_TASK_TRANSITION:
+                found_transition = True
+
+        except Exception:
+            logger.warning(
+                SESSION_REPLAY_ERROR,
+                execution_id=execution_id,
+                event_name=event.event_name,
+                reason="failed to process event",
+            )
+
+    completeness = _compute_completeness(
+        found_engine_start=found_engine_start,
+        found_context_created=found_context_created,
+        turn_numbers=turn_numbers,
+        total_cost=total_cost,
+        found_transition=found_transition,
+    )
+
+    event_name = (
+        SESSION_REPLAY_COMPLETE
+        if completeness >= _COMPLETENESS_THRESHOLD
+        else SESSION_REPLAY_PARTIAL
+    )
+    logger.info(
+        event_name,
+        execution_id=execution_id,
+        replay_completeness=completeness,
+        turns_replayed=len(turn_numbers),
+        events_processed=processed,
+    )
+
+    return ReplayResult(
+        context=ctx,
+        replay_completeness=completeness,
+        events_processed=processed,
+        events_total=len(sorted_events),
+    )
+
+
+def _compute_completeness(
+    *,
+    found_engine_start: bool,
+    found_context_created: bool,
+    turn_numbers: list[int],
+    total_cost: float,
+    found_transition: bool,
+) -> float:
+    """Compute replay completeness as a weighted score.
+
+    Weights:
+        Engine start event:          0.15
+        Context created event:       0.10
+        At least one turn event:     0.20
+        Contiguous turn sequence:    0.25
+        Cost data in turn events:    0.15
+        Task transition events:      0.15
+    """
+    score = 0.0
+
+    if found_engine_start:
+        score += 0.15
+    if found_context_created:
+        score += 0.10
+    if turn_numbers:
+        score += 0.20
+        # Check contiguity: turns should be 1, 2, 3, ...
+        expected = list(range(1, len(turn_numbers) + 1))
+        if sorted(turn_numbers) == expected:
+            score += 0.25
+    if total_cost > 0.0:
+        score += 0.15
+    if found_transition:
+        score += 0.15
+
+    return min(score, 1.0)

--- a/src/synthorg/engine/session.py
+++ b/src/synthorg/engine/session.py
@@ -7,13 +7,13 @@ that enables brain-failure recovery without persistence dependencies.
 
 Terminology follows the Anthropic managed-agents engineering post:
 
-- **Brain**: inference loop (``harness.py``, ``AgentContext``, loop protocol)
+- **Brain**: inference loop (``agent_engine.py``, ``AgentContext``, loop protocol)
 - **Hands**: tool execution (``ToolInvoker``, ``tools/sandbox/``, credential proxy)
 - **Session**: durable event history (``observability/events/``, replay)
 """
 
 import copy
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol, Self, runtime_checkable
 
 from pydantic import (
     AwareDatetime,
@@ -65,7 +65,7 @@ class SessionEvent(BaseModel):
 
     model_config = ConfigDict(frozen=True, allow_inf_nan=False)
 
-    event_name: str = Field(description="Dotted event constant")
+    event_name: NotBlankStr = Field(description="Dotted event constant")
     timestamp: AwareDatetime = Field(description="Event timestamp")
     execution_id: NotBlankStr = Field(
         description="Execution run this event belongs to",
@@ -111,6 +111,17 @@ class ReplayResult(BaseModel):
         ge=0,
         description="Total events found for this execution",
     )
+
+    @model_validator(mode="after")
+    def _validate_processed_le_total(self) -> Self:
+        """Ensure events_processed does not exceed events_total."""
+        if self.events_processed > self.events_total:
+            msg = (
+                f"events_processed ({self.events_processed}) "
+                f"cannot exceed events_total ({self.events_total})"
+            )
+            raise ValueError(msg)
+        return self
 
 
 # ── Protocol ──────────────────────────────────────────────────────
@@ -175,11 +186,12 @@ class Session:
 
         try:
             events = await event_reader.read_events(execution_id)
-        except Exception:
+        except Exception as exc:
             logger.exception(
                 SESSION_REPLAY_ERROR,
                 execution_id=execution_id,
-                reason="failed to read events",
+                reason="failed to read events from event_reader",
+                error_type=type(exc).__name__,
             )
             raise
 
@@ -267,12 +279,23 @@ def _replay_from_events(
             elif name == EXECUTION_TASK_TRANSITION:
                 found_transition = True
 
-        except Exception:
+        except MemoryError, RecursionError:
+            raise
+        except (ValueError, TypeError, KeyError) as exc:
             logger.warning(
                 SESSION_REPLAY_ERROR,
                 execution_id=execution_id,
                 event_name=event.event_name,
-                reason="failed to process event",
+                reason="malformed event data",
+                error_type=type(exc).__name__,
+                error=str(exc),
+            )
+        except Exception:
+            logger.exception(
+                SESSION_REPLAY_ERROR,
+                execution_id=execution_id,
+                event_name=event.event_name,
+                reason="unexpected error processing event",
             )
 
     completeness = _compute_completeness(
@@ -312,15 +335,16 @@ def _compute_completeness(
     total_cost: float,
     found_transition: bool,
 ) -> float:
-    """Compute replay completeness as a weighted score.
+    """Compute replay completeness as a weighted additive score.
 
-    Weights:
-        Engine start event:          0.15
-        Context created event:       0.10
-        At least one turn event:     0.20
-        Contiguous turn sequence:    0.25
-        Cost data in turn events:    0.15
-        Task transition events:      0.15
+    Each condition contributes independently (capped at 1.0):
+
+        Engine start event:          +0.15
+        Context created event:       +0.10
+        At least one turn event:     +0.20
+        Contiguous turn sequence:    +0.25 (bonus on top of turn)
+        Cost data in turn events:    +0.15
+        Task transition events:      +0.15
     """
     score = 0.0
 

--- a/src/synthorg/engine/session.py
+++ b/src/synthorg/engine/session.py
@@ -5,7 +5,7 @@ recorded during a previous execution.  This is a lighter-weight
 alternative to full checkpoint/resume: read-only reconstruction
 that enables brain-failure recovery without persistence dependencies.
 
-Terminology follows the Anthropic managed-agents engineering post:
+Terminology follows the managed-agents engineering pattern:
 
 - **Brain**: inference loop (``agent_engine.py``, ``AgentContext``, loop protocol)
 - **Hands**: tool execution (``ToolInvoker``, ``tools/sandbox/``, credential proxy)
@@ -24,6 +24,7 @@ from pydantic import (
 )
 
 from synthorg.core.agent import AgentIdentity  # noqa: TC001
+from synthorg.core.enums import TaskStatus
 from synthorg.core.task import Task  # noqa: TC001
 from synthorg.core.types import NotBlankStr  # noqa: TC001
 from synthorg.engine.context import DEFAULT_MAX_TURNS, AgentContext
@@ -42,7 +43,7 @@ from synthorg.observability.events.session import (
     SESSION_REPLAY_START,
 )
 from synthorg.providers.enums import MessageRole
-from synthorg.providers.models import ChatMessage, TokenUsage
+from synthorg.providers.models import ChatMessage, TokenUsage, add_token_usage
 
 logger = get_logger(__name__)
 
@@ -205,6 +206,8 @@ class Session:
                 task=task,
                 max_turns=max_turns,
             )
+            # Preserve original execution lineage even with no events.
+            ctx = ctx.model_copy(update={"execution_id": execution_id})
             return ReplayResult(
                 context=ctx,
                 replay_completeness=0.0,
@@ -220,6 +223,64 @@ class Session:
             max_turns=max_turns,
             execution_id=execution_id,
         )
+
+
+# ── Internal replay helpers ───────────────────────────────────────
+
+
+def _apply_turn_event(
+    ctx: AgentContext,
+    event: SessionEvent,
+) -> tuple[AgentContext, int, float]:
+    """Apply a single turn event to the context.
+
+    Returns:
+        Tuple of (updated context, turn number, cost_usd).
+
+    Raises:
+        KeyError: If ``turn`` key is missing.
+        ValueError: If ``turn`` < 1 or non-numeric.
+    """
+    turn = event.data.get("turn")
+    if turn is None:
+        msg = "Missing 'turn' in EXECUTION_CONTEXT_TURN event"
+        raise KeyError(msg)
+    turn = int(turn)
+    if turn < 1:
+        msg = f"Turn number must be >= 1, got {turn}"
+        raise ValueError(msg)
+    cost_usd = float(event.data.get("cost_usd", 0.0))
+
+    usage = TokenUsage(input_tokens=0, output_tokens=0, cost_usd=cost_usd)
+    replay_msg = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        content=f"[replayed turn {turn}]",
+    )
+    updates: dict[str, object] = {
+        "turn_count": ctx.turn_count + 1,
+        "conversation": (*ctx.conversation, replay_msg),
+        "accumulated_cost": add_token_usage(ctx.accumulated_cost, usage),
+    }
+    if ctx.task_execution is not None:
+        updates["task_execution"] = ctx.task_execution.with_cost(usage)
+    return ctx.model_copy(update=updates), turn, cost_usd
+
+
+def _apply_transition_event(
+    ctx: AgentContext,
+    event: SessionEvent,
+) -> AgentContext:
+    """Apply a task-transition event to the context."""
+    target = event.data.get("target_status")
+    if target is not None and ctx.task_execution is not None:
+        ctx = ctx.model_copy(
+            update={
+                "task_execution": ctx.task_execution.model_copy(
+                    update={"status": TaskStatus(str(target))},
+                ),
+            },
+        )
+    return ctx
 
 
 # ── Internal replay logic ─────────────────────────────────────────
@@ -238,6 +299,14 @@ def _replay_from_events(
         identity,
         task=task,
         max_turns=max_turns,
+    )
+    # Preserve original execution lineage and seed started_at from
+    # the earliest event timestamp.
+    ctx = ctx.model_copy(
+        update={
+            "execution_id": execution_id,
+            "started_at": sorted_events[0].timestamp,
+        },
     )
 
     # Tracking for completeness scoring.
@@ -260,24 +329,13 @@ def _replay_from_events(
                 found_context_created = True
 
             elif name == EXECUTION_CONTEXT_TURN:
-                turn = event.data.get("turn", 0)
-                cost_usd = float(event.data.get("cost_usd", 0.0))
-                turn_numbers.append(int(turn))
+                ctx, turn, cost_usd = _apply_turn_event(ctx, event)
+                turn_numbers.append(turn)
                 total_cost += cost_usd
-
-                usage = TokenUsage(
-                    input_tokens=0,
-                    output_tokens=0,
-                    cost_usd=cost_usd,
-                )
-                replay_msg = ChatMessage(
-                    role=MessageRole.ASSISTANT,
-                    content=f"[replayed turn {turn}]",
-                )
-                ctx = ctx.with_turn_completed(usage, replay_msg)
 
             elif name == EXECUTION_TASK_TRANSITION:
                 found_transition = True
+                ctx = _apply_transition_event(ctx, event)
 
         except MemoryError, RecursionError:
             raise
@@ -354,9 +412,11 @@ def _compute_completeness(
         score += 0.10
     if turn_numbers:
         score += 0.20
-        # Check contiguity: turns should be 1, 2, 3, ...
-        expected = list(range(1, len(turn_numbers) + 1))
-        if sorted(turn_numbers) == expected:
+        # Deduplicate before contiguity check so duplicate turn
+        # events (e.g. retransmitted events) don't penalize the score.
+        unique_turns = sorted(set(turn_numbers))
+        expected = list(range(1, len(unique_turns) + 1))
+        if unique_turns == expected:
             score += 0.25
     if total_cost > 0.0:
         score += 0.15

--- a/src/synthorg/observability/events/execution.py
+++ b/src/synthorg/observability/events/execution.py
@@ -110,3 +110,8 @@ EXECUTION_METRICS_UNEXPECTED_TYPE: Final[str] = "execution.metrics.unexpected_ty
 
 # -- Project validation events --
 EXECUTION_PROJECT_VALIDATION_FAILED: Final[str] = "execution.project.validation_failed"
+
+# -- Credential isolation events --
+EXECUTION_CREDENTIAL_ISOLATION_VIOLATION: Final[str] = (
+    "execution.credential_isolation.violation"
+)

--- a/src/synthorg/observability/events/session.py
+++ b/src/synthorg/observability/events/session.py
@@ -1,0 +1,10 @@
+"""Session replay event constants."""
+
+from typing import Final
+
+SESSION_REPLAY_START: Final[str] = "session.replay.start"
+SESSION_REPLAY_COMPLETE: Final[str] = "session.replay.complete"
+SESSION_REPLAY_PARTIAL: Final[str] = "session.replay.partial"
+SESSION_REPLAY_NO_EVENTS: Final[str] = "session.replay.no_events"
+SESSION_REPLAY_ERROR: Final[str] = "session.replay.error"
+SESSION_REPLAY_LOW_COMPLETENESS: Final[str] = "session.replay.low_completeness"

--- a/tests/baselines/unit_timing.json
+++ b/tests/baselines/unit_timing.json
@@ -1,6 +1,6 @@
 {
   "unit_suite_seconds": 95,
-  "test_count": 18809,
+  "test_count": 18828,
   "commit": "9704ab17",
   "measured_at": "2026-04-13",
   "regression_threshold_secs": 10,

--- a/tests/baselines/unit_timing.json
+++ b/tests/baselines/unit_timing.json
@@ -1,7 +1,7 @@
 {
   "unit_suite_seconds": 95,
-  "test_count": 18772,
-  "commit": "ee27b08a",
+  "test_count": 18809,
+  "commit": "9704ab17",
   "measured_at": "2026-04-13",
   "regression_threshold_secs": 10,
   "regression_threshold_ratio": 1.3

--- a/tests/unit/engine/test_credential_isolation.py
+++ b/tests/unit/engine/test_credential_isolation.py
@@ -64,6 +64,20 @@ class TestCredentialIsolationValidator:
             validate_task_metadata(task, agent_id="a1", task_id="t1")
         assert "password" in str(exc_info.value)
 
+    def test_rejects_nested_credential_key(self) -> None:
+        task = _make_task({"config": {"db_password": "leaked"}})
+        with pytest.raises(ExecutionStateError, match="db_password"):
+            validate_task_metadata(task, agent_id="a1", task_id="t1")
+
+    def test_rejects_deeply_nested_credential_key(self) -> None:
+        task = _make_task({"a": {"b": [{"api_key": "leaked"}]}})
+        with pytest.raises(ExecutionStateError, match="api_key"):
+            validate_task_metadata(task, agent_id="a1", task_id="t1")
+
+    def test_accepts_safe_nested_metadata(self) -> None:
+        task = _make_task({"config": {"retries": 3, "timeout": 30}})
+        validate_task_metadata(task, agent_id="a1", task_id="t1")
+
     def test_logs_violation_event(self) -> None:
         task = _make_task({"api_token": "leaked"})
         with (

--- a/tests/unit/engine/test_credential_isolation.py
+++ b/tests/unit/engine/test_credential_isolation.py
@@ -33,34 +33,21 @@ def _make_task(metadata: dict[str, object]) -> Task:
 class TestCredentialIsolationValidator:
     """validate_task_metadata rejects credential-like keys."""
 
-    def test_rejects_token_key(self) -> None:
-        task = _make_task({"api_token": "leaked"})
-        with pytest.raises(ExecutionStateError, match="api_token"):
-            validate_task_metadata(task, agent_id="a1", task_id="t1")
-
-    def test_rejects_secret_key(self) -> None:
-        task = _make_task({"my_secret": "leaked"})
-        with pytest.raises(ExecutionStateError, match="my_secret"):
-            validate_task_metadata(task, agent_id="a1", task_id="t1")
-
-    def test_rejects_api_key(self) -> None:
-        task = _make_task({"API_KEY": "leaked"})
-        with pytest.raises(ExecutionStateError, match="API_KEY"):
-            validate_task_metadata(task, agent_id="a1", task_id="t1")
-
-    def test_rejects_api_key_with_hyphen(self) -> None:
-        task = _make_task({"api-key": "leaked"})
-        with pytest.raises(ExecutionStateError, match="api-key"):
-            validate_task_metadata(task, agent_id="a1", task_id="t1")
-
-    def test_rejects_password_key(self) -> None:
-        task = _make_task({"db_password": "leaked"})
-        with pytest.raises(ExecutionStateError, match="db_password"):
-            validate_task_metadata(task, agent_id="a1", task_id="t1")
-
-    def test_rejects_bearer_key(self) -> None:
-        task = _make_task({"bearer_token": "leaked"})
-        with pytest.raises(ExecutionStateError, match="bearer"):
+    @pytest.mark.parametrize(
+        ("key", "match"),
+        [
+            pytest.param("api_token", "api_token", id="token"),
+            pytest.param("my_secret", "my_secret", id="secret"),
+            pytest.param("API_KEY", "API_KEY", id="api_key"),
+            pytest.param("api-key", "api-key", id="api_key_hyphen"),
+            pytest.param("db_password", "db_password", id="password"),
+            pytest.param("bearer_token", "bearer", id="bearer"),
+            pytest.param("SECRET_VALUE", "SECRET_VALUE", id="case_insensitive"),
+        ],
+    )
+    def test_rejects_credential_key(self, key: str, match: str) -> None:
+        task = _make_task({key: "leaked"})
+        with pytest.raises(ExecutionStateError, match=match):
             validate_task_metadata(task, agent_id="a1", task_id="t1")
 
     def test_accepts_safe_metadata(self) -> None:
@@ -76,11 +63,6 @@ class TestCredentialIsolationValidator:
         with pytest.raises(ExecutionStateError, match="api_token") as exc_info:
             validate_task_metadata(task, agent_id="a1", task_id="t1")
         assert "password" in str(exc_info.value)
-
-    def test_case_insensitive_matching(self) -> None:
-        task = _make_task({"SECRET_VALUE": "leaked"})
-        with pytest.raises(ExecutionStateError, match="SECRET_VALUE"):
-            validate_task_metadata(task, agent_id="a1", task_id="t1")
 
     def test_logs_violation_event(self) -> None:
         task = _make_task({"api_token": "leaked"})

--- a/tests/unit/engine/test_credential_isolation.py
+++ b/tests/unit/engine/test_credential_isolation.py
@@ -1,0 +1,100 @@
+"""Tests for credential isolation boundary enforcement."""
+
+import pytest
+import structlog.testing
+
+from synthorg.core.enums import Complexity, Priority, TaskStatus, TaskType
+from synthorg.core.task import Task
+from synthorg.engine._validation import validate_task_metadata
+from synthorg.engine.errors import ExecutionStateError
+from synthorg.observability.events.execution import (
+    EXECUTION_CREDENTIAL_ISOLATION_VIOLATION,
+)
+
+
+def _make_task(metadata: dict[str, object]) -> Task:
+    """Create a minimal task with the given metadata."""
+    return Task(
+        id="task-cred-001",
+        title="Test task",
+        description="Task for credential isolation testing.",
+        type=TaskType.DEVELOPMENT,
+        priority=Priority.MEDIUM,
+        project="proj-001",
+        created_by="tester",
+        assigned_to="agent-001",
+        status=TaskStatus.ASSIGNED,
+        estimated_complexity=Complexity.SIMPLE,
+        metadata=metadata,
+    )
+
+
+@pytest.mark.unit
+class TestCredentialIsolationValidator:
+    """validate_task_metadata rejects credential-like keys."""
+
+    def test_rejects_token_key(self) -> None:
+        task = _make_task({"api_token": "leaked"})
+        with pytest.raises(ExecutionStateError, match="api_token"):
+            validate_task_metadata(task, agent_id="a1", task_id="t1")
+
+    def test_rejects_secret_key(self) -> None:
+        task = _make_task({"my_secret": "leaked"})
+        with pytest.raises(ExecutionStateError, match="my_secret"):
+            validate_task_metadata(task, agent_id="a1", task_id="t1")
+
+    def test_rejects_api_key(self) -> None:
+        task = _make_task({"API_KEY": "leaked"})
+        with pytest.raises(ExecutionStateError, match="API_KEY"):
+            validate_task_metadata(task, agent_id="a1", task_id="t1")
+
+    def test_rejects_api_key_with_hyphen(self) -> None:
+        task = _make_task({"api-key": "leaked"})
+        with pytest.raises(ExecutionStateError, match="api-key"):
+            validate_task_metadata(task, agent_id="a1", task_id="t1")
+
+    def test_rejects_password_key(self) -> None:
+        task = _make_task({"db_password": "leaked"})
+        with pytest.raises(ExecutionStateError, match="db_password"):
+            validate_task_metadata(task, agent_id="a1", task_id="t1")
+
+    def test_rejects_bearer_key(self) -> None:
+        task = _make_task({"bearer_token": "leaked"})
+        with pytest.raises(ExecutionStateError, match="bearer"):
+            validate_task_metadata(task, agent_id="a1", task_id="t1")
+
+    def test_accepts_safe_metadata(self) -> None:
+        task = _make_task({"priority": "high", "team": "backend"})
+        validate_task_metadata(task, agent_id="a1", task_id="t1")
+
+    def test_accepts_empty_metadata(self) -> None:
+        task = _make_task({})
+        validate_task_metadata(task, agent_id="a1", task_id="t1")
+
+    def test_rejects_multiple_violations(self) -> None:
+        task = _make_task({"api_token": "x", "password": "y"})
+        with pytest.raises(ExecutionStateError, match="api_token") as exc_info:
+            validate_task_metadata(task, agent_id="a1", task_id="t1")
+        assert "password" in str(exc_info.value)
+
+    def test_case_insensitive_matching(self) -> None:
+        task = _make_task({"SECRET_VALUE": "leaked"})
+        with pytest.raises(ExecutionStateError, match="SECRET_VALUE"):
+            validate_task_metadata(task, agent_id="a1", task_id="t1")
+
+    def test_logs_violation_event(self) -> None:
+        task = _make_task({"api_token": "leaked"})
+        with (
+            structlog.testing.capture_logs() as logs,
+            pytest.raises(ExecutionStateError),
+        ):
+            validate_task_metadata(task, agent_id="a1", task_id="t1")
+
+        violation_logs = [
+            log
+            for log in logs
+            if log.get("event") == EXECUTION_CREDENTIAL_ISOLATION_VIOLATION
+        ]
+        assert len(violation_logs) == 1
+        assert violation_logs[0]["agent_id"] == "a1"
+        assert violation_logs[0]["task_id"] == "t1"

--- a/tests/unit/engine/test_credential_schema_audit.py
+++ b/tests/unit/engine/test_credential_schema_audit.py
@@ -1,5 +1,6 @@
 """Schema audit: credential-bearing fields never leak into context models."""
 
+from collections.abc import Mapping
 from typing import Any, get_args, get_origin
 
 import pytest
@@ -112,12 +113,22 @@ class TestCredentialSchemaAudit:
     def test_task_metadata_is_the_extensibility_point(
         self,
     ) -> None:
-        """Task.metadata is the only dict[str, Any] on Task."""
+        """Task.metadata is the only dict/Mapping field on Task."""
+
+        def _is_mapping_type(annotation: Any) -> bool:
+            origin = get_origin(annotation)
+            if origin is not None:
+                if isinstance(origin, type) and issubclass(origin, Mapping):
+                    return True
+                return any(_is_mapping_type(a) for a in get_args(annotation))
+            return isinstance(annotation, type) and issubclass(
+                annotation,
+                Mapping,
+            )
+
         dict_fields = [
-            n
-            for n, f in Task.model_fields.items()
-            if "dict" in str(f.annotation).lower()
+            n for n, f in Task.model_fields.items() if _is_mapping_type(f.annotation)
         ]
         assert dict_fields == ["metadata"], (
-            f"Expected only 'metadata' as dict field, found: {dict_fields}"
+            f"Expected only 'metadata' as mapping field, found: {dict_fields}"
         )

--- a/tests/unit/engine/test_credential_schema_audit.py
+++ b/tests/unit/engine/test_credential_schema_audit.py
@@ -3,6 +3,7 @@
 from typing import Any, get_args, get_origin
 
 import pytest
+from pydantic import BaseModel
 
 from synthorg.core.task import Task
 from synthorg.engine._validation import _CREDENTIAL_KEY_PATTERNS
@@ -38,27 +39,69 @@ def _could_carry_credential(annotation: Any) -> bool:
     )
 
 
+def _check_model_recursive(
+    model_cls: type[BaseModel],
+    path: str,
+    visited: set[type],
+    violations: list[str],
+) -> None:
+    """Recursively check a Pydantic model for credential-bearing fields."""
+    if model_cls in visited:
+        return
+    visited.add(model_cls)
+
+    for name, info in model_cls.model_fields.items():
+        field_path = f"{path}.{name}"
+        annotation = info.annotation
+
+        # Check the field name itself against credential patterns.
+        if _could_carry_credential(annotation) and _matches_credential_pattern(
+            name,
+        ):
+            violations.append(
+                f"{field_path} (type={annotation}) matches a credential pattern",
+            )
+
+        # Recurse into nested BaseModel subclasses.
+        origin = get_origin(annotation)
+        targets: list[Any] = []
+        if origin is not None:
+            targets.extend(get_args(annotation))
+        else:
+            targets.append(annotation)
+
+        for target in targets:
+            if (
+                isinstance(target, type)
+                and issubclass(target, BaseModel)
+                and target not in visited
+            ):
+                _check_model_recursive(target, field_path, visited, violations)
+
+
 @pytest.mark.unit
 class TestCredentialSchemaAudit:
     """Ensure sensitive models have no credential-bearing fields."""
 
     def test_agent_context_has_no_credential_fields(self) -> None:
-        for name, info in AgentContext.model_fields.items():
-            if not _could_carry_credential(info.annotation):
-                continue
-            assert not _matches_credential_pattern(name), (
-                f"AgentContext.{name} (type={info.annotation}) "
-                f"matches a credential pattern"
-            )
+        violations: list[str] = []
+        _check_model_recursive(
+            AgentContext,
+            "AgentContext",
+            set(),
+            violations,
+        )
+        assert not violations, f"Credential-bearing fields found: {violations}"
 
     def test_turn_record_has_no_credential_fields(self) -> None:
-        for name, info in TurnRecord.model_fields.items():
-            if not _could_carry_credential(info.annotation):
-                continue
-            assert not _matches_credential_pattern(name), (
-                f"TurnRecord.{name} (type={info.annotation}) "
-                f"matches a credential pattern"
-            )
+        violations: list[str] = []
+        _check_model_recursive(
+            TurnRecord,
+            "TurnRecord",
+            set(),
+            violations,
+        )
+        assert not violations, f"Credential-bearing fields found: {violations}"
 
     def test_task_metadata_is_the_extensibility_point(
         self,

--- a/tests/unit/engine/test_credential_schema_audit.py
+++ b/tests/unit/engine/test_credential_schema_audit.py
@@ -40,6 +40,20 @@ def _could_carry_credential(annotation: Any) -> bool:
     )
 
 
+def _contains_base_model(annotation: Any) -> bool:
+    """Return True if the annotation contains a BaseModel subclass.
+
+    Walks into unions, optionals, and generic containers so that
+    ``SomeModel | None`` and ``list[SomeModel]`` are detected.
+    """
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return True
+    origin = get_origin(annotation)
+    if origin is not None:
+        return any(_contains_base_model(a) for a in get_args(annotation))
+    return False
+
+
 def _check_model_recursive(
     model_cls: type[BaseModel],
     path: str,
@@ -56,14 +70,11 @@ def _check_model_recursive(
         annotation = info.annotation
 
         # Check the field name if the type could carry credentials.
-        # BaseModel fields are included: a field named "api_key" is
-        # suspicious even if wrapped in a Pydantic model.
-        is_model = isinstance(annotation, type) and issubclass(
-            annotation,
-            BaseModel,
-        )
+        # BaseModel fields are included (even wrapped in unions or
+        # containers): a field named "api_key" is suspicious whether
+        # typed as SomeModel, SomeModel | None, or list[SomeModel].
         if (
-            _could_carry_credential(annotation) or is_model
+            _could_carry_credential(annotation) or _contains_base_model(annotation)
         ) and _matches_credential_pattern(name):
             violations.append(
                 f"{field_path} (type={annotation}) matches a credential pattern",

--- a/tests/unit/engine/test_credential_schema_audit.py
+++ b/tests/unit/engine/test_credential_schema_audit.py
@@ -1,0 +1,74 @@
+"""Schema audit: credential-bearing fields never leak into context models."""
+
+from typing import Any, get_args, get_origin
+
+import pytest
+
+from synthorg.core.task import Task
+from synthorg.engine._validation import _CREDENTIAL_KEY_PATTERNS
+from synthorg.engine.context import AgentContext
+from synthorg.engine.loop_protocol import TurnRecord
+
+_PATTERNS = _CREDENTIAL_KEY_PATTERNS
+
+# Types that could plausibly carry credential values.
+_CREDENTIAL_CARRYING_TYPES = (str, dict, bytes, bytearray)
+
+
+def _matches_credential_pattern(name: str) -> bool:
+    """Check if a field name matches any credential pattern."""
+    return any(p.search(name) for p in _PATTERNS)
+
+
+def _could_carry_credential(annotation: Any) -> bool:
+    """Return True if the annotation could hold a credential.
+
+    Numeric fields (int, float, bool) and enum fields cannot carry
+    credential strings, so ``input_tokens: int`` is safe even
+    though the name contains "token".
+    """
+    origin = get_origin(annotation)
+    if origin is not None:
+        args = get_args(annotation)
+        return any(_could_carry_credential(a) for a in args)
+    if annotation is Any:
+        return True
+    return isinstance(annotation, type) and issubclass(
+        annotation, _CREDENTIAL_CARRYING_TYPES
+    )
+
+
+@pytest.mark.unit
+class TestCredentialSchemaAudit:
+    """Ensure sensitive models have no credential-bearing fields."""
+
+    def test_agent_context_has_no_credential_fields(self) -> None:
+        for name, info in AgentContext.model_fields.items():
+            if not _could_carry_credential(info.annotation):
+                continue
+            assert not _matches_credential_pattern(name), (
+                f"AgentContext.{name} (type={info.annotation}) "
+                f"matches a credential pattern"
+            )
+
+    def test_turn_record_has_no_credential_fields(self) -> None:
+        for name, info in TurnRecord.model_fields.items():
+            if not _could_carry_credential(info.annotation):
+                continue
+            assert not _matches_credential_pattern(name), (
+                f"TurnRecord.{name} (type={info.annotation}) "
+                f"matches a credential pattern"
+            )
+
+    def test_task_metadata_is_the_extensibility_point(
+        self,
+    ) -> None:
+        """Task.metadata is the only dict[str, Any] on Task."""
+        dict_fields = [
+            n
+            for n, f in Task.model_fields.items()
+            if "dict" in str(f.annotation).lower()
+        ]
+        assert dict_fields == ["metadata"], (
+            f"Expected only 'metadata' as dict field, found: {dict_fields}"
+        )

--- a/tests/unit/engine/test_credential_schema_audit.py
+++ b/tests/unit/engine/test_credential_schema_audit.py
@@ -69,45 +69,40 @@ def _check_model_recursive(
                 f"{field_path} (type={annotation}) matches a credential pattern",
             )
 
-        # Recurse into nested BaseModel subclasses.
-        origin = get_origin(annotation)
-        targets: list[Any] = []
-        if origin is not None:
-            targets.extend(get_args(annotation))
-        else:
-            targets.append(annotation)
-
-        for target in targets:
-            if (
-                isinstance(target, type)
-                and issubclass(target, BaseModel)
-                and target not in visited
+        # Recurse into nested BaseModel subclasses, fully unpacking
+        # generic containers (e.g. list[list[SomeModel]]).
+        stack: list[Any] = [annotation]
+        while stack:
+            item = stack.pop()
+            item_origin = get_origin(item)
+            if item_origin is not None:
+                stack.extend(get_args(item))
+            elif (
+                isinstance(item, type)
+                and issubclass(item, BaseModel)
+                and item not in visited
             ):
-                _check_model_recursive(target, field_path, visited, violations)
+                _check_model_recursive(item, field_path, visited, violations)
 
 
 @pytest.mark.unit
 class TestCredentialSchemaAudit:
     """Ensure sensitive models have no credential-bearing fields."""
 
-    def test_agent_context_has_no_credential_fields(self) -> None:
+    @pytest.mark.parametrize(
+        ("model_cls", "display_name"),
+        [
+            pytest.param(AgentContext, "AgentContext", id="agent_context"),
+            pytest.param(TurnRecord, "TurnRecord", id="turn_record"),
+        ],
+    )
+    def test_no_credential_fields(
+        self,
+        model_cls: type[BaseModel],
+        display_name: str,
+    ) -> None:
         violations: list[str] = []
-        _check_model_recursive(
-            AgentContext,
-            "AgentContext",
-            set(),
-            violations,
-        )
-        assert not violations, f"Credential-bearing fields found: {violations}"
-
-    def test_turn_record_has_no_credential_fields(self) -> None:
-        violations: list[str] = []
-        _check_model_recursive(
-            TurnRecord,
-            "TurnRecord",
-            set(),
-            violations,
-        )
+        _check_model_recursive(model_cls, display_name, set(), violations)
         assert not violations, f"Credential-bearing fields found: {violations}"
 
     def test_task_metadata_is_the_extensibility_point(

--- a/tests/unit/engine/test_credential_schema_audit.py
+++ b/tests/unit/engine/test_credential_schema_audit.py
@@ -54,10 +54,16 @@ def _check_model_recursive(
         field_path = f"{path}.{name}"
         annotation = info.annotation
 
-        # Check the field name itself against credential patterns.
-        if _could_carry_credential(annotation) and _matches_credential_pattern(
-            name,
-        ):
+        # Check the field name if the type could carry credentials.
+        # BaseModel fields are included: a field named "api_key" is
+        # suspicious even if wrapped in a Pydantic model.
+        is_model = isinstance(annotation, type) and issubclass(
+            annotation,
+            BaseModel,
+        )
+        if (
+            _could_carry_credential(annotation) or is_model
+        ) and _matches_credential_pattern(name):
             violations.append(
                 f"{field_path} (type={annotation}) matches a credential pattern",
             )

--- a/tests/unit/engine/test_session_replay.py
+++ b/tests/unit/engine/test_session_replay.py
@@ -296,3 +296,63 @@ class TestSessionReplay:
             f"completeness={result.replay_completeness:.2f} "
             f"not in [{expected_min}, {expected_max}]"
         )
+
+
+@pytest.mark.unit
+class TestSessionReplayErrorHandling:
+    """Error handling in Session.replay()."""
+
+    async def test_event_reader_exception_propagates(
+        self,
+        sample_agent_with_personality: AgentIdentity,
+    ) -> None:
+        """EventReader exception is logged and re-raised."""
+
+        class FailingReader:
+            async def read_events(
+                self,
+                execution_id: str,
+            ) -> tuple[SessionEvent, ...]:
+                msg = "connection failed"
+                raise OSError(msg)
+
+        with pytest.raises(OSError, match="connection failed"):
+            await Session.replay(
+                execution_id=EXEC_ID,
+                event_reader=FailingReader(),
+                identity=sample_agent_with_personality,
+            )
+
+    async def test_malformed_turn_event_skipped(
+        self,
+        sample_agent_with_personality: AgentIdentity,
+    ) -> None:
+        """Malformed turn event is skipped; valid events processed."""
+        events = (
+            _event(EXECUTION_ENGINE_START, EXEC_ID, 0),
+            _event(
+                EXECUTION_CONTEXT_TURN,
+                EXEC_ID,
+                1,
+                turn="not-a-number",
+                cost_usd=0.01,
+            ),
+            _event(
+                EXECUTION_CONTEXT_TURN,
+                EXEC_ID,
+                2,
+                turn=2,
+                cost_usd=0.02,
+            ),
+        )
+        reader = StubEventReader(events)
+        result = await Session.replay(
+            execution_id=EXEC_ID,
+            event_reader=reader,
+            identity=sample_agent_with_personality,
+        )
+        assert result.events_processed == 3
+        assert result.context.turn_count == 1
+        assert result.context.accumulated_cost.cost_usd == pytest.approx(
+            0.02,
+        )

--- a/tests/unit/engine/test_session_replay.py
+++ b/tests/unit/engine/test_session_replay.py
@@ -1,0 +1,298 @@
+"""Tests for Session.replay() -- stateless session recovery from event log."""
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from synthorg.core.agent import AgentIdentity
+from synthorg.core.enums import TaskStatus
+from synthorg.core.task import Task
+from synthorg.engine.context import AgentContext
+from synthorg.engine.session import (
+    EventReader,
+    ReplayResult,
+    Session,
+    SessionEvent,
+)
+from synthorg.observability.events.execution import (
+    EXECUTION_CONTEXT_CREATED,
+    EXECUTION_CONTEXT_TURN,
+    EXECUTION_ENGINE_START,
+    EXECUTION_TASK_TRANSITION,
+)
+
+# ── Stub EventReader ──────────────────────────────────────────────
+
+
+class StubEventReader:
+    """In-memory EventReader for testing."""
+
+    def __init__(self, events: tuple[SessionEvent, ...] = ()) -> None:
+        self._events = events
+
+    async def read_events(
+        self,
+        execution_id: str,
+    ) -> tuple[SessionEvent, ...]:
+        return tuple(e for e in self._events if e.execution_id == execution_id)
+
+
+def _ts(minute: int) -> datetime:
+    """Create a UTC timestamp at the given minute offset."""
+    return datetime(2026, 4, 13, 12, minute, 0, tzinfo=UTC)
+
+
+def _event(
+    name: str,
+    execution_id: str,
+    minute: int,
+    **data: object,
+) -> SessionEvent:
+    """Create a SessionEvent with convenience defaults."""
+    return SessionEvent(
+        event_name=name,
+        timestamp=_ts(minute),
+        execution_id=execution_id,
+        data=dict(data),
+    )
+
+
+EXEC_ID = "exec-replay-001"
+
+
+def _build_scenario_events(
+    scenario: str,
+) -> list[SessionEvent]:
+    """Build event lists for parametrized completeness tests."""
+    minute = 0
+    events: list[SessionEvent] = []
+
+    if scenario == "empty":
+        return events
+
+    if scenario in ("full", "start-only"):
+        events.append(
+            _event(EXECUTION_ENGINE_START, EXEC_ID, minute),
+        )
+        minute += 1
+
+    if scenario == "full":
+        events.append(
+            _event(EXECUTION_CONTEXT_CREATED, EXEC_ID, minute),
+        )
+        minute += 1
+
+    if scenario in ("full", "turns-only"):
+        cost = 0.01
+        events.append(
+            _event(
+                EXECUTION_CONTEXT_TURN,
+                EXEC_ID,
+                minute,
+                turn=1,
+                cost_usd=cost,
+            ),
+        )
+        minute += 1
+        events.append(
+            _event(
+                EXECUTION_CONTEXT_TURN,
+                EXEC_ID,
+                minute,
+                turn=2,
+                cost_usd=cost,
+            ),
+        )
+        minute += 1
+
+    if scenario == "full":
+        events.append(
+            _event(
+                EXECUTION_TASK_TRANSITION,
+                EXEC_ID,
+                minute,
+                target_status=TaskStatus.IN_PROGRESS.value,
+            ),
+        )
+
+    return events
+
+
+# ── Tests ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestEventReaderProtocol:
+    """EventReader is a runtime-checkable Protocol."""
+
+    def test_stub_implements_protocol(self) -> None:
+        reader = StubEventReader()
+        assert isinstance(reader, EventReader)
+
+
+@pytest.mark.unit
+class TestReplayResult:
+    """ReplayResult model validation."""
+
+    def test_completeness_bounds(
+        self,
+        sample_agent_context: AgentContext,
+    ) -> None:
+        with pytest.raises(ValidationError):
+            ReplayResult(
+                context=sample_agent_context,
+                replay_completeness=1.5,
+                events_processed=0,
+                events_total=0,
+            )
+
+    def test_valid_construction(
+        self,
+        sample_agent_context: AgentContext,
+    ) -> None:
+        result = ReplayResult(
+            context=sample_agent_context,
+            replay_completeness=0.75,
+            events_processed=5,
+            events_total=7,
+        )
+        assert result.replay_completeness == 0.75
+        assert result.events_processed == 5
+
+
+@pytest.mark.unit
+class TestSessionReplay:
+    """Session.replay() reconstructs AgentContext from events."""
+
+    async def test_replay_empty_events(
+        self,
+        sample_agent_with_personality: AgentIdentity,
+        sample_task_with_criteria: Task,
+    ) -> None:
+        reader = StubEventReader()
+        result = await Session.replay(
+            execution_id=EXEC_ID,
+            event_reader=reader,
+            identity=sample_agent_with_personality,
+            task=sample_task_with_criteria,
+        )
+        assert result.replay_completeness == 0.0
+        assert result.events_processed == 0
+        assert result.context.turn_count == 0
+
+    async def test_replay_full_event_stream(
+        self,
+        sample_agent_with_personality: AgentIdentity,
+        sample_task_with_criteria: Task,
+    ) -> None:
+        events = (
+            _event(EXECUTION_ENGINE_START, EXEC_ID, 0),
+            _event(
+                EXECUTION_CONTEXT_CREATED,
+                EXEC_ID,
+                1,
+                agent_id=str(sample_agent_with_personality.id),
+            ),
+            _event(EXECUTION_CONTEXT_TURN, EXEC_ID, 2, turn=1, cost_usd=0.01),
+            _event(EXECUTION_CONTEXT_TURN, EXEC_ID, 3, turn=2, cost_usd=0.02),
+            _event(EXECUTION_CONTEXT_TURN, EXEC_ID, 4, turn=3, cost_usd=0.03),
+            _event(
+                EXECUTION_TASK_TRANSITION,
+                EXEC_ID,
+                5,
+                task_id=sample_task_with_criteria.id,
+                target_status=TaskStatus.IN_PROGRESS.value,
+            ),
+        )
+        reader = StubEventReader(events)
+        result = await Session.replay(
+            execution_id=EXEC_ID,
+            event_reader=reader,
+            identity=sample_agent_with_personality,
+            task=sample_task_with_criteria,
+        )
+        assert result.context.turn_count == 3
+        assert result.context.accumulated_cost.cost_usd == pytest.approx(0.06)
+        assert result.replay_completeness >= 0.85
+        assert result.events_processed == 6
+        assert result.events_total == 6
+
+    async def test_replay_partial_event_stream(
+        self,
+        sample_agent_with_personality: AgentIdentity,
+        sample_task_with_criteria: Task,
+    ) -> None:
+        events = (
+            _event(EXECUTION_CONTEXT_TURN, EXEC_ID, 2, turn=1, cost_usd=0.01),
+            _event(EXECUTION_CONTEXT_TURN, EXEC_ID, 3, turn=2, cost_usd=0.02),
+        )
+        reader = StubEventReader(events)
+        result = await Session.replay(
+            execution_id=EXEC_ID,
+            event_reader=reader,
+            identity=sample_agent_with_personality,
+            task=sample_task_with_criteria,
+        )
+        assert result.context.turn_count == 2
+        assert result.context.accumulated_cost.cost_usd == pytest.approx(0.03)
+        assert 0.3 <= result.replay_completeness <= 0.7
+        assert result.events_processed == 2
+
+    async def test_replay_preserves_identity(
+        self,
+        sample_agent_with_personality: AgentIdentity,
+    ) -> None:
+        events = (_event(EXECUTION_ENGINE_START, EXEC_ID, 0),)
+        reader = StubEventReader(events)
+        result = await Session.replay(
+            execution_id=EXEC_ID,
+            event_reader=reader,
+            identity=sample_agent_with_personality,
+        )
+        assert result.context.identity is sample_agent_with_personality
+
+    async def test_replay_preserves_task(
+        self,
+        sample_agent_with_personality: AgentIdentity,
+        sample_task_with_criteria: Task,
+    ) -> None:
+        events = (_event(EXECUTION_ENGINE_START, EXEC_ID, 0),)
+        reader = StubEventReader(events)
+        result = await Session.replay(
+            execution_id=EXEC_ID,
+            event_reader=reader,
+            identity=sample_agent_with_personality,
+            task=sample_task_with_criteria,
+        )
+        assert result.context.task_execution is not None
+        assert result.context.task_execution.task is sample_task_with_criteria
+
+    @pytest.mark.parametrize(
+        ("scenario", "expected_min", "expected_max"),
+        [
+            pytest.param("full", 0.85, 1.0, id="full"),
+            pytest.param("turns-only", 0.4, 0.7, id="turns-only"),
+            pytest.param("start-only", 0.1, 0.25, id="start-only"),
+            pytest.param("empty", 0.0, 0.0, id="empty"),
+        ],
+    )
+    async def test_replay_completeness_scoring(
+        self,
+        sample_agent_with_personality: AgentIdentity,
+        *,
+        scenario: str,
+        expected_min: float,
+        expected_max: float,
+    ) -> None:
+        events = _build_scenario_events(scenario)
+        reader = StubEventReader(tuple(events))
+        result = await Session.replay(
+            execution_id=EXEC_ID,
+            event_reader=reader,
+            identity=sample_agent_with_personality,
+        )
+        assert expected_min <= result.replay_completeness <= expected_max, (
+            f"completeness={result.replay_completeness:.2f} "
+            f"not in [{expected_min}, {expected_max}]"
+        )

--- a/tests/unit/engine/test_session_replay.py
+++ b/tests/unit/engine/test_session_replay.py
@@ -180,6 +180,8 @@ class TestSessionReplay:
         assert result.replay_completeness == 0.0
         assert result.events_processed == 0
         assert result.context.turn_count == 0
+        # Execution lineage preserved even with no events.
+        assert result.context.execution_id == EXEC_ID
 
     async def test_replay_full_event_stream(
         self,
@@ -217,6 +219,11 @@ class TestSessionReplay:
         assert result.replay_completeness >= 0.85
         assert result.events_processed == 6
         assert result.events_total == 6
+        # Execution lineage preserved.
+        assert result.context.execution_id == EXEC_ID
+        # Task transition replayed.
+        assert result.context.task_execution is not None
+        assert result.context.task_execution.status == TaskStatus.IN_PROGRESS
 
     async def test_replay_partial_event_stream(
         self,
@@ -323,19 +330,45 @@ class TestSessionReplayErrorHandling:
                 identity=sample_agent_with_personality,
             )
 
+    @pytest.mark.parametrize(
+        ("data", "error_id"),
+        [
+            pytest.param(
+                {"turn": "not-a-number", "cost_usd": 0.01},
+                "non_numeric_turn",
+                id="non_numeric_turn",
+            ),
+            pytest.param(
+                {"cost_usd": 0.01},
+                "missing_turn",
+                id="missing_turn_key",
+            ),
+            pytest.param(
+                {"turn": 0, "cost_usd": 0.01},
+                "zero_turn",
+                id="zero_turn_number",
+            ),
+            pytest.param(
+                {"turn": 1, "cost_usd": "invalid"},
+                "non_numeric_cost",
+                id="non_numeric_cost",
+            ),
+        ],
+    )
     async def test_malformed_turn_event_skipped(
         self,
         sample_agent_with_personality: AgentIdentity,
+        data: dict[str, object],
+        error_id: str,
     ) -> None:
         """Malformed turn event is skipped; valid events processed."""
         events = (
             _event(EXECUTION_ENGINE_START, EXEC_ID, 0),
-            _event(
-                EXECUTION_CONTEXT_TURN,
-                EXEC_ID,
-                1,
-                turn="not-a-number",
-                cost_usd=0.01,
+            SessionEvent(
+                event_name=EXECUTION_CONTEXT_TURN,
+                timestamp=_ts(1),
+                execution_id=EXEC_ID,
+                data=data,
             ),
             _event(
                 EXECUTION_CONTEXT_TURN,
@@ -356,3 +389,51 @@ class TestSessionReplayErrorHandling:
         assert result.context.accumulated_cost.cost_usd == pytest.approx(
             0.02,
         )
+
+
+@pytest.mark.unit
+class TestSessionReplayTaskNone:
+    """Session.replay() with task=None."""
+
+    async def test_replay_without_task(
+        self,
+        sample_agent_with_personality: AgentIdentity,
+    ) -> None:
+        """Replay works when task is None (no task_execution)."""
+        events = (
+            _event(EXECUTION_ENGINE_START, EXEC_ID, 0),
+            _event(EXECUTION_CONTEXT_TURN, EXEC_ID, 1, turn=1, cost_usd=0.01),
+        )
+        reader = StubEventReader(events)
+        result = await Session.replay(
+            execution_id=EXEC_ID,
+            event_reader=reader,
+            identity=sample_agent_with_personality,
+            task=None,
+        )
+        assert result.context.task_execution is None
+        assert result.context.turn_count == 1
+        assert result.context.accumulated_cost.cost_usd == pytest.approx(0.01)
+        assert result.context.execution_id == EXEC_ID
+
+
+@pytest.mark.unit
+class TestSessionReplayExecutionLineage:
+    """Execution lineage preservation during replay."""
+
+    async def test_started_at_from_earliest_event(
+        self,
+        sample_agent_with_personality: AgentIdentity,
+    ) -> None:
+        """Replayed context started_at comes from earliest event."""
+        events = (
+            _event(EXECUTION_ENGINE_START, EXEC_ID, 5),
+            _event(EXECUTION_CONTEXT_TURN, EXEC_ID, 10, turn=1, cost_usd=0.01),
+        )
+        reader = StubEventReader(events)
+        result = await Session.replay(
+            execution_id=EXEC_ID,
+            event_reader=reader,
+            identity=sample_agent_with_personality,
+        )
+        assert result.context.started_at == _ts(5)

--- a/tests/unit/engine/test_session_replay_integration.py
+++ b/tests/unit/engine/test_session_replay_integration.py
@@ -1,0 +1,149 @@
+"""Integration test: session recovery after simulated brain failure."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from synthorg.core.agent import AgentIdentity
+from synthorg.core.enums import TaskStatus
+from synthorg.core.task import Task
+from synthorg.engine.session import Session, SessionEvent
+from synthorg.observability.events.execution import (
+    EXECUTION_CONTEXT_CREATED,
+    EXECUTION_CONTEXT_TURN,
+    EXECUTION_ENGINE_START,
+    EXECUTION_TASK_TRANSITION,
+)
+
+
+class InMemoryEventReader:
+    """EventReader that collects events in memory during a simulated run.
+
+    Simulates what an operator's observability backend would store.
+    """
+
+    def __init__(self) -> None:
+        self._events: list[SessionEvent] = []
+
+    def record(self, event: SessionEvent) -> None:
+        """Record an event (simulates the sink writing to storage)."""
+        self._events.append(event)
+
+    async def read_events(
+        self,
+        execution_id: str,
+    ) -> tuple[SessionEvent, ...]:
+        return tuple(e for e in self._events if e.execution_id == execution_id)
+
+
+def _ts(minute: int) -> datetime:
+    return datetime(2026, 4, 13, 12, minute, 0, tzinfo=UTC)
+
+
+@pytest.mark.unit
+class TestBrainFailureRecovery:
+    """Simulate a brain failure and recover via Session.replay()."""
+
+    async def test_recovery_after_simulated_crash(
+        self,
+        sample_agent_with_personality: AgentIdentity,
+        sample_task_with_criteria: Task,
+    ) -> None:
+        """Simulate: agent runs 3 turns, crashes, replays from events."""
+        exec_id = "exec-crash-sim-001"
+        store = InMemoryEventReader()
+
+        # Phase 1: Simulate normal execution emitting events.
+        store.record(
+            SessionEvent(
+                event_name=EXECUTION_ENGINE_START,
+                timestamp=_ts(0),
+                execution_id=exec_id,
+            )
+        )
+        store.record(
+            SessionEvent(
+                event_name=EXECUTION_CONTEXT_CREATED,
+                timestamp=_ts(1),
+                execution_id=exec_id,
+                data={"agent_id": str(sample_agent_with_personality.id)},
+            )
+        )
+        for turn in range(1, 4):
+            store.record(
+                SessionEvent(
+                    event_name=EXECUTION_CONTEXT_TURN,
+                    timestamp=_ts(1 + turn),
+                    execution_id=exec_id,
+                    data={"turn": turn, "cost_usd": 0.01 * turn},
+                )
+            )
+        store.record(
+            SessionEvent(
+                event_name=EXECUTION_TASK_TRANSITION,
+                timestamp=_ts(5),
+                execution_id=exec_id,
+                data={"target_status": TaskStatus.IN_PROGRESS.value},
+            )
+        )
+        # Phase 2: Brain crashes here (no EXECUTION_ENGINE_COMPLETE).
+
+        # Phase 3: Recovery via Session.replay().
+        result = await Session.replay(
+            execution_id=exec_id,
+            event_reader=store,
+            identity=sample_agent_with_personality,
+            task=sample_task_with_criteria,
+        )
+
+        # Verify recovered state.
+        assert result.context.turn_count == 3
+        assert result.context.accumulated_cost.cost_usd == pytest.approx(0.06)
+        assert result.replay_completeness >= 0.85
+        assert result.events_processed == 6
+        assert result.context.identity is sample_agent_with_personality
+        assert result.context.task_execution is not None
+
+    async def test_recovery_with_partial_events(
+        self,
+        sample_agent_with_personality: AgentIdentity,
+    ) -> None:
+        """Crash after 1 turn, only turn event survived."""
+        exec_id = "exec-crash-sim-002"
+        store = InMemoryEventReader()
+
+        store.record(
+            SessionEvent(
+                event_name=EXECUTION_CONTEXT_TURN,
+                timestamp=_ts(2),
+                execution_id=exec_id,
+                data={"turn": 1, "cost_usd": 0.05},
+            )
+        )
+
+        result = await Session.replay(
+            execution_id=exec_id,
+            event_reader=store,
+            identity=sample_agent_with_personality,
+        )
+
+        assert result.context.turn_count == 1
+        assert result.context.accumulated_cost.cost_usd == pytest.approx(0.05)
+        assert result.replay_completeness < 0.85
+        assert result.replay_completeness > 0.0
+
+    async def test_recovery_unknown_execution_returns_fresh(
+        self,
+        sample_agent_with_personality: AgentIdentity,
+    ) -> None:
+        """Unknown execution ID returns fresh context."""
+        store = InMemoryEventReader()
+
+        result = await Session.replay(
+            execution_id="nonexistent",
+            event_reader=store,
+            identity=sample_agent_with_personality,
+        )
+
+        assert result.context.turn_count == 0
+        assert result.replay_completeness == 0.0

--- a/tests/unit/engine/test_validation.py
+++ b/tests/unit/engine/test_validation.py
@@ -2,7 +2,9 @@
 
 import pytest
 
+from synthorg.core.agent import AgentIdentity
 from synthorg.core.enums import AgentStatus, TaskStatus
+from synthorg.core.task import Task
 from synthorg.engine._validation import (
     validate_agent,
     validate_run_inputs,
@@ -74,7 +76,7 @@ class TestValidateAgent:
 
     def test_rejects_onboarding_agent(
         self,
-        sample_agent_with_personality,
+        sample_agent_with_personality: AgentIdentity,
     ) -> None:
         agent = sample_agent_with_personality.model_copy(
             update={"status": AgentStatus.ONBOARDING},
@@ -84,7 +86,7 @@ class TestValidateAgent:
 
     def test_rejects_terminated_agent(
         self,
-        sample_agent_with_personality,
+        sample_agent_with_personality: AgentIdentity,
     ) -> None:
         agent = sample_agent_with_personality.model_copy(
             update={"status": AgentStatus.TERMINATED},
@@ -94,7 +96,7 @@ class TestValidateAgent:
 
     def test_accepts_active_agent(
         self,
-        sample_agent_with_personality,
+        sample_agent_with_personality: AgentIdentity,
     ) -> None:
         validate_agent(
             sample_agent_with_personality,
@@ -108,7 +110,7 @@ class TestValidateTask:
 
     def test_rejects_created_task(
         self,
-        sample_task_with_criteria,
+        sample_task_with_criteria: Task,
     ) -> None:
         task = sample_task_with_criteria.model_copy(
             update={"status": TaskStatus.CREATED},
@@ -118,7 +120,7 @@ class TestValidateTask:
 
     def test_rejects_completed_task(
         self,
-        sample_task_with_criteria,
+        sample_task_with_criteria: Task,
     ) -> None:
         task = sample_task_with_criteria.model_copy(
             update={"status": TaskStatus.COMPLETED},
@@ -128,7 +130,7 @@ class TestValidateTask:
 
     def test_rejects_wrong_assignee(
         self,
-        sample_task_with_criteria,
+        sample_task_with_criteria: Task,
     ) -> None:
         with pytest.raises(ExecutionStateError, match="not to agent"):
             validate_task(
@@ -139,7 +141,7 @@ class TestValidateTask:
 
     def test_accepts_assigned_task(
         self,
-        sample_task_with_criteria,
+        sample_task_with_criteria: Task,
     ) -> None:
         validate_task(
             sample_task_with_criteria,
@@ -149,7 +151,7 @@ class TestValidateTask:
 
     def test_accepts_in_progress_task(
         self,
-        sample_task_with_criteria,
+        sample_task_with_criteria: Task,
     ) -> None:
         task = sample_task_with_criteria.model_copy(
             update={"status": TaskStatus.IN_PROGRESS},

--- a/tests/unit/engine/test_validation.py
+++ b/tests/unit/engine/test_validation.py
@@ -1,0 +1,161 @@
+"""Tests for engine input validation functions."""
+
+import pytest
+
+from synthorg.core.enums import AgentStatus, TaskStatus
+from synthorg.engine._validation import (
+    validate_agent,
+    validate_run_inputs,
+    validate_task,
+)
+from synthorg.engine.errors import ExecutionStateError
+
+
+@pytest.mark.unit
+class TestValidateRunInputs:
+    """validate_run_inputs rejects invalid scalar arguments."""
+
+    def test_rejects_zero_max_turns(self) -> None:
+        with pytest.raises(ValueError, match="max_turns must be >= 1"):
+            validate_run_inputs(
+                agent_id="a1",
+                task_id="t1",
+                max_turns=0,
+                timeout_seconds=None,
+            )
+
+    def test_rejects_negative_max_turns(self) -> None:
+        with pytest.raises(ValueError, match="max_turns must be >= 1"):
+            validate_run_inputs(
+                agent_id="a1",
+                task_id="t1",
+                max_turns=-5,
+                timeout_seconds=None,
+            )
+
+    def test_rejects_zero_timeout(self) -> None:
+        with pytest.raises(ValueError, match="timeout_seconds must be > 0"):
+            validate_run_inputs(
+                agent_id="a1",
+                task_id="t1",
+                max_turns=10,
+                timeout_seconds=0,
+            )
+
+    def test_rejects_negative_timeout(self) -> None:
+        with pytest.raises(ValueError, match="timeout_seconds must be > 0"):
+            validate_run_inputs(
+                agent_id="a1",
+                task_id="t1",
+                max_turns=10,
+                timeout_seconds=-1.0,
+            )
+
+    def test_accepts_valid_inputs(self) -> None:
+        validate_run_inputs(
+            agent_id="a1",
+            task_id="t1",
+            max_turns=20,
+            timeout_seconds=30.0,
+        )
+
+    def test_accepts_none_timeout(self) -> None:
+        validate_run_inputs(
+            agent_id="a1",
+            task_id="t1",
+            max_turns=1,
+            timeout_seconds=None,
+        )
+
+
+@pytest.mark.unit
+class TestValidateAgent:
+    """validate_agent rejects non-ACTIVE agents."""
+
+    def test_rejects_onboarding_agent(
+        self,
+        sample_agent_with_personality,
+    ) -> None:
+        agent = sample_agent_with_personality.model_copy(
+            update={"status": AgentStatus.ONBOARDING},
+        )
+        with pytest.raises(ExecutionStateError, match="onboarding"):
+            validate_agent(agent, str(agent.id))
+
+    def test_rejects_terminated_agent(
+        self,
+        sample_agent_with_personality,
+    ) -> None:
+        agent = sample_agent_with_personality.model_copy(
+            update={"status": AgentStatus.TERMINATED},
+        )
+        with pytest.raises(ExecutionStateError, match="terminated"):
+            validate_agent(agent, str(agent.id))
+
+    def test_accepts_active_agent(
+        self,
+        sample_agent_with_personality,
+    ) -> None:
+        validate_agent(
+            sample_agent_with_personality,
+            str(sample_agent_with_personality.id),
+        )
+
+
+@pytest.mark.unit
+class TestValidateTask:
+    """validate_task rejects non-executable or wrongly assigned tasks."""
+
+    def test_rejects_created_task(
+        self,
+        sample_task_with_criteria,
+    ) -> None:
+        task = sample_task_with_criteria.model_copy(
+            update={"status": TaskStatus.CREATED},
+        )
+        with pytest.raises(ExecutionStateError, match="created"):
+            validate_task(task, agent_id="a1", task_id=task.id)
+
+    def test_rejects_completed_task(
+        self,
+        sample_task_with_criteria,
+    ) -> None:
+        task = sample_task_with_criteria.model_copy(
+            update={"status": TaskStatus.COMPLETED},
+        )
+        with pytest.raises(ExecutionStateError, match="completed"):
+            validate_task(task, agent_id="a1", task_id=task.id)
+
+    def test_rejects_wrong_assignee(
+        self,
+        sample_task_with_criteria,
+    ) -> None:
+        with pytest.raises(ExecutionStateError, match="not to agent"):
+            validate_task(
+                sample_task_with_criteria,
+                agent_id="wrong-agent",
+                task_id=sample_task_with_criteria.id,
+            )
+
+    def test_accepts_assigned_task(
+        self,
+        sample_task_with_criteria,
+    ) -> None:
+        validate_task(
+            sample_task_with_criteria,
+            agent_id=sample_task_with_criteria.assigned_to,
+            task_id=sample_task_with_criteria.id,
+        )
+
+    def test_accepts_in_progress_task(
+        self,
+        sample_task_with_criteria,
+    ) -> None:
+        task = sample_task_with_criteria.model_copy(
+            update={"status": TaskStatus.IN_PROGRESS},
+        )
+        validate_task(
+            task,
+            agent_id=task.assigned_to,
+            task_id=task.id,
+        )

--- a/tests/unit/engine/test_validation.py
+++ b/tests/unit/engine/test_validation.py
@@ -143,6 +143,7 @@ class TestValidateTask:
         self,
         sample_task_with_criteria: Task,
     ) -> None:
+        assert sample_task_with_criteria.assigned_to is not None
         validate_task(
             sample_task_with_criteria,
             agent_id=sample_task_with_criteria.assigned_to,
@@ -156,6 +157,7 @@ class TestValidateTask:
         task = sample_task_with_criteria.model_copy(
             update={"status": TaskStatus.IN_PROGRESS},
         )
+        assert task.assigned_to is not None
         validate_task(
             task,
             agent_id=task.assigned_to,

--- a/tests/unit/observability/test_events.py
+++ b/tests/unit/observability/test_events.py
@@ -228,6 +228,7 @@ class TestEventConstants:
             "blueprint",
             "sandbox",
             "security",
+            "session",
             "stagnation",
             "strategy",
             "task",


### PR DESCRIPTION
## Summary

Adopts Anthropic's brain/hands/session decoupling pattern from the managed agents engineering post. Three concrete changes plus documentation alignment.

### What changed

- **Credential isolation validator** (`engine/_validation.py`): `validate_task_metadata()` rejects `Task.metadata` keys matching credential patterns (token, secret, api_key, password, bearer) at the engine input boundary. Logs `CREDENTIAL_ISOLATION_VIOLATION` at ERROR
- **Task.metadata field** (`core/task.py`): new `dict[str, Any]` field with deepcopy validator for pipeline tracking and labels
- **Session replay** (`engine/session.py`): `Session.replay(execution_id)` reconstructs `AgentContext` from the observability event log. `EventReader` protocol for pluggable backends. `ReplayResult` with `replay_completeness` score (0.0--1.0)
- **AgentEngine wiring**: `event_reader` param on init, `resume_execution_id` on run(). Replay gated on both being present
- **CompanyConfig**: `session_replay_on_start` flag
- **Brain/Hands/Session docs** (`engine.md`, `operations.md`): plane-to-module mapping table, resilience property, credential isolation boundary

### Schema audit

Tests verify `AgentContext` and `TurnRecord` have no credential-bearing string/dict fields. `Task.metadata` is confirmed as the only `dict[str, Any]` extensibility point.

### Test plan

- 31 new tests across 4 test files (credential isolation, schema audit, session replay, integration)
- Full suite: 18809 passed, 0 failed
- Credential validator: all 5 patterns, case insensitivity, multiple violations, log verification
- Session replay: full/partial/empty streams, completeness scoring, identity/task preservation, error propagation, malformed event handling
- Integration: simulated brain failure with recovery via event replay

### Review coverage

Pre-reviewed by 6 agents (code-reviewer, python-reviewer, test-analyzer, silent-failure-hunter, type-design-analyzer, docs-consistency). 8 findings addressed.

Closes #1261