### PR TITLE
chore: consolidate Renovate PR groups to eliminate overlaps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -56,18 +56,21 @@
       "labels": ["dependencies", "type:chore", "scope:cli"]
     },
     {
-      "description": "Container dependencies (Docker images, Compose, apko)",
-      "matchManagers": ["dockerfile", "docker-compose", "custom.regex"],
+      "description": "Container dependencies (all Dockerfile and Docker Compose images)",
+      "matchManagers": ["dockerfile", "docker-compose"],
       "groupName": "Container dependencies",
       "groupSlug": "container",
       "commitMessagePrefix": "chore:",
-      "labels": ["dependencies", "type:chore", "scope:docker"],
-      "matchDepNames": [
-        "/dhi\\.io/.*/",
-        "/busybox/",
-        "/postgres/",
-        "/nats/"
-      ]
+      "labels": ["dependencies", "type:chore", "scope:docker"]
+    },
+    {
+      "description": "Container dependencies (compose template images via custom regex)",
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["/dhi\\.io/.*/", "/busybox/", "/postgres/", "/nats/"],
+      "groupName": "Container dependencies",
+      "groupSlug": "container",
+      "commitMessagePrefix": "chore:",
+      "labels": ["dependencies", "type:chore", "scope:docker"]
     },
     {
       "description": "CI tool dependencies (Actions SHAs + binary tools)",
@@ -94,6 +97,34 @@
       "groupSlug": "container",
       "commitMessagePrefix": "chore:",
       "labels": ["dependencies", "type:chore", "scope:docker"]
+    },
+    {
+      "description": "Route Python lock file maintenance into Python group",
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "matchManagers": ["pep621", "pre-commit"],
+      "groupName": "Python dependencies",
+      "groupSlug": "python",
+      "additionalBranchPrefix": "",
+      "commitMessagePrefix": "chore:",
+      "labels": ["dependencies", "type:chore"]
+    },
+    {
+      "description": "Route npm lock file maintenance into Web group",
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "matchManagers": ["npm"],
+      "groupName": "Web dependencies",
+      "groupSlug": "web",
+      "commitMessagePrefix": "chore:",
+      "labels": ["dependencies", "type:chore", "scope:web"]
+    },
+    {
+      "description": "Route Go lock file maintenance into CLI group",
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "matchManagers": ["gomod"],
+      "groupName": "CLI dependencies",
+      "groupSlug": "cli",
+      "commitMessagePrefix": "chore:",
+      "labels": ["dependencies", "type:chore", "scope:cli"]
     },
     {
       "description": "Do not pin requires-python -- it is a compatibility range, not a dependency",


### PR DESCRIPTION
## Problem

Renovate creates overlapping PRs that touch the same lock files and ungrouped PRs for Docker images:

1. **Lock file maintenance** creates separate PRs that overlap with ecosystem groups:
   - `uv.lock` updated in both "Python dependencies" and "Lock file maintenance"
   - `package-lock.json` updated in both "Web dependencies" and "Lock file maintenance"

2. **Container group's `matchDepNames`** is too restrictive -- only matches `dhi.io/*`, `busybox`, `postgres`, `nats`. Docker images like `ghcr.io/astral-sh/uv` and `golang` escape the group and create individual PRs.

Today's example: 8 PRs where 4 would suffice.

## Changes

**Split container rule** into two:
- `matchManagers: ["dockerfile", "docker-compose"]` -- catches ALL Docker images (uv, golang, python, etc.)
- `matchManagers: ["custom.regex"]` + `matchDepNames` -- compose template images only (dhi.io, busybox, postgres, nats)

**Route lock file maintenance** into existing ecosystem groups:
- `pep621`/`pre-commit` lock maintenance -> Python dependencies group
- `npm` lock maintenance -> Web dependencies group
- `gomod` lock maintenance -> CLI dependencies group

## Result

Max 5 PRs instead of 8+:

| Group | Contents |
|-------|----------|
| Python | pep621 + pre-commit bumps + uv.lock maintenance |
| Web | npm bumps + package-lock.json maintenance |
| CLI | gomod bumps + go.sum maintenance + tool versions |
| Container | ALL Docker images + compose template images + apko |
| CI tools | GitHub Actions + binary tool versions |
