### PR TITLE
chore: add Renovate best practices (configMigration, minimumReleaseAge, security bypass)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
   "registryAliases": {
     "dhi.io": "dhi.io"
   },
+  "configMigration": true,
   "pre-commit": {
     "enabled": true
   },
@@ -110,6 +111,20 @@
       "description": "Ignore test golden files -- not real compose configs",
       "matchFileNames": ["cli/testdata/**"],
       "enabled": false
+    },
+    {
+      "description": "Security updates bypass schedule and limits",
+      "matchCategories": ["security"],
+      "schedule": ["at any time"],
+      "dependencyDashboardApproval": false,
+      "minimumReleaseAge": null,
+      "prPriority": 10,
+      "labels": ["dependencies", "security"]
+    },
+    {
+      "description": "Wait 3 days before updating to avoid broken releases",
+      "matchDepPatterns": ["*"],
+      "minimumReleaseAge": "3 days"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
- `configMigration: true` -- auto-creates config migration PRs without manual checkbox
- `minimumReleaseAge: 3 days` -- wait 3 days before creating PRs for non-security updates, avoids transient PyPI/npm propagation failures (like the pydantic no-result)
- Security updates bypass schedule (`at any time`), skip release age waiting, get highest PR priority (`prPriority: 10`), and get a `security` label