### PR TITLE
chore: enable Renovate pre-commit manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,9 @@
     "helpers:pinGitHubActionDigests",
     "docker:pinDigests"
   ],
+  "pre-commit": {
+    "enabled": true
+  },
   "schedule": ["before 7am"],
   "timezone": "Etc/UTC",
   "labels": ["dependencies"],


### PR DESCRIPTION
Renovate's `pre-commit` manager was not detecting `.pre-commit-config.yaml` despite having a package rule for it. Explicitly enable it so Renovate tracks the 5 versioned external repos (pre-commit-hooks, ruff, gitleaks, commitizen, hadolint) and groups their updates into the existing "Python dependencies" PR group.