### PR TITLE
fix: use pep621 manager and enable lock file maintenance in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -110,7 +110,7 @@
   ],
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 7am on monday"]
+    "schedule": ["before 5am on monday"]
   },
   "customManagers": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -18,8 +18,8 @@
   "prHourlyLimit": 5,
   "packageRules": [
     {
-      "description": "Python dependencies (uv + pre-commit)",
-      "matchManagers": ["uv", "pre-commit"],
+      "description": "Python dependencies (pep621 + pre-commit)",
+      "matchManagers": ["pep621", "pre-commit"],
       "groupName": "Python dependencies",
       "groupSlug": "python",
       "additionalBranchPrefix": "",
@@ -108,6 +108,10 @@
       "enabled": false
     }
   ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 7am on monday"]
+  },
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary

Fixes two Renovate config issues discovered during dep PR review (#1346, #1347, #1348, #1349):

- **Fix Python grouping**: `matchManagers` used `"uv"` which is not a valid Renovate manager name -- the correct name is `"pep621"`. This caused Python deps (packaging, hypothesis, etc.) to bypass the group rule entirely, resulting in individual PRs instead of grouped ones, wrong commit prefixes (`fix(deps):` instead of `chore:`), and missing `type:chore` labels.
- **Enable lock file maintenance**: Adds weekly `uv.lock` refresh (Monday before 7am UTC) to pick up transitive dependency updates.

## Changes

- `renovate.json`: `"uv"` -> `"pep621"` in Python dependencies rule + `lockFileMaintenance` block

## Test Plan

- Next Renovate run will group Python deps into `renovate/python` branch
- Lock file maintenance PR will appear on next Monday schedule
- Verify grouped PRs get correct labels (`dependencies`, `type:chore`) and commit prefix (`chore:`)

## Review

Quick mode -- config-only change, no code, no agents needed.