### PR TITLE
fix: kill stubs across engine/meta/security/tools/communication

### DIFF
--- a/docs/design/communication.md
+++ b/docs/design/communication.md
@@ -659,19 +659,34 @@ These fields are applied to all meeting endpoints (list, detail, trigger).
 
 ### Auto-Wiring
 
-The `MeetingOrchestrator` and `MeetingScheduler` are auto-wired at startup
-alongside Phase 1 services (no persistence dependency). All three meeting
-protocols are registered with default configs.
+The `MeetingOrchestrator` is auto-wired at startup alongside Phase 1
+services (no persistence dependency). All three meeting protocols are
+registered with default configs.
 
-When both `agent_registry` and `provider_registry` are available at wire
-time, the `agent_caller` dispatches a real LLM call per turn (one
-`provider.complete()` per agent per turn, with automatic retry + rate
-limiting via `BaseCompletionProvider`). When either dependency is
-missing, the orchestrator is still constructed so REST endpoints remain
-available, but any attempt to invoke an agent raises
-`MeetingAgentCallerNotConfiguredError` at call time -- no silent empty
-responses. This forces operators to surface wiring gaps instead of
-producing meaningless participation.
+**Fully-wired mode.** When both `agent_registry` and `provider_registry`
+are available, the `agent_caller` dispatches a real LLM call per turn
+(one `provider.complete()` per agent per turn, with automatic retry +
+rate limiting via `BaseCompletionProvider`). The `MeetingScheduler` and
+`CeremonyScheduler` are auto-wired alongside the orchestrator so
+periodic and event-triggered meetings run on schedule.
+
+**Degraded (unconfigured) mode.** When either `agent_registry` or
+`provider_registry` is missing, the orchestrator is still constructed
+so REST endpoints stay available, but:
+
+- The `agent_caller` returned by `build_unconfigured_meeting_agent_caller`
+  raises `MeetingAgentCallerNotConfiguredError` at call time -- no
+  silent empty responses.
+- `MeetingScheduler` and `CeremonyScheduler` are **not** auto-wired
+  (`meeting_wire.meeting_scheduler is None`,
+  `meeting_wire.ceremony_scheduler is None`).  Running scheduled
+  meetings against a known-failing caller would only produce background
+  noise, so periodic and ceremony-triggered meetings are skipped
+  entirely until the missing dependencies are provided.
+
+This forces operators to surface wiring gaps instead of producing
+meaningless participation, and prevents the schedulers from spamming
+logs with avoidable failures during degraded startup.
 
 ---
 

--- a/docs/design/communication.md
+++ b/docs/design/communication.md
@@ -661,10 +661,17 @@ These fields are applied to all meeting endpoints (list, detail, trigger).
 
 The `MeetingOrchestrator` and `MeetingScheduler` are auto-wired at startup
 alongside Phase 1 services (no persistence dependency). All three meeting
-protocols are registered with default configs. A stub `agent_caller` returns
-empty `AgentResponse` instances, making the meeting endpoints structurally
-available (no 503 on listing) while actual agent invocation requires a
-coordinator to be explicitly provided.
+protocols are registered with default configs.
+
+When both `agent_registry` and `provider_registry` are available at wire
+time, the `agent_caller` dispatches a real LLM call per turn (one
+`provider.complete()` per agent per turn, with automatic retry + rate
+limiting via `BaseCompletionProvider`). When either dependency is
+missing, the orchestrator is still constructed so REST endpoints remain
+available, but any attempt to invoke an agent raises
+`MeetingAgentCallerNotConfiguredError` at call time -- no silent empty
+responses. This forces operators to surface wiring gaps instead of
+producing meaningless participation.
 
 ---
 

--- a/docs/design/operations.md
+++ b/docs/design/operations.md
@@ -1403,7 +1403,7 @@ Policies are loaded from files at company boot. No external process needed.
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `engine` | `"none"` | Backend: `"cedar"` or `"none"` (Rego adapter planned; not yet implemented) |
+| `engine` | `"none"` | Backend: `"cedar"` or `"none"` |
 | `policy_files` | `()` | Paths to Cedar policy files |
 | `evaluation_mode` | `"log_only"` | `"enforce"` blocks; `"log_only"` logs only |
 | `fail_closed` | `False` | Deny on evaluation errors if `True` |

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -1357,6 +1357,7 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
         meeting_orchestrator=meeting_orchestrator,
         meeting_scheduler=meeting_scheduler,
         agent_registry=agent_registry,
+        provider_registry=provider_registry,
     )
     meeting_orchestrator = meeting_wire.meeting_orchestrator
     meeting_scheduler = meeting_wire.meeting_scheduler

--- a/src/synthorg/api/auto_wire.py
+++ b/src/synthorg/api/auto_wire.py
@@ -73,14 +73,19 @@ class Phase1Result(NamedTuple):
 class MeetingWireResult(NamedTuple):
     """Services created during meeting auto-wiring.
 
-    All fields are guaranteed non-``None`` after
-    ``auto_wire_meetings()`` returns -- explicit values pass through
-    and ``None`` inputs are replaced with auto-wired instances.
+    ``meeting_orchestrator`` is always non-``None``.  ``meeting_scheduler``
+    and ``ceremony_scheduler`` are ``None`` when auto-wiring discovered
+    missing dependencies (agent_registry / provider_registry) and so the
+    caller is known-failing -- running scheduled meetings against a
+    caller that is guaranteed to raise would produce background noise
+    with no useful output, so the schedulers are intentionally not
+    wired until the operator provides the missing dependencies.
+    Explicit values always pass through unchanged.
     """
 
     meeting_orchestrator: MeetingOrchestrator
-    meeting_scheduler: MeetingScheduler
-    ceremony_scheduler: CeremonyScheduler
+    meeting_scheduler: MeetingScheduler | None
+    ceremony_scheduler: CeremonyScheduler | None
 
 
 class BuildDispatcherFn(Protocol):
@@ -370,6 +375,15 @@ def auto_wire_meetings(
     lifecycle stage as Phase 1 -- meeting services don't need
     connected persistence.
 
+    When auto-wiring the orchestrator without an agent registry or
+    provider registry, the resulting agent caller is guaranteed to
+    raise :class:`MeetingAgentCallerNotConfiguredError` at call time.
+    Running scheduled meetings against a known-failing caller only
+    produces background noise, so ``meeting_scheduler`` and
+    ``ceremony_scheduler`` are intentionally left ``None`` in that
+    case.  Providing the missing dependencies on a subsequent app
+    build wires the schedulers for real.
+
     Args:
         effective_config: Root company configuration.
         meeting_orchestrator: Explicit orchestrator or ``None`` to
@@ -388,8 +402,16 @@ def auto_wire_meetings(
             calls fail loudly with actionable error context.
 
     Returns:
-        A ``MeetingWireResult`` with both services.
+        A ``MeetingWireResult``.  ``meeting_scheduler`` and
+        ``ceremony_scheduler`` may be ``None`` when the auto-wired
+        orchestrator has a known-failing caller (see docstring).
     """
+    orchestrator_was_auto_wired = meeting_orchestrator is None
+    missing_dependencies: tuple[str, ...] = _missing_meeting_dependencies(
+        agent_registry=agent_registry,
+        provider_registry=provider_registry,
+    )
+
     if meeting_orchestrator is None:
         meeting_orchestrator = _wire_meeting_orchestrator(
             agent_registry=agent_registry,
@@ -405,6 +427,34 @@ def auto_wire_meetings(
                     "Provide both or neither for consistent state"
                 ),
             )
+
+    # Skip scheduler/ceremony wiring only when the auto-wired
+    # orchestrator has a guaranteed-failing caller AND the operator
+    # did not supply an explicit scheduler.  Explicit schedulers always
+    # pass through unchanged so operators can mix wiring strategies.
+    skip_scheduler_wiring = (
+        orchestrator_was_auto_wired
+        and bool(missing_dependencies)
+        and meeting_scheduler is None
+    )
+
+    if skip_scheduler_wiring:
+        logger.warning(
+            API_APP_STARTUP,
+            note=(
+                "Skipping MeetingScheduler and CeremonyScheduler wiring "
+                "because meeting agent caller is unconfigured -- "
+                "scheduled meetings would invoke a caller guaranteed "
+                "to raise MeetingAgentCallerNotConfiguredError.  Provide "
+                "the missing dependencies to wire the full meeting stack"
+            ),
+            missing_dependencies=missing_dependencies,
+        )
+        return MeetingWireResult(
+            meeting_orchestrator=meeting_orchestrator,
+            meeting_scheduler=None,
+            ceremony_scheduler=None,
+        )
 
     if meeting_scheduler is None:
         meeting_scheduler = _wire_meeting_scheduler(
@@ -423,6 +473,20 @@ def auto_wire_meetings(
         meeting_scheduler=meeting_scheduler,
         ceremony_scheduler=ceremony_scheduler,
     )
+
+
+def _missing_meeting_dependencies(
+    *,
+    agent_registry: AgentRegistryService | None,
+    provider_registry: ProviderRegistry | None,
+) -> tuple[str, ...]:
+    """Return the names of meeting dependencies that are ``None``."""
+    missing: list[str] = []
+    if agent_registry is None:
+        missing.append("agent_registry")
+    if provider_registry is None:
+        missing.append("provider_registry")
+    return tuple(missing)
 
 
 def _build_protocol_registry() -> Mapping[MeetingProtocolType, MeetingProtocol]:
@@ -498,23 +562,22 @@ def _wire_meeting_orchestrator(
     """
     try:
         protocol_registry = _build_protocol_registry()
-        missing: list[str] = []
-        if agent_registry is None:
-            missing.append("agent_registry")
-        if provider_registry is None:
-            missing.append("provider_registry")
+        missing = _missing_meeting_dependencies(
+            agent_registry=agent_registry,
+            provider_registry=provider_registry,
+        )
         if missing:
             logger.warning(
                 API_APP_STARTUP,
                 note=(
-                    "MeetingOrchestrator wired without "
-                    + ", ".join(missing)
-                    + "; agent invocation will fail at call time "
-                    "until those dependencies are provided"
+                    "MeetingOrchestrator wired with an unconfigured agent "
+                    "caller; agent invocation will fail at call time until "
+                    "the missing dependencies are provided"
                 ),
+                missing_dependencies=missing,
             )
             agent_caller: AgentCaller = build_unconfigured_meeting_agent_caller(
-                missing_dependencies=tuple(missing),
+                missing_dependencies=missing,
             )
         else:
             # Both registries are non-None (the `missing` check above).

--- a/src/synthorg/api/auto_wire.py
+++ b/src/synthorg/api/auto_wire.py
@@ -463,9 +463,16 @@ def auto_wire_meetings(
             agent_registry,
         )
 
-    ceremony_scheduler = CeremonyScheduler(
-        meeting_scheduler=meeting_scheduler,
-    )
+    try:
+        ceremony_scheduler = CeremonyScheduler(
+            meeting_scheduler=meeting_scheduler,
+        )
+    except Exception:
+        logger.exception(
+            API_APP_STARTUP,
+            error="Failed to auto-wire ceremony scheduler",
+        )
+        raise
     logger.info(API_SERVICE_AUTO_WIRED, service="ceremony_scheduler")
 
     return MeetingWireResult(

--- a/src/synthorg/api/auto_wire.py
+++ b/src/synthorg/api/auto_wire.py
@@ -16,8 +16,11 @@ from typing import TYPE_CHECKING, NamedTuple, Protocol
 
 from synthorg.api.channels import ALL_CHANNELS
 from synthorg.budget.tracker import CostTracker
+from synthorg.communication.meeting.agent_caller import (
+    build_meeting_agent_caller,
+    build_unconfigured_meeting_agent_caller,
+)
 from synthorg.communication.meeting.enums import MeetingProtocolType
-from synthorg.communication.meeting.models import AgentResponse
 from synthorg.communication.meeting.orchestrator import MeetingOrchestrator
 from synthorg.communication.meeting.scheduler import MeetingScheduler
 from synthorg.engine.task_engine import TaskEngine
@@ -27,7 +30,6 @@ from synthorg.observability.events.api import (
     API_APP_STARTUP,
     API_SERVICE_AUTO_WIRED,
 )
-from synthorg.observability.events.meeting import MEETING_STUB_AGENT_CALLER
 from synthorg.providers.health import ProviderHealthTracker
 from synthorg.providers.registry import ProviderRegistry
 
@@ -359,6 +361,7 @@ def auto_wire_meetings(
     meeting_orchestrator: MeetingOrchestrator | None,
     meeting_scheduler: MeetingScheduler | None,
     agent_registry: AgentRegistryService | None,
+    provider_registry: ProviderRegistry | None,
 ) -> MeetingWireResult:
     """Auto-wire meeting orchestrator and scheduler.
 
@@ -372,14 +375,28 @@ def auto_wire_meetings(
         meeting_orchestrator: Explicit orchestrator or ``None`` to
             auto-wire.
         meeting_scheduler: Explicit scheduler or ``None`` to auto-wire.
-        agent_registry: Agent registry (may be ``None``).  When
-            ``None``, a passthrough participant resolver is used.
+        agent_registry: Agent registry.  Required when auto-wiring the
+            orchestrator so meeting turns can resolve agent identities.
+            May be ``None`` when *meeting_orchestrator* is supplied
+            explicitly; in that case a passthrough participant resolver
+            is used for scheduling.
+        provider_registry: Provider registry.  Required when
+            auto-wiring the orchestrator so meeting turns can dispatch
+            LLM calls.  May be ``None`` when *meeting_orchestrator* is
+            supplied explicitly.
 
     Returns:
         A ``MeetingWireResult`` with both services.
+
+    Raises:
+        RuntimeError: When auto-wiring the orchestrator without both
+            *agent_registry* and *provider_registry*.
     """
     if meeting_orchestrator is None:
-        meeting_orchestrator = _wire_meeting_orchestrator()
+        meeting_orchestrator = _wire_meeting_orchestrator(
+            agent_registry=agent_registry,
+            provider_registry=provider_registry,
+        )
         if meeting_scheduler is not None:
             logger.warning(
                 API_APP_STARTUP,
@@ -458,51 +475,57 @@ def _build_protocol_registry() -> Mapping[MeetingProtocolType, MeetingProtocol]:
     return registry
 
 
-def _build_stub_agent_caller() -> AgentCaller:
-    """Create a stub agent caller for auto-wired meetings.
+def _wire_meeting_orchestrator(
+    *,
+    agent_registry: AgentRegistryService | None,
+    provider_registry: ProviderRegistry | None,
+) -> MeetingOrchestrator:
+    """Create a MeetingOrchestrator wired to real LLM dispatch.
 
-    Returns an async callback that produces placeholder
-    ``AgentResponse`` instances with zero tokens and empty content.
-    This allows the meeting subsystem to be structurally available
-    (no 503) while actual agent invocation requires a coordinator.
+    When both *agent_registry* and *provider_registry* are available,
+    the orchestrator dispatches real LLM calls per turn.  When either
+    is missing, the orchestrator is still constructed so the REST
+    surface stays available, but any attempt to invoke an agent raises
+    :class:`MeetingAgentCallerNotConfiguredError` at call time -- no
+    silent empty responses.
 
-    Returns:
-        An ``AgentCaller`` compatible async callback.
-    """
-
-    async def _stub_caller(
-        agent_id: str,
-        _prompt: str,
-        _max_tokens: int,
-    ) -> AgentResponse:
-        logger.warning(
-            MEETING_STUB_AGENT_CALLER,
-            agent_id=agent_id,
-            note=(
-                "Stub agent caller invoked -- response will be "
-                "empty until a coordinator is configured"
-            ),
-        )
-        return AgentResponse(
-            agent_id=agent_id,
-            content="",
-            input_tokens=0,
-            output_tokens=0,
-            cost_usd=0.0,
-        )
-
-    return _stub_caller
-
-
-def _wire_meeting_orchestrator() -> MeetingOrchestrator:
-    """Create a MeetingOrchestrator with all protocols registered.
+    Args:
+        agent_registry: Source of truth for agent identity lookup,
+            or ``None`` when not yet available.
+        provider_registry: Source of truth for LLM providers,
+            or ``None`` when not yet available.
 
     Returns:
-        A configured ``MeetingOrchestrator`` instance.
+        A configured ``MeetingOrchestrator``.
     """
     try:
         protocol_registry = _build_protocol_registry()
-        agent_caller = _build_stub_agent_caller()
+        missing: list[str] = []
+        if agent_registry is None:
+            missing.append("agent_registry")
+        if provider_registry is None:
+            missing.append("provider_registry")
+        if missing:
+            logger.warning(
+                API_APP_STARTUP,
+                note=(
+                    "MeetingOrchestrator wired without "
+                    + ", ".join(missing)
+                    + "; agent invocation will fail at call time "
+                    "until those dependencies are provided"
+                ),
+            )
+            agent_caller: AgentCaller = build_unconfigured_meeting_agent_caller(
+                missing_dependencies=tuple(missing),
+            )
+        else:
+            # Both registries are non-None (the `missing` check above).
+            assert agent_registry is not None  # noqa: S101
+            assert provider_registry is not None  # noqa: S101
+            agent_caller = build_meeting_agent_caller(
+                agent_registry=agent_registry,
+                provider_registry=provider_registry,
+            )
         orchestrator = MeetingOrchestrator(
             protocol_registry=protocol_registry,
             agent_caller=agent_caller,

--- a/src/synthorg/api/auto_wire.py
+++ b/src/synthorg/api/auto_wire.py
@@ -380,17 +380,15 @@ def auto_wire_meetings(
             May be ``None`` when *meeting_orchestrator* is supplied
             explicitly; in that case a passthrough participant resolver
             is used for scheduling.
-        provider_registry: Provider registry.  Required when
-            auto-wiring the orchestrator so meeting turns can dispatch
-            LLM calls.  May be ``None`` when *meeting_orchestrator* is
-            supplied explicitly.
+        provider_registry: Provider registry.  Used for real LLM
+            dispatch per meeting turn when auto-wiring.  When ``None``,
+            an unconfigured caller is wired that raises
+            :class:`MeetingAgentCallerNotConfiguredError` at first
+            invocation -- the REST surface stays available but agent
+            calls fail loudly with actionable error context.
 
     Returns:
         A ``MeetingWireResult`` with both services.
-
-    Raises:
-        RuntimeError: When auto-wiring the orchestrator without both
-            *agent_registry* and *provider_registry*.
     """
     if meeting_orchestrator is None:
         meeting_orchestrator = _wire_meeting_orchestrator(

--- a/src/synthorg/api/controllers/meetings.py
+++ b/src/synthorg/api/controllers/meetings.py
@@ -247,7 +247,18 @@ class MeetingController(Controller):
 
         Returns:
             Tuple of meeting responses for all triggered meetings.
+
+        Raises:
+            ServiceUnavailableError: Raised by the
+                ``app_state.meeting_scheduler`` property (503) when the
+                scheduler was not auto-wired -- happens in the degraded
+                (unconfigured) meeting agent caller mode.  The operator
+                must provide the agent and provider registries before
+                meetings can be triggered.
         """
+        # ``app_state.meeting_scheduler`` raises ServiceUnavailableError
+        # when the scheduler is ``None`` (degraded mode), so this
+        # endpoint fails with a clean 503 rather than AttributeError.
         scheduler = state.app_state.meeting_scheduler
         records = await scheduler.trigger_event(
             data.event_name,

--- a/src/synthorg/communication/delegation/record_store.py
+++ b/src/synthorg/communication/delegation/record_store.py
@@ -6,6 +6,7 @@ count exceeds ``max_records``, oldest entries are evicted (FIFO).
 """
 
 import asyncio
+import threading
 from collections import deque
 from typing import TYPE_CHECKING
 
@@ -36,12 +37,16 @@ class DelegationRecordStore:
     ``max_records``, oldest entries are evicted (FIFO) via bounded
     ``deque``.
 
-    Concurrency note: ``record_sync`` does not acquire ``_lock``.
-    The lock serialises concurrent async readers only.  Cooperative
-    asyncio scheduling and deque's internal maxlen enforcement make
-    single-call sync writes safe (``deque.append`` cannot be
-    interrupted).  The eviction warning is best-effort under this
-    model.
+    Concurrency note: ``record_sync`` does not acquire the async
+    ``_lock`` (which serialises concurrent async readers only).
+    Cooperative asyncio scheduling and deque's internal maxlen
+    enforcement make single-call sync writes safe
+    (``deque.append`` cannot be interrupted).  The one-shot
+    eviction warning is protected by ``_warning_lock``
+    (``threading.Lock``) so the check-then-set on
+    ``_eviction_warned`` is atomic across threads and coroutines:
+    exactly one warning is emitted per fill cycle, and ``clear()``
+    cleanly resets the flag for the next cycle.
 
     Args:
         max_records: Maximum records before oldest are evicted.
@@ -62,13 +67,15 @@ class DelegationRecordStore:
             maxlen=max_records,
         )
         self._lock: asyncio.Lock = asyncio.Lock()
+        self._warning_lock: threading.Lock = threading.Lock()
         self._eviction_warned: bool = False
 
     def clear(self) -> None:
         """Reset all delegation records for test isolation."""
         cleared_count = len(self._records)
         self._records.clear()
-        self._eviction_warned = False
+        with self._warning_lock:
+            self._eviction_warned = False
         logger.info(
             DELEGATION_RECORD_STORE_CLEARED,
             cleared_count=cleared_count,
@@ -84,12 +91,13 @@ class DelegationRecordStore:
         Args:
             delegation: Immutable delegation record to store.
         """
-        if not self._eviction_warned and len(self._records) == self._records.maxlen:
-            logger.warning(
-                DELEGATION_RECORD_EVICTED,
-                max_records=self._records.maxlen,
-            )
-            self._eviction_warned = True
+        with self._warning_lock:
+            if not self._eviction_warned and len(self._records) == self._records.maxlen:
+                logger.warning(
+                    DELEGATION_RECORD_EVICTED,
+                    max_records=self._records.maxlen,
+                )
+                self._eviction_warned = True
         self._records.append(delegation)
         logger.debug(
             DELEGATION_RECORD_STORED,

--- a/src/synthorg/communication/delegation/record_store.py
+++ b/src/synthorg/communication/delegation/record_store.py
@@ -41,12 +41,17 @@ class DelegationRecordStore:
     ``_lock`` (which serialises concurrent async readers only).
     Cooperative asyncio scheduling and deque's internal maxlen
     enforcement make single-call sync writes safe
-    (``deque.append`` cannot be interrupted).  The one-shot
-    eviction warning is protected by ``_warning_lock``
-    (``threading.Lock``) so the check-then-set on
-    ``_eviction_warned`` is atomic across threads and coroutines:
-    exactly one warning is emitted per fill cycle, and ``clear()``
-    cleanly resets the flag for the next cycle.
+    (``deque.append`` cannot be interrupted).  The eviction warning
+    flag and the record buffer mutations are both held under
+    ``_warning_lock`` (``threading.Lock``) so the check-then-set on
+    ``_eviction_warned`` and the subsequent ``deque.append`` /
+    ``deque.clear`` happen as a single atomic unit.  This prevents
+    duplicate warnings caused by interleaving between checking the
+    flag and updating it, and it keeps the flag in step with the
+    buffer length -- ``clear()`` resets the flag for subsequent
+    writes under the same lock.  Concurrent fill cycles may still
+    observe each other's clears; the lock protects atomicity, not
+    sequencing across independent cycles.
 
     Args:
         max_records: Maximum records before oldest are evicted.
@@ -72,9 +77,9 @@ class DelegationRecordStore:
 
     def clear(self) -> None:
         """Reset all delegation records for test isolation."""
-        cleared_count = len(self._records)
-        self._records.clear()
         with self._warning_lock:
+            cleared_count = len(self._records)
+            self._records.clear()
             self._eviction_warned = False
         logger.info(
             DELEGATION_RECORD_STORE_CLEARED,
@@ -98,7 +103,7 @@ class DelegationRecordStore:
                     max_records=self._records.maxlen,
                 )
                 self._eviction_warned = True
-        self._records.append(delegation)
+            self._records.append(delegation)
         logger.debug(
             DELEGATION_RECORD_STORED,
             delegation_id=delegation.delegation_id,

--- a/src/synthorg/communication/delegation/record_store.py
+++ b/src/synthorg/communication/delegation/record_store.py
@@ -196,9 +196,16 @@ class DelegationRecordStore:
         return _filter(snapshot, start=start, end=end)
 
     async def _snapshot(self) -> tuple[DelegationRecord, ...]:
-        """Return an immutable snapshot of all current records."""
+        """Return an immutable snapshot of all current records.
+
+        The async ``_lock`` serialises overlapping async readers, and
+        the sync ``_warning_lock`` is also taken briefly while copying
+        the deque so the snapshot cannot race with writes done under
+        the same sync lock (``record_sync`` / ``clear``).
+        """
         async with self._lock:
-            return tuple(self._records)
+            with self._warning_lock:
+                return tuple(self._records)
 
 
 # ── Module-level pure helpers ────────────────────────────────────

--- a/src/synthorg/communication/meeting/agent_caller.py
+++ b/src/synthorg/communication/meeting/agent_caller.py
@@ -1,10 +1,18 @@
-"""Real :data:`AgentCaller` factory for meeting orchestration.
+""":data:`AgentCaller` factories for meeting orchestration.
 
 The meeting orchestrator invokes agents through an :data:`AgentCaller`
 callable with the signature ``(agent_id, prompt, max_tokens) ->
-AgentResponse``.  This module produces that callable by composing an
-:class:`AgentRegistryService` (for agent identity lookup) with a
-:class:`ProviderRegistry` (for LLM dispatch).
+AgentResponse``.  This module provides two factories:
+
+- :func:`build_meeting_agent_caller` -- the real caller used in
+  production.  Composes an :class:`AgentRegistryService` (for agent
+  identity lookup) with a :class:`ProviderRegistry` (for LLM dispatch)
+  and runs one ``provider.complete()`` call per invocation.
+- :func:`build_unconfigured_meeting_agent_caller` -- a fallback caller
+  used when registries are not yet available at wire time.  It raises
+  :class:`MeetingAgentCallerNotConfiguredError` at call time, replacing
+  the old silent empty-response stub.  Operators see a loud failure
+  instead of meaningless meeting contributions.
 
 One turn = one LLM call.  Meeting protocols (round robin, position
 papers, structured phases) are responsible for sequencing turns; this
@@ -33,7 +41,18 @@ logger = get_logger(__name__)
 
 
 class UnknownMeetingAgentError(LookupError):
-    """Raised when the meeting orchestrator invokes an unregistered agent."""
+    """Raised when the meeting orchestrator invokes an unregistered agent.
+
+    Attributes:
+        agent_id: The agent identifier that was not found in the registry.
+    """
+
+    def __init__(self, agent_id: str) -> None:
+        super().__init__(
+            f"Meeting agent {agent_id!r} is not registered in the "
+            f"agent registry; cannot dispatch LLM call"
+        )
+        self.agent_id = agent_id
 
 
 def build_meeting_agent_caller(
@@ -64,11 +83,7 @@ def build_meeting_agent_caller(
         )
         identity = await agent_registry.get(NotBlankStr(agent_id))
         if identity is None:
-            msg = (
-                f"Meeting agent {agent_id!r} is not registered in the "
-                f"agent registry; cannot dispatch LLM call"
-            )
-            raise UnknownMeetingAgentError(msg)
+            raise UnknownMeetingAgentError(agent_id)
 
         provider = provider_registry.get(str(identity.model.provider))
         messages = _build_messages(identity, prompt)
@@ -144,7 +159,29 @@ class MeetingAgentCallerNotConfiguredError(RuntimeError):
     (for LLM dispatch).  When either is absent at wire time, meetings
     that try to invoke an agent receive this error instead of the
     previous silent empty-response stub.
+
+    Attributes:
+        agent_id: The agent identifier that the meeting tried to invoke.
+        missing_dependencies: Names of the dependencies that were
+            absent at wire time (e.g. ``("agent_registry",
+            "provider_registry")``).
     """
+
+    def __init__(
+        self,
+        *,
+        agent_id: str,
+        missing_dependencies: tuple[str, ...],
+    ) -> None:
+        missing = ", ".join(missing_dependencies)
+        super().__init__(
+            f"Meeting agent caller invoked for {agent_id!r} but the "
+            f"following dependencies were missing at wire time: "
+            f"{missing}.  Provide them via create_app(...) so meeting "
+            f"turns can dispatch real LLM calls."
+        )
+        self.agent_id = agent_id
+        self.missing_dependencies = missing_dependencies
 
 
 def build_unconfigured_meeting_agent_caller(
@@ -158,15 +195,15 @@ def build_unconfigured_meeting_agent_caller(
     at first use rather than silently succeeding with empty content.
     """
 
-    async def _caller(agent_id: str, _prompt: str, _max_tokens: int) -> AgentResponse:
-        missing = ", ".join(missing_dependencies)
-        msg = (
-            f"Meeting agent caller invoked for {agent_id!r} but the "
-            f"following dependencies were missing at wire time: "
-            f"{missing}.  Provide them via create_app(...) so meeting "
-            f"turns can dispatch real LLM calls."
+    async def _caller(
+        agent_id: str,
+        _prompt: str,
+        _max_tokens: int,
+    ) -> AgentResponse:
+        raise MeetingAgentCallerNotConfiguredError(
+            agent_id=agent_id,
+            missing_dependencies=missing_dependencies,
         )
-        raise MeetingAgentCallerNotConfiguredError(msg)
 
     return _caller
 

--- a/src/synthorg/communication/meeting/agent_caller.py
+++ b/src/synthorg/communication/meeting/agent_caller.py
@@ -1,0 +1,179 @@
+"""Real :data:`AgentCaller` factory for meeting orchestration.
+
+The meeting orchestrator invokes agents through an :data:`AgentCaller`
+callable with the signature ``(agent_id, prompt, max_tokens) ->
+AgentResponse``.  This module produces that callable by composing an
+:class:`AgentRegistryService` (for agent identity lookup) with a
+:class:`ProviderRegistry` (for LLM dispatch).
+
+One turn = one LLM call.  Meeting protocols (round robin, position
+papers, structured phases) are responsible for sequencing turns; this
+module only runs a single agent's inference.
+"""
+
+from typing import TYPE_CHECKING
+
+from synthorg.communication.meeting.models import AgentResponse
+from synthorg.core.types import NotBlankStr
+from synthorg.observability import get_logger
+from synthorg.observability.events.meeting import (
+    MEETING_AGENT_CALLED,
+    MEETING_AGENT_RESPONDED,
+)
+from synthorg.providers.enums import MessageRole
+from synthorg.providers.models import ChatMessage, CompletionConfig
+
+if TYPE_CHECKING:
+    from synthorg.communication.meeting.protocol import AgentCaller
+    from synthorg.core.agent import AgentIdentity
+    from synthorg.hr.registry import AgentRegistryService
+    from synthorg.providers.registry import ProviderRegistry
+
+logger = get_logger(__name__)
+
+
+class UnknownMeetingAgentError(LookupError):
+    """Raised when the meeting orchestrator invokes an unregistered agent."""
+
+
+def build_meeting_agent_caller(
+    *,
+    agent_registry: AgentRegistryService,
+    provider_registry: ProviderRegistry,
+) -> AgentCaller:
+    """Construct a meeting :data:`AgentCaller` backed by real services.
+
+    Args:
+        agent_registry: Source of truth for agent identities.
+        provider_registry: Source of truth for LLM providers.
+
+    Returns:
+        An async callback matching the :data:`AgentCaller` contract.
+    """
+
+    async def _caller(
+        agent_id: str,
+        prompt: str,
+        max_tokens: int,
+    ) -> AgentResponse:
+        logger.info(
+            MEETING_AGENT_CALLED,
+            agent_id=agent_id,
+            max_tokens=max_tokens,
+            prompt_length=len(prompt),
+        )
+        identity = await agent_registry.get(NotBlankStr(agent_id))
+        if identity is None:
+            msg = (
+                f"Meeting agent {agent_id!r} is not registered in the "
+                f"agent registry; cannot dispatch LLM call"
+            )
+            raise UnknownMeetingAgentError(msg)
+
+        provider = provider_registry.get(str(identity.model.provider))
+        messages = _build_messages(identity, prompt)
+        config = CompletionConfig(
+            temperature=identity.model.temperature,
+            max_tokens=max_tokens,
+        )
+        response = await provider.complete(
+            messages,
+            str(identity.model.model_id),
+            config=config,
+        )
+        agent_response = AgentResponse(
+            agent_id=NotBlankStr(agent_id),
+            content=response.content or "",
+            input_tokens=response.usage.input_tokens,
+            output_tokens=response.usage.output_tokens,
+            cost_usd=response.usage.cost_usd,
+        )
+        logger.info(
+            MEETING_AGENT_RESPONDED,
+            agent_id=agent_id,
+            input_tokens=agent_response.input_tokens,
+            output_tokens=agent_response.output_tokens,
+            cost_usd=agent_response.cost_usd,
+        )
+        return agent_response
+
+    return _caller
+
+
+def _build_messages(
+    identity: AgentIdentity,
+    prompt: str,
+) -> list[ChatMessage]:
+    """Assemble the minimal ``system`` + ``user`` pair for a meeting turn.
+
+    The system message is derived from the agent identity (role +
+    personality traits) so the LLM stays in character across the
+    meeting.  Protocols inject the full turn context into ``prompt``
+    (agenda, prior contributions, lens), so the system prompt only
+    carries agent-stable identity.
+    """
+    system_content = _render_system_prompt(identity)
+    return [
+        ChatMessage(role=MessageRole.SYSTEM, content=system_content),
+        ChatMessage(role=MessageRole.USER, content=prompt),
+    ]
+
+
+def _render_system_prompt(identity: AgentIdentity) -> str:
+    """Render a compact system prompt from an :class:`AgentIdentity`."""
+    lines: list[str] = [
+        f"You are {identity.name}, a {identity.role} "
+        f"in the {identity.department} department.",
+        f"Seniority level: {identity.level.value}.",
+    ]
+    traits = identity.personality.traits
+    if traits:
+        lines.append("Personality traits: " + ", ".join(traits) + ".")
+    communication_style = identity.personality.communication_style
+    if communication_style:
+        lines.append(f"Communication style: {communication_style}.")
+    return "\n".join(lines)
+
+
+class MeetingAgentCallerNotConfiguredError(RuntimeError):
+    """Raised when a meeting runs without an agent + provider registry.
+
+    The meeting orchestrator is structurally wired during Phase 1 so
+    the REST surface is never 503, but calling an agent requires the
+    agent registry (for identity lookup) and the provider registry
+    (for LLM dispatch).  When either is absent at wire time, meetings
+    that try to invoke an agent receive this error instead of the
+    previous silent empty-response stub.
+    """
+
+
+def build_unconfigured_meeting_agent_caller(
+    *,
+    missing_dependencies: tuple[str, ...],
+) -> AgentCaller:
+    """Return a caller that raises loudly if invoked.
+
+    Used when the orchestrator is wired before the agent / provider
+    registries are available.  Surfaces the root cause to operators
+    at first use rather than silently succeeding with empty content.
+    """
+
+    async def _caller(agent_id: str, _prompt: str, _max_tokens: int) -> AgentResponse:
+        missing = ", ".join(missing_dependencies)
+        msg = (
+            f"Meeting agent caller invoked for {agent_id!r} but the "
+            f"following dependencies were missing at wire time: "
+            f"{missing}.  Provide them via create_app(...) so meeting "
+            f"turns can dispatch real LLM calls."
+        )
+        raise MeetingAgentCallerNotConfiguredError(msg)
+
+    return _caller
+
+
+__all__ = [
+    "MeetingAgentCallerNotConfiguredError",
+    "UnknownMeetingAgentError",
+    "build_meeting_agent_caller",
+    "build_unconfigured_meeting_agent_caller",
+]

--- a/src/synthorg/communication/meeting/agent_caller.py
+++ b/src/synthorg/communication/meeting/agent_caller.py
@@ -85,6 +85,11 @@ def build_meeting_agent_caller(
         )
         identity = await agent_registry.get(typed_agent_id)
         if identity is None:
+            logger.warning(
+                MEETING_AGENT_CALL_FAILED,
+                agent_id=agent_id,
+                error_type="UnknownMeetingAgentError",
+            )
             raise UnknownMeetingAgentError(typed_agent_id)
 
         provider_name = str(identity.model.provider)
@@ -239,6 +244,12 @@ def build_unconfigured_meeting_agent_caller(
         _prompt: str,
         _max_tokens: int,
     ) -> AgentResponse:
+        logger.warning(
+            MEETING_AGENT_CALL_FAILED,
+            agent_id=agent_id,
+            error_type="MeetingAgentCallerNotConfiguredError",
+            missing_dependencies=missing_dependencies,
+        )
         raise MeetingAgentCallerNotConfiguredError(
             agent_id=NotBlankStr(agent_id),
             missing_dependencies=missing_dependencies,

--- a/src/synthorg/communication/meeting/agent_caller.py
+++ b/src/synthorg/communication/meeting/agent_caller.py
@@ -25,6 +25,7 @@ from synthorg.communication.meeting.models import AgentResponse
 from synthorg.core.types import NotBlankStr
 from synthorg.observability import get_logger
 from synthorg.observability.events.meeting import (
+    MEETING_AGENT_CALL_FAILED,
     MEETING_AGENT_CALLED,
     MEETING_AGENT_RESPONDED,
 )
@@ -47,12 +48,12 @@ class UnknownMeetingAgentError(LookupError):
         agent_id: The agent identifier that was not found in the registry.
     """
 
-    def __init__(self, agent_id: str) -> None:
+    def __init__(self, agent_id: NotBlankStr) -> None:
         super().__init__(
             f"Meeting agent {agent_id!r} is not registered in the "
             f"agent registry; cannot dispatch LLM call"
         )
-        self.agent_id = agent_id
+        self.agent_id: NotBlankStr = agent_id
 
 
 def build_meeting_agent_caller(
@@ -75,29 +76,43 @@ def build_meeting_agent_caller(
         prompt: str,
         max_tokens: int,
     ) -> AgentResponse:
+        typed_agent_id = NotBlankStr(agent_id)
         logger.info(
             MEETING_AGENT_CALLED,
             agent_id=agent_id,
             max_tokens=max_tokens,
             prompt_length=len(prompt),
         )
-        identity = await agent_registry.get(NotBlankStr(agent_id))
+        identity = await agent_registry.get(typed_agent_id)
         if identity is None:
-            raise UnknownMeetingAgentError(agent_id)
+            raise UnknownMeetingAgentError(typed_agent_id)
 
-        provider = provider_registry.get(str(identity.model.provider))
+        provider_name = str(identity.model.provider)
+        provider = provider_registry.get(provider_name)
         messages = _build_messages(identity, prompt)
+        effective_max_tokens = min(max_tokens, identity.model.max_tokens)
         config = CompletionConfig(
             temperature=identity.model.temperature,
-            max_tokens=max_tokens,
+            max_tokens=effective_max_tokens,
         )
-        response = await provider.complete(
-            messages,
-            str(identity.model.model_id),
-            config=config,
-        )
+        try:
+            response = await provider.complete(
+                messages,
+                str(identity.model.model_id),
+                config=config,
+            )
+        except MemoryError, RecursionError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                MEETING_AGENT_CALL_FAILED,
+                agent_id=agent_id,
+                provider=provider_name,
+                error_type=type(exc).__name__,
+            )
+            raise
         agent_response = AgentResponse(
-            agent_id=NotBlankStr(agent_id),
+            agent_id=typed_agent_id,
             content=response.content or "",
             input_tokens=response.usage.input_tokens,
             output_tokens=response.usage.output_tokens,
@@ -164,15 +179,26 @@ class MeetingAgentCallerNotConfiguredError(RuntimeError):
         agent_id: The agent identifier that the meeting tried to invoke.
         missing_dependencies: Names of the dependencies that were
             absent at wire time (e.g. ``("agent_registry",
-            "provider_registry")``).
+            "provider_registry")``).  Guaranteed non-empty: the error
+            is only meaningful when at least one dependency is missing.
+
+    Raises:
+        ValueError: If *missing_dependencies* is empty -- the error is
+            only meaningful when at least one dependency is missing.
     """
 
     def __init__(
         self,
         *,
-        agent_id: str,
+        agent_id: NotBlankStr,
         missing_dependencies: tuple[str, ...],
     ) -> None:
+        if not missing_dependencies:
+            msg = (
+                "MeetingAgentCallerNotConfiguredError requires at least one "
+                "entry in missing_dependencies"
+            )
+            raise ValueError(msg)
         missing = ", ".join(missing_dependencies)
         super().__init__(
             f"Meeting agent caller invoked for {agent_id!r} but the "
@@ -180,8 +206,8 @@ class MeetingAgentCallerNotConfiguredError(RuntimeError):
             f"{missing}.  Provide them via create_app(...) so meeting "
             f"turns can dispatch real LLM calls."
         )
-        self.agent_id = agent_id
-        self.missing_dependencies = missing_dependencies
+        self.agent_id: NotBlankStr = agent_id
+        self.missing_dependencies: tuple[str, ...] = missing_dependencies
 
 
 def build_unconfigured_meeting_agent_caller(
@@ -193,7 +219,20 @@ def build_unconfigured_meeting_agent_caller(
     Used when the orchestrator is wired before the agent / provider
     registries are available.  Surfaces the root cause to operators
     at first use rather than silently succeeding with empty content.
+
+    Args:
+        missing_dependencies: Names of the dependencies missing at wire
+            time.  Must be non-empty.
+
+    Raises:
+        ValueError: If *missing_dependencies* is empty.
     """
+    if not missing_dependencies:
+        msg = (
+            "build_unconfigured_meeting_agent_caller requires at least one "
+            "entry in missing_dependencies"
+        )
+        raise ValueError(msg)
 
     async def _caller(
         agent_id: str,
@@ -201,7 +240,7 @@ def build_unconfigured_meeting_agent_caller(
         _max_tokens: int,
     ) -> AgentResponse:
         raise MeetingAgentCallerNotConfiguredError(
-            agent_id=agent_id,
+            agent_id=NotBlankStr(agent_id),
             missing_dependencies=missing_dependencies,
         )
 

--- a/src/synthorg/meta/signal_models.py
+++ b/src/synthorg/meta/signal_models.py
@@ -122,6 +122,10 @@ class ScalingDecisionSummary(BaseModel):
     """Summary of a recent scaling decision and its outcome.
 
     Attributes:
+        decision_id: Stable identifier from the underlying scaling
+            decision.  Exposed so consumers and tests can join outcomes
+            back to specific decisions without relying on positional
+            ordering or other fields that may not be unique.
         action_type: What was proposed (hire/prune/hold).
         outcome: What happened (executed/failed/deferred/rejected).
         source_strategy: Which strategy proposed it.
@@ -131,6 +135,7 @@ class ScalingDecisionSummary(BaseModel):
 
     model_config = ConfigDict(frozen=True, allow_inf_nan=False)
 
+    decision_id: NotBlankStr
     action_type: NotBlankStr
     outcome: NotBlankStr
     source_strategy: NotBlankStr

--- a/src/synthorg/meta/signals/scaling.py
+++ b/src/synthorg/meta/signals/scaling.py
@@ -69,7 +69,14 @@ class ScalingSignalAggregator:
 
         Returns:
             Org-wide scaling summary.  Returns an empty summary when
-            the service raises or no decisions fall in the window.
+            no decisions fall in the window, or when the service
+            raises a non-fatal exception (the error is logged via
+            ``META_SIGNAL_AGGREGATION_FAILED``).
+
+        Raises:
+            MemoryError: Re-raised without logging -- fatal.
+            RecursionError: Re-raised without logging -- fatal.
+            asyncio.CancelledError: Re-raised without logging -- honoured.
         """
         try:
             decisions = self._service.get_recent_decisions()

--- a/src/synthorg/meta/signals/scaling.py
+++ b/src/synthorg/meta/signals/scaling.py
@@ -1,26 +1,54 @@
-"""Scaling history signal aggregator (placeholder).
+"""Scaling history signal aggregator.
 
-Will wrap the ScalingService to produce an OrgScalingSummary with
-recent decisions and their outcomes. Currently returns an empty
-summary until the real ScalingService integration is wired.
+Wraps :class:`synthorg.hr.scaling.service.ScalingService` to produce an
+:class:`OrgScalingSummary` with recent decisions, their outcomes, and
+derived success-rate / most-common-signal metrics.
 """
 
+import asyncio
+from collections import Counter
 from typing import TYPE_CHECKING
 
 from synthorg.core.types import NotBlankStr
-from synthorg.meta.models import OrgScalingSummary
+from synthorg.hr.scaling.enums import ScalingOutcome
+from synthorg.meta.signal_models import (
+    OrgScalingSummary,
+    ScalingDecisionSummary,
+)
 from synthorg.observability import get_logger
+from synthorg.observability.events.meta import (
+    META_SIGNAL_AGGREGATION_COMPLETED,
+    META_SIGNAL_AGGREGATION_FAILED,
+)
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    from synthorg.hr.scaling.models import ScalingDecision
+    from synthorg.hr.scaling.service import ScalingService
 
 logger = get_logger(__name__)
 
 _EMPTY = OrgScalingSummary()
 
+_PENDING_OUTCOME = NotBlankStr("pending")
+
 
 class ScalingSignalAggregator:
-    """Aggregates scaling decisions into org-wide summaries."""
+    """Aggregates recent scaling decisions into an org-wide summary.
+
+    Queries :class:`ScalingService` for the bounded in-memory history of
+    decisions and action records, joins them by ``decision_id`` to
+    project each decision's outcome, filters to the requested time
+    window, and reduces to an :class:`OrgScalingSummary`.
+
+    Args:
+        service: The active scaling service instance whose recent
+            decisions and actions are aggregated.
+    """
+
+    def __init__(self, *, service: ScalingService) -> None:
+        self._service = service
 
     @property
     def domain(self) -> NotBlankStr:
@@ -33,18 +61,86 @@ class ScalingSignalAggregator:
         since: datetime,
         until: datetime,
     ) -> OrgScalingSummary:
-        """Aggregate scaling signals for the time window.
+        """Aggregate scaling signals for the ``[since, until)`` window.
 
         Args:
-            since: Start of observation window.
-            until: End of observation window.
+            since: Inclusive lower bound on decision ``created_at``.
+            until: Exclusive upper bound on decision ``created_at``.
 
         Returns:
-            Org-wide scaling summary.
+            Org-wide scaling summary.  Returns an empty summary when
+            the service raises or no decisions fall in the window.
         """
-        _ = since, until  # Will be used by real implementation.
-        logger.debug(
-            "meta.signals.placeholder_skipped",
-            domain="scaling",
+        try:
+            decisions = self._service.get_recent_decisions()
+            actions = self._service.get_recent_actions()
+
+            filtered = tuple(d for d in decisions if since <= d.created_at < until)
+            if not filtered:
+                logger.info(
+                    META_SIGNAL_AGGREGATION_COMPLETED,
+                    domain="scaling",
+                    total_decisions=0,
+                )
+                return _EMPTY
+
+            outcome_by_decision = {a.decision_id: a.outcome for a in actions}
+            summaries = tuple(
+                _build_summary(d, outcome_by_decision.get(d.id)) for d in filtered
+            )
+
+            total_decisions = len(filtered)
+            executed_count = sum(
+                1 for s in summaries if s.outcome == ScalingOutcome.EXECUTED.value
+            )
+            success_rate = executed_count / total_decisions
+
+            counter = Counter(s.source_strategy for s in summaries)
+            # Counter.most_common returns items sorted by count desc,
+            # insertion order preserved for ties -- deterministic.
+            most_common_signal = counter.most_common(1)[0][0]
+        except MemoryError, RecursionError:
+            raise
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception(
+                META_SIGNAL_AGGREGATION_FAILED,
+                domain="scaling",
+            )
+            return _EMPTY
+
+        summary = OrgScalingSummary(
+            recent_decisions=summaries,
+            total_decisions=total_decisions,
+            success_rate=success_rate,
+            most_common_signal=most_common_signal,
         )
-        return _EMPTY
+        logger.info(
+            META_SIGNAL_AGGREGATION_COMPLETED,
+            domain="scaling",
+            total_decisions=total_decisions,
+            success_rate=round(success_rate, 4),
+            most_common_signal=most_common_signal,
+        )
+        return summary
+
+
+def _build_summary(
+    decision: ScalingDecision,
+    outcome: ScalingOutcome | None,
+) -> ScalingDecisionSummary:
+    """Project a decision + optional action outcome into a summary row."""
+    outcome_str = (
+        NotBlankStr(outcome.value) if outcome is not None else _PENDING_OUTCOME
+    )
+    return ScalingDecisionSummary(
+        action_type=NotBlankStr(decision.action_type.value),
+        outcome=outcome_str,
+        source_strategy=NotBlankStr(decision.source_strategy.value),
+        rationale=decision.rationale,
+        created_at=decision.created_at,
+    )
+
+
+__all__ = ["ScalingSignalAggregator"]

--- a/src/synthorg/meta/signals/scaling.py
+++ b/src/synthorg/meta/signals/scaling.py
@@ -96,30 +96,50 @@ class ScalingSignalAggregator:
             )
             return _EMPTY
 
-        filtered = tuple(d for d in decisions if since <= d.created_at < until)
-        if not filtered:
-            logger.info(
-                META_SIGNAL_AGGREGATION_COMPLETED,
-                domain="scaling",
-                total_decisions=0,
+        # Local aggregation (filter / join / reduce) must NOT be
+        # swallowed as an empty summary -- service-layer errors were
+        # already handled above.  Wrap the reducer in a narrow
+        # log-and-rethrow so operators see aggregation bugs in the
+        # observability pipeline while callers still get a real
+        # exception instead of silently degraded output.
+        try:
+            filtered = tuple(d for d in decisions if since <= d.created_at < until)
+            if not filtered:
+                logger.info(
+                    META_SIGNAL_AGGREGATION_COMPLETED,
+                    domain="scaling",
+                    total_decisions=0,
+                )
+                return _EMPTY
+
+            outcome_by_decision = {a.decision_id: a.outcome for a in actions}
+            summaries = tuple(
+                _build_summary(d, outcome_by_decision.get(d.id)) for d in filtered
             )
-            return _EMPTY
 
-        outcome_by_decision = {a.decision_id: a.outcome for a in actions}
-        summaries = tuple(
-            _build_summary(d, outcome_by_decision.get(d.id)) for d in filtered
-        )
+            total_decisions = len(filtered)
+            executed_count = sum(
+                1 for s in summaries if s.outcome == ScalingOutcome.EXECUTED.value
+            )
+            success_rate = executed_count / total_decisions
 
-        total_decisions = len(filtered)
-        executed_count = sum(
-            1 for s in summaries if s.outcome == ScalingOutcome.EXECUTED.value
-        )
-        success_rate = executed_count / total_decisions
-
-        counter = Counter(s.source_strategy for s in summaries)
-        # Counter.most_common returns items sorted by count desc,
-        # insertion order preserved for ties -- deterministic.
-        most_common_signal = counter.most_common(1)[0][0]
+            counter = Counter(s.source_strategy for s in summaries)
+            # Counter.most_common returns items sorted by count desc,
+            # insertion order preserved for ties -- deterministic.
+            most_common_signal = counter.most_common(1)[0][0]
+        except MemoryError, RecursionError:
+            raise
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception(
+                META_SIGNAL_AGGREGATION_FAILED,
+                domain="scaling",
+                stage="reduce",
+                decision_count=len(decisions),
+                action_count=len(actions),
+            )
+            raise
 
         summary = OrgScalingSummary(
             recent_decisions=summaries,

--- a/src/synthorg/meta/signals/scaling.py
+++ b/src/synthorg/meta/signals/scaling.py
@@ -146,6 +146,7 @@ def _build_summary(
         NotBlankStr(outcome.value) if outcome is not None else _PENDING_OUTCOME
     )
     return ScalingDecisionSummary(
+        decision_id=decision.id,
         action_type=NotBlankStr(decision.action_type.value),
         outcome=outcome_str,
         source_strategy=NotBlankStr(decision.source_strategy.value),

--- a/src/synthorg/meta/signals/scaling.py
+++ b/src/synthorg/meta/signals/scaling.py
@@ -69,43 +69,22 @@ class ScalingSignalAggregator:
 
         Returns:
             Org-wide scaling summary.  Returns an empty summary when
-            no decisions fall in the window, or when the service
-            raises a non-fatal exception (the error is logged via
-            ``META_SIGNAL_AGGREGATION_FAILED``).
+            no decisions fall in the window, or when the underlying
+            :class:`ScalingService` raises a non-fatal exception while
+            fetching recent history (the error is logged via
+            ``META_SIGNAL_AGGREGATION_FAILED``).  Bugs in local
+            aggregation (filtering, joining, reducing) propagate
+            unchanged so they are never masked as empty summaries.
 
         Raises:
             MemoryError: Re-raised without logging -- fatal.
             RecursionError: Re-raised without logging -- fatal.
-            asyncio.CancelledError: Re-raised without logging -- honoured.
+            asyncio.CancelledError: Re-raised without logging so task
+                cancellation propagates as normal control flow.
         """
         try:
             decisions = self._service.get_recent_decisions()
             actions = self._service.get_recent_actions()
-
-            filtered = tuple(d for d in decisions if since <= d.created_at < until)
-            if not filtered:
-                logger.info(
-                    META_SIGNAL_AGGREGATION_COMPLETED,
-                    domain="scaling",
-                    total_decisions=0,
-                )
-                return _EMPTY
-
-            outcome_by_decision = {a.decision_id: a.outcome for a in actions}
-            summaries = tuple(
-                _build_summary(d, outcome_by_decision.get(d.id)) for d in filtered
-            )
-
-            total_decisions = len(filtered)
-            executed_count = sum(
-                1 for s in summaries if s.outcome == ScalingOutcome.EXECUTED.value
-            )
-            success_rate = executed_count / total_decisions
-
-            counter = Counter(s.source_strategy for s in summaries)
-            # Counter.most_common returns items sorted by count desc,
-            # insertion order preserved for ties -- deterministic.
-            most_common_signal = counter.most_common(1)[0][0]
         except MemoryError, RecursionError:
             raise
         except asyncio.CancelledError:
@@ -116,6 +95,31 @@ class ScalingSignalAggregator:
                 domain="scaling",
             )
             return _EMPTY
+
+        filtered = tuple(d for d in decisions if since <= d.created_at < until)
+        if not filtered:
+            logger.info(
+                META_SIGNAL_AGGREGATION_COMPLETED,
+                domain="scaling",
+                total_decisions=0,
+            )
+            return _EMPTY
+
+        outcome_by_decision = {a.decision_id: a.outcome for a in actions}
+        summaries = tuple(
+            _build_summary(d, outcome_by_decision.get(d.id)) for d in filtered
+        )
+
+        total_decisions = len(filtered)
+        executed_count = sum(
+            1 for s in summaries if s.outcome == ScalingOutcome.EXECUTED.value
+        )
+        success_rate = executed_count / total_decisions
+
+        counter = Counter(s.source_strategy for s in summaries)
+        # Counter.most_common returns items sorted by count desc,
+        # insertion order preserved for ties -- deterministic.
+        most_common_signal = counter.most_common(1)[0][0]
 
         summary = OrgScalingSummary(
             recent_decisions=summaries,

--- a/src/synthorg/observability/events/meeting.py
+++ b/src/synthorg/observability/events/meeting.py
@@ -15,6 +15,7 @@ MEETING_PHASE_COMPLETED: Final[str] = "meeting.phase.completed"
 # Agent interaction
 MEETING_AGENT_CALLED: Final[str] = "meeting.agent.called"
 MEETING_AGENT_RESPONDED: Final[str] = "meeting.agent.responded"
+MEETING_AGENT_CALL_FAILED: Final[str] = "meeting.agent.call_failed"
 MEETING_CONTRIBUTION_RECORDED: Final[str] = "meeting.contribution.recorded"
 
 # Conflict detection

--- a/src/synthorg/observability/events/meeting.py
+++ b/src/synthorg/observability/events/meeting.py
@@ -58,9 +58,6 @@ MEETING_EVENT_COOLDOWN_SKIPPED: Final[str] = "meeting.scheduler.event_cooldown_s
 # Task capping
 MEETING_TASKS_CAPPED: Final[str] = "meeting.task.capped"
 
-# Auto-wiring
-MEETING_STUB_AGENT_CALLER: Final[str] = "meeting.auto_wire.stub_agent_caller"
-
 # Strategy integration
 MEETING_LENS_ASSIGNMENT_FAILED: Final[str] = "meeting.strategy.lens_assignment_failed"
 

--- a/src/synthorg/security/policy_engine/config.py
+++ b/src/synthorg/security/policy_engine/config.py
@@ -29,9 +29,9 @@ class SecurityPolicyConfig(BaseModel):
 
     model_config = ConfigDict(frozen=True, allow_inf_nan=False)
 
-    engine: Literal["cedar", "rego", "none"] = Field(
+    engine: Literal["cedar", "none"] = Field(
         default="none",
-        description="Policy engine backend (Rego adapter planned, not yet implemented)",
+        description="Policy engine backend",
     )
     policy_files: tuple[Path, ...] = Field(
         default=(),
@@ -100,10 +100,6 @@ def build_policy_engine(
             policy_texts=tuple(policy_texts),
             fail_closed=config.fail_closed,
         )
-
-    if config.engine == "rego":
-        msg = "Rego policy engine adapter is planned but not yet implemented"
-        raise NotImplementedError(msg)
 
     msg = f"Unknown policy engine: {config.engine!r}"  # type: ignore[unreachable]
     raise ValueError(msg)

--- a/src/synthorg/tools/communication/__init__.py
+++ b/src/synthorg/tools/communication/__init__.py
@@ -1,5 +1,12 @@
 """Built-in communication tools for email, notifications, and messaging."""
 
+from synthorg.tools.communication.async_task_tools import (
+    CancelAsyncTaskTool,
+    CheckAsyncTaskTool,
+    ListAsyncTasksTool,
+    StartAsyncTaskTool,
+    UpdateAsyncTaskTool,
+)
 from synthorg.tools.communication.base_communication_tool import (
     BaseCommunicationTool,
 )
@@ -18,10 +25,15 @@ from synthorg.tools.communication.template_formatter import (
 
 __all__ = [
     "BaseCommunicationTool",
+    "CancelAsyncTaskTool",
+    "CheckAsyncTaskTool",
     "CommunicationToolsConfig",
     "EmailConfig",
     "EmailSenderTool",
+    "ListAsyncTasksTool",
     "NotificationDispatcherProtocol",
     "NotificationSenderTool",
+    "StartAsyncTaskTool",
     "TemplateFormatterTool",
+    "UpdateAsyncTaskTool",
 ]

--- a/src/synthorg/tools/examples/echo.py
+++ b/src/synthorg/tools/examples/echo.py
@@ -13,6 +13,12 @@ from synthorg.tools.base import BaseTool, ToolExecutionResult
 class EchoTool(BaseTool):
     """Echoes the input message back as the tool result.
 
+    This is a reference / example implementation of ``BaseTool`` used
+    for documentation, wiring smoke tests, and as a starting point for
+    new tools.  It reflects its input unchanged, so operators should
+    only register it in trusted contexts where reflecting the ``message``
+    argument in the result is acceptable.
+
     Examples:
         Basic usage::
 

--- a/src/synthorg/tools/factory.py
+++ b/src/synthorg/tools/factory.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from pathlib import Path
 
+    from synthorg.communication.async_tasks.service import AsyncTaskService
     from synthorg.config.schema import RootConfig
     from synthorg.tools.analytics.config import AnalyticsToolsConfig
     from synthorg.tools.analytics.data_aggregator import AnalyticsProvider
@@ -213,6 +214,64 @@ def _build_communication_tools(
     return tuple(tools)
 
 
+def _build_async_task_tools(
+    *,
+    service: AsyncTaskService | None,
+    supervisor_id: str,
+    supervisor_task_id: str,
+) -> tuple[BaseTool, ...]:
+    """Instantiate the five async task steering tools.
+
+    Returns an empty tuple when *service* is ``None``.
+    """
+    if service is None:
+        return ()
+    from synthorg.tools.communication import (  # noqa: PLC0415
+        CancelAsyncTaskTool,
+        CheckAsyncTaskTool,
+        ListAsyncTasksTool,
+        StartAsyncTaskTool,
+        UpdateAsyncTaskTool,
+    )
+
+    return (
+        StartAsyncTaskTool(
+            service=service,
+            supervisor_id=supervisor_id,
+            supervisor_task_id=supervisor_task_id,
+        ),
+        CheckAsyncTaskTool(service=service),
+        UpdateAsyncTaskTool(service=service),
+        CancelAsyncTaskTool(service=service, supervisor_id=supervisor_id),
+        ListAsyncTasksTool(
+            service=service,
+            supervisor_task_id=supervisor_task_id,
+        ),
+    )
+
+
+def _build_code_execution_tools(
+    *,
+    sandbox: SandboxBackend | None,
+) -> tuple[BaseTool, ...]:
+    """Instantiate the built-in code execution tools.
+
+    Returns an empty tuple when *sandbox* is ``None``.
+    """
+    if sandbox is None:
+        return ()
+    from synthorg.tools.code_runner import CodeRunnerTool  # noqa: PLC0415
+
+    return (CodeRunnerTool(sandbox=sandbox),)
+
+
+def _build_other_tools() -> tuple[BaseTool, ...]:
+    """Instantiate reference tools that have no dependencies."""
+    from synthorg.tools.examples.echo import EchoTool  # noqa: PLC0415
+
+    return (EchoTool(),)
+
+
 def _build_analytics_tools(
     *,
     config: AnalyticsToolsConfig | None = None,
@@ -257,6 +316,10 @@ def build_default_tools(  # noqa: PLR0913
     analytics_config: AnalyticsToolsConfig | None = None,
     analytics_provider: AnalyticsProvider | None = None,
     metric_sink: MetricSink | None = None,
+    async_task_service: AsyncTaskService | None = None,
+    async_task_supervisor_id: str = "supervisor",
+    async_task_supervisor_task_id: str = "default",
+    code_execution_sandbox: SandboxBackend | None = None,
 ) -> tuple[BaseTool, ...]:
     """Instantiate all built-in workspace tools.
 
@@ -284,6 +347,15 @@ def build_default_tools(  # noqa: PLR0913
             skips analytics tool creation.
         analytics_provider: Analytics data provider.
         metric_sink: Metric recording sink.
+        async_task_service: Service backing the 5 async task steering
+            tools.  When ``None``, no async task tools are registered.
+        async_task_supervisor_id: Supervisor agent ID bound to the
+            ``start_async_task`` and ``cancel_async_task`` tools.
+        async_task_supervisor_task_id: Supervisor task ID bound to the
+            ``start_async_task`` and ``list_async_tasks`` tools.
+        code_execution_sandbox: Sandbox backend for the
+            ``code_runner`` tool.  When ``None``, ``code_runner`` is
+            not registered.
 
     Returns:
         Sorted tuple of ``BaseTool`` instances.
@@ -345,6 +417,17 @@ def build_default_tools(  # noqa: PLR0913
             metric_sink=metric_sink,
         ),
     )
+    all_tools.extend(
+        _build_async_task_tools(
+            service=async_task_service,
+            supervisor_id=async_task_supervisor_id,
+            supervisor_task_id=async_task_supervisor_task_id,
+        ),
+    )
+    all_tools.extend(
+        _build_code_execution_tools(sandbox=code_execution_sandbox),
+    )
+    all_tools.extend(_build_other_tools())
 
     result = tuple(sorted(all_tools, key=lambda t: t.name))
 
@@ -371,6 +454,7 @@ def build_default_tools_from_config(  # noqa: PLR0913
     communication_dispatcher: NotificationDispatcherProtocol | None = None,
     analytics_provider: AnalyticsProvider | None = None,
     metric_sink: MetricSink | None = None,
+    async_task_service: AsyncTaskService | None = None,
 ) -> tuple[BaseTool, ...]:
     """Build default tools using parameters from a ``RootConfig``.
 
@@ -396,6 +480,9 @@ def build_default_tools_from_config(  # noqa: PLR0913
             the notification sender tool.
         analytics_provider: Optional analytics data provider.
         metric_sink: Optional metric recording sink.
+        async_task_service: Optional ``AsyncTaskService`` backing the
+            async task steering tools.  When ``None``, those tools are
+            skipped.
 
     Returns:
         Sorted tuple of ``BaseTool`` instances.
@@ -444,6 +531,23 @@ def build_default_tools_from_config(  # noqa: PLR0913
                 ),
             )
 
+    # Resolve code execution sandbox if configured.
+    code_execution_sandbox: SandboxBackend | None = None
+    try:
+        code_execution_sandbox = resolve_sandbox_for_category(
+            config=config.sandboxing,
+            backends=resolved_backends,
+            category=ToolCategory.CODE_EXECUTION,
+        )
+    except KeyError:
+        logger.warning(
+            TOOL_FACTORY_ERROR,
+            error=(
+                "No sandbox backend for CODE_EXECUTION category; "
+                "code_runner tool will not be registered"
+            ),
+        )
+
     # Extract web config
     web_policy: NetworkPolicy | None = None
     if config.web is not None:
@@ -465,4 +569,6 @@ def build_default_tools_from_config(  # noqa: PLR0913
         analytics_config=config.analytics_tools,
         analytics_provider=analytics_provider,
         metric_sink=metric_sink,
+        async_task_service=async_task_service,
+        code_execution_sandbox=code_execution_sandbox,
     )

--- a/src/synthorg/tools/factory.py
+++ b/src/synthorg/tools/factory.py
@@ -223,9 +223,17 @@ def _build_async_task_tools(
     """Instantiate the five async task steering tools.
 
     Returns an empty tuple when *service* is ``None``.
+
+    Raises:
+        ValueError: When *service* is provided but either
+            *supervisor_id* or *supervisor_task_id* is empty or
+            whitespace-only.  Blank identifiers silently produce
+            orphan async tasks, so we fail loudly at wire time.
     """
     if service is None:
         return ()
+    _require_non_blank(supervisor_id, name="async_task_supervisor_id")
+    _require_non_blank(supervisor_task_id, name="async_task_supervisor_task_id")
     from synthorg.tools.communication import (  # noqa: PLC0415
         CancelAsyncTaskTool,
         CheckAsyncTaskTool,
@@ -248,6 +256,13 @@ def _build_async_task_tools(
             supervisor_task_id=supervisor_task_id,
         ),
     )
+
+
+def _require_non_blank(value: str, *, name: str) -> None:
+    """Raise ``ValueError`` if *value* is empty or whitespace-only."""
+    if not value or not value.strip():
+        msg = f"{name} must be a non-empty, non-whitespace string, got {value!r}"
+        raise ValueError(msg)
 
 
 def _build_code_execution_tools(

--- a/tests/integration/tools/test_factory_integration.py
+++ b/tests/integration/tools/test_factory_integration.py
@@ -12,7 +12,7 @@ from synthorg.tools.factory import (
 from synthorg.tools.git_tools import GitCloneTool
 from synthorg.tools.registry import ToolRegistry
 
-_EXPECTED_TOOL_COUNT: int = 15
+_EXPECTED_TOOL_COUNT: int = 16
 
 
 @pytest.mark.integration

--- a/tests/unit/api/controllers/test_meetings.py
+++ b/tests/unit/api/controllers/test_meetings.py
@@ -33,7 +33,7 @@ from tests.unit.api.conftest import (
 def _create_meeting_test_app(
     *,
     meeting_orchestrator: MagicMock,
-    meeting_scheduler: MagicMock,
+    meeting_scheduler: MagicMock | None,
 ) -> Any:
     """Build a Litestar test app with the given meeting services."""
     from synthorg.api.approval_store import ApprovalStore
@@ -283,6 +283,37 @@ class TestMeetingController:
             "deploy_complete",
             context={},
         )
+
+    def test_trigger_returns_503_when_scheduler_not_configured(
+        self,
+        mock_orchestrator: MagicMock,
+        mock_scheduler: MagicMock,
+    ) -> None:
+        """Degraded mode (``meeting_scheduler=None``) yields 503, not 500.
+
+        When the meeting agent caller is unconfigured,
+        ``auto_wire_meetings`` leaves ``meeting_scheduler`` as ``None``
+        and ``app_state.meeting_scheduler`` raises
+        ``ServiceUnavailableError`` on access.  Simulating the
+        post-wire state here (by clearing the stored scheduler after
+        construction) verifies that the controller returns a clean
+        503 instead of the PR regressing to an ``AttributeError``
+        that would surface as a 500.
+        """
+        app = _create_meeting_test_app(
+            meeting_orchestrator=mock_orchestrator,
+            meeting_scheduler=mock_scheduler,
+        )
+        app.state.app_state._meeting_scheduler = None
+        with TestClient(app) as client:
+            client.headers.update(make_auth_headers("ceo"))
+            resp = client.post(
+                "/api/v1/meetings/trigger",
+                json={"event_name": "deploy_complete"},
+            )
+            assert resp.status_code == 503
+            body = resp.json()
+            assert body["success"] is False
 
     def test_trigger_response_includes_analytics(
         self,

--- a/tests/unit/api/test_auto_wire_meetings.py
+++ b/tests/unit/api/test_auto_wire_meetings.py
@@ -1,6 +1,6 @@
 """Tests for meeting service auto-wiring."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import structlog.testing
@@ -146,8 +146,17 @@ class TestAutoWireMeetings:
 
         assert isinstance(result.meeting_orchestrator, MeetingOrchestrator)
         caller = result.meeting_orchestrator._agent_caller
-        with pytest.raises(MeetingAgentCallerNotConfiguredError):
+        with pytest.raises(MeetingAgentCallerNotConfiguredError) as exc_info:
             await caller("agent-1", "prompt", 100)
+        # Error carries agent_id and names both missing dependencies so
+        # operators can act without parsing the message string.
+        assert exc_info.value.agent_id == "agent-1"
+        assert set(exc_info.value.missing_dependencies) == {
+            "agent_registry",
+            "provider_registry",
+        }
+        assert "agent_registry" in str(exc_info.value)
+        assert "provider_registry" in str(exc_info.value)
 
     def test_preserves_explicit_orchestrator(self) -> None:
         from synthorg.api.auto_wire import auto_wire_meetings
@@ -224,6 +233,84 @@ class TestAutoWireMeetings:
         services = [e.get("service") for e in captured]
         assert "meeting_orchestrator" in services
         assert "meeting_scheduler" in services
+
+    async def test_real_caller_end_to_end_with_both_registries(self) -> None:
+        """Wiring both registries produces a caller that dispatches real LLM calls.
+
+        Integration test: construct auto_wire_meetings with fake (but
+        shape-correct) agent registry + provider registry, invoke the
+        wired ``agent_caller`` directly, and assert it reaches the
+        provider and returns an ``AgentResponse`` with provider-sourced
+        tokens/cost.  Catches wiring regressions that pure unit tests
+        of each layer miss.
+        """
+        from datetime import date
+        from uuid import uuid4
+
+        from synthorg.api.auto_wire import auto_wire_meetings
+        from synthorg.communication.meeting.models import AgentResponse
+        from synthorg.core.agent import (
+            AgentIdentity,
+            ModelConfig,
+            PersonalityConfig,
+        )
+        from synthorg.core.enums import AgentStatus, SeniorityLevel
+        from synthorg.core.types import NotBlankStr
+        from synthorg.providers.enums import FinishReason
+        from synthorg.providers.models import CompletionResponse, TokenUsage
+
+        identity = AgentIdentity(
+            id=uuid4(),
+            name=NotBlankStr("Sarah Chen"),
+            role=NotBlankStr("engineer"),
+            department=NotBlankStr("engineering"),
+            level=SeniorityLevel.MID,
+            personality=PersonalityConfig(
+                communication_style=NotBlankStr("concise"),
+            ),
+            model=ModelConfig(
+                provider=NotBlankStr("test-provider"),
+                model_id=NotBlankStr("test-medium-001"),
+            ),
+            hiring_date=date(2026, 1, 1),
+            status=AgentStatus.ACTIVE,
+        )
+        agent_registry = MagicMock()
+        agent_registry.get = AsyncMock(return_value=identity)
+
+        provider = MagicMock()
+        provider.complete = AsyncMock(
+            return_value=CompletionResponse(
+                content="I recommend a task queue.",
+                finish_reason=FinishReason.STOP,
+                usage=TokenUsage(
+                    input_tokens=12,
+                    output_tokens=7,
+                    cost_usd=0.0005,
+                ),
+                model=NotBlankStr("test-medium-001"),
+            )
+        )
+        provider_registry = MagicMock()
+        provider_registry.get = MagicMock(return_value=provider)
+
+        result = auto_wire_meetings(
+            effective_config=_default_config(),
+            meeting_orchestrator=None,
+            meeting_scheduler=None,
+            agent_registry=agent_registry,
+            provider_registry=provider_registry,
+        )
+
+        caller = result.meeting_orchestrator._agent_caller
+        response = await caller(str(identity.id), "What is next?", 256)
+
+        assert isinstance(response, AgentResponse)
+        assert response.content == "I recommend a task queue."
+        assert response.input_tokens == 12
+        assert response.output_tokens == 7
+        provider_registry.get.assert_called_once_with("test-provider")
+        provider.complete.assert_awaited_once()
 
     def test_with_agent_registry(self) -> None:
         from synthorg.api.auto_wire import auto_wire_meetings

--- a/tests/unit/api/test_auto_wire_meetings.py
+++ b/tests/unit/api/test_auto_wire_meetings.py
@@ -145,6 +145,11 @@ class TestAutoWireMeetings:
         )
 
         assert isinstance(result.meeting_orchestrator, MeetingOrchestrator)
+        # Schedulers must stay ``None`` when the caller is guaranteed to
+        # raise -- running scheduled meetings against an unconfigured
+        # caller would only produce background noise.
+        assert result.meeting_scheduler is None
+        assert result.ceremony_scheduler is None
         caller = result.meeting_orchestrator._agent_caller
         with pytest.raises(MeetingAgentCallerNotConfiguredError) as exc_info:
             await caller("agent-1", "prompt", 100)
@@ -157,6 +162,52 @@ class TestAutoWireMeetings:
         }
         assert "agent_registry" in str(exc_info.value)
         assert "provider_registry" in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        ("agent_registry_value", "provider_registry_value", "expected_missing"),
+        [
+            pytest.param(
+                None,
+                MagicMock(),
+                ("agent_registry",),
+                id="only-agent-missing",
+            ),
+            pytest.param(
+                MagicMock(),
+                None,
+                ("provider_registry",),
+                id="only-provider-missing",
+            ),
+        ],
+    )
+    async def test_partial_missing_registries_names_exact_gap(
+        self,
+        agent_registry_value: MagicMock | None,
+        provider_registry_value: MagicMock | None,
+        expected_missing: tuple[str, ...],
+    ) -> None:
+        """Only the actually-missing dependency appears in the error."""
+        from synthorg.api.auto_wire import auto_wire_meetings
+        from synthorg.communication.meeting.agent_caller import (
+            MeetingAgentCallerNotConfiguredError,
+        )
+
+        config = _default_config()
+        result = auto_wire_meetings(
+            effective_config=config,
+            meeting_orchestrator=None,
+            meeting_scheduler=None,
+            agent_registry=agent_registry_value,
+            provider_registry=provider_registry_value,
+        )
+
+        assert isinstance(result.meeting_orchestrator, MeetingOrchestrator)
+        assert result.meeting_scheduler is None
+        assert result.ceremony_scheduler is None
+        caller = result.meeting_orchestrator._agent_caller
+        with pytest.raises(MeetingAgentCallerNotConfiguredError) as exc_info:
+            await caller("agent-1", "prompt", 100)
+        assert exc_info.value.missing_dependencies == expected_missing
 
     def test_preserves_explicit_orchestrator(self) -> None:
         from synthorg.api.auto_wire import auto_wire_meetings

--- a/tests/unit/api/test_auto_wire_meetings.py
+++ b/tests/unit/api/test_auto_wire_meetings.py
@@ -6,7 +6,6 @@ import pytest
 import structlog.testing
 
 from synthorg.communication.meeting.enums import MeetingProtocolType
-from synthorg.communication.meeting.models import AgentResponse
 from synthorg.communication.meeting.orchestrator import MeetingOrchestrator
 from synthorg.communication.meeting.participant import (
     PassthroughParticipantResolver,
@@ -18,6 +17,11 @@ from synthorg.config.schema import RootConfig
 
 def _default_config() -> RootConfig:
     return RootConfig(company_name="test-company")
+
+
+def _fake_registries() -> tuple[MagicMock, MagicMock]:
+    """Return (agent_registry, provider_registry) fakes for wiring tests."""
+    return MagicMock(), MagicMock()
 
 
 @pytest.mark.unit
@@ -44,31 +48,17 @@ class TestBuildProtocolRegistry:
 
 
 @pytest.mark.unit
-class TestStubAgentCaller:
-    """Tests for _build_stub_agent_caller helper."""
-
-    async def test_returns_valid_agent_response(self) -> None:
-        from synthorg.api.auto_wire import _build_stub_agent_caller
-
-        caller = _build_stub_agent_caller()
-        response = await caller("agent-1", "test prompt", 100)
-
-        assert isinstance(response, AgentResponse)
-        assert response.agent_id == "agent-1"
-        assert response.input_tokens == 0
-        assert response.output_tokens == 0
-        assert response.cost_usd == 0.0
-        assert response.content == ""
-
-
-@pytest.mark.unit
 class TestWireMeetingOrchestrator:
     """Tests for _wire_meeting_orchestrator helper."""
 
     def test_creates_valid_orchestrator(self) -> None:
         from synthorg.api.auto_wire import _wire_meeting_orchestrator
 
-        orchestrator = _wire_meeting_orchestrator()
+        agent_registry, provider_registry = _fake_registries()
+        orchestrator = _wire_meeting_orchestrator(
+            agent_registry=agent_registry,
+            provider_registry=provider_registry,
+        )
 
         assert isinstance(orchestrator, MeetingOrchestrator)
         assert orchestrator.get_records() == ()
@@ -85,7 +75,11 @@ class TestWireMeetingScheduler:
         )
 
         config = _default_config()
-        orchestrator = _wire_meeting_orchestrator()
+        agent_registry, provider_registry = _fake_registries()
+        orchestrator = _wire_meeting_orchestrator(
+            agent_registry=agent_registry,
+            provider_registry=provider_registry,
+        )
         registry = MagicMock()
 
         scheduler = _wire_meeting_scheduler(config, orchestrator, registry)
@@ -100,7 +94,11 @@ class TestWireMeetingScheduler:
         )
 
         config = _default_config()
-        orchestrator = _wire_meeting_orchestrator()
+        agent_registry, provider_registry = _fake_registries()
+        orchestrator = _wire_meeting_orchestrator(
+            agent_registry=agent_registry,
+            provider_registry=provider_registry,
+        )
 
         scheduler = _wire_meeting_scheduler(config, orchestrator, None)
 
@@ -116,15 +114,40 @@ class TestAutoWireMeetings:
         from synthorg.api.auto_wire import auto_wire_meetings
 
         config = _default_config()
+        agent_registry, provider_registry = _fake_registries()
+        result = auto_wire_meetings(
+            effective_config=config,
+            meeting_orchestrator=None,
+            meeting_scheduler=None,
+            agent_registry=agent_registry,
+            provider_registry=provider_registry,
+        )
+
+        assert isinstance(result.meeting_orchestrator, MeetingOrchestrator)
+        assert isinstance(result.meeting_scheduler, MeetingScheduler)
+
+    async def test_wires_unconfigured_caller_when_registries_missing(
+        self,
+    ) -> None:
+        """Orchestrator still wires without registries; call raises loudly."""
+        from synthorg.api.auto_wire import auto_wire_meetings
+        from synthorg.communication.meeting.agent_caller import (
+            MeetingAgentCallerNotConfiguredError,
+        )
+
+        config = _default_config()
         result = auto_wire_meetings(
             effective_config=config,
             meeting_orchestrator=None,
             meeting_scheduler=None,
             agent_registry=None,
+            provider_registry=None,
         )
 
         assert isinstance(result.meeting_orchestrator, MeetingOrchestrator)
-        assert isinstance(result.meeting_scheduler, MeetingScheduler)
+        caller = result.meeting_orchestrator._agent_caller
+        with pytest.raises(MeetingAgentCallerNotConfiguredError):
+            await caller("agent-1", "prompt", 100)
 
     def test_preserves_explicit_orchestrator(self) -> None:
         from synthorg.api.auto_wire import auto_wire_meetings
@@ -137,6 +160,7 @@ class TestAutoWireMeetings:
             meeting_orchestrator=explicit_orch,
             meeting_scheduler=None,
             agent_registry=None,
+            provider_registry=None,
         )
 
         assert result.meeting_orchestrator is explicit_orch
@@ -149,12 +173,14 @@ class TestAutoWireMeetings:
         # Cannot use spec=MeetingScheduler: PEP 649 deferred
         # annotation for MeetingsConfig causes NameError in inspect.
         explicit_sched = MagicMock()
+        agent_registry, provider_registry = _fake_registries()
 
         result = auto_wire_meetings(
             effective_config=config,
             meeting_orchestrator=None,
             meeting_scheduler=explicit_sched,
-            agent_registry=None,
+            agent_registry=agent_registry,
+            provider_registry=provider_registry,
         )
 
         assert isinstance(result.meeting_orchestrator, MeetingOrchestrator)
@@ -174,6 +200,7 @@ class TestAutoWireMeetings:
             meeting_orchestrator=explicit_orch,
             meeting_scheduler=explicit_sched,
             agent_registry=None,
+            provider_registry=None,
         )
 
         assert result.meeting_orchestrator is explicit_orch
@@ -183,13 +210,15 @@ class TestAutoWireMeetings:
         from synthorg.api.auto_wire import auto_wire_meetings
 
         config = _default_config()
+        agent_registry, provider_registry = _fake_registries()
 
         with structlog.testing.capture_logs() as captured:
             auto_wire_meetings(
                 effective_config=config,
                 meeting_orchestrator=None,
                 meeting_scheduler=None,
-                agent_registry=None,
+                agent_registry=agent_registry,
+                provider_registry=provider_registry,
             )
 
         services = [e.get("service") for e in captured]
@@ -201,12 +230,14 @@ class TestAutoWireMeetings:
 
         config = _default_config()
         registry = MagicMock()
+        provider_registry = MagicMock()
 
         result = auto_wire_meetings(
             effective_config=config,
             meeting_orchestrator=None,
             meeting_scheduler=None,
             agent_registry=registry,
+            provider_registry=provider_registry,
         )
 
         assert isinstance(result.meeting_orchestrator, MeetingOrchestrator)
@@ -224,6 +255,7 @@ class TestWireMeetingOrchestratorError:
     def test_orchestrator_creation_failure_propagates(self) -> None:
         from synthorg.api.auto_wire import _wire_meeting_orchestrator
 
+        agent_registry, provider_registry = _fake_registries()
         with (
             patch(
                 "synthorg.api.auto_wire._build_protocol_registry",
@@ -231,7 +263,10 @@ class TestWireMeetingOrchestratorError:
             ),
             pytest.raises(RuntimeError, match="boom"),
         ):
-            _wire_meeting_orchestrator()
+            _wire_meeting_orchestrator(
+                agent_registry=agent_registry,
+                provider_registry=provider_registry,
+            )
 
     def test_scheduler_creation_failure_propagates(self) -> None:
         from synthorg.api.auto_wire import (
@@ -240,7 +275,11 @@ class TestWireMeetingOrchestratorError:
         )
 
         config = _default_config()
-        orchestrator = _wire_meeting_orchestrator()
+        agent_registry, provider_registry = _fake_registries()
+        orchestrator = _wire_meeting_orchestrator(
+            agent_registry=agent_registry,
+            provider_registry=provider_registry,
+        )
 
         with (
             patch(

--- a/tests/unit/communication/delegation/test_record_store.py
+++ b/tests/unit/communication/delegation/test_record_store.py
@@ -291,37 +291,44 @@ class TestEvictionWarningConcurrency:
 
         assert _count_eviction_warnings(cap) == 2
 
-    def test_interleaved_clear_and_record_never_drops_warning(self) -> None:
+    def test_interleaved_clear_and_record_emits_exactly_one_warning_per_cycle(
+        self,
+    ) -> None:
         """Each fill cycle that overflows emits its warning exactly once.
 
-        With the ``threading.Lock`` around the check-then-set, the naive
-        race (where ``clear()`` resets the flag between another thread's
-        check and set, dropping the warning for that cycle) is gone.
-        Every cycle whose ``fills_per_cycle >= max_records + 1`` must
-        fire one and only one ``DELEGATION_RECORD_EVICTED`` warning
-        before the closing ``clear()``.
+        Cycles are serialised by a barrier so each executes fully before
+        the next starts -- this is what "exactly once per cycle" actually
+        means.  Threads within a cycle race through 12 ``record_sync``
+        calls concurrently past ``max_records=3`` and the closing
+        ``clear()``; because the check/set on ``_eviction_warned`` and
+        the buffer mutations are both held under ``_warning_lock``, the
+        cycle emits exactly one warning regardless of thread scheduling.
         """
         store = DelegationRecordStore(max_records=3)
         cycles = 30
         fills_per_cycle = 12
+        threads_per_cycle = 8
 
-        def fill_cycle() -> None:
+        def fill_thread(start: threading.Barrier, done: threading.Barrier) -> None:
+            start.wait()
             for i in range(fills_per_cycle):
                 store.record_sync(_make_record(delegation_id=f"d-{i:03d}"))
-            store.clear()
+            done.wait()
 
-        with (
-            structlog.testing.capture_logs() as cap,
-            ThreadPoolExecutor(max_workers=8) as executor,
-        ):
-            futures = [executor.submit(fill_cycle) for _ in range(cycles)]
-            for future in futures:
-                future.result()
+        with structlog.testing.capture_logs() as cap:
+            for _cycle in range(cycles):
+                start = threading.Barrier(threads_per_cycle)
+                done = threading.Barrier(threads_per_cycle + 1)
+                with ThreadPoolExecutor(max_workers=threads_per_cycle) as executor:
+                    futures = [
+                        executor.submit(fill_thread, start, done)
+                        for _ in range(threads_per_cycle)
+                    ]
+                    done.wait()
+                    for future in futures:
+                        future.result()
+                store.clear()
 
-        warnings = _count_eviction_warnings(cap)
-        # With the lock, each cycle emits exactly one warning. Parallel
-        # cycles can observe each other's clears, so one cycle may produce
-        # up to two warnings if a concurrent clear resets the flag between
-        # its own fills. The lower bound is the number of cycles; the
-        # upper bound is 2x the cycles as a generous safety net.
-        assert cycles <= warnings <= 2 * cycles
+        # With per-cycle serialisation + the lock protecting both the
+        # flag and the buffer, exactly one warning fires per cycle.
+        assert _count_eviction_warnings(cap) == cycles

--- a/tests/unit/communication/delegation/test_record_store.py
+++ b/tests/unit/communication/delegation/test_record_store.py
@@ -292,7 +292,15 @@ class TestEvictionWarningConcurrency:
         assert _count_eviction_warnings(cap) == 2
 
     def test_interleaved_clear_and_record_never_drops_warning(self) -> None:
-        """Each fill cycle must emit at least one warning, even under races."""
+        """Each fill cycle that overflows emits its warning exactly once.
+
+        With the ``threading.Lock`` around the check-then-set, the naive
+        race (where ``clear()`` resets the flag between another thread's
+        check and set, dropping the warning for that cycle) is gone.
+        Every cycle whose ``fills_per_cycle >= max_records + 1`` must
+        fire one and only one ``DELEGATION_RECORD_EVICTED`` warning
+        before the closing ``clear()``.
+        """
         store = DelegationRecordStore(max_records=3)
         cycles = 30
         fills_per_cycle = 12
@@ -310,9 +318,10 @@ class TestEvictionWarningConcurrency:
             for future in futures:
                 future.result()
 
-        # At least one warning per overflow cycle is the invariant we
-        # protect: the naive implementation drops warnings when clear()
-        # resets the flag between another thread's check and set, so pre-fix
-        # counts can easily skip cycles. With the lock, every cycle that
-        # fills past maxlen while the flag is False emits its warning.
-        assert _count_eviction_warnings(cap) >= 1
+        warnings = _count_eviction_warnings(cap)
+        # With the lock, each cycle emits exactly one warning. Parallel
+        # cycles can observe each other's clears, so one cycle may produce
+        # up to two warnings if a concurrent clear resets the flag between
+        # its own fills. The lower bound is the number of cycles; the
+        # upper bound is 2x the cycles as a generous safety net.
+        assert cycles <= warnings <= 2 * cycles

--- a/tests/unit/communication/delegation/test_record_store.py
+++ b/tests/unit/communication/delegation/test_record_store.py
@@ -1,13 +1,18 @@
 """Tests for DelegationRecordStore."""
 
+import threading
+from collections.abc import Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 
 import pytest
+import structlog
 
 from synthorg.communication.delegation.models import DelegationRecord
 from synthorg.communication.delegation.record_store import (
     DelegationRecordStore,
 )
+from synthorg.observability.events.delegation import DELEGATION_RECORD_EVICTED
 
 _NOW = datetime(2026, 3, 24, 12, 0, 0, tzinfo=UTC)
 
@@ -242,3 +247,72 @@ class TestDelegationRecordStoreEviction:
         records = await store.get_all_records()
         assert len(records) == 1
         assert records[0].delegation_id == "del-last"
+
+
+# ── Concurrency: warning guarded by threading.Lock ────────────
+
+
+def _count_eviction_warnings(cap: Sequence[Mapping[str, object]]) -> int:
+    return sum(1 for e in cap if e.get("event") == DELEGATION_RECORD_EVICTED)
+
+
+@pytest.mark.unit
+class TestEvictionWarningConcurrency:
+    """Check-then-set on _eviction_warned must be serialized."""
+
+    def test_single_warning_under_thread_flood(self) -> None:
+        """Many threads filling past maxlen emit exactly one warning."""
+        store = DelegationRecordStore(max_records=5)
+        record_count = 200
+        barrier = threading.Barrier(record_count)
+
+        def worker(i: int) -> None:
+            barrier.wait()
+            store.record_sync(_make_record(delegation_id=f"del-{i:04d}"))
+
+        with (
+            structlog.testing.capture_logs() as cap,
+            ThreadPoolExecutor(max_workers=record_count) as executor,
+        ):
+            list(executor.map(worker, range(record_count)))
+
+        assert _count_eviction_warnings(cap) == 1
+
+    def test_clear_then_refill_re_emits_warning(self) -> None:
+        """clear() resets the flag so a subsequent fill warns again."""
+        store = DelegationRecordStore(max_records=3)
+
+        with structlog.testing.capture_logs() as cap:
+            for i in range(5):
+                store.record_sync(_make_record(delegation_id=f"a-{i}"))
+            store.clear()
+            for i in range(5):
+                store.record_sync(_make_record(delegation_id=f"b-{i}"))
+
+        assert _count_eviction_warnings(cap) == 2
+
+    def test_interleaved_clear_and_record_never_drops_warning(self) -> None:
+        """Each fill cycle must emit at least one warning, even under races."""
+        store = DelegationRecordStore(max_records=3)
+        cycles = 30
+        fills_per_cycle = 12
+
+        def fill_cycle() -> None:
+            for i in range(fills_per_cycle):
+                store.record_sync(_make_record(delegation_id=f"d-{i:03d}"))
+            store.clear()
+
+        with (
+            structlog.testing.capture_logs() as cap,
+            ThreadPoolExecutor(max_workers=8) as executor,
+        ):
+            futures = [executor.submit(fill_cycle) for _ in range(cycles)]
+            for future in futures:
+                future.result()
+
+        # At least one warning per overflow cycle is the invariant we
+        # protect: the naive implementation drops warnings when clear()
+        # resets the flag between another thread's check and set, so pre-fix
+        # counts can easily skip cycles. With the lock, every cycle that
+        # fills past maxlen while the flag is False emits its warning.
+        assert _count_eviction_warnings(cap) >= 1

--- a/tests/unit/communication/meeting/test_agent_caller.py
+++ b/tests/unit/communication/meeting/test_agent_caller.py
@@ -142,7 +142,10 @@ class TestBuildMeetingAgentCaller:
 
     async def test_unknown_agent_raises(self) -> None:
         caller, _reg, _providers = _build_caller(identity=None)
-        with pytest.raises(UnknownMeetingAgentError) as exc_info:
+        with (
+            structlog.testing.capture_logs() as cap,
+            pytest.raises(UnknownMeetingAgentError) as exc_info,
+        ):
             await caller(_AGENT_ID, "prompt", 100)
         # LookupError-compatible so callers can catch with existing
         # lookup-failure handlers.
@@ -150,6 +153,12 @@ class TestBuildMeetingAgentCaller:
         # agent_id must be available as a typed attribute for
         # programmatic handling (logging, retries, metric tagging).
         assert exc_info.value.agent_id == _AGENT_ID
+        # Error path must log before raising so operators see agent_id
+        # in structured logs even when the error is caught upstream.
+        failures = [e for e in cap if e.get("event") == MEETING_AGENT_CALL_FAILED]
+        assert len(failures) == 1
+        assert failures[0]["agent_id"] == _AGENT_ID
+        assert failures[0]["error_type"] == "UnknownMeetingAgentError"
 
     async def test_empty_content_maps_to_empty_string(self) -> None:
         identity = _identity()
@@ -268,10 +277,24 @@ class TestBuildUnconfiguredMeetingAgentCaller:
         caller = build_unconfigured_meeting_agent_caller(
             missing_dependencies=("agent_registry", "provider_registry"),
         )
-        with pytest.raises(MeetingAgentCallerNotConfiguredError) as exc_info:
+        with (
+            structlog.testing.capture_logs() as cap,
+            pytest.raises(MeetingAgentCallerNotConfiguredError) as exc_info,
+        ):
             await caller("agent-1", "prompt", 100)
         assert exc_info.value.agent_id == "agent-1"
         assert exc_info.value.missing_dependencies == (
+            "agent_registry",
+            "provider_registry",
+        )
+        # Error path must log before raising so the structured context
+        # (agent_id + missing_dependencies) reaches observability even
+        # when upstream callers swallow or rewrap the exception.
+        failures = [e for e in cap if e.get("event") == MEETING_AGENT_CALL_FAILED]
+        assert len(failures) == 1
+        assert failures[0]["agent_id"] == "agent-1"
+        assert failures[0]["error_type"] == "MeetingAgentCallerNotConfiguredError"
+        assert failures[0]["missing_dependencies"] == (
             "agent_registry",
             "provider_registry",
         )

--- a/tests/unit/communication/meeting/test_agent_caller.py
+++ b/tests/unit/communication/meeting/test_agent_caller.py
@@ -16,9 +16,8 @@ from synthorg.core.agent import (
     AgentIdentity,
     ModelConfig,
     PersonalityConfig,
-    SeniorityLevel,
 )
-from synthorg.core.enums import AgentStatus
+from synthorg.core.enums import AgentStatus, SeniorityLevel
 from synthorg.core.types import NotBlankStr
 from synthorg.observability.events.meeting import (
     MEETING_AGENT_CALLED,

--- a/tests/unit/communication/meeting/test_agent_caller.py
+++ b/tests/unit/communication/meeting/test_agent_caller.py
@@ -12,6 +12,7 @@ from synthorg.communication.meeting.agent_caller import (
     build_meeting_agent_caller,
 )
 from synthorg.communication.meeting.models import AgentResponse
+from synthorg.communication.meeting.protocol import AgentCaller
 from synthorg.core.agent import (
     AgentIdentity,
     ModelConfig,
@@ -85,7 +86,7 @@ def _build_caller(
     identity: AgentIdentity | None = None,
     response: CompletionResponse | None = None,
     provider_error: Exception | None = None,
-) -> tuple[object, MagicMock, MagicMock]:
+) -> tuple[AgentCaller, MagicMock, MagicMock]:
     """Produce ``(caller, agent_registry, provider_registry)``."""
     agent_registry = MagicMock()
     agent_registry.get = AsyncMock(return_value=identity)
@@ -122,8 +123,7 @@ class TestBuildMeetingAgentCaller:
             response=response,
         )
 
-        result = await caller(_AGENT_ID, "Agenda: queueing", 500)  # type: ignore[operator]
-
+        result = await caller(_AGENT_ID, "Agenda: queueing", 500)
         assert isinstance(result, AgentResponse)
         assert result.agent_id == _AGENT_ID
         assert result.content == "I propose adding a queue."
@@ -133,8 +133,14 @@ class TestBuildMeetingAgentCaller:
 
     async def test_unknown_agent_raises(self) -> None:
         caller, _reg, _providers = _build_caller(identity=None)
-        with pytest.raises(UnknownMeetingAgentError):
-            await caller(_AGENT_ID, "prompt", 100)  # type: ignore[operator]
+        with pytest.raises(UnknownMeetingAgentError) as exc_info:
+            await caller(_AGENT_ID, "prompt", 100)
+        # LookupError-compatible so callers can catch with existing
+        # lookup-failure handlers.
+        assert isinstance(exc_info.value, LookupError)
+        # agent_id must be available as a typed attribute for
+        # programmatic handling (logging, retries, metric tagging).
+        assert exc_info.value.agent_id == _AGENT_ID
 
     async def test_empty_content_maps_to_empty_string(self) -> None:
         identity = _identity()
@@ -142,7 +148,7 @@ class TestBuildMeetingAgentCaller:
             identity=identity,
             response=_completion(content=""),
         )
-        result = await caller(_AGENT_ID, "prompt", 100)  # type: ignore[operator]
+        result = await caller(_AGENT_ID, "prompt", 100)
         assert result.content == ""
 
     async def test_provider_error_propagates(self) -> None:
@@ -152,15 +158,14 @@ class TestBuildMeetingAgentCaller:
             provider_error=RuntimeError("provider boom"),
         )
         with pytest.raises(RuntimeError, match="provider boom"):
-            await caller(_AGENT_ID, "prompt", 100)  # type: ignore[operator]
+            await caller(_AGENT_ID, "prompt", 100)
 
     async def test_logs_called_and_responded_events(self) -> None:
         identity = _identity()
         caller, _reg, _providers = _build_caller(identity=identity)
 
         with structlog.testing.capture_logs() as cap:
-            await caller(_AGENT_ID, "prompt", 100)  # type: ignore[operator]
-
+            await caller(_AGENT_ID, "prompt", 100)
         events = [e.get("event") for e in cap]
         assert MEETING_AGENT_CALLED in events
         assert MEETING_AGENT_RESPONDED in events
@@ -168,13 +173,13 @@ class TestBuildMeetingAgentCaller:
     async def test_dispatches_to_agent_provider(self) -> None:
         identity = _identity(provider="example-provider")
         caller, _reg, provider_registry = _build_caller(identity=identity)
-        await caller(_AGENT_ID, "prompt", 256)  # type: ignore[operator]
+        await caller(_AGENT_ID, "prompt", 256)
         provider_registry.get.assert_called_once_with("example-provider")
 
     async def test_passes_max_tokens_into_completion_config(self) -> None:
         identity = _identity()
         caller, _reg, provider_registry = _build_caller(identity=identity)
-        await caller(_AGENT_ID, "agenda", 777)  # type: ignore[operator]
+        await caller(_AGENT_ID, "agenda", 777)
         provider = provider_registry.get.return_value
         provider.complete.assert_awaited_once()
         call = provider.complete.await_args

--- a/tests/unit/communication/meeting/test_agent_caller.py
+++ b/tests/unit/communication/meeting/test_agent_caller.py
@@ -8,8 +8,10 @@ import pytest
 import structlog
 
 from synthorg.communication.meeting.agent_caller import (
+    MeetingAgentCallerNotConfiguredError,
     UnknownMeetingAgentError,
     build_meeting_agent_caller,
+    build_unconfigured_meeting_agent_caller,
 )
 from synthorg.communication.meeting.models import AgentResponse
 from synthorg.communication.meeting.protocol import AgentCaller
@@ -20,12 +22,15 @@ from synthorg.core.agent import (
 )
 from synthorg.core.enums import AgentStatus, SeniorityLevel
 from synthorg.core.types import NotBlankStr
+from synthorg.hr.registry import AgentRegistryService
 from synthorg.observability.events.meeting import (
+    MEETING_AGENT_CALL_FAILED,
     MEETING_AGENT_CALLED,
     MEETING_AGENT_RESPONDED,
 )
 from synthorg.providers.enums import FinishReason, MessageRole
 from synthorg.providers.models import CompletionResponse, TokenUsage
+from synthorg.providers.registry import ProviderRegistry
 
 pytestmark = pytest.mark.unit
 
@@ -87,8 +92,12 @@ def _build_caller(
     response: CompletionResponse | None = None,
     provider_error: Exception | None = None,
 ) -> tuple[AgentCaller, MagicMock, MagicMock]:
-    """Produce ``(caller, agent_registry, provider_registry)``."""
-    agent_registry = MagicMock()
+    """Produce ``(caller, agent_registry, provider_registry)``.
+
+    Uses ``spec=`` so interface drift between the mocks and the real
+    services surfaces as a test failure instead of silently passing.
+    """
+    agent_registry = MagicMock(spec=AgentRegistryService)
     agent_registry.get = AsyncMock(return_value=identity)
 
     provider = MagicMock()
@@ -99,7 +108,7 @@ def _build_caller(
             return_value=response or _completion(),
         )
 
-    provider_registry = MagicMock()
+    provider_registry = MagicMock(spec=ProviderRegistry)
     provider_registry.get = MagicMock(return_value=provider)
 
     caller = build_meeting_agent_caller(
@@ -189,6 +198,88 @@ class TestBuildMeetingAgentCaller:
         assert messages[0].role == MessageRole.SYSTEM
         assert messages[1].role == MessageRole.USER
         assert "agenda" in (messages[1].content or "")
+
+    async def test_clamps_max_tokens_to_identity_cap(self) -> None:
+        """A caller asking for more than the model allows is clamped down."""
+        identity = _identity()
+        assert identity.model.max_tokens == 4096
+        caller, _reg, provider_registry = _build_caller(identity=identity)
+        await caller(_AGENT_ID, "agenda", 10_000)
+        provider = provider_registry.get.return_value
+        config = provider.complete.await_args.kwargs["config"]
+        # min(10_000, 4096) == 4096.  Without the clamp the per-turn
+        # request would overshoot the agent's configured limit and the
+        # provider would either reject or silently truncate.
+        assert config.max_tokens == 4096
+
+    async def test_provider_error_logs_failure_event_before_raising(self) -> None:
+        identity = _identity()
+        caller, _reg, _providers = _build_caller(
+            identity=identity,
+            provider_error=RuntimeError("provider boom"),
+        )
+
+        with (
+            structlog.testing.capture_logs() as cap,
+            pytest.raises(RuntimeError, match="provider boom"),
+        ):
+            await caller(_AGENT_ID, "prompt", 100)
+
+        failures = [e for e in cap if e.get("event") == MEETING_AGENT_CALL_FAILED]
+        assert len(failures) == 1
+        assert failures[0]["agent_id"] == _AGENT_ID
+        assert failures[0]["error_type"] == "RuntimeError"
+
+    async def test_renders_prompt_without_traits_when_tuple_empty(
+        self,
+    ) -> None:
+        """Empty traits render without a Personality traits line.
+
+        ``PersonalityConfig.traits`` defaults to an empty tuple and
+        ``communication_style`` defaults to ``"neutral"``; both are
+        conditionally rendered.  This test pins the empty-traits branch
+        so a regression (always rendering "Personality traits:") would
+        fail fast.
+        """
+        identity = _identity()
+        identity = AgentIdentity(
+            id=identity.id,
+            name=identity.name,
+            role=identity.role,
+            department=identity.department,
+            level=identity.level,
+            personality=PersonalityConfig(),
+            model=identity.model,
+            hiring_date=identity.hiring_date,
+            status=identity.status,
+        )
+        caller, _reg, provider_registry = _build_caller(identity=identity)
+        await caller(_AGENT_ID, "agenda", 100)
+        messages = provider_registry.get.return_value.complete.await_args.args[0]
+        system_content = messages[0].content or ""
+        assert "Personality traits" not in system_content
+        # communication_style defaults to "neutral" (NotBlankStr), which
+        # is always rendered -- pin that branch too.
+        assert "Communication style: neutral." in system_content
+
+
+class TestBuildUnconfiguredMeetingAgentCaller:
+    async def test_caller_raises_with_typed_attributes(self) -> None:
+        caller = build_unconfigured_meeting_agent_caller(
+            missing_dependencies=("agent_registry", "provider_registry"),
+        )
+        with pytest.raises(MeetingAgentCallerNotConfiguredError) as exc_info:
+            await caller("agent-1", "prompt", 100)
+        assert exc_info.value.agent_id == "agent-1"
+        assert exc_info.value.missing_dependencies == (
+            "agent_registry",
+            "provider_registry",
+        )
+
+    def test_rejects_empty_missing_dependencies(self) -> None:
+        """A caller with no missing deps is a programming error, not a wire gap."""
+        with pytest.raises(ValueError, match="missing_dependencies"):
+            build_unconfigured_meeting_agent_caller(missing_dependencies=())
 
 
 _ = UTC  # keep datetime-aware reference for future date-sensitive tests

--- a/tests/unit/communication/meeting/test_agent_caller.py
+++ b/tests/unit/communication/meeting/test_agent_caller.py
@@ -1,0 +1,190 @@
+"""Unit tests for the meeting agent caller factory."""
+
+from datetime import UTC, date
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+import structlog
+
+from synthorg.communication.meeting.agent_caller import (
+    UnknownMeetingAgentError,
+    build_meeting_agent_caller,
+)
+from synthorg.communication.meeting.models import AgentResponse
+from synthorg.core.agent import (
+    AgentIdentity,
+    ModelConfig,
+    PersonalityConfig,
+    SeniorityLevel,
+)
+from synthorg.core.enums import AgentStatus
+from synthorg.core.types import NotBlankStr
+from synthorg.observability.events.meeting import (
+    MEETING_AGENT_CALLED,
+    MEETING_AGENT_RESPONDED,
+)
+from synthorg.providers.enums import FinishReason, MessageRole
+from synthorg.providers.models import CompletionResponse, TokenUsage
+
+pytestmark = pytest.mark.unit
+
+
+def _identity(
+    *,
+    name: str = "Sarah Chen",
+    role: str = "engineer",
+    department: str = "engineering",
+    provider: str = "example-provider",
+    model_id: str = "example-medium-001",
+) -> AgentIdentity:
+    return AgentIdentity(
+        id=uuid4(),
+        name=NotBlankStr(name),
+        role=NotBlankStr(role),
+        department=NotBlankStr(department),
+        level=SeniorityLevel.MID,
+        personality=PersonalityConfig(
+            traits=(NotBlankStr("analytical"), NotBlankStr("curious")),
+            communication_style=NotBlankStr("concise"),
+        ),
+        model=ModelConfig(
+            provider=NotBlankStr(provider),
+            model_id=NotBlankStr(model_id),
+            temperature=0.7,
+            max_tokens=4096,
+        ),
+        hiring_date=date(2026, 1, 1),
+        status=AgentStatus.ACTIVE,
+    )
+
+
+def _completion(
+    *,
+    content: str = "Here is my input.",
+    input_tokens: int = 17,
+    output_tokens: int = 42,
+    cost_usd: float = 0.00042,
+) -> CompletionResponse:
+    return CompletionResponse(
+        content=content,
+        finish_reason=FinishReason.STOP,
+        usage=TokenUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=cost_usd,
+        ),
+        model=NotBlankStr("example-medium-001"),
+    )
+
+
+_AGENT_ID = "agent-sarah"
+
+
+def _build_caller(
+    *,
+    identity: AgentIdentity | None = None,
+    response: CompletionResponse | None = None,
+    provider_error: Exception | None = None,
+) -> tuple[object, MagicMock, MagicMock]:
+    """Produce ``(caller, agent_registry, provider_registry)``."""
+    agent_registry = MagicMock()
+    agent_registry.get = AsyncMock(return_value=identity)
+
+    provider = MagicMock()
+    if provider_error is not None:
+        provider.complete = AsyncMock(side_effect=provider_error)
+    else:
+        provider.complete = AsyncMock(
+            return_value=response or _completion(),
+        )
+
+    provider_registry = MagicMock()
+    provider_registry.get = MagicMock(return_value=provider)
+
+    caller = build_meeting_agent_caller(
+        agent_registry=agent_registry,
+        provider_registry=provider_registry,
+    )
+    return caller, agent_registry, provider_registry
+
+
+class TestBuildMeetingAgentCaller:
+    async def test_round_trip_maps_completion_to_agent_response(self) -> None:
+        identity = _identity()
+        response = _completion(
+            content="I propose adding a queue.",
+            input_tokens=20,
+            output_tokens=30,
+            cost_usd=0.001,
+        )
+        caller, _registry, _providers = _build_caller(
+            identity=identity,
+            response=response,
+        )
+
+        result = await caller(_AGENT_ID, "Agenda: queueing", 500)  # type: ignore[operator]
+
+        assert isinstance(result, AgentResponse)
+        assert result.agent_id == _AGENT_ID
+        assert result.content == "I propose adding a queue."
+        assert result.input_tokens == 20
+        assert result.output_tokens == 30
+        assert result.cost_usd == pytest.approx(0.001)
+
+    async def test_unknown_agent_raises(self) -> None:
+        caller, _reg, _providers = _build_caller(identity=None)
+        with pytest.raises(UnknownMeetingAgentError):
+            await caller(_AGENT_ID, "prompt", 100)  # type: ignore[operator]
+
+    async def test_empty_content_maps_to_empty_string(self) -> None:
+        identity = _identity()
+        caller, _reg, _providers = _build_caller(
+            identity=identity,
+            response=_completion(content=""),
+        )
+        result = await caller(_AGENT_ID, "prompt", 100)  # type: ignore[operator]
+        assert result.content == ""
+
+    async def test_provider_error_propagates(self) -> None:
+        identity = _identity()
+        caller, _reg, _providers = _build_caller(
+            identity=identity,
+            provider_error=RuntimeError("provider boom"),
+        )
+        with pytest.raises(RuntimeError, match="provider boom"):
+            await caller(_AGENT_ID, "prompt", 100)  # type: ignore[operator]
+
+    async def test_logs_called_and_responded_events(self) -> None:
+        identity = _identity()
+        caller, _reg, _providers = _build_caller(identity=identity)
+
+        with structlog.testing.capture_logs() as cap:
+            await caller(_AGENT_ID, "prompt", 100)  # type: ignore[operator]
+
+        events = [e.get("event") for e in cap]
+        assert MEETING_AGENT_CALLED in events
+        assert MEETING_AGENT_RESPONDED in events
+
+    async def test_dispatches_to_agent_provider(self) -> None:
+        identity = _identity(provider="example-provider")
+        caller, _reg, provider_registry = _build_caller(identity=identity)
+        await caller(_AGENT_ID, "prompt", 256)  # type: ignore[operator]
+        provider_registry.get.assert_called_once_with("example-provider")
+
+    async def test_passes_max_tokens_into_completion_config(self) -> None:
+        identity = _identity()
+        caller, _reg, provider_registry = _build_caller(identity=identity)
+        await caller(_AGENT_ID, "agenda", 777)  # type: ignore[operator]
+        provider = provider_registry.get.return_value
+        provider.complete.assert_awaited_once()
+        call = provider.complete.await_args
+        messages = call.args[0]
+        config = call.kwargs["config"]
+        assert config.max_tokens == 777
+        assert messages[0].role == MessageRole.SYSTEM
+        assert messages[1].role == MessageRole.USER
+        assert "agenda" in (messages[1].content or "")
+
+
+_ = UTC  # keep datetime-aware reference for future date-sensitive tests

--- a/tests/unit/meta/signals/test_scaling.py
+++ b/tests/unit/meta/signals/test_scaling.py
@@ -234,7 +234,10 @@ class TestAggregate:
         than being masked as "no activity".  A decision with a
         non-datetime ``created_at`` triggers the filter comparison to
         raise, and we assert the ``TypeError`` escapes ``aggregate``
-        without the broad fallback catching it.
+        without the broad fallback catching it -- and that the reducer
+        logs a ``META_SIGNAL_AGGREGATION_FAILED`` event with the
+        ``stage="reduce"`` tag before re-raising so operators see the
+        failure in observability.
         """
         broken = MagicMock()
         broken.created_at = MagicMock()  # not a datetime -> comparison fails
@@ -244,8 +247,20 @@ class TestAggregate:
         agg = ScalingSignalAggregator(service=service)
         since, until = _window()
 
-        with pytest.raises(TypeError):
+        with (
+            structlog.testing.capture_logs() as cap,
+            pytest.raises(TypeError),
+        ):
             await agg.aggregate(since=since, until=until)
+
+        failures = [
+            e
+            for e in cap
+            if e.get("event") == META_SIGNAL_AGGREGATION_FAILED
+            and e.get("stage") == "reduce"
+        ]
+        assert len(failures) == 1
+        assert failures[0]["decision_count"] == 1
 
     async def test_logs_completed_on_success(self) -> None:
         decisions = (_decision(),)

--- a/tests/unit/meta/signals/test_scaling.py
+++ b/tests/unit/meta/signals/test_scaling.py
@@ -155,6 +155,30 @@ class TestAggregate:
         assert summary.total_decisions == 1
         assert summary.recent_decisions[0].outcome == "executed"
 
+    async def test_window_is_half_open_inclusive_start_exclusive_end(
+        self,
+    ) -> None:
+        """Boundaries: decision at ``since`` included, at ``until`` excluded."""
+        since = _NOW
+        until = _NOW + timedelta(hours=1)
+        decisions = (
+            _decision(
+                decision_id="d-at-since",
+                created_at=since,
+            ),
+            _decision(
+                decision_id="d-just-before-until",
+                created_at=until - timedelta(microseconds=1),
+            ),
+            _decision(
+                decision_id="d-at-until",
+                created_at=until,
+            ),
+        )
+        agg = ScalingSignalAggregator(service=_service(decisions=decisions))
+        summary = await agg.aggregate(since=since, until=until)
+        assert summary.total_decisions == 2
+
     async def test_most_common_signal_picks_top_strategy(self) -> None:
         workload_decisions = tuple(
             _decision(

--- a/tests/unit/meta/signals/test_scaling.py
+++ b/tests/unit/meta/signals/test_scaling.py
@@ -1,0 +1,212 @@
+"""Unit tests for ScalingSignalAggregator."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+import structlog
+
+from synthorg.core.types import NotBlankStr
+from synthorg.hr.scaling.enums import (
+    ScalingActionType,
+    ScalingOutcome,
+    ScalingStrategyName,
+)
+from synthorg.hr.scaling.models import ScalingActionRecord, ScalingDecision
+from synthorg.meta.models import OrgScalingSummary
+from synthorg.meta.signals.scaling import ScalingSignalAggregator
+from synthorg.observability.events.meta import (
+    META_SIGNAL_AGGREGATION_COMPLETED,
+    META_SIGNAL_AGGREGATION_FAILED,
+)
+
+pytestmark = pytest.mark.unit
+
+_NOW = datetime(2026, 4, 17, 12, 0, 0, tzinfo=UTC)
+
+
+def _window() -> tuple[datetime, datetime]:
+    return _NOW - timedelta(days=7), _NOW + timedelta(hours=1)
+
+
+def _decision(  # noqa: PLR0913
+    *,
+    decision_id: str = "d-001",
+    action_type: ScalingActionType = ScalingActionType.HIRE,
+    strategy: ScalingStrategyName = ScalingStrategyName.WORKLOAD,
+    rationale: str = "workload up",
+    created_at: datetime = _NOW,
+    target_role: str | None = "engineer",
+    target_agent_id: str | None = None,
+) -> ScalingDecision:
+    return ScalingDecision(
+        id=NotBlankStr(decision_id),
+        action_type=action_type,
+        source_strategy=strategy,
+        target_role=NotBlankStr(target_role) if target_role else None,
+        target_agent_id=(NotBlankStr(target_agent_id) if target_agent_id else None),
+        rationale=NotBlankStr(rationale),
+        confidence=0.8,
+        created_at=created_at,
+    )
+
+
+def _action(
+    *,
+    decision_id: str,
+    outcome: ScalingOutcome,
+    result_id: str | None = "r-1",
+    reason: str | None = None,
+    executed_at: datetime = _NOW,
+) -> ScalingActionRecord:
+    return ScalingActionRecord(
+        decision_id=NotBlankStr(decision_id),
+        outcome=outcome,
+        result_id=NotBlankStr(result_id) if result_id else None,
+        reason=NotBlankStr(reason) if reason else None,
+        executed_at=executed_at,
+    )
+
+
+def _service(
+    *,
+    decisions: tuple[ScalingDecision, ...] = (),
+    actions: tuple[ScalingActionRecord, ...] = (),
+) -> MagicMock:
+    service = MagicMock()
+    service.get_recent_decisions = MagicMock(return_value=decisions)
+    service.get_recent_actions = MagicMock(return_value=actions)
+    return service
+
+
+class TestAggregate:
+    async def test_empty_service_returns_empty_summary(self) -> None:
+        agg = ScalingSignalAggregator(service=_service())
+        since, until = _window()
+        summary = await agg.aggregate(since=since, until=until)
+        assert summary == OrgScalingSummary()
+
+    async def test_joins_decisions_with_actions(self) -> None:
+        decisions = (
+            _decision(
+                decision_id="d-hire",
+                action_type=ScalingActionType.HIRE,
+                strategy=ScalingStrategyName.WORKLOAD,
+            ),
+            _decision(
+                decision_id="d-prune",
+                action_type=ScalingActionType.PRUNE,
+                strategy=ScalingStrategyName.PERFORMANCE_PRUNING,
+                target_role=None,
+                target_agent_id="agent-1",
+            ),
+        )
+        actions = (
+            _action(
+                decision_id="d-hire",
+                outcome=ScalingOutcome.EXECUTED,
+            ),
+            _action(
+                decision_id="d-prune",
+                outcome=ScalingOutcome.FAILED,
+                result_id=None,
+                reason="offboarding vetoed",
+            ),
+        )
+        agg = ScalingSignalAggregator(
+            service=_service(decisions=decisions, actions=actions),
+        )
+        since, until = _window()
+        summary = await agg.aggregate(since=since, until=until)
+
+        assert summary.total_decisions == 2
+        assert summary.success_rate == 0.5
+        outcomes = {s.outcome for s in summary.recent_decisions}
+        assert outcomes == {"executed", "failed"}
+        assert summary.most_common_signal in {
+            "workload",
+            "performance_pruning",
+        }
+
+    async def test_decision_without_action_is_pending(self) -> None:
+        decisions = (_decision(decision_id="d-orphan"),)
+        agg = ScalingSignalAggregator(service=_service(decisions=decisions))
+        since, until = _window()
+        summary = await agg.aggregate(since=since, until=until)
+
+        assert summary.total_decisions == 1
+        assert summary.success_rate == 0.0
+        assert summary.recent_decisions[0].outcome == "pending"
+
+    async def test_filters_outside_window(self) -> None:
+        past = _NOW - timedelta(days=30)
+        future = _NOW + timedelta(days=30)
+        decisions = (
+            _decision(decision_id="d-past", created_at=past),
+            _decision(decision_id="d-now", created_at=_NOW),
+            _decision(decision_id="d-future", created_at=future),
+        )
+        actions = (_action(decision_id="d-now", outcome=ScalingOutcome.EXECUTED),)
+        agg = ScalingSignalAggregator(
+            service=_service(decisions=decisions, actions=actions),
+        )
+        since, until = _window()
+        summary = await agg.aggregate(since=since, until=until)
+        assert summary.total_decisions == 1
+        assert summary.recent_decisions[0].outcome == "executed"
+
+    async def test_most_common_signal_picks_top_strategy(self) -> None:
+        workload_decisions = tuple(
+            _decision(
+                decision_id=f"d-{i}",
+                strategy=ScalingStrategyName.WORKLOAD,
+            )
+            for i in range(3)
+        )
+        decisions = (
+            *workload_decisions,
+            _decision(
+                decision_id="d-skill",
+                strategy=ScalingStrategyName.SKILL_GAP,
+            ),
+        )
+        agg = ScalingSignalAggregator(service=_service(decisions=decisions))
+        since, until = _window()
+        summary = await agg.aggregate(since=since, until=until)
+        assert summary.most_common_signal == "workload"
+        assert summary.total_decisions == 4
+
+    async def test_service_exception_returns_empty_and_logs(self) -> None:
+        service = MagicMock()
+        service.get_recent_decisions = MagicMock(
+            side_effect=RuntimeError("boom"),
+        )
+        service.get_recent_actions = MagicMock(return_value=())
+        agg = ScalingSignalAggregator(service=service)
+        since, until = _window()
+
+        with structlog.testing.capture_logs() as cap:
+            summary = await agg.aggregate(since=since, until=until)
+
+        assert summary == OrgScalingSummary()
+        failures = [e for e in cap if e.get("event") == META_SIGNAL_AGGREGATION_FAILED]
+        assert len(failures) == 1
+
+    async def test_logs_completed_on_success(self) -> None:
+        decisions = (_decision(),)
+        actions = (_action(decision_id="d-001", outcome=ScalingOutcome.EXECUTED),)
+        agg = ScalingSignalAggregator(
+            service=_service(decisions=decisions, actions=actions),
+        )
+        since, until = _window()
+        with structlog.testing.capture_logs() as cap:
+            await agg.aggregate(since=since, until=until)
+        events = [e for e in cap if e.get("event") == META_SIGNAL_AGGREGATION_COMPLETED]
+        assert any(
+            e.get("total_decisions") == 1 and e.get("success_rate") == 1.0
+            for e in events
+        )
+
+    def test_domain_is_scaling(self) -> None:
+        agg = ScalingSignalAggregator(service=_service())
+        assert agg.domain == "scaling"

--- a/tests/unit/meta/signals/test_scaling.py
+++ b/tests/unit/meta/signals/test_scaling.py
@@ -121,16 +121,14 @@ class TestAggregate:
 
         assert summary.total_decisions == 2
         assert summary.success_rate == 0.5
-        # Assert the join by decision_id explicitly -- a positional
-        # match would pass even if the implementation accidentally
-        # paired by order instead of decision_id.
+        # Assert the join by decision_id explicitly so a positional
+        # bug (pairing by index instead of by id) would fail loudly.
         outcome_by_decision = {
-            s.action_type + "/" + s.source_strategy: s.outcome
-            for s in summary.recent_decisions
+            s.decision_id: s.outcome for s in summary.recent_decisions
         }
         assert outcome_by_decision == {
-            "hire/workload": "executed",
-            "prune/performance_pruning": "failed",
+            "d-hire": "executed",
+            "d-prune": "failed",
         }
         # Counter.most_common preserves insertion order for ties, so
         # the first-inserted strategy (workload) wins deterministically.
@@ -144,6 +142,7 @@ class TestAggregate:
 
         assert summary.total_decisions == 1
         assert summary.success_rate == 0.0
+        assert summary.recent_decisions[0].decision_id == "d-orphan"
         assert summary.recent_decisions[0].outcome == "pending"
 
     async def test_filters_outside_window(self) -> None:

--- a/tests/unit/meta/signals/test_scaling.py
+++ b/tests/unit/meta/signals/test_scaling.py
@@ -121,12 +121,20 @@ class TestAggregate:
 
         assert summary.total_decisions == 2
         assert summary.success_rate == 0.5
-        outcomes = {s.outcome for s in summary.recent_decisions}
-        assert outcomes == {"executed", "failed"}
-        assert summary.most_common_signal in {
-            "workload",
-            "performance_pruning",
+        # Assert the join by decision_id explicitly -- a positional
+        # match would pass even if the implementation accidentally
+        # paired by order instead of decision_id.
+        outcome_by_decision = {
+            s.action_type + "/" + s.source_strategy: s.outcome
+            for s in summary.recent_decisions
         }
+        assert outcome_by_decision == {
+            "hire/workload": "executed",
+            "prune/performance_pruning": "failed",
+        }
+        # Counter.most_common preserves insertion order for ties, so
+        # the first-inserted strategy (workload) wins deterministically.
+        assert summary.most_common_signal == "workload"
 
     async def test_decision_without_action_is_pending(self) -> None:
         decisions = (_decision(decision_id="d-orphan"),)
@@ -212,9 +220,33 @@ class TestAggregate:
         with structlog.testing.capture_logs() as cap:
             summary = await agg.aggregate(since=since, until=until)
 
+        assert summary is not None
+        assert isinstance(summary, OrgScalingSummary)
         assert summary == OrgScalingSummary()
         failures = [e for e in cap if e.get("event") == META_SIGNAL_AGGREGATION_FAILED]
         assert len(failures) == 1
+
+    async def test_local_aggregation_bugs_propagate(self) -> None:
+        """Bugs in local reducing must not be swallowed as empty summaries.
+
+        Only :class:`ScalingService` fetch errors are mapped to
+        ``_EMPTY``; errors in the local filter/join/reduce steps must
+        propagate so they surface through normal error handling rather
+        than being masked as "no activity".  A decision with a
+        non-datetime ``created_at`` triggers the filter comparison to
+        raise, and we assert the ``TypeError`` escapes ``aggregate``
+        without the broad fallback catching it.
+        """
+        broken = MagicMock()
+        broken.created_at = MagicMock()  # not a datetime -> comparison fails
+        service = MagicMock()
+        service.get_recent_decisions = MagicMock(return_value=(broken,))
+        service.get_recent_actions = MagicMock(return_value=())
+        agg = ScalingSignalAggregator(service=service)
+        since, until = _window()
+
+        with pytest.raises(TypeError):
+            await agg.aggregate(since=since, until=until)
 
     async def test_logs_completed_on_success(self) -> None:
         decisions = (_decision(),)

--- a/tests/unit/meta/test_models.py
+++ b/tests/unit/meta/test_models.py
@@ -568,6 +568,7 @@ class TestScalingDecisionSummary:
 
     def test_valid(self) -> None:
         s = ScalingDecisionSummary(
+            decision_id="scaling-d-001",
             action_type="hire",
             outcome="executed",
             source_strategy="workload",
@@ -575,6 +576,7 @@ class TestScalingDecisionSummary:
             created_at=datetime.now(UTC),
         )
         assert s.action_type == "hire"
+        assert s.decision_id == "scaling-d-001"
 
 
 class TestErrorCategorySummary:

--- a/tests/unit/meta/test_signals.py
+++ b/tests/unit/meta/test_signals.py
@@ -205,7 +205,10 @@ class TestScalingSignalAggregator:
     """Scaling aggregator tests."""
 
     async def test_returns_scaling_summary(self) -> None:
-        agg = ScalingSignalAggregator()
+        service = MagicMock()
+        service.get_recent_decisions = MagicMock(return_value=())
+        service.get_recent_actions = MagicMock(return_value=())
+        agg = ScalingSignalAggregator(service=service)
         result = await agg.aggregate(since=_week_ago(), until=_now())
         assert isinstance(result, OrgScalingSummary)
 
@@ -246,6 +249,9 @@ class TestSnapshotBuilder:
     def _make_builder(self) -> SnapshotBuilder:
         """Create a builder with default aggregators."""
         tracker = _make_mock_tracker()
+        scaling_service = MagicMock()
+        scaling_service.get_recent_decisions = MagicMock(return_value=())
+        scaling_service.get_recent_actions = MagicMock(return_value=())
         return SnapshotBuilder(
             performance=PerformanceSignalAggregator(
                 tracker=tracker,
@@ -253,7 +259,7 @@ class TestSnapshotBuilder:
             ),
             budget=BudgetSignalAggregator(cost_record_provider=list),
             coordination=CoordinationSignalAggregator(),
-            scaling=ScalingSignalAggregator(),
+            scaling=ScalingSignalAggregator(service=scaling_service),
             errors=ErrorSignalAggregator(),
             evolution=EvolutionSignalAggregator(),
             telemetry=TelemetrySignalAggregator(),

--- a/tests/unit/tools/test_factory.py
+++ b/tests/unit/tools/test_factory.py
@@ -19,6 +19,7 @@ from synthorg.tools.git_url_validator import GitCloneNetworkPolicy
 _EXPECTED_TOOL_NAMES: tuple[str, ...] = (
     "compact_context",
     "delete_file",
+    "echo",
     "edit_file",
     "git_branch",
     "git_clone",
@@ -43,7 +44,7 @@ class TestBuildDefaultTools:
         self,
         tmp_path: Path,
     ) -> None:
-        """Factory returns all 15 built-in tools sorted by name."""
+        """Factory returns all default built-in tools sorted by name."""
         tools = build_default_tools(workspace=tmp_path)
         names = tuple(t.name for t in tools)
         assert names == _EXPECTED_TOOL_NAMES
@@ -524,3 +525,123 @@ class TestBuildDefaultToolsFromConfig:
         clone = next(t for t in tools if t.name == "git_clone")
         assert isinstance(clone, _BaseGitTool)
         assert clone._sandbox is mock_instance
+
+
+_ASYNC_TASK_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "start_async_task",
+        "check_async_task",
+        "update_async_task",
+        "cancel_async_task",
+        "list_async_tasks",
+    }
+)
+
+
+@pytest.mark.unit
+class TestBuildAsyncTaskTools:
+    """Tests for async task tool registration via build_default_tools."""
+
+    def test_async_task_tools_skipped_when_service_none(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        tools = build_default_tools(
+            workspace=tmp_path,
+            async_task_service=None,
+        )
+        names = {t.name for t in tools}
+        assert names.isdisjoint(_ASYNC_TASK_TOOL_NAMES)
+
+    def test_async_task_tools_registered_when_service_provided(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from synthorg.communication.async_tasks.service import (
+            AsyncTaskService,
+        )
+
+        service = MagicMock(spec=AsyncTaskService)
+        tools = build_default_tools(
+            workspace=tmp_path,
+            async_task_service=service,
+        )
+        names = {t.name for t in tools}
+        assert names >= _ASYNC_TASK_TOOL_NAMES
+
+    def test_async_task_tools_receive_service(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from synthorg.communication.async_tasks.service import (
+            AsyncTaskService,
+        )
+
+        service = MagicMock(spec=AsyncTaskService)
+        tools = build_default_tools(
+            workspace=tmp_path,
+            async_task_service=service,
+        )
+        for tool in tools:
+            if tool.name in _ASYNC_TASK_TOOL_NAMES:
+                assert tool._service is service
+
+
+@pytest.mark.unit
+class TestBuildCodeExecutionTools:
+    """Tests for CodeRunnerTool registration via build_default_tools."""
+
+    def test_code_runner_skipped_when_sandbox_none(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        tools = build_default_tools(
+            workspace=tmp_path,
+            code_execution_sandbox=None,
+        )
+        names = {t.name for t in tools}
+        assert "code_runner" not in names
+
+    def test_code_runner_registered_with_sandbox(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        mock_sandbox = MagicMock()
+        tools = build_default_tools(
+            workspace=tmp_path,
+            code_execution_sandbox=mock_sandbox,
+        )
+        names = {t.name for t in tools}
+        assert "code_runner" in names
+
+    def test_code_runner_receives_sandbox(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from synthorg.tools.code_runner import CodeRunnerTool
+
+        mock_sandbox = MagicMock()
+        tools = build_default_tools(
+            workspace=tmp_path,
+            code_execution_sandbox=mock_sandbox,
+        )
+        runner = next(t for t in tools if t.name == "code_runner")
+        assert isinstance(runner, CodeRunnerTool)
+        assert runner._sandbox is mock_sandbox
+
+
+@pytest.mark.unit
+class TestEchoTool:
+    """EchoTool is registered unconditionally as a reference tool."""
+
+    def test_echo_always_present(self, tmp_path: Path) -> None:
+        tools = build_default_tools(workspace=tmp_path)
+        names = {t.name for t in tools}
+        assert "echo" in names
+
+    async def test_echo_executes(self, tmp_path: Path) -> None:
+        tools = build_default_tools(workspace=tmp_path)
+        echo = next(t for t in tools if t.name == "echo")
+        result = await echo.execute(arguments={"message": "hi"})
+        assert result.content == "hi"
+        assert not result.is_error

--- a/tests/unit/tools/test_factory.py
+++ b/tests/unit/tools/test_factory.py
@@ -584,7 +584,7 @@ class TestBuildAsyncTaskTools:
         )
         for tool in tools:
             if tool.name in _ASYNC_TASK_TOOL_NAMES:
-                assert tool._service is service
+                assert getattr(tool, "_service") is service  # noqa: B009
 
 
 @pytest.mark.unit

--- a/tests/unit/tools/test_factory_new_categories.py
+++ b/tests/unit/tools/test_factory_new_categories.py
@@ -134,10 +134,9 @@ class TestFactoryToolCount:
 
     @pytest.mark.unit
     def test_default_tool_count(self, workspace: Path) -> None:
-        """Default: 5 fs + 6 git + 2 web + 1 terminal + 1 context = 15 tools."""
-
+        """Default: 5 fs + 6 git + 2 web + 1 terminal + 1 context + 1 echo."""
         tools = build_default_tools(workspace=workspace)
-        assert len(tools) == 15
+        assert len(tools) == 16
 
     @pytest.mark.unit
     def test_tools_sorted_by_name(self, workspace: Path) -> None:

--- a/tests/unit/tools/test_factory_sandbox_wiring.py
+++ b/tests/unit/tools/test_factory_sandbox_wiring.py
@@ -43,6 +43,8 @@ _EXPECTED_TOOL_COUNT: int = (
     + len(_WEB_TOOL_NAMES)
     + len(_TERMINAL_TOOL_NAMES)
     + 1  # compact_context (context management)
+    + 1  # echo (reference tool)
+    + 1  # code_runner (conditional on CODE_EXECUTION sandbox)
 )
 
 


### PR DESCRIPTION
## Summary

Replaces five advertised-but-inert code paths with real behavior (or removes the dead surface) so configs and docs match runtime.

- **#1408 delegation record store race** — guards `_eviction_warned` check-then-set with `threading.Lock`; exactly-one-warning invariant now holds under concurrent `record_sync()` + `clear()`.
- **#1392 tool factory registrations** — wires `StartAsyncTaskTool`, `CheckAsyncTaskTool`, `UpdateAsyncTaskTool`, `CancelAsyncTaskTool`, `ListAsyncTasksTool` (conditional on `AsyncTaskService`), `CodeRunnerTool` (conditional on `CODE_EXECUTION` sandbox), and `EchoTool` (unconditional) into `build_default_tools` and `build_default_tools_from_config`. Exports added in `tools/communication/__init__.py`.
- **#1414 scaling signal aggregator** — `ScalingSignalAggregator.aggregate()` now queries `ScalingService.get_recent_decisions()` / `get_recent_actions()`, joins by `decision_id`, filters to the requested window, and returns a populated `OrgScalingSummary` with real `total_decisions`, `success_rate`, and `most_common_signal`.
- **#1413 Rego policy engine** — removed `"rego"` from `SecurityPolicyConfig.engine` Literal and deleted the `NotImplementedError` branch in `build_policy_engine()`. Cedar is the sole implemented backend; docs updated.
- **#1419 meetings agent caller** — deleted `_build_stub_agent_caller()` and the `MEETING_STUB_AGENT_CALLER` event. New `src/synthorg/communication/meeting/agent_caller.py` provides `build_meeting_agent_caller(agent_registry, provider_registry)` which resolves agent identity, builds a minimal system prompt, and dispatches a real `provider.complete()` per turn. When registries aren't available at wire time, `build_unconfigured_meeting_agent_caller` wires a caller that raises `MeetingAgentCallerNotConfiguredError` at call time (no silent empty responses). `auto_wire_meetings` now accepts `provider_registry`; one forwarding line added to `api/app.py`.

## Test plan

- `uv run ruff check src/ tests/` — clean
- `uv run ruff format src/ tests/` — clean
- `uv run mypy src/ tests/` — clean (2937 source files)
- `uv run python -m pytest tests/ -m unit -n 8` — **21 017 passed, 6 skipped**

New tests:
- `tests/unit/communication/delegation/test_record_store.py::TestEvictionWarningConcurrency` (3 concurrency tests: thread flood, clear-then-refill, interleaved clear/record)
- `tests/unit/meta/signals/test_scaling.py` (8 tests, incl. boundary half-open window, service exception fallback, `most_common_signal` tie-breaker)
- `tests/unit/communication/meeting/test_agent_caller.py` (7 tests, incl. `UnknownMeetingAgentError` inheritance + `agent_id` attribute, empty content mapping, provider error propagation)
- `tests/unit/tools/test_factory.py::TestBuildAsyncTaskTools`, `TestBuildCodeExecutionTools`, `TestEchoTool`
- `tests/unit/api/test_auto_wire_meetings.py::test_real_caller_end_to_end_with_both_registries` — integration test that wires the full pipeline with fake registries and asserts the caller dispatches real provider calls
- `tests/unit/api/test_auto_wire_meetings.py::test_wires_unconfigured_caller_when_registries_missing` — asserts `MeetingAgentCallerNotConfiguredError` carries `agent_id` + `missing_dependencies` attributes

## Review coverage

Pre-reviewed by 11 agents (`/pre-pr-review` pipeline): `docs-consistency`, `python-reviewer`, `logging-audit`, `resilience-audit`, `conventions-enforcer`, `security-reviewer`, `silent-failure-hunter`, `type-design-analyzer`, `test-quality-reviewer`, `async-concurrency-reviewer`, `comment-analyzer`, `issue-resolution-verifier`. All five issues verified RESOLVED. 11 valid findings addressed in the follow-up commit (typed exception attributes, docstring drift, strengthened tests, end-to-end integration coverage); 4 false-positive findings (PEP 758 except syntax claims that contradict CLAUDE.md) documented and skipped.

Closes #1408
Closes #1392
Closes #1414
Closes #1413
Closes #1419