### PR TITLE
fix: resolve Renovate DHI registry lookup failures

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -147,7 +147,7 @@
     {
       "customType": "regex",
       "description": "DHI images in compose template (image: dhi.io/name:tag@sha256:...)",
-      "managerFilePatterns": ["/compose\\.yml\\.tmpl$/", "/docker/compose\\.yml$/"],
+      "managerFilePatterns": ["/compose\\.yml\\.tmpl$/"],
       "matchStrings": [
         "image:\\s+(?<depName>dhi\\.io/[^:]+):(?<currentValue>[^@]+)@(?<currentDigest>sha256:[a-f0-9]+)"
       ],
@@ -157,7 +157,7 @@
     {
       "customType": "regex",
       "description": "Busybox sidecar in compose files",
-      "managerFilePatterns": ["/compose\\.yml\\.tmpl$/", "/docker/compose\\.yml$/"],
+      "managerFilePatterns": ["/compose\\.yml\\.tmpl$/"],
       "matchStrings": [
         "image:\\s+(?<depName>busybox):(?<currentValue>[^@]+)@(?<currentDigest>sha256:[a-f0-9]+)"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,9 @@
     "helpers:pinGitHubActionDigests",
     "docker:pinDigests"
   ],
+  "registryAliases": {
+    "dhi.io": "dhi.io"
+  },
   "pre-commit": {
     "enabled": true
   },


### PR DESCRIPTION
Add `registryAliases` so Renovate treats `dhi.io` as a registry host instead of a Docker Hub namespace. Without this, Renovate queries `index.docker.io/v2/dhi.io/postgres/tags/list` which returns `no-result`.

Also removes `docker/compose.yml` from custom regex managers since the built-in `docker-compose` manager already handles it (eliminates duplicate lookups).