### PR TITLE
chore: block opentelemetry-* >=1.41.0 in Renovate while logfire pins &lt;1.41.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -144,6 +144,15 @@
       "allowedVersions": "<=1.83.0"
     },
     {
+      "description": "Block opentelemetry-* >=1.41.0 while logfire pins opentelemetry-sdk<1.41.0 (see logfire pyproject.toml on main). Without this, every Renovate run produces a grouped Python PR whose uv.lock regeneration fails. Lift the cap when logfire releases a version that allows OTel 1.41+.",
+      "matchDepNames": [
+        "opentelemetry-api",
+        "opentelemetry-sdk",
+        "opentelemetry-exporter-otlp-proto-http"
+      ],
+      "allowedVersions": "<1.41.0"
+    },
+    {
       "description": "Ignore test golden files -- not real compose configs",
       "matchFileNames": ["cli/testdata/**"],
       "enabled": false


### PR DESCRIPTION
## Summary

Adds a `packageRules` entry to `renovate.json` that blocks `opentelemetry-api`, `opentelemetry-sdk`, and `opentelemetry-exporter-otlp-proto-http` at versions `>=1.41.0`.

## Why

`logfire==4.32.1` (our `telemetry` extra in `pyproject.toml:53`) hard-pins `opentelemetry-sdk >= 1.39.0, < 1.41.0`. Logfire's `main` branch still carries the same upper bound; there is no open PR or issue in `pydantic/logfire` tracking OTel 1.41 compatibility at the time of writing.

Without this rule, every Renovate run produces a grouped Python PR (e.g. #1449) whose `uv.lock` regeneration fails with:

```
Because logfire==4.32.1 depends on opentelemetry-sdk>=1.39.0,<1.41.0
and your project depends on opentelemetry-sdk==1.41.0,
your project's requirements are unsatisfiable.
```

That in turn cascades into failing Type Check, Lint, Test, Schema Validation, and Python Security Audit jobs -- because `uv sync` errors before they can run. The `renovate/artifacts` status already surfaces the conflict, but Renovate does not auto-suppress the PR; the `allowedVersions` packageRule idiom is the canonical answer (we already use it for `litellm<=1.83.0` at `renovate.json:141-145`).

## When to lift

Remove this rule when a `logfire` release ships that allows `opentelemetry-sdk >= 1.41.0`. Watch https://github.com/pydantic/logfire/releases.

## Scope

- Single file: `renovate.json` (+9 lines)
- No code, tests, or runtime behaviour affected

## Context

Follow-up to PR #1449 (to be closed after this lands).

## Test Plan

- JSON schema validity: pre-commit `check json` hook passes on commit and push
- Renovate will pick up the new rule on its next scheduled run (before 7am UTC)

## Review coverage

Quick mode -- no agent review. Only `renovate.json` changed; no Python/Go/TS code touched.
