### PR TITLE
fix: dashboard quality pass (locale, DTO parity, a11y, training UI)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,8 @@ See [docs/reference/claude-reference.md](docs/reference/claude-reference.md) for
 See `web/CLAUDE.md` for the full component inventory, design token rules, and post-training references (TS6, Storybook 10). Key rules:
 - **ALWAYS reuse** existing components from `web/src/components/ui/` before creating new ones
 - **NEVER hardcode** hex colors, font-family, pixel spacing, or Motion transitions -- use design tokens and `@/lib/motion` presets
-- A PostToolUse hook (`scripts/check_web_design_system.py`) enforces these rules on every Edit/Write to `web/src/`
+- **NEVER hardcode** BCP 47 locale strings (e.g. `'en-US'`) or call bare `.toLocaleString()` -- use the helpers in `@/utils/format` which read `getLocale()` from `@/utils/locale`
+- A PostToolUse hook (`scripts/check_web_design_system.py`) enforces these rules on every Edit/Write to `web/src/` (colors, fonts, Motion durations, hardcoded locales, bare `.toLocale*String()` calls, missing Storybook stories, duplicate component patterns)
 
 ## Shell Usage
 

--- a/scripts/check_web_design_system.py
+++ b/scripts/check_web_design_system.py
@@ -116,6 +116,14 @@ BARE_TOLOCALE_RE = re.compile(
     r"\.toLocale(?:Date|Time)?String\(\s*\)",
 )
 
+# Any use of Intl.* or .toLocale*String(...) anywhere in the file.
+# If present, every hardcoded BCP 47 literal in the file is suspicious
+# even when not adjacent to the call site (e.g. `const locale = 'en-US'`
+# later passed to `new Intl.NumberFormat(locale)`).
+LOCALE_USAGE_RE = re.compile(
+    r"\bIntl\.|\.toLocale(?:Date|Time)?String\(",
+)
+
 # Allowlist files where `'en-US'` is the legitimate default constant or
 # the centralized helper itself.
 _LOCALE_SKIP_PATHS: set[str] = {
@@ -308,50 +316,26 @@ def check_hardcoded_motion_transitions(
     return warnings
 
 
-def check_hardcoded_locale(
-    content: str,
-    file_path: Path,
-    project_root: Path,
+def _locate(stripped: str, lines: list[str], start: int) -> tuple[int, int, str, str]:
+    """Resolve a match offset to (line_num, col, original_line, line_text)."""
+    line_num = stripped[:start].count("\n") + 1
+    col = start - stripped.rfind("\n", 0, start) - 1
+    original_line = lines[line_num - 1]
+    return line_num, col, original_line, original_line.strip()
+
+
+def _collect_hardcoded_locale_literals(
+    stripped: str,
+    lines: list[str],
+    rel_path: Path,
 ) -> list[str]:
-    """Find hardcoded BCP 47 locale literals and bare ``.toLocale*String`` calls.
-
-    Formatters live in ``@/utils/format`` and accept an optional
-    ``locale?: string`` parameter that defaults to ``getLocale()``.
-    Hardcoded ``'en-US'`` literals and locale-less ``.toLocaleString()``
-    calls bypass the i18n-ready pipeline.
-    """
-    rel_str = file_path.relative_to(project_root).as_posix()
-    if rel_str in _LOCALE_SKIP_PATHS:
-        return []
-    if file_path.suffix not in {".tsx", ".ts"}:
-        return []
-
+    """Flag BCP 47 literals (matches already come from Intl-using files)."""
     warnings: list[str] = []
-    rel_path = file_path.relative_to(project_root)
-    lines = content.splitlines()
-
-    # Mask block comments so the regex does not match inside /* ... */.
-    stripped = _BLOCK_COMMENT_RE.sub(
-        lambda cm: "".join(" " if c != "\n" else "\n" for c in cm.group()),
-        content,
-    )
-
     for m in HARDCODED_LOCALE_RE.finditer(stripped):
-        line_num = stripped[: m.start()].count("\n") + 1
-        col = m.start() - stripped.rfind("\n", 0, m.start()) - 1
-        original_line = lines[line_num - 1]
-        line_text = original_line.strip()
+        line_num, col, original_line, line_text = _locate(stripped, lines, m.start())
         if line_text.startswith(_COMMENT_PREFIXES):
             continue
         if _is_in_comment_context(original_line, col):
-            continue
-        # Only flag locales used as Intl / toLocale arguments. Skipping
-        # narrative mentions inside longer prose strings.
-        context = stripped[max(0, m.start() - 64) : m.end() + 4]
-        if not re.search(
-            r"(?:Intl\.|toLocale(?:Date|Time)?String)",
-            context,
-        ):
             continue
         warnings.append(
             f"  {rel_path}:{line_num}: Hardcoded locale `{m.group('locale')}` "
@@ -359,12 +343,18 @@ def check_hardcoded_locale(
             f"or pass the locale explicitly via the helper parameter.\n"
             f"    {line_text}"
         )
+    return warnings
 
+
+def _collect_bare_tolocale_calls(
+    stripped: str,
+    lines: list[str],
+    rel_path: Path,
+) -> list[str]:
+    """Flag ``.toLocale*String()`` calls that omit an explicit locale."""
+    warnings: list[str] = []
     for m in BARE_TOLOCALE_RE.finditer(stripped):
-        line_num = stripped[: m.start()].count("\n") + 1
-        col = m.start() - stripped.rfind("\n", 0, m.start()) - 1
-        original_line = lines[line_num - 1]
-        line_text = original_line.strip()
+        line_num, col, original_line, line_text = _locate(stripped, lines, m.start())
         if line_text.startswith(_COMMENT_PREFIXES):
             continue
         if _is_in_comment_context(original_line, col):
@@ -376,7 +366,41 @@ def check_hardcoded_locale(
             f"`@/utils/format` so output is deterministic and locale-aware.\n"
             f"    {line_text}"
         )
+    return warnings
 
+
+def check_hardcoded_locale(
+    content: str,
+    file_path: Path,
+    project_root: Path,
+) -> list[str]:
+    """Find hardcoded BCP 47 locale literals and bare ``.toLocale*String`` calls.
+
+    Formatters live in ``@/utils/format`` and accept an optional
+    ``locale?: string`` parameter that defaults to ``getLocale()``.
+    Hardcoded ``'en-US'`` literals and locale-less ``.toLocaleString()``
+    calls bypass the i18n-ready pipeline. Any BCP 47 literal in a file
+    that uses ``Intl.*`` or ``.toLocale*String(...)`` anywhere is treated
+    as suspicious (catches ``const locale = 'en-US'; Intl.X(locale)``
+    patterns the previous heuristic missed).
+    """
+    rel_str = file_path.relative_to(project_root).as_posix()
+    if rel_str in _LOCALE_SKIP_PATHS:
+        return []
+    if file_path.suffix not in {".tsx", ".ts"}:
+        return []
+    if not LOCALE_USAGE_RE.search(content):
+        return []
+
+    rel_path = file_path.relative_to(project_root)
+    lines = content.splitlines()
+    stripped = _BLOCK_COMMENT_RE.sub(
+        lambda cm: "".join(" " if c != "\n" else "\n" for c in cm.group()),
+        content,
+    )
+
+    warnings = _collect_hardcoded_locale_literals(stripped, lines, rel_path)
+    warnings.extend(_collect_bare_tolocale_calls(stripped, lines, rel_path))
     return warnings
 
 

--- a/scripts/check_web_design_system.py
+++ b/scripts/check_web_design_system.py
@@ -102,6 +102,27 @@ HARDCODED_MOTION_DURATION_RE = re.compile(
     re.DOTALL,
 )
 
+# BCP 47 language-region literals used inside Intl or toLocale* calls.
+# Formatter helpers should accept `locale?: string` with getLocale() default;
+# hardcoded literals bypass the i18n-ready pipeline.
+HARDCODED_LOCALE_RE = re.compile(
+    r"""['"](?P<locale>[a-z]{2}-[A-Z]{2})['"]""",
+)
+
+# Bare `.toLocaleString(`, `.toLocaleDateString(`, `.toLocaleTimeString(`
+# calls that do not pass an explicit locale argument. These fall back to
+# the browser default and diverge in dev vs prod. Use format.ts helpers.
+BARE_TOLOCALE_RE = re.compile(
+    r"\.toLocale(?:Date|Time)?String\(\s*\)",
+)
+
+# Allowlist files where `'en-US'` is the legitimate default constant or
+# the centralized helper itself.
+_LOCALE_SKIP_PATHS: set[str] = {
+    "web/src/utils/locale.ts",
+    "web/src/utils/format.ts",
+}
+
 # Files where inline Motion durations are intentional (relative paths).
 _MOTION_DURATION_SKIP_PATHS: set[str] = {
     "web/src/lib/motion.ts",
@@ -281,6 +302,78 @@ def check_hardcoded_motion_transitions(
             f"  {rel_path}:{line_num}: Hardcoded Motion duration "
             f"-- use a preset from `@/lib/motion` or "
             f"`useAnimationPreset()` hook.\n"
+            f"    {line_text}"
+        )
+
+    return warnings
+
+
+def check_hardcoded_locale(
+    content: str,
+    file_path: Path,
+    project_root: Path,
+) -> list[str]:
+    """Find hardcoded BCP 47 locale literals and bare ``.toLocale*String`` calls.
+
+    Formatters live in ``@/utils/format`` and accept an optional
+    ``locale?: string`` parameter that defaults to ``getLocale()``.
+    Hardcoded ``'en-US'`` literals and locale-less ``.toLocaleString()``
+    calls bypass the i18n-ready pipeline.
+    """
+    rel_str = file_path.relative_to(project_root).as_posix()
+    if rel_str in _LOCALE_SKIP_PATHS:
+        return []
+    if file_path.suffix not in {".tsx", ".ts"}:
+        return []
+
+    warnings: list[str] = []
+    rel_path = file_path.relative_to(project_root)
+    lines = content.splitlines()
+
+    # Mask block comments so the regex does not match inside /* ... */.
+    stripped = _BLOCK_COMMENT_RE.sub(
+        lambda cm: "".join(" " if c != "\n" else "\n" for c in cm.group()),
+        content,
+    )
+
+    for m in HARDCODED_LOCALE_RE.finditer(stripped):
+        line_num = stripped[: m.start()].count("\n") + 1
+        col = m.start() - stripped.rfind("\n", 0, m.start()) - 1
+        original_line = lines[line_num - 1]
+        line_text = original_line.strip()
+        if line_text.startswith(_COMMENT_PREFIXES):
+            continue
+        if _is_in_comment_context(original_line, col):
+            continue
+        # Only flag locales used as Intl / toLocale arguments. Skipping
+        # narrative mentions inside longer prose strings.
+        context = stripped[max(0, m.start() - 64) : m.end() + 4]
+        if not re.search(
+            r"(?:Intl\.|toLocale(?:Date|Time)?String)",
+            context,
+        ):
+            continue
+        warnings.append(
+            f"  {rel_path}:{line_num}: Hardcoded locale `{m.group('locale')}` "
+            f"-- use a helper from `@/utils/format` (reads `getLocale()`) "
+            f"or pass the locale explicitly via the helper parameter.\n"
+            f"    {line_text}"
+        )
+
+    for m in BARE_TOLOCALE_RE.finditer(stripped):
+        line_num = stripped[: m.start()].count("\n") + 1
+        col = m.start() - stripped.rfind("\n", 0, m.start()) - 1
+        original_line = lines[line_num - 1]
+        line_text = original_line.strip()
+        if line_text.startswith(_COMMENT_PREFIXES):
+            continue
+        if _is_in_comment_context(original_line, col):
+            continue
+        warnings.append(
+            f"  {rel_path}:{line_num}: Bare `.toLocaleString()` call "
+            f"-- use `formatNumber`, `formatDateTime`, `formatDateOnly`, "
+            f"`formatTime`, `formatTokenCount`, or another helper from "
+            f"`@/utils/format` so output is deterministic and locale-aware.\n"
             f"    {line_text}"
         )
 
@@ -475,6 +568,7 @@ def check_file(file_path: Path, project_root: Path) -> list[str]:
     all_warnings.extend(
         check_hardcoded_motion_transitions(content, file_path, project_root),
     )
+    all_warnings.extend(check_hardcoded_locale(content, file_path, project_root))
     all_warnings.extend(check_missing_story(file_path, project_root))
     all_warnings.extend(check_duplicate_patterns(content, file_path, project_root))
     all_warnings.extend(propose_shared_components(content, file_path, project_root))

--- a/src/synthorg/api/controllers/training.py
+++ b/src/synthorg/api/controllers/training.py
@@ -339,6 +339,47 @@ class TrainingController(Controller):
 
         return ApiResponse(data=_result_to_response(result))
 
+    @get(
+        "/plan",
+        guards=[require_read_access],
+        status_code=HTTP_200_OK,
+    )
+    async def get_latest_plan(
+        self,
+        app_state: AppState,
+        agent_name: PathName,
+    ) -> ApiResponse[TrainingPlanResponse]:
+        """Get the most recently created training plan for an agent.
+
+        Unlike ``/execute``, this returns the latest plan regardless of
+        status so the dashboard can rehydrate its view after a reload
+        (the "Create Plan" form should not reappear once a plan has
+        been executed).
+
+        Args:
+            app_state: Litestar application state.
+            agent_name: Agent identifier from the URL path.
+
+        Raises:
+            NotFoundError: If no plan has been created for the agent.
+        """
+        identity = await _resolve_agent(app_state, agent_name)
+        agent_id = str(identity.id)
+
+        plans = await app_state.persistence.training_plans.list_by_agent(
+            NotBlankStr(agent_id),
+        )
+        if not plans:
+            logger.warning(
+                API_RESOURCE_NOT_FOUND,
+                resource="training_plan",
+                agent_id=agent_id,
+            )
+            msg = "No training plan found"
+            raise NotFoundError(msg)
+
+        return ApiResponse(data=_plan_to_response(plans[0]))
+
     @post(
         "/preview",
         guards=[require_read_access],

--- a/src/synthorg/api/controllers/training.py
+++ b/src/synthorg/api/controllers/training.py
@@ -366,10 +366,10 @@ class TrainingController(Controller):
         identity = await _resolve_agent(app_state, agent_name)
         agent_id = str(identity.id)
 
-        plans = await app_state.persistence.training_plans.list_by_agent(
+        plan = await app_state.persistence.training_plans.latest_by_agent(
             NotBlankStr(agent_id),
         )
-        if not plans:
+        if plan is None:
             logger.warning(
                 API_RESOURCE_NOT_FOUND,
                 resource="training_plan",
@@ -378,7 +378,7 @@ class TrainingController(Controller):
             msg = "No training plan found"
             raise NotFoundError(msg)
 
-        return ApiResponse(data=_plan_to_response(plans[0]))
+        return ApiResponse(data=_plan_to_response(plan))
 
     @post(
         "/preview",

--- a/src/synthorg/api/dto_org.py
+++ b/src/synthorg/api/dto_org.py
@@ -43,7 +43,7 @@ class UpdateDepartmentRequest(BaseModel):
     head: NotBlankStr | None = None
     budget_percent: float | None = Field(default=None, ge=0.0, le=100.0)
     autonomy_level: AutonomyLevel | None = None
-    teams: tuple[Team, ...] | None = None
+    teams: tuple[Team, ...] | None = Field(default=None, max_length=64)
     ceremony_policy: dict[str, object] | None = None
 
     @field_validator("ceremony_policy", mode="before")

--- a/src/synthorg/api/dto_org.py
+++ b/src/synthorg/api/dto_org.py
@@ -2,6 +2,7 @@
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from synthorg.core.company import Team  # noqa: TC001
 from synthorg.core.enums import AutonomyLevel, SeniorityLevel
 from synthorg.core.types import NotBlankStr  # noqa: TC001
 from synthorg.engine.workflow.ceremony_policy import CeremonyPolicyConfig
@@ -42,7 +43,7 @@ class UpdateDepartmentRequest(BaseModel):
     head: NotBlankStr | None = None
     budget_percent: float | None = Field(default=None, ge=0.0, le=100.0)
     autonomy_level: AutonomyLevel | None = None
-    teams: tuple[dict[str, object], ...] | None = None
+    teams: tuple[Team, ...] | None = None
     ceremony_policy: dict[str, object] | None = None
 
     @field_validator("ceremony_policy", mode="before")

--- a/src/synthorg/api/dto_org.py
+++ b/src/synthorg/api/dto_org.py
@@ -44,6 +44,9 @@ class UpdateDepartmentRequest(BaseModel):
     budget_percent: float | None = Field(default=None, ge=0.0, le=100.0)
     autonomy_level: AutonomyLevel | None = None
     teams: tuple[Team, ...] | None = Field(default=None, max_length=64)
+    # Stored as a raw dict at the domain level for YAML-level flexibility
+    # (see ``Department.ceremony_policy``); validated against
+    # ``CeremonyPolicyConfig`` but not coerced to the typed model.
     ceremony_policy: dict[str, object] | None = None
 
     @field_validator("ceremony_policy", mode="before")

--- a/src/synthorg/persistence/postgres/training_plan_repo.py
+++ b/src/synthorg/persistence/postgres/training_plan_repo.py
@@ -238,10 +238,13 @@ LIMIT 1""",
                 conn.cursor(row_factory=dict_row) as cur,
             ):
                 await cur.execute(
+                    # ``id DESC`` breaks ties deterministically when two
+                    # plans share ``created_at`` -- plan IDs are UUIDs
+                    # so the ordering is arbitrary but stable.
                     """\
 SELECT * FROM training_plans
 WHERE new_agent_id = %s
-ORDER BY created_at DESC
+ORDER BY created_at DESC, id DESC
 LIMIT 1""",
                     (str(agent_id),),
                 )

--- a/src/synthorg/persistence/postgres/training_plan_repo.py
+++ b/src/synthorg/persistence/postgres/training_plan_repo.py
@@ -231,7 +231,18 @@ LIMIT 1""",
         self,
         agent_id: NotBlankStr,
     ) -> TrainingPlan | None:
-        """Return the most recently created plan for an agent (any status)."""
+        """Return the most recently created plan for an agent (any status).
+
+        Args:
+            agent_id: Target agent identifier.
+
+        Returns:
+            The latest plan (by ``created_at`` DESC, then ``id`` DESC),
+            or ``None`` if the agent has no plans yet.
+
+        Raises:
+            QueryError: If the underlying Postgres query fails.
+        """
         try:
             async with (
                 self._pool.connection() as conn,

--- a/src/synthorg/persistence/postgres/training_plan_repo.py
+++ b/src/synthorg/persistence/postgres/training_plan_repo.py
@@ -227,6 +227,37 @@ LIMIT 1""",
             return None
         return _row_to_plan(row)
 
+    async def latest_by_agent(
+        self,
+        agent_id: NotBlankStr,
+    ) -> TrainingPlan | None:
+        """Return the most recently created plan for an agent (any status)."""
+        try:
+            async with (
+                self._pool.connection() as conn,
+                conn.cursor(row_factory=dict_row) as cur,
+            ):
+                await cur.execute(
+                    """\
+SELECT * FROM training_plans
+WHERE new_agent_id = %s
+ORDER BY created_at DESC
+LIMIT 1""",
+                    (str(agent_id),),
+                )
+                row = await cur.fetchone()
+        except psycopg.Error as exc:
+            msg = f"Failed to fetch latest plan for {agent_id!r}"
+            logger.exception(
+                HR_TRAINING_PERSISTENCE_ERROR,
+                agent_id=str(agent_id),
+                error=str(exc),
+            )
+            raise QueryError(msg) from exc
+        if row is None:
+            return None
+        return _row_to_plan(row)
+
     async def list_by_agent(
         self,
         agent_id: NotBlankStr,

--- a/src/synthorg/persistence/sqlite/training_plan_repo.py
+++ b/src/synthorg/persistence/sqlite/training_plan_repo.py
@@ -247,6 +247,33 @@ LIMIT 1""",
             return None
         return _row_to_plan(row)
 
+    async def latest_by_agent(
+        self,
+        agent_id: NotBlankStr,
+    ) -> TrainingPlan | None:
+        """Return the most recently created plan for an agent (any status)."""
+        try:
+            cursor = await self._db.execute(
+                """\
+SELECT * FROM training_plans
+WHERE new_agent_id = ?
+ORDER BY created_at DESC
+LIMIT 1""",
+                (str(agent_id),),
+            )
+            row = await cursor.fetchone()
+        except (sqlite3.Error, aiosqlite.Error) as exc:
+            msg = f"Failed to fetch latest plan for {agent_id!r}"
+            logger.exception(
+                HR_TRAINING_PERSISTENCE_ERROR,
+                agent_id=str(agent_id),
+                error=str(exc),
+            )
+            raise QueryError(msg) from exc
+        if row is None:
+            return None
+        return _row_to_plan(row)
+
     async def list_by_agent(
         self,
         agent_id: NotBlankStr,

--- a/src/synthorg/persistence/sqlite/training_plan_repo.py
+++ b/src/synthorg/persistence/sqlite/training_plan_repo.py
@@ -251,7 +251,18 @@ LIMIT 1""",
         self,
         agent_id: NotBlankStr,
     ) -> TrainingPlan | None:
-        """Return the most recently created plan for an agent (any status)."""
+        """Return the most recently created plan for an agent (any status).
+
+        Args:
+            agent_id: Target agent identifier.
+
+        Returns:
+            The latest plan (by ``created_at`` DESC, then ``id`` DESC),
+            or ``None`` if the agent has no plans yet.
+
+        Raises:
+            QueryError: If the underlying SQLite query fails.
+        """
         try:
             cursor = await self._db.execute(
                 # ``id DESC`` breaks ties deterministically when two

--- a/src/synthorg/persistence/sqlite/training_plan_repo.py
+++ b/src/synthorg/persistence/sqlite/training_plan_repo.py
@@ -254,10 +254,13 @@ LIMIT 1""",
         """Return the most recently created plan for an agent (any status)."""
         try:
             cursor = await self._db.execute(
+                # ``id DESC`` breaks ties deterministically when two
+                # plans share ``created_at`` -- plan IDs are UUIDs so
+                # the ordering is arbitrary but stable.
                 """\
 SELECT * FROM training_plans
 WHERE new_agent_id = ?
-ORDER BY created_at DESC
+ORDER BY created_at DESC, id DESC
 LIMIT 1""",
                 (str(agent_id),),
             )

--- a/src/synthorg/persistence/training_repos.py
+++ b/src/synthorg/persistence/training_repos.py
@@ -54,6 +54,25 @@ class TrainingPlanRepository(Protocol):
         """
         ...
 
+    async def latest_by_agent(
+        self,
+        agent_id: NotBlankStr,
+    ) -> TrainingPlan | None:
+        """Return the most recently created plan for an agent.
+
+        Unlike :meth:`latest_pending`, this does not filter on status --
+        it returns the head of the plan history regardless of whether
+        the plan is still pending, executed, or failed. Used to
+        rehydrate the dashboard's training view after a reload.
+
+        Args:
+            agent_id: Target agent identifier.
+
+        Returns:
+            The latest plan, or ``None`` if no plans exist.
+        """
+        ...
+
     async def list_by_agent(
         self,
         agent_id: NotBlankStr,

--- a/tests/unit/api/fakes_backend.py
+++ b/tests/unit/api/fakes_backend.py
@@ -257,6 +257,17 @@ class FakeTrainingPlanRepository:
             return None
         return max(pending, key=lambda p: p.created_at)
 
+    async def latest_by_agent(
+        self,
+        agent_id: NotBlankStr,
+    ) -> TrainingPlan | None:
+        plans = [
+            p for p in self._plans.values() if str(p.new_agent_id) == str(agent_id)
+        ]
+        if not plans:
+            return None
+        return max(plans, key=lambda p: p.created_at)
+
     async def list_by_agent(
         self,
         agent_id: NotBlankStr,

--- a/tests/unit/api/test_dto_parity.py
+++ b/tests/unit/api/test_dto_parity.py
@@ -1,0 +1,135 @@
+"""Tests for DTO parity fixes from issue #1386.
+
+Covers:
+- ``UpdateDepartmentRequest.teams`` now requires structured ``Team`` objects
+- ``UpdateAgentOrgRequest`` gained ``model_provider`` / ``model_id`` with the
+  pair-validation rule shared with ``CreateAgentOrgRequest``.
+- ``PullModelRequest`` / ``UpdateModelConfigRequest`` accept the expected
+  payloads and reject malformed input.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from synthorg.api.dto_org import (
+    UpdateAgentOrgRequest,
+    UpdateDepartmentRequest,
+)
+from synthorg.api.dto_providers import PullModelRequest, UpdateModelConfigRequest
+from synthorg.config.schema import LocalModelParams
+from synthorg.core.company import Team
+
+
+class TestUpdateDepartmentRequestTeams:
+    """`teams` is now a tuple of typed Team models, not raw dicts."""
+
+    def test_accepts_team_model_instances(self) -> None:
+        req = UpdateDepartmentRequest(
+            teams=(
+                Team(name="alpha", lead="lead-agent", members=("m1", "m2")),
+                Team(name="beta", lead="lead-two"),
+            ),
+        )
+
+        assert req.teams is not None
+        assert len(req.teams) == 2
+        assert req.teams[0].name == "alpha"
+        assert req.teams[0].members == ("m1", "m2")
+        assert req.teams[1].members == ()
+
+    def test_accepts_dict_payload_by_coercion(self) -> None:
+        """JSON decoded into dicts must still validate into Team objects."""
+        req = UpdateDepartmentRequest.model_validate(
+            {
+                "teams": [
+                    {"name": "alpha", "lead": "l1", "members": ["m1"]},
+                ],
+            },
+        )
+
+        assert req.teams is not None
+        assert isinstance(req.teams[0], Team)
+        assert req.teams[0].members == ("m1",)
+
+    def test_rejects_team_missing_required_field(self) -> None:
+        with pytest.raises(ValidationError):
+            UpdateDepartmentRequest.model_validate(
+                {"teams": [{"name": "alpha"}]},  # missing required `lead`
+            )
+
+    def test_rejects_team_with_blank_name(self) -> None:
+        with pytest.raises(ValidationError):
+            UpdateDepartmentRequest.model_validate(
+                {"teams": [{"name": "   ", "lead": "l1"}]},
+            )
+
+    def test_teams_none_is_allowed(self) -> None:
+        req = UpdateDepartmentRequest()
+
+        assert req.teams is None
+
+
+class TestUpdateAgentOrgRequestModel:
+    """Added `model_provider` + `model_id` with paired validation."""
+
+    def test_accepts_both_provider_and_id(self) -> None:
+        req = UpdateAgentOrgRequest(
+            model_provider="test-provider",
+            model_id="test-medium-001",
+        )
+
+        assert req.model_provider == "test-provider"
+        assert req.model_id == "test-medium-001"
+
+    def test_accepts_neither_provider_nor_id(self) -> None:
+        req = UpdateAgentOrgRequest(role="engineer")
+
+        assert req.model_provider is None
+        assert req.model_id is None
+
+    def test_rejects_only_provider(self) -> None:
+        with pytest.raises(ValidationError, match="model_provider and model_id"):
+            UpdateAgentOrgRequest(model_provider="test-provider")
+
+    def test_rejects_only_model_id(self) -> None:
+        with pytest.raises(ValidationError, match="model_provider and model_id"):
+            UpdateAgentOrgRequest(model_id="test-medium-001")
+
+
+class TestPullModelRequest:
+    """Allowed character set and length guardrails."""
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "test-local-001",
+            "test-local-001:latest",
+            "vendor/model:v1.2",
+            "model_name.with-dots@tag",
+        ],
+    )
+    def test_accepts_valid_names(self, model_name: str) -> None:
+        req = PullModelRequest(model_name=model_name)
+
+        assert req.model_name == model_name
+
+    def test_rejects_blank(self) -> None:
+        with pytest.raises(ValidationError):
+            PullModelRequest(model_name="   ")
+
+    def test_rejects_illegal_chars(self) -> None:
+        with pytest.raises(ValidationError):
+            PullModelRequest(model_name="bad name!")
+
+
+class TestUpdateModelConfigRequest:
+    def test_accepts_local_params(self) -> None:
+        params = LocalModelParams(num_ctx=4096, num_threads=8)
+        req = UpdateModelConfigRequest(local_params=params)
+
+        assert req.local_params.num_ctx == 4096
+        assert req.local_params.num_threads == 8
+
+    def test_rejects_missing_params(self) -> None:
+        with pytest.raises(ValidationError):
+            UpdateModelConfigRequest.model_validate({})

--- a/tests/unit/api/test_dto_parity.py
+++ b/tests/unit/api/test_dto_parity.py
@@ -19,6 +19,8 @@ from synthorg.api.dto_providers import PullModelRequest, UpdateModelConfigReques
 from synthorg.config.schema import LocalModelParams
 from synthorg.core.company import Team
 
+pytestmark = pytest.mark.unit
+
 
 class TestUpdateDepartmentRequestTeams:
     """`teams` is now a tuple of typed Team models, not raw dicts."""

--- a/tests/unit/api/test_dto_parity.py
+++ b/tests/unit/api/test_dto_parity.py
@@ -68,6 +68,13 @@ class TestUpdateDepartmentRequestTeams:
 
         assert req.teams is None
 
+    def test_rejects_teams_beyond_max_length(self) -> None:
+        oversize = tuple(
+            Team(name=f"team-{i:03d}", lead=f"lead-{i}") for i in range(65)
+        )
+        with pytest.raises(ValidationError):
+            UpdateDepartmentRequest(teams=oversize)
+
 
 class TestUpdateAgentOrgRequestModel:
     """Added `model_provider` + `model_id` with paired validation."""

--- a/tests/unit/persistence/test_protocol.py
+++ b/tests/unit/persistence/test_protocol.py
@@ -764,6 +764,9 @@ class _FakeTrainingPlanRepository:
     async def latest_pending(self, agent_id: Any) -> Any | None:
         return None
 
+    async def latest_by_agent(self, agent_id: Any) -> Any | None:
+        return None
+
     async def list_by_agent(self, agent_id: Any) -> tuple[Any, ...]:
         return ()
 

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -30,9 +30,9 @@ web/src/
   hooks/          # React hooks (auth, login lockout, WebSocket, polling, optimistic updates, command palette, flash effects, status transitions, page data composition, count animation, auto-scroll, roving tabindex, breakpoint detection, update tracking, animation presets, settings dirty state, settings keyboard shortcuts, communication edges, artifact/project data composition, useWorkflowsData)
   lib/            # Utilities (cn() class merging, semantic color mappers), Motion presets, CSP nonce reader, structured logger factory
   mocks/          # MSW request handlers for Storybook API mocking (handlers/)
-  pages/          # Lazy-loaded page components (one per route); page-scoped sub-components in pages/<page-name>/ subdirs (e.g. tasks/, org-edit/, settings/, workflows/, fine-tuning/)
+  pages/          # Lazy-loaded page components (one per route); page-scoped sub-components in pages/<page-name>/ subdirs (e.g. tasks/, org-edit/, settings/, workflows/, fine-tuning/, training/)
   router/         # React Router config, route constants (incl. DOCUMENTATION -- external, not SPA-routed), auth/setup guards
-  stores/         # Zustand stores (auth, WebSocket, toast, analytics, setup wizard, company, agents, approvals, budget, meetings, messages, tasks, settings, sinks, providers (split into providers/ sub-modules), artifacts, projects, theme, workflow-editor, workflows, fine-tuning, ceremony-policy, setup, and per-domain stores for each page)
+  stores/         # Zustand stores (auth, WebSocket, toast, analytics, setup wizard, company, agents, approvals, budget, meetings, messages, tasks, settings, sinks, providers (split into providers/ sub-modules), artifacts, projects, theme, workflow-editor, workflows, fine-tuning, ceremony-policy, setup, training, and per-domain stores for each page)
   styles/         # Design tokens (--so-* CSS custom properties, single source of truth) and Tailwind theme bridge
   utils/          # Constants, error handling, formatting, logging
   __tests__/      # Vitest unit + property tests (mirrors src/ structure)
@@ -68,7 +68,7 @@ All Zustand store **mutation** actions (create/update/delete) MUST follow the `s
 
 | Component | Import | Use for |
 |-----------|--------|---------|
-| `StatusBadge` | `@/components/ui/status-badge` | Agent/task/system status indicators (colored dot + optional built-in label toggle) |
+| `StatusBadge` | `@/components/ui/status-badge` | Agent/task/system status indicators (colored dot + optional built-in `label`). Default emits `role="img"` with an aria-label. Pass `decorative` when the badge is visually labeled by adjacent text (emits `aria-hidden`); pass `announce` for live WS updates (emits `role="status"` + `aria-live="polite"`). |
 | `MetricCard` | `@/components/ui/metric-card` | Numeric KPIs with sparkline, change badge, progress bar |
 | `Sparkline` | `@/components/ui/sparkline` | Inline SVG trend lines with `color?` and `animated?` props (used inside MetricCard or standalone) |
 | `SectionCard` | `@/components/ui/section-card` | Titled card wrapper with icon and action slot |
@@ -118,6 +118,7 @@ All Zustand store **mutation** actions (create/update/delete) MUST follow the `s
 - **Shadows/Borders**: use token variables (`var(--so-shadow-card-hover)`, `border-border`, `border-bright`).
 - **Chart SVG attributes** (Recharts, xyflow, `<svg>`): use `var(--so-stroke-hairline)` (1) or `var(--so-stroke-thin)` (1.5) for `strokeWidth`; `var(--so-chart-fill-opacity-strong)` (0.3) or `var(--so-chart-fill-opacity-subtle)` (0.15) for `stopOpacity`; `var(--so-dash-tight)` / `--so-dash-compact` / `--so-dash-medium` / `--so-dash-loose` / `--so-dash-wide` for `strokeDasharray`. Modern browsers resolve CSS variables inside SVG presentation attributes. **Exception**: xyflow's `MiniMap` props (`maskStrokeWidth`, `nodeStrokeWidth`, `nodeBorderRadius`) and Recharts' `margin` prop are typed as `number` and reject CSS vars -- use numeric constants and a comment pointing to the token.
 - **Currency**: NEVER hardcode currency codes (`'EUR'`, `'USD'`) or symbols (`€`, `$`) in formatter calls. Import `DEFAULT_CURRENCY` from `@/utils/currencies` and pass it to `formatCurrency(value, DEFAULT_CURRENCY)` or read the runtime currency from the company/settings store where available.
+- **Locale / i18n**: NEVER hardcode BCP 47 locale strings (`'en-US'`, `'fr-FR'`) or call bare `.toLocaleString()` / `.toLocaleDateString()` / `.toLocaleTimeString()`. Use the helpers in `@/utils/format` -- `formatDateTime`, `formatDateOnly`, `formatTime`, `formatDayLabel`, `formatTodayLabel`, `formatRelativeTime`, `formatNumber`, `formatCurrency`, `formatCurrencyCompact`, `formatTokenCount` -- all of which accept an optional `locale?: string` that defaults to `getLocale()` from `@/utils/locale`. The locale source of truth is `APP_LOCALE` in `@/utils/locale`; swap in a settings-store read there when we add a user-facing locale toggle.
 
 ### Creating New Components
 
@@ -150,6 +151,8 @@ A PostToolUse hook (`scripts/check_web_design_system.py`) runs automatically on 
 - Hardcoded hex colors and rgba values
 - Hardcoded font-family declarations
 - Hardcoded Motion transition durations (should use `@/lib/motion` presets)
+- Hardcoded BCP 47 locale literals (`'en-US'`, `'de-DE'`, etc.) in files that use `Intl.*` or `.toLocale*String(...)` -- use helpers from `@/utils/format` instead
+- Bare `.toLocaleString()` / `.toLocaleDateString()` / `.toLocaleTimeString()` calls without an explicit locale
 - New components without Storybook stories
 - Duplicate patterns that should use existing shared components
 - Complex `.map()` blocks that should be extracted

--- a/web/src/__tests__/components/layout/SidebarNavItem.test.tsx
+++ b/web/src/__tests__/components/layout/SidebarNavItem.test.tsx
@@ -108,7 +108,17 @@ describe('SidebarNavItem', () => {
 
       const link = screen.getByRole('link', { name: /docs/i })
       expect(link).toHaveAttribute('href', '/docs/')
-      expect(link).not.toHaveAttribute('rel')
+      // External links open in a new tab and carry the security rel.
+      expect(link).toHaveAttribute('target', '_blank')
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    })
+
+    it('announces new-tab behavior to screen readers', () => {
+      renderWithRouter(
+        <SidebarNavItem to="/docs/" icon={Users} label="Docs" collapsed={false} external />,
+      )
+
+      expect(screen.getByText(/opens in new tab/i)).toBeInTheDocument()
     })
 
     it('shows title tooltip when collapsed', () => {

--- a/web/src/__tests__/components/ui/status-badge.test.tsx
+++ b/web/src/__tests__/components/ui/status-badge.test.tsx
@@ -61,4 +61,39 @@ describe('StatusBadge', () => {
 
     expect(dot).not.toHaveClass('animate-pulse')
   })
+
+  it('emits role="img" with aria-label for standalone use', () => {
+    const { container } = render(<StatusBadge status="active" />)
+    const wrapper = container.firstElementChild
+
+    expect(wrapper).toHaveAttribute('role', 'img')
+    expect(wrapper).toHaveAttribute('aria-label', 'Active')
+  })
+
+  it('uses aria-hidden when decorative is true', () => {
+    const { container } = render(
+      <StatusBadge status="active" decorative />,
+    )
+    const wrapper = container.firstElementChild
+
+    expect(wrapper).toHaveAttribute('aria-hidden', 'true')
+    expect(wrapper).not.toHaveAttribute('role')
+    expect(wrapper).not.toHaveAttribute('aria-label')
+  })
+
+  it('decorative mode still preserves visible label when label prop is true', () => {
+    render(<StatusBadge status="error" label decorative />)
+
+    expect(screen.getByText('Error')).toBeInTheDocument()
+  })
+
+  it('announce mode sets role="status" and polite live region', () => {
+    const { container } = render(
+      <StatusBadge status="active" announce />,
+    )
+    const wrapper = container.firstElementChild
+
+    expect(wrapper).toHaveAttribute('role', 'status')
+    expect(wrapper).toHaveAttribute('aria-live', 'polite')
+  })
 })

--- a/web/src/__tests__/helpers/factories.ts
+++ b/web/src/__tests__/helpers/factories.ts
@@ -222,6 +222,7 @@ export function makeApproval(id: string, overrides?: Partial<ApprovalResponse>):
     created_at: new Date(Date.now() - 3600_000).toISOString(), // 1 hour ago
     decided_at: null,
     expires_at: null,
+    evidence_package: null,
     seconds_remaining: null,
     urgency_level: 'no_expiry',
     ...overrides,

--- a/web/src/__tests__/pages/AgentDetailPage.test.tsx
+++ b/web/src/__tests__/pages/AgentDetailPage.test.tsx
@@ -108,6 +108,14 @@ describe('AgentDetailPage', () => {
     expect(screen.getByTestId('identity-header')).toBeInTheDocument()
   })
 
+  it('composes the mocked TrainingSection for an agent', () => {
+    renderDetail()
+    // Guards against regressions where AgentDetailPage removes or
+    // re-routes the per-agent training panel. The mock is declared
+    // above; this assertion checks the composition still happens.
+    expect(screen.getByTestId('training-section')).toBeInTheDocument()
+  })
+
   it('shows WebSocket disconnect warning when not connected', () => {
     hookReturn = { ...defaultHookReturn, wsConnected: false }
     renderDetail()

--- a/web/src/__tests__/pages/AgentDetailPage.test.tsx
+++ b/web/src/__tests__/pages/AgentDetailPage.test.tsx
@@ -33,6 +33,12 @@ vi.mock('@/pages/agents/TaskHistory', () => ({
 vi.mock('@/pages/agents/ActivityLog', () => ({
   ActivityLog: () => <div data-testid="activity-log" />,
 }))
+// Stub TrainingSection so its useEffect doesn't kick off real HTTP calls
+// into the training store, which leave pending promises that the test
+// harness (`--detect-async-leaks`) flags as unhandled rejections.
+vi.mock('@/pages/agents/TrainingSection', () => ({
+  TrainingSection: () => <div data-testid="training-section" />,
+}))
 
 
 const defaultHookReturn: UseAgentDetailDataReturn = {

--- a/web/src/__tests__/pages/ProviderDetailPage.test.tsx
+++ b/web/src/__tests__/pages/ProviderDetailPage.test.tsx
@@ -126,7 +126,7 @@ describe('ProviderDetailPage', () => {
     renderDetail()
     expect(screen.getByText('500')).toBeInTheDocument()
     expect(screen.getByText('250ms')).toBeInTheDocument()
-    expect(screen.getByText('50.0K')).toBeInTheDocument()
+    expect(screen.getByText(/^50K$/i)).toBeInTheDocument()
     expect(screen.getByText(/1\.25/)).toBeInTheDocument()
   })
 

--- a/web/src/__tests__/pages/tasks/TaskCard.test.tsx
+++ b/web/src/__tests__/pages/tasks/TaskCard.test.tsx
@@ -78,8 +78,11 @@ describe('TaskCard', () => {
 
   it('does not render cost when cost_usd is 0', () => {
     render(<TaskCard task={makeTask({ cost_usd: 0 })} onSelect={() => {}} />)
-    // Cost element should not be present since cost is 0
-    expect(screen.queryByText(/\$0\.00/)).not.toBeInTheDocument()
+    // Cost element should not be present since cost is 0. Currency
+    // symbol is whatever ``DEFAULT_CURRENCY`` resolves to at render
+    // time, so we assert on the numeric formatting rather than a
+    // fixed symbol to keep this currency-agnostic.
+    expect(screen.queryByText(/0\.00/)).not.toBeInTheDocument()
   })
 
   it('renders deadline when set', () => {

--- a/web/src/__tests__/stores/budget.test.ts
+++ b/web/src/__tests__/stores/budget.test.ts
@@ -64,6 +64,7 @@ const mockTrends: TrendsResponse = {
 const mockCostRecord: CostRecord = {
   agent_id: 'a1',
   task_id: 't1',
+  project_id: null,
   provider: 'test-provider',
   model: 'test-model-001',
   input_tokens: 100,
@@ -71,6 +72,13 @@ const mockCostRecord: CostRecord = {
   cost_usd: 1.0,
   timestamp: '2026-03-20T10:00:00Z',
   call_category: 'productive',
+  accuracy_effort_ratio: null,
+  latency_ms: null,
+  cache_hit: null,
+  retry_count: null,
+  retry_reason: null,
+  finish_reason: null,
+  success: null,
 }
 
 // ── Helpers ────────────────────────────────────────────────

--- a/web/src/__tests__/stores/training.test.ts
+++ b/web/src/__tests__/stores/training.test.ts
@@ -93,7 +93,11 @@ describe('useTrainingStore', () => {
   })
 
   it('fetchResult treats a 404 as an empty cache (no error banner)', async () => {
+    // Shape mirrors `axios.isAxiosError`: the helper checks the
+    // `isAxiosError` flag, not just `response`. Without the flag, the
+    // store treats the rejection as a generic error and shows a toast.
     const notFound = Object.assign(new Error('Not Found'), {
+      isAxiosError: true,
       response: { status: 404 },
     })
     vi.spyOn(trainingApi, 'getTrainingResult').mockRejectedValueOnce(notFound)
@@ -119,7 +123,11 @@ describe('useTrainingStore', () => {
   })
 
   it('fetchPlan treats a 404 as an empty cache', async () => {
+    // Shape mirrors `axios.isAxiosError`: the helper checks the
+    // `isAxiosError` flag, not just `response`. Without the flag, the
+    // store treats the rejection as a generic error and shows a toast.
     const notFound = Object.assign(new Error('Not Found'), {
+      isAxiosError: true,
       response: { status: 404 },
     })
     vi.spyOn(trainingApi, 'getLatestTrainingPlan').mockRejectedValueOnce(

--- a/web/src/__tests__/stores/training.test.ts
+++ b/web/src/__tests__/stores/training.test.ts
@@ -8,62 +8,71 @@ import type {
 import { useTrainingStore } from '@/stores/training'
 import { useToastStore } from '@/stores/toast'
 
-function mockPlan(overrides: Partial<TrainingPlanResponse> = {}): TrainingPlanResponse {
-  return {
-    id: 'plan-1',
-    new_agent_id: 'agent-1',
-    new_agent_role: 'engineer',
-    source_selector_type: 'seniority',
-    enabled_content_types: ['procedural', 'semantic', 'tool_patterns'],
-    curation_strategy_type: 'default',
-    volume_caps: [],
-    override_sources: [],
-    skip_training: false,
-    require_review: true,
-    status: 'pending',
-    created_at: '2026-04-01T00:00:00Z',
-    executed_at: null,
-    ...overrides,
-  }
-}
-
-function mockResult(overrides: Partial<TrainingResultResponse> = {}): TrainingResultResponse {
-  return {
-    id: 'res-1',
-    plan_id: 'plan-1',
-    new_agent_id: 'agent-1',
-    source_agents_used: ['source-1'],
-    items_extracted: [['procedural', 3]],
-    items_after_curation: [['procedural', 3]],
-    items_after_guards: [['procedural', 3]],
-    items_stored: [['procedural', 3]],
-    approval_item_id: null,
-    review_pending: false,
-    errors: [],
-    started_at: '2026-04-01T00:00:00Z',
-    completed_at: '2026-04-01T00:05:00Z',
-    ...overrides,
-  }
-}
-
 describe('useTrainingStore', () => {
+  function mockPlan(
+    overrides: Partial<TrainingPlanResponse> = {},
+  ): TrainingPlanResponse {
+    return {
+      id: 'plan-1',
+      new_agent_id: 'agent-1',
+      new_agent_role: 'engineer',
+      source_selector_type: 'seniority',
+      enabled_content_types: ['procedural', 'semantic', 'tool_patterns'],
+      curation_strategy_type: 'default',
+      volume_caps: [],
+      override_sources: [],
+      skip_training: false,
+      require_review: true,
+      status: 'pending',
+      created_at: '2026-04-01T00:00:00Z',
+      executed_at: null,
+      ...overrides,
+    }
+  }
+
+  function mockResult(
+    overrides: Partial<TrainingResultResponse> = {},
+  ): TrainingResultResponse {
+    return {
+      id: 'res-1',
+      plan_id: 'plan-1',
+      new_agent_id: 'agent-1',
+      source_agents_used: ['source-1'],
+      items_extracted: [['procedural', 3]],
+      items_after_curation: [['procedural', 3]],
+      items_after_guards: [['procedural', 3]],
+      items_stored: [['procedural', 3]],
+      approval_item_id: null,
+      review_pending: false,
+      errors: [],
+      started_at: '2026-04-01T00:00:00Z',
+      completed_at: '2026-04-01T00:05:00Z',
+      ...overrides,
+    }
+  }
+
+  /**
+   * Snapshot of the initial store state. Used by ``beforeEach`` to
+   * restore every caches + flag key (not just the subset the test
+   * cares about) so leftover mutations from a prior test cannot leak.
+   */
+  const initialStoreState = useTrainingStore.getState()
+
   beforeEach(() => {
-    useTrainingStore.setState({
-      plansByAgent: {},
-      resultsByAgent: {},
-      loading: {},
-      error: {},
-    })
+    useTrainingStore.setState(initialStoreState, true)
     useToastStore.setState({ toasts: [] })
     vi.restoreAllMocks()
   })
 
   it('fetchResult stores the result and clears loading', async () => {
     const result = mockResult()
-    vi.spyOn(trainingApi, 'getTrainingResult').mockResolvedValueOnce(result)
+    const spy = vi
+      .spyOn(trainingApi, 'getTrainingResult')
+      .mockResolvedValueOnce(result)
 
     await useTrainingStore.getState().fetchResult('agent-1')
 
+    expect(spy).toHaveBeenCalledWith('agent-1')
     const state = useTrainingStore.getState()
     expect(state.resultsByAgent['agent-1']).toEqual(result)
     expect(state.loading['agent-1']).toBe(false)
@@ -78,21 +87,86 @@ describe('useTrainingStore', () => {
     await useTrainingStore.getState().fetchResult('agent-1')
 
     const state = useTrainingStore.getState()
-    expect(state.resultsByAgent['agent-1']).toBeUndefined()
+    expect(state.resultsByAgent).not.toHaveProperty('agent-1')
     expect(state.loading['agent-1']).toBe(false)
     expect(state.error['agent-1']).toContain('offline')
   })
 
+  it('fetchResult treats a 404 as an empty cache (no error banner)', async () => {
+    const notFound = Object.assign(new Error('Not Found'), {
+      response: { status: 404 },
+    })
+    vi.spyOn(trainingApi, 'getTrainingResult').mockRejectedValueOnce(notFound)
+
+    await useTrainingStore.getState().fetchResult('agent-1')
+
+    const state = useTrainingStore.getState()
+    expect(state.resultsByAgent['agent-1']).toBeNull()
+    expect(state.error['agent-1']).toBeNull()
+    expect(state.loading['agent-1']).toBe(false)
+  })
+
+  it('fetchPlan stores the plan on success', async () => {
+    const plan = mockPlan()
+    const spy = vi
+      .spyOn(trainingApi, 'getLatestTrainingPlan')
+      .mockResolvedValueOnce(plan)
+
+    await useTrainingStore.getState().fetchPlan('agent-1')
+
+    expect(spy).toHaveBeenCalledWith('agent-1')
+    expect(useTrainingStore.getState().plansByAgent['agent-1']).toEqual(plan)
+  })
+
+  it('fetchPlan treats a 404 as an empty cache', async () => {
+    const notFound = Object.assign(new Error('Not Found'), {
+      response: { status: 404 },
+    })
+    vi.spyOn(trainingApi, 'getLatestTrainingPlan').mockRejectedValueOnce(
+      notFound,
+    )
+
+    await useTrainingStore.getState().fetchPlan('agent-1')
+
+    expect(useTrainingStore.getState().plansByAgent['agent-1']).toBeNull()
+    expect(useTrainingStore.getState().error['agent-1']).toBeNull()
+  })
+
+  it('hydrateForAgent fetches plan and result in parallel', async () => {
+    const plan = mockPlan({ status: 'executed' })
+    const result = mockResult()
+    const planSpy = vi
+      .spyOn(trainingApi, 'getLatestTrainingPlan')
+      .mockResolvedValueOnce(plan)
+    const resultSpy = vi
+      .spyOn(trainingApi, 'getTrainingResult')
+      .mockResolvedValueOnce(result)
+
+    await useTrainingStore.getState().hydrateForAgent('agent-1')
+
+    expect(planSpy).toHaveBeenCalledWith('agent-1')
+    expect(resultSpy).toHaveBeenCalledWith('agent-1')
+    const state = useTrainingStore.getState()
+    expect(state.plansByAgent['agent-1']).toEqual(plan)
+    expect(state.resultsByAgent['agent-1']).toEqual(result)
+  })
+
   it('createPlan updates the store and emits a success toast', async () => {
     const plan = mockPlan()
-    vi.spyOn(trainingApi, 'createTrainingPlan').mockResolvedValueOnce(plan)
-
-    const returned = await useTrainingStore.getState().createPlan('agent-1', {
+    const request = {
       override_sources: [],
       skip_training: false,
       require_review: true,
-    })
+    }
+    const spy = vi
+      .spyOn(trainingApi, 'createTrainingPlan')
+      .mockResolvedValueOnce(plan)
 
+    const returned = await useTrainingStore
+      .getState()
+      .createPlan('agent-1', request)
+
+    expect(spy).toHaveBeenCalledWith('agent-1', request)
     expect(returned).toEqual(plan)
     expect(useTrainingStore.getState().plansByAgent['agent-1']).toEqual(plan)
     const toasts = useToastStore.getState().toasts
@@ -117,26 +191,52 @@ describe('useTrainingStore', () => {
     expect(toasts[0]?.description).toContain('server exploded')
   })
 
-  it('executePlan stores the result on success', async () => {
-    const result = mockResult()
-    vi.spyOn(trainingApi, 'executeTrainingPlan').mockResolvedValueOnce(result)
+  it('executePlan stores the result and marks the cached plan as executed', async () => {
+    const plan = mockPlan({ status: 'pending' })
+    const result = mockResult({ completed_at: '2026-04-01T01:00:00Z' })
+    useTrainingStore.setState((state) => ({
+      plansByAgent: { ...state.plansByAgent, 'agent-1': plan },
+    }))
+    const spy = vi
+      .spyOn(trainingApi, 'executeTrainingPlan')
+      .mockResolvedValueOnce(result)
 
     const returned = await useTrainingStore.getState().executePlan('agent-1')
 
+    expect(spy).toHaveBeenCalledWith('agent-1')
     expect(returned).toEqual(result)
-    expect(useTrainingStore.getState().resultsByAgent['agent-1']).toEqual(result)
+    const state = useTrainingStore.getState()
+    expect(state.resultsByAgent['agent-1']).toEqual(result)
+    expect(state.plansByAgent['agent-1']?.status).toBe('executed')
+    expect(state.plansByAgent['agent-1']?.executed_at).toBe(
+      '2026-04-01T01:00:00Z',
+    )
+  })
+
+  it('executePlan without a cached plan still stores the result', async () => {
+    const result = mockResult()
+    vi.spyOn(trainingApi, 'executeTrainingPlan').mockResolvedValueOnce(result)
+
+    await useTrainingStore.getState().executePlan('agent-1')
+
+    const state = useTrainingStore.getState()
+    expect(state.resultsByAgent['agent-1']).toEqual(result)
+    expect(state.plansByAgent).not.toHaveProperty('agent-1')
   })
 
   it('updateOverrides replaces the cached plan on success', async () => {
     const updated = mockPlan({ status: 'executed' })
-    vi.spyOn(trainingApi, 'updateTrainingOverrides').mockResolvedValueOnce(
-      updated,
-    )
+    const spy = vi
+      .spyOn(trainingApi, 'updateTrainingOverrides')
+      .mockResolvedValueOnce(updated)
 
     const returned = await useTrainingStore
       .getState()
       .updateOverrides('agent-1', 'plan-1', { override_sources: ['s2'] })
 
+    expect(spy).toHaveBeenCalledWith('agent-1', 'plan-1', {
+      override_sources: ['s2'],
+    })
     expect(returned).toEqual(updated)
     expect(useTrainingStore.getState().plansByAgent['agent-1']).toEqual(updated)
   })

--- a/web/src/__tests__/stores/training.test.ts
+++ b/web/src/__tests__/stores/training.test.ts
@@ -64,7 +64,7 @@ describe('useTrainingStore', () => {
     vi.restoreAllMocks()
   })
 
-  it('fetchResult stores the result and clears loading', async () => {
+  it('fetchResult stores the result and clears resultLoading/resultError', async () => {
     const result = mockResult()
     const spy = vi
       .spyOn(trainingApi, 'getTrainingResult')
@@ -75,11 +75,11 @@ describe('useTrainingStore', () => {
     expect(spy).toHaveBeenCalledWith('agent-1')
     const state = useTrainingStore.getState()
     expect(state.resultsByAgent['agent-1']).toEqual(result)
-    expect(state.loading['agent-1']).toBe(false)
-    expect(state.error['agent-1']).toBeNull()
+    expect(state.resultLoading['agent-1']).toBe(false)
+    expect(state.resultError['agent-1']).toBeNull()
   })
 
-  it('fetchResult sets error when the API rejects', async () => {
+  it('fetchResult sets resultError when the API rejects (plan slot untouched)', async () => {
     vi.spyOn(trainingApi, 'getTrainingResult').mockRejectedValueOnce(
       new Error('offline'),
     )
@@ -88,8 +88,11 @@ describe('useTrainingStore', () => {
 
     const state = useTrainingStore.getState()
     expect(state.resultsByAgent).not.toHaveProperty('agent-1')
-    expect(state.loading['agent-1']).toBe(false)
-    expect(state.error['agent-1']).toContain('offline')
+    expect(state.resultLoading['agent-1']).toBe(false)
+    expect(state.resultError['agent-1']).toContain('offline')
+    // Plan-side state must not be mutated by a result-side failure.
+    expect(state.planError).not.toHaveProperty('agent-1')
+    expect(state.planLoading).not.toHaveProperty('agent-1')
   })
 
   it('fetchResult treats a 404 as an empty cache (no error banner)', async () => {
@@ -106,8 +109,8 @@ describe('useTrainingStore', () => {
 
     const state = useTrainingStore.getState()
     expect(state.resultsByAgent['agent-1']).toBeNull()
-    expect(state.error['agent-1']).toBeNull()
-    expect(state.loading['agent-1']).toBe(false)
+    expect(state.resultError['agent-1']).toBeNull()
+    expect(state.resultLoading['agent-1']).toBe(false)
   })
 
   it('fetchPlan stores the plan on success', async () => {
@@ -119,7 +122,10 @@ describe('useTrainingStore', () => {
     await useTrainingStore.getState().fetchPlan('agent-1')
 
     expect(spy).toHaveBeenCalledWith('agent-1')
-    expect(useTrainingStore.getState().plansByAgent['agent-1']).toEqual(plan)
+    const state = useTrainingStore.getState()
+    expect(state.plansByAgent['agent-1']).toEqual(plan)
+    expect(state.planLoading['agent-1']).toBe(false)
+    expect(state.planError['agent-1']).toBeNull()
   })
 
   it('fetchPlan treats a 404 as an empty cache', async () => {
@@ -136,8 +142,32 @@ describe('useTrainingStore', () => {
 
     await useTrainingStore.getState().fetchPlan('agent-1')
 
-    expect(useTrainingStore.getState().plansByAgent['agent-1']).toBeNull()
-    expect(useTrainingStore.getState().error['agent-1']).toBeNull()
+    const state = useTrainingStore.getState()
+    expect(state.plansByAgent['agent-1']).toBeNull()
+    expect(state.planError['agent-1']).toBeNull()
+    expect(state.planLoading['agent-1']).toBe(false)
+  })
+
+  it('fetchPlan failure does not clobber an in-flight fetchResult', async () => {
+    // Race guard: simulate a slow plan fetch that fails AFTER a
+    // separate result fetch has already completed successfully. With
+    // shared maps this would have wiped ``resultLoading`` back to
+    // ``false`` (already false) and -- worse -- left a stale plan
+    // error banner on the result side. With split maps the two
+    // slots stay independent.
+    const result = mockResult()
+    vi.spyOn(trainingApi, 'getTrainingResult').mockResolvedValueOnce(result)
+    vi.spyOn(trainingApi, 'getLatestTrainingPlan').mockRejectedValueOnce(
+      new Error('plan outage'),
+    )
+
+    await useTrainingStore.getState().fetchResult('agent-1')
+    await useTrainingStore.getState().fetchPlan('agent-1')
+
+    const state = useTrainingStore.getState()
+    expect(state.resultsByAgent['agent-1']).toEqual(result)
+    expect(state.resultError['agent-1']).toBeNull()
+    expect(state.planError['agent-1']).toContain('plan outage')
   })
 
   it('hydrateForAgent fetches plan and result in parallel', async () => {

--- a/web/src/__tests__/stores/training.test.ts
+++ b/web/src/__tests__/stores/training.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as trainingApi from '@/api/endpoints/training'
+import type {
+  TrainingPlanResponse,
+  TrainingResultResponse,
+} from '@/api/endpoints/training'
+import { useTrainingStore } from '@/stores/training'
+import { useToastStore } from '@/stores/toast'
+
+function mockPlan(overrides: Partial<TrainingPlanResponse> = {}): TrainingPlanResponse {
+  return {
+    id: 'plan-1',
+    new_agent_id: 'agent-1',
+    new_agent_role: 'engineer',
+    source_selector_type: 'seniority',
+    enabled_content_types: ['procedural', 'semantic', 'tool_patterns'],
+    curation_strategy_type: 'default',
+    volume_caps: [],
+    override_sources: [],
+    skip_training: false,
+    require_review: true,
+    status: 'pending',
+    created_at: '2026-04-01T00:00:00Z',
+    executed_at: null,
+    ...overrides,
+  }
+}
+
+function mockResult(overrides: Partial<TrainingResultResponse> = {}): TrainingResultResponse {
+  return {
+    id: 'res-1',
+    plan_id: 'plan-1',
+    new_agent_id: 'agent-1',
+    source_agents_used: ['source-1'],
+    items_extracted: [['procedural', 3]],
+    items_after_curation: [['procedural', 3]],
+    items_after_guards: [['procedural', 3]],
+    items_stored: [['procedural', 3]],
+    approval_item_id: null,
+    review_pending: false,
+    errors: [],
+    started_at: '2026-04-01T00:00:00Z',
+    completed_at: '2026-04-01T00:05:00Z',
+    ...overrides,
+  }
+}
+
+describe('useTrainingStore', () => {
+  beforeEach(() => {
+    useTrainingStore.setState({
+      plansByAgent: {},
+      resultsByAgent: {},
+      loading: {},
+      error: {},
+    })
+    useToastStore.setState({ toasts: [] })
+    vi.restoreAllMocks()
+  })
+
+  it('fetchResult stores the result and clears loading', async () => {
+    const result = mockResult()
+    vi.spyOn(trainingApi, 'getTrainingResult').mockResolvedValueOnce(result)
+
+    await useTrainingStore.getState().fetchResult('agent-1')
+
+    const state = useTrainingStore.getState()
+    expect(state.resultsByAgent['agent-1']).toEqual(result)
+    expect(state.loading['agent-1']).toBe(false)
+    expect(state.error['agent-1']).toBeNull()
+  })
+
+  it('fetchResult sets error when the API rejects', async () => {
+    vi.spyOn(trainingApi, 'getTrainingResult').mockRejectedValueOnce(
+      new Error('offline'),
+    )
+
+    await useTrainingStore.getState().fetchResult('agent-1')
+
+    const state = useTrainingStore.getState()
+    expect(state.resultsByAgent['agent-1']).toBeUndefined()
+    expect(state.loading['agent-1']).toBe(false)
+    expect(state.error['agent-1']).toContain('offline')
+  })
+
+  it('createPlan updates the store and emits a success toast', async () => {
+    const plan = mockPlan()
+    vi.spyOn(trainingApi, 'createTrainingPlan').mockResolvedValueOnce(plan)
+
+    const returned = await useTrainingStore.getState().createPlan('agent-1', {
+      override_sources: [],
+      skip_training: false,
+      require_review: true,
+    })
+
+    expect(returned).toEqual(plan)
+    expect(useTrainingStore.getState().plansByAgent['agent-1']).toEqual(plan)
+    const toasts = useToastStore.getState().toasts
+    expect(toasts).toHaveLength(1)
+    expect(toasts[0]?.variant).toBe('success')
+  })
+
+  it('createPlan returns null and emits an error toast on failure', async () => {
+    vi.spyOn(trainingApi, 'createTrainingPlan').mockRejectedValueOnce(
+      new Error('server exploded'),
+    )
+
+    const returned = await useTrainingStore.getState().createPlan('agent-1', {
+      override_sources: [],
+      skip_training: false,
+      require_review: true,
+    })
+
+    expect(returned).toBeNull()
+    const toasts = useToastStore.getState().toasts
+    expect(toasts[0]?.variant).toBe('error')
+    expect(toasts[0]?.description).toContain('server exploded')
+  })
+
+  it('executePlan stores the result on success', async () => {
+    const result = mockResult()
+    vi.spyOn(trainingApi, 'executeTrainingPlan').mockResolvedValueOnce(result)
+
+    const returned = await useTrainingStore.getState().executePlan('agent-1')
+
+    expect(returned).toEqual(result)
+    expect(useTrainingStore.getState().resultsByAgent['agent-1']).toEqual(result)
+  })
+
+  it('updateOverrides replaces the cached plan on success', async () => {
+    const updated = mockPlan({ status: 'executed' })
+    vi.spyOn(trainingApi, 'updateTrainingOverrides').mockResolvedValueOnce(
+      updated,
+    )
+
+    const returned = await useTrainingStore
+      .getState()
+      .updateOverrides('agent-1', 'plan-1', { override_sources: ['s2'] })
+
+    expect(returned).toEqual(updated)
+    expect(useTrainingStore.getState().plansByAgent['agent-1']).toEqual(updated)
+  })
+})

--- a/web/src/__tests__/stores/training.test.ts
+++ b/web/src/__tests__/stores/training.test.ts
@@ -262,6 +262,23 @@ describe('useTrainingStore', () => {
     expect(state.plansByAgent).not.toHaveProperty('agent-1')
   })
 
+  it('mutation success clears stale read-error banners', async () => {
+    // Arrange: seed both error slots as if an earlier read had failed.
+    useTrainingStore.setState((state) => ({
+      planError: { ...state.planError, 'agent-1': 'stale plan boom' },
+      resultError: { ...state.resultError, 'agent-1': 'stale result boom' },
+    }))
+
+    const result = mockResult({ completed_at: '2026-04-01T02:00:00Z' })
+    vi.spyOn(trainingApi, 'executeTrainingPlan').mockResolvedValueOnce(result)
+
+    await useTrainingStore.getState().executePlan('agent-1')
+
+    const state = useTrainingStore.getState()
+    expect(state.resultError['agent-1']).toBeNull()
+    expect(state.planError['agent-1']).toBeNull()
+  })
+
   it('updateOverrides replaces the cached plan on success', async () => {
     const updated = mockPlan({ status: 'executed' })
     const spy = vi

--- a/web/src/__tests__/utils/budget.property.test.ts
+++ b/web/src/__tests__/utils/budget.property.test.ts
@@ -18,9 +18,19 @@ const callCategoryArb = fc.oneof(
   fc.constant(null),
 )
 
+const finishReasonArb = fc.oneof(
+  fc.constant('stop' as const),
+  fc.constant('max_tokens' as const),
+  fc.constant('tool_use' as const),
+  fc.constant('content_filter' as const),
+  fc.constant('error' as const),
+  fc.constant(null),
+)
+
 const costRecordArb: fc.Arbitrary<CostRecord> = fc.record({
   agent_id: fc.stringMatching(/^agent-[0-9]{1,3}$/),
   task_id: fc.stringMatching(/^task-[0-9]{1,3}$/),
+  project_id: fc.oneof(fc.stringMatching(/^proj-[0-9]{1,3}$/), fc.constant(null)),
   provider: fc.stringMatching(/^prov-[a-z]{1,3}$/),
   model: fc.constant('test-model-001'),
   input_tokens: fc.nat({ max: 10000 }),
@@ -28,6 +38,13 @@ const costRecordArb: fc.Arbitrary<CostRecord> = fc.record({
   cost_usd: fc.double({ min: 0, max: 100, noNaN: true }),
   timestamp: fc.constant('2026-03-20T10:00:00Z'),
   call_category: callCategoryArb,
+  accuracy_effort_ratio: fc.oneof(fc.double({ min: 0, max: 1, noNaN: true }), fc.constant(null)),
+  latency_ms: fc.oneof(fc.double({ min: 0, max: 10000, noNaN: true }), fc.constant(null)),
+  cache_hit: fc.oneof(fc.boolean(), fc.constant(null)),
+  retry_count: fc.oneof(fc.nat({ max: 5 }), fc.constant(null)),
+  retry_reason: fc.oneof(fc.stringMatching(/^[a-z_]{3,20}$/), fc.constant(null)),
+  finish_reason: finishReasonArb,
+  success: fc.oneof(fc.boolean(), fc.constant(null)),
 })
 
 const alertsArb: fc.Arbitrary<BudgetAlertConfig> = fc

--- a/web/src/__tests__/utils/budget.test.ts
+++ b/web/src/__tests__/utils/budget.test.ts
@@ -18,6 +18,7 @@ function makeRecord(overrides: Partial<CostRecord> = {}): CostRecord {
   return {
     agent_id: 'agent-1',
     task_id: 'task-1',
+    project_id: null,
     provider: 'test-provider',
     model: 'test-model-001',
     input_tokens: 100,
@@ -25,6 +26,13 @@ function makeRecord(overrides: Partial<CostRecord> = {}): CostRecord {
     cost_usd: 1.0,
     timestamp: '2026-03-20T10:00:00Z',
     call_category: 'productive',
+    accuracy_effort_ratio: null,
+    latency_ms: null,
+    cache_hit: null,
+    retry_count: null,
+    retry_reason: null,
+    finish_reason: null,
+    success: null,
     ...overrides,
   }
 }

--- a/web/src/__tests__/utils/format.test.ts
+++ b/web/src/__tests__/utils/format.test.ts
@@ -1,32 +1,104 @@
 import {
   formatDate,
+  formatDateOnly,
+  formatDateTime,
+  formatDayLabel,
   formatRelativeTime,
   formatCurrency,
   formatCurrencyCompact,
-  formatNumber,
-  formatUptime,
+  formatFileSize,
   formatLabel,
+  formatNumber,
+  formatTime,
+  formatTodayLabel,
+  formatTokenCount,
+  formatUptime,
 } from '@/utils/format'
 
-describe('formatDate', () => {
+describe('formatDateTime', () => {
   it('returns -- for null/undefined', () => {
-    expect(formatDate(null)).toBe('--')
-    expect(formatDate(undefined)).toBe('--')
+    expect(formatDateTime(null)).toBe('--')
+    expect(formatDateTime(undefined)).toBe('--')
   })
 
   it('returns -- for empty string', () => {
-    expect(formatDate('')).toBe('--')
+    expect(formatDateTime('')).toBe('--')
   })
 
   it('returns -- for invalid date', () => {
-    expect(formatDate('not-a-date')).toBe('--')
+    expect(formatDateTime('not-a-date')).toBe('--')
   })
 
-  it('formats valid ISO date', () => {
-    const result = formatDate('2025-01-15T10:30:00Z')
+  it('formats valid ISO date under en-US', () => {
+    const result = formatDateTime('2025-01-15T10:30:00Z', 'en-US')
     expect(result).toContain('Jan')
     expect(result).toContain('15')
     expect(result).toContain('2025')
+  })
+
+  it('respects an explicit locale override', () => {
+    const en = formatDateTime('2025-01-15T10:30:00Z', 'en-US')
+    const de = formatDateTime('2025-01-15T10:30:00Z', 'de-DE')
+    expect(en).not.toBe(de)
+  })
+})
+
+describe('formatDate (alias)', () => {
+  it('is the same function as formatDateTime', () => {
+    expect(formatDate).toBe(formatDateTime)
+  })
+})
+
+describe('formatDateOnly', () => {
+  it('returns -- for null', () => {
+    expect(formatDateOnly(null)).toBe('--')
+  })
+
+  it('formats as month+day+year without time', () => {
+    const result = formatDateOnly('2025-01-15T10:30:00Z', 'en-US')
+    expect(result).toContain('Jan')
+    expect(result).toContain('15')
+    expect(result).toContain('2025')
+    expect(result).not.toMatch(/\d{1,2}:\d{2}/)
+  })
+})
+
+describe('formatTime', () => {
+  it('returns -- for null', () => {
+    expect(formatTime(null)).toBe('--')
+  })
+
+  it('returns a time-only string', () => {
+    const result = formatTime('2025-01-15T10:30:00Z', 'en-US')
+    expect(result).toMatch(/\d/)
+    expect(result).not.toContain('Jan')
+    expect(result).not.toContain('2025')
+  })
+})
+
+describe('formatDayLabel', () => {
+  it('formats an ISO string', () => {
+    expect(formatDayLabel('2025-01-15T10:30:00Z', 'en-US')).toContain('Jan')
+  })
+
+  it('formats a Date', () => {
+    expect(formatDayLabel(new Date('2025-01-15T10:30:00Z'), 'en-US')).toContain('15')
+  })
+
+  it('formats a numeric timestamp', () => {
+    const ms = new Date('2025-01-15T10:30:00Z').getTime()
+    expect(formatDayLabel(ms, 'en-US')).toContain('Jan')
+  })
+
+  it('returns -- for invalid input', () => {
+    expect(formatDayLabel('nope')).toBe('--')
+  })
+})
+
+describe('formatTodayLabel', () => {
+  it('returns a short month+day string under en-US', () => {
+    const result = formatTodayLabel('en-US')
+    expect(result).toMatch(/^[A-Z][a-z]{2} \d{1,2}$/)
   })
 })
 
@@ -60,14 +132,14 @@ describe('formatRelativeTime', () => {
     expect(formatRelativeTime(twoDaysAgo)).toBe('2d ago')
   })
 
-  it('falls back to formatDate for old dates', () => {
+  it('falls back to formatDateTime for old dates', () => {
     const twoWeeksAgo = new Date(Date.now() - 14 * 86400 * 1000).toISOString()
     const result = formatRelativeTime(twoWeeksAgo)
     expect(result).not.toContain('ago')
     expect(result).not.toBe('--')
   })
 
-  it('falls back to formatDate for future dates', () => {
+  it('falls back to formatDateTime for future dates', () => {
     const future = new Date(Date.now() + 86400 * 1000).toISOString()
     const result = formatRelativeTime(future)
     expect(result).not.toContain('ago')
@@ -127,15 +199,49 @@ describe('formatCurrency', () => {
     expect(formatCurrency(Infinity, 'USD')).toBe('--')
     expect(formatCurrency(NaN, 'USD')).toBe('--')
   })
+
+  it('respects an explicit locale override', () => {
+    const en = formatCurrency(1234.5, 'USD', 'en-US')
+    const de = formatCurrency(1234.5, 'USD', 'de-DE')
+    expect(en).not.toBe(de)
+  })
 })
 
 describe('formatNumber', () => {
-  it('formats with separators', () => {
-    expect(formatNumber(1000000)).toBe('1,000,000')
+  it('formats with separators under en-US', () => {
+    expect(formatNumber(1000000, 'en-US')).toBe('1,000,000')
   })
 
   it('formats zero', () => {
     expect(formatNumber(0)).toBe('0')
+  })
+
+  it('returns -- for non-finite values', () => {
+    expect(formatNumber(Infinity)).toBe('--')
+    expect(formatNumber(NaN)).toBe('--')
+  })
+
+  it('respects explicit locale override', () => {
+    const en = formatNumber(1234.5, 'en-US')
+    const de = formatNumber(1234.5, 'de-DE')
+    expect(en).not.toBe(de)
+  })
+})
+
+describe('formatTokenCount', () => {
+  it('uses plain separators under 1000', () => {
+    expect(formatTokenCount(42, 'en-US')).toBe('42')
+    expect(formatTokenCount(999, 'en-US')).toBe('999')
+  })
+
+  it('uses compact notation for >=1000', () => {
+    expect(formatTokenCount(1200, 'en-US')).toMatch(/K/i)
+    expect(formatTokenCount(2_500_000, 'en-US')).toMatch(/M/i)
+  })
+
+  it('returns -- for non-finite values', () => {
+    expect(formatTokenCount(Infinity)).toBe('--')
+    expect(formatTokenCount(NaN)).toBe('--')
   })
 })
 
@@ -166,6 +272,21 @@ describe('formatUptime', () => {
 
   it('handles NaN', () => {
     expect(formatUptime(NaN)).toBe('0m')
+  })
+})
+
+describe('formatFileSize', () => {
+  it('formats zero', () => {
+    expect(formatFileSize(0)).toBe('0 B')
+  })
+
+  it('formats kilobytes', () => {
+    expect(formatFileSize(2048)).toBe('2.0 KB')
+  })
+
+  it('returns -- for negative and non-finite', () => {
+    expect(formatFileSize(-1)).toBe('--')
+    expect(formatFileSize(NaN)).toBe('--')
   })
 })
 

--- a/web/src/__tests__/utils/format.test.ts
+++ b/web/src/__tests__/utils/format.test.ts
@@ -1,3 +1,5 @@
+import { afterEach, beforeEach, vi } from 'vitest'
+import { DEFAULT_CURRENCY } from '@/utils/currencies'
 import {
   formatDate,
   formatDateOnly,
@@ -103,6 +105,17 @@ describe('formatTodayLabel', () => {
 })
 
 describe('formatRelativeTime', () => {
+  // Freeze the clock so "just now" / "5 minutes ago" / "3 hours ago"
+  // assertions cannot flip across the second boundary on slow CI hosts.
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-01T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('returns -- for null/undefined', () => {
     expect(formatRelativeTime(null)).toBe('--')
     expect(formatRelativeTime(undefined)).toBe('--')
@@ -155,10 +168,14 @@ describe('formatRelativeTime', () => {
 })
 
 describe('formatCurrency', () => {
-  it('defaults to EUR', () => {
+  it('defaults to DEFAULT_CURRENCY', () => {
     const result = formatCurrency(42.5)
+    const expected = formatCurrency(42.5, DEFAULT_CURRENCY, 'en-US')
+    expect(formatCurrency(42.5, DEFAULT_CURRENCY)).toBe(result)
     expect(result).toContain('42.50')
-    expect(result).toContain('\u20ac')
+    // Round-trip: the default call must match an explicit
+    // ``DEFAULT_CURRENCY`` call under the same locale.
+    expect(formatCurrency(42.5, DEFAULT_CURRENCY, 'en-US')).toBe(expected)
   })
 
   it('formats USD values', () => {
@@ -312,10 +329,11 @@ describe('formatLabel', () => {
 })
 
 describe('formatCurrencyCompact', () => {
-  it('formats a small value with default EUR currency', () => {
+  it('formats a small value with DEFAULT_CURRENCY', () => {
     const result = formatCurrencyCompact(5)
+    const explicit = formatCurrencyCompact(5, DEFAULT_CURRENCY)
+    expect(result).toBe(explicit)
     expect(result).toMatch(/5/)
-    expect(result).toMatch(/€|EUR/)
   })
 
   it('formats large values with compact notation', () => {

--- a/web/src/__tests__/utils/format.test.ts
+++ b/web/src/__tests__/utils/format.test.ts
@@ -112,24 +112,31 @@ describe('formatRelativeTime', () => {
     expect(formatRelativeTime('not-a-date')).toBe('--')
   })
 
-  it('returns "just now" for recent timestamps', () => {
+  it('renders "now" for immediate timestamps under en-US', () => {
     const now = new Date().toISOString()
-    expect(formatRelativeTime(now)).toBe('just now')
+    expect(formatRelativeTime(now, 'en-US')).toBe('now')
   })
 
-  it('returns minutes ago for recent timestamps', () => {
+  it('renders minutes ago under en-US', () => {
     const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString()
-    expect(formatRelativeTime(fiveMinAgo)).toBe('5m ago')
+    expect(formatRelativeTime(fiveMinAgo, 'en-US')).toBe('5 minutes ago')
   })
 
-  it('returns hours ago', () => {
+  it('renders hours ago under en-US', () => {
     const threeHoursAgo = new Date(Date.now() - 3 * 3600 * 1000).toISOString()
-    expect(formatRelativeTime(threeHoursAgo)).toBe('3h ago')
+    expect(formatRelativeTime(threeHoursAgo, 'en-US')).toBe('3 hours ago')
   })
 
-  it('returns days ago', () => {
+  it('renders days ago under en-US', () => {
     const twoDaysAgo = new Date(Date.now() - 2 * 86400 * 1000).toISOString()
-    expect(formatRelativeTime(twoDaysAgo)).toBe('2d ago')
+    expect(formatRelativeTime(twoDaysAgo, 'en-US')).toBe('2 days ago')
+  })
+
+  it('respects an explicit locale override', () => {
+    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString()
+    const en = formatRelativeTime(fiveMinAgo, 'en-US')
+    const de = formatRelativeTime(fiveMinAgo, 'de-DE')
+    expect(en).not.toBe(de)
   })
 
   it('falls back to formatDateTime for old dates', () => {
@@ -329,16 +336,14 @@ describe('formatCurrencyCompact', () => {
     expect(formatCurrencyCompact(-Infinity)).toBe('--')
   })
 
-  it('normalizes invalid currency code to EUR', () => {
+  it('falls back to "CODE N" when currency is invalid', () => {
     const result = formatCurrencyCompact(100, 'INVALID')
-    const expected = formatCurrencyCompact(100, 'EUR')
-    expect(result).toBe(expected)
+    expect(result).toBe('INVALID 100')
   })
 
-  it('trims whitespace and uppercases currency code', () => {
-    const result = formatCurrencyCompact(100, ' usd ')
-    const expected = formatCurrencyCompact(100, 'USD')
-    expect(result).toBe(expected)
+  it('accepts a lowercase currency code (Intl normalizes it)', () => {
+    const result = formatCurrencyCompact(100, 'usd')
+    expect(result).toMatch(/\$/)
   })
 
   it('formats zero correctly', () => {

--- a/web/src/__tests__/utils/locale.test.ts
+++ b/web/src/__tests__/utils/locale.test.ts
@@ -6,20 +6,30 @@ describe('APP_LOCALE', () => {
     expect(APP_LOCALE.length).toBeGreaterThan(0)
   })
 
-  it('matches IETF BCP 47 language-region shape', () => {
-    expect(APP_LOCALE).toMatch(/^[a-z]{2}-[A-Z]{2}$/)
+  it('canonicalizes to itself via Intl.getCanonicalLocales', () => {
+    const canonical = Intl.getCanonicalLocales(APP_LOCALE)
+    expect(canonical).toEqual([APP_LOCALE])
   })
 
   it('is a valid Intl locale', () => {
     expect(() => new Intl.Locale(APP_LOCALE)).not.toThrow()
   })
 
-  it.each(['en_US', 'en-us', 'EN-US', 'en', ''])(
-    'rejects the malformed candidate %j against the BCP 47 shape regex',
-    (candidate) => {
-      expect(candidate).not.toMatch(/^[a-z]{2}-[A-Z]{2}$/)
-    },
-  )
+  it.each([
+    'en_US', // underscore instead of hyphen
+    'en', // language-only (accepted by Intl but not our APP_LOCALE shape)
+    '', // empty string
+    'not a locale', // whitespace, no region
+  ])('rejects the malformed candidate %j', (candidate) => {
+    if (candidate === 'en') {
+      // `Intl.getCanonicalLocales('en')` succeeds; assert it does NOT
+      // normalize to APP_LOCALE so the test still catches unintended
+      // language-only drift for our BCP 47 language-region requirement.
+      expect(Intl.getCanonicalLocales(candidate)).not.toEqual([APP_LOCALE])
+    } else {
+      expect(() => Intl.getCanonicalLocales(candidate)).toThrow()
+    }
+  })
 })
 
 describe('getLocale', () => {

--- a/web/src/__tests__/utils/locale.test.ts
+++ b/web/src/__tests__/utils/locale.test.ts
@@ -13,6 +13,13 @@ describe('APP_LOCALE', () => {
   it('is a valid Intl locale', () => {
     expect(() => new Intl.Locale(APP_LOCALE)).not.toThrow()
   })
+
+  it.each(['en_US', 'en-us', 'EN-US', 'en', ''])(
+    'rejects the malformed candidate %j against the BCP 47 shape regex',
+    (candidate) => {
+      expect(candidate).not.toMatch(/^[a-z]{2}-[A-Z]{2}$/)
+    },
+  )
 })
 
 describe('getLocale', () => {

--- a/web/src/__tests__/utils/locale.test.ts
+++ b/web/src/__tests__/utils/locale.test.ts
@@ -1,0 +1,36 @@
+import { APP_LOCALE, getLocale } from '@/utils/locale'
+
+describe('APP_LOCALE', () => {
+  it('is a non-empty string', () => {
+    expect(typeof APP_LOCALE).toBe('string')
+    expect(APP_LOCALE.length).toBeGreaterThan(0)
+  })
+
+  it('matches IETF BCP 47 language-region shape', () => {
+    expect(APP_LOCALE).toMatch(/^[a-z]{2}-[A-Z]{2}$/)
+  })
+
+  it('is a valid Intl locale', () => {
+    expect(() => new Intl.Locale(APP_LOCALE)).not.toThrow()
+  })
+})
+
+describe('getLocale', () => {
+  it('returns a string', () => {
+    expect(typeof getLocale()).toBe('string')
+  })
+
+  it('defaults to APP_LOCALE when no override is configured', () => {
+    expect(getLocale()).toBe(APP_LOCALE)
+  })
+
+  it('returns a value usable by Intl APIs', () => {
+    const locale = getLocale()
+    expect(() =>
+      new Intl.NumberFormat(locale).format(1000),
+    ).not.toThrow()
+    expect(() =>
+      new Intl.DateTimeFormat(locale).format(new Date()),
+    ).not.toThrow()
+  })
+})

--- a/web/src/__tests__/utils/providers.test.ts
+++ b/web/src/__tests__/utils/providers.test.ts
@@ -226,11 +226,11 @@ describe('formatTokenCount', () => {
   })
 
   it('formats thousands with K suffix', () => {
-    expect(formatTokenCount(50_000)).toBe('50.0K')
+    expect(formatTokenCount(50_000)).toMatch(/^50K$/i)
   })
 
   it('formats millions with M suffix', () => {
-    expect(formatTokenCount(1_234_567)).toBe('1.2M')
+    expect(formatTokenCount(1_234_567)).toMatch(/^1\.2M$/i)
   })
 
   it('formats small numbers with locale string', () => {

--- a/web/src/api/endpoints/providers.ts
+++ b/web/src/api/endpoints/providers.ts
@@ -13,6 +13,8 @@ import type {
   ProbePresetResponse,
   ProviderConfig,
   ProviderHealthSummary,
+  PullModelRequest,
+  UpdateModelConfigRequest,
   ProviderModelResponse,
   ProviderPreset,
   PullProgressEvent,
@@ -180,7 +182,7 @@ export async function pullModel(
       'Content-Type': 'application/json',
       ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}),
     },
-    body: JSON.stringify({ model_name: modelName }),
+    body: JSON.stringify({ model_name: modelName } satisfies PullModelRequest),
     signal,
   })
 
@@ -246,9 +248,10 @@ export async function updateModelConfig(
   modelId: string,
   params: LocalModelParams,
 ): Promise<ProviderModelResponse> {
+  const payload: UpdateModelConfigRequest = { local_params: params }
   const response = await apiClient.put<ApiResponse<ProviderModelResponse>>(
     `/providers/${encodeURIComponent(name)}/models/${encodeModelIdPath(modelId)}/config`,
-    { local_params: params },
+    payload,
   )
   return unwrap(response)
 }

--- a/web/src/api/endpoints/training.ts
+++ b/web/src/api/endpoints/training.ts
@@ -83,6 +83,15 @@ export async function getTrainingResult(
   return unwrap(response)
 }
 
+export async function getLatestTrainingPlan(
+  agentName: string,
+): Promise<TrainingPlanResponse> {
+  const response = await apiClient.get<ApiResponse<TrainingPlanResponse>>(
+    `/agents/${encodeURIComponent(agentName)}/training/plan`,
+  )
+  return unwrap(response)
+}
+
 export async function previewTrainingPlan(
   agentName: string,
 ): Promise<TrainingResultResponse> {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -749,11 +749,34 @@ export interface CreateDepartmentRequest {
   autonomy_level?: AutonomyLevel | null
 }
 
+/**
+ * Request-specific team payload nested inside
+ * {@link UpdateDepartmentRequest}.
+ *
+ * Distinct from the response-side {@link TeamConfig} so form/store
+ * callers cannot accidentally send response-only fields. The backend
+ * caps ``teams`` at {@link UPDATE_DEPARTMENT_MAX_TEAMS} entries --
+ * validate length at the form/store boundary before issuing the
+ * request rather than surfacing a server 422.
+ */
+export interface UpdateDepartmentTeam {
+  name: string
+  lead: string
+  readonly members?: readonly string[]
+}
+
+/**
+ * Matches ``UpdateDepartmentRequest.teams`` ``max_length=64`` bound on
+ * ``synthorg.api.dto_org``. Exported so forms/stores validate before
+ * sending rather than surfacing a server 422.
+ */
+export const UPDATE_DEPARTMENT_MAX_TEAMS = 64
+
 export interface UpdateDepartmentRequest {
   head?: string | null
   budget_percent?: number
   autonomy_level?: AutonomyLevel | null
-  teams?: readonly TeamConfig[]
+  teams?: readonly UpdateDepartmentTeam[]
   ceremony_policy?: CeremonyPolicyConfig | null
 }
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -307,6 +307,48 @@ export interface TaskFilters {
 
 // ── Approvals ────────────────────────────────────────────────
 
+/** Mirrors `synthorg.core.evidence.RecommendedAction`. */
+export interface RecommendedAction {
+  action_type: string
+  label: string
+  description: string
+  confirmation_required: boolean
+}
+
+/** Mirrors `synthorg.core.evidence.EvidencePackageSignature`. */
+export interface EvidencePackageSignature {
+  approver_id: string
+  algorithm: 'ml-dsa-65' | 'ed25519'
+  /** Raw signature bytes, base64-encoded in transit. */
+  signature_bytes: string
+  signed_at: string
+  chain_position: number
+}
+
+/**
+ * Mirrors `synthorg.core.evidence.EvidencePackage` (extends
+ * ``StructuredArtifact``). Structured payload for HITL approval
+ * decisions: narrative, reasoning trace, recommended actions, and
+ * audit-chain signatures.
+ */
+export interface EvidencePackage {
+  id: string
+  title: string
+  narrative: string
+  reasoning_trace: readonly string[]
+  recommended_actions: readonly RecommendedAction[]
+  source_agent_id: string
+  task_id: string | null
+  risk_level: ApprovalRiskLevel
+  metadata: Record<string, unknown>
+  signature_threshold: number
+  signatures: readonly EvidencePackageSignature[]
+  /** Computed field -- whether the signature threshold has been met. */
+  is_fully_signed: boolean
+  /** Inherited from StructuredArtifact. */
+  created_at: string
+}
+
 export interface ApprovalItem {
   id: string
   action_type: string
@@ -322,6 +364,8 @@ export interface ApprovalItem {
   created_at: string
   decided_at: string | null
   expires_at: string | null
+  /** Structured HITL evidence for rich approval UIs. */
+  evidence_package: EvidencePackage | null
 }
 
 export interface ApprovalResponse extends ApprovalItem {
@@ -470,9 +514,18 @@ export interface CareerEvent {
 
 // ── Budget ───────────────────────────────────────────────────
 
+/** Mirrors `synthorg.core.enums.FinishReason`. */
+export type FinishReason =
+  | 'stop'
+  | 'max_tokens'
+  | 'tool_use'
+  | 'content_filter'
+  | 'error'
+
 export interface CostRecord {
   agent_id: string
   task_id: string
+  project_id: string | null
   provider: string
   model: string
   input_tokens: number
@@ -480,6 +533,23 @@ export interface CostRecord {
   cost_usd: number
   timestamp: string
   call_category: 'productive' | 'coordination' | 'system' | 'embedding' | null
+  /** Quality-vs-cost ratio for the call, when measurable. */
+  accuracy_effort_ratio: number | null
+  /** Observed provider latency in milliseconds. */
+  latency_ms: number | null
+  /** Whether the response was served from a cache layer. */
+  cache_hit: boolean | null
+  /**
+   * Number of automatic retries performed before success / failure.
+   * Implies `retry_reason` is populated when > 0.
+   */
+  retry_count: number | null
+  /** Retry trigger (e.g. `rate_limit`, `timeout`). */
+  retry_reason: string | null
+  /** Provider finish reason (mirrors backend `FinishReason` enum). */
+  finish_reason: FinishReason | null
+  /** Whether the call completed without error. */
+  success: boolean | null
 }
 
 export interface DailySummary {
@@ -709,12 +779,21 @@ export interface CreateAgentOrgRequest {
   model_id?: string
 }
 
+/**
+ * Partial update for an agent. Mirrors
+ * `synthorg.api.dto_org.UpdateAgentOrgRequest`.
+ *
+ * Backend validator requires `model_provider` and `model_id` to be
+ * either both set or both omitted (partial pairs rejected with 422).
+ */
 export interface UpdateAgentOrgRequest {
   name?: string
   role?: string
   department?: DepartmentName
   level?: SeniorityLevel
   autonomy_level?: AutonomyLevel | null
+  model_provider?: string
+  model_id?: string
 }
 
 export interface ReorderAgentsRequest {
@@ -743,6 +822,26 @@ export interface LocalModelParams {
   num_threads: number | null
   num_batch: number | null
   repeat_penalty: number | null
+}
+
+/**
+ * Payload for pulling a model on a local provider. Mirrors
+ * `synthorg.api.dto_providers.PullModelRequest`.
+ */
+export interface PullModelRequest {
+  /**
+   * Model name/tag to pull (e.g. ``"test-local-001:latest"``). Must
+   * match ``^[a-zA-Z0-9._:/@-]+$`` and be at most 256 characters.
+   */
+  model_name: string
+}
+
+/**
+ * Payload for updating per-model launch parameters. Mirrors
+ * `synthorg.api.dto_providers.UpdateModelConfigRequest`.
+ */
+export interface UpdateModelConfigRequest {
+  local_params: LocalModelParams
 }
 
 export interface PullProgressEvent {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -319,7 +319,16 @@ export interface RecommendedAction {
 export interface EvidencePackageSignature {
   approver_id: string
   algorithm: 'ml-dsa-65' | 'ed25519'
-  /** Raw signature bytes, base64-encoded in transit. */
+  /**
+   * Signature bytes serialized as a base64 string.
+   *
+   * The backend model stores raw ``bytes`` and the Pydantic JSON
+   * encoder emits standard RFC 4648 base64 (no URL-safe alphabet,
+   * padding preserved). Callers that need the raw bytes should run
+   * ``atob(signature_bytes)`` then convert the result to a
+   * ``Uint8Array``. This contract is verified by the DTO parity
+   * tests in ``tests/unit/api/test_dto_parity.py``.
+   */
   signature_bytes: string
   signed_at: string
   chain_position: number
@@ -780,21 +789,30 @@ export interface CreateAgentOrgRequest {
 }
 
 /**
+ * Optional pair of (provider, model id) used by agent mutation DTOs.
+ * Either both fields are present as non-empty strings, or both are
+ * omitted -- the backend validator rejects partial pairs with 422.
+ * Expressed as a discriminated union so the TypeScript compiler flags
+ * half-filled requests at the call site.
+ */
+export type AgentModelSelector =
+  | { model_provider: string; model_id: string }
+  | { model_provider?: undefined; model_id?: undefined }
+
+/**
  * Partial update for an agent. Mirrors
  * `synthorg.api.dto_org.UpdateAgentOrgRequest`.
  *
  * Backend validator requires `model_provider` and `model_id` to be
- * either both set or both omitted (partial pairs rejected with 422).
+ * either both set or both omitted. See {@link AgentModelSelector}.
  */
-export interface UpdateAgentOrgRequest {
+export type UpdateAgentOrgRequest = {
   name?: string
   role?: string
   department?: DepartmentName
   level?: SeniorityLevel
   autonomy_level?: AutonomyLevel | null
-  model_provider?: string
-  model_id?: string
-}
+} & AgentModelSelector
 
 export interface ReorderAgentsRequest {
   readonly agent_names: readonly string[]

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   Command,
   Cpu,
   DollarSign,
+  GraduationCap,
   FolderKanban,
   GitBranch,
   Inbox,
@@ -238,6 +239,7 @@ function SidebarNav({ collapsed }: { collapsed: boolean }) {
         )}
         <div className="flex flex-col gap-1">
           <SidebarNavItem to={ROUTES.AGENTS} icon={Users} label="Agents" collapsed={collapsed} />
+          <SidebarNavItem to={ROUTES.TRAINING} icon={GraduationCap} label="Training" collapsed={collapsed} />
           <SidebarNavItem to={ROUTES.PROJECTS} icon={FolderKanban} label="Projects" collapsed={collapsed} />
           <SidebarNavItem to={ROUTES.WORKFLOWS} icon={Workflow} label="Workflows" collapsed={collapsed} />
           <SidebarNavItem to={ROUTES.SUBWORKFLOWS} icon={Layers} label="Subworkflows" collapsed={collapsed} />

--- a/web/src/components/layout/SidebarNavItem.tsx
+++ b/web/src/components/layout/SidebarNavItem.tsx
@@ -62,6 +62,10 @@ export function SidebarNavItem({
   )
 
   if (external) {
+    // When collapsed the visible label is hidden, so the sr-only span
+    // has to carry both the destination name and the new-tab hint.
+    // Expanded renders the label visibly, so only the hint is needed.
+    const srText = collapsed ? `${label} (opens in new tab)` : '(opens in new tab)'
     return (
       <a
         href={to}
@@ -71,7 +75,7 @@ export function SidebarNavItem({
         rel="noopener noreferrer"
       >
         {content}
-        <span className="sr-only">(opens in new tab)</span>
+        <span className="sr-only">{srText}</span>
       </a>
     )
   }

--- a/web/src/components/layout/SidebarNavItem.tsx
+++ b/web/src/components/layout/SidebarNavItem.tsx
@@ -63,8 +63,15 @@ export function SidebarNavItem({
 
   if (external) {
     return (
-      <a href={to} title={collapsed ? label : undefined} className={baseClass}>
+      <a
+        href={to}
+        title={collapsed ? label : undefined}
+        className={baseClass}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         {content}
+        <span className="sr-only">(opens in new tab)</span>
       </a>
     )
   }

--- a/web/src/components/ui/health-popover.tsx
+++ b/web/src/components/ui/health-popover.tsx
@@ -18,6 +18,7 @@ import {
 import { getHealth } from '@/api/endpoints/health'
 import { useWebSocketStore } from '@/stores/websocket'
 import { createLogger } from '@/lib/logger'
+import { formatTime } from '@/utils/format'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import type { HealthStatus } from '@/api/types'
@@ -298,7 +299,7 @@ export function HealthPopover({ children }: HealthPopoverProps) {
 
   const fetchedAtLabel =
     loadState.state === 'ok' || loadState.state === 'error'
-      ? `${loadState.fetchedAt.toLocaleTimeString()} (${formatRelative(loadState.fetchedAt.getTime(), nowMs)})`
+      ? `${formatTime(loadState.fetchedAt.toISOString())} (${formatRelative(loadState.fetchedAt.getTime(), nowMs)})`
       : null
 
   return (

--- a/web/src/components/ui/sparkline.tsx
+++ b/web/src/components/ui/sparkline.tsx
@@ -8,7 +8,15 @@ export interface SparklineProps {
   height?: number
   animated?: boolean
   className?: string
-  /** When provided, sets role="img" and aria-label instead of aria-hidden. Use for standalone sparklines. */
+  /**
+   * Accessible name for the chart. Required for standalone usage (the
+   * sparkline becomes a labeled `role="img"` when set).
+   *
+   * When omitted, the sparkline is treated as decoration and emits
+   * `aria-hidden="true"`. Use this mode when the chart is layered
+   * beside a labeled sibling (for example, inside a `MetricCard`
+   * whose `label` + `value` already carry the semantic meaning).
+   */
   ariaLabel?: string
 }
 

--- a/web/src/components/ui/stagger-group.tsx
+++ b/web/src/components/ui/stagger-group.tsx
@@ -9,6 +9,12 @@ export interface StaggerGroupProps {
   staggerDelay?: number
   /** Whether to animate on mount (default: true). */
   animate?: boolean
+  /** ARIA role (e.g. "list"). When set, children should carry `role="listitem"`. */
+  role?: string
+  /** Accessible name for the group when `role` is set. */
+  'aria-label'?: string
+  /** ID of an element that labels the group. */
+  'aria-labelledby'?: string
 }
 
 export interface StaggerItemProps {
@@ -19,6 +25,8 @@ export interface StaggerItemProps {
   /** Enable layout animation for smooth size changes. */
   layout?: boolean
   'data-testid'?: string
+  /** ARIA role (e.g. "listitem"). */
+  role?: string
 }
 
 /**
@@ -32,6 +40,9 @@ export function StaggerGroup({
   className,
   staggerDelay = 0.03,
   animate = true,
+  role,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
 }: StaggerGroupProps) {
   const containerVariants = useMemo(
     () => ({
@@ -52,6 +63,9 @@ export function StaggerGroup({
       initial={animate ? 'hidden' : false}
       animate={animate ? 'visible' : false}
       className={className}
+      role={role}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
     >
       {children}
     </motion.div>
@@ -70,6 +84,7 @@ export function StaggerItem({
   layoutId,
   layout,
   'data-testid': testId,
+  role,
 }: StaggerItemProps) {
   return (
     <motion.div
@@ -78,6 +93,7 @@ export function StaggerItem({
       layout={layout}
       className={className}
       data-testid={testId}
+      role={role}
     >
       {children}
     </motion.div>

--- a/web/src/components/ui/status-badge.tsx
+++ b/web/src/components/ui/status-badge.tsx
@@ -26,19 +26,70 @@ export interface StatusBadgeProps {
   animated?: boolean
   /** Enable live-region announcements for dynamic state changes. Default: false. */
   announce?: boolean
+  /**
+   * When true, treat this badge as decoration layered beside an already
+   * labeled sibling (e.g. inside `AgentNode` where the agent name is
+   * displayed adjacent to the badge). The wrapper becomes
+   * `aria-hidden` so screen readers do not announce redundant status
+   * text. Default: false.
+   */
+  decorative?: boolean
 }
 
-export function StatusBadge({ status, label = false, pulse = false, className, animated = false, announce = false }: StatusBadgeProps) {
+export function StatusBadge({
+  status,
+  label = false,
+  pulse = false,
+  className,
+  animated = false,
+  announce = false,
+  decorative = false,
+}: StatusBadgeProps) {
   const color = getStatusColor(status)
   const statusLabel = STATUS_LABELS[status]
   const { motionProps } = useStatusTransition(status)
 
+  // Decorative mode: the caller already names the status; hide the dot
+  // tree entirely from screen readers.
+  if (decorative) {
+    return (
+      <span
+        className={cn('inline-flex items-center gap-1.5', className)}
+        aria-hidden="true"
+      >
+        {animated ? (
+          <motion.span
+            data-slot="status-dot"
+            className={cn(
+              'size-1.5 shrink-0 rounded-full',
+              DOT_COLOR_CLASSES[color],
+              pulse && 'animate-pulse',
+            )}
+            {...motionProps}
+          />
+        ) : (
+          <span
+            data-slot="status-dot"
+            className={cn(
+              'size-1.5 shrink-0 rounded-full',
+              DOT_COLOR_CLASSES[color],
+              pulse && 'animate-pulse',
+            )}
+          />
+        )}
+        {label && (
+          <span className="text-xs text-text-secondary">{statusLabel}</span>
+        )}
+      </span>
+    )
+  }
+
   return (
     <span
-      className={cn('inline-flex items-center gap-1.5', className)}
+      role={announce ? 'status' : 'img'}
       aria-label={statusLabel}
-      role={announce ? 'status' : undefined}
       aria-live={announce ? 'polite' : undefined}
+      className={cn('inline-flex items-center gap-1.5', className)}
     >
       {animated ? (
         <motion.span

--- a/web/src/components/ui/tag-input.tsx
+++ b/web/src/components/ui/tag-input.tsx
@@ -99,7 +99,7 @@ export function TagInput({ value, onChange, disabled, placeholder, className }: 
                 className="rounded-sm hover:bg-accent/20"
                 aria-label={`Remove ${item}`}
               >
-                <X className="size-3" aria-hidden />
+                <X className="size-3" aria-hidden="true" />
               </button>
             )}
           </span>

--- a/web/src/components/ui/token-usage-bar.tsx
+++ b/web/src/components/ui/token-usage-bar.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/utils'
+import { formatNumber } from '@/utils/format'
 
 export interface TokenSegment {
   label: string
@@ -33,7 +34,7 @@ export function TokenUsageBar({ segments, total, className }: TokenUsageBarProps
       aria-valuenow={clampedNow}
       aria-valuemin={0}
       aria-valuemax={clampedMax}
-      aria-valuetext={`${usedTokens.toLocaleString()} of ${total.toLocaleString()}`}
+      aria-valuetext={`${formatNumber(usedTokens)} of ${formatNumber(total)}`}
       aria-label="Token usage"
       className={cn('flex flex-col gap-1', className)}
     >
@@ -52,7 +53,7 @@ export function TokenUsageBar({ segments, total, className }: TokenUsageBarProps
                 width: `${(segment.value / usedTokens) * 100}%`,
                 transitionTimingFunction: 'cubic-bezier(0.4, 0, 0.2, 1)',
               }}
-              title={`${segment.label}: ${segment.value.toLocaleString()} tokens`}
+              title={`${segment.label}: ${formatNumber(segment.value)} tokens`}
             />
           ))}
         </div>

--- a/web/src/hooks/useToolbarKeyboardNav.ts
+++ b/web/src/hooks/useToolbarKeyboardNav.ts
@@ -7,9 +7,10 @@ import { useCallback, useRef, type KeyboardEvent, type RefObject } from 'react'
  * an ``onKeyDown`` handler that moves focus among the container's
  * focusable children on Arrow (up/down/left/right), ``Home``, and
  * ``End``. The hook only owns those keys -- it does not implement
- * roving tabindex, so ``Tab``/``Shift+Tab`` still step through every
- * control in normal DOM order, which is what consumers of this
- * toolbar have historically relied on.
+ * roving tabindex, so Tab behavior remains native (driven by each
+ * child's tabbability, ``disabled`` state, and any composite-widget
+ * interception). Consumers that need Tab to skip past the toolbar
+ * should manage that with ``tabIndex`` on the children themselves.
  */
 export interface ToolbarKeyboardNav<T extends HTMLElement> {
   ref: RefObject<T | null>

--- a/web/src/hooks/useToolbarKeyboardNav.ts
+++ b/web/src/hooks/useToolbarKeyboardNav.ts
@@ -4,10 +4,12 @@ import { useCallback, useRef, type KeyboardEvent, type RefObject } from 'react'
  * ARIA toolbar keyboard navigation.
  *
  * Returns a ref to attach to the container with ``role="toolbar"`` and
- * an ``onKeyDown`` handler that routes arrow keys, ``Home``, and
- * ``End`` to the focusable children of the container so tab does not
- * need to step through every control. Tab continues to move focus to
- * the next focusable element outside the toolbar.
+ * an ``onKeyDown`` handler that moves focus among the container's
+ * focusable children on Arrow (up/down/left/right), ``Home``, and
+ * ``End``. The hook only owns those keys -- it does not implement
+ * roving tabindex, so ``Tab``/``Shift+Tab`` still step through every
+ * control in normal DOM order, which is what consumers of this
+ * toolbar have historically relied on.
  */
 export interface ToolbarKeyboardNav<T extends HTMLElement> {
   ref: RefObject<T | null>

--- a/web/src/hooks/useToolbarKeyboardNav.ts
+++ b/web/src/hooks/useToolbarKeyboardNav.ts
@@ -31,23 +31,42 @@ export function useToolbarKeyboardNav<
   const onKeyDown = useCallback((event: KeyboardEvent<T>) => {
     const container = ref.current
     if (!container) return
+
+    // Do not intercept arrow keys inside editable controls -- the
+    // native caret/value navigation must take precedence. Home/End
+    // inside inputs also matters for text editing and we intentionally
+    // leave them to the browser.
+    const active = document.activeElement
+    if (active instanceof HTMLElement) {
+      const editable =
+        active.tagName === 'INPUT' ||
+        active.tagName === 'TEXTAREA' ||
+        active.tagName === 'SELECT' ||
+        active.isContentEditable
+      if (editable) return
+    }
+
     const items = Array.from(
       container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
     ).filter((el) => !el.hasAttribute('data-toolbar-skip'))
     if (items.length === 0) return
 
-    const activeIndex = items.indexOf(document.activeElement as HTMLElement)
+    const activeIndex = items.indexOf(active as HTMLElement)
 
     let nextIndex: number
     switch (event.key) {
       case 'ArrowRight':
       case 'ArrowDown':
-        nextIndex = (Math.max(activeIndex, 0) + 1) % items.length
+        // -1 (no active item) starts from the first control; from any
+        // live index, wrap forward via the cyclic modulo.
+        nextIndex = activeIndex < 0 ? 0 : (activeIndex + 1) % items.length
         break
       case 'ArrowLeft':
       case 'ArrowUp':
         nextIndex =
-          (Math.max(activeIndex, 0) - 1 + items.length) % items.length
+          activeIndex < 0
+            ? items.length - 1
+            : (activeIndex - 1 + items.length) % items.length
         break
       case 'Home':
         nextIndex = 0

--- a/web/src/hooks/useToolbarKeyboardNav.ts
+++ b/web/src/hooks/useToolbarKeyboardNav.ts
@@ -32,6 +32,12 @@ export function useToolbarKeyboardNav<
     const container = ref.current
     if (!container) return
 
+    // Preserve browser and assistive-tech shortcuts (Ctrl/Cmd/Alt/Shift
+    // chords) -- the toolbar only owns plain arrow/Home/End navigation.
+    if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) {
+      return
+    }
+
     // Do not intercept arrow keys inside editable controls -- the
     // native caret/value navigation must take precedence. Home/End
     // inside inputs also matters for text editing and we intentionally

--- a/web/src/hooks/useToolbarKeyboardNav.ts
+++ b/web/src/hooks/useToolbarKeyboardNav.ts
@@ -1,0 +1,67 @@
+import { useCallback, useRef, type KeyboardEvent, type RefObject } from 'react'
+
+/**
+ * ARIA toolbar keyboard navigation.
+ *
+ * Returns a ref to attach to the container with ``role="toolbar"`` and
+ * an ``onKeyDown`` handler that routes arrow keys, ``Home``, and
+ * ``End`` to the focusable children of the container so tab does not
+ * need to step through every control. Tab continues to move focus to
+ * the next focusable element outside the toolbar.
+ */
+export interface ToolbarKeyboardNav<T extends HTMLElement> {
+  ref: RefObject<T | null>
+  onKeyDown: (event: KeyboardEvent<T>) => void
+}
+
+const FOCUSABLE_SELECTOR = [
+  'button:not([disabled])',
+  '[href]',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+export function useToolbarKeyboardNav<
+  T extends HTMLElement = HTMLDivElement,
+>(): ToolbarKeyboardNav<T> {
+  const ref = useRef<T | null>(null)
+
+  const onKeyDown = useCallback((event: KeyboardEvent<T>) => {
+    const container = ref.current
+    if (!container) return
+    const items = Array.from(
+      container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+    ).filter((el) => !el.hasAttribute('data-toolbar-skip'))
+    if (items.length === 0) return
+
+    const activeIndex = items.indexOf(document.activeElement as HTMLElement)
+
+    let nextIndex: number
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        nextIndex = (Math.max(activeIndex, 0) + 1) % items.length
+        break
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        nextIndex =
+          (Math.max(activeIndex, 0) - 1 + items.length) % items.length
+        break
+      case 'Home':
+        nextIndex = 0
+        break
+      case 'End':
+        nextIndex = items.length - 1
+        break
+      default:
+        return
+    }
+
+    event.preventDefault()
+    items[nextIndex]?.focus()
+  }, [])
+
+  return { ref, onKeyDown }
+}

--- a/web/src/hooks/useToolbarKeyboardNav.ts
+++ b/web/src/hooks/useToolbarKeyboardNav.ts
@@ -32,6 +32,12 @@ export function useToolbarKeyboardNav<
     const container = ref.current
     if (!container) return
 
+    // Let nested composite controls own the event when they call
+    // preventDefault themselves (e.g. a Menu or Combobox inside the
+    // toolbar). Without this guard the toolbar would re-handle the
+    // arrow key and move focus away mid-interaction.
+    if (event.defaultPrevented) return
+
     // Preserve browser and assistive-tech shortcuts (Ctrl/Cmd/Alt/Shift
     // chords) -- the toolbar only owns plain arrow/Home/End navigation.
     if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) {

--- a/web/src/pages/AgentDetailPage.tsx
+++ b/web/src/pages/AgentDetailPage.tsx
@@ -12,6 +12,7 @@ import { CareerTimeline } from './agents/CareerTimeline'
 import { TaskHistory } from './agents/TaskHistory'
 import { ActivityLog } from './agents/ActivityLog'
 import { QualityScoreOverride } from './agents/QualityScoreOverride'
+import { TrainingSection } from './agents/TrainingSection'
 
 export default function AgentDetailPage() {
   // URLs use the agent's stable ID (or name as a fallback when an
@@ -96,6 +97,10 @@ export default function AgentDetailPage() {
 
       <ErrorBoundary level="section">
         {agent.id && <QualityScoreOverride agentId={agent.id} />}
+      </ErrorBoundary>
+
+      <ErrorBoundary level="section">
+        <TrainingSection agentName={agent.name} />
       </ErrorBoundary>
 
       <div className="grid grid-cols-2 gap-grid-gap max-[1023px]:grid-cols-1">

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -13,7 +13,7 @@ import { useWebSocket } from '@/hooks/useWebSocket'
 import { useTasksStore } from '@/stores/tasks'
 import { useToastStore } from '@/stores/toast'
 import { getTaskStatusLabel, getTaskTypeLabel, getAvailableTransitions, getPriorityLabel } from '@/utils/tasks'
-import { COST_USD_CURRENCY } from '@/utils/currencies'
+import { DEFAULT_CURRENCY } from '@/utils/currencies'
 import { formatDate, formatCurrency } from '@/utils/format'
 import { getErrorMessage } from '@/utils/errors'
 import { ROUTES } from '@/router/routes'
@@ -208,7 +208,7 @@ export default function TaskDetailPage() {
             <div><span className="block text-[10px] text-text-muted">Created</span><span className="font-mono text-xs text-foreground">{formatDate(task.created_at)}</span></div>
             <div><span className="block text-[10px] text-text-muted">Updated</span><span className="font-mono text-xs text-foreground">{formatDate(task.updated_at)}</span></div>
             {task.cost_usd != null && (
-              <div><span className="block text-[10px] text-text-muted">Cost</span><span className="font-mono text-xs text-foreground">{formatCurrency(task.cost_usd, COST_USD_CURRENCY)}</span></div>
+              <div><span className="block text-[10px] text-text-muted">Cost</span><span className="font-mono text-xs text-foreground">{formatCurrency(task.cost_usd, DEFAULT_CURRENCY)}</span></div>
             )}
           </div>
 

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -13,6 +13,7 @@ import { useWebSocket } from '@/hooks/useWebSocket'
 import { useTasksStore } from '@/stores/tasks'
 import { useToastStore } from '@/stores/toast'
 import { getTaskStatusLabel, getTaskTypeLabel, getAvailableTransitions, getPriorityLabel } from '@/utils/tasks'
+import { COST_USD_CURRENCY } from '@/utils/currencies'
 import { formatDate, formatCurrency } from '@/utils/format'
 import { getErrorMessage } from '@/utils/errors'
 import { ROUTES } from '@/router/routes'
@@ -207,7 +208,7 @@ export default function TaskDetailPage() {
             <div><span className="block text-[10px] text-text-muted">Created</span><span className="font-mono text-xs text-foreground">{formatDate(task.created_at)}</span></div>
             <div><span className="block text-[10px] text-text-muted">Updated</span><span className="font-mono text-xs text-foreground">{formatDate(task.updated_at)}</span></div>
             {task.cost_usd != null && (
-              <div><span className="block text-[10px] text-text-muted">Cost</span><span className="font-mono text-xs text-foreground">{formatCurrency(task.cost_usd, 'USD')}</span></div>
+              <div><span className="block text-[10px] text-text-muted">Cost</span><span className="font-mono text-xs text-foreground">{formatCurrency(task.cost_usd, COST_USD_CURRENCY)}</span></div>
             )}
           </div>
 

--- a/web/src/pages/TrainingPage.tsx
+++ b/web/src/pages/TrainingPage.tsx
@@ -54,10 +54,21 @@ export default function TrainingPage() {
   }, [])
 
   useEffect(() => {
-    // Hydrate plan + result for each agent (best-effort; missing rows
-    // surface as "no plan" instead of errors -- the store swallows 404).
-    for (const agent of agents) {
-      void hydrateForAgent(agent.name)
+    // Hydrate plan + result for each agent in bounded batches so a
+    // large roster does not fan out 200 concurrent requests at once.
+    // Best-effort: missing rows surface as "no plan" instead of errors
+    // (the store swallows 404).
+    const BATCH_SIZE = 10
+    let cancelled = false
+    void (async () => {
+      for (let i = 0; i < agents.length; i += BATCH_SIZE) {
+        if (cancelled) return
+        const batch = agents.slice(i, i + BATCH_SIZE)
+        await Promise.all(batch.map((agent) => hydrateForAgent(agent.name)))
+      }
+    })()
+    return () => {
+      cancelled = true
     }
   }, [agents, hydrateForAgent])
 

--- a/web/src/pages/TrainingPage.tsx
+++ b/web/src/pages/TrainingPage.tsx
@@ -1,0 +1,135 @@
+import { AlertTriangle, GraduationCap } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { listAgents } from '@/api/endpoints/agents'
+import { MetricCard } from '@/components/ui/metric-card'
+import { SectionCard } from '@/components/ui/section-card'
+import { SkeletonTable } from '@/components/ui/skeleton'
+import { StaggerGroup, StaggerItem } from '@/components/ui/stagger-group'
+import { createLogger } from '@/lib/logger'
+import { useTrainingStore } from '@/stores/training'
+import type { AgentConfig } from '@/api/types'
+import { getErrorMessage } from '@/utils/errors'
+import {
+  TrainingPlanTable,
+  type TrainingPlanRow,
+} from './training/TrainingPlanTable'
+
+const log = createLogger('training-page')
+
+export default function TrainingPage() {
+  const [agents, setAgents] = useState<readonly AgentConfig[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const plansByAgent = useTrainingStore((s) => s.plansByAgent)
+  const resultsByAgent = useTrainingStore((s) => s.resultsByAgent)
+  const fetchResult = useTrainingStore((s) => s.fetchResult)
+  const executePlan = useTrainingStore((s) => s.executePlan)
+
+  useEffect(() => {
+    let cancelled = false
+    // Kick off the fetch in a microtask so the initial render completes
+    // first (avoids the synchronous set-state-in-effect lint rule).
+    void Promise.resolve()
+      .then(() => listAgents())
+      .then((paginated) => {
+        if (!cancelled) {
+          setAgents(paginated.data)
+          setLoading(false)
+        }
+      })
+      .catch((err: unknown) => {
+        log.error('Failed to load agents:', err)
+        if (!cancelled) {
+          setError(getErrorMessage(err))
+          setLoading(false)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    // Hydrate training results for each agent (best-effort; missing results
+    // surface as "no plan" rows instead of errors).
+    for (const agent of agents) {
+      void fetchResult(agent.name)
+    }
+  }, [agents, fetchResult])
+
+  const rows: readonly TrainingPlanRow[] = useMemo(
+    () =>
+      agents.map((agent) => ({
+        agentName: agent.name,
+        plan: plansByAgent[agent.name] ?? null,
+        result: resultsByAgent[agent.name] ?? null,
+      })),
+    [agents, plansByAgent, resultsByAgent],
+  )
+
+  const handleExecute = useCallback(
+    (agentName: string) => {
+      void executePlan(agentName)
+    },
+    [executePlan],
+  )
+
+  const metrics = useMemo(() => {
+    const totalPlans = rows.filter((r) => r.plan !== null).length
+    const pending = rows.filter((r) => r.plan?.status === 'pending').length
+    const executed = rows.filter((r) => r.plan?.status === 'executed').length
+    const totalItems = rows.reduce(
+      (sum, r) =>
+        sum + (r.result?.items_stored.reduce((s, [, c]) => s + c, 0) ?? 0),
+      0,
+    )
+    return { totalPlans, pending, executed, totalItems }
+  }, [rows])
+
+  return (
+    <div className="space-y-section-gap">
+      <div className="flex items-center justify-between">
+        <h1 className="text-lg font-semibold text-foreground">Training</h1>
+        <span className="text-sm text-muted-foreground">
+          {rows.length} agents
+        </span>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          aria-live="assertive"
+          className="flex items-center gap-2 rounded-lg border border-danger/30 bg-danger/5 p-card text-sm text-danger"
+        >
+          <AlertTriangle className="size-4 shrink-0" aria-hidden="true" />
+          {error}
+        </div>
+      )}
+
+      <StaggerGroup className="grid grid-cols-2 gap-grid-gap lg:grid-cols-4">
+        <StaggerItem>
+          <MetricCard label="TOTAL PLANS" value={metrics.totalPlans} />
+        </StaggerItem>
+        <StaggerItem>
+          <MetricCard label="PENDING" value={metrics.pending} />
+        </StaggerItem>
+        <StaggerItem>
+          <MetricCard label="EXECUTED" value={metrics.executed} />
+        </StaggerItem>
+        <StaggerItem>
+          <MetricCard label="ITEMS STORED" value={metrics.totalItems} />
+        </StaggerItem>
+      </StaggerGroup>
+
+      <SectionCard title="Agent training plans" icon={GraduationCap}>
+        {loading ? (
+          <SkeletonTable rows={6} />
+        ) : (
+          <TrainingPlanTable rows={rows} onExecute={handleExecute} />
+        )}
+      </SectionCard>
+    </div>
+  )
+}

--- a/web/src/pages/TrainingPage.tsx
+++ b/web/src/pages/TrainingPage.tsx
@@ -24,15 +24,17 @@ export default function TrainingPage() {
 
   const plansByAgent = useTrainingStore((s) => s.plansByAgent)
   const resultsByAgent = useTrainingStore((s) => s.resultsByAgent)
-  const fetchResult = useTrainingStore((s) => s.fetchResult)
+  const hydrateForAgent = useTrainingStore((s) => s.hydrateForAgent)
   const executePlan = useTrainingStore((s) => s.executePlan)
 
   useEffect(() => {
     let cancelled = false
     // Kick off the fetch in a microtask so the initial render completes
     // first (avoids the synchronous set-state-in-effect lint rule).
+    // Ask for the full roster up-front so the table does not silently
+    // truncate to the default 50-agent page.
     void Promise.resolve()
-      .then(() => listAgents())
+      .then(() => listAgents({ limit: 200 }))
       .then((paginated) => {
         if (!cancelled) {
           setAgents(paginated.data)
@@ -52,12 +54,12 @@ export default function TrainingPage() {
   }, [])
 
   useEffect(() => {
-    // Hydrate training results for each agent (best-effort; missing results
-    // surface as "no plan" rows instead of errors).
+    // Hydrate plan + result for each agent (best-effort; missing rows
+    // surface as "no plan" instead of errors -- the store swallows 404).
     for (const agent of agents) {
-      void fetchResult(agent.name)
+      void hydrateForAgent(agent.name)
     }
-  }, [agents, fetchResult])
+  }, [agents, hydrateForAgent])
 
   const rows: readonly TrainingPlanRow[] = useMemo(
     () =>

--- a/web/src/pages/TrainingPage.tsx
+++ b/web/src/pages/TrainingPage.tsx
@@ -10,6 +10,7 @@ import { createLogger } from '@/lib/logger'
 import { useTrainingStore } from '@/stores/training'
 import type { AgentConfig } from '@/api/types'
 import { getErrorMessage } from '@/utils/errors'
+import { sanitizeForLog } from '@/utils/logging'
 import {
   TrainingPlanTable,
   type TrainingPlanRow,
@@ -42,7 +43,10 @@ export default function TrainingPage() {
         }
       })
       .catch((err: unknown) => {
-        log.error('Failed to load agents:', err)
+        log.error(
+          'Failed to load agents',
+          sanitizeForLog({ err, message: getErrorMessage(err) }),
+        )
         if (!cancelled) {
           setError(getErrorMessage(err))
           setLoading(false)

--- a/web/src/pages/WorkflowEditorPage.tsx
+++ b/web/src/pages/WorkflowEditorPage.tsx
@@ -350,11 +350,16 @@ function WorkflowEditorInner() {
               </h3>
               <ul aria-labelledby="workflow-editor-node-summary-edges">
                 {edges.map((edge) => {
-                  const label =
+                  // Always expose topology (source → target); append
+                  // the human label in parens when it is set, so the
+                  // screen-reader summary retains both the graph shape
+                  // and any branch semantics.
+                  const topology = `${edge.source} → ${edge.target}`
+                  const text =
                     typeof edge.label === 'string' && edge.label
-                      ? edge.label
-                      : `${edge.source} → ${edge.target}`
-                  return <li key={edge.id}>{`Edge: ${label}`}</li>
+                      ? `${topology} (${edge.label})`
+                      : topology
+                  return <li key={edge.id}>{`Edge: ${text}`}</li>
                 })}
               </ul>
             </section>

--- a/web/src/pages/WorkflowEditorPage.tsx
+++ b/web/src/pages/WorkflowEditorPage.tsx
@@ -353,12 +353,20 @@ function WorkflowEditorInner() {
                   // Always expose topology (source → target); append
                   // the human label in parens when it is set, so the
                   // screen-reader summary retains both the graph shape
-                  // and any branch semantics.
+                  // and any branch semantics. Labels may live on
+                  // ``edge.label`` (xyflow default) or on
+                  // ``edge.data.label`` when the persistence layer
+                  // stores branch metadata under ``data``.
                   const topology = `${edge.source} → ${edge.target}`
-                  const text =
-                    typeof edge.label === 'string' && edge.label
-                      ? `${topology} (${edge.label})`
-                      : topology
+                  const dataLabel =
+                    edge.data && typeof edge.data === 'object' &&
+                      'label' in edge.data &&
+                      typeof (edge.data as { label?: unknown }).label === 'string'
+                      ? ((edge.data as { label: string }).label)
+                      : ''
+                  const rawLabel =
+                    (typeof edge.label === 'string' && edge.label) || dataLabel
+                  const text = rawLabel ? `${topology} (${rawLabel})` : topology
                   return <li key={edge.id}>{`Edge: ${text}`}</li>
                 })}
               </ul>

--- a/web/src/pages/WorkflowEditorPage.tsx
+++ b/web/src/pages/WorkflowEditorPage.tsx
@@ -319,18 +319,45 @@ function WorkflowEditorInner() {
              * the canvas is the full-fidelity keyboard-accessible
              * alternative for editing.
              */}
-            <ul id="workflow-editor-node-summary" className="sr-only">
-              {nodes.map((node) => (
-                <li key={node.id}>
-                  {`Node ${node.id}: ${node.type ?? 'unknown'}`}
-                </li>
-              ))}
-              {edges.map((edge) => (
-                <li key={edge.id}>
-                  {`Edge: ${edge.source} → ${edge.target}`}
-                </li>
-              ))}
-            </ul>
+            <section
+              id="workflow-editor-node-summary"
+              aria-labelledby="workflow-editor-node-summary-heading"
+              className="sr-only"
+            >
+              <h2 id="workflow-editor-node-summary-heading">
+                Workflow graph summary
+              </h2>
+              <h3 id="workflow-editor-node-summary-nodes">
+                Nodes ({nodes.length})
+              </h3>
+              <ul aria-labelledby="workflow-editor-node-summary-nodes">
+                {nodes.map((node) => {
+                  const label =
+                    (node.data && typeof node.data === 'object' && 'label' in node.data
+                      ? String((node.data as { label?: unknown }).label ?? '')
+                      : '') ||
+                    node.type ||
+                    node.id
+                  return (
+                    <li key={node.id}>
+                      {`Node ${node.id} (${node.type ?? 'unknown'}): ${label}`}
+                    </li>
+                  )
+                })}
+              </ul>
+              <h3 id="workflow-editor-node-summary-edges">
+                Edges ({edges.length})
+              </h3>
+              <ul aria-labelledby="workflow-editor-node-summary-edges">
+                {edges.map((edge) => {
+                  const label =
+                    typeof edge.label === 'string' && edge.label
+                      ? edge.label
+                      : `${edge.source} → ${edge.target}`
+                  return <li key={edge.id}>{`Edge: ${label}`}</li>
+                })}
+              </ul>
+            </section>
             <ReactFlow
               aria-label="Workflow editor canvas"
               aria-describedby="workflow-editor-node-summary"

--- a/web/src/pages/WorkflowEditorPage.tsx
+++ b/web/src/pages/WorkflowEditorPage.tsx
@@ -311,8 +311,29 @@ function WorkflowEditorInner() {
       {editorMode === 'visual' ? (
         <>
           <div className="relative min-h-0 flex-1 rounded-lg border border-border">
+            {/*
+             * Accessible text summary of the graph. ReactFlow's visual
+             * canvas is mouse-first; screen-reader users get a
+             * sr-only outline of nodes and edges here, referenced via
+             * `aria-describedby` on the canvas. The YAML editor below
+             * the canvas is the full-fidelity keyboard-accessible
+             * alternative for editing.
+             */}
+            <ul id="workflow-editor-node-summary" className="sr-only">
+              {nodes.map((node) => (
+                <li key={node.id}>
+                  {`Node ${node.id}: ${node.type ?? 'unknown'}`}
+                </li>
+              ))}
+              {edges.map((edge) => (
+                <li key={edge.id}>
+                  {`Edge: ${edge.source} → ${edge.target}`}
+                </li>
+              ))}
+            </ul>
             <ReactFlow
               aria-label="Workflow editor canvas"
+              aria-describedby="workflow-editor-node-summary"
               nodes={nodes}
               edges={edges}
               nodeTypes={nodeTypes}

--- a/web/src/pages/agents/ActivityLog.tsx
+++ b/web/src/pages/agents/ActivityLog.tsx
@@ -36,10 +36,17 @@ export function ActivityLog({ events, total, onLoadMore, className }: ActivityLo
           description="Recent actions will appear here."
         />
       ) : (
-        <StaggerGroup className="divide-y divide-border">
+        <StaggerGroup
+          className="divide-y divide-border"
+          role="list"
+          aria-label="Agent activity log"
+        >
           {events.map((event, index) => (
-            // eslint-disable-next-line @eslint-react/no-array-index-key -- events lack unique IDs; type+timestamp may collide for same-second events
-            <StaggerItem key={`${event.event_type}-${event.timestamp}-${index}`}>
+            <StaggerItem
+              // eslint-disable-next-line @eslint-react/no-array-index-key -- events lack unique IDs; type+timestamp may collide for same-second events
+              key={`${event.event_type}-${event.timestamp}-${index}`}
+              role="listitem"
+            >
               <ActivityLogItem event={event} />
             </StaggerItem>
           ))}

--- a/web/src/pages/agents/QualityScoreOverride.tsx
+++ b/web/src/pages/agents/QualityScoreOverride.tsx
@@ -14,6 +14,7 @@ import {
   clearQualityOverride,
 } from '@/api/endpoints/quality'
 import { getErrorMessage } from '@/utils/errors'
+import { formatDateOnly } from '@/utils/format'
 import type { OverrideResponse } from '@/api/types'
 import type { AxiosError } from 'axios'
 
@@ -149,12 +150,12 @@ export function QualityScoreOverride({
             <StatPill label="Applied by" value={override.applied_by} />
             <StatPill
               label="Applied"
-              value={new Date(override.applied_at).toLocaleDateString()}
+              value={formatDateOnly(override.applied_at)}
             />
             {override.expires_at && (
               <StatPill
                 label="Expires"
-                value={new Date(override.expires_at).toLocaleDateString()}
+                value={formatDateOnly(override.expires_at)}
               />
             )}
           </div>

--- a/web/src/pages/agents/TrainingPanel.tsx
+++ b/web/src/pages/agents/TrainingPanel.tsx
@@ -27,6 +27,7 @@ import { cn } from '@/lib/utils'
 import { createLogger } from '@/lib/logger'
 import { sanitizeForLog } from '@/utils/logging'
 import type {
+  TrainingPlanRequest,
   TrainingPlanResponse,
   TrainingResultResponse,
 } from '@/api/endpoints/training'
@@ -49,19 +50,11 @@ interface CustomCap {
   cap: number
 }
 
-interface CreatePlanOverrides {
-  override_sources: string[]
-  content_types?: string[]
-  custom_caps?: Record<string, number>
-  skip_training: boolean
-  require_review: boolean
-}
-
 interface TrainingPanelProps {
   agentName: string
   plan?: TrainingPlanResponse | null
   result?: TrainingResultResponse | null
-  onCreatePlan?: (overrides: CreatePlanOverrides) => void
+  onCreatePlan?: (overrides: TrainingPlanRequest) => void
   onExecute?: () => void
   className?: string
 }

--- a/web/src/pages/agents/TrainingSection.tsx
+++ b/web/src/pages/agents/TrainingSection.tsx
@@ -19,7 +19,7 @@ export interface TrainingSectionProps {
  */
 export function TrainingSection({ agentName }: TrainingSectionProps) {
   const { plan, result } = useTrainingForAgent(agentName)
-  const fetchResult = useTrainingStore((s) => s.fetchResult)
+  const hydrateForAgent = useTrainingStore((s) => s.hydrateForAgent)
   const createPlan = useTrainingStore((s) => s.createPlan)
   const executePlan = useTrainingStore((s) => s.executePlan)
   const updateOverrides = useTrainingStore((s) => s.updateOverrides)
@@ -34,8 +34,10 @@ export function TrainingSection({ agentName }: TrainingSectionProps) {
 
   useEffect(() => {
     if (!agentName) return
-    void fetchResult(agentName)
-  }, [agentName, fetchResult])
+    // Hydrate both plan + result so a page refresh after executing
+    // does not drop back to the "Create Plan" form (issue #1394).
+    void hydrateForAgent(agentName)
+  }, [agentName, hydrateForAgent])
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
@@ -62,8 +64,12 @@ export function TrainingSection({ agentName }: TrainingSectionProps) {
     // Approve the current overrides unchanged (human review gate, no
     // edits). Overrides that are partial or edited are a future
     // enhancement -- this hook is the point where they would flow in.
-    await updateOverrides(agentName, plan.id, {})
-    setDismissedPlanId(plan.id)
+    const updated = await updateOverrides(agentName, plan.id, {})
+    // Keep the review modal open on failure so the user can retry;
+    // only dismiss when the API confirms the save.
+    if (updated !== null) {
+      setDismissedPlanId(plan.id)
+    }
   }, [agentName, plan, updateOverrides])
 
   // Map TrainingResultResponse.items_after_guards (tuple pairs) into the

--- a/web/src/pages/agents/TrainingSection.tsx
+++ b/web/src/pages/agents/TrainingSection.tsx
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { TrainingPanel } from '@/pages/agents/TrainingPanel'
+import { TrainingReviewModal } from '@/pages/agents/TrainingReviewModal'
+import {
+  useTrainingForAgent,
+  useTrainingStore,
+} from '@/stores/training'
+
+export interface TrainingSectionProps {
+  agentName: string
+}
+
+/**
+ * Host section for the per-agent training flow. Renders
+ * {@link TrainingPanel} for plan creation + execution, and surfaces
+ * {@link TrainingReviewModal} when the backend requires human review
+ * before storing extracted items.
+ */
+export function TrainingSection({ agentName }: TrainingSectionProps) {
+  const { plan, result } = useTrainingForAgent(agentName)
+  const fetchResult = useTrainingStore((s) => s.fetchResult)
+  const createPlan = useTrainingStore((s) => s.createPlan)
+  const executePlan = useTrainingStore((s) => s.executePlan)
+  const updateOverrides = useTrainingStore((s) => s.updateOverrides)
+
+  // Track whether the user has manually dismissed the review modal for
+  // the current plan. The modal is derived from `result.review_pending`
+  // minus dismissals, avoiding synchronous set-state inside an effect.
+  const [dismissedPlanId, setDismissedPlanId] = useState<string | null>(null)
+  const reviewOpen =
+    Boolean(result?.review_pending) &&
+    (plan?.id ?? null) !== dismissedPlanId
+
+  useEffect(() => {
+    if (!agentName) return
+    void fetchResult(agentName)
+  }, [agentName, fetchResult])
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open && plan) {
+        setDismissedPlanId(plan.id)
+      }
+    },
+    [plan],
+  )
+
+  const handleCreatePlan = useCallback(
+    (overrides: Parameters<typeof createPlan>[1]) => {
+      void createPlan(agentName, overrides)
+    },
+    [agentName, createPlan],
+  )
+
+  const handleExecute = useCallback(() => {
+    void executePlan(agentName)
+  }, [agentName, executePlan])
+
+  const handleApprove = useCallback(async () => {
+    if (!plan) return
+    // Approve the current overrides unchanged (human review gate, no
+    // edits). Overrides that are partial or edited are a future
+    // enhancement -- this hook is the point where they would flow in.
+    await updateOverrides(agentName, plan.id, {})
+    setDismissedPlanId(plan.id)
+  }, [agentName, plan, updateOverrides])
+
+  // Map TrainingResultResponse.items_after_guards (tuple pairs) into the
+  // row shape the modal consumes.
+  const reviewItems = useMemo(() => {
+    if (!result) return []
+    return result.items_after_guards.map(([contentType, itemCount]) => ({
+      content_type: contentType,
+      item_count: itemCount,
+      source_agents: result.source_agents_used,
+    }))
+  }, [result])
+
+  return (
+    <>
+      <TrainingPanel
+        agentName={agentName}
+        plan={plan}
+        result={result}
+        onCreatePlan={handleCreatePlan}
+        onExecute={handleExecute}
+      />
+      {plan && result?.approval_item_id && (
+        <TrainingReviewModal
+          open={reviewOpen}
+          planId={plan.id}
+          approvalId={result.approval_item_id}
+          items={reviewItems}
+          onApprove={handleApprove}
+          onOpenChange={handleOpenChange}
+        />
+      )}
+    </>
+  )
+}

--- a/web/src/pages/approvals/ApprovalCard.stories.tsx
+++ b/web/src/pages/approvals/ApprovalCard.stories.tsx
@@ -18,6 +18,7 @@ const base: ApprovalResponse = {
   created_at: '2026-03-27T10:00:00Z',
   decided_at: null,
   expires_at: '2026-03-27T14:00:00Z',
+  evidence_package: null,
   seconds_remaining: 7200,
   urgency_level: 'high',
 }

--- a/web/src/pages/approvals/ApprovalDetailDrawer.stories.tsx
+++ b/web/src/pages/approvals/ApprovalDetailDrawer.stories.tsx
@@ -18,6 +18,7 @@ const base: ApprovalResponse = {
   created_at: '2026-03-27T10:00:00Z',
   decided_at: null,
   expires_at: '2026-03-27T14:00:00Z',
+  evidence_package: null,
   seconds_remaining: 7200,
   urgency_level: 'high',
 }

--- a/web/src/pages/approvals/ApprovalTimeline.stories.tsx
+++ b/web/src/pages/approvals/ApprovalTimeline.stories.tsx
@@ -17,6 +17,7 @@ const base: ApprovalResponse = {
   created_at: '2026-03-27T10:00:00Z',
   decided_at: null,
   expires_at: '2026-03-27T14:00:00Z',
+  evidence_package: null,
   seconds_remaining: 14400,
   urgency_level: 'high',
 }

--- a/web/src/pages/budget/BudgetPage.stories.tsx
+++ b/web/src/pages/budget/BudgetPage.stories.tsx
@@ -54,13 +54,27 @@ const mockForecast: ForecastResponse = {
   currency: 'EUR',
 }
 
+function makeCostRecord(fields: Partial<CostRecord> & Pick<CostRecord, 'agent_id' | 'task_id' | 'provider' | 'model' | 'input_tokens' | 'output_tokens' | 'cost_usd' | 'timestamp' | 'call_category'>): CostRecord {
+  return {
+    project_id: null,
+    accuracy_effort_ratio: null,
+    latency_ms: null,
+    cache_hit: null,
+    retry_count: null,
+    retry_reason: null,
+    finish_reason: null,
+    success: null,
+    ...fields,
+  }
+}
+
 const mockCostRecords: CostRecord[] = [
-  { agent_id: 'a1', task_id: 't1', provider: 'prov-a', model: 'm1', input_tokens: 500, output_tokens: 200, cost_usd: 15, timestamp: '2026-03-25T10:00:00Z', call_category: 'productive' },
-  { agent_id: 'a1', task_id: 't2', provider: 'prov-a', model: 'm1', input_tokens: 300, output_tokens: 100, cost_usd: 8, timestamp: '2026-03-25T11:00:00Z', call_category: 'coordination' },
-  { agent_id: 'a2', task_id: 't3', provider: 'prov-b', model: 'm2', input_tokens: 800, output_tokens: 400, cost_usd: 12, timestamp: '2026-03-25T12:00:00Z', call_category: 'productive' },
-  { agent_id: 'a3', task_id: 't4', provider: 'prov-a', model: 'm1', input_tokens: 200, output_tokens: 100, cost_usd: 5, timestamp: '2026-03-25T13:00:00Z', call_category: 'system' },
-  { agent_id: 'a1', task_id: 't5', provider: 'prov-a', model: 'm1', input_tokens: 400, output_tokens: 0, cost_usd: 3.5, timestamp: '2026-03-25T14:00:00Z', call_category: 'embedding' },
-  { agent_id: 'a2', task_id: 't6', provider: 'prov-b', model: 'm2', input_tokens: 100, output_tokens: 50, cost_usd: 2.17, timestamp: '2026-03-25T15:00:00Z', call_category: null },
+  makeCostRecord({ agent_id: 'a1', task_id: 't1', provider: 'prov-a', model: 'm1', input_tokens: 500, output_tokens: 200, cost_usd: 15, timestamp: '2026-03-25T10:00:00Z', call_category: 'productive' }),
+  makeCostRecord({ agent_id: 'a1', task_id: 't2', provider: 'prov-a', model: 'm1', input_tokens: 300, output_tokens: 100, cost_usd: 8, timestamp: '2026-03-25T11:00:00Z', call_category: 'coordination' }),
+  makeCostRecord({ agent_id: 'a2', task_id: 't3', provider: 'prov-b', model: 'm2', input_tokens: 800, output_tokens: 400, cost_usd: 12, timestamp: '2026-03-25T12:00:00Z', call_category: 'productive' }),
+  makeCostRecord({ agent_id: 'a3', task_id: 't4', provider: 'prov-a', model: 'm1', input_tokens: 200, output_tokens: 100, cost_usd: 5, timestamp: '2026-03-25T13:00:00Z', call_category: 'system' }),
+  makeCostRecord({ agent_id: 'a1', task_id: 't5', provider: 'prov-a', model: 'm1', input_tokens: 400, output_tokens: 0, cost_usd: 3.5, timestamp: '2026-03-25T14:00:00Z', call_category: 'embedding' }),
+  makeCostRecord({ agent_id: 'a2', task_id: 't6', provider: 'prov-b', model: 'm2', input_tokens: 100, output_tokens: 50, cost_usd: 2.17, timestamp: '2026-03-25T15:00:00Z', call_category: null }),
 ]
 
 function setStoreState(overrides: Record<string, unknown> = {}) {

--- a/web/src/pages/budget/SpendBurnChart.tsx
+++ b/web/src/pages/budget/SpendBurnChart.tsx
@@ -12,7 +12,11 @@ import { TrendingUp } from 'lucide-react'
 import { SectionCard } from '@/components/ui/section-card'
 import { StatPill } from '@/components/ui/stat-pill'
 import { EmptyState } from '@/components/ui/empty-state'
-import { formatCurrency } from '@/utils/format'
+import {
+  formatCurrency,
+  formatDayLabel as formatDayLabelHelper,
+  formatTodayLabel,
+} from '@/utils/format'
 import type { BudgetAlertConfig, ForecastResponse, TrendDataPoint } from '@/api/types'
 
 export interface SpendBurnChartProps {
@@ -43,11 +47,11 @@ function parseChartDate(dateStr: string): Date {
 function formatDayLabel(dateStr: string): string {
   const date = parseChartDate(dateStr)
   if (Number.isNaN(date.getTime())) return dateStr
-  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  return formatDayLabelHelper(date)
 }
 
 function getTodayLabel(): string {
-  return new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  return formatTodayLabel()
 }
 
 function buildChartData(

--- a/web/src/pages/dashboard/BudgetBurnChart.tsx
+++ b/web/src/pages/dashboard/BudgetBurnChart.tsx
@@ -12,7 +12,12 @@ import { DollarSign } from 'lucide-react'
 import { SectionCard } from '@/components/ui/section-card'
 import { StatPill } from '@/components/ui/stat-pill'
 import { EmptyState } from '@/components/ui/empty-state'
-import { formatCurrency, formatCurrencyCompact } from '@/utils/format'
+import {
+  formatCurrency,
+  formatCurrencyCompact,
+  formatDayLabel as formatDayLabelHelper,
+  formatTodayLabel,
+} from '@/utils/format'
 import type { ForecastResponse, TrendDataPoint } from '@/api/types'
 
 interface BudgetBurnChartProps {
@@ -68,11 +73,11 @@ function parseChartDate(dateStr: string): Date {
 function formatDayLabel(dateStr: string): string {
   const date = parseChartDate(dateStr)
   if (Number.isNaN(date.getTime())) return dateStr
-  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  return formatDayLabelHelper(date)
 }
 
 function getTodayLabel(): string {
-  return new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  return formatTodayLabel()
 }
 
 function ChartTooltipContent({ active, payload, label, currency }: {

--- a/web/src/pages/fine-tuning/CheckpointTable.tsx
+++ b/web/src/pages/fine-tuning/CheckpointTable.tsx
@@ -7,6 +7,7 @@ import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { EmptyState } from '@/components/ui/empty-state'
 import { StatusBadge } from '@/components/ui/status-badge'
 import { useFineTuningStore } from '@/stores/fine-tuning'
+import { formatDateOnly } from '@/utils/format'
 
 interface CheckpointRowProps {
   checkpoint: CheckpointRecord
@@ -19,7 +20,7 @@ function CheckpointRow({ checkpoint: cp, onDeploy, onRollback, onDelete }: Check
   return (
     <tr className="border-b border-border/50">
       <td className="py-2 pr-4 font-mono text-xs">
-        {new Date(cp.created_at).toLocaleDateString()}
+        {formatDateOnly(cp.created_at)}
       </td>
       <td className="py-2 pr-4">{cp.base_model}</td>
       <td className="py-2 pr-4">{cp.doc_count}</td>

--- a/web/src/pages/fine-tuning/RunHistoryTable.tsx
+++ b/web/src/pages/fine-tuning/RunHistoryTable.tsx
@@ -5,6 +5,7 @@ import { ACTIVE_STAGES } from '@/api/endpoints/fine-tuning'
 import { EmptyState } from '@/components/ui/empty-state'
 import { StatusBadge } from '@/components/ui/status-badge'
 import { useFineTuningStore } from '@/stores/fine-tuning'
+import { formatDateTime } from '@/utils/format'
 
 const STAGE_STATUS_MAP: Record<FineTuneStage, 'active' | 'idle' | 'error' | 'offline'> = {
   complete: 'active',
@@ -21,7 +22,7 @@ function RunRow({ run }: { run: FineTuneRun }) {
   return (
     <tr className="border-b border-border/50">
       <td className="py-2 pr-4 font-mono text-xs">
-        {new Date(run.started_at).toLocaleString()}
+        {formatDateTime(run.started_at)}
       </td>
       <td className="py-2 pr-4 font-mono text-xs">
         {run.duration_seconds != null

--- a/web/src/pages/meetings/ContributionBubble.tsx
+++ b/web/src/pages/meetings/ContributionBubble.tsx
@@ -1,6 +1,6 @@
 import { Avatar } from '@/components/ui/avatar'
 import { cn } from '@/lib/utils'
-import { formatLabel } from '@/utils/format'
+import { formatLabel, formatTokenCount } from '@/utils/format'
 import { getPhaseColor, getPhaseLabel, STATUS_BADGE_CLASSES } from '@/utils/meetings'
 import type { MeetingContribution } from '@/api/types'
 
@@ -42,8 +42,8 @@ export function ContributionBubble({ contribution, className }: ContributionBubb
 
         {/* Token stats */}
         <div className="flex gap-3 font-mono text-micro text-muted-foreground">
-          <span>{contribution.input_tokens.toLocaleString()} in</span>
-          <span>{contribution.output_tokens.toLocaleString()} out</span>
+          <span>{formatTokenCount(contribution.input_tokens)} in</span>
+          <span>{formatTokenCount(contribution.output_tokens)} out</span>
         </div>
       </div>
     </div>

--- a/web/src/pages/meetings/MeetingCard.tsx
+++ b/web/src/pages/meetings/MeetingCard.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router'
 import { Clock, Users } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { formatLabel, formatRelativeTime } from '@/utils/format'
+import { formatLabel, formatRelativeTime, formatTokenCount } from '@/utils/format'
 import {
   formatMeetingDuration,
   getMeetingStatusColor,
@@ -67,7 +67,7 @@ export function MeetingCard({ meeting, className }: MeetingCardProps) {
         </span>
         {meeting.minutes && (
           <span className="font-mono">
-            {meeting.minutes.total_tokens.toLocaleString()} tokens
+            {formatTokenCount(meeting.minutes.total_tokens)} tokens
           </span>
         )}
       </div>

--- a/web/src/pages/meetings/MeetingDetailHeader.tsx
+++ b/web/src/pages/meetings/MeetingDetailHeader.tsx
@@ -3,7 +3,7 @@ import { ArrowLeft, Clock, Hash } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { StatPill } from '@/components/ui/stat-pill'
-import { formatDate, formatLabel } from '@/utils/format'
+import { formatDate, formatLabel, formatTokenCount } from '@/utils/format'
 import {
   formatMeetingDuration,
   getMeetingStatusColor,
@@ -63,9 +63,9 @@ export function MeetingDetailHeader({ meeting, className }: MeetingDetailHeaderP
         />
         <StatPill label="Participants" value={participantCount} />
         {meeting.minutes && (
-          <StatPill label="Tokens" value={meeting.minutes.total_tokens.toLocaleString()} />
+          <StatPill label="Tokens" value={formatTokenCount(meeting.minutes.total_tokens)} />
         )}
-        <StatPill label="Budget" value={meeting.token_budget.toLocaleString()} />
+        <StatPill label="Budget" value={formatTokenCount(meeting.token_budget)} />
       </div>
 
       {/* Timestamps */}

--- a/web/src/pages/meetings/MeetingMetricCards.tsx
+++ b/web/src/pages/meetings/MeetingMetricCards.tsx
@@ -1,6 +1,7 @@
 import { MetricCard } from '@/components/ui/metric-card'
 import { StaggerGroup, StaggerItem } from '@/components/ui/stagger-group'
 import { cn } from '@/lib/utils'
+import { formatTokenCount } from '@/utils/format'
 import { countByStatus, totalTokensUsed } from '@/utils/meetings'
 import type { MeetingResponse } from '@/api/types'
 
@@ -27,7 +28,7 @@ export function MeetingMetricCards({ meetings, className }: MeetingMetricCardsPr
         <MetricCard label="COMPLETED" value={completed} />
       </StaggerItem>
       <StaggerItem>
-        <MetricCard label="TOTAL TOKENS" value={tokens.toLocaleString()} />
+        <MetricCard label="TOTAL TOKENS" value={formatTokenCount(tokens)} />
       </StaggerItem>
     </StaggerGroup>
   )

--- a/web/src/pages/meetings/MeetingTokenBreakdown.tsx
+++ b/web/src/pages/meetings/MeetingTokenBreakdown.tsx
@@ -2,7 +2,7 @@ import { BarChart3 } from 'lucide-react'
 import { Avatar } from '@/components/ui/avatar'
 import { SectionCard } from '@/components/ui/section-card'
 import { TokenUsageBar } from '@/components/ui/token-usage-bar'
-import { formatLabel } from '@/utils/format'
+import { formatLabel, formatTokenCount } from '@/utils/format'
 import { computeTokenUsagePercent, getParticipantTokenShare } from '@/utils/meetings'
 import type { MeetingResponse } from '@/api/types'
 
@@ -37,7 +37,7 @@ function ParticipantTokenRow({ agentId, tokens, share, rankLabel }: ParticipantT
             )}
           </div>
           <span className="shrink-0 font-mono text-xs text-muted-foreground">
-            {tokens.toLocaleString()}
+            {formatTokenCount(tokens)}
           </span>
         </div>
         <div className="mt-1 h-1 w-full overflow-hidden rounded-full bg-border">
@@ -69,7 +69,7 @@ export function MeetingTokenBreakdown({ meeting, className }: MeetingTokenBreakd
         <div className="space-y-1">
           <div className="flex items-baseline justify-between">
             <span className="text-xs text-muted-foreground">
-              {totalTokens.toLocaleString()} / {meeting.token_budget.toLocaleString()} tokens
+              {formatTokenCount(totalTokens)} / {formatTokenCount(meeting.token_budget)} tokens
             </span>
             <span className="font-mono text-xs font-semibold text-foreground">
               {overallPercent.toFixed(0)}%

--- a/web/src/pages/messages/MessageDetailDrawer.tsx
+++ b/web/src/pages/messages/MessageDetailDrawer.tsx
@@ -1,6 +1,6 @@
 import { Drawer } from '@/components/ui/drawer'
 import { Avatar } from '@/components/ui/avatar'
-import { COST_USD_CURRENCY } from '@/utils/currencies'
+import { DEFAULT_CURRENCY } from '@/utils/currencies'
 import { formatDate, formatCurrency } from '@/utils/format'
 import { MessageTypeBadge } from './MessageTypeBadge'
 import { AttachmentList } from './AttachmentList'
@@ -76,7 +76,7 @@ function MessageDetailContent({ message }: MessageDetailContentProps) {
             <MetadataRow label="Tokens" value={String(message.metadata.tokens_used)} mono />
           )}
           {message.metadata.cost_usd !== null && (
-            <MetadataRow label="Cost" value={formatCurrency(message.metadata.cost_usd, COST_USD_CURRENCY)} mono />
+            <MetadataRow label="Cost" value={formatCurrency(message.metadata.cost_usd, DEFAULT_CURRENCY)} mono />
           )}
           {message.metadata.extra.map(([key, value], i) => (
             <MetadataRow

--- a/web/src/pages/messages/MessageDetailDrawer.tsx
+++ b/web/src/pages/messages/MessageDetailDrawer.tsx
@@ -1,5 +1,6 @@
 import { Drawer } from '@/components/ui/drawer'
 import { Avatar } from '@/components/ui/avatar'
+import { COST_USD_CURRENCY } from '@/utils/currencies'
 import { formatDate, formatCurrency } from '@/utils/format'
 import { MessageTypeBadge } from './MessageTypeBadge'
 import { AttachmentList } from './AttachmentList'
@@ -75,7 +76,7 @@ function MessageDetailContent({ message }: MessageDetailContentProps) {
             <MetadataRow label="Tokens" value={String(message.metadata.tokens_used)} mono />
           )}
           {message.metadata.cost_usd !== null && (
-            <MetadataRow label="Cost" value={formatCurrency(message.metadata.cost_usd, 'USD')} mono />
+            <MetadataRow label="Cost" value={formatCurrency(message.metadata.cost_usd, COST_USD_CURRENCY)} mono />
           )}
           {message.metadata.extra.map(([key, value], i) => (
             <MetadataRow

--- a/web/src/pages/org-edit/AgentEditDrawer.tsx
+++ b/web/src/pages/org-edit/AgentEditDrawer.tsx
@@ -9,6 +9,7 @@ import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Button } from '@/components/ui/button'
 import { StatusBadge } from '@/components/ui/status-badge'
 import { getErrorMessage } from '@/utils/errors'
+import { formatDateOnly } from '@/utils/format'
 import { toRuntimeStatus } from '@/utils/agents'
 
 export interface AgentEditDrawerProps {
@@ -63,7 +64,7 @@ export function AgentEditDrawer({
     [departments],
   )
   const hiredDate = useMemo(
-    () => agent?.hiring_date ? new Date(agent.hiring_date).toLocaleDateString() : '',
+    () => agent?.hiring_date ? formatDateOnly(agent.hiring_date) : '',
     [agent],
   )
   const modelDisplay = useMemo(() => {

--- a/web/src/pages/org/AgentNode.tsx
+++ b/web/src/pages/org/AgentNode.tsx
@@ -51,7 +51,13 @@ function AgentNodeComponent({ data }: NodeProps<AgentNodeType>) {
       data-testid="agent-node"
       aria-label={`Agent: ${data.name}, ${data.role}, ${data.runtimeStatus}${data.isDeptLead ? ', department lead' : ''}`}
     >
-      <Handle type="target" position={Position.Top} className={HANDLE_CLASSES} />
+      <Handle
+        type="target"
+        position={Position.Top}
+        className={HANDLE_CLASSES}
+        isConnectable={false}
+        aria-hidden="true"
+      />
 
       {/* LEAD badge on the highest-seniority agent in the dept --
           derived from build-org-tree's `isDeptLead` flag.  Hidden
@@ -75,6 +81,7 @@ function AgentNodeComponent({ data }: NodeProps<AgentNodeType>) {
             <StatusBadge
               status={data.runtimeStatus}
               pulse={isActive || data.runtimeStatus === 'error'}
+              decorative
             />
           </div>
           <span className="block truncate font-sans text-micro text-muted-foreground">
@@ -83,7 +90,13 @@ function AgentNodeComponent({ data }: NodeProps<AgentNodeType>) {
         </div>
       </div>
 
-      <Handle type="source" position={Position.Bottom} className={HANDLE_CLASSES} />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className={HANDLE_CLASSES}
+        isConnectable={false}
+        aria-hidden="true"
+      />
     </div>
   )
 }

--- a/web/src/pages/org/OrgChartToolbar.tsx
+++ b/web/src/pages/org/OrgChartToolbar.tsx
@@ -97,6 +97,9 @@ export function OrgChartToolbar({
 
   return (
     <div
+      role="toolbar"
+      aria-label="Org chart controls"
+      aria-orientation="horizontal"
       className={cn(
         'flex flex-wrap items-center gap-1 rounded-lg border border-border bg-card p-1',
         className,

--- a/web/src/pages/org/OrgChartToolbar.tsx
+++ b/web/src/pages/org/OrgChartToolbar.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { SegmentedControl, type SegmentedControlOption } from '@/components/ui/segmented-control'
+import { useToolbarKeyboardNav } from '@/hooks/useToolbarKeyboardNav'
 import { cn } from '@/lib/utils'
 import {
   useOrgChartPrefs,
@@ -94,9 +95,13 @@ export function OrgChartToolbar({
   const setShowStatusDots = useOrgChartPrefs((s) => s.setShowStatusDots)
   const showMinimap = useOrgChartPrefs((s) => s.showMinimap)
   const setShowMinimap = useOrgChartPrefs((s) => s.setShowMinimap)
+  const { ref: toolbarRef, onKeyDown } =
+    useToolbarKeyboardNav<HTMLDivElement>()
 
   return (
     <div
+      ref={toolbarRef}
+      onKeyDown={onKeyDown}
       role="toolbar"
       aria-label="Org chart controls"
       aria-orientation="horizontal"

--- a/web/src/pages/providers/ProviderHealthMetrics.tsx
+++ b/web/src/pages/providers/ProviderHealthMetrics.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { MetricCard } from '@/components/ui/metric-card'
+import { formatDateTime, formatNumber } from '@/utils/format'
 import { formatLatency, formatErrorRate, formatTokenCount, formatCost } from '@/utils/providers'
 import type { ProviderHealthSummary } from '@/api/types'
 
@@ -9,9 +10,7 @@ interface ProviderHealthMetricsProps {
 
 export function ProviderHealthMetrics({ health }: ProviderHealthMetricsProps) {
   const lastCheck = useMemo(
-    () => health.last_check_timestamp
-      ? new Date(health.last_check_timestamp).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
-      : '--',
+    () => formatDateTime(health.last_check_timestamp),
     [health.last_check_timestamp],
   )
 
@@ -19,7 +18,7 @@ export function ProviderHealthMetrics({ health }: ProviderHealthMetricsProps) {
     <div className="grid grid-cols-6 gap-grid-gap max-[1279px]:grid-cols-3 max-[767px]:grid-cols-2">
       <MetricCard
         label="Calls (24h)"
-        value={health.calls_last_24h.toLocaleString()}
+        value={formatNumber(health.calls_last_24h)}
       />
       <MetricCard
         label="Tokens (24h)"

--- a/web/src/pages/tasks/TaskCard.tsx
+++ b/web/src/pages/tasks/TaskCard.tsx
@@ -5,6 +5,7 @@ import { Avatar } from '@/components/ui/avatar'
 import { TaskStatusIndicator } from '@/components/ui/task-status-indicator'
 import { PriorityBadge } from '@/components/ui/task-status-indicator'
 import { useFlash } from '@/hooks/useFlash'
+import { DEFAULT_CURRENCY } from '@/utils/currencies'
 import { formatRelativeTime, formatCurrency } from '@/utils/format'
 import type { Task } from '@/api/types'
 
@@ -87,7 +88,7 @@ export function TaskCard({ task, onSelect, isDragging, isOverlay, className, ref
 
           {task.cost_usd != null && task.cost_usd > 0 && (
             <span className="text-[10px] font-mono">
-              {formatCurrency(task.cost_usd, 'USD')}
+              {formatCurrency(task.cost_usd, DEFAULT_CURRENCY)}
             </span>
           )}
 

--- a/web/src/pages/tasks/TaskCard.tsx
+++ b/web/src/pages/tasks/TaskCard.tsx
@@ -5,9 +5,16 @@ import { Avatar } from '@/components/ui/avatar'
 import { TaskStatusIndicator } from '@/components/ui/task-status-indicator'
 import { PriorityBadge } from '@/components/ui/task-status-indicator'
 import { useFlash } from '@/hooks/useFlash'
-import { DEFAULT_CURRENCY } from '@/utils/currencies'
 import { formatRelativeTime, formatCurrency } from '@/utils/format'
 import type { Task } from '@/api/types'
+
+// ``Task.cost_usd`` is intrinsically USD-denominated on the backend
+// (see ``synthorg.budget.cost_record.CostRecord.cost_usd``). Format
+// it with its native currency code rather than ``DEFAULT_CURRENCY``
+// so the symbol matches the value. Converting to another currency
+// would require an up-to-date FX rate which the dashboard does not
+// currently carry.
+const COST_USD_CURRENCY_CODE = 'USD'
 
 export interface TaskCardProps {
   task: Task
@@ -88,7 +95,7 @@ export function TaskCard({ task, onSelect, isDragging, isOverlay, className, ref
 
           {task.cost_usd != null && task.cost_usd > 0 && (
             <span className="text-[10px] font-mono">
-              {formatCurrency(task.cost_usd, DEFAULT_CURRENCY)}
+              {formatCurrency(task.cost_usd, COST_USD_CURRENCY_CODE)}
             </span>
           )}
 

--- a/web/src/pages/tasks/TaskCard.tsx
+++ b/web/src/pages/tasks/TaskCard.tsx
@@ -35,7 +35,7 @@ export function TaskCard({ task, onSelect, isDragging, isOverlay, className, ref
       tabIndex={0}
       aria-label={`Task: ${task.title}`}
       aria-roledescription="draggable task"
-      aria-pressed={isDragging}
+      data-dragging={isDragging ? 'true' : undefined}
       onClick={() => onSelect(task.id)}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
@@ -46,7 +46,7 @@ export function TaskCard({ task, onSelect, isDragging, isOverlay, className, ref
       style={flashStyle}
       className={cn(
         'cursor-pointer rounded-lg border border-border bg-card p-card transition-colors',
-        'hover:border-border-bright hover:bg-card-hover hover:-translate-y-px hover:shadow-[0_4px_24px_var(--so-accent-8)]',
+        'hover:border-border-bright hover:bg-card-hover hover:-translate-y-px hover:shadow-[var(--so-shadow-card-hover)]',
         FOCUS_RING,
         isDragging && 'scale-[1.02] opacity-50 shadow-lg',
         isOverlay && 'scale-[1.02] shadow-lg border-accent/50',

--- a/web/src/pages/tasks/TaskCard.tsx
+++ b/web/src/pages/tasks/TaskCard.tsx
@@ -34,6 +34,8 @@ export function TaskCard({ task, onSelect, isDragging, isOverlay, className, ref
       role="button"
       tabIndex={0}
       aria-label={`Task: ${task.title}`}
+      aria-roledescription="draggable task"
+      aria-pressed={isDragging}
       onClick={() => onSelect(task.id)}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {

--- a/web/src/pages/tasks/TaskCard.tsx
+++ b/web/src/pages/tasks/TaskCard.tsx
@@ -5,7 +5,7 @@ import { Avatar } from '@/components/ui/avatar'
 import { TaskStatusIndicator } from '@/components/ui/task-status-indicator'
 import { PriorityBadge } from '@/components/ui/task-status-indicator'
 import { useFlash } from '@/hooks/useFlash'
-import { COST_USD_CURRENCY } from '@/utils/currencies'
+import { DEFAULT_CURRENCY } from '@/utils/currencies'
 import { formatRelativeTime, formatCurrency } from '@/utils/format'
 import type { Task } from '@/api/types'
 
@@ -90,7 +90,7 @@ export function TaskCard({ task, onSelect, isDragging, isOverlay, className, ref
 
           {task.cost_usd != null && task.cost_usd > 0 && (
             <span className="text-[10px] font-mono">
-              {formatCurrency(task.cost_usd, COST_USD_CURRENCY)}
+              {formatCurrency(task.cost_usd, DEFAULT_CURRENCY)}
             </span>
           )}
 

--- a/web/src/pages/tasks/TaskCard.tsx
+++ b/web/src/pages/tasks/TaskCard.tsx
@@ -5,16 +5,9 @@ import { Avatar } from '@/components/ui/avatar'
 import { TaskStatusIndicator } from '@/components/ui/task-status-indicator'
 import { PriorityBadge } from '@/components/ui/task-status-indicator'
 import { useFlash } from '@/hooks/useFlash'
+import { COST_USD_CURRENCY } from '@/utils/currencies'
 import { formatRelativeTime, formatCurrency } from '@/utils/format'
 import type { Task } from '@/api/types'
-
-// ``Task.cost_usd`` is intrinsically USD-denominated on the backend
-// (see ``synthorg.budget.cost_record.CostRecord.cost_usd``). Format
-// it with its native currency code rather than ``DEFAULT_CURRENCY``
-// so the symbol matches the value. Converting to another currency
-// would require an up-to-date FX rate which the dashboard does not
-// currently carry.
-const COST_USD_CURRENCY_CODE = 'USD'
 
 export interface TaskCardProps {
   task: Task
@@ -56,8 +49,10 @@ export function TaskCard({ task, onSelect, isDragging, isOverlay, className, ref
         'cursor-pointer rounded-lg border border-border bg-card p-card transition-colors',
         'hover:border-border-bright hover:bg-card-hover hover:-translate-y-px hover:shadow-[var(--so-shadow-card-hover)]',
         FOCUS_RING,
-        isDragging && 'scale-[1.02] opacity-50 shadow-lg',
-        isOverlay && 'scale-[1.02] shadow-lg border-accent/50',
+        // Elevated shadow while drag/overlay is active -- same token the
+        // hover state uses, keeps shadow weight consistent across states.
+        isDragging && 'scale-[1.02] opacity-50 shadow-[var(--so-shadow-card-hover)]',
+        isOverlay && 'scale-[1.02] shadow-[var(--so-shadow-card-hover)] border-accent/50',
         className,
       )}
       {...props}
@@ -95,7 +90,7 @@ export function TaskCard({ task, onSelect, isDragging, isOverlay, className, ref
 
           {task.cost_usd != null && task.cost_usd > 0 && (
             <span className="text-[10px] font-mono">
-              {formatCurrency(task.cost_usd, COST_USD_CURRENCY_CODE)}
+              {formatCurrency(task.cost_usd, COST_USD_CURRENCY)}
             </span>
           )}
 

--- a/web/src/pages/tasks/TaskColumn.tsx
+++ b/web/src/pages/tasks/TaskColumn.tsx
@@ -54,17 +54,27 @@ export function TaskColumn({ column, tasks, onSelectTask }: TaskColumnProps) {
   const taskIds = tasks.map((t) => t.id)
 
   return (
-    <div
+    <section
       className="flex w-72 shrink-0 flex-col"
       data-column-id={column.id}
+      aria-labelledby={`task-column-${column.id}-label`}
     >
       {/* Column header */}
       <div className="mb-3 flex items-center gap-2 px-1">
-        <span className={cn('size-2 rounded-full', COLOR_CLASSES[column.color])} />
-        <span className="text-[13px] font-semibold text-foreground">
+        <span
+          className={cn('size-2 rounded-full', COLOR_CLASSES[column.color])}
+          aria-hidden="true"
+        />
+        <span
+          id={`task-column-${column.id}-label`}
+          className="text-[13px] font-semibold text-foreground"
+        >
           {column.label}
         </span>
-        <span className="rounded-full bg-surface px-1.5 py-0.5 text-[10px] font-mono text-text-muted">
+        <span
+          className="rounded-full bg-surface px-1.5 py-0.5 text-[10px] font-mono text-text-muted"
+          aria-label={`${tasks.length} task${tasks.length === 1 ? '' : 's'}`}
+        >
           {tasks.length}
         </span>
       </div>
@@ -96,6 +106,6 @@ export function TaskColumn({ column, tasks, onSelectTask }: TaskColumnProps) {
           )}
         </SortableContext>
       </div>
-    </div>
+    </section>
   )
 }

--- a/web/src/pages/tasks/TaskDetailPanel.tsx
+++ b/web/src/pages/tasks/TaskDetailPanel.tsx
@@ -10,6 +10,7 @@ import { PriorityBadge } from '@/components/ui/task-status-indicator'
 import { Avatar } from '@/components/ui/avatar'
 import { springDefault, overlayBackdrop, tweenExitFast } from '@/lib/motion'
 import { getTaskStatusLabel, getTaskTypeLabel, getAvailableTransitions, getPriorityLabel } from '@/utils/tasks'
+import { COST_USD_CURRENCY } from '@/utils/currencies'
 import { formatDate, formatCurrency } from '@/utils/format'
 import { useToastStore } from '@/stores/toast'
 import { getErrorMessage } from '@/utils/errors'
@@ -228,7 +229,7 @@ export function TaskDetailPanel({
                   <MetaField icon={Calendar} label="Deadline" value={formatDate(task.deadline)} />
                 )}
                 {task.cost_usd != null && (
-                  <MetaField icon={Tag} label="Cost" value={formatCurrency(task.cost_usd, 'USD')} />
+                  <MetaField icon={Tag} label="Cost" value={formatCurrency(task.cost_usd, COST_USD_CURRENCY)} />
                 )}
               </div>
 

--- a/web/src/pages/tasks/TaskDetailPanel.tsx
+++ b/web/src/pages/tasks/TaskDetailPanel.tsx
@@ -10,7 +10,7 @@ import { PriorityBadge } from '@/components/ui/task-status-indicator'
 import { Avatar } from '@/components/ui/avatar'
 import { springDefault, overlayBackdrop, tweenExitFast } from '@/lib/motion'
 import { getTaskStatusLabel, getTaskTypeLabel, getAvailableTransitions, getPriorityLabel } from '@/utils/tasks'
-import { COST_USD_CURRENCY } from '@/utils/currencies'
+import { DEFAULT_CURRENCY } from '@/utils/currencies'
 import { formatDate, formatCurrency } from '@/utils/format'
 import { useToastStore } from '@/stores/toast'
 import { getErrorMessage } from '@/utils/errors'
@@ -229,7 +229,7 @@ export function TaskDetailPanel({
                   <MetaField icon={Calendar} label="Deadline" value={formatDate(task.deadline)} />
                 )}
                 {task.cost_usd != null && (
-                  <MetaField icon={Tag} label="Cost" value={formatCurrency(task.cost_usd, COST_USD_CURRENCY)} />
+                  <MetaField icon={Tag} label="Cost" value={formatCurrency(task.cost_usd, DEFAULT_CURRENCY)} />
                 )}
               </div>
 

--- a/web/src/pages/tasks/TaskListView.tsx
+++ b/web/src/pages/tasks/TaskListView.tsx
@@ -6,7 +6,7 @@ import { PriorityBadge } from '@/components/ui/task-status-indicator'
 import { StaggerGroup, StaggerItem } from '@/components/ui/stagger-group'
 import { EmptyState } from '@/components/ui/empty-state'
 import { getTaskTypeLabel } from '@/utils/tasks'
-import { COST_USD_CURRENCY } from '@/utils/currencies'
+import { DEFAULT_CURRENCY } from '@/utils/currencies'
 import { formatRelativeTime, formatCurrency } from '@/utils/format'
 import { ArrowDown, ArrowUp, Inbox } from 'lucide-react'
 import type { Task } from '@/api/types'
@@ -152,7 +152,7 @@ function TaskListRow({ task, onSelectTask }: { task: Task; onSelectTask: (taskId
         {task.deadline ? formatRelativeTime(task.deadline) : '--'}
       </span>
       <span className="w-20 text-right font-mono text-[10px] text-text-muted">
-        {task.cost_usd != null ? formatCurrency(task.cost_usd, COST_USD_CURRENCY) : '--'}
+        {task.cost_usd != null ? formatCurrency(task.cost_usd, DEFAULT_CURRENCY) : '--'}
       </span>
     </div>
   )

--- a/web/src/pages/tasks/TaskListView.tsx
+++ b/web/src/pages/tasks/TaskListView.tsx
@@ -6,6 +6,7 @@ import { PriorityBadge } from '@/components/ui/task-status-indicator'
 import { StaggerGroup, StaggerItem } from '@/components/ui/stagger-group'
 import { EmptyState } from '@/components/ui/empty-state'
 import { getTaskTypeLabel } from '@/utils/tasks'
+import { COST_USD_CURRENCY } from '@/utils/currencies'
 import { formatRelativeTime, formatCurrency } from '@/utils/format'
 import { ArrowDown, ArrowUp, Inbox } from 'lucide-react'
 import type { Task } from '@/api/types'
@@ -151,7 +152,7 @@ function TaskListRow({ task, onSelectTask }: { task: Task; onSelectTask: (taskId
         {task.deadline ? formatRelativeTime(task.deadline) : '--'}
       </span>
       <span className="w-20 text-right font-mono text-[10px] text-text-muted">
-        {task.cost_usd != null ? formatCurrency(task.cost_usd, 'USD') : '--'}
+        {task.cost_usd != null ? formatCurrency(task.cost_usd, COST_USD_CURRENCY) : '--'}
       </span>
     </div>
   )

--- a/web/src/pages/training/TrainingPlanTable.tsx
+++ b/web/src/pages/training/TrainingPlanTable.tsx
@@ -40,6 +40,60 @@ function statusDot(plan: TrainingPlanResponse | null): AgentRuntimeStatus {
   }
 }
 
+interface TrainingPlanTableRowProps {
+  row: TrainingPlanRow
+  onExecute: (agentName: string) => void
+}
+
+function TrainingPlanTableRow({ row, onExecute }: TrainingPlanTableRowProps) {
+  return (
+    <tr className="border-b border-border/50">
+      <td className="p-card">
+        <Link
+          to={`/agents/${encodeURIComponent(row.agentName)}`}
+          className="font-medium text-foreground hover:text-accent"
+        >
+          {row.agentName}
+        </Link>
+      </td>
+      <td className="p-card">
+        <span className="inline-flex items-center gap-1.5">
+          <StatusBadge status={statusDot(row.plan)} decorative />
+          <span className="text-xs text-muted-foreground">
+            {row.plan?.status ?? 'no plan'}
+          </span>
+        </span>
+      </td>
+      <td className="p-card text-right font-mono text-xs">
+        {row.result ? formatNumber(row.result.source_agents_used.length) : '--'}
+      </td>
+      <td className="p-card text-right font-mono text-xs">
+        {row.result ? formatNumber(sumStored(row.result)) : '--'}
+      </td>
+      <td className="p-card text-xs text-muted-foreground">
+        {row.plan ? formatDateTime(row.plan.created_at) : '--'}
+      </td>
+      <td className="p-card text-right">
+        {row.plan?.status === 'pending' ? (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => onExecute(row.agentName)}
+          >
+            Execute
+          </Button>
+        ) : (
+          <Button asChild size="sm" variant="ghost">
+            <Link to={`/agents/${encodeURIComponent(row.agentName)}`}>
+              Open
+            </Link>
+          </Button>
+        )}
+      </td>
+    </tr>
+  )
+}
+
 export function TrainingPlanTable({ rows, onExecute }: TrainingPlanTableProps) {
   const navigate = useNavigate()
 
@@ -62,60 +116,21 @@ export function TrainingPlanTable({ rows, onExecute }: TrainingPlanTableProps) {
       <table className="w-full text-sm" role="table">
         <thead>
           <tr className="border-b border-border bg-muted/50">
-            <th className="px-4 py-2 text-left font-medium text-muted-foreground">Agent</th>
-            <th className="px-4 py-2 text-left font-medium text-muted-foreground">Status</th>
-            <th className="px-4 py-2 text-right font-medium text-muted-foreground">Sources</th>
-            <th className="px-4 py-2 text-right font-medium text-muted-foreground">Items stored</th>
-            <th className="px-4 py-2 text-left font-medium text-muted-foreground">Created</th>
-            <th className="px-4 py-2 text-right font-medium text-muted-foreground">Actions</th>
+            <th className="p-card text-left font-medium text-muted-foreground">Agent</th>
+            <th className="p-card text-left font-medium text-muted-foreground">Status</th>
+            <th className="p-card text-right font-medium text-muted-foreground">Sources</th>
+            <th className="p-card text-right font-medium text-muted-foreground">Items stored</th>
+            <th className="p-card text-left font-medium text-muted-foreground">Created</th>
+            <th className="p-card text-right font-medium text-muted-foreground">Actions</th>
           </tr>
         </thead>
         <tbody>
           {rows.map((row) => (
-            <tr key={row.agentName} className="border-b border-border/50">
-              <td className="px-4 py-2">
-                <Link
-                  to={`/agents/${encodeURIComponent(row.agentName)}`}
-                  className="font-medium text-foreground hover:text-accent"
-                >
-                  {row.agentName}
-                </Link>
-              </td>
-              <td className="px-4 py-2">
-                <span className="inline-flex items-center gap-1.5">
-                  <StatusBadge status={statusDot(row.plan)} decorative />
-                  <span className="text-xs text-muted-foreground">
-                    {row.plan?.status ?? 'no plan'}
-                  </span>
-                </span>
-              </td>
-              <td className="px-4 py-2 text-right font-mono text-xs">
-                {row.result ? formatNumber(row.result.source_agents_used.length) : '--'}
-              </td>
-              <td className="px-4 py-2 text-right font-mono text-xs">
-                {row.result ? formatNumber(sumStored(row.result)) : '--'}
-              </td>
-              <td className="px-4 py-2 text-xs text-muted-foreground">
-                {row.plan ? formatDateTime(row.plan.created_at) : '--'}
-              </td>
-              <td className="px-4 py-2 text-right">
-                {row.plan?.status === 'pending' ? (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => onExecute(row.agentName)}
-                  >
-                    Execute
-                  </Button>
-                ) : (
-                  <Button asChild size="sm" variant="ghost">
-                    <Link to={`/agents/${encodeURIComponent(row.agentName)}`}>
-                      Open
-                    </Link>
-                  </Button>
-                )}
-              </td>
-            </tr>
+            <TrainingPlanTableRow
+              key={row.agentName}
+              row={row}
+              onExecute={onExecute}
+            />
           ))}
         </tbody>
       </table>

--- a/web/src/pages/training/TrainingPlanTable.tsx
+++ b/web/src/pages/training/TrainingPlanTable.tsx
@@ -37,6 +37,10 @@ function statusDot(plan: TrainingPlanResponse | null): AgentRuntimeStatus {
       return 'error'
     case 'pending':
       return 'idle'
+    // Defensive fallback: a future `TrainingPlanStatus` variant should
+    // map to a neutral dot rather than render `undefined`.
+    default:
+      return 'offline'
   }
 }
 

--- a/web/src/pages/training/TrainingPlanTable.tsx
+++ b/web/src/pages/training/TrainingPlanTable.tsx
@@ -117,7 +117,7 @@ export function TrainingPlanTable({ rows, onExecute }: TrainingPlanTableProps) {
 
   return (
     <div className="overflow-x-auto rounded-lg border border-border">
-      <table className="w-full text-sm" role="table">
+      <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-border bg-muted/50">
             <th className="p-card text-left font-medium text-muted-foreground">Agent</th>

--- a/web/src/pages/training/TrainingPlanTable.tsx
+++ b/web/src/pages/training/TrainingPlanTable.tsx
@@ -1,0 +1,124 @@
+import { Link, useNavigate } from 'react-router'
+
+import { Button } from '@/components/ui/button'
+import { EmptyState } from '@/components/ui/empty-state'
+import { StatusBadge } from '@/components/ui/status-badge'
+import { ROUTES } from '@/router/routes'
+import { formatDateTime, formatNumber } from '@/utils/format'
+import { GraduationCap } from 'lucide-react'
+import type {
+  TrainingPlanResponse,
+  TrainingResultResponse,
+} from '@/api/endpoints/training'
+import type { AgentRuntimeStatus } from '@/lib/utils'
+
+export interface TrainingPlanRow {
+  agentName: string
+  plan: TrainingPlanResponse | null
+  result: TrainingResultResponse | null
+}
+
+export interface TrainingPlanTableProps {
+  rows: readonly TrainingPlanRow[]
+  onExecute: (agentName: string) => void
+}
+
+function sumStored(result: TrainingResultResponse | null): number {
+  if (!result) return 0
+  return result.items_stored.reduce((sum, [, count]) => sum + count, 0)
+}
+
+function statusDot(plan: TrainingPlanResponse | null): AgentRuntimeStatus {
+  if (!plan) return 'offline'
+  switch (plan.status) {
+    case 'executed':
+      return 'active'
+    case 'failed':
+      return 'error'
+    case 'pending':
+      return 'idle'
+  }
+}
+
+export function TrainingPlanTable({ rows, onExecute }: TrainingPlanTableProps) {
+  const navigate = useNavigate()
+
+  if (rows.length === 0) {
+    return (
+      <EmptyState
+        icon={GraduationCap}
+        title="No training plans yet"
+        description="Open an agent to customize and create a training plan."
+        action={{
+          label: 'Browse agents',
+          onClick: () => { void navigate(ROUTES.AGENTS) },
+        }}
+      />
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border">
+      <table className="w-full text-sm" role="table">
+        <thead>
+          <tr className="border-b border-border bg-muted/50">
+            <th className="px-4 py-2 text-left font-medium text-muted-foreground">Agent</th>
+            <th className="px-4 py-2 text-left font-medium text-muted-foreground">Status</th>
+            <th className="px-4 py-2 text-right font-medium text-muted-foreground">Sources</th>
+            <th className="px-4 py-2 text-right font-medium text-muted-foreground">Items stored</th>
+            <th className="px-4 py-2 text-left font-medium text-muted-foreground">Created</th>
+            <th className="px-4 py-2 text-right font-medium text-muted-foreground">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.agentName} className="border-b border-border/50">
+              <td className="px-4 py-2">
+                <Link
+                  to={`/agents/${encodeURIComponent(row.agentName)}`}
+                  className="font-medium text-foreground hover:text-accent"
+                >
+                  {row.agentName}
+                </Link>
+              </td>
+              <td className="px-4 py-2">
+                <span className="inline-flex items-center gap-1.5">
+                  <StatusBadge status={statusDot(row.plan)} decorative />
+                  <span className="text-xs text-muted-foreground">
+                    {row.plan?.status ?? 'no plan'}
+                  </span>
+                </span>
+              </td>
+              <td className="px-4 py-2 text-right font-mono text-xs">
+                {row.result ? formatNumber(row.result.source_agents_used.length) : '--'}
+              </td>
+              <td className="px-4 py-2 text-right font-mono text-xs">
+                {row.result ? formatNumber(sumStored(row.result)) : '--'}
+              </td>
+              <td className="px-4 py-2 text-xs text-muted-foreground">
+                {row.plan ? formatDateTime(row.plan.created_at) : '--'}
+              </td>
+              <td className="px-4 py-2 text-right">
+                {row.plan?.status === 'pending' ? (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => onExecute(row.agentName)}
+                  >
+                    Execute
+                  </Button>
+                ) : (
+                  <Button asChild size="sm" variant="ghost">
+                    <Link to={`/agents/${encodeURIComponent(row.agentName)}`}>
+                      Open
+                    </Link>
+                  </Button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/web/src/pages/workflows/WorkflowTableView.tsx
+++ b/web/src/pages/workflows/WorkflowTableView.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react'
 import { ROUTES } from '@/router/routes'
 import { EmptyState } from '@/components/ui/empty-state'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { formatDateTime } from '@/utils/format'
 import type { WorkflowDefinition } from '@/api/types'
 
 interface WorkflowTableViewProps {
@@ -14,12 +15,7 @@ interface WorkflowTableViewProps {
 }
 
 function formatDate(iso: string): string {
-  return new Date(iso).toLocaleString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
+  return formatDateTime(iso)
 }
 
 export function WorkflowTableView({ workflows, onDelete, onDuplicate }: WorkflowTableViewProps) {

--- a/web/src/pages/workflows/WorkflowTableView.tsx
+++ b/web/src/pages/workflows/WorkflowTableView.tsx
@@ -14,10 +14,6 @@ interface WorkflowTableViewProps {
   onDuplicate: (id: string) => void
 }
 
-function formatDate(iso: string): string {
-  return formatDateTime(iso)
-}
-
 export function WorkflowTableView({ workflows, onDelete, onDuplicate }: WorkflowTableViewProps) {
   const navigate = useNavigate()
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
@@ -72,7 +68,7 @@ export function WorkflowTableView({ workflows, onDelete, onDuplicate }: Workflow
                   <td className="px-4 py-2.5 text-right text-muted-foreground">{w.nodes.length}</td>
                   <td className="px-4 py-2.5 text-right text-muted-foreground">{w.edges.length}</td>
                   <td className="px-4 py-2.5 text-right text-muted-foreground">v{w.version}</td>
-                  <td className="px-4 py-2.5 text-muted-foreground">{formatDate(w.updated_at)}</td>
+                  <td className="px-4 py-2.5 text-muted-foreground">{formatDateTime(w.updated_at)}</td>
                   <td className="px-2 py-2.5">
                     <Menu.Root>
                       <Menu.Trigger

--- a/web/src/router/index.tsx
+++ b/web/src/router/index.tsx
@@ -125,7 +125,7 @@ export const router = createBrowserRouter([
               { path: ROUTES.META.slice(1), element: <MetaPage /> },
               { path: 'agents', element: <AgentsPage /> },
               { path: 'agents/:agentId', element: <AgentDetailPage /> },
-              { path: 'training', element: <TrainingPage /> },
+              { path: ROUTES.TRAINING.slice(1), element: <TrainingPage /> },
               { path: 'messages', element: <MessagesPage /> },
               { path: 'meetings', element: <MeetingsPage /> },
               { path: 'meetings/:meetingId', element: <MeetingDetailPage /> },

--- a/web/src/router/index.tsx
+++ b/web/src/router/index.tsx
@@ -18,6 +18,7 @@ const ScalingPage = lazy(() => import('@/pages/ScalingPage'))
 const MetaPage = lazy(() => import('@/pages/MetaPage'))
 const AgentsPage = lazy(() => import('@/pages/AgentsPage'))
 const AgentDetailPage = lazy(() => import('@/pages/AgentDetailPage'))
+const TrainingPage = lazy(() => import('@/pages/TrainingPage'))
 const MessagesPage = lazy(() => import('@/pages/MessagesPage'))
 const MeetingsPage = lazy(() => import('@/pages/MeetingsPage'))
 const MeetingDetailPage = lazy(() => import('@/pages/MeetingDetailPage'))
@@ -124,6 +125,7 @@ export const router = createBrowserRouter([
               { path: ROUTES.META.slice(1), element: <MetaPage /> },
               { path: 'agents', element: <AgentsPage /> },
               { path: 'agents/:agentId', element: <AgentDetailPage /> },
+              { path: 'training', element: <TrainingPage /> },
               { path: 'messages', element: <MessagesPage /> },
               { path: 'meetings', element: <MeetingsPage /> },
               { path: 'meetings/:meetingId', element: <MeetingDetailPage /> },

--- a/web/src/router/routes.ts
+++ b/web/src/router/routes.ts
@@ -20,6 +20,7 @@ export const ROUTES = {
   META: '/meta',
   AGENTS: '/agents',
   AGENT_DETAIL: '/agents/:agentId',
+  TRAINING: '/training',
   MESSAGES: '/messages',
   MEETINGS: '/meetings',
   MEETING_DETAIL: '/meetings/:meetingId',

--- a/web/src/stores/training.ts
+++ b/web/src/stores/training.ts
@@ -186,6 +186,20 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
         resultsByAgent: setMap(state.resultsByAgent, agentName, null),
         planError: setMap(state.planError, agentName, null),
         resultError: setMap(state.resultError, agentName, null),
+        // Bump both request tokens so any in-flight plan/result fetch
+        // that started before this mutation will see a mismatch on
+        // completion and skip its write-back -- otherwise a slow
+        // pre-mutation fetch could overwrite the authoritative plan.
+        planRequestTokens: setMap(
+          state.planRequestTokens,
+          agentName,
+          (state.planRequestTokens[agentName] ?? 0) + 1,
+        ),
+        resultRequestTokens: setMap(
+          state.resultRequestTokens,
+          agentName,
+          (state.resultRequestTokens[agentName] ?? 0) + 1,
+        ),
       }))
       useToastStore.getState().add({
         variant: 'success',
@@ -217,6 +231,19 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
           // the plan status below is also updated.
           resultError: setMap(state.resultError, agentName, null),
           planError: setMap(state.planError, agentName, null),
+          // Bump both tokens: an earlier ``fetchResult``/``fetchPlan``
+          // completing after ``executePlan`` would otherwise overwrite
+          // the authoritative execution state.
+          planRequestTokens: setMap(
+            state.planRequestTokens,
+            agentName,
+            (state.planRequestTokens[agentName] ?? 0) + 1,
+          ),
+          resultRequestTokens: setMap(
+            state.resultRequestTokens,
+            agentName,
+            (state.resultRequestTokens[agentName] ?? 0) + 1,
+          ),
         }
         // Mirror the server-side plan transition to EXECUTED so the UI
         // (status badge, disabled "Execute" button) stays consistent
@@ -275,6 +302,13 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
         plansByAgent: setMap(state.plansByAgent, agentName, plan),
         // Fresh write supersedes any stale plan-read error banner.
         planError: setMap(state.planError, agentName, null),
+        // Bump the plan token so an in-flight ``fetchPlan`` finishing
+        // after this write cannot overwrite the authoritative plan.
+        planRequestTokens: setMap(
+          state.planRequestTokens,
+          agentName,
+          (state.planRequestTokens[agentName] ?? 0) + 1,
+        ),
       }))
       useToastStore.getState().add({
         variant: 'success',

--- a/web/src/stores/training.ts
+++ b/web/src/stores/training.ts
@@ -154,6 +154,8 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
       const plan = await createTrainingPlan(agentName, overrides)
       set((state) => ({
         plansByAgent: setMap(state.plansByAgent, agentName, plan),
+        // Fresh write supersedes any stale plan-read error banner.
+        planError: setMap(state.planError, agentName, null),
       }))
       useToastStore.getState().add({
         variant: 'success',
@@ -180,6 +182,11 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
       set((state) => {
         const next: Partial<TrainingState> = {
           resultsByAgent: setMap(state.resultsByAgent, agentName, result),
+          // Fresh result supersedes any stale read-error banner for
+          // this agent; plan-side error is cleared alongside because
+          // the plan status below is also updated.
+          resultError: setMap(state.resultError, agentName, null),
+          planError: setMap(state.planError, agentName, null),
         }
         // Mirror the server-side plan transition to EXECUTED so the UI
         // (status badge, disabled "Execute" button) stays consistent
@@ -236,6 +243,8 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
       const plan = await updateTrainingOverrides(agentName, planId, data)
       set((state) => ({
         plansByAgent: setMap(state.plansByAgent, agentName, plan),
+        // Fresh write supersedes any stale plan-read error banner.
+        planError: setMap(state.planError, agentName, null),
       }))
       useToastStore.getState().add({
         variant: 'success',

--- a/web/src/stores/training.ts
+++ b/web/src/stores/training.ts
@@ -26,11 +26,19 @@ type PerAgent<T> = Readonly<Record<string, T | null>>
 type LoadingMap = Readonly<Record<string, boolean>>
 type ErrorMap = Readonly<Record<string, string | null>>
 
+/**
+ * Plan and result fetches run in parallel (see ``hydrateForAgent``)
+ * so they each need their own loading/error slot; sharing the same
+ * keys races -- whichever request finishes last stomps the other's
+ * state. The UI reads a merged view via ``useTrainingForAgent``.
+ */
 interface TrainingState {
   plansByAgent: PerAgent<TrainingPlanResponse>
   resultsByAgent: PerAgent<TrainingResultResponse>
-  loading: LoadingMap
-  error: ErrorMap
+  planLoading: LoadingMap
+  resultLoading: LoadingMap
+  planError: ErrorMap
+  resultError: ErrorMap
 
   fetchPlan: (agentName: string) => Promise<void>
   fetchResult: (agentName: string) => Promise<void>
@@ -67,22 +75,29 @@ function isExpectedNotFound(err: unknown): boolean {
 export const useTrainingStore = create<TrainingState>()((set, get) => ({
   plansByAgent: {},
   resultsByAgent: {},
-  loading: {},
-  error: {},
+  planLoading: {},
+  resultLoading: {},
+  planError: {},
+  resultError: {},
 
   fetchPlan: async (agentName) => {
+    set((state) => ({
+      planLoading: setMap(state.planLoading, agentName, true),
+      planError: setMap(state.planError, agentName, null),
+    }))
     try {
       const plan = await getLatestTrainingPlan(agentName)
       set((state) => ({
         plansByAgent: setMap(state.plansByAgent, agentName, plan),
-        // A successful read clears any stale per-agent error banner.
-        error: setMap(state.error, agentName, null),
+        planLoading: setMap(state.planLoading, agentName, false),
+        planError: setMap(state.planError, agentName, null),
       }))
     } catch (err) {
       if (isExpectedNotFound(err)) {
         set((state) => ({
           plansByAgent: setMap(state.plansByAgent, agentName, null),
-          error: setMap(state.error, agentName, null),
+          planLoading: setMap(state.planLoading, agentName, false),
+          planError: setMap(state.planError, agentName, null),
         }))
         return
       }
@@ -91,31 +106,30 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
         sanitizeForLog({ agentName, err, message: getErrorMessage(err) }),
       )
       set((state) => ({
-        error: setMap(state.error, agentName, getErrorMessage(err)),
+        planLoading: setMap(state.planLoading, agentName, false),
+        planError: setMap(state.planError, agentName, getErrorMessage(err)),
       }))
     }
   },
 
   fetchResult: async (agentName) => {
     set((state) => ({
-      loading: setMap(state.loading, agentName, true),
-      error: setMap(state.error, agentName, null),
+      resultLoading: setMap(state.resultLoading, agentName, true),
+      resultError: setMap(state.resultError, agentName, null),
     }))
     try {
       const result = await getTrainingResult(agentName)
       set((state) => ({
         resultsByAgent: setMap(state.resultsByAgent, agentName, result),
-        loading: setMap(state.loading, agentName, false),
-        // Successful read supersedes any older per-agent error banner
-        // so overlapping requests cannot leave stale state behind.
-        error: setMap(state.error, agentName, null),
+        resultLoading: setMap(state.resultLoading, agentName, false),
+        resultError: setMap(state.resultError, agentName, null),
       }))
     } catch (err) {
       if (isExpectedNotFound(err)) {
         set((state) => ({
           resultsByAgent: setMap(state.resultsByAgent, agentName, null),
-          loading: setMap(state.loading, agentName, false),
-          error: setMap(state.error, agentName, null),
+          resultLoading: setMap(state.resultLoading, agentName, false),
+          resultError: setMap(state.resultError, agentName, null),
         }))
         return
       }
@@ -125,8 +139,8 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
         sanitizeForLog({ agentName, err, message }),
       )
       set((state) => ({
-        loading: setMap(state.loading, agentName, false),
-        error: setMap(state.error, agentName, message),
+        resultLoading: setMap(state.resultLoading, agentName, false),
+        resultError: setMap(state.resultError, agentName, message),
       }))
     }
   },
@@ -251,8 +265,21 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
 export interface TrainingForAgent {
   plan: TrainingPlanResponse | null
   result: TrainingResultResponse | null
+  /** True while either plan or result is in-flight for this agent. */
   loading: boolean
+  /** Plan fetch in-flight. */
+  planLoading: boolean
+  /** Result fetch in-flight. */
+  resultLoading: boolean
+  /**
+   * First non-null error across plan/result (plan wins if both set)
+   * -- keeps the single-banner UI consumers working without forcing
+   * them to reconcile two sources. Granular callers should read
+   * ``planError`` / ``resultError`` directly.
+   */
   error: string | null
+  planError: string | null
+  resultError: string | null
 }
 
 /**
@@ -262,11 +289,21 @@ export interface TrainingForAgent {
  */
 export function useTrainingForAgent(agentName: string): TrainingForAgent {
   return useTrainingStore(
-    useShallow((state): TrainingForAgent => ({
-      plan: state.plansByAgent[agentName] ?? null,
-      result: state.resultsByAgent[agentName] ?? null,
-      loading: state.loading[agentName] ?? false,
-      error: state.error[agentName] ?? null,
-    })),
+    useShallow((state): TrainingForAgent => {
+      const planError = state.planError[agentName] ?? null
+      const resultError = state.resultError[agentName] ?? null
+      const planLoading = state.planLoading[agentName] ?? false
+      const resultLoading = state.resultLoading[agentName] ?? false
+      return {
+        plan: state.plansByAgent[agentName] ?? null,
+        result: state.resultsByAgent[agentName] ?? null,
+        loading: planLoading || resultLoading,
+        planLoading,
+        resultLoading,
+        error: planError ?? resultError,
+        planError,
+        resultError,
+      }
+    }),
   )
 }

--- a/web/src/stores/training.ts
+++ b/web/src/stores/training.ts
@@ -186,6 +186,11 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
         resultsByAgent: setMap(state.resultsByAgent, agentName, null),
         planError: setMap(state.planError, agentName, null),
         resultError: setMap(state.resultError, agentName, null),
+        // Clear loading flags so if a pre-mutation fetch was in
+        // flight, the token bump below drops its write-back and the
+        // UI does not stay stuck in a spinner state.
+        planLoading: setMap(state.planLoading, agentName, false),
+        resultLoading: setMap(state.resultLoading, agentName, false),
         // Bump both request tokens so any in-flight plan/result fetch
         // that started before this mutation will see a mismatch on
         // completion and skip its write-back -- otherwise a slow
@@ -231,6 +236,11 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
           // the plan status below is also updated.
           resultError: setMap(state.resultError, agentName, null),
           planError: setMap(state.planError, agentName, null),
+          // Clear loading flags so any in-flight pre-mutation fetch
+          // (whose result we are about to invalidate via the token
+          // bump) does not leave the UI stuck in a spinner state.
+          planLoading: setMap(state.planLoading, agentName, false),
+          resultLoading: setMap(state.resultLoading, agentName, false),
           // Bump both tokens: an earlier ``fetchResult``/``fetchPlan``
           // completing after ``executePlan`` would otherwise overwrite
           // the authoritative execution state.
@@ -302,6 +312,10 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
         plansByAgent: setMap(state.plansByAgent, agentName, plan),
         // Fresh write supersedes any stale plan-read error banner.
         planError: setMap(state.planError, agentName, null),
+        // Clear plan loading so a pre-mutation fetch whose write-back
+        // is about to be dropped (via the token bump below) does not
+        // leave the UI stuck in a spinner state.
+        planLoading: setMap(state.planLoading, agentName, false),
         // Bump the plan token so an in-flight ``fetchPlan`` finishing
         // after this write cannot overwrite the authoritative plan.
         planRequestTokens: setMap(

--- a/web/src/stores/training.ts
+++ b/web/src/stores/training.ts
@@ -106,12 +106,16 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
       set((state) => ({
         resultsByAgent: setMap(state.resultsByAgent, agentName, result),
         loading: setMap(state.loading, agentName, false),
+        // Successful read supersedes any older per-agent error banner
+        // so overlapping requests cannot leave stale state behind.
+        error: setMap(state.error, agentName, null),
       }))
     } catch (err) {
       if (isExpectedNotFound(err)) {
         set((state) => ({
           resultsByAgent: setMap(state.resultsByAgent, agentName, null),
           loading: setMap(state.loading, agentName, false),
+          error: setMap(state.error, agentName, null),
         }))
         return
       }

--- a/web/src/stores/training.ts
+++ b/web/src/stores/training.ts
@@ -1,8 +1,10 @@
 import { create } from 'zustand'
+import { useShallow } from 'zustand/react/shallow'
 
 import {
   createTrainingPlan,
   executeTrainingPlan,
+  getLatestTrainingPlan,
   getTrainingResult,
   previewTrainingPlan,
   updateTrainingOverrides,
@@ -29,7 +31,9 @@ interface TrainingState {
   loading: LoadingMap
   error: ErrorMap
 
+  fetchPlan: (agentName: string) => Promise<void>
   fetchResult: (agentName: string) => Promise<void>
+  hydrateForAgent: (agentName: string) => Promise<void>
   createPlan: (
     agentName: string,
     overrides: TrainingPlanRequest,
@@ -51,11 +55,46 @@ function setMap<V>(
   return { ...map, [key]: value }
 }
 
-export const useTrainingStore = create<TrainingState>()((set) => ({
+/**
+ * 404 is the expected signal that nothing has been persisted yet for
+ * the agent; we clear the cache entry and suppress the toast/error.
+ */
+function isExpectedNotFound(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'response' in err &&
+    typeof (err as { response?: { status?: unknown } }).response === 'object' &&
+    (err as { response: { status?: unknown } }).response.status === 404
+  )
+}
+
+export const useTrainingStore = create<TrainingState>()((set, get) => ({
   plansByAgent: {},
   resultsByAgent: {},
   loading: {},
   error: {},
+
+  fetchPlan: async (agentName) => {
+    try {
+      const plan = await getLatestTrainingPlan(agentName)
+      set((state) => ({
+        plansByAgent: setMap(state.plansByAgent, agentName, plan),
+      }))
+    } catch (err) {
+      if (isExpectedNotFound(err)) {
+        set((state) => ({
+          plansByAgent: setMap(state.plansByAgent, agentName, null),
+          error: setMap(state.error, agentName, null),
+        }))
+        return
+      }
+      log.error('fetchPlan failed:', sanitizeForLog(agentName), err)
+      set((state) => ({
+        error: setMap(state.error, agentName, getErrorMessage(err)),
+      }))
+    }
+  },
 
   fetchResult: async (agentName) => {
     set((state) => ({
@@ -69,6 +108,13 @@ export const useTrainingStore = create<TrainingState>()((set) => ({
         loading: setMap(state.loading, agentName, false),
       }))
     } catch (err) {
+      if (isExpectedNotFound(err)) {
+        set((state) => ({
+          resultsByAgent: setMap(state.resultsByAgent, agentName, null),
+          loading: setMap(state.loading, agentName, false),
+        }))
+        return
+      }
       const message = getErrorMessage(err)
       log.error('fetchResult failed:', sanitizeForLog(agentName), err)
       set((state) => ({
@@ -76,6 +122,10 @@ export const useTrainingStore = create<TrainingState>()((set) => ({
         error: setMap(state.error, agentName, message),
       }))
     }
+  },
+
+  hydrateForAgent: async (agentName) => {
+    await Promise.all([get().fetchPlan(agentName), get().fetchResult(agentName)])
   },
 
   createPlan: async (agentName, overrides) => {
@@ -103,9 +153,23 @@ export const useTrainingStore = create<TrainingState>()((set) => ({
   executePlan: async (agentName) => {
     try {
       const result = await executeTrainingPlan(agentName)
-      set((state) => ({
-        resultsByAgent: setMap(state.resultsByAgent, agentName, result),
-      }))
+      set((state) => {
+        const next: Partial<TrainingState> = {
+          resultsByAgent: setMap(state.resultsByAgent, agentName, result),
+        }
+        // Mirror the server-side plan transition to EXECUTED so the UI
+        // (status badge, disabled "Execute" button) stays consistent
+        // without a separate re-fetch.
+        const cached = state.plansByAgent[agentName]
+        if (cached) {
+          next.plansByAgent = setMap(state.plansByAgent, agentName, {
+            ...cached,
+            status: 'executed',
+            executed_at: result.completed_at,
+          })
+        }
+        return next
+      })
       useToastStore.getState().add({
         variant: 'success',
         title: 'Training executed',
@@ -160,11 +224,25 @@ export const useTrainingStore = create<TrainingState>()((set) => ({
   },
 }))
 
-export function useTrainingForAgent(agentName: string) {
-  return useTrainingStore((state) => ({
-    plan: state.plansByAgent[agentName] ?? null,
-    result: state.resultsByAgent[agentName] ?? null,
-    loading: state.loading[agentName] ?? false,
-    error: state.error[agentName] ?? null,
-  }))
+export interface TrainingForAgent {
+  plan: TrainingPlanResponse | null
+  result: TrainingResultResponse | null
+  loading: boolean
+  error: string | null
+}
+
+/**
+ * Subscribe to the training state for a single agent. Uses
+ * ``useShallow`` so re-renders only fire when one of the underlying
+ * fields changes, not on every store update.
+ */
+export function useTrainingForAgent(agentName: string): TrainingForAgent {
+  return useTrainingStore(
+    useShallow((state): TrainingForAgent => ({
+      plan: state.plansByAgent[agentName] ?? null,
+      result: state.resultsByAgent[agentName] ?? null,
+      loading: state.loading[agentName] ?? false,
+      error: state.error[agentName] ?? null,
+    })),
+  )
 }

--- a/web/src/stores/training.ts
+++ b/web/src/stores/training.ts
@@ -1,3 +1,4 @@
+import axios from 'axios'
 import { create } from 'zustand'
 import { useShallow } from 'zustand/react/shallow'
 
@@ -60,13 +61,7 @@ function setMap<V>(
  * the agent; we clear the cache entry and suppress the toast/error.
  */
 function isExpectedNotFound(err: unknown): boolean {
-  return (
-    typeof err === 'object' &&
-    err !== null &&
-    'response' in err &&
-    typeof (err as { response?: { status?: unknown } }).response === 'object' &&
-    (err as { response: { status?: unknown } }).response.status === 404
-  )
+  return axios.isAxiosError(err) && err.response?.status === 404
 }
 
 export const useTrainingStore = create<TrainingState>()((set, get) => ({

--- a/web/src/stores/training.ts
+++ b/web/src/stores/training.ts
@@ -75,6 +75,8 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
       const plan = await getLatestTrainingPlan(agentName)
       set((state) => ({
         plansByAgent: setMap(state.plansByAgent, agentName, plan),
+        // A successful read clears any stale per-agent error banner.
+        error: setMap(state.error, agentName, null),
       }))
     } catch (err) {
       if (isExpectedNotFound(err)) {
@@ -84,7 +86,10 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
         }))
         return
       }
-      log.error('fetchPlan failed:', sanitizeForLog(agentName), err)
+      log.error(
+        'fetchPlan failed',
+        sanitizeForLog({ agentName, err, message: getErrorMessage(err) }),
+      )
       set((state) => ({
         error: setMap(state.error, agentName, getErrorMessage(err)),
       }))
@@ -111,7 +116,10 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
         return
       }
       const message = getErrorMessage(err)
-      log.error('fetchResult failed:', sanitizeForLog(agentName), err)
+      log.error(
+        'fetchResult failed',
+        sanitizeForLog({ agentName, err, message }),
+      )
       set((state) => ({
         loading: setMap(state.loading, agentName, false),
         error: setMap(state.error, agentName, message),
@@ -135,7 +143,10 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
       })
       return plan
     } catch (err) {
-      log.error('createPlan failed:', sanitizeForLog(agentName), err)
+      log.error(
+        'createPlan failed',
+        sanitizeForLog({ agentName, err, message: getErrorMessage(err) }),
+      )
       useToastStore.getState().add({
         variant: 'error',
         title: 'Failed to create training plan',
@@ -171,7 +182,10 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
       })
       return result
     } catch (err) {
-      log.error('executePlan failed:', sanitizeForLog(agentName), err)
+      log.error(
+        'executePlan failed',
+        sanitizeForLog({ agentName, err, message: getErrorMessage(err) }),
+      )
       useToastStore.getState().add({
         variant: 'error',
         title: 'Training execution failed',
@@ -186,7 +200,10 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
       const preview = await previewTrainingPlan(agentName)
       return preview
     } catch (err) {
-      log.error('previewPlan failed:', sanitizeForLog(agentName), err)
+      log.error(
+        'previewPlan failed',
+        sanitizeForLog({ agentName, err, message: getErrorMessage(err) }),
+      )
       useToastStore.getState().add({
         variant: 'error',
         title: 'Training preview failed',
@@ -208,7 +225,15 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
       })
       return plan
     } catch (err) {
-      log.error('updateOverrides failed:', sanitizeForLog(agentName), err)
+      log.error(
+        'updateOverrides failed',
+        sanitizeForLog({
+          agentName,
+          planId,
+          err,
+          message: getErrorMessage(err),
+        }),
+      )
       useToastStore.getState().add({
         variant: 'error',
         title: 'Failed to save overrides',

--- a/web/src/stores/training.ts
+++ b/web/src/stores/training.ts
@@ -25,12 +25,18 @@ type PerAgent<T> = Readonly<Record<string, T | null>>
 
 type LoadingMap = Readonly<Record<string, boolean>>
 type ErrorMap = Readonly<Record<string, string | null>>
+type TokenMap = Readonly<Record<string, number>>
 
 /**
  * Plan and result fetches run in parallel (see ``hydrateForAgent``)
  * so they each need their own loading/error slot; sharing the same
  * keys races -- whichever request finishes last stomps the other's
- * state. The UI reads a merged view via ``useTrainingForAgent``.
+ * state. ``planRequestTokens`` / ``resultRequestTokens`` add per-agent
+ * monotonic counters so a stale in-flight response (e.g. the user
+ * clicked away and back) cannot overwrite a newer one: each fetch
+ * captures the current token, and only commits state updates when
+ * the captured token is still the agent's latest. The UI reads a
+ * merged view via ``useTrainingForAgent``.
  */
 interface TrainingState {
   plansByAgent: PerAgent<TrainingPlanResponse>
@@ -39,6 +45,8 @@ interface TrainingState {
   resultLoading: LoadingMap
   planError: ErrorMap
   resultError: ErrorMap
+  planRequestTokens: TokenMap
+  resultRequestTokens: TokenMap
 
   fetchPlan: (agentName: string) => Promise<void>
   fetchResult: (agentName: string) => Promise<void>
@@ -79,20 +87,31 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
   resultLoading: {},
   planError: {},
   resultError: {},
+  planRequestTokens: {},
+  resultRequestTokens: {},
 
   fetchPlan: async (agentName) => {
+    // Claim a fresh token and mark loading. Any prior in-flight
+    // fetchPlan for this agent will see a mismatch on completion and
+    // skip its state update.
+    const token = (get().planRequestTokens[agentName] ?? 0) + 1
     set((state) => ({
       planLoading: setMap(state.planLoading, agentName, true),
       planError: setMap(state.planError, agentName, null),
+      planRequestTokens: setMap(state.planRequestTokens, agentName, token),
     }))
+    const isCurrent = () =>
+      get().planRequestTokens[agentName] === token
     try {
       const plan = await getLatestTrainingPlan(agentName)
+      if (!isCurrent()) return
       set((state) => ({
         plansByAgent: setMap(state.plansByAgent, agentName, plan),
         planLoading: setMap(state.planLoading, agentName, false),
         planError: setMap(state.planError, agentName, null),
       }))
     } catch (err) {
+      if (!isCurrent()) return
       if (isExpectedNotFound(err)) {
         set((state) => ({
           plansByAgent: setMap(state.plansByAgent, agentName, null),
@@ -113,18 +132,24 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
   },
 
   fetchResult: async (agentName) => {
+    const token = (get().resultRequestTokens[agentName] ?? 0) + 1
     set((state) => ({
       resultLoading: setMap(state.resultLoading, agentName, true),
       resultError: setMap(state.resultError, agentName, null),
+      resultRequestTokens: setMap(state.resultRequestTokens, agentName, token),
     }))
+    const isCurrent = () =>
+      get().resultRequestTokens[agentName] === token
     try {
       const result = await getTrainingResult(agentName)
+      if (!isCurrent()) return
       set((state) => ({
         resultsByAgent: setMap(state.resultsByAgent, agentName, result),
         resultLoading: setMap(state.resultLoading, agentName, false),
         resultError: setMap(state.resultError, agentName, null),
       }))
     } catch (err) {
+      if (!isCurrent()) return
       if (isExpectedNotFound(err)) {
         set((state) => ({
           resultsByAgent: setMap(state.resultsByAgent, agentName, null),
@@ -154,8 +179,13 @@ export const useTrainingStore = create<TrainingState>()((set, get) => ({
       const plan = await createTrainingPlan(agentName, overrides)
       set((state) => ({
         plansByAgent: setMap(state.plansByAgent, agentName, plan),
-        // Fresh write supersedes any stale plan-read error banner.
+        // Fresh plan invalidates any cached result (which belonged to
+        // the previous plan) and wipes stale error banners on both
+        // sides so the UI does not show a stale execution for the new
+        // plan.
+        resultsByAgent: setMap(state.resultsByAgent, agentName, null),
         planError: setMap(state.planError, agentName, null),
+        resultError: setMap(state.resultError, agentName, null),
       }))
       useToastStore.getState().add({
         variant: 'success',

--- a/web/src/stores/training.ts
+++ b/web/src/stores/training.ts
@@ -1,0 +1,170 @@
+import { create } from 'zustand'
+
+import {
+  createTrainingPlan,
+  executeTrainingPlan,
+  getTrainingResult,
+  previewTrainingPlan,
+  updateTrainingOverrides,
+  type TrainingOverridesRequest,
+  type TrainingPlanRequest,
+  type TrainingPlanResponse,
+  type TrainingResultResponse,
+} from '@/api/endpoints/training'
+import { createLogger } from '@/lib/logger'
+import { sanitizeForLog } from '@/utils/logging'
+import { getErrorMessage } from '@/utils/errors'
+import { useToastStore } from '@/stores/toast'
+
+const log = createLogger('training')
+
+type PerAgent<T> = Readonly<Record<string, T | null>>
+
+type LoadingMap = Readonly<Record<string, boolean>>
+type ErrorMap = Readonly<Record<string, string | null>>
+
+interface TrainingState {
+  plansByAgent: PerAgent<TrainingPlanResponse>
+  resultsByAgent: PerAgent<TrainingResultResponse>
+  loading: LoadingMap
+  error: ErrorMap
+
+  fetchResult: (agentName: string) => Promise<void>
+  createPlan: (
+    agentName: string,
+    overrides: TrainingPlanRequest,
+  ) => Promise<TrainingPlanResponse | null>
+  executePlan: (agentName: string) => Promise<TrainingResultResponse | null>
+  previewPlan: (agentName: string) => Promise<TrainingResultResponse | null>
+  updateOverrides: (
+    agentName: string,
+    planId: string,
+    data: TrainingOverridesRequest,
+  ) => Promise<TrainingPlanResponse | null>
+}
+
+function setMap<V>(
+  map: Readonly<Record<string, V>>,
+  key: string,
+  value: V,
+): Readonly<Record<string, V>> {
+  return { ...map, [key]: value }
+}
+
+export const useTrainingStore = create<TrainingState>()((set) => ({
+  plansByAgent: {},
+  resultsByAgent: {},
+  loading: {},
+  error: {},
+
+  fetchResult: async (agentName) => {
+    set((state) => ({
+      loading: setMap(state.loading, agentName, true),
+      error: setMap(state.error, agentName, null),
+    }))
+    try {
+      const result = await getTrainingResult(agentName)
+      set((state) => ({
+        resultsByAgent: setMap(state.resultsByAgent, agentName, result),
+        loading: setMap(state.loading, agentName, false),
+      }))
+    } catch (err) {
+      const message = getErrorMessage(err)
+      log.error('fetchResult failed:', sanitizeForLog(agentName), err)
+      set((state) => ({
+        loading: setMap(state.loading, agentName, false),
+        error: setMap(state.error, agentName, message),
+      }))
+    }
+  },
+
+  createPlan: async (agentName, overrides) => {
+    try {
+      const plan = await createTrainingPlan(agentName, overrides)
+      set((state) => ({
+        plansByAgent: setMap(state.plansByAgent, agentName, plan),
+      }))
+      useToastStore.getState().add({
+        variant: 'success',
+        title: 'Training plan created',
+      })
+      return plan
+    } catch (err) {
+      log.error('createPlan failed:', sanitizeForLog(agentName), err)
+      useToastStore.getState().add({
+        variant: 'error',
+        title: 'Failed to create training plan',
+        description: getErrorMessage(err),
+      })
+      return null
+    }
+  },
+
+  executePlan: async (agentName) => {
+    try {
+      const result = await executeTrainingPlan(agentName)
+      set((state) => ({
+        resultsByAgent: setMap(state.resultsByAgent, agentName, result),
+      }))
+      useToastStore.getState().add({
+        variant: 'success',
+        title: 'Training executed',
+      })
+      return result
+    } catch (err) {
+      log.error('executePlan failed:', sanitizeForLog(agentName), err)
+      useToastStore.getState().add({
+        variant: 'error',
+        title: 'Training execution failed',
+        description: getErrorMessage(err),
+      })
+      return null
+    }
+  },
+
+  previewPlan: async (agentName) => {
+    try {
+      const preview = await previewTrainingPlan(agentName)
+      return preview
+    } catch (err) {
+      log.error('previewPlan failed:', sanitizeForLog(agentName), err)
+      useToastStore.getState().add({
+        variant: 'error',
+        title: 'Preview failed',
+        description: getErrorMessage(err),
+      })
+      return null
+    }
+  },
+
+  updateOverrides: async (agentName, planId, data) => {
+    try {
+      const plan = await updateTrainingOverrides(agentName, planId, data)
+      set((state) => ({
+        plansByAgent: setMap(state.plansByAgent, agentName, plan),
+      }))
+      useToastStore.getState().add({
+        variant: 'success',
+        title: 'Overrides saved',
+      })
+      return plan
+    } catch (err) {
+      log.error('updateOverrides failed:', sanitizeForLog(agentName), err)
+      useToastStore.getState().add({
+        variant: 'error',
+        title: 'Failed to save overrides',
+        description: getErrorMessage(err),
+      })
+      return null
+    }
+  },
+}))
+
+export function useTrainingForAgent(agentName: string) {
+  return useTrainingStore((state) => ({
+    plan: state.plansByAgent[agentName] ?? null,
+    result: state.resultsByAgent[agentName] ?? null,
+    loading: state.loading[agentName] ?? false,
+    error: state.error[agentName] ?? null,
+  }))
+}

--- a/web/src/stores/training.ts
+++ b/web/src/stores/training.ts
@@ -130,7 +130,7 @@ export const useTrainingStore = create<TrainingState>()((set) => ({
       log.error('previewPlan failed:', sanitizeForLog(agentName), err)
       useToastStore.getState().add({
         variant: 'error',
-        title: 'Preview failed',
+        title: 'Training preview failed',
         description: getErrorMessage(err),
       })
       return null

--- a/web/src/utils/budget.ts
+++ b/web/src/utils/budget.ts
@@ -1,7 +1,7 @@
 /** Budget page utility functions -- pure computations with no side effects. */
 
 import { computeSpendTrend } from '@/utils/dashboard'
-import { formatCurrency } from '@/utils/format'
+import { formatCurrency, formatDateOnly } from '@/utils/format'
 import type { MetricCardProps } from '@/components/ui/metric-card'
 import type {
   ActivityItem,
@@ -242,11 +242,7 @@ export function computeExhaustionDate(
   if (daysUntilExhausted === null) return null
   const date = new Date()
   date.setDate(date.getDate() + daysUntilExhausted)
-  return date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  })
+  return formatDateOnly(date.toISOString())
 }
 
 /**

--- a/web/src/utils/currencies.ts
+++ b/web/src/utils/currencies.ts
@@ -43,3 +43,14 @@ export type CurrencyCode = (typeof CURRENCY_OPTIONS)[number]['value']
 
 /** Default currency code (matches backend DEFAULT_CURRENCY). */
 export const DEFAULT_CURRENCY: CurrencyCode = 'EUR'
+
+/**
+ * Currency used to render ``cost_usd`` fields surfaced by the backend
+ * (``Task.cost_usd``, ``Message.metadata.cost_usd``, etc.). These
+ * values are intrinsically USD-denominated on the server
+ * (``synthorg.budget.cost_record``); formatting them with any other
+ * code would display a mismatched symbol. Kept as a named constant so
+ * the intent is greppable and the design-system rule about avoiding
+ * inline currency literals still reads cleanly at call sites.
+ */
+export const COST_USD_CURRENCY: CurrencyCode = 'USD'

--- a/web/src/utils/currencies.ts
+++ b/web/src/utils/currencies.ts
@@ -43,14 +43,3 @@ export type CurrencyCode = (typeof CURRENCY_OPTIONS)[number]['value']
 
 /** Default currency code (matches backend DEFAULT_CURRENCY). */
 export const DEFAULT_CURRENCY: CurrencyCode = 'EUR'
-
-/**
- * Currency used to render ``cost_usd`` fields surfaced by the backend
- * (``Task.cost_usd``, ``Message.metadata.cost_usd``, etc.). These
- * values are intrinsically USD-denominated on the server
- * (``synthorg.budget.cost_record``); formatting them with any other
- * code would display a mismatched symbol. Kept as a named constant so
- * the intent is greppable and the design-system rule about avoiding
- * inline currency literals still reads cleanly at call sites.
- */
-export const COST_USD_CURRENCY: CurrencyCode = 'USD'

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -16,9 +16,30 @@ const COMPACT_K_THRESHOLD = 1000
 
 type DateInput = string | number | Date | null | undefined
 
+const DATE_ONLY_RE = /^(\d{4})-(\d{2})-(\d{2})$/
+
+/**
+ * Parse {@link DateInput} to a ``Date`` (or ``null`` on invalid input).
+ *
+ * Date-only ISO strings (``YYYY-MM-DD``) are parsed into the local
+ * midnight of that calendar day rather than the UTC midnight
+ * ``new Date(string)`` would produce -- the latter can shift the
+ * displayed day backward for viewers in negative-UTC timezones.
+ */
 function toDate(value: DateInput): Date | null {
   if (value == null) return null
-  const date = value instanceof Date ? value : new Date(value)
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value
+  }
+  if (typeof value === 'string') {
+    const match = DATE_ONLY_RE.exec(value)
+    if (match) {
+      const [, y, m, d] = match
+      const local = new Date(Number(y), Number(m) - 1, Number(d))
+      return Number.isNaN(local.getTime()) ? null : local
+    }
+  }
+  const date = new Date(value)
   return Number.isNaN(date.getTime()) ? null : date
 }
 
@@ -93,8 +114,8 @@ export function formatDayLabel(
   value: string | number | Date,
   locale: string = getLocale(),
 ): string {
-  const date = value instanceof Date ? value : new Date(value)
-  if (Number.isNaN(date.getTime())) return '--'
+  const date = toDate(value)
+  if (!date) return '--'
   return date.toLocaleDateString(locale, { month: 'short', day: 'numeric' })
 }
 

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -3,6 +3,7 @@
 import { createLogger } from '@/lib/logger'
 import { DEFAULT_CURRENCY } from '@/utils/currencies'
 import { getLocale } from '@/utils/locale'
+import { sanitizeForLog } from '@/utils/logging'
 
 const log = createLogger('format')
 
@@ -35,8 +36,22 @@ function toDate(value: DateInput): Date | null {
     const match = DATE_ONLY_RE.exec(value)
     if (match) {
       const [, y, m, d] = match
-      const local = new Date(Number(y), Number(m) - 1, Number(d))
-      return Number.isNaN(local.getTime()) ? null : local
+      const year = Number(y)
+      const monthIdx = Number(m) - 1
+      const day = Number(d)
+      const local = new Date(year, monthIdx, day)
+      // ``new Date(2025, 1, 30)`` silently wraps to 2025-03-02; reject
+      // overflowed inputs (e.g. ``2025-02-30``) so only true calendar
+      // days are accepted.
+      if (
+        Number.isNaN(local.getTime()) ||
+        local.getFullYear() !== year ||
+        local.getMonth() !== monthIdx ||
+        local.getDate() !== day
+      ) {
+        return null
+      }
+      return local
     }
   }
   const date = new Date(value)
@@ -141,8 +156,12 @@ export function formatRelativeTime(
   locale: string = getLocale(),
 ): string {
   if (!iso) return '--'
-  const date = new Date(iso)
-  if (Number.isNaN(date.getTime())) return '--'
+  // Route through ``toDate`` so ``YYYY-MM-DD`` strings are read as
+  // local midnight (same parsing contract as ``formatDateTime`` and
+  // siblings). ``new Date(iso)`` would read them as UTC midnight and
+  // shift the displayed day in negative-UTC timezones.
+  const date = toDate(iso)
+  if (!date) return '--'
   const now = new Date()
   const diffMs = now.getTime() - date.getTime()
   if (diffMs < 0) return formatDateTime(iso, locale)
@@ -182,7 +201,11 @@ export function formatCurrency(
       currency: currencyCode,
     }).format(value)
   } catch (error) {
-    log.error('Intl.NumberFormat failed for currency', { currencyCode }, error)
+    log.error(
+      'Intl.NumberFormat failed for currency',
+      sanitizeForLog({ currencyCode }),
+      error,
+    )
     const digits = ZERO_DECIMAL_CURRENCIES.has(currencyCode) ? 0 : THREE_DECIMAL_CURRENCIES.has(currencyCode) ? 3 : 2
     return `${currencyCode} ${value.toFixed(digits)}`
   }
@@ -207,7 +230,11 @@ export function formatCurrencyCompact(
       notation: 'compact',
     }).format(value)
   } catch (error) {
-    log.error('Intl.NumberFormat compact failed for currency', { currencyCode }, error)
+    log.error(
+      'Intl.NumberFormat compact failed for currency',
+      sanitizeForLog({ currencyCode }),
+      error,
+    )
     return `${currencyCode} ${Math.round(value)}`
   }
 }

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -1,6 +1,7 @@
 /** Formatting utilities for dates, currency, and numbers. */
 
 import { createLogger } from '@/lib/logger'
+import { DEFAULT_CURRENCY } from '@/utils/currencies'
 import { getLocale } from '@/utils/locale'
 
 const log = createLogger('format')
@@ -13,16 +14,25 @@ const SEC_PER_WEEK = 604800
 const BYTES_PER_KB = 1024
 const COMPACT_K_THRESHOLD = 1000
 
+type DateInput = string | number | Date | null | undefined
+
+function toDate(value: DateInput): Date | null {
+  if (value == null) return null
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
 /**
- * Format an ISO 8601 date string as date + time (e.g. "Jan 15, 2025, 10:30 AM").
+ * Format a date as date + time (e.g. "Jan 15, 2025, 10:30 AM").
+ *
+ * Accepts an ISO string, a `Date`, or a millisecond timestamp.
  */
 export function formatDateTime(
-  iso: string | null | undefined,
+  value: DateInput,
   locale: string = getLocale(),
 ): string {
-  if (!iso) return '--'
-  const date = new Date(iso)
-  if (Number.isNaN(date.getTime())) return '--'
+  const date = toDate(value)
+  if (!date) return '--'
   return date.toLocaleString(locale, {
     month: 'short',
     day: 'numeric',
@@ -40,15 +50,16 @@ export function formatDateTime(
 export const formatDate = formatDateTime
 
 /**
- * Format an ISO 8601 date as a date-only string (e.g. "Jan 15, 2025").
+ * Format a date as a date-only string (e.g. "Jan 15, 2025").
+ *
+ * Accepts an ISO string, a `Date`, or a millisecond timestamp.
  */
 export function formatDateOnly(
-  iso: string | null | undefined,
+  value: DateInput,
   locale: string = getLocale(),
 ): string {
-  if (!iso) return '--'
-  const date = new Date(iso)
-  if (Number.isNaN(date.getTime())) return '--'
+  const date = toDate(value)
+  if (!date) return '--'
   return date.toLocaleDateString(locale, {
     month: 'short',
     day: 'numeric',
@@ -57,15 +68,16 @@ export function formatDateOnly(
 }
 
 /**
- * Format an ISO 8601 date as a time-only string (e.g. "10:30 AM").
+ * Format a date as a time-only string (e.g. "10:30 AM").
+ *
+ * Accepts an ISO string, a `Date`, or a millisecond timestamp.
  */
 export function formatTime(
-  iso: string | null | undefined,
+  value: DateInput,
   locale: string = getLocale(),
 ): string {
-  if (!iso) return '--'
-  const date = new Date(iso)
-  if (Number.isNaN(date.getTime())) return '--'
+  const date = toDate(value)
+  if (!date) return '--'
   return date.toLocaleTimeString(locale, {
     hour: '2-digit',
     minute: '2-digit',
@@ -95,7 +107,13 @@ export function formatTodayLabel(locale: string = getLocale()): string {
 }
 
 /**
- * Format a date as relative time (e.g., "2 hours ago").
+ * Format a date as locale-aware relative time (e.g. "5 minutes ago",
+ * "il y a 5 minutes", "hace 5 minutos"). Uses `Intl.RelativeTimeFormat`
+ * with `numeric: 'auto'` so near boundaries render as "yesterday" /
+ * "tomorrow" rather than "1 day ago" / "in 1 day".
+ *
+ * Falls back to {@link formatDateTime} for dates older than a week, for
+ * future dates, and for invalid/missing input.
  */
 export function formatRelativeTime(
   iso: string | null | undefined,
@@ -108,12 +126,17 @@ export function formatRelativeTime(
   const diffMs = now.getTime() - date.getTime()
   if (diffMs < 0) return formatDateTime(iso, locale)
   const diffSec = Math.floor(diffMs / MS_PER_SECOND)
+  if (diffSec >= SEC_PER_WEEK) return formatDateTime(iso, locale)
 
-  if (diffSec < SEC_PER_MIN) return 'just now'
-  if (diffSec < SEC_PER_HOUR) return `${Math.floor(diffSec / SEC_PER_MIN)}m ago`
-  if (diffSec < SEC_PER_DAY) return `${Math.floor(diffSec / SEC_PER_HOUR)}h ago`
-  if (diffSec < SEC_PER_WEEK) return `${Math.floor(diffSec / SEC_PER_DAY)}d ago`
-  return formatDateTime(iso, locale)
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' })
+  if (diffSec < SEC_PER_MIN) return rtf.format(-diffSec, 'second')
+  if (diffSec < SEC_PER_HOUR) {
+    return rtf.format(-Math.floor(diffSec / SEC_PER_MIN), 'minute')
+  }
+  if (diffSec < SEC_PER_DAY) {
+    return rtf.format(-Math.floor(diffSec / SEC_PER_HOUR), 'hour')
+  }
+  return rtf.format(-Math.floor(diffSec / SEC_PER_DAY), 'day')
 }
 
 /** ISO 4217 currencies that use zero decimal places. */
@@ -124,10 +147,11 @@ const THREE_DECIMAL_CURRENCIES = new Set(['BHD','IQD','JOD','KWD','LYD','OMR','T
 
 /**
  * Format a currency value using the given ISO 4217 currency code.
+ * Defaults to {@link DEFAULT_CURRENCY} when no code is provided.
  */
 export function formatCurrency(
   value: number,
-  currencyCode: string = 'EUR',
+  currencyCode: string = DEFAULT_CURRENCY,
   locale: string = getLocale(),
 ): string {
   if (!Number.isFinite(value)) return '--'
@@ -137,7 +161,7 @@ export function formatCurrency(
       currency: currencyCode,
     }).format(value)
   } catch (error) {
-    log.error('Intl.NumberFormat failed for currency:', currencyCode, error)
+    log.error('Intl.NumberFormat failed for currency', { currencyCode }, error)
     const digits = ZERO_DECIMAL_CURRENCIES.has(currencyCode) ? 0 : THREE_DECIMAL_CURRENCIES.has(currencyCode) ? 3 : 2
     return `${currencyCode} ${value.toFixed(digits)}`
   }
@@ -145,27 +169,25 @@ export function formatCurrency(
 
 /**
  * Format a currency value compactly for chart axes (e.g. "$5", "$10K").
- * Exact format depends on locale and currency. Falls back to "CODE N" on error.
+ * Exact format depends on locale and currency. Falls back to "CODE N" on
+ * error without silently swapping the currency.
  */
 export function formatCurrencyCompact(
   value: number,
-  currencyCode: string = 'EUR',
+  currencyCode: string = DEFAULT_CURRENCY,
   locale: string = getLocale(),
 ): string {
   if (!Number.isFinite(value)) return '--'
-  // Normalize to 3-letter uppercase ISO 4217 code; fall back to EUR
-  const trimmed = currencyCode.trim()
-  const code = /^[A-Za-z]{3}$/.test(trimmed) ? trimmed.toUpperCase() : 'EUR'
   try {
     return new Intl.NumberFormat(locale, {
       style: 'currency',
-      currency: code,
+      currency: currencyCode,
       maximumFractionDigits: 0,
       notation: 'compact',
     }).format(value)
   } catch (error) {
-    log.error(`Intl.NumberFormat compact failed for currency "${code}":`, error)
-    return `${code} ${Math.round(value)}`
+    log.error('Intl.NumberFormat compact failed for currency', { currencyCode }, error)
+    return `${currencyCode} ${Math.round(value)}`
   }
 }
 

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -1,17 +1,29 @@
 /** Formatting utilities for dates, currency, and numbers. */
 
 import { createLogger } from '@/lib/logger'
+import { getLocale } from '@/utils/locale'
 
 const log = createLogger('format')
 
+const MS_PER_SECOND = 1000
+const SEC_PER_MIN = 60
+const SEC_PER_HOUR = 3600
+const SEC_PER_DAY = 86400
+const SEC_PER_WEEK = 604800
+const BYTES_PER_KB = 1024
+const COMPACT_K_THRESHOLD = 1000
+
 /**
- * Format an ISO 8601 date string to a human-readable locale string.
+ * Format an ISO 8601 date string as date + time (e.g. "Jan 15, 2025, 10:30 AM").
  */
-export function formatDate(iso: string | null | undefined): string {
+export function formatDateTime(
+  iso: string | null | undefined,
+  locale: string = getLocale(),
+): string {
   if (!iso) return '--'
   const date = new Date(iso)
   if (Number.isNaN(date.getTime())) return '--'
-  return date.toLocaleString('en-US', {
+  return date.toLocaleString(locale, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
@@ -21,22 +33,87 @@ export function formatDate(iso: string | null | undefined): string {
 }
 
 /**
+ * Alias of {@link formatDateTime} kept for the existing call sites that
+ * import `formatDate`. New code should prefer `formatDateTime` for
+ * clarity or `formatDateOnly` when no time is needed.
+ */
+export const formatDate = formatDateTime
+
+/**
+ * Format an ISO 8601 date as a date-only string (e.g. "Jan 15, 2025").
+ */
+export function formatDateOnly(
+  iso: string | null | undefined,
+  locale: string = getLocale(),
+): string {
+  if (!iso) return '--'
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return '--'
+  return date.toLocaleDateString(locale, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+/**
+ * Format an ISO 8601 date as a time-only string (e.g. "10:30 AM").
+ */
+export function formatTime(
+  iso: string | null | undefined,
+  locale: string = getLocale(),
+): string {
+  if (!iso) return '--'
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return '--'
+  return date.toLocaleTimeString(locale, {
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+/**
+ * Format a short day label for chart axes (e.g. "Jan 15").
+ *
+ * Accepts either an ISO string, a `Date`, or a millisecond timestamp.
+ */
+export function formatDayLabel(
+  value: string | number | Date,
+  locale: string = getLocale(),
+): string {
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return '--'
+  return date.toLocaleDateString(locale, { month: 'short', day: 'numeric' })
+}
+
+/**
+ * Format today's short day label (e.g. "Jan 15"). Useful as a reference
+ * line label on burn/trend charts.
+ */
+export function formatTodayLabel(locale: string = getLocale()): string {
+  return formatDayLabel(new Date(), locale)
+}
+
+/**
  * Format a date as relative time (e.g., "2 hours ago").
  */
-export function formatRelativeTime(iso: string | null | undefined): string {
+export function formatRelativeTime(
+  iso: string | null | undefined,
+  locale: string = getLocale(),
+): string {
   if (!iso) return '--'
   const date = new Date(iso)
   if (Number.isNaN(date.getTime())) return '--'
   const now = new Date()
   const diffMs = now.getTime() - date.getTime()
-  if (diffMs < 0) return formatDate(iso)
-  const diffSec = Math.floor(diffMs / 1000)
+  if (diffMs < 0) return formatDateTime(iso, locale)
+  const diffSec = Math.floor(diffMs / MS_PER_SECOND)
 
-  if (diffSec < 60) return 'just now'
-  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`
-  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`
-  if (diffSec < 604800) return `${Math.floor(diffSec / 86400)}d ago`
-  return formatDate(iso)
+  if (diffSec < SEC_PER_MIN) return 'just now'
+  if (diffSec < SEC_PER_HOUR) return `${Math.floor(diffSec / SEC_PER_MIN)}m ago`
+  if (diffSec < SEC_PER_DAY) return `${Math.floor(diffSec / SEC_PER_HOUR)}h ago`
+  if (diffSec < SEC_PER_WEEK) return `${Math.floor(diffSec / SEC_PER_DAY)}d ago`
+  return formatDateTime(iso, locale)
 }
 
 /** ISO 4217 currencies that use zero decimal places. */
@@ -48,10 +125,14 @@ const THREE_DECIMAL_CURRENCIES = new Set(['BHD','IQD','JOD','KWD','LYD','OMR','T
 /**
  * Format a currency value using the given ISO 4217 currency code.
  */
-export function formatCurrency(value: number, currencyCode: string = 'EUR'): string {
+export function formatCurrency(
+  value: number,
+  currencyCode: string = 'EUR',
+  locale: string = getLocale(),
+): string {
   if (!Number.isFinite(value)) return '--'
   try {
-    return new Intl.NumberFormat('en-US', {
+    return new Intl.NumberFormat(locale, {
       style: 'currency',
       currency: currencyCode,
     }).format(value)
@@ -66,13 +147,17 @@ export function formatCurrency(value: number, currencyCode: string = 'EUR'): str
  * Format a currency value compactly for chart axes (e.g. "$5", "$10K").
  * Exact format depends on locale and currency. Falls back to "CODE N" on error.
  */
-export function formatCurrencyCompact(value: number, currencyCode: string = 'EUR'): string {
+export function formatCurrencyCompact(
+  value: number,
+  currencyCode: string = 'EUR',
+  locale: string = getLocale(),
+): string {
   if (!Number.isFinite(value)) return '--'
   // Normalize to 3-letter uppercase ISO 4217 code; fall back to EUR
   const trimmed = currencyCode.trim()
   const code = /^[A-Za-z]{3}$/.test(trimmed) ? trimmed.toUpperCase() : 'EUR'
   try {
-    return new Intl.NumberFormat('en-US', {
+    return new Intl.NumberFormat(locale, {
       style: 'currency',
       currency: code,
       maximumFractionDigits: 0,
@@ -87,9 +172,29 @@ export function formatCurrencyCompact(value: number, currencyCode: string = 'EUR
 /**
  * Format a number with locale-appropriate separators.
  */
-export function formatNumber(value: number): string {
+export function formatNumber(
+  value: number,
+  locale: string = getLocale(),
+): string {
   if (!Number.isFinite(value)) return '--'
-  return new Intl.NumberFormat('en-US').format(value)
+  return new Intl.NumberFormat(locale).format(value)
+}
+
+/**
+ * Format a count of tokens for display. Values under 1000 use
+ * locale-appropriate separators (typically just the number); larger
+ * values use compact notation (e.g. "12K", "1.5M").
+ */
+export function formatTokenCount(
+  value: number,
+  locale: string = getLocale(),
+): string {
+  if (!Number.isFinite(value)) return '--'
+  if (value < COMPACT_K_THRESHOLD) return formatNumber(value, locale)
+  return new Intl.NumberFormat(locale, {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  }).format(value)
 }
 
 /**
@@ -97,9 +202,9 @@ export function formatNumber(value: number): string {
  */
 export function formatUptime(seconds: number): string {
   const s = (!Number.isFinite(seconds) || seconds < 0) ? 0 : seconds
-  const days = Math.floor(s / 86400)
-  const hours = Math.floor((s % 86400) / 3600)
-  const mins = Math.floor((s % 3600) / 60)
+  const days = Math.floor(s / SEC_PER_DAY)
+  const hours = Math.floor((s % SEC_PER_DAY) / SEC_PER_HOUR)
+  const mins = Math.floor((s % SEC_PER_HOUR) / SEC_PER_MIN)
   const parts: string[] = []
   if (days > 0) parts.push(`${days}d`)
   if (hours > 0) parts.push(`${hours}h`)
@@ -114,8 +219,8 @@ export function formatFileSize(bytes: number): string {
   if (!Number.isFinite(bytes) || bytes < 0) return '--'
   if (bytes === 0) return '0 B'
   const units = ['B', 'KB', 'MB', 'GB', 'TB']
-  const exponent = Math.max(0, Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1))
-  const value = bytes / 1024 ** exponent
+  const exponent = Math.max(0, Math.min(Math.floor(Math.log(bytes) / Math.log(BYTES_PER_KB)), units.length - 1))
+  const value = bytes / BYTES_PER_KB ** exponent
   return exponent === 0 ? `${bytes} B` : `${value.toFixed(1)} ${units[exponent]}`
 }
 

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -20,6 +20,38 @@ type DateInput = string | number | Date | null | undefined
 const DATE_ONLY_RE = /^(\d{4})-(\d{2})-(\d{2})$/
 
 /**
+ * Memoized locale-validation cache. ``Intl.getCanonicalLocales`` throws
+ * ``RangeError`` on malformed BCP 47 tags; we catch that once per tag
+ * and remember the outcome so formatter helpers can fall back to
+ * ``getLocale()`` instead of crashing the render path.
+ */
+const LOCALE_VALIDITY_CACHE = new Map<string, boolean>()
+
+function isValidLocale(locale: string): boolean {
+  const cached = LOCALE_VALIDITY_CACHE.get(locale)
+  if (cached !== undefined) return cached
+  let valid: boolean
+  try {
+    Intl.getCanonicalLocales(locale)
+    valid = true
+  } catch {
+    valid = false
+  }
+  LOCALE_VALIDITY_CACHE.set(locale, valid)
+  return valid
+}
+
+/**
+ * Return ``locale`` when it is a valid BCP 47 tag, otherwise fall back
+ * to {@link getLocale}. Prevents caller-supplied malformed locales
+ * (e.g. from a settings store that has not yet been validated) from
+ * throwing ``RangeError`` inside ``toLocaleString`` / ``Intl.*``.
+ */
+function resolveLocale(locale: string): string {
+  return isValidLocale(locale) ? locale : getLocale()
+}
+
+/**
  * Parse {@link DateInput} to a ``Date`` (or ``null`` on invalid input).
  *
  * Date-only ISO strings (``YYYY-MM-DD``) are parsed into the local
@@ -69,7 +101,7 @@ export function formatDateTime(
 ): string {
   const date = toDate(value)
   if (!date) return '--'
-  return date.toLocaleString(locale, {
+  return date.toLocaleString(resolveLocale(locale), {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
@@ -96,7 +128,7 @@ export function formatDateOnly(
 ): string {
   const date = toDate(value)
   if (!date) return '--'
-  return date.toLocaleDateString(locale, {
+  return date.toLocaleDateString(resolveLocale(locale), {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
@@ -114,7 +146,7 @@ export function formatTime(
 ): string {
   const date = toDate(value)
   if (!date) return '--'
-  return date.toLocaleTimeString(locale, {
+  return date.toLocaleTimeString(resolveLocale(locale), {
     hour: '2-digit',
     minute: '2-digit',
   })
@@ -131,7 +163,10 @@ export function formatDayLabel(
 ): string {
   const date = toDate(value)
   if (!date) return '--'
-  return date.toLocaleDateString(locale, { month: 'short', day: 'numeric' })
+  return date.toLocaleDateString(resolveLocale(locale), {
+    month: 'short',
+    day: 'numeric',
+  })
 }
 
 /**
@@ -168,7 +203,9 @@ export function formatRelativeTime(
   const diffSec = Math.floor(diffMs / MS_PER_SECOND)
   if (diffSec >= SEC_PER_WEEK) return formatDateTime(iso, locale)
 
-  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' })
+  const rtf = new Intl.RelativeTimeFormat(resolveLocale(locale), {
+    numeric: 'auto',
+  })
   if (diffSec < SEC_PER_MIN) return rtf.format(-diffSec, 'second')
   if (diffSec < SEC_PER_HOUR) {
     return rtf.format(-Math.floor(diffSec / SEC_PER_MIN), 'minute')
@@ -196,7 +233,7 @@ export function formatCurrency(
 ): string {
   if (!Number.isFinite(value)) return '--'
   try {
-    return new Intl.NumberFormat(locale, {
+    return new Intl.NumberFormat(resolveLocale(locale), {
       style: 'currency',
       currency: currencyCode,
     }).format(value)
@@ -223,7 +260,7 @@ export function formatCurrencyCompact(
 ): string {
   if (!Number.isFinite(value)) return '--'
   try {
-    return new Intl.NumberFormat(locale, {
+    return new Intl.NumberFormat(resolveLocale(locale), {
       style: 'currency',
       currency: currencyCode,
       maximumFractionDigits: 0,
@@ -247,7 +284,7 @@ export function formatNumber(
   locale: string = getLocale(),
 ): string {
   if (!Number.isFinite(value)) return '--'
-  return new Intl.NumberFormat(locale).format(value)
+  return new Intl.NumberFormat(resolveLocale(locale)).format(value)
 }
 
 /**
@@ -261,7 +298,7 @@ export function formatTokenCount(
 ): string {
   if (!Number.isFinite(value)) return '--'
   if (value < COMPACT_K_THRESHOLD) return formatNumber(value, locale)
-  return new Intl.NumberFormat(locale, {
+  return new Intl.NumberFormat(resolveLocale(locale), {
     notation: 'compact',
     maximumFractionDigits: 1,
   }).format(value)

--- a/web/src/utils/locale.ts
+++ b/web/src/utils/locale.ts
@@ -1,24 +1,63 @@
 /**
  * Locale source of truth for the dashboard.
  *
- * Parallel to `@/utils/currencies` -- export a default constant plus a
- * runtime reader that can later resolve a per-user or per-company locale
- * override from the settings store. Every formatter helper in
- * `@/utils/format` accepts an optional `locale?: string` parameter and
- * falls back to `getLocale()` when not provided.
+ * Parallel to `@/utils/currencies` -- export a fallback constant plus a
+ * runtime reader that resolves, in precedence order:
+ *
+ *   1. A user / company override (wired in a later change once the
+ *      settings store exposes a ``display.locale`` setting).
+ *   2. The browser's language tag (``navigator.language``), so a user
+ *      in Zurich lands on ``de-CH`` and a user in Paris lands on
+ *      ``fr-FR`` without any configuration.
+ *   3. {@link APP_LOCALE_FALLBACK} (``en-US``), used only when no
+ *      browser tag is available (e.g. SSR, non-browser tests).
+ *
+ * Every formatter helper in `@/utils/format` accepts an optional
+ * `locale?: string` parameter and falls back to `getLocale()` when
+ * not provided.
  */
 
-/** IETF BCP 47 default locale. */
-export const APP_LOCALE = 'en-US'
+/**
+ * Last-resort fallback BCP 47 tag. Applied only when the browser
+ * does not expose ``navigator.language`` (SSR, unit tests) and no
+ * user/company override is configured. Consumers should prefer
+ * {@link getLocale} over this constant so the runtime resolution
+ * wins at every callsite.
+ */
+export const APP_LOCALE_FALLBACK = 'en-US'
+
+/**
+ * Backwards-compatible alias for {@link APP_LOCALE_FALLBACK}.
+ *
+ * @deprecated Prefer {@link getLocale} so runtime resolution (browser
+ * locale, then user override) is applied. Kept as an exported name
+ * because existing tests import ``APP_LOCALE`` to assert the
+ * fallback-shape contract.
+ */
+export const APP_LOCALE = APP_LOCALE_FALLBACK
+
+function readBrowserLocale(): string | null {
+  if (typeof navigator === 'undefined') return null
+  const raw = navigator.language
+  if (typeof raw !== 'string' || raw.length === 0) return null
+  try {
+    Intl.getCanonicalLocales(raw)
+    return raw
+  } catch {
+    return null
+  }
+}
 
 /**
  * Return the active locale for display formatting.
  *
- * Currently always returns `APP_LOCALE`. The function exists as the
- * central hook so the settings store can swap in a user-selected locale
- * once the backend exposes a `display.locale` setting without churning
- * every callsite.
+ * Resolution order: user/company override (not yet wired) →
+ * browser language → {@link APP_LOCALE_FALLBACK}. Centralizing this
+ * lookup means we can plug in a settings-store reader later without
+ * churning every callsite.
  */
 export function getLocale(): string {
-  return APP_LOCALE
+  // TODO(settings-store): consult the company/user override first
+  // once the backend exposes a ``display.locale`` setting.
+  return readBrowserLocale() ?? APP_LOCALE_FALLBACK
 }

--- a/web/src/utils/locale.ts
+++ b/web/src/utils/locale.ts
@@ -1,0 +1,24 @@
+/**
+ * Locale source of truth for the dashboard.
+ *
+ * Parallel to `@/utils/currencies` -- export a default constant plus a
+ * runtime reader that can later resolve a per-user or per-company locale
+ * override from the settings store. Every formatter helper in
+ * `@/utils/format` accepts an optional `locale?: string` parameter and
+ * falls back to `getLocale()` when not provided.
+ */
+
+/** IETF BCP 47 default locale. */
+export const APP_LOCALE = 'en-US'
+
+/**
+ * Return the active locale for display formatting.
+ *
+ * Currently always returns `APP_LOCALE`. The function exists as the
+ * central hook so the settings store can swap in a user-selected locale
+ * once the backend exposes a `display.locale` setting without churning
+ * every callsite.
+ */
+export function getLocale(): string {
+  return APP_LOCALE
+}

--- a/web/src/utils/messages.ts
+++ b/web/src/utils/messages.ts
@@ -117,7 +117,7 @@ export function getDateGroupLabel(dateKey: string): string {
   if (target.getTime() === today.getTime()) return 'Today'
   if (target.getTime() === yesterday.getTime()) return 'Yesterday'
 
-  return formatDateOnly(target.toISOString())
+  return formatDateOnly(target)
 }
 
 // ── Thread grouping ────────────────────────────────────────

--- a/web/src/utils/messages.ts
+++ b/web/src/utils/messages.ts
@@ -1,5 +1,6 @@
 import type { Message, MessagePriority, MessageType, ChannelType } from '@/api/types'
 import type { SemanticColor } from '@/lib/utils'
+import { formatDateOnly } from '@/utils/format'
 
 // ── Message type labels ────────────────────────────────────
 
@@ -116,11 +117,7 @@ export function getDateGroupLabel(dateKey: string): string {
   if (target.getTime() === today.getTime()) return 'Today'
   if (target.getTime() === yesterday.getTime()) return 'Yesterday'
 
-  return target.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  })
+  return formatDateOnly(target.toISOString())
 }
 
 // ── Thread grouping ────────────────────────────────────────

--- a/web/src/utils/providers.ts
+++ b/web/src/utils/providers.ts
@@ -6,7 +6,7 @@ import type {
   ProviderHealthSummary,
 } from '@/api/types'
 import type { SemanticColor } from '@/lib/utils'
-import { formatCurrency } from '@/utils/format'
+import { formatCurrency, formatTokenCount as formatTokenCountBase } from '@/utils/format'
 
 // ── Types ─────────────────────────────────────────────────────
 
@@ -136,12 +136,9 @@ export function formatErrorRate(rate: number): string {
   return `${rate.toFixed(1)}%`
 }
 
-/** Format a token count with K/M suffixes. */
+/** Format a token count with K/M suffixes (locale-aware). */
 export function formatTokenCount(n: number): string {
-  if (n === 0) return '0'
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
-  return n.toLocaleString()
+  return formatTokenCountBase(n)
 }
 
 /** Format a cost value using the project currency (defaults to EUR). */

--- a/web/src/utils/providers.ts
+++ b/web/src/utils/providers.ts
@@ -6,6 +6,7 @@ import type {
   ProviderHealthSummary,
 } from '@/api/types'
 import type { SemanticColor } from '@/lib/utils'
+import { DEFAULT_CURRENCY } from '@/utils/currencies'
 import { formatCurrency, formatTokenCount as formatTokenCountBase } from '@/utils/format'
 
 // ── Types ─────────────────────────────────────────────────────
@@ -137,14 +138,17 @@ export function formatErrorRate(rate: number): string {
 }
 
 /** Format a token count with K/M suffixes (locale-aware). */
-export function formatTokenCount(n: number): string {
-  return formatTokenCountBase(n)
+export function formatTokenCount(n: number, locale?: string): string {
+  return formatTokenCountBase(n, locale)
 }
 
-/** Format a cost value using the project currency (defaults to EUR). */
+/**
+ * Format a cost value using the project currency (defaults to
+ * {@link DEFAULT_CURRENCY}).
+ */
 export function formatCost(
   cost: number,
-  currencyCode: string = 'EUR',
+  currencyCode: string = DEFAULT_CURRENCY,
 ): string {
   if (cost === 0) return formatCurrency(0, currencyCode)
   if (cost > 0 && cost < 0.01) {


### PR DESCRIPTION
## Summary

Quality-pass bundle that resolves four dashboard correctness / contract / a11y issues in a single surface.

### Changes

- **#1402 -- Centralize locale + formatter helpers** (`web/src/utils/locale.ts` new, `web/src/utils/format.ts` refactored). `APP_LOCALE` + `getLocale()` reader parallel to `DEFAULT_CURRENCY`. Every helper accepts optional `locale?: string`. New helpers: `formatDateOnly`, `formatDateTime`, `formatTime`, `formatDayLabel`, `formatTodayLabel`, `formatTokenCount`. Migrated all 25 hardcoded `'en-US'` literals and bare `.toLocaleString()` callsites across 18 files. PostToolUse hook `scripts/check_web_design_system.py` extended to flag regressions.
- **#1386 -- Frontend-backend DTO parity**. `CostRecord` TS gains 8 missing fields (`project_id`, `accuracy_effort_ratio`, `latency_ms`, `cache_hit`, `retry_count`, `retry_reason`, `finish_reason`, `success`). `ApprovalItem.evidence_package` with full nested TS mirror (`EvidencePackage`, `RecommendedAction`, `EvidencePackageSignature`). `UpdateAgentOrgRequest` gains `model_provider` / `model_id`. Backend `UpdateDepartmentRequest.teams` tightened from `tuple[dict[str, object], ...]` to `tuple[Team, ...]` (typed, `max_length=64`). New TS types `PullModelRequest`, `UpdateModelConfigRequest`. Contract tests in `tests/unit/api/test_dto_parity.py`.
- **#1389 -- A11y fixes across 10 components**. `TaskColumn` semantic `<section>` + labeled counts. `OrgChartToolbar` `role="toolbar"`. `TagInput` `aria-hidden="true"`. `TaskCard` `aria-pressed`/`aria-roledescription` drag state. `StatusBadge` `role="img"` by default + new `decorative` prop for embedded usage (applied in `AgentNode`). `ActivityLog` `role="list"` / `role="listitem"` semantics (StaggerGroup/Item accept new role props). `SidebarNavItem` external links gain `target="_blank" rel="noopener noreferrer"` + sr-only "opens in new tab". `WorkflowEditorPage` sr-only graph summary with `aria-describedby`. `AgentNode` handles marked `aria-hidden` + `isConnectable={false}` for read-only use. `Sparkline` JSDoc clarifies labeled vs decorative contract.
- **#1394 -- Wire training UI end-to-end**. New Zustand store `web/src/stores/training.ts` (follows mandatory try/catch + toast + sentinel pattern). New `/training` page with metric cards + `TrainingPlanTable`. `TrainingPanel`, `TrainingProgress`, `TrainingReviewModal` embedded in `AgentDetailPage` via new `TrainingSection` wrapper. Sidebar entry under Agents. Route constant `ROUTES.TRAINING`. `TrainingPanel` now consumes the canonical `TrainingPlanRequest` type (drops local duplicate).

### Test plan

- `uv run ruff check src/ tests/` -- clean
- `uv run mypy src/synthorg` -- clean (1527 source files)
- `uv run python -m pytest tests/ -m unit -n 8 --timeout=30` -- 20,989 passed, 6 skipped
- `uv run python -m pytest tests/unit/api/test_dto_parity.py -n 8` -- 18 passed (new parity + max_length)
- `npm --prefix web run lint` -- clean (zero warnings)
- `npm --prefix web run type-check` -- clean
- `npm --prefix web run test` -- 2,500 passed
- Hook coverage extended: hardcoded locales + bare `.toLocaleString()` now flagged by `scripts/check_web_design_system.py`

### Review coverage

Pre-reviewed by 4 agents (frontend, python, api-contract-drift, security). Zero critical/major drift. Two minor findings addressed:
- Training store `previewPlan` error-toast title clarified
- `UpdateDepartmentRequest.teams` DoS bound (`max_length=64`)

False-positive findings skipped with justification recorded in review:
- React auto-stringifies boolean `aria-pressed` per spec (TaskCard)
- `Intl.NumberFormat(..., { notation: 'compact', maximumFractionDigits: 1 }).format(50000)` returns `'50K'` (regex already matches)
- `ApprovalItem.evidence_package` UI rendering is a follow-up -- type parity is this PR's scope

Closes #1402
Closes #1386
Closes #1389
Closes #1394
