### PR TITLE
chore: rewrite /codebase-audit skill with 58-agent roster and file-based output

### DIFF
--- a/.claude/skills/codebase-audit/SKILL.md
+++ b/.claude/skills/codebase-audit/SKILL.md
@@ -26,10 +26,10 @@ Launch 58 specialized agents to audit the entire codebase (or a targeted scope),
 | Argument | Directories | Agent Waves |
 |----------|-------------|-------------|
 | `full` (default) | All | All 10 waves (58 agents) |
-| `src/` | `src/synthorg/`, `tests/` | 01-08, 11-16, 20-45, 51-54 |
-| `web/` | `web/src/` | 09-10, 15, 17-19, 33, 36, 46-50 |
+| `src/` | `src/synthorg/`, `tests/`, `web/src/types/`, `docs/design/` | 01-08, 11-16, 20-45, 51-54 |
+| `web/` | `web/src/`, `src/synthorg/api/controllers/` | 09-10, 15, 17-19, 33, 36, 46-50 |
 | `cli/` | `cli/` | 22, 33, 55-58 |
-| `docs/` | `docs/`, `site/` | 22, 25, 54 |
+| `docs/` | `docs/`, `site/`, `src/synthorg/` | 22, 25, 54 |
 
 Flags:
 - `--report-only` -- skip issue creation, findings files only
@@ -111,7 +111,7 @@ If zero findings, still create the file with `**Findings**: 0` and a brief note 
 
 Every agent gets this structure (fill in the blanks per agent):
 
-```
+```text
 You are auditing the SynthOrg codebase for ONE specific concern: {FOCUS}.
 
 ## Architecture Context
@@ -163,7 +163,7 @@ Report to user after each batch: "Batch X complete (N/58 agents done)."
 
 **Agent 01 -- missing-logger** (haiku)
 File: `_audit/findings/01-missing-logger.md`
-```
+```text
 Search every .py file in src/synthorg/ for modules that contain business logic
 but do NOT have `logger = get_logger(__name__)`.
 
@@ -179,7 +179,7 @@ handlers) but no logger, that's a finding.
 
 **Agent 02 -- wrong-logger-pattern** (haiku)
 File: `_audit/findings/02-wrong-logger-pattern.md`
-```
+```text
 Search ALL .py files in src/synthorg/ and tests/ for forbidden logging patterns:
 
 1. `import logging` (except in observability/setup.py, observability/sinks.py,
@@ -196,7 +196,7 @@ Severity: medium for app code, low for test code.
 
 **Agent 03 -- missing-event-constants** (sonnet)
 File: `_audit/findings/03-missing-event-constants.md`
-```
+```text
 The project requires all logger calls to use event constants from
 src/synthorg/observability/events/ modules (e.g. API_REQUEST_STARTED from
 events.api, TOOL_INVOKE_START from events.tool).
@@ -217,7 +217,7 @@ Severity: low.
 
 **Agent 04 -- unstructured-logging** (haiku)
 File: `_audit/findings/04-unstructured-logging.md`
-```
+```text
 Search ALL logger calls in src/synthorg/ for unstructured formatting:
 
 WRONG: logger.info("Processing user %s", user_id)
@@ -233,7 +233,7 @@ Severity: low.
 
 **Agent 05 -- missing-error-logging** (sonnet)
 File: `_audit/findings/05-missing-error-logging.md`
-```
+```text
 Project convention: "All error paths must log at WARNING or ERROR with context
 before raising."
 
@@ -254,7 +254,7 @@ Severity: medium for service/engine code, low for model validation.
 
 **Agent 06 -- missing-state-transition-log** (sonnet)
 File: `_audit/findings/06-missing-state-transition-log.md`
-```
+```text
 Project convention: "All state transitions must log at INFO."
 
 Focus on these domains where state machines matter:
@@ -276,7 +276,7 @@ there's an INFO-level log call nearby. Missing transitions are severity=medium.
 
 **Agent 07 -- observability-completeness** (sonnet)
 File: `_audit/findings/07-observability-completeness.md`
-```
+```text
 Check whether key operations have full observability coverage:
 
 1. Prometheus metrics (src/synthorg/observability/prometheus_collector.py):
@@ -300,7 +300,7 @@ low for nice-to-have.
 
 **Agent 08 -- unwired-api-controllers** (sonnet)
 File: `_audit/findings/08-unwired-api-controllers.md`
-```
+```text
 Check api/controllers/ for controller classes not registered in auto_wire.py
 or app.py. Also check for route handler methods that exist but are not mapped
 to any HTTP route. Do NOT check frontend-to-backend connectivity (Agent 15
@@ -309,7 +309,7 @@ owns that). Severity: high (unreachable code).
 
 **Agent 09 -- unwired-web-stores** (sonnet)
 File: `_audit/findings/09-unwired-web-stores.md`
-```
+```text
 Check every Zustand store file in web/src/stores/. For each store, grep the
 entire web/src/ directory for imports of that store. If a store is imported by
 zero pages or components, it's dead. Severity: medium.
@@ -317,7 +317,7 @@ zero pages or components, it's dead. Severity: medium.
 
 **Agent 10 -- unwired-web-pages** (sonnet)
 File: `_audit/findings/10-unwired-web-pages.md`
-```
+```text
 Find all .tsx files in web/src/pages/ that are NOT imported by any other file
 (not by routes.ts, not by another page as a nested layout). Pages with no
 route AND no parent import are unreachable. Severity: medium.
@@ -325,7 +325,7 @@ route AND no parent import are unreachable. Severity: medium.
 
 **Agent 11 -- unwired-settings** (sonnet)
 File: `_audit/findings/11-unwired-settings.md`
-```
+```text
 Check settings/definitions/ for setting definitions. For each, check if it is:
 (a) subscribed to via settings/subscribers/, AND
 (b) exposed via an API endpoint in api/controllers/settings.py.
@@ -334,7 +334,7 @@ Settings defined but never consumed are dead config. Severity: medium.
 
 **Agent 12 -- unwired-tools** (sonnet)
 File: `_audit/findings/12-unwired-tools.md`
-```
+```text
 Check tool classes in tools/ subdirectories. For each tool class that extends
 BaseTool, verify it is registered in tools/factory.py or tools/registry.py.
 Unregistered tools are dead code. Severity: medium.
@@ -342,7 +342,7 @@ Unregistered tools are dead code. Severity: medium.
 
 **Agent 13 -- unwired-protocols** (sonnet)
 File: `_audit/findings/13-unwired-protocols.md`
-```
+```text
 Find all Protocol classes in src/synthorg/. For each, find concrete
 implementations (classes that implement the protocol). Then check if those
 implementations are registered in their factory. Report:
@@ -352,7 +352,7 @@ implementations are registered in their factory. Report:
 
 **Agent 14 -- unwired-notifications** (sonnet)
 File: `_audit/findings/14-unwired-notifications.md`
-```
+```text
 Check notifications/adapters/ for adapter classes. Verify each is registered
 in notifications/factory.py. Also check if notification events are dispatched
 from business logic. Report adapters with no factory registration and
@@ -361,7 +361,7 @@ notification types never dispatched. Severity: medium.
 
 **Agent 15 -- frontend-backend-mismatch** (sonnet)
 File: `_audit/findings/15-frontend-backend-mismatch.md`
-```
+```text
 Cross-reference web/src/api/ and web/src/services/ API calls with backend
 api/controllers/ endpoints. Report:
 - Frontend calls targeting endpoints that don't exist in backend (high)
@@ -372,7 +372,7 @@ api/controllers/ endpoints. Report:
 
 **Agent 16 -- unused-python-exports** (sonnet)
 File: `_audit/findings/16-unused-python-exports.md`
-```
+```text
 Find public functions and classes in src/synthorg/ that are not imported by
 any other module, not re-exported in __init__.py, and not referenced in tests/.
 Exclude: __init__ methods, property descriptors, __repr__/__str__, metaclass
@@ -381,7 +381,7 @@ methods, enum members, Pydantic field definitions. Severity: medium.
 
 **Agent 17 -- unused-web-components** (sonnet)
 File: `_audit/findings/17-unused-web-components.md`
-```
+```text
 Check every component file in web/src/components/ (excluding .stories.tsx).
 Grep web/src/ for imports of each component. Components imported by zero
 consumers are dead code. Severity: medium.
@@ -389,21 +389,21 @@ consumers are dead code. Severity: medium.
 
 **Agent 18 -- unused-web-hooks** (haiku)
 File: `_audit/findings/18-unused-web-hooks.md`
-```
+```text
 Check every hook file in web/src/hooks/. Grep web/src/ for imports of each
 hook. Hooks imported by zero files are dead code. Severity: medium.
 ```
 
 **Agent 19 -- unused-web-utils** (haiku)
 File: `_audit/findings/19-unused-web-utils.md`
-```
+```text
 Check exported functions in web/src/utils/ and web/src/lib/. Grep web/src/
 for imports. Unused exports are dead code. Severity: low.
 ```
 
 **Agent 20 -- unused-dto-fields** (sonnet)
 File: `_audit/findings/20-unused-dto-fields.md`
-```
+```text
 Compare DTO classes in api/dto*.py with frontend TypeScript types in
 web/src/types/. Flag fields present in backend DTOs but absent from frontend
 types (or vice versa). This suggests unused serialization. Severity: low.
@@ -412,7 +412,7 @@ Only runs for `full` or `src/` scope (requires both backend and frontend).
 
 **Agent 21 -- orphan-test-helpers** (sonnet)
 File: `_audit/findings/21-orphan-test-helpers.md`
-```
+```text
 Check all conftest.py files in tests/ for fixtures and helper functions.
 Grep tests/ for usage of each. Unused fixtures/helpers are dead test code.
 Severity: low.
@@ -422,15 +422,15 @@ Severity: low.
 
 **Agent 22 -- todo-comments** (haiku)
 File: `_audit/findings/22-todo-comments.md`
-```
-Grep ALL source files (src/, tests/, web/src/, cli/) for TODO, FIXME, HACK,
+```text
+Grep source files in the provided scope for TODO, FIXME, HACK,
 XXX, TEMPORARY, WORKAROUND comments. List each with file:line and the full
 comment text. Severity: info.
 ```
 
 **Agent 23 -- not-implemented** (haiku)
 File: `_audit/findings/23-not-implemented.md`
-```
+```text
 Grep src/synthorg/ and cli/ for: NotImplementedError, pass-only function
 bodies (def/async def with only pass), and Ellipsis (...) as sole function
 body. Severity: info for abstract methods, medium for concrete stubs.
@@ -438,7 +438,7 @@ body. Severity: info for abstract methods, medium for concrete stubs.
 
 **Agent 24 -- placeholder-stubs** (sonnet)
 File: `_audit/findings/24-placeholder-stubs.md`
-```
+```text
 Find functions that return hardcoded dummy values, empty lists/dicts, or have
 "placeholder", "stub", "temporary", "mock" in their comments/docstrings.
 These suggest incomplete implementations. Severity: medium.
@@ -446,7 +446,7 @@ These suggest incomplete implementations. Severity: medium.
 
 **Agent 25 -- deferred-features** (sonnet)
 File: `_audit/findings/25-deferred-features.md`
-```
+```text
 Read docs/design/ pages and cross-reference with src/synthorg/. Find features
 described in the design spec that have no corresponding implementation.
 Focus on major features (not minor details). Severity: info.
@@ -456,7 +456,7 @@ Focus on major features (not minor details). Severity: info.
 
 **Agent 26 -- silent-exception-swallow** (sonnet)
 File: `_audit/findings/26-silent-exception-swallow.md`
-```
+```text
 Find except blocks that swallow exceptions silently: bare `except:`,
 `except Exception: pass`, `except Exception as e:` with only DEBUG logging
 (should be WARNING+), catching too broadly. Skip intentional patterns like
@@ -465,7 +465,7 @@ graceful shutdown cleanup. Severity: high for business logic, medium for cleanup
 
 **Agent 27 -- input-validation-gaps** (sonnet)
 File: `_audit/findings/27-input-validation-gaps.md`
-```
+```text
 Check API controller methods for user input that bypasses validation. Look for
 path/query parameters used directly without Pydantic validation, raw request
 body access, and missing type coercion. Severity: high.
@@ -473,14 +473,14 @@ body access, and missing type coercion. Severity: high.
 
 **Agent 28 -- sql-injection-risk** (sonnet)
 File: `_audit/findings/28-sql-injection-risk.md`
-```
+```text
 Search persistence/ and any file using SQL for string concatenation or f-strings
 in SQL queries instead of parameterized queries. Severity: critical.
 ```
 
 **Agent 29 -- missing-auth-checks** (sonnet)
 File: `_audit/findings/29-missing-auth-checks.md`
-```
+```text
 Check API controllers for endpoints missing auth guards. Compare with auth
 middleware/dependency injection. Public endpoints should be explicitly marked.
 Severity: high for data-mutating endpoints, medium for read-only.
@@ -488,7 +488,7 @@ Severity: high for data-mutating endpoints, medium for read-only.
 
 **Agent 30 -- unsafe-deserialization** (haiku)
 File: `_audit/findings/30-unsafe-deserialization.md`
-```
+```text
 Flag ANY use of yaml.load (even with Loader parameter -- verify SafeLoader),
 pickle.loads, eval(), exec(). Flag compile() ONLY if the argument contains a
 variable or function parameter (not a string literal). Severity: critical.
@@ -496,7 +496,7 @@ variable or function parameter (not a string literal). Severity: critical.
 
 **Agent 31 -- hardcoded-secrets** (haiku)
 File: `_audit/findings/31-hardcoded-secrets.md`
-```
+```text
 Grep for patterns suggesting hardcoded secrets: password=", api_key=",
 token=", secret=", followed by string literals. Skip test files and .env
 examples. Severity: critical.
@@ -504,7 +504,7 @@ examples. Severity: critical.
 
 **Agent 32 -- missing-rate-limiting** (sonnet)
 File: `_audit/findings/32-missing-rate-limiting.md`
-```
+```text
 Check public-facing API endpoints for rate limiting. Check expensive operations
 (LLM calls, bulk DB writes, file uploads) for throttling. Severity: medium.
 ```
@@ -513,15 +513,15 @@ Check public-facing API endpoints for rate limiting. Check expensive operations
 
 **Agent 33 -- hardcoded-urls-ports** (haiku)
 File: `_audit/findings/33-hardcoded-urls-ports.md`
-```
-Grep src/, web/src/, cli/ for hardcoded URLs, ports, hostnames, IP addresses
-that should come from config or env vars. Skip test files and documentation.
-Severity: medium.
+```text
+Grep files in the provided scope for hardcoded URLs, ports, hostnames, IP
+addresses that should come from config or env vars. Skip test files and
+documentation. Severity: medium.
 ```
 
 **Agent 34 -- hardcoded-timeouts-limits** (haiku)
 File: `_audit/findings/34-hardcoded-timeouts-limits.md`
-```
+```text
 Grep src/synthorg/ for hardcoded timeout values (seconds/ms), retry counts,
 batch sizes, max limits that should be configurable. Look for bare numeric
 literals in asyncio.wait_for, sleep, timeout parameters. Severity: low.
@@ -529,7 +529,7 @@ literals in asyncio.wait_for, sleep, timeout parameters. Severity: low.
 
 **Agent 35 -- hardcoded-magic-numbers** (haiku)
 File: `_audit/findings/35-hardcoded-magic-numbers.md`
-```
+```text
 Find magic numbers in business logic: bare numeric literals (not 0, 1, -1)
 without named constants. Focus on src/synthorg/ business logic, skip tests
 and config defaults. Severity: low.
@@ -537,9 +537,10 @@ and config defaults. Severity: low.
 
 **Agent 36 -- vendor-name-leaks** (haiku)
 File: `_audit/findings/36-vendor-name-leaks.md`
-```
-Grep for real vendor names: Anthropic, OpenAI, Claude, GPT, Gemini, Mistral
-in project-owned code. ALLOWED exceptions (do NOT flag):
+```text
+Grep files in the provided scope for real vendor names: Anthropic, OpenAI,
+Claude, GPT, Gemini, Mistral in project-owned code. ALLOWED exceptions (do
+NOT flag):
 - providers/presets.py (user-facing runtime data)
 - .claude/ directory files
 - Third-party import paths (litellm.types.llms.openai etc)
@@ -549,7 +550,7 @@ Everything else is a violation. Severity: low.
 
 **Agent 37 -- hardcoded-display-values** (sonnet)
 File: `_audit/findings/37-hardcoded-display-values.md`
-```
+```text
 Find hardcoded currencies (should default EUR not USD), date formats, number
 formats, locale-specific strings in both src/synthorg/ and web/src/.
 Severity: medium for USD defaults, low for format strings.
@@ -557,7 +558,7 @@ Severity: medium for USD defaults, low for format strings.
 
 **Agent 38 -- missing-settings-bridge** (sonnet)
 File: `_audit/findings/38-missing-settings-bridge.md`
-```
+```text
 Cross-reference hardcoded values in src/synthorg/ with settings definitions in
 settings/definitions/. Find values that SHOULD be configurable but are hardcoded,
 and settings defined but never consumed by any code. Severity: medium.
@@ -567,7 +568,7 @@ and settings defined but never consumed by any code. Severity: medium.
 
 **Agent 39 -- long-functions** (haiku)
 File: `_audit/findings/39-long-functions.md`
-```
+```text
 Find functions exceeding line limits: Python over 50 lines, Go over 80 lines,
 TypeScript over 60 lines. Report file:line of function def and line count.
 Severity: low.
@@ -575,14 +576,14 @@ Severity: low.
 
 **Agent 40 -- long-files** (haiku)
 File: `_audit/findings/40-long-files.md`
-```
+```text
 Find files exceeding size limits: Python over 800 lines, TypeScript over 600
 lines, Go over 1000 lines. Report file path and line count. Severity: low.
 ```
 
 **Agent 41 -- model-convention-violations** (sonnet)
 File: `_audit/findings/41-model-convention-violations.md`
-```
+```text
 Check Pydantic models in src/synthorg/ for convention violations:
 - Missing frozen=True in ConfigDict (config/identity models must be frozen)
 - Missing allow_inf_nan=False in ConfigDict
@@ -593,7 +594,7 @@ Severity: medium.
 
 **Agent 42 -- missing-immutability** (sonnet)
 File: `_audit/findings/42-missing-immutability.md`
-```
+```text
 Find violations of immutability conventions:
 - dict/list exposed without MappingProxyType wrapping (non-Pydantic)
 - Mutable default arguments (def f(x=[]))
@@ -604,7 +605,7 @@ Severity: medium.
 
 **Agent 43 -- async-antipatterns** (sonnet)
 File: `_audit/findings/43-async-antipatterns.md`
-```
+```text
 Find async antipatterns in src/synthorg/:
 - Bare asyncio.create_task without TaskGroup
 - Missing await on coroutine calls
@@ -616,7 +617,7 @@ Severity: high for missing await, medium for others.
 
 **Agent 44 -- error-handling-consistency** (sonnet)
 File: `_audit/findings/44-error-handling-consistency.md`
-```
+```text
 Check error handling conventions:
 - Custom exceptions not inheriting from project error hierarchy
 - API error responses not using RFC 9457 structured format
@@ -627,7 +628,7 @@ Severity: medium.
 
 **Agent 45 -- future-annotations-leak** (haiku)
 File: `_audit/findings/45-future-annotations-leak.md`
-```
+```text
 Grep for "from __future__ import annotations" in ALL Python files. This is
 forbidden on Python 3.14 (PEP 649 native). Severity: low.
 ```
@@ -636,7 +637,7 @@ forbidden on Python 3.14 (PEP 649 native). Severity: low.
 
 **Agent 46 -- missing-accessibility** (sonnet)
 File: `_audit/findings/46-missing-accessibility.md`
-```
+```text
 Check web/src/components/ and web/src/pages/ for accessibility issues:
 missing aria-label on interactive elements, missing role attributes, missing
 keyboard navigation (onKeyDown handlers), missing focus management after
@@ -645,7 +646,7 @@ navigation, images without alt text. Severity: medium.
 
 **Agent 47 -- missing-loading-states** (sonnet)
 File: `_audit/findings/47-missing-loading-states.md`
-```
+```text
 Check pages/components that fetch data (useQuery, useEffect with fetch) for
 missing loading skeletons/spinners, missing empty states when data is [],
 and missing error boundaries around async content. Severity: medium.
@@ -653,7 +654,7 @@ and missing error boundaries around async content. Severity: medium.
 
 **Agent 48 -- hardcoded-frontend-strings** (haiku)
 File: `_audit/findings/48-hardcoded-frontend-strings.md`
-```
+```text
 Find user-facing strings hardcoded directly in TSX files. Look for text
 content in JSX elements that should be centralized for i18n readiness.
 Skip component prop names and technical strings. Severity: info.
@@ -661,7 +662,7 @@ Skip component prop names and technical strings. Severity: info.
 
 **Agent 49 -- design-token-violations** (sonnet)
 File: `_audit/findings/49-design-token-violations.md`
-```
+```text
 Check web/src/ for design system violations: hardcoded hex colors (#xxx),
 hardcoded px values for spacing/padding/margins, raw font-family declarations,
 raw CSS transition/animation values instead of @/lib/motion presets.
@@ -670,7 +671,7 @@ Severity: medium.
 
 **Agent 50 -- missing-error-handling-fe** (sonnet)
 File: `_audit/findings/50-missing-error-handling-fe.md`
-```
+```text
 Check web/src/ for API calls without error handling: missing .catch() or
 try/catch, missing toast/notification on failure, optimistic updates without
 rollback on error, console.error without user feedback. Severity: medium.
@@ -680,7 +681,7 @@ rollback on error, console.error without user feedback. Severity: medium.
 
 **Agent 51 -- race-conditions** (sonnet)
 File: `_audit/findings/51-race-conditions.md`
-```
+```text
 Find potential race conditions: shared mutable state without locks/mutexes,
 TOCTOU patterns (check-then-act without atomicity), concurrent dict/list
 modification, DB read-modify-write without transactions. Severity: high.
@@ -688,7 +689,7 @@ modification, DB read-modify-write without transactions. Severity: high.
 
 **Agent 52 -- resource-leaks** (sonnet)
 File: `_audit/findings/52-resource-leaks.md`
-```
+```text
 Find unclosed resources: HTTP clients/sessions not using async with,
 file handles not in with blocks, DB connections not properly returned to pool,
 aiohttp sessions created but not closed. Severity: high.
@@ -696,7 +697,7 @@ aiohttp sessions created but not closed. Severity: high.
 
 **Agent 53 -- circular-dependencies** (sonnet)
 File: `_audit/findings/53-circular-dependencies.md`
-```
+```text
 Find import cycles between src/synthorg/ packages. Check for circular
 references that could cause runtime ImportError or require deferred imports.
 Also check for TYPE_CHECKING guards that hide real circular deps. Severity: medium.
@@ -704,7 +705,7 @@ Also check for TYPE_CHECKING guards that hide real circular deps. Severity: medi
 
 **Agent 54 -- design-spec-drift** (sonnet)
 File: `_audit/findings/54-design-spec-drift.md`
-```
+```text
 Compare implementation in src/synthorg/ with docs/design/ specs. Find
 behaviors, models, or flows that diverge from what the spec describes without
 documented rationale. Focus on major architectural decisions. Severity: medium.
@@ -714,7 +715,7 @@ documented rationale. Focus on major architectural decisions. Severity: medium.
 
 **Agent 55 -- go-error-handling** (sonnet)
 File: `_audit/findings/55-go-error-handling.md`
-```
+```text
 Check cli/ Go code for: ignored error returns (assigned to _), missing error
 wrapping (fmt.Errorf with %w), bare log.Fatal instead of returning errors,
 os.Exit in non-main functions. Severity: medium.
@@ -722,7 +723,7 @@ os.Exit in non-main functions. Severity: medium.
 
 **Agent 56 -- go-resource-leaks** (sonnet)
 File: `_audit/findings/56-go-resource-leaks.md`
-```
+```text
 Check cli/ for unclosed resources: Docker clients without defer Close(),
 HTTP response bodies not closed, file handles without defer Close(),
 context cancellation not propagated. Severity: high.
@@ -730,14 +731,14 @@ context cancellation not propagated. Severity: high.
 
 **Agent 57 -- go-hardcoded-values** (haiku)
 File: `_audit/findings/57-go-hardcoded-values.md`
-```
+```text
 Grep cli/ for hardcoded Docker image tags, ports, paths, timeouts that should
 be configurable via flags or config. Severity: low.
 ```
 
 **Agent 58 -- go-cli-wiring** (sonnet)
 File: `_audit/findings/58-go-cli-wiring.md`
-```
+```text
 Check cobra command registration in cli/cmd/. Find commands registered but
 non-functional, flags defined but never read, subcommands with no RunE.
 Severity: medium.
@@ -747,21 +748,21 @@ Severity: medium.
 
 ## Phase 3: Validate Findings (sonnet agents)
 
-**MANDATORY. Never skip this phase.**
+**Required for standard runs.** For `--quick` runs or when fewer than 5 critical+high findings exist, validation may be skipped.
 
-After all 58 audit agents complete, launch validation agents to verify findings.
+After all launched audit agents complete, launch validation agents to verify findings. The number of agents depends on scope (58 for `full`, fewer for scoped runs).
 
 ### Process
 
-1. Read all 58 finding files from `_audit/findings/`
+1. Read all finding files present in `_audit/findings/`
 2. Collect all critical + high severity findings into a validation queue
 3. If queue exceeds 50 findings, prioritize by clustering related findings (same file/module)
 4. Split the queue into batches of ~12 findings each
-4. Launch one **sonnet** validation agent per batch (in parallel, `run_in_background: true`)
+5. Launch one **sonnet** validation agent per batch (in parallel, `run_in_background: true`)
 
 ### Validation Agent Prompt
 
-```
+```text
 You are validating audit findings by reading the ACTUAL SOURCE CODE.
 
 For each finding below, do:
@@ -791,7 +792,7 @@ Findings to validate:
 3. Mark INTENTIONAL findings as excluded (keep in file but prefix with `[INTENTIONAL]`)
 4. Report: "Validated N findings. Removed M false positives (X%)."
 
-Skip validation for `--quick` runs or if total critical+high findings are under 5.
+Validation may be skipped when `--quick` is set or when fewer than 5 critical+high findings exist.
 
 ---
 
@@ -804,7 +805,7 @@ After validation, read all finding files and build `_audit/INDEX.md`:
 
 **Date**: {date}
 **Scope**: {scope}
-**Agents**: 58
+**Agents**: {agents_launched}
 **Total findings**: {count}
 **False positives removed**: {count} ({percent}%)
 
@@ -870,7 +871,7 @@ If `--report-only`, skip this phase entirely.
 
 1. **Every agent writes to `_audit/findings/`** using the Write tool, not Bash
 2. **Architecture brief in every prompt** -- no blind agents
-3. **Validation is mandatory** for critical+high findings
+3. **Validation is required** for critical+high findings on standard runs (may be skipped with `--quick` or fewer than 5 findings)
 4. **Batch execution** -- ~10 agents per batch, wait between batches
 5. **Sonnet for analysis, Haiku for pattern matching** -- never Opus for audit agents
 6. **Do NOT fix anything** -- audit only, findings only

--- a/.claude/skills/codebase-audit/SKILL.md
+++ b/.claude/skills/codebase-audit/SKILL.md
@@ -26,10 +26,10 @@ Launch 58 specialized agents to audit the entire codebase (or a targeted scope),
 | Argument | Directories | Agent Waves |
 |----------|-------------|-------------|
 | `full` (default) | All | All 10 waves (58 agents) |
-| `src/` | `src/synthorg/`, `tests/` | Waves 1-5, 7, 9 (Python-focused) |
-| `web/` | `web/src/` | Wave 8 + relevant from 2-3 |
-| `cli/` | `cli/` | Wave 10 only |
-| `docs/` | `docs/`, `site/` | Wave 4 (TODOs) + spec drift from Wave 9 |
+| `src/` | `src/synthorg/`, `tests/` | 01-08, 11-16, 20-45, 51-54 |
+| `web/` | `web/src/` | 09-10, 15, 17-19, 33, 36, 46-50 |
+| `cli/` | `cli/` | 22, 33, 55-58 |
+| `docs/` | `docs/`, `site/` | 22, 25, 54 |
 
 Flags:
 - `--report-only` -- skip issue creation, findings files only
@@ -58,12 +58,17 @@ Read these files to build context injected into EVERY agent prompt:
 7. `docs/DESIGN_SPEC.md` -- spec index
 8. Existing open issues: `gh issue list --state open --limit 200 --json number,title,labels`
 
-Produce an **Architecture Brief** (~300 words) covering:
+Produce an **Architecture Brief** (~400 words) covering:
 - Logging: `get_logger(__name__)`, structlog, event constants in `observability/events/`, structured kwargs
 - Wiring: `auto_wire.py` phases, controller registration, factory pattern
 - Frontend: router structure, Zustand stores, API layer
-- Conventions: immutability, frozen Pydantic, `NotBlankStr`, vendor-agnostic naming, error hierarchy
-- Testing: markers, xdist, async auto mode, Hypothesis
+- Conventions: immutability, frozen Pydantic, `NotBlankStr`, vendor-agnostic naming
+- Error hierarchy: custom exceptions inherit from project base, RFC 9457 responses
+- Providers: all LLM calls through `BaseCompletionProvider` (auto-retry, rate limit)
+- Pluggable subsystems: Protocol + concrete implementations + factory + config discriminator
+- Database: SQLite + Postgres dual-backend, Atlas migrations in `persistence/*/revisions/`
+- Async: `asyncio.TaskGroup` preferred, never bare `create_task`
+- Testing: markers, xdist, async auto mode, Hypothesis profiles
 
 This brief is a string variable reused in all agent prompts below.
 
@@ -232,9 +237,10 @@ File: `_audit/findings/05-missing-error-logging.md`
 Project convention: "All error paths must log at WARNING or ERROR with context
 before raising."
 
-Search src/synthorg/ for `raise` statements that are NOT preceded (within the
-same function, within ~10 lines above) by a logger.warning() or logger.error()
-call.
+Search src/synthorg/ for `raise` statements that are NOT preceded by a
+logger.warning() or logger.error() call anywhere in the same function before
+the raise. If a function has multiple raises, each must have its own preceding
+log call or be inside an except block that already logged.
 
 Exceptions to skip:
 - `raise` inside `__init__` for validation errors (Pydantic handles these)
@@ -258,6 +264,11 @@ Focus on these domains where state machines matter:
 - engine/workflow/ (workflow execution state changes)
 - workers/ (worker claim/dispatch state)
 - security/autonomy/ (autonomy level changes)
+- api/ (request lifecycle, startup/shutdown phases)
+- notifications/ (delivery state changes)
+- persistence/ (connection state, transaction state)
+- backup/ (backup job state)
+If you find state machines in other modules, include them too.
 
 For each domain, find where status/state fields are modified and check if
 there's an INFO-level log call nearby. Missing transitions are severity=medium.
@@ -292,7 +303,8 @@ File: `_audit/findings/08-unwired-api-controllers.md`
 ```
 Check api/controllers/ for controller classes not registered in auto_wire.py
 or app.py. Also check for route handler methods that exist but are not mapped
-to any HTTP route. Severity: high (unreachable code).
+to any HTTP route. Do NOT check frontend-to-backend connectivity (Agent 15
+owns that). Severity: high (unreachable code).
 ```
 
 **Agent 09 -- unwired-web-stores** (sonnet)
@@ -306,9 +318,9 @@ zero pages or components, it's dead. Severity: medium.
 **Agent 10 -- unwired-web-pages** (sonnet)
 File: `_audit/findings/10-unwired-web-pages.md`
 ```
-Check every page component in web/src/pages/. Cross-reference with
-web/src/router/routes.ts. Pages not in the router are unreachable.
-Severity: medium.
+Find all .tsx files in web/src/pages/ that are NOT imported by any other file
+(not by routes.ts, not by another page as a nested layout). Pages with no
+route AND no parent import are unreachable. Severity: medium.
 ```
 
 **Agent 11 -- unwired-settings** (sonnet)
@@ -363,7 +375,8 @@ File: `_audit/findings/16-unused-python-exports.md`
 ```
 Find public functions and classes in src/synthorg/ that are not imported by
 any other module, not re-exported in __init__.py, and not referenced in tests/.
-Focus on non-trivial code (skip dataclass fields, enum members). Severity: medium.
+Exclude: __init__ methods, property descriptors, __repr__/__str__, metaclass
+methods, enum members, Pydantic field definitions. Severity: medium.
 ```
 
 **Agent 17 -- unused-web-components** (sonnet)
@@ -394,6 +407,7 @@ File: `_audit/findings/20-unused-dto-fields.md`
 Compare DTO classes in api/dto*.py with frontend TypeScript types in
 web/src/types/. Flag fields present in backend DTOs but absent from frontend
 types (or vice versa). This suggests unused serialization. Severity: low.
+Only runs for `full` or `src/` scope (requires both backend and frontend).
 ```
 
 **Agent 21 -- orphan-test-helpers** (sonnet)
@@ -475,8 +489,9 @@ Severity: high for data-mutating endpoints, medium for read-only.
 **Agent 30 -- unsafe-deserialization** (haiku)
 File: `_audit/findings/30-unsafe-deserialization.md`
 ```
-Grep for yaml.load() without SafeLoader, pickle.loads, eval(), exec(),
-compile() with user input. Severity: critical.
+Flag ANY use of yaml.load (even with Loader parameter -- verify SafeLoader),
+pickle.loads, eval(), exec(). Flag compile() ONLY if the argument contains a
+variable or function parameter (not a string literal). Severity: critical.
 ```
 
 **Agent 31 -- hardcoded-secrets** (haiku)
@@ -740,7 +755,8 @@ After all 58 audit agents complete, launch validation agents to verify findings.
 
 1. Read all 58 finding files from `_audit/findings/`
 2. Collect all critical + high severity findings into a validation queue
-3. Split the queue into batches of ~12 findings each
+3. If queue exceeds 50 findings, prioritize by clustering related findings (same file/module)
+4. Split the queue into batches of ~12 findings each
 4. Launch one **sonnet** validation agent per batch (in parallel, `run_in_background: true`)
 
 ### Validation Agent Prompt
@@ -771,7 +787,7 @@ Findings to validate:
 ### After Validation
 
 1. Read all `validate-batch-*.md` files
-2. Remove FALSE_POSITIVE findings from the audit files (edit in place)
+2. Delete FALSE_POSITIVE findings entirely from the audit files (edit in place)
 3. Mark INTENTIONAL findings as excluded (keep in file but prefix with `[INTENTIONAL]`)
 4. Report: "Validated N findings. Removed M false positives (X%)."
 
@@ -804,8 +820,8 @@ After validation, read all finding files and build `_audit/INDEX.md`:
 
 ## By Wave
 
-| Wave | Findings | Top Issue |
-|------|----------|-----------|
+| Wave | Findings | Top Issue (highest severity finding) |
+|------|----------|--------------------------------------|
 | 1. Observability | N | ... |
 | 2. Wiring | N | ... |
 | ... | ... | ... |
@@ -819,7 +835,9 @@ After validation, read all finding files and build `_audit/INDEX.md`:
 
 ## Zero-Finding Categories
 
-These agents found nothing (may warrant deeper investigation):
+These agents found no issues. Review the agent prompt to understand what was
+checked -- this may indicate code quality in that area, or the search pattern
+may not match the codebase's conventions:
 - ...
 
 ## Finding Files

--- a/.claude/skills/codebase-audit/SKILL.md
+++ b/.claude/skills/codebase-audit/SKILL.md
@@ -1,401 +1,861 @@
 ---
-description: "Deep codebase audit: launches specialized parallel agents to find issues, validates findings, groups into work packages, and creates GitHub issues"
-argument-hint: "<scope: full | src/ | src/synthorg/ | web/ | cli/ | docs/ | site/ | .github/ | ci | docker/> [--report-only] [--quick]"
-allowed-tools: ["Agent", "Bash", "Read", "Glob", "Grep", "WebFetch", "WebSearch", "AskUserQuestion", "mcp__github__issue_write", "mcp__github__issue_read", "mcp__github__list_issues", "mcp__github__search_issues"]
+description: "Full codebase audit: launches 58 specialized agents to find issues across Python/React/Go, writes findings to _audit/findings/, then triages with user"
+argument-hint: "<scope: full | src/ | web/ | cli/ | docs/> [--report-only] [--quick]"
+allowed-tools: ["Agent", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion", "mcp__github__issue_write", "mcp__github__issue_read", "mcp__github__list_issues", "mcp__github__search_issues"]
 ---
 
-# /codebase-audit -- Deep Codebase Audit
+# /codebase-audit -- Full Codebase Audit
 
-Launch a swarm of specialized agents to find issues across the entire codebase (or a targeted scope), validate all findings against actual code, group into developer-friendly work packages, and optionally create GitHub issues.
+Launch 58 specialized agents to audit the entire codebase (or a targeted scope), write findings to `_audit/findings/`, build an index, and triage with the user.
 
-## Key Principles (from battle-tested sessions)
+## Key Principles
 
-1. **Never present unvalidated findings** -- validation is mandatory before presenting findings to the user
-2. **Research architecture BEFORE auditing** -- agents that don't understand the system produce false positives
-3. **Skepticism is required** -- "100% clean" results are suspicious and trigger deeper investigation
-4. **Group by code proximity, NOT severity** -- work packages are what a developer would naturally fix together
-5. **No meta/tracking issues** -- every finding is a real issue or part of a real work package
-6. **Existing issue dedup happens TWICE** -- once in agent prompts, once after validation
-7. **Fix everything valid** -- no deferring, no "out of scope", no "future work"
-
----
-
-## Phase 0: Parse Arguments & Determine Scope
-
-Parse the user's argument to determine audit scope:
-
-| Argument | Scope | Agent Categories |
-|----------|-------|------------------|
-| `full` (default) | Entire codebase | All categories |
-| `src/` or `src/synthorg/` | Python backend only | Python-focused categories |
-| `web/` | React dashboard only | Frontend categories |
-| `cli/` | Go CLI only | Go categories |
-| `docs/` or `site/` | Documentation/site | Docs/content categories |
-| `.github/` or `ci` | CI/CD only | CI/workflow categories |
-| `docker/` | Docker/compose only | Infrastructure categories |
-| `--report-only` | Any scope | Skip issue creation, report only |
-| `--quick` | Any scope | Skip Phase 5 deep dive on zero-finding categories |
-
-If no argument given, default to `full`.
+1. **File-based output** -- agents write to `_audit/findings/`, not in-session. Scales to 50+ agents.
+2. **One concern per agent** -- each agent searches for exactly ONE type of issue.
+3. **Architecture context in every prompt** -- no blind agents. All get the Architecture Brief.
+4. **Severity-tagged findings** -- critical/high/medium/low/info with file:line references.
+5. **Triage together** -- user reviews INDEX.md before any issues are created.
+6. **Rerunnable** -- cleans `_audit/` on start.
 
 ---
 
-## Phase 1: Gather Context
+## Phase 0: Parse Arguments & Setup
 
-**This phase is CRITICAL. Agents without context produce false positives.**
+### Parse scope
 
-### Step 1a: Fetch existing GitHub issues
+| Argument | Directories | Agent Waves |
+|----------|-------------|-------------|
+| `full` (default) | All | All 10 waves (58 agents) |
+| `src/` | `src/synthorg/`, `tests/` | Waves 1-5, 7, 9 (Python-focused) |
+| `web/` | `web/src/` | Wave 8 + relevant from 2-3 |
+| `cli/` | `cli/` | Wave 10 only |
+| `docs/` | `docs/`, `site/` | Wave 4 (TODOs) + spec drift from Wave 9 |
+
+Flags:
+- `--report-only` -- skip issue creation, findings files only
+- `--quick` -- skip deep-dive on zero-finding categories
+
+### Setup output directory
 
 ```bash
-gh issue list --repo OWNER/REPO --state open --limit 200 --json number,title,labels
+rm -rf _audit && mkdir -p _audit/findings
 ```
 
-Parse into a compact reference list: `#N: title [labels]`. This list is passed to EVERY audit agent.
-
-### Step 1b: Research project architecture
-
-Read key architectural files to build context that agents need. At minimum:
-
-1. **CLAUDE.md** (already in context) -- project conventions, code standards, testing rules
-2. **Observability stack** -- read `src/synthorg/observability/__init__.py`, `_logger.py`, `sinks.py`, `setup.py`, `correlation.py` to understand logging architecture, sink routing, correlation ID system
-3. **DI/wiring** -- read `src/synthorg/api/auto_wire.py` and `src/synthorg/api/lifecycle.py` to understand service initialization
-4. **Testing setup** -- read `conftest.py` files, `pyproject.toml` test config section
-5. **Design spec pointer** -- read `docs/DESIGN_SPEC.md` to know which spec pages exist
-
-Produce a **Architecture Brief** (200-400 words) summarizing:
-- Logging: how it works, sink routing rules, correlation IDs
-- DI: how services are wired, lifecycle phases
-- Testing: markers, parallelism, async mode, coverage requirements
-- Key conventions: immutability, error handling, vendor-agnostic naming
-
-This brief is injected into every agent's prompt.
-
-### Step 1c: Identify scope-specific files
-
-If scope is targeted (not `full`), glob the target directory to understand what's there.
+Verify `_audit/` is in `.gitignore`. If not, add it.
 
 ---
 
-## Phase 2: Select & Launch Audit Agents
+## Phase 1: Build Architecture Brief
 
-### Agent Roster
+Read these files to build context injected into EVERY agent prompt:
 
-Select agents based on scope. Each agent searches for ONE type of issue only.
+1. `src/synthorg/observability/__init__.py` + `_logger.py` -- logging stack
+2. `src/synthorg/observability/events/` -- list all event constant modules
+3. `src/synthorg/api/auto_wire.py` -- service wiring
+4. `src/synthorg/api/app.py` -- route registration
+5. `web/src/router/routes.ts` -- frontend routing
+6. `web/src/stores/` -- list all stores
+7. `docs/DESIGN_SPEC.md` -- spec index
+8. Existing open issues: `gh issue list --state open --limit 200 --json number,title,labels`
 
-#### Python Backend Agents (scope includes `src/`)
+Produce an **Architecture Brief** (~300 words) covering:
+- Logging: `get_logger(__name__)`, structlog, event constants in `observability/events/`, structured kwargs
+- Wiring: `auto_wire.py` phases, controller registration, factory pattern
+- Frontend: router structure, Zustand stores, API layer
+- Conventions: immutability, frozen Pydantic, `NotBlankStr`, vendor-agnostic naming, error hierarchy
+- Testing: markers, xdist, async auto mode, Hypothesis
 
-| Agent | What It Searches For |
-|-------|---------------------|
-| `missing-logging` | Business logic modules without `get_logger`, error paths that don't log before raising, state transitions without INFO logging, missing DEBUG at decision points |
-| `event-constants` | Log calls using raw strings instead of event constants from `observability/events/` |
-| `silent-errors` | Bare `except:`, `except Exception: pass`, catch blocks that swallow without logging |
-| `test-coverage` | Public modules with no corresponding test file, empty test files |
-| `flaky-tests` | Unmocked time, real asyncio.sleep in tests, timing-dependent assertions, skipped tests |
-| `wiring-lifecycle` | Incorrectly wired services, missing DI, lifecycle gaps, protocol implementations incomplete |
-| `dead-code` | Unreachable functions, unused imports, orphaned modules |
-| `todo-fixme` | Unresolved TODOs that should be tracked as issues |
-| `spec-drift` | Implementation diverging from design spec behavior |
-| `api-consistency` | REST endpoint issues: wrong status codes, missing validation, inconsistent patterns |
-| `async-patterns` | Bare create_task, missing await, blocking in async, race conditions |
-| `immutability` | Mutable defaults, in-place mutation of frozen models, missing deepcopy |
-| `missing-validation` | System boundary inputs without validation (API params, config loading, external data) |
-| `type-hints` | Missing return types, bare Any, missing NotBlankStr on identifiers |
-| `vendor-names` | Real vendor names used where generic names should be (per CLAUDE.md rules) |
-| `observability-gaps` | Sink routing gaps, correlation ID propagation drops, missing event constant modules |
+This brief is a string variable reused in all agent prompts below.
 
-#### Frontend Agents (scope includes `web/`)
+---
 
-| Agent | What It Searches For |
-|-------|---------------------|
-| `react-dashboard` | Broken API refs, missing error handling, console.log in prod, TypeScript gaps, a11y |
+## Phase 2: Launch Agents
 
-#### Go CLI Agents (scope includes `cli/`)
+### Finding File Format
 
-| Agent | What It Searches For |
-|-------|---------------------|
-| `go-cli` | Ignored errors, resource leaks, missing error wrapping, cross-platform issues |
+Every agent MUST write its output file using this exact format:
 
-#### Infrastructure Agents
+```markdown
+# [Agent Title]
 
-| Agent | What It Searches For |
-|-------|---------------------|
-| `docker-infra` | Dockerfile issues, compose config, port security, healthchecks (run when scope includes `docker/`) |
-| `ci-workflows` | Missing timeouts, script injection, permissions gaps, silent failures (run when scope includes `.github/` or `ci`) |
+**Scope**: [directories/files searched]
+**Files scanned**: [approximate count]
+**Findings**: [count]
 
-#### Documentation Agents (scope includes `docs/` or `site/`)
+## Findings
 
-| Agent | What It Searches For |
-|-------|---------------------|
-| `docs-consistency` | Broken links, outdated info, wrong commands, inconsistent terminology |
-| `landing-site` | SEO gaps, broken links, a11y issues, missing error pages |
+### [critical|high|medium|low|info] path/to/file.py:LINE
 
-#### Cross-Cutting Agents (always included)
+Description of the issue.
 
-| Agent | What It Searches For |
-|-------|---------------------|
-| `security-gaps` | Cross-stack security issues: SSRF, XSS, injection vectors, hardcoded secrets across all languages |
-| `dependency-issues` | Unused deps, missing deps, version conflicts across all package managers |
-| `docstring-gaps` | Public classes/functions missing Google-style docstrings |
+**Suggestion**: How to fix it.
+
+---
+```
+
+Severity definitions:
+- **critical**: Security hole, data loss risk, silent corruption
+- **high**: Logic error, broken feature, missing safety check
+- **medium**: Dead code, missing wiring, inconsistency, hardcoded value that should be configurable
+- **low**: Code quality, convention violation, missing docs
+- **info**: TODO/deferred work, improvement opportunity
+
+If zero findings, still create the file with `**Findings**: 0` and a brief note on what was checked.
 
 ### Agent Prompt Template
 
-Every agent receives this structure:
+Every agent gets this structure (fill in the blanks per agent):
 
-```text
-## Task
-You are searching the codebase for ONE specific type of issue: {ISSUE_TYPE}.
+```
+You are auditing the SynthOrg codebase for ONE specific concern: {FOCUS}.
 
 ## Architecture Context
-{ARCHITECTURE_BRIEF from Phase 1b}
+{ARCHITECTURE_BRIEF}
 
-## Existing Open Issues (do NOT report these)
-{ISSUE_LIST from Phase 1a}
+## Existing Open Issues (do NOT duplicate these)
+{ISSUE_LIST}
 
-## Scope
-Search: {SCOPE_DIRECTORIES}
+## Your Task
+{DETAILED_INSTRUCTIONS}
 
-## Rules
-1. For each finding, report: file path, line number, what's wrong, operational impact
-2. Cross-reference against the existing issues list -- only report what's NOT already tracked
-3. BE SKEPTICAL of your own findings -- verify each one by reading the actual code
-4. If you find ZERO issues, state that clearly but also explain what you checked
-5. Do NOT flag things that are intentional design decisions (check comments, docstrings)
-6. Rate each finding: CONFIRMED (verified in code) or LIKELY (needs validation)
+## Output
+Write ALL findings to: _audit/findings/{FILENAME}
 
-## What to Search For
-{CATEGORY-SPECIFIC INSTRUCTIONS}
+Use this exact format for each finding:
+### [severity] path/to/file:LINE
+Description.
+**Suggestion**: Fix.
+---
+
+Rules:
+- Be thorough -- check EVERY relevant file in scope
+- Only report REAL issues with file:line references
+- If zero issues, still create the file and note what you checked
+- Do NOT fix anything -- audit only
+- Do NOT use Bash to write files -- use the Write tool
 ```
 
-### Launch
+### Batch Execution
 
-Launch ALL selected agents in parallel using the Agent tool with `run_in_background: true`. Give each a descriptive `name` for tracking.
+Launch agents in 6 batches of ~10 each. All agents within a batch run in parallel (`run_in_background: true`). Wait for each batch to complete before launching the next.
 
-Track agent count and report to user: "Launched N audit agents in parallel. Waiting for results..."
+| Batch | Agent #s | Count |
+|-------|----------|-------|
+| A | 01-10 | 10 |
+| B | 11-20 | 10 |
+| C | 21-30 | 10 |
+| D | 31-40 | 10 |
+| E | 41-50 | 10 |
+| F | 51-58 | 8 |
 
----
-
-## Phase 3: Collect & Deduplicate
-
-As agents complete, collect their findings. Once ALL agents have reported:
-
-### Step 3a: Check for suspicious clean results
-
-If any agent reported zero findings, flag it:
-- "Agent `{name}` found zero issues. This may be accurate or the agent may have been too shallow."
-- These categories are candidates for Phase 5 (deep dive).
-
-### Step 3b: Merge all findings into a single list
-
-Combine findings from all agents into one flat list with columns:
-- Source agent
-- File path : line number
-- Category
-- Description
-- Agent's self-assessed confidence (CONFIRMED / LIKELY)
-
-### Step 3c: Deduplicate
-
-- Multiple agents may flag the same line/issue (e.g., security + validation both flag missing input checks)
-- Merge duplicates, keep the most detailed description
-- Remove findings that match existing open GitHub issues (by file path + description similarity)
+Report to user after each batch: "Batch X complete (N/58 agents done)."
 
 ---
 
-## Phase 4: Validate Findings
+## Agent Roster
+
+### Wave 1: Observability & Logging (7 agents)
+
+**Agent 01 -- missing-logger** (haiku)
+File: `_audit/findings/01-missing-logger.md`
+```
+Search every .py file in src/synthorg/ for modules that contain business logic
+but do NOT have `logger = get_logger(__name__)`.
+
+Skip these (they legitimately don't need loggers):
+- __init__.py files that only re-export
+- Files containing ONLY: type aliases, enums, constants, Pydantic model definitions
+- Files under observability/ (they ARE the logging system)
+
+For each missing logger, report severity=low with the file path.
+If a file has business logic (functions with if/try/for/while, service methods,
+handlers) but no logger, that's a finding.
+```
+
+**Agent 02 -- wrong-logger-pattern** (haiku)
+File: `_audit/findings/02-wrong-logger-pattern.md`
+```
+Search ALL .py files in src/synthorg/ and tests/ for forbidden logging patterns:
+
+1. `import logging` (except in observability/setup.py, observability/sinks.py,
+   observability/syslog_handler.py, observability/http_handler.py,
+   observability/otlp_handler.py)
+2. `logging.getLogger` (same exceptions)
+3. `print(` in application code (except observability/ exceptions above and
+   tests/). print() in test helpers is fine.
+4. Logger variable named anything other than `logger` (e.g. `_logger`, `log`,
+   `LOG`)
+
+Severity: medium for app code, low for test code.
+```
+
+**Agent 03 -- missing-event-constants** (sonnet)
+File: `_audit/findings/03-missing-event-constants.md`
+```
+The project requires all logger calls to use event constants from
+src/synthorg/observability/events/ modules (e.g. API_REQUEST_STARTED from
+events.api, TOOL_INVOKE_START from events.tool).
+
+Search ALL logger.info/warning/error/debug/critical calls in src/synthorg/
+(excluding observability/ itself). Flag calls where the first argument is:
+- A string literal ("something happened")
+- An f-string (f"processing {x}")
+- A %-format string ("processing %s")
+
+These should instead use a constant from observability/events/.
+
+First, list all event constant modules in observability/events/ to understand
+what's available. Then check every logger call.
+
+Severity: low.
+```
+
+**Agent 04 -- unstructured-logging** (haiku)
+File: `_audit/findings/04-unstructured-logging.md`
+```
+Search ALL logger calls in src/synthorg/ for unstructured formatting:
+
+WRONG: logger.info("Processing user %s", user_id)
+WRONG: logger.info(f"Processing user {user_id}")
+WRONG: logger.info("Processing user " + user_id)
+RIGHT: logger.info(EVENT_CONSTANT, user_id=user_id)
+
+Flag any logger.info/warning/error/debug call that uses %s, %d, %f formatting,
+f-strings, or string concatenation as arguments.
+
+Severity: low.
+```
+
+**Agent 05 -- missing-error-logging** (sonnet)
+File: `_audit/findings/05-missing-error-logging.md`
+```
+Project convention: "All error paths must log at WARNING or ERROR with context
+before raising."
+
+Search src/synthorg/ for `raise` statements that are NOT preceded (within the
+same function, within ~10 lines above) by a logger.warning() or logger.error()
+call.
+
+Exceptions to skip:
+- `raise` inside `__init__` for validation errors (Pydantic handles these)
+- Re-raising with bare `raise` in except blocks (the original error was
+  presumably already logged)
+- `raise NotImplementedError` in abstract/protocol methods
+- `raise StopIteration` / `raise StopAsyncIteration`
+
+Severity: medium for service/engine code, low for model validation.
+```
+
+**Agent 06 -- missing-state-transition-log** (sonnet)
+File: `_audit/findings/06-missing-state-transition-log.md`
+```
+Project convention: "All state transitions must log at INFO."
+
+Focus on these domains where state machines matter:
+- engine/ (agent state transitions: idle, running, paused, completed, failed)
+- hr/ (hiring, onboarding, evaluation, promotion, offboarding)
+- core/task.py + core/task_transitions.py (task status changes)
+- engine/workflow/ (workflow execution state changes)
+- workers/ (worker claim/dispatch state)
+- security/autonomy/ (autonomy level changes)
+
+For each domain, find where status/state fields are modified and check if
+there's an INFO-level log call nearby. Missing transitions are severity=medium.
+```
+
+**Agent 07 -- observability-completeness** (sonnet)
+File: `_audit/findings/07-observability-completeness.md`
+```
+Check whether key operations have full observability coverage:
+
+1. Prometheus metrics (src/synthorg/observability/prometheus_collector.py):
+   - Are all API endpoints instrumented? (request count, latency, error rate)
+   - Are LLM provider calls tracked? (token usage, cost, latency per provider)
+   - Are task/workflow state transitions counted?
+
+2. OTLP traces (observability/otlp_handler.py):
+   - Are spans created for LLM calls, tool invocations, task execution?
+
+3. Audit chain (observability/audit_chain/):
+   - Are security-sensitive operations (auth, permission changes, config
+     changes) captured in the audit trail?
+
+For each gap, describe what operation is missing coverage and suggest which
+metric/trace/event to add. Severity: medium for missing metrics on key paths,
+low for nice-to-have.
+```
+
+### Wave 2: Wiring & Integration (8 agents)
+
+**Agent 08 -- unwired-api-controllers** (sonnet)
+File: `_audit/findings/08-unwired-api-controllers.md`
+```
+Check api/controllers/ for controller classes not registered in auto_wire.py
+or app.py. Also check for route handler methods that exist but are not mapped
+to any HTTP route. Severity: high (unreachable code).
+```
+
+**Agent 09 -- unwired-web-stores** (sonnet)
+File: `_audit/findings/09-unwired-web-stores.md`
+```
+Check every Zustand store file in web/src/stores/. For each store, grep the
+entire web/src/ directory for imports of that store. If a store is imported by
+zero pages or components, it's dead. Severity: medium.
+```
+
+**Agent 10 -- unwired-web-pages** (sonnet)
+File: `_audit/findings/10-unwired-web-pages.md`
+```
+Check every page component in web/src/pages/. Cross-reference with
+web/src/router/routes.ts. Pages not in the router are unreachable.
+Severity: medium.
+```
+
+**Agent 11 -- unwired-settings** (sonnet)
+File: `_audit/findings/11-unwired-settings.md`
+```
+Check settings/definitions/ for setting definitions. For each, check if it is:
+(a) subscribed to via settings/subscribers/, AND
+(b) exposed via an API endpoint in api/controllers/settings.py.
+Settings defined but never consumed are dead config. Severity: medium.
+```
+
+**Agent 12 -- unwired-tools** (sonnet)
+File: `_audit/findings/12-unwired-tools.md`
+```
+Check tool classes in tools/ subdirectories. For each tool class that extends
+BaseTool, verify it is registered in tools/factory.py or tools/registry.py.
+Unregistered tools are dead code. Severity: medium.
+```
+
+**Agent 13 -- unwired-protocols** (sonnet)
+File: `_audit/findings/13-unwired-protocols.md`
+```
+Find all Protocol classes in src/synthorg/. For each, find concrete
+implementations (classes that implement the protocol). Then check if those
+implementations are registered in their factory. Report:
+- Protocols with zero implementations (severity: medium)
+- Implementations not registered in any factory (severity: medium)
+```
+
+**Agent 14 -- unwired-notifications** (sonnet)
+File: `_audit/findings/14-unwired-notifications.md`
+```
+Check notifications/adapters/ for adapter classes. Verify each is registered
+in notifications/factory.py. Also check if notification events are dispatched
+from business logic. Report adapters with no factory registration and
+notification types never dispatched. Severity: medium.
+```
+
+**Agent 15 -- frontend-backend-mismatch** (sonnet)
+File: `_audit/findings/15-frontend-backend-mismatch.md`
+```
+Cross-reference web/src/api/ and web/src/services/ API calls with backend
+api/controllers/ endpoints. Report:
+- Frontend calls targeting endpoints that don't exist in backend (high)
+- Backend endpoints with zero frontend consumers (low -- may be API-only)
+```
+
+### Wave 3: Dead Code & Unused (6 agents)
+
+**Agent 16 -- unused-python-exports** (sonnet)
+File: `_audit/findings/16-unused-python-exports.md`
+```
+Find public functions and classes in src/synthorg/ that are not imported by
+any other module, not re-exported in __init__.py, and not referenced in tests/.
+Focus on non-trivial code (skip dataclass fields, enum members). Severity: medium.
+```
+
+**Agent 17 -- unused-web-components** (sonnet)
+File: `_audit/findings/17-unused-web-components.md`
+```
+Check every component file in web/src/components/ (excluding .stories.tsx).
+Grep web/src/ for imports of each component. Components imported by zero
+consumers are dead code. Severity: medium.
+```
+
+**Agent 18 -- unused-web-hooks** (haiku)
+File: `_audit/findings/18-unused-web-hooks.md`
+```
+Check every hook file in web/src/hooks/. Grep web/src/ for imports of each
+hook. Hooks imported by zero files are dead code. Severity: medium.
+```
+
+**Agent 19 -- unused-web-utils** (haiku)
+File: `_audit/findings/19-unused-web-utils.md`
+```
+Check exported functions in web/src/utils/ and web/src/lib/. Grep web/src/
+for imports. Unused exports are dead code. Severity: low.
+```
+
+**Agent 20 -- unused-dto-fields** (sonnet)
+File: `_audit/findings/20-unused-dto-fields.md`
+```
+Compare DTO classes in api/dto*.py with frontend TypeScript types in
+web/src/types/. Flag fields present in backend DTOs but absent from frontend
+types (or vice versa). This suggests unused serialization. Severity: low.
+```
+
+**Agent 21 -- orphan-test-helpers** (sonnet)
+File: `_audit/findings/21-orphan-test-helpers.md`
+```
+Check all conftest.py files in tests/ for fixtures and helper functions.
+Grep tests/ for usage of each. Unused fixtures/helpers are dead test code.
+Severity: low.
+```
+
+### Wave 4: TODOs & Deferred (4 agents)
+
+**Agent 22 -- todo-comments** (haiku)
+File: `_audit/findings/22-todo-comments.md`
+```
+Grep ALL source files (src/, tests/, web/src/, cli/) for TODO, FIXME, HACK,
+XXX, TEMPORARY, WORKAROUND comments. List each with file:line and the full
+comment text. Severity: info.
+```
+
+**Agent 23 -- not-implemented** (haiku)
+File: `_audit/findings/23-not-implemented.md`
+```
+Grep src/synthorg/ and cli/ for: NotImplementedError, pass-only function
+bodies (def/async def with only pass), and Ellipsis (...) as sole function
+body. Severity: info for abstract methods, medium for concrete stubs.
+```
+
+**Agent 24 -- placeholder-stubs** (sonnet)
+File: `_audit/findings/24-placeholder-stubs.md`
+```
+Find functions that return hardcoded dummy values, empty lists/dicts, or have
+"placeholder", "stub", "temporary", "mock" in their comments/docstrings.
+These suggest incomplete implementations. Severity: medium.
+```
+
+**Agent 25 -- deferred-features** (sonnet)
+File: `_audit/findings/25-deferred-features.md`
+```
+Read docs/design/ pages and cross-reference with src/synthorg/. Find features
+described in the design spec that have no corresponding implementation.
+Focus on major features (not minor details). Severity: info.
+```
+
+### Wave 5: Safety & Security (7 agents)
+
+**Agent 26 -- silent-exception-swallow** (sonnet)
+File: `_audit/findings/26-silent-exception-swallow.md`
+```
+Find except blocks that swallow exceptions silently: bare `except:`,
+`except Exception: pass`, `except Exception as e:` with only DEBUG logging
+(should be WARNING+), catching too broadly. Skip intentional patterns like
+graceful shutdown cleanup. Severity: high for business logic, medium for cleanup.
+```
+
+**Agent 27 -- input-validation-gaps** (sonnet)
+File: `_audit/findings/27-input-validation-gaps.md`
+```
+Check API controller methods for user input that bypasses validation. Look for
+path/query parameters used directly without Pydantic validation, raw request
+body access, and missing type coercion. Severity: high.
+```
+
+**Agent 28 -- sql-injection-risk** (sonnet)
+File: `_audit/findings/28-sql-injection-risk.md`
+```
+Search persistence/ and any file using SQL for string concatenation or f-strings
+in SQL queries instead of parameterized queries. Severity: critical.
+```
+
+**Agent 29 -- missing-auth-checks** (sonnet)
+File: `_audit/findings/29-missing-auth-checks.md`
+```
+Check API controllers for endpoints missing auth guards. Compare with auth
+middleware/dependency injection. Public endpoints should be explicitly marked.
+Severity: high for data-mutating endpoints, medium for read-only.
+```
+
+**Agent 30 -- unsafe-deserialization** (haiku)
+File: `_audit/findings/30-unsafe-deserialization.md`
+```
+Grep for yaml.load() without SafeLoader, pickle.loads, eval(), exec(),
+compile() with user input. Severity: critical.
+```
+
+**Agent 31 -- hardcoded-secrets** (haiku)
+File: `_audit/findings/31-hardcoded-secrets.md`
+```
+Grep for patterns suggesting hardcoded secrets: password=", api_key=",
+token=", secret=", followed by string literals. Skip test files and .env
+examples. Severity: critical.
+```
+
+**Agent 32 -- missing-rate-limiting** (sonnet)
+File: `_audit/findings/32-missing-rate-limiting.md`
+```
+Check public-facing API endpoints for rate limiting. Check expensive operations
+(LLM calls, bulk DB writes, file uploads) for throttling. Severity: medium.
+```
+
+### Wave 6: Configuration & Hardcoding (6 agents)
+
+**Agent 33 -- hardcoded-urls-ports** (haiku)
+File: `_audit/findings/33-hardcoded-urls-ports.md`
+```
+Grep src/, web/src/, cli/ for hardcoded URLs, ports, hostnames, IP addresses
+that should come from config or env vars. Skip test files and documentation.
+Severity: medium.
+```
+
+**Agent 34 -- hardcoded-timeouts-limits** (haiku)
+File: `_audit/findings/34-hardcoded-timeouts-limits.md`
+```
+Grep src/synthorg/ for hardcoded timeout values (seconds/ms), retry counts,
+batch sizes, max limits that should be configurable. Look for bare numeric
+literals in asyncio.wait_for, sleep, timeout parameters. Severity: low.
+```
+
+**Agent 35 -- hardcoded-magic-numbers** (haiku)
+File: `_audit/findings/35-hardcoded-magic-numbers.md`
+```
+Find magic numbers in business logic: bare numeric literals (not 0, 1, -1)
+without named constants. Focus on src/synthorg/ business logic, skip tests
+and config defaults. Severity: low.
+```
+
+**Agent 36 -- vendor-name-leaks** (haiku)
+File: `_audit/findings/36-vendor-name-leaks.md`
+```
+Grep for real vendor names: Anthropic, OpenAI, Claude, GPT, Gemini, Mistral
+in project-owned code. ALLOWED exceptions (do NOT flag):
+- providers/presets.py (user-facing runtime data)
+- .claude/ directory files
+- Third-party import paths (litellm.types.llms.openai etc)
+- docs/design/operations.md provider list
+Everything else is a violation. Severity: low.
+```
+
+**Agent 37 -- hardcoded-display-values** (sonnet)
+File: `_audit/findings/37-hardcoded-display-values.md`
+```
+Find hardcoded currencies (should default EUR not USD), date formats, number
+formats, locale-specific strings in both src/synthorg/ and web/src/.
+Severity: medium for USD defaults, low for format strings.
+```
+
+**Agent 38 -- missing-settings-bridge** (sonnet)
+File: `_audit/findings/38-missing-settings-bridge.md`
+```
+Cross-reference hardcoded values in src/synthorg/ with settings definitions in
+settings/definitions/. Find values that SHOULD be configurable but are hardcoded,
+and settings defined but never consumed by any code. Severity: medium.
+```
+
+### Wave 7: Code Quality & Conventions (7 agents)
+
+**Agent 39 -- long-functions** (haiku)
+File: `_audit/findings/39-long-functions.md`
+```
+Find functions exceeding line limits: Python over 50 lines, Go over 80 lines,
+TypeScript over 60 lines. Report file:line of function def and line count.
+Severity: low.
+```
+
+**Agent 40 -- long-files** (haiku)
+File: `_audit/findings/40-long-files.md`
+```
+Find files exceeding size limits: Python over 800 lines, TypeScript over 600
+lines, Go over 1000 lines. Report file path and line count. Severity: low.
+```
+
+**Agent 41 -- model-convention-violations** (sonnet)
+File: `_audit/findings/41-model-convention-violations.md`
+```
+Check Pydantic models in src/synthorg/ for convention violations:
+- Missing frozen=True in ConfigDict (config/identity models must be frozen)
+- Missing allow_inf_nan=False in ConfigDict
+- Identifier/name fields not using NotBlankStr type
+- Mutable runtime fields mixed with config fields in one model
+Severity: medium.
+```
+
+**Agent 42 -- missing-immutability** (sonnet)
+File: `_audit/findings/42-missing-immutability.md`
+```
+Find violations of immutability conventions:
+- dict/list exposed without MappingProxyType wrapping (non-Pydantic)
+- Mutable default arguments (def f(x=[]))
+- In-place mutations of frozen model instances
+- Missing copy.deepcopy at system boundaries
+Severity: medium.
+```
+
+**Agent 43 -- async-antipatterns** (sonnet)
+File: `_audit/findings/43-async-antipatterns.md`
+```
+Find async antipatterns in src/synthorg/:
+- Bare asyncio.create_task without TaskGroup
+- Missing await on coroutine calls
+- Blocking I/O (open(), requests.) in async functions
+- Fire-and-forget tasks with no error handling
+- sync sleep() in async context
+Severity: high for missing await, medium for others.
+```
+
+**Agent 44 -- error-handling-consistency** (sonnet)
+File: `_audit/findings/44-error-handling-consistency.md`
+```
+Check error handling conventions:
+- Custom exceptions not inheriting from project error hierarchy
+- API error responses not using RFC 9457 structured format
+- Missing error mapping in controllers (raw exceptions leaking to clients)
+- Inconsistent error response shapes across endpoints
+Severity: medium.
+```
+
+**Agent 45 -- future-annotations-leak** (haiku)
+File: `_audit/findings/45-future-annotations-leak.md`
+```
+Grep for "from __future__ import annotations" in ALL Python files. This is
+forbidden on Python 3.14 (PEP 649 native). Severity: low.
+```
+
+### Wave 8: Frontend Quality (5 agents)
+
+**Agent 46 -- missing-accessibility** (sonnet)
+File: `_audit/findings/46-missing-accessibility.md`
+```
+Check web/src/components/ and web/src/pages/ for accessibility issues:
+missing aria-label on interactive elements, missing role attributes, missing
+keyboard navigation (onKeyDown handlers), missing focus management after
+navigation, images without alt text. Severity: medium.
+```
+
+**Agent 47 -- missing-loading-states** (sonnet)
+File: `_audit/findings/47-missing-loading-states.md`
+```
+Check pages/components that fetch data (useQuery, useEffect with fetch) for
+missing loading skeletons/spinners, missing empty states when data is [],
+and missing error boundaries around async content. Severity: medium.
+```
+
+**Agent 48 -- hardcoded-frontend-strings** (haiku)
+File: `_audit/findings/48-hardcoded-frontend-strings.md`
+```
+Find user-facing strings hardcoded directly in TSX files. Look for text
+content in JSX elements that should be centralized for i18n readiness.
+Skip component prop names and technical strings. Severity: info.
+```
+
+**Agent 49 -- design-token-violations** (sonnet)
+File: `_audit/findings/49-design-token-violations.md`
+```
+Check web/src/ for design system violations: hardcoded hex colors (#xxx),
+hardcoded px values for spacing/padding/margins, raw font-family declarations,
+raw CSS transition/animation values instead of @/lib/motion presets.
+Severity: medium.
+```
+
+**Agent 50 -- missing-error-handling-fe** (sonnet)
+File: `_audit/findings/50-missing-error-handling-fe.md`
+```
+Check web/src/ for API calls without error handling: missing .catch() or
+try/catch, missing toast/notification on failure, optimistic updates without
+rollback on error, console.error without user feedback. Severity: medium.
+```
+
+### Wave 9: Logic & Architecture (4 agents)
+
+**Agent 51 -- race-conditions** (sonnet)
+File: `_audit/findings/51-race-conditions.md`
+```
+Find potential race conditions: shared mutable state without locks/mutexes,
+TOCTOU patterns (check-then-act without atomicity), concurrent dict/list
+modification, DB read-modify-write without transactions. Severity: high.
+```
+
+**Agent 52 -- resource-leaks** (sonnet)
+File: `_audit/findings/52-resource-leaks.md`
+```
+Find unclosed resources: HTTP clients/sessions not using async with,
+file handles not in with blocks, DB connections not properly returned to pool,
+aiohttp sessions created but not closed. Severity: high.
+```
+
+**Agent 53 -- circular-dependencies** (sonnet)
+File: `_audit/findings/53-circular-dependencies.md`
+```
+Find import cycles between src/synthorg/ packages. Check for circular
+references that could cause runtime ImportError or require deferred imports.
+Also check for TYPE_CHECKING guards that hide real circular deps. Severity: medium.
+```
+
+**Agent 54 -- design-spec-drift** (sonnet)
+File: `_audit/findings/54-design-spec-drift.md`
+```
+Compare implementation in src/synthorg/ with docs/design/ specs. Find
+behaviors, models, or flows that diverge from what the spec describes without
+documented rationale. Focus on major architectural decisions. Severity: medium.
+```
+
+### Wave 10: Go CLI (4 agents)
+
+**Agent 55 -- go-error-handling** (sonnet)
+File: `_audit/findings/55-go-error-handling.md`
+```
+Check cli/ Go code for: ignored error returns (assigned to _), missing error
+wrapping (fmt.Errorf with %w), bare log.Fatal instead of returning errors,
+os.Exit in non-main functions. Severity: medium.
+```
+
+**Agent 56 -- go-resource-leaks** (sonnet)
+File: `_audit/findings/56-go-resource-leaks.md`
+```
+Check cli/ for unclosed resources: Docker clients without defer Close(),
+HTTP response bodies not closed, file handles without defer Close(),
+context cancellation not propagated. Severity: high.
+```
+
+**Agent 57 -- go-hardcoded-values** (haiku)
+File: `_audit/findings/57-go-hardcoded-values.md`
+```
+Grep cli/ for hardcoded Docker image tags, ports, paths, timeouts that should
+be configurable via flags or config. Severity: low.
+```
+
+**Agent 58 -- go-cli-wiring** (sonnet)
+File: `_audit/findings/58-go-cli-wiring.md`
+```
+Check cobra command registration in cli/cmd/. Find commands registered but
+non-functional, flags defined but never read, subcommands with no RunE.
+Severity: medium.
+```
+
+---
+
+## Phase 3: Validate Findings (sonnet agents)
 
 **MANDATORY. Never skip this phase.**
 
-Launch validation agents in parallel. Each validation agent gets a batch of 8-12 findings and is instructed to:
+After all 58 audit agents complete, launch validation agents to verify findings.
 
-1. Read the actual source file at the reported line number
-2. Verify the issue exists as described
-3. Check if the "issue" is actually intentional (read comments, docstrings, related code)
-4. Check if CI/build/tests handle it in a way the audit agent missed
-5. Classify each finding:
-   - **CONFIRMED** -- verified in code, real issue
-   - **LIKELY CONFIRMED** -- code suggests the issue but edge case unclear
-   - **LIKELY FALSE** -- probably not a real issue (explain why)
-   - **FALSE POSITIVE** -- definitely not an issue (explain why)
-6. For intentional patterns (e.g., graceful shutdown error swallowing), mark as "CONFIRMED but INTENTIONAL" -- these are excluded from work packages
+### Process
 
-### Validation Agent Prompt Template
+1. Read all 58 finding files from `_audit/findings/`
+2. Collect all critical + high severity findings into a validation queue
+3. Split the queue into batches of ~12 findings each
+4. Launch one **sonnet** validation agent per batch (in parallel, `run_in_background: true`)
 
-```text
-Validate these audit findings by reading the ACTUAL SOURCE CODE.
-For each finding, determine: CONFIRMED, LIKELY CONFIRMED, LIKELY FALSE, or FALSE POSITIVE.
+### Validation Agent Prompt
 
-For each:
+```
+You are validating audit findings by reading the ACTUAL SOURCE CODE.
+
+For each finding below, do:
 1. Read the file at the reported line number
-2. Quote the actual code
-3. Check if it's intentional (read surrounding comments, docstrings)
-4. Check if CI, tests, or build pipelines handle it
-5. Give a clear verdict with evidence
+2. Quote the actual code (2-5 lines)
+3. Check if the issue is real or a false positive
+4. Check if it's intentional (read surrounding comments, docstrings)
+5. Give a verdict: CONFIRMED, FALSE_POSITIVE, or INTENTIONAL
 
-{BATCH OF FINDINGS}
+Write results to: _audit/findings/validate-batch-{N}.md
+
+Format per finding:
+### [original-file]:[line] -- [CONFIRMED|FALSE_POSITIVE|INTENTIONAL]
+**Original**: [description from audit agent]
+**Actual code**: [quoted code]
+**Verdict**: [explanation]
+---
+
+Findings to validate:
+{BATCH_OF_FINDINGS}
 ```
 
-### After validation
+### After Validation
 
-- Remove all FALSE POSITIVE and LIKELY FALSE findings
-- Keep CONFIRMED and LIKELY CONFIRMED
-- Mark CONFIRMED-but-INTENTIONAL as excluded (note in report but don't create issues)
-- Calculate false positive rate: `removed / total`
-- Report: "Validated N findings. Removed M false positives (X%). N remaining confirmed findings."
+1. Read all `validate-batch-*.md` files
+2. Remove FALSE_POSITIVE findings from the audit files (edit in place)
+3. Mark INTENTIONAL findings as excluded (keep in file but prefix with `[INTENTIONAL]`)
+4. Report: "Validated N findings. Removed M false positives (X%)."
+
+Skip validation for `--quick` runs or if total critical+high findings are under 5.
 
 ---
 
-## Phase 5: Deep Dive on Suspicious Clean Results
+## Phase 4: Build INDEX.md
 
-For each audit category that found ZERO issues in Phase 2:
+After validation, read all finding files and build `_audit/INDEX.md`:
 
-1. **Research the relevant architecture first** -- read the actual implementation files to understand how the system works
-2. **Craft a targeted, informed prompt** -- include specific architectural details (e.g., "the observability stack uses structlog with 11 sinks routed by logger name prefix via _SINK_ROUTING in sinks.py")
-3. **Launch a second agent** with the enriched prompt and explicit instructions: "The first audit found nothing. Dig deeper. Check specific functions, look for subtle gaps, verify edge cases."
-4. **Validate any new findings** (same as Phase 4)
-5. Add validated findings to the main list
+```markdown
+# Codebase Audit Index
 
-Skip this phase if the user passed `--quick` or if the zero-finding categories are genuinely well-covered (e.g., dependencies audit finding nothing is believable).
+**Date**: {date}
+**Scope**: {scope}
+**Agents**: 58
+**Total findings**: {count}
+**False positives removed**: {count} ({percent}%)
 
----
+## By Severity
 
-## Phase 6: Present Validated Findings
+| Severity | Count |
+|----------|-------|
+| critical | N |
+| high | N |
+| medium | N |
+| low | N |
+| info | N |
 
-Present the validated, deduplicated findings to the user. Format:
+## By Wave
 
-### Summary Table
-
-```text
-| # | Finding | File:Line | Category | Verdict |
-|---|---------|-----------|----------|---------|
-| 1 | Description | path:123 | category | CONFIRMED |
-| ... | ... | ... | ... | ... |
-```
-
-### Statistics
-
-- Total findings: N
-- False positives removed: M (X%)
-- Confirmed: N1, Likely confirmed: N2
-- Intentional (excluded): N3
-- Categories with zero findings: list
-
-### User Gate
-
-If `--report-only` was passed, skip this gate and go directly to the markdown report (option 3 below).
-
-Otherwise, ask the user:
-1. **"Proceed to group into work packages and create issues" (Recommended)**
-2. "Show me the full detail for each finding first"
-3. "Export as markdown report only (no issues)"
-
----
-
-## Phase 7: Group into Work Packages
-
-**Group by code proximity, NOT by severity.**
-
-### Grouping Rules
-
-1. **Same directory/module** -- findings touching the same `src/synthorg/<module>/` go together
-2. **Same file** -- multiple findings in one file always go in the same package
-3. **Dependency chain** -- if fixing A requires fixing B first, bundle them
-4. **Same developer context** -- what would a developer naturally fix in one sitting?
-5. **Target medium scope** -- each package should be a meaningful PR, not too small (1 finding) or too large (15+ findings)
-6. **Never group by severity** -- a HIGH and LOW in the same file go together; a HIGH and HIGH in different modules do NOT
-
-### Common Groupings
-
-These patterns recur across audits:
-- **API controller sweep** -- validation, response patterns, auth hardening (all in `api/controllers/`)
-- **Observability fixes** -- sink routing, correlation, event constants (all in `observability/`)
-- **Test quality** -- flaky fixes + missing coverage (all in `tests/`)
-- **CI hardening** -- timeouts, permissions, script safety (all in `.github/`)
-- **Documentation** -- content fixes across `docs/` and `site/`
-- **Language-specific** -- Go fixes together, React fixes together
-
-### Standalone features
-
-If a finding is a "feature not yet implemented" (spec drift with TODO/stub), it can be its own issue if medium+ scope. Do NOT create meta/tracking issues -- each issue must be implementable on its own.
-
-### Present to User
-
-Show the proposed work packages:
-
-```text
-## Proposed Work Packages (N total)
-
-### WP1: Name
-| # | Finding |
-|---|---------|
-| 1 | ... |
-| 2 | ... |
-```
-
-**Rationale:** Why these go together.
-
-```text
-### WP2: Name
-...
-```
-
-Ask: "Create issues for all N work packages? Or adjust groupings first?"
-
----
-
-## Phase 8: Final Issue Dedup & Creation
-
-### Step 8a: Final dedup against existing issues
-
-Before creating, do one final check:
-
-```bash
-gh issue list --repo OWNER/REPO --state open --limit 200 --json number,title,labels
-```
-
-For each work package, search for title/description overlap with existing issues. If a finding is already covered by an existing issue, either:
-- Remove it from the work package
-- Note "extends #NNN" in the new issue body
-
-### Step 8b: Create issues
-
-For each work package, create a GitHub issue with:
-
-- **Title**: `<type>: <concise description>` (matching commit convention: fix, feat, chore, docs, test)
-- **Body**:
-  - `## Summary` -- 1-2 sentences
-  - `## Findings` -- table of findings with file:line, description
-  - `## Files to Modify` -- list of files that need changes
-  - Design spec references if applicable
-- **Labels**: appropriate type/scope/spec labels
-
-Use the `mcp__github__issue_write` tool or `gh issue create` via Bash.
-
-**IMPORTANT**: Never use em-dashes or non-ASCII punctuation in issue bodies (project convention).
-
-### Step 8c: Report
-
-Present the complete list of created issues:
-
-```text
-| WP | Issue | Title |
-|----|-------|-------|
-| 1 | #NNN | ... |
+| Wave | Findings | Top Issue |
+|------|----------|-----------|
+| 1. Observability | N | ... |
+| 2. Wiring | N | ... |
 | ... | ... | ... |
+
+## Top 20 Critical + High Findings
+
+| # | Severity | File:Line | Issue | Agent |
+|---|----------|-----------|-------|-------|
+| 1 | critical | ... | ... | ... |
+| ... | ... | ... | ... | ... |
+
+## Zero-Finding Categories
+
+These agents found nothing (may warrant deeper investigation):
+- ...
+
+## Finding Files
+
+- [01-missing-logger.md](findings/01-missing-logger.md) (N findings)
+- [02-wrong-logger-pattern.md](findings/02-wrong-logger-pattern.md) (N findings)
+- ...
 ```
+
+---
+
+## Phase 5: Triage with User
+
+Present INDEX.md to the user. Walk through:
+
+1. Critical + high findings first
+2. Zero-finding categories (suspicious?)
+3. Group related findings into potential GitHub issues by code proximity
+
+Use AskUserQuestion to confirm:
+- Which findings to create issues for
+- How to group them (by module? by wave? by severity?)
+- Whether to create issues now or export report only
+
+If `--report-only`, skip this phase entirely.
 
 ---
 
 ## Rules
 
-1. **NEVER present unvalidated findings to the user.** Validation (Phase 4) is mandatory.
-2. **ALWAYS research architecture before auditing.** Phase 1b is not optional.
-3. **Be skeptical of clean results.** Zero findings triggers Phase 5 deep dive.
-4. **Group by code proximity, NEVER by severity.** What files does a developer touch together?
-5. **No meta/tracking issues.** Every issue must be directly implementable.
-6. **Dedup twice.** Once in agent prompts (Phase 2), once before issue creation (Phase 8a).
-7. **All agents run in parallel.** Never launch agents sequentially when they're independent.
-8. **Agent prompts include architecture context.** Never launch a "blind" agent.
-9. **Intentional patterns are not bugs.** Graceful shutdown error swallowing, defensive cleanup, etc. are valid patterns -- exclude from issues but note in report.
-10. **Respect project conventions.** Read CLAUDE.md, use correct commands (`uv run python -m pytest`, not `uv run pytest`), no vendor names, etc.
-11. **Default to creating issues.** Unless user passes `--report-only`, the skill creates issues.
-12. **Never push code.** This skill audits and creates issues -- it does not fix code.
+1. **Every agent writes to `_audit/findings/`** using the Write tool, not Bash
+2. **Architecture brief in every prompt** -- no blind agents
+3. **Validation is mandatory** for critical+high findings
+4. **Batch execution** -- ~10 agents per batch, wait between batches
+5. **Sonnet for analysis, Haiku for pattern matching** -- never Opus for audit agents
+6. **Do NOT fix anything** -- audit only, findings only
+7. **Rerunnable** -- clean `_audit/` at start of every run
+8. **Never use em-dashes** in any output files (project convention)
+9. **Report progress** after each batch completes

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Audit artifacts
+_audit/
+
 # Python
 __pycache__/
 *.py[cod]

--- a/.opencode/commands/codebase-audit.md
+++ b/.opencode/commands/codebase-audit.md
@@ -1,5 +1,5 @@
 ---
-description: Deep codebase audit with parallel specialized agents
+description: "Full codebase audit: launches 58 specialized agents to find issues across Python/React/Go, writes findings to _audit/findings/, then triages with user"
 ---
 
 # OpenCode Adapter (read this FIRST, before the skill below)
@@ -8,17 +8,11 @@ You are running in **OpenCode**, not Claude Code. Apply these overrides:
 
 ### Subagent spawning
 
-The skill below uses the Claude Code `Agent` tool with `subagent_type` parameters. In OpenCode, spawn subagents using the agent definitions from `.opencode/agents/` directory. Load the agent's `.md` file as the subagent prompt and use the model specified in its frontmatter.
+The rewritten skill launches 58 audit agents with custom embedded prompts via the `Agent` tool. These are NOT mapped to `.opencode/agents/` -- they use inline prompts defined in the skill itself. Spawn each agent with its prompt from the skill's Agent Roster section.
 
-Agent type mapping (same as pre-pr-review/aurelio-review-pr):
+### Scope changes
 
-| Skill references this | Use this OpenCode agent instead |
-|---|---|
-| `pr-review-toolkit:code-reviewer` | `.opencode/agents/code-reviewer.md` |
-| `everything-claude-code:python-reviewer` | `.opencode/agents/python-reviewer.md` |
-| `everything-claude-code:security-reviewer` | `.opencode/agents/security-reviewer.md` |
-| `everything-claude-code:database-reviewer` | `.opencode/agents/persistence-reviewer.md` |
-| `everything-claude-code:go-reviewer` | `.opencode/agents/go-reviewer.md` |
+Supported scopes: `full`, `src/`, `web/`, `cli/`, `docs/`. The old scopes `.github/`, `ci`, `docker/`, `site/`, `src/synthorg/` are no longer valid.
 
 ### GitHub issue creation
 
@@ -26,7 +20,7 @@ The skill uses `mcp__github__issue_write`. In OpenCode, use `gh issue create` vi
 
 ### Shell compatibility
 
-This runs on Windows with PowerShell. Self-correct when bash syntax fails.
+This runs on Windows with PowerShell. Self-correct when bash syntax fails. The `rm -rf _audit` setup command should use `Remove-Item -Recurse -Force _audit -ErrorAction SilentlyContinue`.
 
 ---
 


### PR DESCRIPTION
## Summary

Rewrites the `/codebase-audit` skill from an in-session audit workflow to a file-based 58-agent system that scales to full codebase audits across Python (85k LoC), React/TypeScript (55k LoC), and Go (27k LoC).

## Changes

- **58 specialized agents** across 10 waves: Observability (7), Wiring (8), Dead Code (6), TODOs (4), Security (7), Hardcoding (6), Code Quality (7), Frontend (5), Architecture (4), Go CLI (4)
- **File-based output** to `_audit/findings/` (one markdown file per agent) instead of in-session findings
- **Sonnet validation phase** -- mandatory for critical+high findings before triage
- **Scope filtering** -- `full`, `src/`, `web/`, `cli/`, `docs/` with explicit agent-per-scope dispatch table
- **Architecture Brief** injected into every agent prompt (logging, wiring, providers, error hierarchy, async patterns, DB schema)
- **6-batch execution** (~10 agents per batch, sequential batches)
- **INDEX.md generation** with severity stats, per-wave breakdown, top findings
- **User triage phase** -- walk through findings together before creating issues
- Added `_audit/` to `.gitignore`

## Model assignment

- 37 Sonnet agents (semantic analysis, cross-file relationships)
- 21 Haiku agents (pattern matching, grep-based checks)

## Pre-reviewed by 3 agents, 14 findings addressed

- Tightened vague agent prompts (Agents 05, 06, 10, 16, 30)
- Expanded scope dispatch table with explicit agent numbers per scope
- Added scope filtering note to Agent 20 (DTO drift)
- Clarified Agent 08 ownership boundary (vs Agent 15)
- Expanded Architecture Brief with error hierarchy, providers, pluggable subsystems, DB, async
- Added validation queue cap for large finding sets
- Fixed zero-findings text to be neutral (not implying suspicion)
- Changed validation to delete false positives instead of marking them