### PR TITLE
fix(ci): prevent transitive skip propagation in Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -412,6 +412,10 @@ jobs:
   build-backend:
     name: Build Backend
     needs: [version, build-backend-base]
+    if: >-
+      !cancelled() &&
+      needs.version.result == 'success' &&
+      needs.build-backend-base.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -691,6 +695,10 @@ jobs:
   build-web:
     name: Build Web (apko)
     needs: [version, build-web-assets]
+    if: >-
+      !cancelled() &&
+      needs.version.result == 'success' &&
+      needs.build-web-assets.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -857,6 +865,10 @@ jobs:
   build-sandbox:
     name: Build Sandbox
     needs: [version, build-sandbox-base]
+    if: >-
+      !cancelled() &&
+      needs.version.result == 'success' &&
+      needs.build-sandbox-base.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -1059,8 +1071,13 @@ jobs:
   # Append container image references to the GitHub Release (version tags only)
   update-release:
     name: Update Release Notes
-    if: startsWith(github.ref, 'refs/tags/v') && github.event_name != 'pull_request'
     needs: [version, build-backend-base, build-sandbox-base, build-backend, build-web, build-sandbox]
+    if: >-
+      startsWith(github.ref, 'refs/tags/v') && github.event_name != 'pull_request' &&
+      !cancelled() &&
+      needs.build-backend.result == 'success' &&
+      needs.build-web.result == 'success' &&
+      needs.build-sandbox.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Summary

Fix Docker workflow jobs (`build-backend`, `build-sandbox`, `build-web`, `update-release`) being skipped on push-to-main and tag-push events due to GitHub Actions' transitive skip propagation.

## Problem

The `changes` job (Detect Docker Changes) has `if: github.event_name == 'pull_request'` -- it only runs on PRs. On push/tag events, it's skipped. The base/asset build jobs handle this with explicit `if:` conditions checking `needs.changes.result == 'skipped'`. However, the downstream build jobs had no `if:` conditions, so GitHub's transitive skip propagation caused them to be skipped too -- blocking all image builds and releases.

## Fix

Add explicit `if:` conditions to the four affected jobs:

- **`build-backend`**: `!cancelled() && needs.version.result == 'success' && needs.build-backend-base.result == 'success'`
- **`build-web`**: `!cancelled() && needs.version.result == 'success' && needs.build-web-assets.result == 'success'`
- **`build-sandbox`**: `!cancelled() && needs.version.result == 'success' && needs.build-sandbox-base.result == 'success'`
- **`update-release`**: Added `!cancelled()` + explicit success checks for all three build jobs (on top of existing tag/event guards)

## Test plan

- Merge to main triggers a push event -- verify all build jobs run instead of being skipped
- Next dev release tag push verifies end-to-end: base builds -> app builds -> image push -> release notes update

## Review

Pre-reviewed by 2 agents (docs-consistency, infra-reviewer), 0 findings implemented (1 skipped as over-documenting CI internals).