### PR TITLE
feat: cross-deployment analytics for self-improvement patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ See `web/CLAUDE.md` for the full component inventory, design token rules, and po
   - `engine/classification/protocol.py` (`Detector`, `ScopedContextLoader`, `ClassificationSink`) + `budget/coordination_config.py` dispatcher
   - `engine/quality/decomposer_protocol.py` (`CriteriaDecomposer`) + `engine/quality/grader_protocol.py` (`RubricGrader`) + `engine/quality/verification_factory.py` + `engine/quality/verification_config.py`
   - `meta/chief_of_staff/protocol.py` (`OutcomeStore`, `ConfidenceAdjuster`, `OrgInflectionSink`, `AlertSink`) + `meta/chief_of_staff/config.py` discriminator + `meta/factory.py::build_confidence_adjuster()`
+  - `meta/telemetry/protocol.py` (`AnalyticsEmitter`, `AnalyticsCollector`, `RecommendationProvider`) + `meta/telemetry/config.py` discriminator + `meta/telemetry/factory.py::build_analytics_emitter()`
 - **Line length**: 88 characters (ruff)
 - **Functions**: < 50 lines, files < 800 lines
 - **Errors**: handle explicitly, never silently swallow

--- a/docs/cross-deployment-privacy.md
+++ b/docs/cross-deployment-privacy.md
@@ -79,7 +79,7 @@ Events are visible in the structured log output with event metadata (event type,
 
 ## Data Retention
 
-The default collector (`InMemoryAnalyticsCollector`) stores events **in memory only**. Data is lost on restart. There is no persistent storage in the default configuration.
+The default collector (`InMemoryAnalyticsCollector`) stores events **in memory only** with a bounded FIFO buffer (default: 100,000 events). When the cap is exceeded, the oldest events are evicted. Data is lost on restart. There is no persistent storage in the default configuration. The `max_events` capacity is configurable at construction time.
 
 ## Access Control
 

--- a/docs/cross-deployment-privacy.md
+++ b/docs/cross-deployment-privacy.md
@@ -72,9 +72,9 @@ logging:
     synthorg.meta.telemetry: DEBUG
 ```
 
-Events are visible in the structured log output with event names:
-- `cross_deployment.event.queued` -- event buffered
-- `cross_deployment.batch.flushed` -- batch sent to collector
+Events are visible in the structured log output with event metadata (event type, queue depth, batch size, HTTP status). Note: the full serialized event payload is not logged -- only operational metadata is emitted for diagnostics. Event names:
+- `cross_deployment.event.queued` -- event buffered (logs event_type and pending count)
+- `cross_deployment.batch.flushed` -- batch sent to collector (logs event_count and HTTP status)
 
 ## Data Retention
 
@@ -82,7 +82,7 @@ The default collector (`InMemoryAnalyticsCollector`) stores events **in memory o
 
 ## Access Control
 
-The collector endpoint (`POST /api/meta/analytics/events`) is protected by the standard API authentication and authorization middleware. Only authenticated users with read access can query patterns and recommendations.
+The collector endpoint (`POST /api/meta/analytics/events`) requires **write access** and is protected by the standard API authentication and authorization middleware. Pattern and recommendation queries (`GET`) require read access.
 
 ## Collector Role
 

--- a/docs/cross-deployment-privacy.md
+++ b/docs/cross-deployment-privacy.md
@@ -1,0 +1,100 @@
+# Cross-Deployment Analytics Privacy Policy
+
+Cross-deployment analytics is an **opt-in** feature that aggregates anonymized improvement outcomes across multiple SynthOrg deployments to identify patterns and recommend improved default thresholds.
+
+## What Is Collected
+
+When enabled, the following anonymized fields are sent to the configured collector endpoint after each proposal decision and rollout result:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `deployment_id` | Salted SHA-256 hash | Non-reversible identifier for deployment correlation |
+| `event_type` | Enum | `proposal_decision` or `rollout_result` |
+| `timestamp` | Date (day only) | ISO 8601 date, no time component |
+| `altitude` | Enum | Proposal altitude (config_tuning, architecture, etc.) |
+| `source_rule` | String | Built-in rule name or `"custom"` for user-defined rules |
+| `decision` | Enum | `approved` or `rejected` (decisions only) |
+| `confidence` | Float | Proposal confidence score (0-1) |
+| `rollout_outcome` | Enum | `success`, `regressed`, `rolled_back`, `failed`, `inconclusive` |
+| `regression_verdict` | Enum | `no_regression`, `threshold_breach`, `statistical_regression` |
+| `observation_hours` | Float | Rollout observation window duration |
+| `enabled_altitudes` | List | Which altitudes are enabled (categorical, not config values) |
+| `industry_tag` | String | User-provided industry category (opt-in) |
+| `sdk_version` | String | SynthOrg version |
+
+## What Is NOT Collected
+
+The following fields are **explicitly dropped** during anonymization and never leave the deployment:
+
+- **Company names, org identifiers**: Not present in any event
+- **Agent IDs, agent names**: Not present in any event
+- **User names** (`decided_by`): Dropped
+- **Free-text reasons** (`decision_reason`, `details`): Dropped
+- **Proposal titles and descriptions**: Dropped
+- **Config values**: Only categorical altitude names are sent, never actual thresholds or settings
+- **Raw UUIDs** (`proposal_id`): Dropped (deployment_id is a salted hash, not a UUID)
+- **Exact timestamps**: Coarsened to day granularity (no time, no timezone)
+- **Custom rule names**: Mapped to generic `"custom"` to prevent logic leakage
+
+## How Anonymization Works
+
+1. **Strict allowlist**: Only the fields listed above survive. Everything else is dropped.
+2. **Salted hashing**: The `deployment_id` is computed as `SHA-256(salt)` where the salt is a secret string configured by the deployment operator. Changing the salt invalidates all correlation.
+3. **Timestamp coarsening**: Timestamps are truncated to day granularity (`YYYY-MM-DD`), removing time-of-day information that could enable timing correlation.
+4. **Rule classification**: Custom rule names are replaced with the generic string `"custom"` to prevent leaking deployment-specific detection logic.
+
+The anonymization is implemented as a **pure function** (`anonymize_decision` / `anonymize_rollout`) that is easy to audit and test.
+
+## How to Opt In
+
+Cross-deployment analytics is **disabled by default**. To enable:
+
+```yaml
+self_improvement:
+  cross_deployment_analytics:
+    enabled: true
+    collector_url: "https://your-collector.example.com/api/meta/analytics"
+    deployment_id_salt: "your-secret-salt-string"
+    industry_tag: "technology"  # optional
+```
+
+Required fields when `enabled: true`:
+- `collector_url`: HTTPS endpoint to POST anonymized events to
+- `deployment_id_salt`: Secret salt for deployment identification
+
+## How to Inspect Events
+
+All anonymized events are logged at DEBUG level before sending. Enable debug logging for the `synthorg.meta.telemetry` logger to inspect exactly what is being sent:
+
+```yaml
+logging:
+  per_logger_levels:
+    synthorg.meta.telemetry: DEBUG
+```
+
+Events are visible in the structured log output with event names:
+- `cross_deployment.event.queued` -- event buffered
+- `cross_deployment.batch.flushed` -- batch sent to collector
+
+## Data Retention
+
+The default collector (`InMemoryAnalyticsCollector`) stores events **in memory only**. Data is lost on restart. There is no persistent storage in the default configuration.
+
+## Access Control
+
+The collector endpoint (`POST /api/meta/analytics/events`) is protected by the standard API authentication and authorization middleware. Only authenticated users with read access can query patterns and recommendations.
+
+## Collector Role
+
+A deployment can optionally act as a collector that receives events from other deployments:
+
+```yaml
+self_improvement:
+  cross_deployment_analytics:
+    enabled: true
+    collector_url: "https://this-deployment/api/meta/analytics"
+    deployment_id_salt: "salt"
+    collector_enabled: true  # enable collector role
+```
+
+The collector never sees unanonymized data -- it only receives the anonymized events described above.

--- a/docs/cross-deployment-privacy.md
+++ b/docs/cross-deployment-privacy.md
@@ -8,6 +8,7 @@ When enabled, the following anonymized fields are sent to the configured collect
 
 | Field | Type | Description |
 |-------|------|-------------|
+| `schema_version` | String | Wire format version (currently `"1"`) for forward compatibility |
 | `deployment_id` | Salted SHA-256 hash | Non-reversible identifier for deployment correlation |
 | `event_type` | Enum | `proposal_decision` or `rollout_result` |
 | `timestamp` | Date (day only) | ISO 8601 date, no time component |
@@ -64,7 +65,7 @@ Required fields when `enabled: true`:
 
 ## How to Inspect Events
 
-All anonymized events are logged at DEBUG level before sending. Enable debug logging for the `synthorg.meta.telemetry` logger to inspect exactly what is being sent:
+Enabling DEBUG logging for the `synthorg.meta.telemetry` logger emits queue/flush operational metadata (event type, queue depth, batch size, HTTP status). The full serialized event payload is **not logged** -- only diagnostics metadata is emitted:
 
 ```yaml
 logging:

--- a/docs/design/self-improvement.md
+++ b/docs/design/self-improvement.md
@@ -120,7 +120,7 @@ src/synthorg/meta/
     anonymizer.py      -- Pure anonymization functions (strict allowlist)
     emitter.py         -- HttpAnalyticsEmitter (async httpx, batching, retry)
     collector.py       -- InMemoryAnalyticsCollector (event storage + pattern queries)
-    aggregator.py      -- PatternAggregator (cross-deployment pattern identification)
+    aggregator.py      -- aggregate_patterns() (cross-deployment pattern identification)
     recommender.py     -- DefaultThresholdRecommender (pattern-to-threshold recommendations)
     factory.py         -- Component construction from config
 ```

--- a/docs/design/self-improvement.md
+++ b/docs/design/self-improvement.md
@@ -112,6 +112,17 @@ src/synthorg/meta/
     monitor.py         -- OrgInflectionMonitor (async background loop)
     alerts.py          -- ProactiveAlertService + LoggingAlertSink
     chat.py            -- ChiefOfStaffChat (LLM-powered explanations)
+
+  telemetry/           -- Cross-deployment analytics (opt-in, anonymized)
+    config.py          -- CrossDeploymentAnalyticsConfig (disabled by default)
+    models.py          -- AnonymizedOutcomeEvent, EventBatch, AggregatedPattern, ThresholdRecommendation
+    protocol.py        -- AnalyticsEmitter, AnalyticsCollector, RecommendationProvider
+    anonymizer.py      -- Pure anonymization functions (strict allowlist)
+    emitter.py         -- HttpAnalyticsEmitter (async httpx, batching, retry)
+    collector.py       -- InMemoryAnalyticsCollector (event storage + pattern queries)
+    aggregator.py      -- PatternAggregator (cross-deployment pattern identification)
+    recommender.py     -- DefaultThresholdRecommender (pattern-to-threshold recommendations)
+    factory.py         -- Component construction from config
 ```
 
 ## Design Decisions

--- a/docs/design/self-improvement.md
+++ b/docs/design/self-improvement.md
@@ -214,6 +214,18 @@ self_improvement:
   guards:
     proposal_rate_limit: 10
     rate_limit_window_hours: 24
+  # Cross-deployment analytics (#1341) -- opt-in, disabled by default.
+  cross_deployment_analytics:
+    enabled: false                       # Master switch
+    collector_url: null                  # HTTPS endpoint for event POST (required when enabled)
+    deployment_id_salt: null             # Secret salt for SHA-256 deployment hash (required when enabled)
+    collector_enabled: false             # Also act as a collector receiving events
+    industry_tag: null                   # Optional industry category (max 100 chars)
+    batch_size: 50                       # Max events buffered before flush
+    flush_interval_seconds: 30.0         # Periodic flush interval
+    http_timeout_seconds: 10.0           # HTTP POST timeout
+    min_deployments_for_pattern: 3       # Min unique deployments for pattern reporting
+    recommendation_min_observations: 10  # Min events for threshold recommendations
 ```
 
 ## Safety Mechanisms

--- a/docs/design/self-improvement.md
+++ b/docs/design/self-improvement.md
@@ -128,6 +128,9 @@ src/synthorg/meta/
 | Signals consumed | All 7 domains | Performance, budget, coordination, scaling, errors, evolution, telemetry |
 | Evolution boundary | Org-wide default; override + advisory alternatives | Clear separation from per-agent #243 |
 | Safe defaults | Disabled, opt-in, mandatory approval | Never auto-applies without human review |
+| Cross-deployment analytics | Dedicated protocol in `meta/telemetry/` | Domain events, not log records; follows meta/ pluggable pattern |
+| Analytics anonymization | Strict allowlist (enums + numerics only) | Maximum privacy; free text dropped, UUIDs hashed, timestamps coarsened |
+| Analytics aggregation | In-process API endpoints | Zero extra infra; any deployment can be emitter and/or collector |
 
 ## Signal Domains
 
@@ -217,6 +220,6 @@ self_improvement:
 
 1. ~~Full API-as-MCP server~~ -- completed via #1353 (issue #1339; 204 tools, 15 domains, capability-based scoping)
 2. ~~Product-level improvement~~ -- completed via #1340 (CODE_MODIFICATION altitude, LLM code gen, CI validation, draft PR creation)
-3. Cross-deployment analytics (anonymized multi-org patterns)
+3. ~~Cross-deployment analytics~~ -- completed via #1341 (opt-in anonymized telemetry, pattern aggregation, threshold recommendations; see `docs/cross-deployment-privacy.md`)
 4. ~~Chief of Staff advanced capabilities~~ -- completed via #1342 (outcome learning, proactive alerts, NL chat)
 5. ~~Custom rule authoring UI (visual rule builder)~~ -- shipped in v0.6.5 (#1343 / PR #1355)

--- a/src/synthorg/api/controllers/__init__.py
+++ b/src/synthorg/api/controllers/__init__.py
@@ -47,6 +47,7 @@ from synthorg.api.controllers.meetings import MeetingController
 from synthorg.api.controllers.memory import MemoryAdminController
 from synthorg.api.controllers.messages import MessageController
 from synthorg.api.controllers.meta import MetaController
+from synthorg.api.controllers.meta_analytics import MetaAnalyticsController
 from synthorg.api.controllers.metrics import MetricsController
 from synthorg.api.controllers.oauth import OAuthController
 from synthorg.api.controllers.ontology import OntologyController
@@ -137,6 +138,7 @@ BASE_CONTROLLERS: tuple[type[Controller], ...] = (
     ScalingController,
     TrainingController,
     MetaController,
+    MetaAnalyticsController,
     CustomRuleController,
 )
 
@@ -193,6 +195,7 @@ __all__ = [
     "MeetingController",
     "MemoryAdminController",
     "MessageController",
+    "MetaAnalyticsController",
     "MetaController",
     "MetricsController",
     "OAuthController",

--- a/src/synthorg/api/controllers/meta_analytics.py
+++ b/src/synthorg/api/controllers/meta_analytics.py
@@ -27,11 +27,14 @@ logger = get_logger(__name__)
 # Created lazily by the app startup hook; None when collector is disabled.
 _collector: InMemoryAnalyticsCollector | None = None
 _recommender: DefaultThresholdRecommender | None = None
+_min_deployments_floor: int = 3
 
 
 def configure_analytics_controller(
     collector: InMemoryAnalyticsCollector | None,
     recommender: DefaultThresholdRecommender | None,
+    *,
+    min_deployments_floor: int = 3,
 ) -> None:
     """Configure the analytics controller with collector and recommender.
 
@@ -40,10 +43,13 @@ def configure_analytics_controller(
     Args:
         collector: Collector instance, or None if disabled.
         recommender: Recommender instance, or None if disabled.
+        min_deployments_floor: Minimum deployments for pattern queries
+            (from ``CrossDeploymentAnalyticsConfig.min_deployments_for_pattern``).
     """
-    global _collector, _recommender  # noqa: PLW0603
+    global _collector, _recommender, _min_deployments_floor  # noqa: PLW0603
     _collector = collector
     _recommender = recommender
+    _min_deployments_floor = min_deployments_floor
 
 
 def _require_collector() -> InMemoryAnalyticsCollector:
@@ -101,8 +107,11 @@ class MetaAnalyticsController(Controller):
             Aggregated patterns.
         """
         collector = _require_collector()
+        # Clamp to configured privacy floor so callers cannot
+        # request patterns below the deployment-count minimum.
+        effective = max(min_deployments, _min_deployments_floor)
         patterns = await collector.query_patterns(
-            min_deployments=min_deployments,
+            min_deployments=effective,
         )
         return ApiResponse[list[AggregatedPattern]](
             data=list(patterns),

--- a/src/synthorg/api/controllers/meta_analytics.py
+++ b/src/synthorg/api/controllers/meta_analytics.py
@@ -1,0 +1,124 @@
+"""Cross-deployment analytics API controller.
+
+Provides endpoints for event ingestion (collector role),
+pattern querying, and threshold recommendations.
+"""
+
+from typing import Any
+
+from litestar import Controller, get, post
+
+from synthorg.api.dto import ApiResponse
+from synthorg.api.errors import ServiceUnavailableError
+from synthorg.api.guards import require_read_access
+from synthorg.meta.telemetry.collector import InMemoryAnalyticsCollector  # noqa: TC001
+from synthorg.meta.telemetry.models import EventBatch  # noqa: TC001
+from synthorg.meta.telemetry.recommender import (
+    DefaultThresholdRecommender,  # noqa: TC001
+)
+from synthorg.observability import get_logger
+
+logger = get_logger(__name__)
+
+# Module-level singleton instances.
+# Created lazily by the app startup hook; None when collector is disabled.
+_collector: InMemoryAnalyticsCollector | None = None
+_recommender: DefaultThresholdRecommender | None = None
+
+
+def configure_analytics_controller(
+    collector: InMemoryAnalyticsCollector | None,
+    recommender: DefaultThresholdRecommender | None,
+) -> None:
+    """Configure the analytics controller with collector and recommender.
+
+    Called during app startup when the collector role is enabled.
+
+    Args:
+        collector: Collector instance, or None if disabled.
+        recommender: Recommender instance, or None if disabled.
+    """
+    global _collector, _recommender  # noqa: PLW0603
+    _collector = collector
+    _recommender = recommender
+
+
+def _require_collector() -> InMemoryAnalyticsCollector:
+    """Get the collector or raise ServiceUnavailableError."""
+    if _collector is None:
+        msg = "Cross-deployment analytics collector is not enabled"
+        raise ServiceUnavailableError(msg)
+    return _collector
+
+
+class MetaAnalyticsController(Controller):
+    """Cross-deployment analytics API endpoints.
+
+    Provides event ingestion for the collector role and
+    pattern/recommendation queries.
+    """
+
+    path = "/meta/analytics"
+    tags = ["meta-analytics"]  # noqa: RUF012
+    guards = [require_read_access]  # noqa: RUF012
+
+    @post("/events")
+    async def ingest_events(
+        self,
+        data: EventBatch,
+    ) -> ApiResponse[dict[str, int]]:
+        """Ingest a batch of anonymized outcome events.
+
+        Only available when ``collector_enabled=True``.
+
+        Args:
+            data: Batch of anonymized events.
+
+        Returns:
+            Number of events ingested.
+        """
+        collector = _require_collector()
+        count = await collector.ingest(data.events)
+        return ApiResponse[dict[str, int]](
+            data={"ingested": count},
+        )
+
+    @get("/patterns")
+    async def get_patterns(
+        self,
+        min_deployments: int = 3,
+    ) -> ApiResponse[list[dict[str, Any]]]:
+        """Query aggregated cross-deployment patterns.
+
+        Args:
+            min_deployments: Minimum unique deployments for pattern.
+
+        Returns:
+            Aggregated patterns.
+        """
+        collector = _require_collector()
+        patterns = await collector.query_patterns(
+            min_deployments=min_deployments,
+        )
+        return ApiResponse[list[dict[str, Any]]](
+            data=[p.model_dump() for p in patterns],
+        )
+
+    @get("/recommendations")
+    async def get_recommendations(
+        self,
+    ) -> ApiResponse[list[dict[str, Any]]]:
+        """Get threshold recommendations from aggregated data.
+
+        Returns:
+            Threshold recommendations sorted by confidence.
+        """
+        collector = _require_collector()
+        if _recommender is None:
+            return ApiResponse[list[dict[str, Any]]](data=[])
+        recs = await _recommender.get_recommendations(
+            collector=collector,
+        )
+        return ApiResponse[list[dict[str, Any]]](
+            data=[r.model_dump() for r in recs],
+        )

--- a/src/synthorg/api/controllers/meta_analytics.py
+++ b/src/synthorg/api/controllers/meta_analytics.py
@@ -4,15 +4,18 @@ Provides endpoints for event ingestion (collector role),
 pattern querying, and threshold recommendations.
 """
 
-from typing import Any
-
 from litestar import Controller, get, post
+from litestar.params import Parameter
 
 from synthorg.api.dto import ApiResponse
 from synthorg.api.errors import ServiceUnavailableError
-from synthorg.api.guards import require_read_access
+from synthorg.api.guards import require_read_access, require_write_access
 from synthorg.meta.telemetry.collector import InMemoryAnalyticsCollector  # noqa: TC001
-from synthorg.meta.telemetry.models import EventBatch  # noqa: TC001
+from synthorg.meta.telemetry.models import (
+    AggregatedPattern,
+    EventBatch,
+    ThresholdRecommendation,
+)
 from synthorg.meta.telemetry.recommender import (
     DefaultThresholdRecommender,  # noqa: TC001
 )
@@ -62,7 +65,7 @@ class MetaAnalyticsController(Controller):
     tags = ["meta-analytics"]  # noqa: RUF012
     guards = [require_read_access]  # noqa: RUF012
 
-    @post("/events")
+    @post("/events", guards=[require_write_access])
     async def ingest_events(
         self,
         data: EventBatch,
@@ -70,6 +73,7 @@ class MetaAnalyticsController(Controller):
         """Ingest a batch of anonymized outcome events.
 
         Only available when ``collector_enabled=True``.
+        Requires write access.
 
         Args:
             data: Batch of anonymized events.
@@ -86,8 +90,8 @@ class MetaAnalyticsController(Controller):
     @get("/patterns")
     async def get_patterns(
         self,
-        min_deployments: int = 3,
-    ) -> ApiResponse[list[dict[str, Any]]]:
+        min_deployments: int = Parameter(default=3, ge=1, le=100),
+    ) -> ApiResponse[list[AggregatedPattern]]:
         """Query aggregated cross-deployment patterns.
 
         Args:
@@ -100,14 +104,14 @@ class MetaAnalyticsController(Controller):
         patterns = await collector.query_patterns(
             min_deployments=min_deployments,
         )
-        return ApiResponse[list[dict[str, Any]]](
-            data=[p.model_dump() for p in patterns],
+        return ApiResponse[list[AggregatedPattern]](
+            data=list(patterns),
         )
 
     @get("/recommendations")
     async def get_recommendations(
         self,
-    ) -> ApiResponse[list[dict[str, Any]]]:
+    ) -> ApiResponse[list[ThresholdRecommendation]]:
         """Get threshold recommendations from aggregated data.
 
         Returns:
@@ -115,10 +119,10 @@ class MetaAnalyticsController(Controller):
         """
         collector = _require_collector()
         if _recommender is None:
-            return ApiResponse[list[dict[str, Any]]](data=[])
+            return ApiResponse[list[ThresholdRecommendation]](data=[])
         recs = await _recommender.get_recommendations(
             collector=collector,
         )
-        return ApiResponse[list[dict[str, Any]]](
-            data=[r.model_dump() for r in recs],
+        return ApiResponse[list[ThresholdRecommendation]](
+            data=list(recs),
         )

--- a/src/synthorg/meta/config.py
+++ b/src/synthorg/meta/config.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from synthorg.core.types import NotBlankStr
 from synthorg.meta.chief_of_staff.config import ChiefOfStaffConfig
 from synthorg.meta.models import EvolutionMode, RolloutStrategyType
+from synthorg.meta.telemetry.config import CrossDeploymentAnalyticsConfig
 from synthorg.observability import get_logger
 
 logger = get_logger(__name__)
@@ -255,6 +256,8 @@ class SelfImprovementConfig(BaseModel):
         code_modification: Code modification strategy configuration.
         chief_of_staff: Chief of Staff advanced capabilities
             (learning, alerts, chat).
+        cross_deployment_analytics: Cross-deployment analytics
+            telemetry (opt-in, disabled by default).
         analysis_model: LLM model identifier for proposal analysis.
         analysis_temperature: Sampling temperature for analysis.
         analysis_max_tokens: Token budget for analysis responses.
@@ -284,6 +287,10 @@ class SelfImprovementConfig(BaseModel):
 
     chief_of_staff: ChiefOfStaffConfig = Field(
         default_factory=ChiefOfStaffConfig,
+    )
+
+    cross_deployment_analytics: CrossDeploymentAnalyticsConfig = Field(
+        default_factory=CrossDeploymentAnalyticsConfig,
     )
 
     analysis_model: NotBlankStr = Field(

--- a/src/synthorg/meta/service.py
+++ b/src/synthorg/meta/service.py
@@ -27,12 +27,17 @@ from synthorg.meta.models import (
     ProposalStatus,
     RolloutResult,
 )
+from synthorg.meta.rules.builtin import default_rules
+from synthorg.meta.telemetry.factory import build_analytics_emitter
 from synthorg.observability import get_logger
 from synthorg.observability.events.chief_of_staff import (
     COS_CONFIDENCE_ADJUSTMENT_FAILED,
     COS_LEARNING_ENABLED,
     COS_OUTCOME_RECORD_FAILED,
     COS_OUTCOME_SKIPPED,
+)
+from synthorg.observability.events.cross_deployment import (
+    XDEPLOY_EVENT_EMIT_FAILED,
 )
 from synthorg.observability.events.meta import (
     META_CYCLE_COMPLETED,
@@ -48,6 +53,7 @@ if TYPE_CHECKING:
     from synthorg.meta.config import SelfImprovementConfig
     from synthorg.meta.models import RuleMatch
     from synthorg.meta.protocol import ImprovementStrategy
+    from synthorg.meta.telemetry.emitter import HttpAnalyticsEmitter
     from synthorg.providers.base import BaseCompletionProvider
 
 logger = get_logger(__name__)
@@ -84,6 +90,12 @@ class SelfImprovementService:
         self._appliers = build_appliers(config)
         self._detector = build_regression_detector()
         self._rollout_strategies = build_rollout_strategies()
+
+        # Cross-deployment analytics emitter.
+        builtin_names = frozenset(r.name for r in default_rules())
+        self._analytics_emitter: HttpAnalyticsEmitter | None = build_analytics_emitter(
+            config, builtin_rule_names=builtin_names
+        )
 
         # Chief of Staff learning.
         self._outcome_store: MemoryBackendOutcomeStore | None = None
@@ -236,11 +248,26 @@ class SelfImprovementService:
             msg = f"No rollout strategy '{strategy_name}'"
             raise ValueError(msg)
 
-        return await rollout.execute(
+        result = await rollout.execute(
             proposal=proposal,
             applier=applier,
             detector=self._detector,
         )
+
+        # Emit anonymized rollout event for cross-deployment analytics.
+        if self._analytics_emitter is not None:
+            try:
+                await self._analytics_emitter.emit_rollout(
+                    result,
+                    proposal=proposal,
+                )
+            except Exception:
+                logger.exception(
+                    XDEPLOY_EVENT_EMIT_FAILED,
+                    proposal_id=str(proposal.id),
+                )
+
+        return result
 
     async def _dispatch_strategies(
         self,
@@ -332,3 +359,21 @@ class SelfImprovementService:
                 COS_OUTCOME_RECORD_FAILED,
                 proposal_id=str(proposal.id),
             )
+
+        # Emit anonymized event for cross-deployment analytics.
+        if self._analytics_emitter is not None:
+            try:
+                await self._analytics_emitter.emit_decision(
+                    outcome,
+                    proposal=proposal,
+                )
+            except Exception:
+                logger.exception(
+                    XDEPLOY_EVENT_EMIT_FAILED,
+                    proposal_id=str(proposal.id),
+                )
+
+    async def close(self) -> None:
+        """Flush analytics emitter and release resources."""
+        if self._analytics_emitter is not None:
+            await self._analytics_emitter.close()

--- a/src/synthorg/meta/service.py
+++ b/src/synthorg/meta/service.py
@@ -265,6 +265,8 @@ class SelfImprovementService:
                 logger.exception(
                     XDEPLOY_EVENT_EMIT_FAILED,
                     proposal_id=str(proposal.id),
+                    event_type="rollout_result",
+                    altitude=proposal.altitude.value,
                 )
 
         return result
@@ -371,9 +373,17 @@ class SelfImprovementService:
                 logger.exception(
                     XDEPLOY_EVENT_EMIT_FAILED,
                     proposal_id=str(proposal.id),
+                    event_type="proposal_decision",
+                    altitude=outcome.altitude.value,
                 )
 
     async def close(self) -> None:
         """Flush analytics emitter and release resources."""
         if self._analytics_emitter is not None:
-            await self._analytics_emitter.close()
+            try:
+                await self._analytics_emitter.close()
+            except Exception:
+                logger.exception(
+                    XDEPLOY_EVENT_EMIT_FAILED,
+                    reason="emitter_close_failed",
+                )

--- a/src/synthorg/meta/service.py
+++ b/src/synthorg/meta/service.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
     from synthorg.meta.config import SelfImprovementConfig
     from synthorg.meta.models import RuleMatch
     from synthorg.meta.protocol import ImprovementStrategy
-    from synthorg.meta.telemetry.emitter import HttpAnalyticsEmitter
+    from synthorg.meta.telemetry.protocol import AnalyticsEmitter
     from synthorg.providers.base import BaseCompletionProvider
 
 logger = get_logger(__name__)
@@ -93,7 +93,7 @@ class SelfImprovementService:
 
         # Cross-deployment analytics emitter.
         builtin_names = frozenset(r.name for r in default_rules())
-        self._analytics_emitter: HttpAnalyticsEmitter | None = build_analytics_emitter(
+        self._analytics_emitter: AnalyticsEmitter | None = build_analytics_emitter(
             config, builtin_rule_names=builtin_names
         )
 
@@ -255,19 +255,12 @@ class SelfImprovementService:
         )
 
         # Emit anonymized rollout event for cross-deployment analytics.
+        # emit_rollout handles its own exceptions internally.
         if self._analytics_emitter is not None:
-            try:
-                await self._analytics_emitter.emit_rollout(
-                    result,
-                    proposal=proposal,
-                )
-            except Exception:
-                logger.exception(
-                    XDEPLOY_EVENT_EMIT_FAILED,
-                    proposal_id=str(proposal.id),
-                    event_type="rollout_result",
-                    altitude=proposal.altitude.value,
-                )
+            await self._analytics_emitter.emit_rollout(
+                result,
+                proposal=proposal,
+            )
 
         return result
 
@@ -308,17 +301,15 @@ class SelfImprovementService:
         self,
         proposal: ImprovementProposal,
     ) -> None:
-        """Record a decided proposal as an outcome for learning.
+        """Record a decided proposal for learning and analytics.
 
         Called by the approval API after a human approves or
-        rejects a proposal. Silently returns if learning is
-        disabled or the proposal lacks decision fields.
+        rejects a proposal. Emits analytics telemetry independently
+        of Chief of Staff learning (outcome_store).
 
         Args:
             proposal: The decided proposal.
         """
-        if self._outcome_store is None:
-            return
         if proposal.decided_at is None or proposal.decided_by is None:
             logger.info(
                 COS_OUTCOME_SKIPPED,
@@ -351,31 +342,24 @@ class SelfImprovementService:
             decided_by=proposal.decided_by,
             decision_reason=proposal.decision_reason,
         )
-        try:
-            await self._outcome_store.record_outcome(outcome)
-        except Exception:
-            # Intentionally not re-raised: outcome recording failure
-            # must not block the approval flow.  The error is logged
-            # at ERROR level (via .exception) for operator visibility.
-            logger.exception(
-                COS_OUTCOME_RECORD_FAILED,
-                proposal_id=str(proposal.id),
-            )
 
-        # Emit anonymized event for cross-deployment analytics.
-        if self._analytics_emitter is not None:
+        # Record outcome for Chief of Staff learning (if enabled).
+        if self._outcome_store is not None:
             try:
-                await self._analytics_emitter.emit_decision(
-                    outcome,
-                    proposal=proposal,
-                )
+                await self._outcome_store.record_outcome(outcome)
             except Exception:
                 logger.exception(
-                    XDEPLOY_EVENT_EMIT_FAILED,
+                    COS_OUTCOME_RECORD_FAILED,
                     proposal_id=str(proposal.id),
-                    event_type="proposal_decision",
-                    altitude=outcome.altitude.value,
                 )
+
+        # Emit anonymized event for cross-deployment analytics.
+        # emit_decision handles its own exceptions internally.
+        if self._analytics_emitter is not None:
+            await self._analytics_emitter.emit_decision(
+                outcome,
+                proposal=proposal,
+            )
 
     async def close(self) -> None:
         """Flush analytics emitter and release resources."""

--- a/src/synthorg/meta/telemetry/__init__.py
+++ b/src/synthorg/meta/telemetry/__init__.py
@@ -1,0 +1,30 @@
+"""Cross-deployment analytics for self-improvement patterns.
+
+Opt-in, privacy-preserving telemetry that aggregates anonymized
+improvement outcomes across multiple SynthOrg deployments to
+identify patterns and recommend improved default thresholds.
+"""
+
+from synthorg.meta.telemetry.config import CrossDeploymentAnalyticsConfig
+from synthorg.meta.telemetry.models import (
+    AggregatedPattern,
+    AnonymizedOutcomeEvent,
+    EventBatch,
+    ThresholdRecommendation,
+)
+from synthorg.meta.telemetry.protocol import (
+    AnalyticsCollector,
+    AnalyticsEmitter,
+    RecommendationProvider,
+)
+
+__all__ = [
+    "AggregatedPattern",
+    "AnalyticsCollector",
+    "AnalyticsEmitter",
+    "AnonymizedOutcomeEvent",
+    "CrossDeploymentAnalyticsConfig",
+    "EventBatch",
+    "RecommendationProvider",
+    "ThresholdRecommendation",
+]

--- a/src/synthorg/meta/telemetry/aggregator.py
+++ b/src/synthorg/meta/telemetry/aggregator.py
@@ -9,6 +9,9 @@ from collections import Counter, defaultdict
 
 from synthorg.core.types import NotBlankStr
 from synthorg.meta.telemetry.models import AggregatedPattern, AnonymizedOutcomeEvent
+from synthorg.observability import get_logger
+
+logger = get_logger(__name__)
 
 
 def aggregate_patterns(
@@ -34,9 +37,13 @@ def aggregate_patterns(
         return ()
 
     # Group events by (source_rule, altitude).
+    # Events without a source_rule are excluded -- no rule means
+    # no actionable threshold to recommend adjusting.
     groups: dict[tuple[str, str], list[AnonymizedOutcomeEvent]] = defaultdict(list)
     for event in events:
-        key = (event.source_rule or "_none_", event.altitude)
+        if event.source_rule is None:
+            continue
+        key = (event.source_rule, event.altitude)
         groups[key].append(event)
 
     patterns: list[AggregatedPattern] = []

--- a/src/synthorg/meta/telemetry/aggregator.py
+++ b/src/synthorg/meta/telemetry/aggregator.py
@@ -1,0 +1,123 @@
+"""Cross-deployment pattern aggregation.
+
+Pure function that groups anonymized events by (source_rule, altitude),
+computes cross-deployment statistics, and filters by minimum deployment
+count.
+"""
+
+from collections import Counter, defaultdict
+
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.telemetry.models import AggregatedPattern, AnonymizedOutcomeEvent
+
+
+def aggregate_patterns(
+    events: tuple[AnonymizedOutcomeEvent, ...],
+    *,
+    min_deployments: int = 3,
+) -> tuple[AggregatedPattern, ...]:
+    """Identify cross-deployment patterns from anonymized events.
+
+    Groups events by ``(source_rule, altitude)`` and computes
+    aggregated statistics. Only groups observed across at least
+    ``min_deployments`` unique deployments are included.
+
+    Args:
+        events: All collected anonymized events.
+        min_deployments: Minimum unique deployments required.
+
+    Returns:
+        Aggregated patterns sorted by deployment count (descending),
+        then by total events (descending).
+    """
+    if not events:
+        return ()
+
+    # Group events by (source_rule, altitude).
+    groups: dict[tuple[str, str], list[AnonymizedOutcomeEvent]] = defaultdict(list)
+    for event in events:
+        key = (event.source_rule or "_none_", event.altitude)
+        groups[key].append(event)
+
+    patterns: list[AggregatedPattern] = []
+    for (rule, altitude), group_events in groups.items():
+        deployment_ids = {e.deployment_id for e in group_events}
+        if len(deployment_ids) < min_deployments:
+            continue
+
+        decisions = [e for e in group_events if e.event_type == "proposal_decision"]
+        rollouts = [e for e in group_events if e.event_type == "rollout_result"]
+
+        approval_rate = _compute_approval_rate(decisions)
+        success_rate = _compute_success_rate(rollouts)
+        avg_confidence = _compute_avg_confidence(decisions)
+        avg_observation = _compute_avg_observation_hours(rollouts)
+        industry = _compute_industry_breakdown(group_events)
+
+        patterns.append(
+            AggregatedPattern(
+                source_rule=NotBlankStr(rule),
+                altitude=NotBlankStr(altitude),
+                deployment_count=len(deployment_ids),
+                total_events=len(group_events),
+                approval_rate=approval_rate,
+                success_rate=success_rate,
+                avg_confidence=avg_confidence,
+                avg_observation_hours=avg_observation,
+                industry_breakdown=industry,
+            ),
+        )
+
+    patterns.sort(key=lambda p: (-p.deployment_count, -p.total_events))
+    return tuple(patterns)
+
+
+def _compute_approval_rate(
+    decisions: list[AnonymizedOutcomeEvent],
+) -> float:
+    """Compute approval rate from decision events."""
+    if not decisions:
+        return 0.0
+    approved = sum(1 for d in decisions if d.decision == "approved")
+    return approved / len(decisions)
+
+
+def _compute_success_rate(
+    rollouts: list[AnonymizedOutcomeEvent],
+) -> float:
+    """Compute rollout success rate."""
+    if not rollouts:
+        return 0.0
+    successes = sum(1 for r in rollouts if r.rollout_outcome == "success")
+    return successes / len(rollouts)
+
+
+def _compute_avg_confidence(
+    decisions: list[AnonymizedOutcomeEvent],
+) -> float:
+    """Compute average confidence from decision events."""
+    confidences = [d.confidence for d in decisions if d.confidence is not None]
+    if not confidences:
+        return 0.0
+    return sum(confidences) / len(confidences)
+
+
+def _compute_avg_observation_hours(
+    rollouts: list[AnonymizedOutcomeEvent],
+) -> float | None:
+    """Compute average observation hours from rollout events."""
+    hours = [r.observation_hours for r in rollouts if r.observation_hours is not None]
+    if not hours:
+        return None
+    return sum(hours) / len(hours)
+
+
+def _compute_industry_breakdown(
+    events: list[AnonymizedOutcomeEvent],
+) -> tuple[tuple[NotBlankStr, int], ...]:
+    """Compute industry tag distribution, sorted by count descending."""
+    counter: Counter[str] = Counter()
+    for event in events:
+        if event.industry_tag is not None:
+            counter[event.industry_tag] += 1
+    return tuple((NotBlankStr(tag), count) for tag, count in counter.most_common())

--- a/src/synthorg/meta/telemetry/aggregator.py
+++ b/src/synthorg/meta/telemetry/aggregator.py
@@ -70,6 +70,7 @@ def aggregate_patterns(
                 altitude=NotBlankStr(altitude),
                 deployment_count=len(deployment_ids),
                 total_events=len(group_events),
+                decision_count=len(decisions),
                 approval_rate=approval_rate,
                 success_rate=success_rate,
                 avg_confidence=avg_confidence,

--- a/src/synthorg/meta/telemetry/aggregator.py
+++ b/src/synthorg/meta/telemetry/aggregator.py
@@ -33,6 +33,9 @@ def aggregate_patterns(
         Aggregated patterns sorted by deployment count (descending),
         then by total events (descending).
     """
+    if min_deployments < 1:
+        msg = f"min_deployments must be >= 1, got {min_deployments}"
+        raise ValueError(msg)
     if not events:
         return ()
 

--- a/src/synthorg/meta/telemetry/anonymizer.py
+++ b/src/synthorg/meta/telemetry/anonymizer.py
@@ -1,0 +1,202 @@
+"""Anonymization functions for cross-deployment analytics.
+
+Pure functions that transform rich domain models into anonymized
+events suitable for cross-deployment aggregation. Only allowlisted
+fields survive: enum values, numeric metrics, and coarsened
+timestamps. All free text, UUIDs, and PII are dropped.
+"""
+
+import hashlib
+from typing import TYPE_CHECKING
+
+from synthorg import __version__
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.telemetry.models import AnonymizedOutcomeEvent
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
+    from datetime import datetime
+
+    from synthorg.meta.chief_of_staff.models import ProposalOutcome
+    from synthorg.meta.config import SelfImprovementConfig
+    from synthorg.meta.models import ImprovementProposal, RolloutResult
+    from synthorg.meta.telemetry.config import CrossDeploymentAnalyticsConfig
+
+
+def anonymize_decision(
+    outcome: ProposalOutcome,
+    *,
+    analytics_config: CrossDeploymentAnalyticsConfig,
+    self_improvement_config: SelfImprovementConfig,
+    builtin_rule_names: Collection[str],
+) -> AnonymizedOutcomeEvent:
+    """Anonymize a proposal decision into a cross-deployment event.
+
+    Drops all PII (decided_by, decision_reason, title, proposal_id).
+    Keeps only categorical enums, numeric metrics, and coarsened
+    timestamps.
+
+    Args:
+        outcome: The proposal outcome to anonymize.
+        analytics_config: Cross-deployment analytics configuration.
+        self_improvement_config: Full self-improvement config (for
+            extracting enabled altitudes).
+        builtin_rule_names: Set of built-in rule names. Custom
+            rules are masked to ``"custom"``.
+
+    Returns:
+        Anonymized event with ``event_type="proposal_decision"``.
+    """
+    assert analytics_config.deployment_id_salt is not None  # noqa: S101
+    return AnonymizedOutcomeEvent(
+        deployment_id=NotBlankStr(
+            _compute_deployment_id(str(analytics_config.deployment_id_salt)),
+        ),
+        event_type="proposal_decision",
+        timestamp=NotBlankStr(_coarsen_timestamp(outcome.decided_at)),
+        altitude=NotBlankStr(outcome.altitude.value),
+        source_rule=_classify_rule(
+            outcome.source_rule,
+            builtin_rule_names,
+        ),
+        decision=outcome.decision,
+        confidence=outcome.confidence_at_decision,
+        rollout_outcome=None,
+        regression_verdict=None,
+        observation_hours=None,
+        enabled_altitudes=_collect_enabled_altitudes(self_improvement_config),
+        industry_tag=analytics_config.industry_tag,
+        sdk_version=NotBlankStr(__version__),
+    )
+
+
+def anonymize_rollout(
+    result: RolloutResult,
+    *,
+    proposal: ImprovementProposal,
+    analytics_config: CrossDeploymentAnalyticsConfig,
+    self_improvement_config: SelfImprovementConfig,
+    builtin_rule_names: Collection[str],
+) -> AnonymizedOutcomeEvent:
+    """Anonymize a rollout result into a cross-deployment event.
+
+    Drops free-text details and raw proposal_id. Keeps rollout
+    outcome enum, regression verdict, and observation duration.
+
+    Args:
+        result: The rollout result to anonymize.
+        proposal: The associated proposal (for altitude/rule context).
+        analytics_config: Cross-deployment analytics configuration.
+        self_improvement_config: Full self-improvement config.
+        builtin_rule_names: Set of built-in rule names.
+
+    Returns:
+        Anonymized event with ``event_type="rollout_result"``.
+    """
+    assert analytics_config.deployment_id_salt is not None  # noqa: S101
+    return AnonymizedOutcomeEvent(
+        deployment_id=NotBlankStr(
+            _compute_deployment_id(str(analytics_config.deployment_id_salt)),
+        ),
+        event_type="rollout_result",
+        timestamp=NotBlankStr(
+            _coarsen_timestamp(result.completed_at),
+        ),
+        altitude=NotBlankStr(proposal.altitude.value),
+        source_rule=_classify_rule(
+            proposal.source_rule,
+            builtin_rule_names,
+        ),
+        decision=None,
+        confidence=None,
+        rollout_outcome=NotBlankStr(result.outcome.value),
+        regression_verdict=(
+            NotBlankStr(result.regression_verdict.value)
+            if result.regression_verdict is not None
+            else None
+        ),
+        observation_hours=result.observation_hours_elapsed,
+        enabled_altitudes=_collect_enabled_altitudes(self_improvement_config),
+        industry_tag=analytics_config.industry_tag,
+        sdk_version=NotBlankStr(__version__),
+    )
+
+
+def _compute_deployment_id(salt: str) -> str:
+    """Compute a salted SHA-256 hash for deployment identification.
+
+    The hash is deterministic for a given salt, enabling
+    cross-event correlation within a deployment without
+    exposing any reversible identifier.
+
+    Args:
+        salt: Deployment-specific salt string.
+
+    Returns:
+        64-character lowercase hex SHA-256 digest.
+    """
+    return hashlib.sha256(salt.encode("utf-8")).hexdigest()
+
+
+def _classify_rule(
+    rule_name: str | None,
+    builtin_names: Collection[str],
+) -> NotBlankStr | None:
+    """Classify a rule name for anonymized output.
+
+    Built-in rule names pass through. Custom rule names are
+    replaced with ``"custom"`` to prevent leaking deployment-
+    specific rule logic.
+
+    Args:
+        rule_name: Original rule name (may be None).
+        builtin_names: Set of known built-in rule names.
+
+    Returns:
+        Classified rule name or None.
+    """
+    if rule_name is None:
+        return None
+    if rule_name in builtin_names:
+        return NotBlankStr(rule_name)
+    return NotBlankStr("custom")
+
+
+def _coarsen_timestamp(dt: datetime) -> str:
+    """Coarsen a datetime to day-granularity ISO date string.
+
+    Strips time, timezone, and sub-day precision to prevent
+    timing-based correlation attacks.
+
+    Args:
+        dt: Aware datetime to coarsen.
+
+    Returns:
+        ISO 8601 date string (e.g., ``"2026-04-16"``).
+    """
+    return dt.date().isoformat()
+
+
+def _collect_enabled_altitudes(
+    config: SelfImprovementConfig,
+) -> tuple[NotBlankStr, ...]:
+    """Extract enabled altitude names from config.
+
+    Returns only categorical names, not the actual config values.
+
+    Args:
+        config: Self-improvement configuration.
+
+    Returns:
+        Tuple of enabled altitude name strings.
+    """
+    altitudes: list[NotBlankStr] = []
+    if config.config_tuning_enabled:
+        altitudes.append(NotBlankStr("config_tuning"))
+    if config.architecture_proposals_enabled:
+        altitudes.append(NotBlankStr("architecture"))
+    if config.prompt_tuning_enabled:
+        altitudes.append(NotBlankStr("prompt_tuning"))
+    if config.code_modification_enabled:
+        altitudes.append(NotBlankStr("code_modification"))
+    return tuple(altitudes)

--- a/src/synthorg/meta/telemetry/anonymizer.py
+++ b/src/synthorg/meta/telemetry/anonymizer.py
@@ -47,7 +47,9 @@ def anonymize_decision(
     Returns:
         Anonymized event with ``event_type="proposal_decision"``.
     """
-    assert analytics_config.deployment_id_salt is not None  # noqa: S101
+    if analytics_config.deployment_id_salt is None:
+        msg = "deployment_id_salt is required for anonymization"
+        raise ValueError(msg)
     return AnonymizedOutcomeEvent(
         deployment_id=NotBlankStr(
             _compute_deployment_id(str(analytics_config.deployment_id_salt)),
@@ -93,7 +95,9 @@ def anonymize_rollout(
     Returns:
         Anonymized event with ``event_type="rollout_result"``.
     """
-    assert analytics_config.deployment_id_salt is not None  # noqa: S101
+    if analytics_config.deployment_id_salt is None:
+        msg = "deployment_id_salt is required for anonymization"
+        raise ValueError(msg)
     return AnonymizedOutcomeEvent(
         deployment_id=NotBlankStr(
             _compute_deployment_id(str(analytics_config.deployment_id_salt)),
@@ -123,14 +127,14 @@ def anonymize_rollout(
 
 
 def _compute_deployment_id(salt: str) -> str:
-    """Compute a salted SHA-256 hash for deployment identification.
+    """Compute a SHA-256 hash of the deployment salt.
 
     The hash is deterministic for a given salt, enabling
     cross-event correlation within a deployment without
-    exposing any reversible identifier.
+    exposing the salt value itself.
 
     Args:
-        salt: Deployment-specific salt string.
+        salt: Deployment-specific secret salt string.
 
     Returns:
         64-character lowercase hex SHA-256 digest.

--- a/src/synthorg/meta/telemetry/collector.py
+++ b/src/synthorg/meta/telemetry/collector.py
@@ -1,0 +1,87 @@
+"""In-memory analytics collector for cross-deployment events.
+
+Stores anonymized events in memory and delegates pattern
+computation to the aggregator module.
+"""
+
+import asyncio
+
+from synthorg.meta.telemetry.aggregator import aggregate_patterns
+from synthorg.meta.telemetry.models import (  # noqa: TC001
+    AggregatedPattern,
+    AnonymizedOutcomeEvent,
+)
+from synthorg.observability import get_logger
+from synthorg.observability.events.cross_deployment import (
+    XDEPLOY_COLLECTOR_INGESTED,
+    XDEPLOY_PATTERN_DETECTED,
+)
+
+logger = get_logger(__name__)
+
+
+class InMemoryAnalyticsCollector:
+    """Stores anonymized events in memory and queries patterns.
+
+    Thread-safe via ``asyncio.Lock``. Events are lost on restart;
+    suitable for pre-alpha and testing. Production backends can
+    implement the ``AnalyticsCollector`` protocol with persistent
+    storage.
+    """
+
+    def __init__(self) -> None:
+        self._events: list[AnonymizedOutcomeEvent] = []
+        self._lock = asyncio.Lock()
+
+    @property
+    def event_count(self) -> int:
+        """Total events stored."""
+        return len(self._events)
+
+    async def ingest(
+        self,
+        events: tuple[AnonymizedOutcomeEvent, ...],
+    ) -> int:
+        """Ingest a batch of anonymized events.
+
+        Args:
+            events: Anonymized events to store.
+
+        Returns:
+            Number of events ingested.
+        """
+        async with self._lock:
+            self._events.extend(events)
+        logger.info(
+            XDEPLOY_COLLECTOR_INGESTED,
+            ingested=len(events),
+            total=len(self._events),
+        )
+        return len(events)
+
+    async def query_patterns(
+        self,
+        *,
+        min_deployments: int = 3,
+    ) -> tuple[AggregatedPattern, ...]:
+        """Query cross-deployment patterns from collected data.
+
+        Args:
+            min_deployments: Minimum unique deployments required.
+
+        Returns:
+            Aggregated patterns sorted by deployment count.
+        """
+        async with self._lock:
+            snapshot = tuple(self._events)
+        patterns = aggregate_patterns(
+            snapshot,
+            min_deployments=min_deployments,
+        )
+        if patterns:
+            logger.info(
+                XDEPLOY_PATTERN_DETECTED,
+                pattern_count=len(patterns),
+                min_deployments=min_deployments,
+            )
+        return patterns

--- a/src/synthorg/meta/telemetry/collector.py
+++ b/src/synthorg/meta/telemetry/collector.py
@@ -41,6 +41,9 @@ class InMemoryAnalyticsCollector:
         *,
         max_events: int = _DEFAULT_MAX_EVENTS,
     ) -> None:
+        if max_events <= 0:
+            msg = f"max_events must be > 0, got {max_events}"
+            raise ValueError(msg)
         self._events: list[AnonymizedOutcomeEvent] = []
         self._lock = asyncio.Lock()
         self._max_events = max_events

--- a/src/synthorg/meta/telemetry/collector.py
+++ b/src/synthorg/meta/telemetry/collector.py
@@ -20,6 +20,9 @@ from synthorg.observability.events.cross_deployment import (
 logger = get_logger(__name__)
 
 
+_DEFAULT_MAX_EVENTS = 100_000
+
+
 class InMemoryAnalyticsCollector:
     """Stores anonymized events in memory and queries patterns.
 
@@ -27,11 +30,20 @@ class InMemoryAnalyticsCollector:
     suitable for pre-alpha and testing. Production backends can
     implement the ``AnalyticsCollector`` protocol with persistent
     storage.
+
+    Args:
+        max_events: Maximum events to retain. Oldest events are
+            discarded when the limit is reached (FIFO).
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        max_events: int = _DEFAULT_MAX_EVENTS,
+    ) -> None:
         self._events: list[AnonymizedOutcomeEvent] = []
         self._lock = asyncio.Lock()
+        self._max_events = max_events
 
     @property
     def event_count(self) -> int:
@@ -52,10 +64,15 @@ class InMemoryAnalyticsCollector:
         """
         async with self._lock:
             self._events.extend(events)
+            # Trim oldest events if capacity exceeded.
+            overflow = len(self._events) - self._max_events
+            if overflow > 0:
+                del self._events[:overflow]
+            total = len(self._events)
         logger.info(
             XDEPLOY_COLLECTOR_INGESTED,
             ingested=len(events),
-            total=len(self._events),
+            total=total,
         )
         return len(events)
 

--- a/src/synthorg/meta/telemetry/config.py
+++ b/src/synthorg/meta/telemetry/config.py
@@ -1,0 +1,66 @@
+"""Configuration for cross-deployment analytics.
+
+Defines the frozen config model that controls opt-in telemetry,
+collector endpoint settings, and anonymization parameters.
+Disabled by default -- requires explicit opt-in.
+"""
+
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from synthorg.core.types import NotBlankStr  # noqa: TC001
+
+
+class CrossDeploymentAnalyticsConfig(BaseModel):
+    """Configuration for cross-deployment analytics telemetry.
+
+    Safe defaults: everything disabled. Requires explicit opt-in
+    with a collector URL and deployment ID salt.
+
+    Attributes:
+        enabled: Master switch for cross-deployment analytics.
+        collector_url: URL to POST anonymized events to.
+        collector_enabled: Whether this deployment acts as a
+            collector that receives events from other deployments.
+        deployment_id_salt: Salt for hashing the deployment UUID.
+            Must be kept secret -- changing it breaks deployment
+            correlation in aggregated data.
+        industry_tag: Optional industry category for cross-industry
+            pattern analysis (user-provided, not inferred).
+        batch_size: Max events to buffer before flushing.
+        flush_interval_seconds: Max seconds between flushes.
+        http_timeout_seconds: HTTP POST timeout.
+        min_deployments_for_pattern: Minimum unique deployments
+            required before a pattern is reported.
+        recommendation_min_observations: Minimum total events
+            required before generating threshold recommendations.
+    """
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False)
+
+    enabled: bool = False
+    collector_url: NotBlankStr | None = None
+    collector_enabled: bool = False
+    deployment_id_salt: NotBlankStr | None = None
+    industry_tag: NotBlankStr | None = None
+    batch_size: int = Field(default=50, ge=1, le=1000)
+    flush_interval_seconds: float = Field(default=30.0, ge=1.0, le=300.0)
+    http_timeout_seconds: float = Field(default=10.0, ge=1.0, le=60.0)
+    min_deployments_for_pattern: int = Field(default=3, ge=2)
+    recommendation_min_observations: int = Field(default=10, ge=3)
+
+    @model_validator(mode="after")
+    def _validate_enabled_requirements(self) -> Self:
+        """Require collector_url and salt when analytics is enabled."""
+        if not self.enabled:
+            return self
+        missing: list[str] = []
+        if self.collector_url is None:
+            missing.append("collector_url")
+        if self.deployment_id_salt is None:
+            missing.append("deployment_id_salt")
+        if missing:
+            msg = "cross_deployment_analytics.enabled requires: " + ", ".join(missing)
+            raise ValueError(msg)
+        return self

--- a/src/synthorg/meta/telemetry/config.py
+++ b/src/synthorg/meta/telemetry/config.py
@@ -7,7 +7,7 @@ Disabled by default -- requires explicit opt-in.
 
 from typing import Self
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from synthorg.core.types import NotBlankStr  # noqa: TC001
 
@@ -20,14 +20,16 @@ class CrossDeploymentAnalyticsConfig(BaseModel):
 
     Attributes:
         enabled: Master switch for cross-deployment analytics.
-        collector_url: URL to POST anonymized events to.
+        collector_url: HTTPS URL to POST anonymized events to.
         collector_enabled: Whether this deployment acts as a
             collector that receives events from other deployments.
-        deployment_id_salt: Salt for hashing the deployment UUID.
-            Must be kept secret -- changing it breaks deployment
-            correlation in aggregated data.
+            Requires ``enabled=True`` to take effect.
+        deployment_id_salt: Secret string hashed to produce a
+            non-reversible deployment identifier. Changing it
+            breaks deployment correlation in aggregated data.
         industry_tag: Optional industry category for cross-industry
             pattern analysis (user-provided, not inferred).
+            Max 100 characters to prevent accidental PII leakage.
         batch_size: Max events to buffer before flushing.
         flush_interval_seconds: Max seconds between flushes.
         http_timeout_seconds: HTTP POST timeout.
@@ -43,12 +45,27 @@ class CrossDeploymentAnalyticsConfig(BaseModel):
     collector_url: NotBlankStr | None = None
     collector_enabled: bool = False
     deployment_id_salt: NotBlankStr | None = None
-    industry_tag: NotBlankStr | None = None
+    industry_tag: NotBlankStr | None = Field(default=None, max_length=100)
     batch_size: int = Field(default=50, ge=1, le=1000)
     flush_interval_seconds: float = Field(default=30.0, ge=1.0, le=300.0)
     http_timeout_seconds: float = Field(default=10.0, ge=1.0, le=60.0)
     min_deployments_for_pattern: int = Field(default=3, ge=2)
     recommendation_min_observations: int = Field(default=10, ge=3)
+
+    @field_validator("collector_url")
+    @classmethod
+    def _validate_collector_url_scheme(
+        cls,
+        v: NotBlankStr | None,
+    ) -> NotBlankStr | None:
+        """Require HTTPS scheme on collector_url."""
+        if v is None:
+            return v
+        url = str(v)
+        if not url.startswith("https://"):
+            msg = "collector_url must use HTTPS scheme"
+            raise ValueError(msg)
+        return v
 
     @model_validator(mode="after")
     def _validate_enabled_requirements(self) -> Self:

--- a/src/synthorg/meta/telemetry/emitter.py
+++ b/src/synthorg/meta/telemetry/emitter.py
@@ -1,0 +1,230 @@
+"""HTTP analytics emitter for cross-deployment telemetry.
+
+Buffers anonymized events and flushes them in batches to the
+configured collector endpoint. Flush triggers: batch size
+threshold or time interval. Retries on 5xx, drops on 4xx.
+"""
+
+import asyncio
+import time
+from typing import TYPE_CHECKING
+
+import httpx
+
+from synthorg.meta.telemetry.anonymizer import anonymize_decision, anonymize_rollout
+from synthorg.meta.telemetry.models import AnonymizedOutcomeEvent, EventBatch
+from synthorg.observability import get_logger
+from synthorg.observability.events.cross_deployment import (
+    XDEPLOY_BATCH_DROPPED,
+    XDEPLOY_BATCH_FLUSH_FAILED,
+    XDEPLOY_BATCH_FLUSH_RETRYING,
+    XDEPLOY_BATCH_FLUSHED,
+    XDEPLOY_EMITTER_CLOSED,
+    XDEPLOY_EMITTER_INITIALIZED,
+    XDEPLOY_EVENT_EMIT_FAILED,
+    XDEPLOY_EVENT_QUEUED,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
+
+    from synthorg.meta.chief_of_staff.models import ProposalOutcome
+    from synthorg.meta.config import SelfImprovementConfig
+    from synthorg.meta.models import ImprovementProposal, RolloutResult
+    from synthorg.meta.telemetry.config import CrossDeploymentAnalyticsConfig
+
+logger = get_logger(__name__)
+
+_MAX_RETRIES = 3
+_BACKOFF_BASE_SECONDS = 1.0
+_CLIENT_ERROR_MIN = 400
+_SERVER_ERROR_MIN = 500
+
+
+class HttpAnalyticsEmitter:
+    """Emits anonymized outcome events to a collector via HTTP POST.
+
+    Events are buffered in memory and flushed when the batch size
+    threshold is reached, the flush interval has elapsed, or
+    ``flush()``/``close()`` is called explicitly.
+
+    Args:
+        analytics_config: Cross-deployment analytics configuration.
+        self_improvement_config: Full self-improvement config.
+        builtin_rule_names: Set of built-in rule names for
+            anonymization classification.
+    """
+
+    def __init__(
+        self,
+        *,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+        builtin_rule_names: Collection[str],
+    ) -> None:
+        self._analytics_config = analytics_config
+        self._self_improvement_config = self_improvement_config
+        self._builtin_rule_names = frozenset(builtin_rule_names)
+        self._buffer: list[AnonymizedOutcomeEvent] = []
+        self._lock = asyncio.Lock()
+        self._last_flush_at = time.monotonic()
+        self._client = httpx.AsyncClient(
+            timeout=httpx.Timeout(analytics_config.http_timeout_seconds),
+        )
+        logger.info(
+            XDEPLOY_EMITTER_INITIALIZED,
+            collector_url=str(analytics_config.collector_url),
+            batch_size=analytics_config.batch_size,
+        )
+
+    @property
+    def pending_count(self) -> int:
+        """Number of events buffered but not yet flushed."""
+        return len(self._buffer)
+
+    async def emit_decision(
+        self,
+        outcome: ProposalOutcome,
+        *,
+        proposal: ImprovementProposal,  # noqa: ARG002
+    ) -> None:
+        """Anonymize and buffer a proposal decision event.
+
+        Args:
+            outcome: The proposal outcome to anonymize.
+            proposal: The decided proposal (for context).
+        """
+        try:
+            event = anonymize_decision(
+                outcome,
+                analytics_config=self._analytics_config,
+                self_improvement_config=self._self_improvement_config,
+                builtin_rule_names=self._builtin_rule_names,
+            )
+            await self._enqueue(event)
+        except Exception:
+            logger.exception(XDEPLOY_EVENT_EMIT_FAILED, event_type="proposal_decision")
+
+    async def emit_rollout(
+        self,
+        result: RolloutResult,
+        *,
+        proposal: ImprovementProposal,
+    ) -> None:
+        """Anonymize and buffer a rollout result event.
+
+        Args:
+            result: The rollout result to anonymize.
+            proposal: The associated proposal (for context).
+        """
+        try:
+            event = anonymize_rollout(
+                result,
+                proposal=proposal,
+                analytics_config=self._analytics_config,
+                self_improvement_config=self._self_improvement_config,
+                builtin_rule_names=self._builtin_rule_names,
+            )
+            await self._enqueue(event)
+        except Exception:
+            logger.exception(XDEPLOY_EVENT_EMIT_FAILED, event_type="rollout_result")
+
+    async def flush(self) -> None:
+        """Flush all buffered events to the collector."""
+        async with self._lock:
+            if not self._buffer:
+                return
+            batch = tuple(self._buffer)
+            self._buffer.clear()
+            self._last_flush_at = time.monotonic()
+        await self._send_batch(batch)
+
+    async def close(self) -> None:
+        """Flush remaining events and close the HTTP client."""
+        await self.flush()
+        await self._client.aclose()
+        logger.info(XDEPLOY_EMITTER_CLOSED)
+
+    async def _enqueue(self, event: AnonymizedOutcomeEvent) -> None:
+        """Add event to buffer and maybe flush."""
+        should_flush = False
+        async with self._lock:
+            self._buffer.append(event)
+            logger.debug(
+                XDEPLOY_EVENT_QUEUED,
+                event_type=event.event_type,
+                pending=len(self._buffer),
+            )
+            if len(self._buffer) >= self._analytics_config.batch_size or (
+                time.monotonic() - self._last_flush_at
+                > self._analytics_config.flush_interval_seconds
+            ):
+                should_flush = True
+        if should_flush:
+            await self.flush()
+
+    async def _send_batch(
+        self,
+        events: tuple[AnonymizedOutcomeEvent, ...],
+    ) -> None:
+        """POST a batch of events to the collector with retry.
+
+        Retries up to ``_MAX_RETRIES`` times on 5xx responses
+        with exponential backoff. Drops the batch on 4xx.
+        """
+        assert self._analytics_config.collector_url is not None  # noqa: S101
+        url = str(self._analytics_config.collector_url).rstrip("/") + "/events"
+        payload = EventBatch(events=events).model_dump(mode="json")
+
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                response = await self._client.post(
+                    url,
+                    json=payload,
+                    headers={"Content-Type": "application/json"},
+                )
+                if response.status_code < _CLIENT_ERROR_MIN:
+                    logger.info(
+                        XDEPLOY_BATCH_FLUSHED,
+                        event_count=len(events),
+                        status=response.status_code,
+                    )
+                    return
+                if _CLIENT_ERROR_MIN <= response.status_code < _SERVER_ERROR_MIN:
+                    logger.warning(
+                        XDEPLOY_BATCH_DROPPED,
+                        event_count=len(events),
+                        status=response.status_code,
+                    )
+                    return
+                # 5xx: retry.
+                if attempt < _MAX_RETRIES:
+                    delay = _BACKOFF_BASE_SECONDS * (2**attempt)
+                    logger.warning(
+                        XDEPLOY_BATCH_FLUSH_RETRYING,
+                        attempt=attempt + 1,
+                        status=response.status_code,
+                        delay_seconds=delay,
+                    )
+                    await asyncio.sleep(delay)
+            except Exception:
+                if attempt < _MAX_RETRIES:
+                    delay = _BACKOFF_BASE_SECONDS * (2**attempt)
+                    logger.warning(
+                        XDEPLOY_BATCH_FLUSH_RETRYING,
+                        attempt=attempt + 1,
+                        delay_seconds=delay,
+                    )
+                    await asyncio.sleep(delay)
+                else:
+                    logger.exception(
+                        XDEPLOY_BATCH_FLUSH_FAILED,
+                        event_count=len(events),
+                    )
+                    return
+
+        logger.error(
+            XDEPLOY_BATCH_FLUSH_FAILED,
+            event_count=len(events),
+            retries_exhausted=True,
+        )

--- a/src/synthorg/meta/telemetry/emitter.py
+++ b/src/synthorg/meta/telemetry/emitter.py
@@ -179,13 +179,16 @@ class HttpAnalyticsEmitter:
             )
 
     async def _periodic_flush(self) -> None:
-        """Background loop that flushes on interval."""
+        """Background loop that flushes on interval.
+
+        Runs until ``close()`` sets ``_closed`` and cancels this
+        task. The cancellation interrupts the sleep, so no
+        post-sleep guard is needed.
+        """
         while not self._closed:
             await asyncio.sleep(
                 self._analytics_config.flush_interval_seconds,
             )
-            if self._closed:
-                break
             await self.flush()
 
     async def _enqueue(self, event: AnonymizedOutcomeEvent) -> None:

--- a/src/synthorg/meta/telemetry/emitter.py
+++ b/src/synthorg/meta/telemetry/emitter.py
@@ -2,10 +2,14 @@
 
 Buffers anonymized events and flushes them in batches to the
 configured collector endpoint. Flush triggers: batch size
-threshold or time interval. Retries on 5xx, drops on 4xx.
+threshold, time interval (periodic background task), or
+explicit ``flush()``/``close()`` call. Retries on 5xx with
+exponential backoff, drops on 4xx. 3xx redirects are treated
+as failures (POST may not have been stored).
 """
 
 import asyncio
+import contextlib
 import time
 from typing import TYPE_CHECKING
 
@@ -37,8 +41,11 @@ logger = get_logger(__name__)
 
 _MAX_RETRIES = 3
 _BACKOFF_BASE_SECONDS = 1.0
+_SUCCESS_MIN = 200
+_SUCCESS_MAX = 300
 _CLIENT_ERROR_MIN = 400
 _SERVER_ERROR_MIN = 500
+_LOG_BODY_MAX_LEN = 500
 
 
 class HttpAnalyticsEmitter:
@@ -46,7 +53,14 @@ class HttpAnalyticsEmitter:
 
     Events are buffered in memory and flushed when the batch size
     threshold is reached, the flush interval has elapsed, or
-    ``flush()``/``close()`` is called explicitly.
+    ``flush()``/``close()`` is called explicitly. A background
+    periodic task ensures buffered events are flushed even when
+    no new events arrive.
+
+    Lock invariants: ``_buffer`` and ``_last_flush_at`` are
+    protected by ``_lock``. ``_analytics_config``,
+    ``_builtin_rule_names``, and ``_client`` are immutable or
+    thread-safe and require no lock.
 
     Args:
         analytics_config: Cross-deployment analytics configuration.
@@ -68,6 +82,8 @@ class HttpAnalyticsEmitter:
         self._buffer: list[AnonymizedOutcomeEvent] = []
         self._lock = asyncio.Lock()
         self._last_flush_at = time.monotonic()
+        self._closed = False
+        self._flush_task: asyncio.Task[None] | None = None
         self._client = httpx.AsyncClient(
             timeout=httpx.Timeout(analytics_config.http_timeout_seconds),
         )
@@ -79,7 +95,12 @@ class HttpAnalyticsEmitter:
 
     @property
     def pending_count(self) -> int:
-        """Number of events buffered but not yet flushed."""
+        """Number of events buffered but not yet flushed.
+
+        Note: reads ``_buffer`` without the lock for simplicity.
+        Only intended for testing and diagnostics -- not for
+        production control flow decisions.
+        """
         return len(self._buffer)
 
     async def emit_decision(
@@ -141,12 +162,35 @@ class HttpAnalyticsEmitter:
 
     async def close(self) -> None:
         """Flush remaining events and close the HTTP client."""
+        self._closed = True
+        if self._flush_task is not None:
+            self._flush_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._flush_task
         await self.flush()
         await self._client.aclose()
         logger.info(XDEPLOY_EMITTER_CLOSED)
 
+    async def _ensure_flush_task(self) -> None:
+        """Start the periodic flush background task if not running."""
+        if self._flush_task is None or self._flush_task.done():
+            self._flush_task = asyncio.create_task(
+                self._periodic_flush(),
+            )
+
+    async def _periodic_flush(self) -> None:
+        """Background loop that flushes on interval."""
+        while not self._closed:
+            await asyncio.sleep(
+                self._analytics_config.flush_interval_seconds,
+            )
+            if self._closed:
+                break
+            await self.flush()
+
     async def _enqueue(self, event: AnonymizedOutcomeEvent) -> None:
         """Add event to buffer and maybe flush."""
+        await self._ensure_flush_task()
         should_flush = False
         async with self._lock:
             self._buffer.append(event)
@@ -155,10 +199,7 @@ class HttpAnalyticsEmitter:
                 event_type=event.event_type,
                 pending=len(self._buffer),
             )
-            if len(self._buffer) >= self._analytics_config.batch_size or (
-                time.monotonic() - self._last_flush_at
-                > self._analytics_config.flush_interval_seconds
-            ):
+            if len(self._buffer) >= self._analytics_config.batch_size:
                 should_flush = True
         if should_flush:
             await self.flush()
@@ -171,8 +212,11 @@ class HttpAnalyticsEmitter:
 
         Retries up to ``_MAX_RETRIES`` times on 5xx responses
         with exponential backoff. Drops the batch on 4xx.
+        Treats 3xx redirects as failures.
         """
-        assert self._analytics_config.collector_url is not None  # noqa: S101
+        if self._analytics_config.collector_url is None:
+            msg = "collector_url is required when analytics is enabled"
+            raise ValueError(msg)
         url = str(self._analytics_config.collector_url).rstrip("/") + "/events"
         payload = EventBatch(events=events).model_dump(mode="json")
 
@@ -188,6 +232,10 @@ class HttpAnalyticsEmitter:
                 continue
             if self._handle_response(response, attempt, len(events)):
                 return
+            # 5xx: sleep before retry (delay logged by _handle_response).
+            if attempt < _MAX_RETRIES:
+                delay = _BACKOFF_BASE_SECONDS * (2**attempt)
+                await asyncio.sleep(delay)
 
         logger.error(
             XDEPLOY_BATCH_FLUSH_FAILED,
@@ -202,7 +250,7 @@ class HttpAnalyticsEmitter:
         event_count: int,
     ) -> bool:
         """Handle HTTP response. Returns True if processing is done."""
-        if response.status_code < _CLIENT_ERROR_MIN:
+        if _SUCCESS_MIN <= response.status_code < _SUCCESS_MAX:
             logger.info(
                 XDEPLOY_BATCH_FLUSHED,
                 event_count=event_count,
@@ -218,14 +266,13 @@ class HttpAnalyticsEmitter:
                 response_body=body,
             )
             return True
+        # 3xx redirects: treat as failure (POST may not be stored).
         # 5xx: will retry if attempts remain.
         if attempt < _MAX_RETRIES:
-            delay = _BACKOFF_BASE_SECONDS * (2**attempt)
             logger.warning(
                 XDEPLOY_BATCH_FLUSH_RETRYING,
                 attempt=attempt + 1,
                 status=response.status_code,
-                delay_seconds=delay,
             )
         return False
 
@@ -253,6 +300,9 @@ class HttpAnalyticsEmitter:
 def _safe_response_text(response: httpx.Response) -> str:
     """Safely extract response body text for logging."""
     try:
-        return response.text[:500]
+        text = response.text
     except Exception:
         return "(unable to read response body)"
+    if len(text) > _LOG_BODY_MAX_LEN:
+        return text[: _LOG_BODY_MAX_LEN - 3] + "..."
+    return text

--- a/src/synthorg/meta/telemetry/emitter.py
+++ b/src/synthorg/meta/telemetry/emitter.py
@@ -183,48 +183,76 @@ class HttpAnalyticsEmitter:
                     json=payload,
                     headers={"Content-Type": "application/json"},
                 )
-                if response.status_code < _CLIENT_ERROR_MIN:
-                    logger.info(
-                        XDEPLOY_BATCH_FLUSHED,
-                        event_count=len(events),
-                        status=response.status_code,
-                    )
-                    return
-                if _CLIENT_ERROR_MIN <= response.status_code < _SERVER_ERROR_MIN:
-                    logger.warning(
-                        XDEPLOY_BATCH_DROPPED,
-                        event_count=len(events),
-                        status=response.status_code,
-                    )
-                    return
-                # 5xx: retry.
-                if attempt < _MAX_RETRIES:
-                    delay = _BACKOFF_BASE_SECONDS * (2**attempt)
-                    logger.warning(
-                        XDEPLOY_BATCH_FLUSH_RETRYING,
-                        attempt=attempt + 1,
-                        status=response.status_code,
-                        delay_seconds=delay,
-                    )
-                    await asyncio.sleep(delay)
             except Exception:
-                if attempt < _MAX_RETRIES:
-                    delay = _BACKOFF_BASE_SECONDS * (2**attempt)
-                    logger.warning(
-                        XDEPLOY_BATCH_FLUSH_RETRYING,
-                        attempt=attempt + 1,
-                        delay_seconds=delay,
-                    )
-                    await asyncio.sleep(delay)
-                else:
-                    logger.exception(
-                        XDEPLOY_BATCH_FLUSH_FAILED,
-                        event_count=len(events),
-                    )
-                    return
+                await self._handle_send_error(attempt, len(events))
+                continue
+            if self._handle_response(response, attempt, len(events)):
+                return
 
         logger.error(
             XDEPLOY_BATCH_FLUSH_FAILED,
             event_count=len(events),
             retries_exhausted=True,
         )
+
+    def _handle_response(
+        self,
+        response: httpx.Response,
+        attempt: int,
+        event_count: int,
+    ) -> bool:
+        """Handle HTTP response. Returns True if processing is done."""
+        if response.status_code < _CLIENT_ERROR_MIN:
+            logger.info(
+                XDEPLOY_BATCH_FLUSHED,
+                event_count=event_count,
+                status=response.status_code,
+            )
+            return True
+        if _CLIENT_ERROR_MIN <= response.status_code < _SERVER_ERROR_MIN:
+            body = _safe_response_text(response)
+            logger.warning(
+                XDEPLOY_BATCH_DROPPED,
+                event_count=event_count,
+                status=response.status_code,
+                response_body=body,
+            )
+            return True
+        # 5xx: will retry if attempts remain.
+        if attempt < _MAX_RETRIES:
+            delay = _BACKOFF_BASE_SECONDS * (2**attempt)
+            logger.warning(
+                XDEPLOY_BATCH_FLUSH_RETRYING,
+                attempt=attempt + 1,
+                status=response.status_code,
+                delay_seconds=delay,
+            )
+        return False
+
+    async def _handle_send_error(
+        self,
+        attempt: int,
+        event_count: int,
+    ) -> None:
+        """Handle send exception with retry or final failure."""
+        if attempt < _MAX_RETRIES:
+            delay = _BACKOFF_BASE_SECONDS * (2**attempt)
+            logger.warning(
+                XDEPLOY_BATCH_FLUSH_RETRYING,
+                attempt=attempt + 1,
+                delay_seconds=delay,
+            )
+            await asyncio.sleep(delay)
+        else:
+            logger.exception(
+                XDEPLOY_BATCH_FLUSH_FAILED,
+                event_count=event_count,
+            )
+
+
+def _safe_response_text(response: httpx.Response) -> str:
+    """Safely extract response body text for logging."""
+    try:
+        return response.text[:500]
+    except Exception:
+        return "(unable to read response body)"

--- a/src/synthorg/meta/telemetry/emitter.py
+++ b/src/synthorg/meta/telemetry/emitter.py
@@ -123,6 +123,8 @@ class HttpAnalyticsEmitter:
                 builtin_rule_names=self._builtin_rule_names,
             )
             await self._enqueue(event)
+        except MemoryError, RecursionError:
+            raise
         except Exception:
             logger.exception(XDEPLOY_EVENT_EMIT_FAILED, event_type="proposal_decision")
 
@@ -147,6 +149,8 @@ class HttpAnalyticsEmitter:
                 builtin_rule_names=self._builtin_rule_names,
             )
             await self._enqueue(event)
+        except MemoryError, RecursionError:
+            raise
         except Exception:
             logger.exception(XDEPLOY_EVENT_EMIT_FAILED, event_type="rollout_result")
 
@@ -192,7 +196,12 @@ class HttpAnalyticsEmitter:
             await self.flush()
 
     async def _enqueue(self, event: AnonymizedOutcomeEvent) -> None:
-        """Add event to buffer and maybe flush."""
+        """Add event to buffer and maybe flush.
+
+        Silently drops events after ``close()`` has been called.
+        """
+        if self._closed:
+            return
         await self._ensure_flush_task()
         should_flush = False
         async with self._lock:

--- a/src/synthorg/meta/telemetry/factory.py
+++ b/src/synthorg/meta/telemetry/factory.py
@@ -1,0 +1,75 @@
+"""Factory functions for cross-deployment analytics components.
+
+Constructs emitters, collectors, and recommenders from
+configuration, following the protocol + strategy + factory
+pattern used throughout the meta subsystem.
+"""
+
+from typing import TYPE_CHECKING
+
+from synthorg.meta.telemetry.collector import InMemoryAnalyticsCollector
+from synthorg.meta.telemetry.emitter import HttpAnalyticsEmitter
+from synthorg.meta.telemetry.recommender import DefaultThresholdRecommender
+from synthorg.observability import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
+
+    from synthorg.meta.config import SelfImprovementConfig
+
+logger = get_logger(__name__)
+
+
+def build_analytics_emitter(
+    config: SelfImprovementConfig,
+    *,
+    builtin_rule_names: Collection[str],
+) -> HttpAnalyticsEmitter | None:
+    """Build an analytics emitter from config.
+
+    Returns ``None`` if cross-deployment analytics is disabled.
+
+    Args:
+        config: Self-improvement configuration.
+        builtin_rule_names: Set of built-in rule names for
+            anonymization.
+
+    Returns:
+        Configured emitter or None.
+    """
+    analytics = config.cross_deployment_analytics
+    if not analytics.enabled:
+        return None
+    return HttpAnalyticsEmitter(
+        analytics_config=analytics,
+        self_improvement_config=config,
+        builtin_rule_names=builtin_rule_names,
+    )
+
+
+def build_analytics_collector(
+    config: SelfImprovementConfig,
+) -> InMemoryAnalyticsCollector | None:
+    """Build an analytics collector from config.
+
+    Returns ``None`` if the collector role is not enabled.
+
+    Args:
+        config: Self-improvement configuration.
+
+    Returns:
+        Configured collector or None.
+    """
+    analytics = config.cross_deployment_analytics
+    if not analytics.collector_enabled:
+        return None
+    return InMemoryAnalyticsCollector()
+
+
+def build_recommender() -> DefaultThresholdRecommender:
+    """Build a threshold recommender.
+
+    Returns:
+        Default recommender instance.
+    """
+    return DefaultThresholdRecommender()

--- a/src/synthorg/meta/telemetry/factory.py
+++ b/src/synthorg/meta/telemetry/factory.py
@@ -52,7 +52,8 @@ def build_analytics_collector(
 ) -> InMemoryAnalyticsCollector | None:
     """Build an analytics collector from config.
 
-    Returns ``None`` if the collector role is not enabled.
+    Returns ``None`` if the collector role is not enabled or
+    if the master analytics switch is off.
 
     Args:
         config: Self-improvement configuration.
@@ -61,15 +62,24 @@ def build_analytics_collector(
         Configured collector or None.
     """
     analytics = config.cross_deployment_analytics
-    if not analytics.collector_enabled:
+    if not analytics.enabled or not analytics.collector_enabled:
         return None
     return InMemoryAnalyticsCollector()
 
 
-def build_recommender() -> DefaultThresholdRecommender:
-    """Build a threshold recommender.
+def build_recommender(
+    config: SelfImprovementConfig,
+) -> DefaultThresholdRecommender:
+    """Build a threshold recommender from config.
+
+    Args:
+        config: Self-improvement configuration.
 
     Returns:
-        Default recommender instance.
+        Configured recommender instance.
     """
-    return DefaultThresholdRecommender()
+    analytics = config.cross_deployment_analytics
+    return DefaultThresholdRecommender(
+        min_deployments=analytics.min_deployments_for_pattern,
+        min_observations=analytics.recommendation_min_observations,
+    )

--- a/src/synthorg/meta/telemetry/models.py
+++ b/src/synthorg/meta/telemetry/models.py
@@ -1,0 +1,134 @@
+"""Domain models for cross-deployment analytics.
+
+Defines anonymized event payloads, aggregated patterns, and
+threshold recommendations. All models are frozen with
+``allow_inf_nan=False``.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from synthorg.core.types import NotBlankStr  # noqa: TC001
+
+
+class AnonymizedOutcomeEvent(BaseModel):
+    """Anonymized outcome event for cross-deployment analytics.
+
+    Single flat model covering both proposal decisions and rollout
+    results. Fields irrelevant to the event type are ``None``.
+
+    No PII survives: free text is dropped, UUIDs are salted-hashed,
+    timestamps are coarsened to day granularity.
+
+    Attributes:
+        schema_version: Wire format version for forward compat.
+        deployment_id: Salted SHA-256 hash of deployment UUID.
+        event_type: Whether this records a decision or rollout.
+        timestamp: ISO 8601 date (day granularity, no time).
+        altitude: Proposal altitude enum value.
+        source_rule: Built-in rule name or ``"custom"`` for
+            user-defined rules. None if no rule triggered.
+        decision: Human decision (proposal_decision events only).
+        confidence: Proposal confidence at decision time.
+        rollout_outcome: Rollout outcome enum value
+            (rollout_result events only).
+        regression_verdict: Regression detection result.
+        observation_hours: Observation window duration in hours.
+        enabled_altitudes: Which altitudes are enabled in the
+            deployment's config (categorical, not config values).
+        industry_tag: Optional user-provided industry category.
+        sdk_version: SynthOrg version string.
+    """
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False)
+
+    schema_version: Literal["1"] = "1"
+    deployment_id: NotBlankStr
+    event_type: Literal["proposal_decision", "rollout_result"]
+    timestamp: NotBlankStr
+    altitude: NotBlankStr
+    source_rule: NotBlankStr | None = None
+    decision: Literal["approved", "rejected"] | None = None
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    rollout_outcome: NotBlankStr | None = None
+    regression_verdict: NotBlankStr | None = None
+    observation_hours: float | None = Field(default=None, ge=0.0)
+    enabled_altitudes: tuple[NotBlankStr, ...] = ()
+    industry_tag: NotBlankStr | None = None
+    sdk_version: NotBlankStr
+
+
+class EventBatch(BaseModel):
+    """Batch of anonymized events for transport.
+
+    Attributes:
+        events: Tuple of anonymized outcome events.
+    """
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False)
+
+    events: tuple[AnonymizedOutcomeEvent, ...]
+
+
+class AggregatedPattern(BaseModel):
+    """Cross-deployment pattern identified from aggregated events.
+
+    Represents a ``(source_rule, altitude)`` combination observed
+    across multiple deployments with computed statistics.
+
+    Attributes:
+        source_rule: Rule name (built-in or ``"custom"``).
+        altitude: Proposal altitude.
+        deployment_count: Unique deployments that observed this.
+        total_events: Total events in this pattern group.
+        approval_rate: Cross-deployment approval rate (0-1).
+        success_rate: Cross-deployment rollout success rate (0-1).
+        avg_confidence: Mean confidence at decision time.
+        avg_observation_hours: Mean observation window (rollout
+            events only, None if no rollout events).
+        industry_breakdown: Sorted (industry_tag, count) pairs.
+    """
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False)
+
+    source_rule: NotBlankStr
+    altitude: NotBlankStr
+    deployment_count: int = Field(ge=1)
+    total_events: int = Field(ge=1)
+    approval_rate: float = Field(ge=0.0, le=1.0)
+    success_rate: float = Field(ge=0.0, le=1.0)
+    avg_confidence: float = Field(ge=0.0, le=1.0)
+    avg_observation_hours: float | None = Field(default=None, ge=0.0)
+    industry_breakdown: tuple[tuple[NotBlankStr, int], ...] = ()
+
+
+class ThresholdRecommendation(BaseModel):
+    """Recommended threshold adjustment from cross-deployment data.
+
+    Generated when a pattern shows consistent outcomes across
+    enough deployments to suggest the default threshold should
+    be adjusted.
+
+    Attributes:
+        rule_name: Built-in rule this recommendation targets.
+        metric_name: Config field path for the threshold
+            (e.g., ``"regression.quality_drop_threshold"``).
+        current_default: Current default threshold value.
+        recommended_value: Suggested new threshold value.
+        confidence: Confidence in this recommendation (0-1).
+        based_on_deployments: Unique deployments in the data.
+        based_on_observations: Total events in the data.
+        rationale: Human-readable explanation.
+    """
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False)
+
+    rule_name: NotBlankStr
+    metric_name: NotBlankStr
+    current_default: float
+    recommended_value: float
+    confidence: float = Field(ge=0.0, le=1.0)
+    based_on_deployments: int = Field(ge=1)
+    based_on_observations: int = Field(ge=1)
+    rationale: NotBlankStr

--- a/src/synthorg/meta/telemetry/models.py
+++ b/src/synthorg/meta/telemetry/models.py
@@ -5,12 +5,16 @@ threshold recommendations. All models are frozen with
 ``allow_inf_nan=False``.
 """
 
+import datetime
 import re
-from typing import Literal, Self
+from typing import Annotated, Literal, Self
 
+from annotated_types import Ge
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from synthorg.core.types import NotBlankStr  # noqa: TC001
+
+NonNegativeInt = Annotated[int, Ge(0)]
 
 _ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
@@ -55,10 +59,15 @@ class AnonymizedOutcomeEvent(BaseModel):
     @field_validator("timestamp")
     @classmethod
     def _validate_timestamp_format(cls, v: str) -> str:
-        """Enforce ISO 8601 date format (YYYY-MM-DD)."""
+        """Enforce valid ISO 8601 date (YYYY-MM-DD) with calendar check."""
         if not _ISO_DATE_RE.match(v):
             msg = f"timestamp must be ISO date (YYYY-MM-DD), got '{v}'"
             raise ValueError(msg)
+        try:
+            datetime.date.fromisoformat(v)
+        except ValueError as exc:
+            msg = f"timestamp is not a valid calendar date: '{v}'"
+            raise ValueError(msg) from exc
         return v
 
     source_rule: NotBlankStr | None = None
@@ -141,7 +150,7 @@ class AggregatedPattern(BaseModel):
     success_rate: float = Field(ge=0.0, le=1.0)
     avg_confidence: float = Field(ge=0.0, le=1.0)
     avg_observation_hours: float | None = Field(default=None, ge=0.0)
-    industry_breakdown: tuple[tuple[NotBlankStr, int], ...] = ()
+    industry_breakdown: tuple[tuple[NotBlankStr, NonNegativeInt], ...] = ()
 
 
 class ThresholdRecommendation(BaseModel):

--- a/src/synthorg/meta/telemetry/models.py
+++ b/src/synthorg/meta/telemetry/models.py
@@ -5,9 +5,9 @@ threshold recommendations. All models are frozen with
 ``allow_inf_nan=False``.
 """
 
-from typing import Literal
+from typing import Literal, Self
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from synthorg.core.types import NotBlankStr  # noqa: TC001
 
@@ -57,6 +57,25 @@ class AnonymizedOutcomeEvent(BaseModel):
     enabled_altitudes: tuple[NotBlankStr, ...] = ()
     industry_tag: NotBlankStr | None = None
     sdk_version: NotBlankStr
+
+    @model_validator(mode="after")
+    def _validate_event_type_fields(self) -> Self:
+        """Enforce proposal_decision XOR rollout_result field presence."""
+        if self.event_type == "proposal_decision":
+            if self.decision is None:
+                msg = "proposal_decision events require decision"
+                raise ValueError(msg)
+            if self.rollout_outcome is not None:
+                msg = "proposal_decision cannot have rollout_outcome"
+                raise ValueError(msg)
+        elif self.event_type == "rollout_result":
+            if self.rollout_outcome is None:
+                msg = "rollout_result events require rollout_outcome"
+                raise ValueError(msg)
+            if self.decision is not None:
+                msg = "rollout_result cannot have decision"
+                raise ValueError(msg)
+        return self
 
 
 class EventBatch(BaseModel):

--- a/src/synthorg/meta/telemetry/models.py
+++ b/src/synthorg/meta/telemetry/models.py
@@ -5,11 +5,14 @@ threshold recommendations. All models are frozen with
 ``allow_inf_nan=False``.
 """
 
+import re
 from typing import Literal, Self
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from synthorg.core.types import NotBlankStr  # noqa: TC001
+
+_ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 class AnonymizedOutcomeEvent(BaseModel):
@@ -46,8 +49,18 @@ class AnonymizedOutcomeEvent(BaseModel):
     schema_version: Literal["1"] = "1"
     deployment_id: NotBlankStr
     event_type: Literal["proposal_decision", "rollout_result"]
-    timestamp: NotBlankStr
+    timestamp: NotBlankStr  # ISO 8601 date (YYYY-MM-DD)
     altitude: NotBlankStr
+
+    @field_validator("timestamp")
+    @classmethod
+    def _validate_timestamp_format(cls, v: str) -> str:
+        """Enforce ISO 8601 date format (YYYY-MM-DD)."""
+        if not _ISO_DATE_RE.match(v):
+            msg = f"timestamp must be ISO date (YYYY-MM-DD), got '{v}'"
+            raise ValueError(msg)
+        return v
+
     source_rule: NotBlankStr | None = None
     decision: Literal["approved", "rejected"] | None = None
     confidence: float | None = Field(default=None, ge=0.0, le=1.0)
@@ -68,12 +81,21 @@ class AnonymizedOutcomeEvent(BaseModel):
             if self.rollout_outcome is not None:
                 msg = "proposal_decision cannot have rollout_outcome"
                 raise ValueError(msg)
+            if self.regression_verdict is not None:
+                msg = "proposal_decision cannot have regression_verdict"
+                raise ValueError(msg)
+            if self.observation_hours is not None:
+                msg = "proposal_decision cannot have observation_hours"
+                raise ValueError(msg)
         elif self.event_type == "rollout_result":
             if self.rollout_outcome is None:
                 msg = "rollout_result events require rollout_outcome"
                 raise ValueError(msg)
             if self.decision is not None:
                 msg = "rollout_result cannot have decision"
+                raise ValueError(msg)
+            if self.confidence is not None:
+                msg = "rollout_result cannot have confidence"
                 raise ValueError(msg)
         return self
 
@@ -87,7 +109,7 @@ class EventBatch(BaseModel):
 
     model_config = ConfigDict(frozen=True, allow_inf_nan=False)
 
-    events: tuple[AnonymizedOutcomeEvent, ...]
+    events: tuple[AnonymizedOutcomeEvent, ...] = Field(max_length=1000)
 
 
 class AggregatedPattern(BaseModel):

--- a/src/synthorg/meta/telemetry/models.py
+++ b/src/synthorg/meta/telemetry/models.py
@@ -132,6 +132,7 @@ class AggregatedPattern(BaseModel):
         altitude: Proposal altitude.
         deployment_count: Unique deployments that observed this.
         total_events: Total events in this pattern group.
+        decision_count: Number of proposal_decision events.
         approval_rate: Cross-deployment approval rate (0-1).
         success_rate: Cross-deployment rollout success rate (0-1).
         avg_confidence: Mean confidence at decision time.
@@ -146,6 +147,7 @@ class AggregatedPattern(BaseModel):
     altitude: NotBlankStr
     deployment_count: int = Field(ge=1)
     total_events: int = Field(ge=1)
+    decision_count: int = Field(ge=0)
     approval_rate: float = Field(ge=0.0, le=1.0)
     success_rate: float = Field(ge=0.0, le=1.0)
     avg_confidence: float = Field(ge=0.0, le=1.0)

--- a/src/synthorg/meta/telemetry/protocol.py
+++ b/src/synthorg/meta/telemetry/protocol.py
@@ -1,0 +1,125 @@
+"""Protocols for cross-deployment analytics.
+
+Defines structural interfaces for emitting anonymized events,
+collecting and querying them, and generating threshold
+recommendations. All protocols are runtime-checkable.
+"""
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from synthorg.meta.chief_of_staff.models import ProposalOutcome
+    from synthorg.meta.models import ImprovementProposal, RolloutResult
+    from synthorg.meta.telemetry.models import (
+        AggregatedPattern,
+        AnonymizedOutcomeEvent,
+        ThresholdRecommendation,
+    )
+
+
+@runtime_checkable
+class AnalyticsEmitter(Protocol):
+    """Emits anonymized outcome events to a collector.
+
+    Implementations buffer events and flush them in batches
+    to the configured collector endpoint.
+    """
+
+    async def emit_decision(
+        self,
+        outcome: ProposalOutcome,
+        *,
+        proposal: ImprovementProposal,
+    ) -> None:
+        """Anonymize and buffer a proposal decision event.
+
+        Args:
+            outcome: The proposal outcome to anonymize.
+            proposal: The decided proposal (for altitude/rule context).
+        """
+        ...
+
+    async def emit_rollout(
+        self,
+        result: RolloutResult,
+        *,
+        proposal: ImprovementProposal,
+    ) -> None:
+        """Anonymize and buffer a rollout result event.
+
+        Args:
+            result: The rollout result to anonymize.
+            proposal: The rolled-out proposal (for altitude/rule context).
+        """
+        ...
+
+    async def flush(self) -> None:
+        """Flush all buffered events to the collector immediately."""
+        ...
+
+    async def close(self) -> None:
+        """Flush remaining events and release resources."""
+        ...
+
+
+@runtime_checkable
+class AnalyticsCollector(Protocol):
+    """Receives and stores anonymized events from deployments.
+
+    Implementations provide event ingestion and cross-deployment
+    pattern querying.
+    """
+
+    async def ingest(
+        self,
+        events: tuple[AnonymizedOutcomeEvent, ...],
+    ) -> int:
+        """Ingest a batch of anonymized events.
+
+        Args:
+            events: Anonymized events to store.
+
+        Returns:
+            Number of events successfully ingested.
+        """
+        ...
+
+    async def query_patterns(
+        self,
+        *,
+        min_deployments: int = 3,
+    ) -> tuple[AggregatedPattern, ...]:
+        """Query cross-deployment patterns.
+
+        Args:
+            min_deployments: Minimum unique deployments required
+                for a pattern to be included.
+
+        Returns:
+            Aggregated patterns sorted by deployment count.
+        """
+        ...
+
+
+@runtime_checkable
+class RecommendationProvider(Protocol):
+    """Generates threshold recommendations from aggregated patterns.
+
+    Implementations analyze cross-deployment patterns and suggest
+    improved default thresholds for new deployments.
+    """
+
+    async def get_recommendations(
+        self,
+        *,
+        collector: AnalyticsCollector,
+    ) -> tuple[ThresholdRecommendation, ...]:
+        """Generate threshold recommendations from collected data.
+
+        Args:
+            collector: Collector to query patterns from.
+
+        Returns:
+            Threshold recommendations sorted by confidence.
+        """
+        ...

--- a/src/synthorg/meta/telemetry/recommender.py
+++ b/src/synthorg/meta/telemetry/recommender.py
@@ -23,7 +23,6 @@ logger = get_logger(__name__)
 _HIGH_APPROVAL_RATE = 0.7
 _HIGH_SUCCESS_RATE = 0.7
 _LOW_APPROVAL_RATE = 0.3
-_MIN_OBSERVATIONS_FOR_RECOMMENDATION = 10
 
 # Mapping of rule names to their configurable threshold fields
 # and current defaults. Used to generate concrete recommendations.
@@ -51,7 +50,22 @@ class DefaultThresholdRecommender:
       relaxing slightly.
     - Low approval rate: threshold may be too aggressive (fires
       often but humans reject). Recommend tightening.
+
+    Args:
+        min_deployments: Minimum unique deployments for pattern
+            inclusion (from config ``min_deployments_for_pattern``).
+        min_observations: Minimum events for recommendations
+            (from config ``recommendation_min_observations``).
     """
+
+    def __init__(
+        self,
+        *,
+        min_deployments: int = 3,
+        min_observations: int = 10,
+    ) -> None:
+        self._min_deployments = min_deployments
+        self._min_observations = min_observations
 
     async def get_recommendations(
         self,
@@ -66,7 +80,9 @@ class DefaultThresholdRecommender:
         Returns:
             Threshold recommendations sorted by confidence.
         """
-        patterns = await collector.query_patterns(min_deployments=3)
+        patterns = await collector.query_patterns(
+            min_deployments=self._min_deployments,
+        )
         recommendations: list[ThresholdRecommendation] = []
 
         for pattern in patterns:
@@ -100,7 +116,7 @@ class DefaultThresholdRecommender:
         if threshold_info is None:
             return None
         metric_name, current_default = threshold_info
-        has_enough = pattern.total_events >= _MIN_OBSERVATIONS_FOR_RECOMMENDATION
+        has_enough = pattern.total_events >= self._min_observations
         if not has_enough:
             return None
 

--- a/src/synthorg/meta/telemetry/recommender.py
+++ b/src/synthorg/meta/telemetry/recommender.py
@@ -99,64 +99,97 @@ class DefaultThresholdRecommender:
         threshold_info = _RULE_THRESHOLD_MAP.get(pattern.source_rule)
         if threshold_info is None:
             return None
-
         metric_name, current_default = threshold_info
+        has_enough = pattern.total_events >= _MIN_OBSERVATIONS_FOR_RECOMMENDATION
+        if not has_enough:
+            return None
 
-        # High approval + high success: threshold may be too conservative.
         if (
             pattern.approval_rate >= _HIGH_APPROVAL_RATE
             and pattern.success_rate >= _HIGH_SUCCESS_RATE
-            and pattern.total_events >= _MIN_OBSERVATIONS_FOR_RECOMMENDATION
         ):
-            # Recommend relaxing by 10-20% based on confidence.
-            adjustment = 0.1 + (0.1 * pattern.avg_confidence)
-            recommended = current_default * (1.0 + adjustment)
-            confidence = min(
-                pattern.avg_confidence,
-                pattern.deployment_count / 10.0,
-            )
-            return ThresholdRecommendation(
-                rule_name=NotBlankStr(pattern.source_rule),
-                metric_name=NotBlankStr(metric_name),
-                current_default=current_default,
-                recommended_value=round(recommended, 4),
-                confidence=min(confidence, 1.0),
-                based_on_deployments=pattern.deployment_count,
-                based_on_observations=pattern.total_events,
-                rationale=NotBlankStr(
-                    f"Rule '{pattern.source_rule}' has "
-                    f"{pattern.approval_rate:.0%} approval and "
-                    f"{pattern.success_rate:.0%} success across "
-                    f"{pattern.deployment_count} deployments. "
-                    f"Threshold may be too conservative."
-                ),
-            )
+            return self._recommend_relax(pattern, metric_name, current_default)
 
-        # Low approval: threshold may be too aggressive.
-        if (
-            pattern.approval_rate <= _LOW_APPROVAL_RATE
-            and pattern.total_events >= _MIN_OBSERVATIONS_FOR_RECOMMENDATION
-        ):
-            adjustment = 0.1 + (0.1 * (1.0 - pattern.avg_confidence))
-            recommended = current_default * (1.0 - adjustment)
-            confidence = min(
-                0.5 + (pattern.deployment_count / 20.0),
-                1.0,
-            )
-            return ThresholdRecommendation(
-                rule_name=NotBlankStr(pattern.source_rule),
-                metric_name=NotBlankStr(metric_name),
-                current_default=current_default,
-                recommended_value=round(recommended, 4),
-                confidence=confidence,
-                based_on_deployments=pattern.deployment_count,
-                based_on_observations=pattern.total_events,
-                rationale=NotBlankStr(
-                    f"Rule '{pattern.source_rule}' has only "
-                    f"{pattern.approval_rate:.0%} approval across "
-                    f"{pattern.deployment_count} deployments. "
-                    f"Threshold may be too aggressive."
-                ),
-            )
+        if pattern.approval_rate <= _LOW_APPROVAL_RATE:
+            return self._recommend_tighten(pattern, metric_name, current_default)
 
         return None
+
+    def _recommend_relax(
+        self,
+        pattern: AggregatedPattern,
+        metric_name: str,
+        current_default: float,
+    ) -> ThresholdRecommendation:
+        """Build a recommendation to relax a too-conservative threshold."""
+        adjustment = 0.1 + (0.1 * pattern.avg_confidence)
+        recommended = current_default * (1.0 + adjustment)
+        confidence = min(
+            pattern.avg_confidence,
+            pattern.deployment_count / 10.0,
+            1.0,
+        )
+        rationale = (
+            f"Rule '{pattern.source_rule}' has "
+            f"{pattern.approval_rate:.0%} approval and "
+            f"{pattern.success_rate:.0%} success across "
+            f"{pattern.deployment_count} deployments. "
+            f"Threshold may be too conservative."
+        )
+        return _build_recommendation(
+            pattern,
+            metric_name,
+            current_default,
+            recommended,
+            confidence,
+            rationale,
+        )
+
+    def _recommend_tighten(
+        self,
+        pattern: AggregatedPattern,
+        metric_name: str,
+        current_default: float,
+    ) -> ThresholdRecommendation:
+        """Build a recommendation to tighten a too-aggressive threshold."""
+        adjustment = 0.1 + (0.1 * (1.0 - pattern.avg_confidence))
+        recommended = current_default * (1.0 - adjustment)
+        confidence = min(
+            0.5 + (pattern.deployment_count / 20.0),
+            1.0,
+        )
+        rationale = (
+            f"Rule '{pattern.source_rule}' has only "
+            f"{pattern.approval_rate:.0%} approval across "
+            f"{pattern.deployment_count} deployments. "
+            f"Threshold may be too aggressive."
+        )
+        return _build_recommendation(
+            pattern,
+            metric_name,
+            current_default,
+            recommended,
+            confidence,
+            rationale,
+        )
+
+
+def _build_recommendation(  # noqa: PLR0913
+    pattern: AggregatedPattern,
+    metric_name: str,
+    current_default: float,
+    recommended: float,
+    confidence: float,
+    rationale: str,
+) -> ThresholdRecommendation:
+    """Construct a ThresholdRecommendation from computed values."""
+    return ThresholdRecommendation(
+        rule_name=NotBlankStr(pattern.source_rule),
+        metric_name=NotBlankStr(metric_name),
+        current_default=current_default,
+        recommended_value=round(recommended, 4),
+        confidence=confidence,
+        based_on_deployments=pattern.deployment_count,
+        based_on_observations=pattern.total_events,
+        rationale=NotBlankStr(rationale),
+    )

--- a/src/synthorg/meta/telemetry/recommender.py
+++ b/src/synthorg/meta/telemetry/recommender.py
@@ -126,7 +126,7 @@ class DefaultThresholdRecommender:
         ):
             return self._recommend_relax(pattern, metric_name, current_default)
 
-        if pattern.approval_rate <= _LOW_APPROVAL_RATE:
+        if pattern.decision_count >= 1 and pattern.approval_rate <= _LOW_APPROVAL_RATE:
             return self._recommend_tighten(pattern, metric_name, current_default)
 
         return None

--- a/src/synthorg/meta/telemetry/recommender.py
+++ b/src/synthorg/meta/telemetry/recommender.py
@@ -1,0 +1,162 @@
+"""Threshold recommendation generator.
+
+Analyzes cross-deployment patterns and suggests threshold
+adjustments for built-in rules based on observed outcomes.
+"""
+
+from typing import TYPE_CHECKING
+
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.telemetry.models import ThresholdRecommendation
+from synthorg.observability import get_logger
+from synthorg.observability.events.cross_deployment import (
+    XDEPLOY_RECOMMENDATION_GENERATED,
+)
+
+if TYPE_CHECKING:
+    from synthorg.meta.telemetry.models import AggregatedPattern
+    from synthorg.meta.telemetry.protocol import AnalyticsCollector
+
+logger = get_logger(__name__)
+
+# Thresholds for recommendation generation.
+_HIGH_APPROVAL_RATE = 0.7
+_HIGH_SUCCESS_RATE = 0.7
+_LOW_APPROVAL_RATE = 0.3
+_MIN_OBSERVATIONS_FOR_RECOMMENDATION = 10
+
+# Mapping of rule names to their configurable threshold fields
+# and current defaults. Used to generate concrete recommendations.
+_RULE_THRESHOLD_MAP: dict[str, tuple[str, float]] = {
+    "quality_declining": ("quality_drop_threshold", 5.0),
+    "success_rate_drop": ("success_rate_threshold", 0.7),
+    "budget_overrun": ("days_until_exhausted_threshold", 14.0),
+    "coordination_cost_ratio": ("coordination_ratio_threshold", 0.4),
+    "coordination_overhead": ("overhead_pct_threshold", 35.0),
+    "straggler_bottleneck": ("straggler_gap_ratio_threshold", 2.0),
+    "redundancy": ("redundancy_rate_threshold", 0.3),
+    "scaling_failure": ("scaling_failure_rate_threshold", 0.5),
+    "error_spike": ("error_findings_threshold", 10.0),
+}
+
+
+class DefaultThresholdRecommender:
+    """Generates threshold recommendations from aggregated patterns.
+
+    Analyzes cross-deployment patterns and recommends threshold
+    adjustments when consistent outcomes are observed:
+
+    - High approval + high success rate: threshold may be too
+      conservative (fires correctly, proposals succeed). Recommend
+      relaxing slightly.
+    - Low approval rate: threshold may be too aggressive (fires
+      often but humans reject). Recommend tightening.
+    """
+
+    async def get_recommendations(
+        self,
+        *,
+        collector: AnalyticsCollector,
+    ) -> tuple[ThresholdRecommendation, ...]:
+        """Generate recommendations from collected data.
+
+        Args:
+            collector: Collector to query patterns from.
+
+        Returns:
+            Threshold recommendations sorted by confidence.
+        """
+        patterns = await collector.query_patterns(min_deployments=3)
+        recommendations: list[ThresholdRecommendation] = []
+
+        for pattern in patterns:
+            rec = self._evaluate_pattern(pattern)
+            if rec is not None:
+                recommendations.append(rec)
+
+        recommendations.sort(key=lambda r: -r.confidence)
+
+        if recommendations:
+            logger.info(
+                XDEPLOY_RECOMMENDATION_GENERATED,
+                count=len(recommendations),
+            )
+
+        return tuple(recommendations)
+
+    def _evaluate_pattern(
+        self,
+        pattern: AggregatedPattern,
+    ) -> ThresholdRecommendation | None:
+        """Evaluate a single pattern for threshold recommendation.
+
+        Args:
+            pattern: Aggregated cross-deployment pattern.
+
+        Returns:
+            A recommendation, or None if no adjustment is warranted.
+        """
+        threshold_info = _RULE_THRESHOLD_MAP.get(pattern.source_rule)
+        if threshold_info is None:
+            return None
+
+        metric_name, current_default = threshold_info
+
+        # High approval + high success: threshold may be too conservative.
+        if (
+            pattern.approval_rate >= _HIGH_APPROVAL_RATE
+            and pattern.success_rate >= _HIGH_SUCCESS_RATE
+            and pattern.total_events >= _MIN_OBSERVATIONS_FOR_RECOMMENDATION
+        ):
+            # Recommend relaxing by 10-20% based on confidence.
+            adjustment = 0.1 + (0.1 * pattern.avg_confidence)
+            recommended = current_default * (1.0 + adjustment)
+            confidence = min(
+                pattern.avg_confidence,
+                pattern.deployment_count / 10.0,
+            )
+            return ThresholdRecommendation(
+                rule_name=NotBlankStr(pattern.source_rule),
+                metric_name=NotBlankStr(metric_name),
+                current_default=current_default,
+                recommended_value=round(recommended, 4),
+                confidence=min(confidence, 1.0),
+                based_on_deployments=pattern.deployment_count,
+                based_on_observations=pattern.total_events,
+                rationale=NotBlankStr(
+                    f"Rule '{pattern.source_rule}' has "
+                    f"{pattern.approval_rate:.0%} approval and "
+                    f"{pattern.success_rate:.0%} success across "
+                    f"{pattern.deployment_count} deployments. "
+                    f"Threshold may be too conservative."
+                ),
+            )
+
+        # Low approval: threshold may be too aggressive.
+        if (
+            pattern.approval_rate <= _LOW_APPROVAL_RATE
+            and pattern.total_events >= _MIN_OBSERVATIONS_FOR_RECOMMENDATION
+        ):
+            adjustment = 0.1 + (0.1 * (1.0 - pattern.avg_confidence))
+            recommended = current_default * (1.0 - adjustment)
+            confidence = min(
+                0.5 + (pattern.deployment_count / 20.0),
+                1.0,
+            )
+            return ThresholdRecommendation(
+                rule_name=NotBlankStr(pattern.source_rule),
+                metric_name=NotBlankStr(metric_name),
+                current_default=current_default,
+                recommended_value=round(recommended, 4),
+                confidence=confidence,
+                based_on_deployments=pattern.deployment_count,
+                based_on_observations=pattern.total_events,
+                rationale=NotBlankStr(
+                    f"Rule '{pattern.source_rule}' has only "
+                    f"{pattern.approval_rate:.0%} approval across "
+                    f"{pattern.deployment_count} deployments. "
+                    f"Threshold may be too aggressive."
+                ),
+            )
+
+        return None

--- a/src/synthorg/observability/events/cross_deployment.py
+++ b/src/synthorg/observability/events/cross_deployment.py
@@ -1,0 +1,39 @@
+"""Cross-deployment analytics event constants for structured logging.
+
+Constants follow the ``cross_deployment.<subject>.<action>`` naming
+convention and are passed as the first argument to structured log calls.
+"""
+
+from typing import Final
+
+# -- Emitter lifecycle -----------------------------------------------------
+
+XDEPLOY_EMITTER_INITIALIZED: Final[str] = "cross_deployment.emitter.initialized"
+XDEPLOY_EMITTER_CLOSED: Final[str] = "cross_deployment.emitter.closed"
+
+# -- Event emission --------------------------------------------------------
+
+XDEPLOY_EVENT_QUEUED: Final[str] = "cross_deployment.event.queued"
+XDEPLOY_EVENT_EMIT_FAILED: Final[str] = "cross_deployment.event.emit_failed"
+
+# -- Batch flushing --------------------------------------------------------
+
+XDEPLOY_BATCH_FLUSHED: Final[str] = "cross_deployment.batch.flushed"
+XDEPLOY_BATCH_FLUSH_FAILED: Final[str] = "cross_deployment.batch.flush_failed"
+XDEPLOY_BATCH_FLUSH_RETRYING: Final[str] = "cross_deployment.batch.flush_retrying"
+XDEPLOY_BATCH_DROPPED: Final[str] = "cross_deployment.batch.dropped"
+
+# -- Collector -------------------------------------------------------------
+
+XDEPLOY_COLLECTOR_INGESTED: Final[str] = "cross_deployment.collector.ingested"
+XDEPLOY_COLLECTOR_INGEST_FAILED: Final[str] = "cross_deployment.collector.ingest_failed"
+
+# -- Pattern aggregation ---------------------------------------------------
+
+XDEPLOY_PATTERN_DETECTED: Final[str] = "cross_deployment.pattern.detected"
+
+# -- Recommendations -------------------------------------------------------
+
+XDEPLOY_RECOMMENDATION_GENERATED: Final[str] = (
+    "cross_deployment.recommendation.generated"
+)

--- a/tests/unit/meta/telemetry/conftest.py
+++ b/tests/unit/meta/telemetry/conftest.py
@@ -1,0 +1,135 @@
+"""Shared fixtures for cross-deployment analytics tests."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.chief_of_staff.models import ProposalOutcome
+from synthorg.meta.config import SelfImprovementConfig
+from synthorg.meta.models import (
+    ConfigChange,
+    ImprovementProposal,
+    ProposalAltitude,
+    ProposalRationale,
+    RegressionVerdict,
+    RollbackOperation,
+    RollbackPlan,
+    RolloutOutcome,
+    RolloutResult,
+    RolloutStrategyType,
+)
+from synthorg.meta.telemetry.config import CrossDeploymentAnalyticsConfig
+
+_NOW = datetime(2026, 4, 16, 12, 0, 0, tzinfo=UTC)
+
+BUILTIN_RULE_NAMES: frozenset[str] = frozenset(
+    {
+        "quality_declining",
+        "success_rate_drop",
+        "budget_overrun",
+        "coordination_cost_ratio",
+        "coordination_overhead",
+        "straggler_bottleneck",
+        "redundancy",
+        "scaling_failure",
+        "error_spike",
+    }
+)
+
+
+@pytest.fixture
+def analytics_config() -> CrossDeploymentAnalyticsConfig:
+    """Enabled analytics config with test salt."""
+    return CrossDeploymentAnalyticsConfig(
+        enabled=True,
+        collector_url=NotBlankStr("https://collector.test/api/meta/analytics"),
+        deployment_id_salt=NotBlankStr("test-salt-value"),
+        industry_tag=NotBlankStr("technology"),
+        batch_size=10,
+        flush_interval_seconds=5.0,
+    )
+
+
+@pytest.fixture
+def self_improvement_config(
+    analytics_config: CrossDeploymentAnalyticsConfig,
+) -> SelfImprovementConfig:
+    """SelfImprovementConfig with analytics enabled."""
+    return SelfImprovementConfig(
+        enabled=True,
+        config_tuning_enabled=True,
+        architecture_proposals_enabled=True,
+        cross_deployment_analytics=analytics_config,
+    )
+
+
+@pytest.fixture
+def sample_proposal() -> ImprovementProposal:
+    """Sample approved proposal for testing."""
+    return ImprovementProposal(
+        altitude=ProposalAltitude.CONFIG_TUNING,
+        title=NotBlankStr("Reduce coordination overhead threshold"),
+        description=NotBlankStr("Lower the coordination overhead threshold"),
+        rationale=ProposalRationale(
+            signal_summary=NotBlankStr("Coordination overhead is 42%"),
+            pattern_detected=NotBlankStr("coordination_overhead_high"),
+            expected_impact=NotBlankStr("Reduce overhead to 35%"),
+            confidence_reasoning=NotBlankStr("Historical data supports this"),
+        ),
+        config_changes=(
+            ConfigChange(
+                path=NotBlankStr("coordination.overhead_threshold"),
+                old_value="0.35",
+                new_value="0.30",
+                description=NotBlankStr("Lower threshold"),
+            ),
+        ),
+        rollback_plan=RollbackPlan(
+            operations=(
+                RollbackOperation(
+                    operation_type=NotBlankStr("revert_config"),
+                    target=NotBlankStr("coordination.overhead_threshold"),
+                    previous_value="0.35",
+                    description=NotBlankStr("Revert threshold to 0.35"),
+                ),
+            ),
+            validation_check=NotBlankStr(
+                "Verify coordination overhead threshold is 0.35",
+            ),
+        ),
+        confidence=0.72,
+        source_rule=NotBlankStr("coordination_overhead"),
+        rollout_strategy=RolloutStrategyType.BEFORE_AFTER,
+    )
+
+
+@pytest.fixture
+def sample_outcome(sample_proposal: ImprovementProposal) -> ProposalOutcome:
+    """Sample proposal outcome for testing."""
+    return ProposalOutcome(
+        proposal_id=sample_proposal.id,
+        title=NotBlankStr("Reduce coordination overhead threshold"),
+        altitude=ProposalAltitude.CONFIG_TUNING,
+        source_rule=NotBlankStr("coordination_overhead"),
+        decision="approved",
+        confidence_at_decision=0.72,
+        decided_at=_NOW,
+        decided_by=NotBlankStr("admin-user"),
+        decision_reason=NotBlankStr("Looks good, proceed with rollout"),
+    )
+
+
+@pytest.fixture
+def sample_rollout_result(
+    sample_proposal: ImprovementProposal,
+) -> RolloutResult:
+    """Sample rollout result for testing."""
+    return RolloutResult(
+        proposal_id=sample_proposal.id,
+        outcome=RolloutOutcome.SUCCESS,
+        regression_verdict=RegressionVerdict.NO_REGRESSION,
+        observation_hours_elapsed=48.0,
+        details=NotBlankStr("Observation window completed without regression"),
+        completed_at=_NOW,
+    )

--- a/tests/unit/meta/telemetry/test_aggregator.py
+++ b/tests/unit/meta/telemetry/test_aggregator.py
@@ -1,0 +1,206 @@
+"""Unit tests for the cross-deployment pattern aggregator."""
+
+import pytest
+
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.telemetry.aggregator import aggregate_patterns
+from synthorg.meta.telemetry.models import AnonymizedOutcomeEvent
+
+pytestmark = pytest.mark.unit
+
+
+def _make_event(  # noqa: PLR0913
+    *,
+    deployment_id: str = "deploy-aaa",
+    event_type: str = "proposal_decision",
+    altitude: str = "config_tuning",
+    source_rule: str = "coordination_overhead",
+    decision: str | None = "approved",
+    confidence: float | None = 0.7,
+    rollout_outcome: str | None = None,
+    regression_verdict: str | None = None,
+    observation_hours: float | None = None,
+    industry_tag: str | None = "technology",
+) -> AnonymizedOutcomeEvent:
+    return AnonymizedOutcomeEvent(
+        deployment_id=NotBlankStr(deployment_id),
+        event_type=event_type,  # type: ignore[arg-type]
+        timestamp=NotBlankStr("2026-04-16"),
+        altitude=NotBlankStr(altitude),
+        source_rule=NotBlankStr(source_rule) if source_rule else None,
+        decision=decision,  # type: ignore[arg-type]
+        confidence=confidence,
+        rollout_outcome=NotBlankStr(rollout_outcome) if rollout_outcome else None,
+        regression_verdict=(
+            NotBlankStr(regression_verdict) if regression_verdict else None
+        ),
+        observation_hours=observation_hours,
+        enabled_altitudes=(NotBlankStr("config_tuning"),),
+        industry_tag=NotBlankStr(industry_tag) if industry_tag else None,
+        sdk_version=NotBlankStr("0.6.8"),
+    )
+
+
+class TestAggregatePatterns:
+    """Tests for aggregate_patterns()."""
+
+    def test_empty_events_returns_empty(self) -> None:
+        assert aggregate_patterns(()) == ()
+
+    def test_below_min_deployments_filtered_out(self) -> None:
+        events = tuple(_make_event(deployment_id=f"deploy-{i}") for i in range(2))
+        result = aggregate_patterns(events, min_deployments=3)
+        assert result == ()
+
+    def test_meets_min_deployments_included(self) -> None:
+        events = tuple(_make_event(deployment_id=f"deploy-{i}") for i in range(3))
+        result = aggregate_patterns(events, min_deployments=3)
+        assert len(result) == 1
+        assert result[0].deployment_count == 3
+        assert result[0].source_rule == "coordination_overhead"
+        assert result[0].altitude == "config_tuning"
+
+    def test_approval_rate_computed(self) -> None:
+        events = (
+            _make_event(deployment_id="a", decision="approved"),
+            _make_event(deployment_id="b", decision="approved"),
+            _make_event(deployment_id="c", decision="rejected"),
+        )
+        result = aggregate_patterns(events, min_deployments=3)
+        assert len(result) == 1
+        assert abs(result[0].approval_rate - 2 / 3) < 0.01
+
+    def test_success_rate_from_rollout_events(self) -> None:
+        events = (
+            _make_event(
+                deployment_id="a",
+                event_type="rollout_result",
+                decision=None,
+                confidence=None,
+                rollout_outcome="success",
+                observation_hours=48.0,
+            ),
+            _make_event(
+                deployment_id="b",
+                event_type="rollout_result",
+                decision=None,
+                confidence=None,
+                rollout_outcome="regressed",
+                observation_hours=24.0,
+            ),
+            _make_event(
+                deployment_id="c",
+                event_type="rollout_result",
+                decision=None,
+                confidence=None,
+                rollout_outcome="success",
+                observation_hours=48.0,
+            ),
+        )
+        result = aggregate_patterns(events, min_deployments=3)
+        assert len(result) == 1
+        assert abs(result[0].success_rate - 2 / 3) < 0.01
+
+    def test_avg_observation_hours(self) -> None:
+        events = (
+            _make_event(
+                deployment_id="a",
+                event_type="rollout_result",
+                decision=None,
+                confidence=None,
+                rollout_outcome="success",
+                observation_hours=48.0,
+            ),
+            _make_event(
+                deployment_id="b",
+                event_type="rollout_result",
+                decision=None,
+                confidence=None,
+                rollout_outcome="success",
+                observation_hours=24.0,
+            ),
+            _make_event(
+                deployment_id="c",
+                event_type="rollout_result",
+                decision=None,
+                confidence=None,
+                rollout_outcome="success",
+                observation_hours=72.0,
+            ),
+        )
+        result = aggregate_patterns(events, min_deployments=3)
+        assert result[0].avg_observation_hours == 48.0
+
+    def test_avg_observation_hours_none_without_rollouts(self) -> None:
+        events = tuple(_make_event(deployment_id=f"deploy-{i}") for i in range(3))
+        result = aggregate_patterns(events, min_deployments=3)
+        assert result[0].avg_observation_hours is None
+
+    def test_industry_breakdown(self) -> None:
+        events = (
+            _make_event(deployment_id="a", industry_tag="technology"),
+            _make_event(deployment_id="b", industry_tag="technology"),
+            _make_event(deployment_id="c", industry_tag="healthcare"),
+        )
+        result = aggregate_patterns(events, min_deployments=3)
+        breakdown = dict(result[0].industry_breakdown)
+        assert breakdown["technology"] == 2
+        assert breakdown["healthcare"] == 1
+
+    def test_multiple_rule_altitude_groups(self) -> None:
+        events = (
+            # Group 1: coordination_overhead / config_tuning.
+            _make_event(deployment_id="a", source_rule="coordination_overhead"),
+            _make_event(deployment_id="b", source_rule="coordination_overhead"),
+            _make_event(deployment_id="c", source_rule="coordination_overhead"),
+            # Group 2: quality_declining / config_tuning.
+            _make_event(deployment_id="a", source_rule="quality_declining"),
+            _make_event(deployment_id="b", source_rule="quality_declining"),
+            _make_event(deployment_id="c", source_rule="quality_declining"),
+        )
+        result = aggregate_patterns(events, min_deployments=3)
+        assert len(result) == 2
+
+    def test_sorted_by_deployment_count_descending(self) -> None:
+        events = (
+            # 4 deployments for coordination_overhead.
+            *[
+                _make_event(
+                    deployment_id=f"d-{i}",
+                    source_rule="coordination_overhead",
+                )
+                for i in range(4)
+            ],
+            # 3 deployments for quality_declining.
+            *[
+                _make_event(
+                    deployment_id=f"d-{i}",
+                    source_rule="quality_declining",
+                )
+                for i in range(3)
+            ],
+        )
+        result = aggregate_patterns(events, min_deployments=3)
+        assert result[0].source_rule == "coordination_overhead"
+        assert result[1].source_rule == "quality_declining"
+
+    def test_mixed_decision_and_rollout_events(self) -> None:
+        events = (
+            _make_event(deployment_id="a", decision="approved"),
+            _make_event(
+                deployment_id="b",
+                event_type="rollout_result",
+                decision=None,
+                confidence=None,
+                rollout_outcome="success",
+                observation_hours=48.0,
+            ),
+            _make_event(deployment_id="c", decision="rejected"),
+        )
+        result = aggregate_patterns(events, min_deployments=3)
+        assert len(result) == 1
+        assert result[0].total_events == 3
+        # 1 approved out of 2 decisions.
+        assert abs(result[0].approval_rate - 0.5) < 0.01
+        # 1 success out of 1 rollout.
+        assert result[0].success_rate == 1.0

--- a/tests/unit/meta/telemetry/test_anonymizer.py
+++ b/tests/unit/meta/telemetry/test_anonymizer.py
@@ -1,0 +1,497 @@
+"""Unit tests for the cross-deployment analytics anonymizer."""
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.chief_of_staff.models import ProposalOutcome
+from synthorg.meta.config import SelfImprovementConfig
+from synthorg.meta.models import (
+    ImprovementProposal,
+    ProposalAltitude,
+    RolloutResult,
+)
+from synthorg.meta.telemetry.anonymizer import (
+    anonymize_decision,
+    anonymize_rollout,
+)
+from synthorg.meta.telemetry.config import CrossDeploymentAnalyticsConfig
+
+from .conftest import BUILTIN_RULE_NAMES
+
+pytestmark = pytest.mark.unit
+
+
+class TestAnonymizeDecision:
+    """Tests for anonymize_decision()."""
+
+    def test_event_type_is_proposal_decision(
+        self,
+        sample_outcome: ProposalOutcome,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        event = anonymize_decision(
+            sample_outcome,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert event.event_type == "proposal_decision"
+
+    def test_altitude_preserved(
+        self,
+        sample_outcome: ProposalOutcome,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        event = anonymize_decision(
+            sample_outcome,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert event.altitude == ProposalAltitude.CONFIG_TUNING.value
+
+    def test_decision_preserved(
+        self,
+        sample_outcome: ProposalOutcome,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        event = anonymize_decision(
+            sample_outcome,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert event.decision == "approved"
+
+    def test_confidence_preserved(
+        self,
+        sample_outcome: ProposalOutcome,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        event = anonymize_decision(
+            sample_outcome,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert event.confidence == 0.72
+
+    def test_builtin_rule_name_preserved(
+        self,
+        sample_outcome: ProposalOutcome,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        event = anonymize_decision(
+            sample_outcome,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert event.source_rule == "coordination_overhead"
+
+    def test_custom_rule_name_masked(
+        self,
+        sample_outcome: ProposalOutcome,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        custom = sample_outcome.model_copy(
+            update={"source_rule": NotBlankStr("my_secret_rule")},
+        )
+        event = anonymize_decision(
+            custom,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert event.source_rule == "custom"
+
+    def test_no_rule_stays_none(
+        self,
+        sample_outcome: ProposalOutcome,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        no_rule = sample_outcome.model_copy(update={"source_rule": None})
+        event = anonymize_decision(
+            no_rule,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert event.source_rule is None
+
+    def test_timestamp_coarsened_to_date(
+        self,
+        sample_outcome: ProposalOutcome,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        event = anonymize_decision(
+            sample_outcome,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        # Day granularity only -- no time component.
+        assert event.timestamp == "2026-04-16"
+
+    def test_deployment_id_is_salted_hash(
+        self,
+        sample_outcome: ProposalOutcome,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        event = anonymize_decision(
+            sample_outcome,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        # Must be a hex SHA-256 (64 chars).
+        assert len(event.deployment_id) == 64
+        assert all(c in "0123456789abcdef" for c in event.deployment_id)
+
+    def test_deployment_id_deterministic(
+        self,
+        sample_outcome: ProposalOutcome,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        e1 = anonymize_decision(
+            sample_outcome,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        e2 = anonymize_decision(
+            sample_outcome,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert e1.deployment_id == e2.deployment_id
+
+    def test_different_salt_different_id(
+        self,
+        sample_outcome: ProposalOutcome,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        cfg1 = CrossDeploymentAnalyticsConfig(
+            enabled=True,
+            collector_url=NotBlankStr("https://test.example"),
+            deployment_id_salt=NotBlankStr("salt-A"),
+        )
+        cfg2 = CrossDeploymentAnalyticsConfig(
+            enabled=True,
+            collector_url=NotBlankStr("https://test.example"),
+            deployment_id_salt=NotBlankStr("salt-B"),
+        )
+        si1 = self_improvement_config.model_copy(
+            update={"cross_deployment_analytics": cfg1},
+        )
+        si2 = self_improvement_config.model_copy(
+            update={"cross_deployment_analytics": cfg2},
+        )
+        e1 = anonymize_decision(
+            sample_outcome,
+            analytics_config=cfg1,
+            self_improvement_config=si1,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        e2 = anonymize_decision(
+            sample_outcome,
+            analytics_config=cfg2,
+            self_improvement_config=si2,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert e1.deployment_id != e2.deployment_id
+
+    def test_enabled_altitudes_from_config(
+        self,
+        sample_outcome: ProposalOutcome,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        event = anonymize_decision(
+            sample_outcome,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        # Config has config_tuning + architecture enabled.
+        assert "config_tuning" in event.enabled_altitudes
+        assert "architecture" in event.enabled_altitudes
+        assert "prompt_tuning" not in event.enabled_altitudes
+
+    def test_industry_tag_from_config(
+        self,
+        sample_outcome: ProposalOutcome,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        event = anonymize_decision(
+            sample_outcome,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert event.industry_tag == "technology"
+
+    def test_pii_fields_not_in_event(
+        self,
+        sample_outcome: ProposalOutcome,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        event = anonymize_decision(
+            sample_outcome,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        serialized = event.model_dump_json()
+        # Must NOT contain PII from the original outcome.
+        assert "admin-user" not in serialized
+        assert "Looks good" not in serialized
+        assert "Reduce coordination" not in serialized
+
+    def test_rollout_fields_are_none(
+        self,
+        sample_outcome: ProposalOutcome,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        event = anonymize_decision(
+            sample_outcome,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert event.rollout_outcome is None
+        assert event.regression_verdict is None
+        assert event.observation_hours is None
+
+    def test_schema_version(
+        self,
+        sample_outcome: ProposalOutcome,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        event = anonymize_decision(
+            sample_outcome,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert event.schema_version == "1"
+
+
+class TestAnonymizeRollout:
+    """Tests for anonymize_rollout()."""
+
+    def test_event_type_is_rollout_result(
+        self,
+        sample_rollout_result: RolloutResult,
+        sample_proposal: ImprovementProposal,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        event = anonymize_rollout(
+            sample_rollout_result,
+            proposal=sample_proposal,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert event.event_type == "rollout_result"
+
+    def test_rollout_outcome_preserved(
+        self,
+        sample_rollout_result: RolloutResult,
+        sample_proposal: ImprovementProposal,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        event = anonymize_rollout(
+            sample_rollout_result,
+            proposal=sample_proposal,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert event.rollout_outcome == "success"
+
+    def test_regression_verdict_preserved(
+        self,
+        sample_rollout_result: RolloutResult,
+        sample_proposal: ImprovementProposal,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        event = anonymize_rollout(
+            sample_rollout_result,
+            proposal=sample_proposal,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert event.regression_verdict == "no_regression"
+
+    def test_observation_hours_preserved(
+        self,
+        sample_rollout_result: RolloutResult,
+        sample_proposal: ImprovementProposal,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        event = anonymize_rollout(
+            sample_rollout_result,
+            proposal=sample_proposal,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert event.observation_hours == 48.0
+
+    def test_altitude_from_proposal(
+        self,
+        sample_rollout_result: RolloutResult,
+        sample_proposal: ImprovementProposal,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        event = anonymize_rollout(
+            sample_rollout_result,
+            proposal=sample_proposal,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert event.altitude == "config_tuning"
+
+    def test_source_rule_from_proposal(
+        self,
+        sample_rollout_result: RolloutResult,
+        sample_proposal: ImprovementProposal,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        event = anonymize_rollout(
+            sample_rollout_result,
+            proposal=sample_proposal,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert event.source_rule == "coordination_overhead"
+
+    def test_decision_field_is_none(
+        self,
+        sample_rollout_result: RolloutResult,
+        sample_proposal: ImprovementProposal,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        event = anonymize_rollout(
+            sample_rollout_result,
+            proposal=sample_proposal,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert event.decision is None
+
+    def test_details_not_in_event(
+        self,
+        sample_rollout_result: RolloutResult,
+        sample_proposal: ImprovementProposal,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        event = anonymize_rollout(
+            sample_rollout_result,
+            proposal=sample_proposal,
+            analytics_config=analytics_config,
+            self_improvement_config=self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        serialized = event.model_dump_json()
+        assert "Observation window completed" not in serialized
+
+
+class TestAnonymizeDecisionProperties:
+    """Hypothesis property-based tests for anonymizer."""
+
+    @given(
+        salt=st.text(min_size=1, max_size=50).filter(lambda s: s.strip()),
+    )
+    @settings(
+        max_examples=10,
+        derandomize=True,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    def test_deployment_id_always_64_hex_chars(
+        self,
+        salt: str,
+        sample_outcome: ProposalOutcome,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        cfg = CrossDeploymentAnalyticsConfig(
+            enabled=True,
+            collector_url=NotBlankStr("https://test.example"),
+            deployment_id_salt=NotBlankStr(salt),
+        )
+        si = self_improvement_config.model_copy(
+            update={"cross_deployment_analytics": cfg},
+        )
+        event = anonymize_decision(
+            sample_outcome,
+            analytics_config=cfg,
+            self_improvement_config=si,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert len(event.deployment_id) == 64
+        # Valid hex.
+        int(event.deployment_id, 16)
+
+    @given(
+        salt=st.text(min_size=1, max_size=50).filter(lambda s: s.strip()),
+    )
+    @settings(
+        max_examples=10,
+        derandomize=True,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    def test_no_pii_in_serialized_output(
+        self,
+        salt: str,
+        sample_outcome: ProposalOutcome,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        cfg = CrossDeploymentAnalyticsConfig(
+            enabled=True,
+            collector_url=NotBlankStr("https://test.example"),
+            deployment_id_salt=NotBlankStr(salt),
+        )
+        si = self_improvement_config.model_copy(
+            update={"cross_deployment_analytics": cfg},
+        )
+        event = anonymize_decision(
+            sample_outcome,
+            analytics_config=cfg,
+            self_improvement_config=si,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        serialized = event.model_dump_json()
+        # PII from the original outcome must never appear.
+        assert "admin-user" not in serialized
+        assert "Looks good" not in serialized
+        assert str(sample_outcome.proposal_id) not in serialized

--- a/tests/unit/meta/telemetry/test_anonymizer.py
+++ b/tests/unit/meta/telemetry/test_anonymizer.py
@@ -434,8 +434,6 @@ class TestAnonymizeDecisionProperties:
         salt=st.text(min_size=1, max_size=50).filter(lambda s: s.strip()),
     )
     @settings(
-        max_examples=10,
-        derandomize=True,
         suppress_health_check=[HealthCheck.function_scoped_fixture],
     )
     def test_deployment_id_always_64_hex_chars(
@@ -466,8 +464,6 @@ class TestAnonymizeDecisionProperties:
         salt=st.text(min_size=1, max_size=50).filter(lambda s: s.strip()),
     )
     @settings(
-        max_examples=10,
-        derandomize=True,
         suppress_health_check=[HealthCheck.function_scoped_fixture],
     )
     def test_no_pii_in_serialized_output(

--- a/tests/unit/meta/telemetry/test_api.py
+++ b/tests/unit/meta/telemetry/test_api.py
@@ -1,0 +1,96 @@
+"""Unit tests for the cross-deployment analytics API controller."""
+
+import pytest
+
+from synthorg.api.controllers.meta_analytics import (
+    _require_collector,
+    configure_analytics_controller,
+)
+from synthorg.api.errors import ServiceUnavailableError
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.telemetry.collector import InMemoryAnalyticsCollector
+from synthorg.meta.telemetry.models import AnonymizedOutcomeEvent, EventBatch
+from synthorg.meta.telemetry.recommender import DefaultThresholdRecommender
+
+pytestmark = pytest.mark.unit
+
+
+def _make_event(
+    deployment_id: str = "d-0",
+    source_rule: str = "coordination_overhead",
+    decision: str | None = "approved",
+    event_type: str = "proposal_decision",
+) -> AnonymizedOutcomeEvent:
+    return AnonymizedOutcomeEvent(
+        deployment_id=NotBlankStr(deployment_id),
+        event_type=event_type,  # type: ignore[arg-type]
+        timestamp=NotBlankStr("2026-04-16"),
+        altitude=NotBlankStr("config_tuning"),
+        source_rule=NotBlankStr(source_rule),
+        decision=decision,  # type: ignore[arg-type]
+        confidence=0.8,
+        enabled_altitudes=(NotBlankStr("config_tuning"),),
+        sdk_version=NotBlankStr("0.6.8"),
+    )
+
+
+class TestRequireCollector:
+    """Tests for _require_collector()."""
+
+    def test_raises_when_collector_not_configured(self) -> None:
+        configure_analytics_controller(None, None)
+        with pytest.raises(ServiceUnavailableError):
+            _require_collector()
+
+    def test_returns_collector_when_configured(self) -> None:
+        collector = InMemoryAnalyticsCollector()
+        configure_analytics_controller(collector, DefaultThresholdRecommender())
+        result = _require_collector()
+        assert result is collector
+
+
+class TestCollectorIngestion:
+    """Tests for direct collector ingestion through the controller path."""
+
+    async def test_ingest_and_query_patterns(self) -> None:
+        collector = InMemoryAnalyticsCollector()
+        configure_analytics_controller(collector, DefaultThresholdRecommender())
+
+        events = tuple(_make_event(deployment_id=f"d-{i}") for i in range(5))
+        batch = EventBatch(events=events)
+        count = await collector.ingest(batch.events)
+        assert count == 5
+        assert collector.event_count == 5
+
+        patterns = await collector.query_patterns(min_deployments=3)
+        assert len(patterns) == 1
+        assert patterns[0].deployment_count == 5
+
+    async def test_ingest_and_get_recommendations(self) -> None:
+        collector = InMemoryAnalyticsCollector()
+        recommender = DefaultThresholdRecommender()
+        configure_analytics_controller(collector, recommender)
+
+        # Build enough data for recommendations.
+        events: list[AnonymizedOutcomeEvent] = []
+        for i in range(5):
+            events.append(
+                _make_event(deployment_id=f"d-{i}", decision="approved"),
+            )
+            rollout = AnonymizedOutcomeEvent(
+                deployment_id=NotBlankStr(f"d-{i}"),
+                event_type="rollout_result",
+                timestamp=NotBlankStr("2026-04-16"),
+                altitude=NotBlankStr("config_tuning"),
+                source_rule=NotBlankStr("coordination_overhead"),
+                rollout_outcome=NotBlankStr("success"),
+                observation_hours=48.0,
+                enabled_altitudes=(NotBlankStr("config_tuning"),),
+                sdk_version=NotBlankStr("0.6.8"),
+            )
+            events.append(rollout)
+        await collector.ingest(tuple(events))
+
+        recs = await recommender.get_recommendations(collector=collector)
+        assert len(recs) >= 1
+        assert recs[0].rule_name == "coordination_overhead"

--- a/tests/unit/meta/telemetry/test_api.py
+++ b/tests/unit/meta/telemetry/test_api.py
@@ -4,6 +4,7 @@ from collections.abc import Generator
 
 import pytest
 
+from synthorg.api.controllers import meta_analytics
 from synthorg.api.controllers.meta_analytics import (
     _require_collector,
     configure_analytics_controller,
@@ -58,8 +59,25 @@ class TestRequireCollector:
         assert result is collector
 
 
-class TestCollectorIngestion:
-    """Tests for direct collector ingestion through the controller path."""
+class TestConfigureAnalyticsController:
+    """Tests for configure_analytics_controller()."""
+
+    def test_sets_min_deployments_floor(self) -> None:
+        collector = InMemoryAnalyticsCollector()
+        configure_analytics_controller(
+            collector,
+            DefaultThresholdRecommender(),
+            min_deployments_floor=7,
+        )
+        assert meta_analytics._min_deployments_floor == 7
+
+    def test_default_floor_is_three(self) -> None:
+        configure_analytics_controller(None, None)
+        assert meta_analytics._min_deployments_floor == 3
+
+
+class TestControllerDataFlow:
+    """Tests for the wired collector/recommender data flow."""
 
     async def test_ingest_and_query_patterns(self) -> None:
         collector = InMemoryAnalyticsCollector()
@@ -75,12 +93,28 @@ class TestCollectorIngestion:
         assert len(patterns) == 1
         assert patterns[0].deployment_count == 5
 
+    async def test_min_deployments_floor_clamps_queries(self) -> None:
+        """Config floor prevents callers from lowering min_deployments."""
+        collector = InMemoryAnalyticsCollector()
+        configure_analytics_controller(
+            collector,
+            DefaultThresholdRecommender(),
+            min_deployments_floor=5,
+        )
+
+        events = tuple(_make_event(deployment_id=f"d-{i}") for i in range(3))
+        await collector.ingest(events)
+
+        # Even requesting min_deployments=1, floor clamps to 5.
+        effective = max(1, meta_analytics._min_deployments_floor)
+        patterns = await collector.query_patterns(min_deployments=effective)
+        assert len(patterns) == 0  # 3 unique deployments < floor of 5
+
     async def test_ingest_and_get_recommendations(self) -> None:
         collector = InMemoryAnalyticsCollector()
         recommender = DefaultThresholdRecommender()
         configure_analytics_controller(collector, recommender)
 
-        # Build enough data for recommendations.
         events: list[AnonymizedOutcomeEvent] = []
         for i in range(5):
             events.append(

--- a/tests/unit/meta/telemetry/test_api.py
+++ b/tests/unit/meta/telemetry/test_api.py
@@ -15,6 +15,13 @@ from synthorg.meta.telemetry.recommender import DefaultThresholdRecommender
 pytestmark = pytest.mark.unit
 
 
+@pytest.fixture(autouse=True)
+def _reset_analytics_controller():
+    """Reset module-level globals after each test."""
+    yield
+    configure_analytics_controller(None, None)
+
+
 def _make_event(
     deployment_id: str = "d-0",
     source_rule: str = "coordination_overhead",

--- a/tests/unit/meta/telemetry/test_api.py
+++ b/tests/unit/meta/telemetry/test_api.py
@@ -1,5 +1,7 @@
 """Unit tests for the cross-deployment analytics API controller."""
 
+from collections.abc import Generator
+
 import pytest
 
 from synthorg.api.controllers.meta_analytics import (
@@ -16,7 +18,7 @@ pytestmark = pytest.mark.unit
 
 
 @pytest.fixture(autouse=True)
-def _reset_analytics_controller():
+def _reset_analytics_controller() -> Generator[None]:
     """Reset module-level globals after each test."""
     yield
     configure_analytics_controller(None, None)

--- a/tests/unit/meta/telemetry/test_collector.py
+++ b/tests/unit/meta/telemetry/test_collector.py
@@ -1,0 +1,62 @@
+"""Unit tests for the in-memory analytics collector."""
+
+import pytest
+
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.telemetry.collector import InMemoryAnalyticsCollector
+from synthorg.meta.telemetry.models import AnonymizedOutcomeEvent
+
+pytestmark = pytest.mark.unit
+
+
+def _make_event(
+    deployment_id: str = "deploy-a",
+    source_rule: str = "coordination_overhead",
+) -> AnonymizedOutcomeEvent:
+    return AnonymizedOutcomeEvent(
+        deployment_id=NotBlankStr(deployment_id),
+        event_type="proposal_decision",
+        timestamp=NotBlankStr("2026-04-16"),
+        altitude=NotBlankStr("config_tuning"),
+        source_rule=NotBlankStr(source_rule),
+        decision="approved",
+        confidence=0.7,
+        enabled_altitudes=(NotBlankStr("config_tuning"),),
+        sdk_version=NotBlankStr("0.6.8"),
+    )
+
+
+class TestInMemoryAnalyticsCollector:
+    """Tests for InMemoryAnalyticsCollector."""
+
+    async def test_ingest_returns_count(self) -> None:
+        collector = InMemoryAnalyticsCollector()
+        events = (_make_event(), _make_event())
+        count = await collector.ingest(events)
+        assert count == 2
+
+    async def test_event_count_after_ingest(self) -> None:
+        collector = InMemoryAnalyticsCollector()
+        await collector.ingest((_make_event(),))
+        await collector.ingest((_make_event(), _make_event()))
+        assert collector.event_count == 3
+
+    async def test_query_patterns_returns_empty_initially(self) -> None:
+        collector = InMemoryAnalyticsCollector()
+        patterns = await collector.query_patterns()
+        assert patterns == ()
+
+    async def test_query_patterns_after_ingestion(self) -> None:
+        collector = InMemoryAnalyticsCollector()
+        events = tuple(_make_event(deployment_id=f"d-{i}") for i in range(3))
+        await collector.ingest(events)
+        patterns = await collector.query_patterns(min_deployments=3)
+        assert len(patterns) == 1
+        assert patterns[0].deployment_count == 3
+
+    async def test_query_patterns_respects_min_deployments(self) -> None:
+        collector = InMemoryAnalyticsCollector()
+        events = tuple(_make_event(deployment_id=f"d-{i}") for i in range(2))
+        await collector.ingest(events)
+        patterns = await collector.query_patterns(min_deployments=3)
+        assert patterns == ()

--- a/tests/unit/meta/telemetry/test_emitter.py
+++ b/tests/unit/meta/telemetry/test_emitter.py
@@ -1,6 +1,5 @@
 """Unit tests for the cross-deployment analytics emitter."""
 
-import time
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -101,20 +100,21 @@ class TestEmitterBuffering:
             # batch_size=10, only 1 event, no flush.
             mock_send.assert_not_awaited()
 
-    async def test_time_threshold_triggers_flush(
+    async def test_periodic_flush_task_created(
         self,
         emitter: HttpAnalyticsEmitter,
         sample_outcome: ProposalOutcome,
         sample_proposal: ImprovementProposal,
     ) -> None:
-        with patch.object(emitter, "_send_batch", new_callable=AsyncMock) as mock_send:
-            # Force last_flush to be old.
-            emitter._last_flush_at = time.monotonic() - 100.0
+        with patch.object(emitter, "_send_batch", new_callable=AsyncMock):
+            assert emitter._flush_task is None
             await emitter.emit_decision(
                 sample_outcome,
                 proposal=sample_proposal,
             )
-            mock_send.assert_awaited_once()
+            # Background flush task should be created on first enqueue.
+            assert emitter._flush_task is not None
+            assert not emitter._flush_task.done()
 
 
 class TestEmitterFlush:
@@ -237,15 +237,25 @@ class TestEmitterHttpBehavior:
 
     async def test_emit_failure_does_not_raise(
         self,
-        emitter: HttpAnalyticsEmitter,
         sample_outcome: ProposalOutcome,
         sample_proposal: ImprovementProposal,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
     ) -> None:
         """Emission errors are logged, not raised."""
-        emitter._last_flush_at = time.monotonic() - 100.0
+        # Use batch_size=1 to trigger immediate flush on emit.
+        small = analytics_config.model_copy(update={"batch_size": 1})
+        si = self_improvement_config.model_copy(
+            update={"cross_deployment_analytics": small},
+        )
+        em = HttpAnalyticsEmitter(
+            analytics_config=small,
+            self_improvement_config=si,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
         with (
             patch.object(
-                emitter._client,
+                em._client,
                 "post",
                 side_effect=httpx.ConnectError("connection refused"),
             ),
@@ -254,9 +264,10 @@ class TestEmitterHttpBehavior:
                 new_callable=AsyncMock,
             ),
         ):
-            # Must not raise.
-            await emitter.emit_decision(
+            # Must not raise despite HTTP failure.
+            await em.emit_decision(
                 sample_outcome,
                 proposal=sample_proposal,
             )
-            assert emitter.pending_count == 0
+            # Buffer cleared by flush attempt (events sent to _send_batch).
+            assert em.pending_count == 0

--- a/tests/unit/meta/telemetry/test_emitter.py
+++ b/tests/unit/meta/telemetry/test_emitter.py
@@ -1,0 +1,262 @@
+"""Unit tests for the cross-deployment analytics emitter."""
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from synthorg.meta.chief_of_staff.models import ProposalOutcome
+from synthorg.meta.config import SelfImprovementConfig
+from synthorg.meta.models import ImprovementProposal, RolloutResult
+from synthorg.meta.telemetry.config import CrossDeploymentAnalyticsConfig
+from synthorg.meta.telemetry.emitter import HttpAnalyticsEmitter
+
+from .conftest import BUILTIN_RULE_NAMES
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def emitter(
+    analytics_config: CrossDeploymentAnalyticsConfig,
+    self_improvement_config: SelfImprovementConfig,
+) -> HttpAnalyticsEmitter:
+    """Create an emitter with test config."""
+    return HttpAnalyticsEmitter(
+        analytics_config=analytics_config,
+        self_improvement_config=self_improvement_config,
+        builtin_rule_names=BUILTIN_RULE_NAMES,
+    )
+
+
+class TestEmitterBuffering:
+    """Tests for event buffering behavior."""
+
+    async def test_emit_decision_buffers_event(
+        self,
+        emitter: HttpAnalyticsEmitter,
+        sample_outcome: ProposalOutcome,
+        sample_proposal: ImprovementProposal,
+    ) -> None:
+        with patch.object(emitter, "_send_batch", new_callable=AsyncMock):
+            await emitter.emit_decision(
+                sample_outcome,
+                proposal=sample_proposal,
+            )
+            assert emitter.pending_count == 1
+
+    async def test_emit_rollout_buffers_event(
+        self,
+        emitter: HttpAnalyticsEmitter,
+        sample_rollout_result: RolloutResult,
+        sample_proposal: ImprovementProposal,
+    ) -> None:
+        with patch.object(emitter, "_send_batch", new_callable=AsyncMock):
+            await emitter.emit_rollout(
+                sample_rollout_result,
+                proposal=sample_proposal,
+            )
+            assert emitter.pending_count == 1
+
+    async def test_batch_threshold_triggers_flush(
+        self,
+        sample_outcome: ProposalOutcome,
+        sample_proposal: ImprovementProposal,
+        analytics_config: CrossDeploymentAnalyticsConfig,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        small_batch = analytics_config.model_copy(
+            update={"batch_size": 3},
+        )
+        si = self_improvement_config.model_copy(
+            update={"cross_deployment_analytics": small_batch},
+        )
+        em = HttpAnalyticsEmitter(
+            analytics_config=small_batch,
+            self_improvement_config=si,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        with patch.object(em, "_send_batch", new_callable=AsyncMock) as mock_send:
+            for _ in range(3):
+                await em.emit_decision(
+                    sample_outcome,
+                    proposal=sample_proposal,
+                )
+            assert mock_send.await_count >= 1
+            # Buffer should be cleared after flush.
+            assert em.pending_count == 0
+
+    async def test_below_threshold_no_flush(
+        self,
+        emitter: HttpAnalyticsEmitter,
+        sample_outcome: ProposalOutcome,
+        sample_proposal: ImprovementProposal,
+    ) -> None:
+        with patch.object(emitter, "_send_batch", new_callable=AsyncMock) as mock_send:
+            await emitter.emit_decision(
+                sample_outcome,
+                proposal=sample_proposal,
+            )
+            # batch_size=10, only 1 event, no flush.
+            mock_send.assert_not_awaited()
+
+    async def test_time_threshold_triggers_flush(
+        self,
+        emitter: HttpAnalyticsEmitter,
+        sample_outcome: ProposalOutcome,
+        sample_proposal: ImprovementProposal,
+    ) -> None:
+        with patch.object(emitter, "_send_batch", new_callable=AsyncMock) as mock_send:
+            # Force last_flush to be old.
+            emitter._last_flush_at = time.monotonic() - 100.0
+            await emitter.emit_decision(
+                sample_outcome,
+                proposal=sample_proposal,
+            )
+            mock_send.assert_awaited_once()
+
+
+class TestEmitterFlush:
+    """Tests for explicit flush and close."""
+
+    async def test_flush_sends_buffered_events(
+        self,
+        emitter: HttpAnalyticsEmitter,
+        sample_outcome: ProposalOutcome,
+        sample_proposal: ImprovementProposal,
+    ) -> None:
+        with patch.object(emitter, "_send_batch", new_callable=AsyncMock) as mock_send:
+            await emitter.emit_decision(
+                sample_outcome,
+                proposal=sample_proposal,
+            )
+            await emitter.flush()
+            mock_send.assert_awaited_once()
+            assert emitter.pending_count == 0
+
+    async def test_flush_noop_when_empty(
+        self,
+        emitter: HttpAnalyticsEmitter,
+    ) -> None:
+        with patch.object(emitter, "_send_batch", new_callable=AsyncMock) as mock_send:
+            await emitter.flush()
+            mock_send.assert_not_awaited()
+
+    async def test_close_flushes_and_closes_client(
+        self,
+        emitter: HttpAnalyticsEmitter,
+        sample_outcome: ProposalOutcome,
+        sample_proposal: ImprovementProposal,
+    ) -> None:
+        with patch.object(emitter, "_send_batch", new_callable=AsyncMock) as mock_send:
+            await emitter.emit_decision(
+                sample_outcome,
+                proposal=sample_proposal,
+            )
+            await emitter.close()
+            mock_send.assert_awaited_once()
+
+
+class TestEmitterHttpBehavior:
+    """Tests for HTTP POST behavior."""
+
+    async def test_successful_post(
+        self,
+        emitter: HttpAnalyticsEmitter,
+        sample_outcome: ProposalOutcome,
+        sample_proposal: ImprovementProposal,
+    ) -> None:
+        mock_response = httpx.Response(200, json={"ingested": 1})
+        with patch.object(
+            emitter._client,
+            "post",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            await emitter.emit_decision(
+                sample_outcome,
+                proposal=sample_proposal,
+            )
+            await emitter.flush()
+            assert emitter.pending_count == 0
+
+    async def test_retry_on_5xx(
+        self,
+        emitter: HttpAnalyticsEmitter,
+        sample_outcome: ProposalOutcome,
+        sample_proposal: ImprovementProposal,
+    ) -> None:
+        responses = [
+            httpx.Response(503),
+            httpx.Response(200, json={"ingested": 1}),
+        ]
+        call_count = 0
+
+        async def mock_post(*args: object, **kwargs: object) -> httpx.Response:
+            nonlocal call_count
+            resp = responses[min(call_count, len(responses) - 1)]
+            call_count += 1
+            return resp
+
+        with (
+            patch.object(emitter._client, "post", side_effect=mock_post),
+            patch(
+                "synthorg.meta.telemetry.emitter.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await emitter.emit_decision(
+                sample_outcome,
+                proposal=sample_proposal,
+            )
+            await emitter.flush()
+            assert call_count == 2
+
+    async def test_drop_on_4xx(
+        self,
+        emitter: HttpAnalyticsEmitter,
+        sample_outcome: ProposalOutcome,
+        sample_proposal: ImprovementProposal,
+    ) -> None:
+        mock_response = httpx.Response(400, json={"error": "bad request"})
+        with patch.object(
+            emitter._client,
+            "post",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_post:
+            await emitter.emit_decision(
+                sample_outcome,
+                proposal=sample_proposal,
+            )
+            await emitter.flush()
+            # Only one attempt -- no retry on 4xx.
+            mock_post.assert_awaited_once()
+            assert emitter.pending_count == 0
+
+    async def test_emit_failure_does_not_raise(
+        self,
+        emitter: HttpAnalyticsEmitter,
+        sample_outcome: ProposalOutcome,
+        sample_proposal: ImprovementProposal,
+    ) -> None:
+        """Emission errors are logged, not raised."""
+        emitter._last_flush_at = time.monotonic() - 100.0
+        with (
+            patch.object(
+                emitter._client,
+                "post",
+                side_effect=httpx.ConnectError("connection refused"),
+            ),
+            patch(
+                "synthorg.meta.telemetry.emitter.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            # Must not raise.
+            await emitter.emit_decision(
+                sample_outcome,
+                proposal=sample_proposal,
+            )
+            assert emitter.pending_count == 0

--- a/tests/unit/meta/telemetry/test_emitter.py
+++ b/tests/unit/meta/telemetry/test_emitter.py
@@ -114,7 +114,6 @@ class TestEmitterBuffering:
             )
             # Background flush task should be created on first enqueue.
             assert emitter._flush_task is not None
-            assert not emitter._flush_task.done()
 
 
 class TestEmitterFlush:

--- a/tests/unit/meta/telemetry/test_factory.py
+++ b/tests/unit/meta/telemetry/test_factory.py
@@ -65,5 +65,21 @@ class TestBuildRecommender:
     """Tests for build_recommender()."""
 
     def test_returns_recommender(self) -> None:
-        result = build_recommender()
+        config = SelfImprovementConfig()
+        result = build_recommender(config)
         assert isinstance(result, DefaultThresholdRecommender)
+
+    def test_uses_config_values(self) -> None:
+        analytics = CrossDeploymentAnalyticsConfig(
+            enabled=True,
+            collector_url=NotBlankStr("https://test.example"),
+            deployment_id_salt=NotBlankStr("test-salt"),
+            min_deployments_for_pattern=5,
+            recommendation_min_observations=20,
+        )
+        config = SelfImprovementConfig(
+            cross_deployment_analytics=analytics,
+        )
+        result = build_recommender(config)
+        assert result._min_deployments == 5
+        assert result._min_observations == 20

--- a/tests/unit/meta/telemetry/test_factory.py
+++ b/tests/unit/meta/telemetry/test_factory.py
@@ -1,0 +1,69 @@
+"""Unit tests for the cross-deployment analytics factory."""
+
+import pytest
+
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.config import SelfImprovementConfig
+from synthorg.meta.telemetry.collector import InMemoryAnalyticsCollector
+from synthorg.meta.telemetry.config import CrossDeploymentAnalyticsConfig
+from synthorg.meta.telemetry.emitter import HttpAnalyticsEmitter
+from synthorg.meta.telemetry.factory import (
+    build_analytics_collector,
+    build_analytics_emitter,
+    build_recommender,
+)
+from synthorg.meta.telemetry.recommender import DefaultThresholdRecommender
+
+from .conftest import BUILTIN_RULE_NAMES
+
+pytestmark = pytest.mark.unit
+
+
+class TestBuildAnalyticsEmitter:
+    """Tests for build_analytics_emitter()."""
+
+    def test_returns_none_when_disabled(self) -> None:
+        config = SelfImprovementConfig()
+        result = build_analytics_emitter(
+            config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert result is None
+
+    def test_returns_emitter_when_enabled(
+        self,
+        self_improvement_config: SelfImprovementConfig,
+    ) -> None:
+        result = build_analytics_emitter(
+            self_improvement_config,
+            builtin_rule_names=BUILTIN_RULE_NAMES,
+        )
+        assert isinstance(result, HttpAnalyticsEmitter)
+
+
+class TestBuildAnalyticsCollector:
+    """Tests for build_analytics_collector()."""
+
+    def test_returns_none_when_disabled(self) -> None:
+        config = SelfImprovementConfig()
+        result = build_analytics_collector(config)
+        assert result is None
+
+    def test_returns_collector_when_enabled(self) -> None:
+        analytics = CrossDeploymentAnalyticsConfig(
+            enabled=True,
+            collector_url=NotBlankStr("https://test.example"),
+            deployment_id_salt=NotBlankStr("test-salt"),
+            collector_enabled=True,
+        )
+        config = SelfImprovementConfig(cross_deployment_analytics=analytics)
+        result = build_analytics_collector(config)
+        assert isinstance(result, InMemoryAnalyticsCollector)
+
+
+class TestBuildRecommender:
+    """Tests for build_recommender()."""
+
+    def test_returns_recommender(self) -> None:
+        result = build_recommender()
+        assert isinstance(result, DefaultThresholdRecommender)

--- a/tests/unit/meta/telemetry/test_recommender.py
+++ b/tests/unit/meta/telemetry/test_recommender.py
@@ -1,0 +1,208 @@
+"""Unit tests for the threshold recommender."""
+
+import pytest
+
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.telemetry.collector import InMemoryAnalyticsCollector
+from synthorg.meta.telemetry.models import AnonymizedOutcomeEvent
+from synthorg.meta.telemetry.recommender import DefaultThresholdRecommender
+
+pytestmark = pytest.mark.unit
+
+
+def _make_event(  # noqa: PLR0913
+    *,
+    deployment_id: str = "d-0",
+    source_rule: str = "coordination_overhead",
+    decision: str | None = "approved",
+    rollout_outcome: str | None = None,
+    event_type: str = "proposal_decision",
+    confidence: float | None = 0.8,
+) -> AnonymizedOutcomeEvent:
+    return AnonymizedOutcomeEvent(
+        deployment_id=NotBlankStr(deployment_id),
+        event_type=event_type,  # type: ignore[arg-type]
+        timestamp=NotBlankStr("2026-04-16"),
+        altitude=NotBlankStr("config_tuning"),
+        source_rule=NotBlankStr(source_rule),
+        decision=decision,  # type: ignore[arg-type]
+        confidence=confidence,
+        rollout_outcome=NotBlankStr(rollout_outcome) if rollout_outcome else None,
+        enabled_altitudes=(NotBlankStr("config_tuning"),),
+        sdk_version=NotBlankStr("0.6.8"),
+    )
+
+
+class TestDefaultThresholdRecommender:
+    """Tests for DefaultThresholdRecommender."""
+
+    async def test_empty_collector_no_recommendations(self) -> None:
+        collector = InMemoryAnalyticsCollector()
+        recommender = DefaultThresholdRecommender()
+        recs = await recommender.get_recommendations(collector=collector)
+        assert recs == ()
+
+    async def test_high_approval_high_success_recommends_relaxing(self) -> None:
+        collector = InMemoryAnalyticsCollector()
+        # 5 deployments, all approved decisions + successful rollouts.
+        events: list[AnonymizedOutcomeEvent] = []
+        for i in range(5):
+            events.append(
+                _make_event(deployment_id=f"d-{i}", decision="approved"),
+            )
+            events.append(
+                _make_event(
+                    deployment_id=f"d-{i}",
+                    event_type="rollout_result",
+                    decision=None,
+                    confidence=None,
+                    rollout_outcome="success",
+                ),
+            )
+        await collector.ingest(tuple(events))
+
+        recommender = DefaultThresholdRecommender()
+        recs = await recommender.get_recommendations(collector=collector)
+        assert len(recs) == 1
+        rec = recs[0]
+        assert rec.rule_name == "coordination_overhead"
+        assert "too conservative" in rec.rationale
+        assert rec.recommended_value > rec.current_default
+
+    async def test_low_approval_recommends_tightening(self) -> None:
+        collector = InMemoryAnalyticsCollector()
+        # 5 deployments, mostly rejected decisions.
+        events: list[AnonymizedOutcomeEvent] = []
+        for i in range(5):
+            events.append(
+                _make_event(
+                    deployment_id=f"d-{i}",
+                    decision="rejected",
+                    confidence=0.3,
+                ),
+            )
+            events.append(
+                _make_event(
+                    deployment_id=f"d-{i}",
+                    decision="rejected",
+                    confidence=0.3,
+                ),
+            )
+        await collector.ingest(tuple(events))
+
+        recommender = DefaultThresholdRecommender()
+        recs = await recommender.get_recommendations(collector=collector)
+        assert len(recs) == 1
+        rec = recs[0]
+        assert "too aggressive" in rec.rationale
+        assert rec.recommended_value < rec.current_default
+
+    async def test_moderate_approval_no_recommendation(self) -> None:
+        collector = InMemoryAnalyticsCollector()
+        # 5 deployments, ~50% approval, ~50% success.
+        events: list[AnonymizedOutcomeEvent] = []
+        for i in range(5):
+            events.append(
+                _make_event(deployment_id=f"d-{i}", decision="approved"),
+            )
+            events.append(
+                _make_event(deployment_id=f"d-{i}", decision="rejected"),
+            )
+        await collector.ingest(tuple(events))
+
+        recommender = DefaultThresholdRecommender()
+        recs = await recommender.get_recommendations(collector=collector)
+        assert recs == ()
+
+    async def test_unknown_rule_skipped(self) -> None:
+        collector = InMemoryAnalyticsCollector()
+        events = tuple(
+            _make_event(
+                deployment_id=f"d-{i}",
+                source_rule="custom",
+                decision="approved",
+            )
+            for i in range(5)
+        )
+        # Add rollout successes too.
+        rollouts = tuple(
+            _make_event(
+                deployment_id=f"d-{i}",
+                source_rule="custom",
+                event_type="rollout_result",
+                decision=None,
+                confidence=None,
+                rollout_outcome="success",
+            )
+            for i in range(5)
+        )
+        await collector.ingest(events + rollouts)
+
+        recommender = DefaultThresholdRecommender()
+        recs = await recommender.get_recommendations(collector=collector)
+        # "custom" is not in the threshold map.
+        assert recs == ()
+
+    async def test_insufficient_observations_no_recommendation(self) -> None:
+        collector = InMemoryAnalyticsCollector()
+        # Only 3 events total across 3 deployments.
+        events = tuple(
+            _make_event(deployment_id=f"d-{i}", decision="approved") for i in range(3)
+        )
+        await collector.ingest(events)
+
+        recommender = DefaultThresholdRecommender()
+        recs = await recommender.get_recommendations(collector=collector)
+        # 3 events < min 10 observations.
+        assert recs == ()
+
+    async def test_recommendations_sorted_by_confidence(self) -> None:
+        collector = InMemoryAnalyticsCollector()
+        events: list[AnonymizedOutcomeEvent] = []
+        # Pattern 1: coordination_overhead, 5 deployments, high confidence.
+        for i in range(5):
+            events.append(
+                _make_event(
+                    deployment_id=f"d-{i}",
+                    source_rule="coordination_overhead",
+                    decision="approved",
+                    confidence=0.9,
+                ),
+            )
+            events.append(
+                _make_event(
+                    deployment_id=f"d-{i}",
+                    source_rule="coordination_overhead",
+                    event_type="rollout_result",
+                    decision=None,
+                    confidence=None,
+                    rollout_outcome="success",
+                ),
+            )
+        # Pattern 2: quality_declining, 3 deployments, lower confidence.
+        for i in range(5):
+            events.append(
+                _make_event(
+                    deployment_id=f"d-{i}",
+                    source_rule="quality_declining",
+                    decision="approved",
+                    confidence=0.5,
+                ),
+            )
+            events.append(
+                _make_event(
+                    deployment_id=f"d-{i}",
+                    source_rule="quality_declining",
+                    event_type="rollout_result",
+                    decision=None,
+                    confidence=None,
+                    rollout_outcome="success",
+                ),
+            )
+        await collector.ingest(tuple(events))
+
+        recommender = DefaultThresholdRecommender()
+        recs = await recommender.get_recommendations(collector=collector)
+        assert len(recs) == 2
+        # First recommendation should have higher confidence.
+        assert recs[0].confidence >= recs[1].confidence

--- a/tests/unit/meta/telemetry/test_recommender.py
+++ b/tests/unit/meta/telemetry/test_recommender.py
@@ -179,7 +179,7 @@ class TestDefaultThresholdRecommender:
                     rollout_outcome="success",
                 ),
             )
-        # Pattern 2: quality_declining, 3 deployments, lower confidence.
+        # Pattern 2: quality_declining, 5 deployments, lower confidence.
         for i in range(5):
             events.append(
                 _make_event(

--- a/tests/unit/observability/test_events.py
+++ b/tests/unit/observability/test_events.py
@@ -202,6 +202,7 @@ class TestEventConstants:
             "consolidation",
             "coordination",
             "correlation",
+            "cross_deployment",
             "decomposition",
             "degradation",
             "delegation",


### PR DESCRIPTION
## Summary

Opt-in, privacy-preserving telemetry that aggregates anonymized improvement outcomes across multiple SynthOrg deployments to identify patterns and recommend improved default thresholds.

- New `meta/telemetry/` package with protocol + strategy + factory + config discriminator pattern
- Strict allowlist anonymization: only enum values, numeric metrics, and day-granularity timestamps survive
- HTTP emitter with batch buffering, exponential backoff retry on 5xx, drop on 4xx
- In-memory collector with cross-deployment pattern aggregation
- Threshold recommender that suggests adjustments based on approval/success rates
- API endpoints at `/meta/analytics/` (events, patterns, recommendations)
- Privacy policy documentation

## Key design decisions

- **Dedicated protocol** in `meta/telemetry/` (not a logging sink) -- domain events, not log records
- **In-process API endpoints** -- any deployment can be emitter and/or collector via config flags
- **Strict allowlist anonymization** -- all free text dropped, UUIDs hashed, timestamps coarsened
- **Flat JSON events** -- single model with nulls for event-type-specific fields

## Test plan

- 70 unit tests covering anonymizer, emitter, collector, aggregator, recommender, factory, and API
- Property-based tests (Hypothesis) verify PII never appears in serialized output
- All 20735 existing unit tests pass (no regressions)
- mypy strict mode clean, ruff clean, pre-commit hooks pass

## Review coverage

Pre-reviewed by 8 agents: code-reviewer, conventions-enforcer, silent-failure-hunter, type-design-analyzer, logging-audit, async-concurrency-reviewer, issue-resolution-verifier, docs-consistency. 9 findings addressed:
- Added XOR model validator on AnonymizedOutcomeEvent
- Refactored _send_batch and _evaluate_pattern under 50-line limit
- Wrapped close() in try/except for graceful shutdown
- Added structured context to emit error logs
- Added response body logging on 4xx drops
- Updated design spec Package Structure with telemetry/ subpackage
- Added telemetry as canonical pluggable pattern example in CLAUDE.md

Closes #1341