### PR TITLE
chore: ignore cli/testdata/ in Renovate (golden files, not real configs)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -101,6 +101,11 @@
       "description": "Block litellm 1.83.1+ (hard-pins pydantic==2.12.5, jsonschema==4.23.0). Upstream: BerriAI/litellm#25280. Re-enable when upstream reverts exact pins.",
       "matchDepNames": ["litellm"],
       "allowedVersions": "<=1.83.0"
+    },
+    {
+      "description": "Ignore test golden files -- not real compose configs",
+      "matchFileNames": ["cli/testdata/**"],
+      "enabled": false
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Renovate was treating cli/testdata/*.yml golden files as live Docker Compose configs and trying to pin image digests (#1328, closed). These files are generated by `UPDATE_GOLDEN=1 go test` and should not be touched by dependency managers.