### PR TITLE
chore: disable Renovate pinning of requires-python

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -86,6 +86,12 @@
       "labels": ["dependencies", "type:chore", "scope:docker"]
     },
     {
+      "description": "Do not pin requires-python -- it is a compatibility range, not a dependency",
+      "matchDepNames": ["python"],
+      "matchDepTypes": ["requires-python"],
+      "enabled": false
+    },
+    {
       "description": "Block Python 3.15+ in Docker images (policy decision)",
       "matchDepNames": ["python"],
       "matchManagers": ["dockerfile"],


### PR DESCRIPTION
requires-python is a compatibility range (>=3.14), not a dependency to pin. Renovate's :pinVersions preset incorrectly tried to change it to ==3.14.4 in #1311 (closed).