### PR TITLE
fix: correct volume ownership for DHI postgres and nats containers

### DIFF
--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -128,7 +128,7 @@ The CLI orchestrates two persistence backends:
 When `--persistence-backend postgres` is selected, `synthorg init`:
 
 1. Adds a `dhi.io/postgres:18-debian13` DHI (Docker Hardened Image) service to the generated `compose.yml` (read-only rootfs, minimal capabilities via `cap_add`, `pg_isready` healthcheck, named volume `synthorg-pgdata`).
-2. Adds a `data-init` helper container (busybox) that ensures the `synthorg-data` volume is owned by the non-root backend user (`65532:65532`) on first start, preventing permission errors.
+2. Adds a `data-init` helper container (busybox) that chowns each named volume to the correct non-root UID on first start: `synthorg-data` to `65532:65532` (backend / distroless nonroot), `synthorg-pgdata` to `70:70` with mode `0700` (DHI postgres user, required by `initdb`), and `synthorg-nats-data` to `65532:65532` when the distributed bus is enabled. Fresh Docker named volumes are root-owned and DHI images run as non-root with no capability to self-chown, so this one-shot container prevents permission errors across all stateful services.
 3. Generates a 32-byte URL-safe random password via `crypto/rand` and persists it to `config.json` (`postgres_password`). Re-init preserves the existing password to avoid breaking the running container.
 4. Wires `SYNTHORG_DATABASE_URL=postgresql://synthorg:<password>@postgres:5432/synthorg` into the backend container's environment. The SQLite-only `SYNTHORG_DB_PATH` variable is omitted.
 5. Declares `depends_on: postgres: condition: service_healthy` on the backend service so backend startup blocks until Postgres accepts connections.

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -123,12 +123,22 @@ The CLI orchestrates two persistence backends:
 | `sqlite` (default) | `--persistence-backend sqlite` | n/a (in-process) | `synthorg-data` | Single-node, development, small deployments |
 | `postgres` | `--persistence-backend postgres` | `3002` (default, override with `--postgres-port`) | `synthorg-pgdata` | Multi-instance, production, high concurrency |
 
+### Volume ownership (`data-init`)
+
+Every generated `compose.yml` includes a `data-init` helper container (busybox) that runs once before the stateful services start. Its job is to chown each named volume to the UID of the non-root user that will own it:
+
+- `synthorg-data` -> `65532:65532` (backend / distroless nonroot)
+- `synthorg-pgdata` -> `70:70` with mode `0700` (DHI postgres user; `initdb` requires exclusive 0700 or it aborts with "permissions should be u=rwx (0700) or u=rwx,g=rx (0750)") -- only mounted when `--persistence-backend postgres`
+- `synthorg-nats-data` -> `65532:65532` (DHI nats `nonroot` user) -- only mounted when `--bus-backend nats`
+
+Fresh Docker named volumes are owned by `root:root` at creation, and DHI images run as non-root with no capability to self-chown, so this one-shot container is required for every backend selection to avoid permission errors. The `postgres` and `nats` services both declare `depends_on: data-init: condition: service_completed_successfully` to block on the chown before starting.
+
 ### Postgres orchestration
 
 When `--persistence-backend postgres` is selected, `synthorg init`:
 
 1. Adds a `dhi.io/postgres:18-debian13` DHI (Docker Hardened Image) service to the generated `compose.yml` (read-only rootfs, minimal capabilities via `cap_add`, `pg_isready` healthcheck, named volume `synthorg-pgdata`).
-2. Adds a `data-init` helper container (busybox) that chowns each named volume to the correct non-root UID on first start: `synthorg-data` to `65532:65532` (backend / distroless nonroot), `synthorg-pgdata` to `70:70` with mode `0700` (DHI postgres user, required by `initdb`), and `synthorg-nats-data` to `65532:65532` when the distributed bus is enabled. Fresh Docker named volumes are root-owned and DHI images run as non-root with no capability to self-chown, so this one-shot container prevents permission errors across all stateful services.
+2. Extends the `data-init` helper (see above) to also chown `synthorg-pgdata` to `70:70` with mode `0700`.
 3. Generates a 32-byte URL-safe random password via `crypto/rand` and persists it to `config.json` (`postgres_password`). Re-init preserves the existing password to avoid breaking the running container.
 4. Wires `SYNTHORG_DATABASE_URL=postgresql://synthorg:<password>@postgres:5432/synthorg` into the backend container's environment. The SQLite-only `SYNTHORG_DB_PATH` variable is omitted.
 5. Declares `depends_on: postgres: condition: service_healthy` on the backend service so backend startup blocks until Postgres accepts connections.

--- a/cli/internal/compose/compose.yml.tmpl
+++ b/cli/internal/compose/compose.yml.tmpl
@@ -10,6 +10,9 @@ services:
       - "{{.PostgresPort}}:5432"
     volumes:
       - synthorg-pgdata:/var/lib/postgresql/data
+    depends_on:
+      data-init:
+        condition: service_completed_successfully
     environment:
       PGDATA: /var/lib/postgresql/data
       POSTGRES_DB: synthorg
@@ -47,8 +50,9 @@ services:
         max-file: "3"
 {{- end}}
 
-  # Init container: ensure the data volume is owned by the app user (65532).
-  # Docker creates named volumes as root; this runs once on first start.
+  # Init container: chown named volumes to the correct non-root UID per service.
+  # Fresh Docker named volumes are root-owned; DHI images run as non-root and
+  # cannot self-chown, so this one-shot container sets ownership on first start.
   data-init:
     # renovate: datasource=docker depName=busybox
     image: busybox:1.37-musl@sha256:19b646668802469d968a05342a601e78da4322a414a7c09b1c9ee25165042138
@@ -57,7 +61,10 @@ services:
 {{- if postgresEnabled}}
       - synthorg-pgdata:/pgdata
 {{- end}}
-    command: ["sh", "-c", "set -e; mkdir -p /data/logs /data/memory; chown -R 65532:65532 /data{{if postgresEnabled}}; chown -R 65532:65532 /pgdata{{end}}"]
+{{- if distributedEnabled}}
+      - synthorg-nats-data:/nats-data
+{{- end}}
+    command: ["sh", "-c", "set -e; mkdir -p /data/logs /data/memory; chown -R 65532:65532 /data{{if postgresEnabled}}; chown -R 70:70 /pgdata; chmod 0700 /pgdata{{end}}{{if distributedEnabled}}; chown -R 65532:65532 /nats-data{{end}}"]
     cap_drop:
       - ALL
     cap_add:
@@ -188,6 +195,9 @@ services:
       - "{{.NatsClientPort}}:4222"
     volumes:
       - synthorg-nats-data:/data
+    depends_on:
+      data-init:
+        condition: service_completed_successfully
     user: "65532:65532"
     security_opt:
       - no-new-privileges:true

--- a/cli/internal/compose/generate_test.go
+++ b/cli/internal/compose/generate_test.go
@@ -532,94 +532,136 @@ func compareGolden(t *testing.T, name string, actual []byte) {
 	}
 }
 
-// TestGenerateDataInitOwnershipPostgres verifies that when postgres is enabled,
-// data-init chowns the pgdata volume to UID 70 (DHI postgres user) -- not the
-// backend UID 65532 -- and applies mode 0700 so initdb can chmod on first run.
-// Regression guard for the "postgres container stuck Restarting" bug where
-// pgdata was chowned to 65532 and initdb failed with "could not change
-// permissions of directory".
-func TestGenerateDataInitOwnershipPostgres(t *testing.T) {
+// TestGenerateDataInitOwnership is a table-driven regression guard for the
+// data-init chown bugs: pgdata was chowned to the backend UID 65532 instead of
+// the DHI postgres UID 70 (initdb aborted with "could not change permissions
+// of directory"); nats-data was never chowned at all (latent -- DHI nats
+// runs as UID 65532 and could not write JetStream state on fresh volumes);
+// and neither postgres nor nats gated startup on data-init completing.
+//
+// The matrix covers all three valid backend combinations so every conditional
+// block in compose.yml.tmpl is exercised:
+//   - postgres_only: the postgres branch fires, the nats branch does not.
+//   - nats_only: the nats branch fires, the postgres branch does not.
+//   - postgres_and_nats: both branches fire simultaneously. This is the
+//     TUI-default combination and therefore the most-used path in production.
+func TestGenerateDataInitOwnership(t *testing.T) {
 	t.Parallel()
-	p := Params{
-		CLIVersion:         "dev",
-		ImageTag:           "latest",
-		BackendPort:        3001,
-		WebPort:            3000,
-		LogLevel:           "info",
-		PersistenceBackend: "postgres",
-		MemoryBackend:      "mem0",
-		BusBackend:         "internal",
-		PostgresPort:       3002,
-		PostgresPassword:   "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-	}
-	out, err := Generate(p)
-	if err != nil {
-		t.Fatalf("Generate: %v", err)
-	}
-	yaml := string(out)
 
-	assertContains(t, yaml, "- synthorg-pgdata:/pgdata")
-	assertContains(t, yaml, "chown -R 70:70 /pgdata")
-	assertContains(t, yaml, "chmod 0700 /pgdata")
-
-	// Postgres must gate on data-init so it never starts before the chown
-	// commits. Without this guard we re-introduce the startup race.
-	postgresBlock := extractServiceBlock(t, yaml, "postgres")
-	if !strings.Contains(postgresBlock, "depends_on:") ||
-		!strings.Contains(postgresBlock, "data-init:") ||
-		!strings.Contains(postgresBlock, "service_completed_successfully") {
-		t.Errorf("postgres service must depend_on data-init: service_completed_successfully\ngot:\n%s", postgresBlock)
+	cases := []struct {
+		name               string
+		persistenceBackend string
+		busBackend         string
+		postgresPort       int
+		natsClientPort     int
+		wantPostgresChown  bool
+		wantNatsChown      bool
+		gatedServices      []string
+		forbiddenStrings   []string
+	}{
+		{
+			name:               "postgres_only",
+			persistenceBackend: "postgres",
+			busBackend:         "internal",
+			postgresPort:       3002,
+			wantPostgresChown:  true,
+			gatedServices:      []string{"postgres"},
+			forbiddenStrings:   []string{"synthorg-nats-data"},
+		},
+		{
+			name:               "nats_only",
+			persistenceBackend: "sqlite",
+			busBackend:         "nats",
+			natsClientPort:     3003,
+			wantNatsChown:      true,
+			gatedServices:      []string{"nats"},
+			forbiddenStrings:   []string{"synthorg-pgdata"},
+		},
+		{
+			name:               "postgres_and_nats",
+			persistenceBackend: "postgres",
+			busBackend:         "nats",
+			postgresPort:       3002,
+			natsClientPort:     3003,
+			wantPostgresChown:  true,
+			wantNatsChown:      true,
+			gatedServices:      []string{"postgres", "nats"},
+		},
 	}
 
-	// Nats-data must NOT appear when distributed is disabled.
-	if strings.Contains(yaml, "synthorg-nats-data") {
-		t.Error("synthorg-nats-data must not appear when bus_backend is internal")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := Params{
+				CLIVersion:         "dev",
+				ImageTag:           "latest",
+				BackendPort:        3001,
+				WebPort:            3000,
+				NatsClientPort:     tc.natsClientPort,
+				LogLevel:           "info",
+				PersistenceBackend: tc.persistenceBackend,
+				MemoryBackend:      "mem0",
+				BusBackend:         tc.busBackend,
+				PostgresPort:       tc.postgresPort,
+				PostgresPassword:   "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			}
+			out, err := Generate(p)
+			if err != nil {
+				t.Fatalf("Generate: %v", err)
+			}
+			yaml := string(out)
+
+			if tc.wantPostgresChown {
+				// UID 70 and mode 0700 are both required: chown alone leaves
+				// initdb rejecting permissions that are too loose (0755 by
+				// default), and chmod alone with the wrong UID still fails.
+				assertContains(t, yaml, "- synthorg-pgdata:/pgdata")
+				assertContains(t, yaml, "chown -R 70:70 /pgdata")
+				assertContains(t, yaml, "chmod 0700 /pgdata")
+				assertContains(t, yaml, "synthorg-pgdata:")
+			}
+			if tc.wantNatsChown {
+				assertContains(t, yaml, "- synthorg-nats-data:/nats-data")
+				assertContains(t, yaml, "chown -R 65532:65532 /nats-data")
+				assertContains(t, yaml, "synthorg-nats-data:")
+			}
+
+			for _, svc := range tc.gatedServices {
+				assertDependsOnDataInit(t, yaml, svc)
+			}
+
+			for _, forbidden := range tc.forbiddenStrings {
+				if strings.Contains(yaml, forbidden) {
+					t.Errorf("yaml must not contain %q in %s config", forbidden, tc.name)
+				}
+			}
+		})
 	}
 }
 
-// TestGenerateDataInitOwnershipDistributed verifies that when the distributed
-// (nats) bus backend is enabled, data-init chowns the nats volume to 65532 and
-// nats depends on data-init completing. Regression guard for the latent bug
-// where fresh nats-data volumes were left root-owned and nats (running as
-// UID 65532) could not write JetStream state.
-func TestGenerateDataInitOwnershipDistributed(t *testing.T) {
-	t.Parallel()
-	p := Params{
-		CLIVersion:         "dev",
-		ImageTag:           "latest",
-		BackendPort:        3001,
-		WebPort:            3000,
-		NatsClientPort:     3003,
-		LogLevel:           "info",
-		PersistenceBackend: "sqlite",
-		MemoryBackend:      "mem0",
-		BusBackend:         "nats",
-	}
-	out, err := Generate(p)
-	if err != nil {
-		t.Fatalf("Generate: %v", err)
-	}
-	yaml := string(out)
-
-	assertContains(t, yaml, "- synthorg-nats-data:/nats-data")
-	assertContains(t, yaml, "chown -R 65532:65532 /nats-data")
-
-	natsBlock := extractServiceBlock(t, yaml, "nats")
-	if !strings.Contains(natsBlock, "depends_on:") ||
-		!strings.Contains(natsBlock, "data-init:") ||
-		!strings.Contains(natsBlock, "service_completed_successfully") {
-		t.Errorf("nats service must depend_on data-init: service_completed_successfully\ngot:\n%s", natsBlock)
-	}
-
-	// Pgdata must NOT appear when persistence is sqlite.
-	if strings.Contains(yaml, "synthorg-pgdata") {
-		t.Error("synthorg-pgdata must not appear when persistence_backend is sqlite")
+// assertDependsOnDataInit verifies that the named top-level service
+// structurally declares `depends_on: data-init: condition:
+// service_completed_successfully` at the expected 4/6/8-space indent. Uses
+// substring matching on the exact multi-line YAML sequence rather than loose
+// "contains data-init:" checks, which would pass on a comment mentioning
+// data-init, a sibling service name, or a `depends_on` key that targets a
+// different service elsewhere in the block.
+func assertDependsOnDataInit(t *testing.T, yaml, service string) {
+	t.Helper()
+	block := extractServiceBlock(t, yaml, service)
+	want := "    depends_on:\n      data-init:\n        condition: service_completed_successfully"
+	if !strings.Contains(block, want) {
+		t.Errorf("%s service must structurally depend on data-init\n  want substring:\n%s\n  got block:\n%s", service, want, block)
 	}
 }
 
-// extractServiceBlock returns the YAML block for a named top-level service,
-// bounded by the next service declaration, a blank separator line, or the end
-// of the services section.
+// extractServiceBlock returns the YAML block for a named top-level service in
+// the `services:` map. The block runs from the service header through (but
+// not including) the next sibling service at the same 2-space indent or the
+// next root-level section (networks:/volumes:). Blank lines inside a block
+// are preserved; termination is purely indent-based, so the helper does not
+// fire early on service internals that happen to contain blank separators.
+// Trailing CR bytes are stripped for CRLF tolerance.
 func extractServiceBlock(t *testing.T, yaml, name string) string {
 	t.Helper()
 	header := "\n  " + name + ":\n"
@@ -628,79 +670,24 @@ func extractServiceBlock(t *testing.T, yaml, name string) string {
 		t.Fatalf("service %q not found in generated yaml", name)
 	}
 	rest := yaml[start+1:]
-	// Next top-level block starts with "\n  <word>:" at the same 2-space indent.
-	// Scan line by line until we find one, a blank separator line, or a
-	// top-level section header (networks:/volumes:).
 	lines := strings.Split(rest, "\n")
 	end := len(lines)
 	for i := 1; i < len(lines); i++ {
-		line := lines[i]
-		if line == "" {
-			// Blank line separates service blocks in the rendered template.
-			end = i
-			break
-		}
-		if len(line) >= 3 && line[0] == ' ' && line[1] == ' ' && line[2] != ' ' {
-			// sibling service at the same 2-space indent
-			end = i
-			break
-		}
+		line := strings.TrimRight(lines[i], "\r")
+		// Root-level section header ends the services map.
 		if strings.HasPrefix(line, "networks:") || strings.HasPrefix(line, "volumes:") {
+			end = i
+			break
+		}
+		// Sibling service: exactly 2 leading spaces then a non-space
+		// non-comment character. Skip 2-space-indented comments so an
+		// inline comment block preceding the next service is treated as the
+		// boundary (the comment is consumed up to but not including itself,
+		// which is fine since it belongs to the following service).
+		if strings.HasPrefix(line, "  ") && !strings.HasPrefix(line, "   ") && len(line) > 2 {
 			end = i
 			break
 		}
 	}
 	return strings.Join(lines[:end], "\n")
-}
-
-// TestGenerateDataInitOwnershipPostgresAndDistributed covers the TUI-default
-// combination (postgres persistence + nats bus). Neither of the single-backend
-// regression tests exercises the case where both conditional blocks fire in
-// the data-init command, and the CLI's interactive mode defaults to this
-// combination -- so it is the most-used path in production.
-func TestGenerateDataInitOwnershipPostgresAndDistributed(t *testing.T) {
-	t.Parallel()
-	p := Params{
-		CLIVersion:         "dev",
-		ImageTag:           "latest",
-		BackendPort:        3001,
-		WebPort:            3000,
-		NatsClientPort:     3003,
-		LogLevel:           "info",
-		PersistenceBackend: "postgres",
-		MemoryBackend:      "mem0",
-		BusBackend:         "nats",
-		PostgresPort:       3002,
-		PostgresPassword:   "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-	}
-	out, err := Generate(p)
-	if err != nil {
-		t.Fatalf("Generate: %v", err)
-	}
-	yaml := string(out)
-
-	// Both mounts present on data-init.
-	assertContains(t, yaml, "- synthorg-pgdata:/pgdata")
-	assertContains(t, yaml, "- synthorg-nats-data:/nats-data")
-
-	// Both chowns present in the single data-init command string. Order
-	// matters: pgdata UID 70, nats-data UID 65532. A bad template edit
-	// that swapped these would brick the stack.
-	assertContains(t, yaml, "chown -R 70:70 /pgdata")
-	assertContains(t, yaml, "chmod 0700 /pgdata")
-	assertContains(t, yaml, "chown -R 65532:65532 /nats-data")
-
-	// Both downstream services must gate on data-init completing.
-	for _, svc := range []string{"postgres", "nats"} {
-		block := extractServiceBlock(t, yaml, svc)
-		if !strings.Contains(block, "depends_on:") ||
-			!strings.Contains(block, "data-init:") ||
-			!strings.Contains(block, "service_completed_successfully") {
-			t.Errorf("%s service must depend_on data-init: service_completed_successfully\ngot:\n%s", svc, block)
-		}
-	}
-
-	// Both volumes must be declared at the top level when both backends are enabled.
-	assertContains(t, yaml, "synthorg-pgdata:")
-	assertContains(t, yaml, "synthorg-nats-data:")
 }

--- a/cli/internal/compose/generate_test.go
+++ b/cli/internal/compose/generate_test.go
@@ -618,7 +618,8 @@ func TestGenerateDataInitOwnershipDistributed(t *testing.T) {
 }
 
 // extractServiceBlock returns the YAML block for a named top-level service,
-// bounded by the next service declaration or the end of the services section.
+// bounded by the next service declaration, a blank separator line, or the end
+// of the services section.
 func extractServiceBlock(t *testing.T, yaml, name string) string {
 	t.Helper()
 	header := "\n  " + name + ":\n"
@@ -628,13 +629,19 @@ func extractServiceBlock(t *testing.T, yaml, name string) string {
 	}
 	rest := yaml[start+1:]
 	// Next top-level block starts with "\n  <word>:" at the same 2-space indent.
-	// Scan line by line until we find one.
+	// Scan line by line until we find one, a blank separator line, or a
+	// top-level section header (networks:/volumes:).
 	lines := strings.Split(rest, "\n")
 	end := len(lines)
 	for i := 1; i < len(lines); i++ {
 		line := lines[i]
+		if line == "" {
+			// Blank line separates service blocks in the rendered template.
+			end = i
+			break
+		}
 		if len(line) >= 3 && line[0] == ' ' && line[1] == ' ' && line[2] != ' ' {
-			// sibling service or networks:/volumes: at top level
+			// sibling service at the same 2-space indent
 			end = i
 			break
 		}
@@ -644,4 +651,56 @@ func extractServiceBlock(t *testing.T, yaml, name string) string {
 		}
 	}
 	return strings.Join(lines[:end], "\n")
+}
+
+// TestGenerateDataInitOwnershipPostgresAndDistributed covers the TUI-default
+// combination (postgres persistence + nats bus). Neither of the single-backend
+// regression tests exercises the case where both conditional blocks fire in
+// the data-init command, and the CLI's interactive mode defaults to this
+// combination -- so it is the most-used path in production.
+func TestGenerateDataInitOwnershipPostgresAndDistributed(t *testing.T) {
+	t.Parallel()
+	p := Params{
+		CLIVersion:         "dev",
+		ImageTag:           "latest",
+		BackendPort:        3001,
+		WebPort:            3000,
+		NatsClientPort:     3003,
+		LogLevel:           "info",
+		PersistenceBackend: "postgres",
+		MemoryBackend:      "mem0",
+		BusBackend:         "nats",
+		PostgresPort:       3002,
+		PostgresPassword:   "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+	}
+	out, err := Generate(p)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	yaml := string(out)
+
+	// Both mounts present on data-init.
+	assertContains(t, yaml, "- synthorg-pgdata:/pgdata")
+	assertContains(t, yaml, "- synthorg-nats-data:/nats-data")
+
+	// Both chowns present in the single data-init command string. Order
+	// matters: pgdata UID 70, nats-data UID 65532. A bad template edit
+	// that swapped these would brick the stack.
+	assertContains(t, yaml, "chown -R 70:70 /pgdata")
+	assertContains(t, yaml, "chmod 0700 /pgdata")
+	assertContains(t, yaml, "chown -R 65532:65532 /nats-data")
+
+	// Both downstream services must gate on data-init completing.
+	for _, svc := range []string{"postgres", "nats"} {
+		block := extractServiceBlock(t, yaml, svc)
+		if !strings.Contains(block, "depends_on:") ||
+			!strings.Contains(block, "data-init:") ||
+			!strings.Contains(block, "service_completed_successfully") {
+			t.Errorf("%s service must depend_on data-init: service_completed_successfully\ngot:\n%s", svc, block)
+		}
+	}
+
+	// Both volumes must be declared at the top level when both backends are enabled.
+	assertContains(t, yaml, "synthorg-pgdata:")
+	assertContains(t, yaml, "synthorg-nats-data:")
 }

--- a/cli/internal/compose/generate_test.go
+++ b/cli/internal/compose/generate_test.go
@@ -531,3 +531,117 @@ func compareGolden(t *testing.T, name string, actual []byte) {
 		t.Errorf("output differs from golden file %s\nRun with UPDATE_GOLDEN=1 to update", name)
 	}
 }
+
+// TestGenerateDataInitOwnershipPostgres verifies that when postgres is enabled,
+// data-init chowns the pgdata volume to UID 70 (DHI postgres user) -- not the
+// backend UID 65532 -- and applies mode 0700 so initdb can chmod on first run.
+// Regression guard for the "postgres container stuck Restarting" bug where
+// pgdata was chowned to 65532 and initdb failed with "could not change
+// permissions of directory".
+func TestGenerateDataInitOwnershipPostgres(t *testing.T) {
+	t.Parallel()
+	p := Params{
+		CLIVersion:         "dev",
+		ImageTag:           "latest",
+		BackendPort:        3001,
+		WebPort:            3000,
+		LogLevel:           "info",
+		PersistenceBackend: "postgres",
+		MemoryBackend:      "mem0",
+		BusBackend:         "internal",
+		PostgresPort:       3002,
+		PostgresPassword:   "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+	}
+	out, err := Generate(p)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	yaml := string(out)
+
+	assertContains(t, yaml, "- synthorg-pgdata:/pgdata")
+	assertContains(t, yaml, "chown -R 70:70 /pgdata")
+	assertContains(t, yaml, "chmod 0700 /pgdata")
+
+	// Postgres must gate on data-init so it never starts before the chown
+	// commits. Without this guard we re-introduce the startup race.
+	postgresBlock := extractServiceBlock(t, yaml, "postgres")
+	if !strings.Contains(postgresBlock, "depends_on:") ||
+		!strings.Contains(postgresBlock, "data-init:") ||
+		!strings.Contains(postgresBlock, "service_completed_successfully") {
+		t.Errorf("postgres service must depend_on data-init: service_completed_successfully\ngot:\n%s", postgresBlock)
+	}
+
+	// Nats-data must NOT appear when distributed is disabled.
+	if strings.Contains(yaml, "synthorg-nats-data") {
+		t.Error("synthorg-nats-data must not appear when bus_backend is internal")
+	}
+}
+
+// TestGenerateDataInitOwnershipDistributed verifies that when the distributed
+// (nats) bus backend is enabled, data-init chowns the nats volume to 65532 and
+// nats depends on data-init completing. Regression guard for the latent bug
+// where fresh nats-data volumes were left root-owned and nats (running as
+// UID 65532) could not write JetStream state.
+func TestGenerateDataInitOwnershipDistributed(t *testing.T) {
+	t.Parallel()
+	p := Params{
+		CLIVersion:         "dev",
+		ImageTag:           "latest",
+		BackendPort:        3001,
+		WebPort:            3000,
+		NatsClientPort:     3003,
+		LogLevel:           "info",
+		PersistenceBackend: "sqlite",
+		MemoryBackend:      "mem0",
+		BusBackend:         "nats",
+	}
+	out, err := Generate(p)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	yaml := string(out)
+
+	assertContains(t, yaml, "- synthorg-nats-data:/nats-data")
+	assertContains(t, yaml, "chown -R 65532:65532 /nats-data")
+
+	natsBlock := extractServiceBlock(t, yaml, "nats")
+	if !strings.Contains(natsBlock, "depends_on:") ||
+		!strings.Contains(natsBlock, "data-init:") ||
+		!strings.Contains(natsBlock, "service_completed_successfully") {
+		t.Errorf("nats service must depend_on data-init: service_completed_successfully\ngot:\n%s", natsBlock)
+	}
+
+	// Pgdata must NOT appear when persistence is sqlite.
+	if strings.Contains(yaml, "synthorg-pgdata") {
+		t.Error("synthorg-pgdata must not appear when persistence_backend is sqlite")
+	}
+}
+
+// extractServiceBlock returns the YAML block for a named top-level service,
+// bounded by the next service declaration or the end of the services section.
+func extractServiceBlock(t *testing.T, yaml, name string) string {
+	t.Helper()
+	header := "\n  " + name + ":\n"
+	start := strings.Index(yaml, header)
+	if start < 0 {
+		t.Fatalf("service %q not found in generated yaml", name)
+	}
+	rest := yaml[start+1:]
+	// Next top-level block starts with "\n  <word>:" at the same 2-space indent.
+	// Scan line by line until we find one.
+	lines := strings.Split(rest, "\n")
+	end := len(lines)
+	for i := 1; i < len(lines); i++ {
+		line := lines[i]
+		if len(line) >= 3 && line[0] == ' ' && line[1] == ' ' && line[2] != ' ' {
+			// sibling service or networks:/volumes: at top level
+			end = i
+			break
+		}
+		if strings.HasPrefix(line, "networks:") || strings.HasPrefix(line, "volumes:") {
+			end = i
+			break
+		}
+	}
+	return strings.Join(lines[:end], "\n")
+}

--- a/cli/testdata/compose_custom_ports.yml
+++ b/cli/testdata/compose_custom_ports.yml
@@ -3,8 +3,9 @@
 
 services:
 
-  # Init container: ensure the data volume is owned by the app user (65532).
-  # Docker creates named volumes as root; this runs once on first start.
+  # Init container: chown named volumes to the correct non-root UID per service.
+  # Fresh Docker named volumes are root-owned; DHI images run as non-root and
+  # cannot self-chown, so this one-shot container sets ownership on first start.
   data-init:
     # renovate: datasource=docker depName=busybox
     image: busybox:1.37-musl@sha256:19b646668802469d968a05342a601e78da4322a414a7c09b1c9ee25165042138

--- a/cli/testdata/compose_default.yml
+++ b/cli/testdata/compose_default.yml
@@ -3,8 +3,9 @@
 
 services:
 
-  # Init container: ensure the data volume is owned by the app user (65532).
-  # Docker creates named volumes as root; this runs once on first start.
+  # Init container: chown named volumes to the correct non-root UID per service.
+  # Fresh Docker named volumes are root-owned; DHI images run as non-root and
+  # cannot self-chown, so this one-shot container sets ownership on first start.
   data-init:
     # renovate: datasource=docker depName=busybox
     image: busybox:1.37-musl@sha256:19b646668802469d968a05342a601e78da4322a414a7c09b1c9ee25165042138

--- a/cli/testdata/compose_digest_pins.yml
+++ b/cli/testdata/compose_digest_pins.yml
@@ -3,8 +3,9 @@
 
 services:
 
-  # Init container: ensure the data volume is owned by the app user (65532).
-  # Docker creates named volumes as root; this runs once on first start.
+  # Init container: chown named volumes to the correct non-root UID per service.
+  # Fresh Docker named volumes are root-owned; DHI images run as non-root and
+  # cannot self-chown, so this one-shot container sets ownership on first start.
   data-init:
     # renovate: datasource=docker depName=busybox
     image: busybox:1.37-musl@sha256:19b646668802469d968a05342a601e78da4322a414a7c09b1c9ee25165042138

--- a/cli/testdata/compose_sandbox.yml
+++ b/cli/testdata/compose_sandbox.yml
@@ -3,8 +3,9 @@
 
 services:
 
-  # Init container: ensure the data volume is owned by the app user (65532).
-  # Docker creates named volumes as root; this runs once on first start.
+  # Init container: chown named volumes to the correct non-root UID per service.
+  # Fresh Docker named volumes are root-owned; DHI images run as non-root and
+  # cannot self-chown, so this one-shot container sets ownership on first start.
   data-init:
     # renovate: datasource=docker depName=busybox
     image: busybox:1.37-musl@sha256:19b646668802469d968a05342a601e78da4322a414a7c09b1c9ee25165042138

--- a/docker/compose.distributed.yml
+++ b/docker/compose.distributed.yml
@@ -20,6 +20,10 @@ services:
     environment:
       SYNTHORG_BUS_BACKEND: "nats"
       SYNTHORG_NATS_URL: "${SYNTHORG_NATS_URL:-nats://nats:4222}"
+    # The `nats` service is a DHI distroless image with no shell/wget, so its
+    # healthcheck lives on the `nats-healthcheck` sidecar. Depending directly
+    # on `nats: service_healthy` would hang forever because Compose cannot
+    # satisfy `service_healthy` for a service without a healthcheck.
     depends_on:
-      nats:
+      nats-healthcheck:
         condition: service_healthy

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -12,6 +12,9 @@ services:
       - "${POSTGRES_PORT:-3002}:5432"
     volumes:
       - synthorg-pgdata:/var/lib/postgresql/data
+    depends_on:
+      data-init:
+        condition: service_completed_successfully
     environment:
       PGDATA: /var/lib/postgresql/data
       POSTGRES_DB: synthorg
@@ -44,15 +47,19 @@ services:
       start_period: 30s
     logging: *logging
 
-  # Init container: ensure the data volume is owned by the app user (65532).
-  # Docker creates named volumes as root; this runs once on first start.
+  # Init container: chown named volumes to the correct non-root UID per service.
+  # Fresh Docker named volumes are root-owned; DHI images run as non-root and
+  # cannot self-chown, so this one-shot container sets ownership on first start.
+  #   /data      -> 65532 (backend)    /pgdata -> 70 (postgres)
+  #   /nats-data -> 65532 (nats)
   data-init:
     # renovate: datasource=docker depName=busybox
     image: busybox:1.37-musl@sha256:19b646668802469d968a05342a601e78da4322a414a7c09b1c9ee25165042138
     volumes:
       - synthorg-data:/data
       - synthorg-pgdata:/pgdata
-    command: ["sh", "-c", "set -e; mkdir -p /data/logs /data/memory; chown -R 65532:65532 /data; chown -R 65532:65532 /pgdata"]
+      - synthorg-nats-data:/nats-data
+    command: ["sh", "-c", "set -e; mkdir -p /data/logs /data/memory; chown -R 65532:65532 /data; chown -R 70:70 /pgdata; chmod 0700 /pgdata; chown -R 65532:65532 /nats-data"]
     cap_drop:
       - ALL
     cap_add:
@@ -140,6 +147,9 @@ services:
       - "${NATS_CLIENT_PORT:-3003}:4222"
     volumes:
       - synthorg-nats-data:/data
+    depends_on:
+      data-init:
+        condition: service_completed_successfully
     user: "65532:65532"
     security_opt:
       - no-new-privileges:true
@@ -187,6 +197,12 @@ services:
 
   # Fine-tuning sidecar (~4 GB, PyTorch + sentence-transformers).
   # Uncomment to enable embedding fine-tuning. Requires local GPU.
+  #
+  # Runs as UID 10003 -- a dedicated non-root user for security isolation
+  # from sandbox (10001), sidecar (10002), and backend (65532). The shared
+  # /data volume is owned by 65532; group_add=65532 gives this container
+  # read access to any group-readable files backend writes (so the mount
+  # keeps working even if backend tightens world-read bits to 640).
   # fine-tune:
   #   image: ghcr.io/aureliolo/synthorg-fine-tune:${SYNTHORG_IMAGE_TAG:-latest}
   #   volumes:
@@ -195,6 +211,8 @@ services:
   #     backend:
   #       condition: service_healthy
   #   user: "10003:10003"
+  #   group_add:
+  #     - "65532"
   #   security_opt:
   #     - no-new-privileges:true
   #   cap_drop:


### PR DESCRIPTION
## Summary

The `data-init` container was chowning volumes to UIDs that don't match the DHI image runtime users, breaking container startup on fresh volumes. Fixes three concrete bugs plus a latent one surfaced during review.

## Bugs fixed

1. **pgdata chowned to the wrong UID.** DHI `postgres:18-debian13` runs as `postgres` (UID 70), not the backend's UID 65532. `initdb` failed at startup with `could not change permissions of directory "/var/lib/postgresql/data": Operation not permitted`, leaving the container in a restart loop. Now chowned to `70:70` with `chmod 0700` (required by `initdb`).
2. **nats-data was never chowned.** Fresh `synthorg-nats-data` volumes stayed root-owned; DHI `nats:2.12-debian13` runs as `nonroot` (UID 65532) and could not write JetStream state. Latent — would have hit any fresh distributed install. Now chowned to `65532:65532`.
3. **`postgres` and `nats` did not `depends_on: data-init`.** Startup race where the service could boot before the chown committed. Now gated on `service_completed_successfully`.

Applied symmetrically to both:
- `docker/compose.yml` (dev/CI reference, all services on)
- `cli/internal/compose/compose.yml.tmpl` (user-facing template; conditional blocks render only the volumes the user actually selected)

Also tightened the commented-out `fine-tune` service in `docker/compose.yml`: added `group_add: ["65532"]` so its UID 10003 (deliberate isolation from sandbox/sidecar/backend) retains reliable read access to the shared `/data` volume even if backend files later lose world-read bits.

## Test plan

Three new regression tests in `cli/internal/compose/generate_test.go`:

- `TestGenerateDataInitOwnershipPostgres` — asserts `chown -R 70:70 /pgdata` + `chmod 0700 /pgdata` + `postgres` service gates on `data-init`, and nats volume is absent when `bus_backend=internal`.
- `TestGenerateDataInitOwnershipDistributed` — asserts `chown -R 65532:65532 /nats-data` + nats gates on `data-init`, and pgdata is absent when `persistence_backend=sqlite`.
- `TestGenerateDataInitOwnershipPostgresAndDistributed` — covers the TUI-default combination (postgres + nats). Asserts both chowns render in the single `data-init` command and both services gate correctly. Added from review feedback — this combination was previously untested despite being the most common production path.

Helper `extractServiceBlock` scans generated YAML for a named service's block, now terminating correctly on blank separator lines.

All four existing golden fixtures (`compose_default.yml` / `compose_custom_ports.yml` / `compose_digest_pins.yml` / `compose_sandbox.yml`) were regenerated — only the data-init comment changed; functional output unchanged for the sqlite+internal default path.

Verified locally:

```bash
go -C cli test ./... -count=1        # all pass, including 3 new tests
go -C cli tool golangci-lint run     # 0 issues
go -C cli vet ./...                   # clean
go -C cli build ./...                 # clean
POSTGRES_PASSWORD=dummy docker compose -f docker/compose.yml config -q   # parses
```

## Review coverage

Pre-reviewed by 4 agents in parallel (`docs-consistency`, `infra-reviewer`, `go-reviewer`, `go-conventions-enforcer`). Four valid findings addressed:

- CLAUDE.md: `data-init` was documented under "Postgres orchestration" but runs for every backend — restructured into a dedicated "Volume ownership" section.
- Missing test coverage for combined postgres + distributed backends — added.
- `extractServiceBlock` did not terminate on blank separator lines — fixed.
- Dedup of two agents flagging the same missing test.

Explicitly skipped with rationale:
- Stricter YAML parsing for `depends_on` assertions — substring check is adequate for a regression guard; adding a YAML parser is overkill.
- Stat-short-circuit in `data-init` chown — `chown -R` on an already-correct volume is metadata-only; the complexity isn't worth the marginal win.

## Documentation

`cli/CLAUDE.md` now has a dedicated "Volume ownership (`data-init`)" section documenting the per-service UID scheme (backend/web/nats `65532`, postgres `70`, fine-tune `10003`, sandbox/sidecar `10001`/`10002`) and why `data-init` is required for every backend selection, not just postgres.