### PR TITLE
fix: include digits in Renovate VERSION regex to detect D2_VERSION

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -122,7 +122,7 @@
       "description": "Binary tool version env vars in CI workflows (Trivy, Grype, Gitleaks, D2, apko)",
       "managerFilePatterns": ["/\\.github/.*\\.ya?ml$/"],
       "matchStrings": [
-        "# renovate: datasource=github-releases depName=(?<depName>[^\\s]+)\\n\\s+[A-Z_]+_VERSION:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?"
+        "# renovate: datasource=github-releases depName=(?<depName>[^\\s]+)\\n\\s+[A-Z0-9_]+_VERSION:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?"
       ],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver"


### PR DESCRIPTION
The custom regex manager pattern `[A-Z_]+_VERSION` only matches uppercase letters and underscores -- not digits. `D2_VERSION` (used in 3 workflow files for the D2 diagramming tool) was silently missed.

Fix: `[A-Z_]+` -> `[A-Z0-9_]+`