### PR TITLE
chore: bump Renovate prHourlyLimit to 5

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,7 @@
   "reviewers": ["Aureliolo"],
   "platformAutomerge": false,
   "prConcurrentLimit": 10,
+  "prHourlyLimit": 5,
   "packageRules": [
     {
       "description": "Python dependencies (uv + pre-commit)",


### PR DESCRIPTION
Bumps `prHourlyLimit` from default 2 to 5 so rate-limited dependency updates clear faster. `prConcurrentLimit` (10) still caps total open PRs.

One-line config change in `renovate.json`.