### PR TITLE
chore: remove redundant Renovate security/releaseAge rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -111,20 +111,6 @@
       "description": "Ignore test golden files -- not real compose configs",
       "matchFileNames": ["cli/testdata/**"],
       "enabled": false
-    },
-    {
-      "description": "Security updates bypass schedule and limits",
-      "matchCategories": ["security"],
-      "schedule": ["at any time"],
-      "dependencyDashboardApproval": false,
-      "minimumReleaseAge": null,
-      "prPriority": 10,
-      "labels": ["dependencies", "security"]
-    },
-    {
-      "description": "Wait 3 days before updating to avoid broken releases",
-      "matchDepPatterns": ["*"],
-      "minimumReleaseAge": "3 days"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
Dependabot already handles security advisories. Remove the redundant Renovate security bypass and minimumReleaseAge rules added in #1371. Keep `configMigration: true`.