### PR TITLE
feat: wire project telemetry, live NATS health probe, web healthcheck

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -375,6 +375,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BASE_IMAGE=${{ needs.build-backend-base.outputs.digest != '' && format('ghcr.io/aureliolo/synthorg-backend-base@{0}', needs.build-backend-base.outputs.digest) || format('ghcr.io/aureliolo/synthorg-backend-base:{0}', needs.build-backend-base.outputs.tag) }}
+            LOGFIRE_PROJECT_TOKEN=${{ secrets.LOGFIRE_PROJECT_TOKEN }}
           cache-from: ${{ github.event_name != 'pull_request' && 'type=gha' || '' }}
           cache-to: ${{ github.event_name != 'pull_request' && 'type=gha,mode=max' || '' }}
           platforms: linux/amd64
@@ -448,6 +449,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BASE_IMAGE=${{ needs.build-backend-base.outputs.digest != '' && format('ghcr.io/aureliolo/synthorg-backend-base@{0}', needs.build-backend-base.outputs.digest) || format('ghcr.io/aureliolo/synthorg-backend-base:{0}', needs.build-backend-base.outputs.tag) }}
+            LOGFIRE_PROJECT_TOKEN=${{ secrets.LOGFIRE_PROJECT_TOKEN }}
           cache-from: type=gha
           platforms: linux/amd64,linux/arm64
           sbom: true

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -65,7 +65,7 @@ No corresponding flag -- settable via env var or `config set`:
 | `SYNTHORG_AUTO_UPDATE_CLI` | Auto-accept CLI self-updates |
 | `SYNTHORG_AUTO_PULL` | Auto-accept container image pulls |
 | `SYNTHORG_AUTO_RESTART` | Auto-restart containers after update |
-| `SYNTHORG_TELEMETRY` | Enable anonymous product telemetry (true/false) |
+| `SYNTHORG_TELEMETRY` | Enable anonymous project telemetry (true/false) |
 | `SYNTHORG_FINE_TUNE_IMAGE` | Fine-tune container image ref read by the backend. Set by the CLI in the generated compose.yml to the variant-specific verified image (`synthorg-fine-tune-gpu` or `synthorg-fine-tune-cpu`), chosen via `synthorg init` and persisted as `fine_tuning_variant` in config.json. Not read by the CLI; manual operator overrides bypass CLI signature/provenance verification and are not supported. |
 | `SYNTHORG_REGISTRY_HOST` | Override default container registry hostname (disables verification when set) |
 | `SYNTHORG_IMAGE_REPO_PREFIX` | Override default image repository prefix (disables verification when set) |

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -609,7 +609,6 @@ func thirdPartyImages(state config.State) []thirdPartyImage {
 	}
 	if state.BusBackend == "nats" {
 		images = append(images, thirdPartyImage{"nats", "dhi.io/nats:2.12-debian13"})
-		images = append(images, thirdPartyImage{"nats-healthcheck", "busybox:1.37-musl"})
 	}
 	return images
 }

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -567,6 +567,9 @@ func renderHealthSection(out *ui.UI, snap statusSnapshot, jsonOut bool) {
 	if hr.MessageBus != nil {
 		out.KeyValue("Message bus", fmt.Sprintf("%v", hr.MessageBus))
 	}
+	if hr.Telemetry != "" {
+		out.KeyValue("Telemetry", hr.Telemetry)
+	}
 	out.Blank()
 }
 
@@ -662,6 +665,7 @@ type healthResponse struct {
 	Version     string  `json:"version"`
 	Persistence any     `json:"persistence"`
 	MessageBus  any     `json:"message_bus"`
+	Telemetry   string  `json:"telemetry"`
 	Uptime      float64 `json:"uptime_seconds"`
 }
 

--- a/cli/internal/compose/compose.yml.tmpl
+++ b/cli/internal/compose/compose.yml.tmpl
@@ -93,8 +93,11 @@ services:
         condition: service_healthy
 {{- end}}
     environment:
-      SYNTHORG_HOST: "0.0.0.0"
-      SYNTHORG_PORT: "3001"
+      # SYNTHORG_HOST/SYNTHORG_PORT/UVICORN_HOST/UVICORN_PORT are baked
+      # into the backend image ENV -- see docker/backend/Dockerfile.
+      # Setting them here only duplicates the defaults; operators who
+      # need to override still do so via env_file / shell env, which
+      # docker-compose forwards into the container.
 {{- if postgresEnabled}}
       SYNTHORG_DATABASE_URL: {{yamlStr pgDSN}}
       # The local Postgres DHI image runs without TLS on the internal
@@ -143,7 +146,8 @@ services:
       # the life of the install.
       SYNTHORG_MASTER_KEY: {{yamlStr .MasterKey}}
 {{- end}}
-    user: "65532:65532"
+    # Image sets USER 65532 (docker/backend/Dockerfile); no compose
+    # override needed.
 {{- if and .Sandbox (ge .DockerSockGID 0)}}
     # Supplementary group matches the host GID owning {{.DockerSock}}, so the
     # non-root backend user (65532) can read/write the mounted socket without
@@ -180,7 +184,8 @@ services:
     depends_on:
       backend:
         condition: service_healthy
-    user: "65532:65532"
+    # apko image sets run-as: "65532" (docker/web/apko.yaml); no
+    # compose override needed.
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -190,6 +195,15 @@ services:
       - /tmp:noexec,nosuid,nodev,size=16m
       - /config/caddy:noexec,nosuid,nodev,size=8m
       - /data/caddy:noexec,nosuid,nodev,size=16m
+    healthcheck:
+      # Caddy serves a plain "ok" 200 at /healthz; the apko image
+      # includes wget solely for this probe. Target 127.0.0.1 to avoid
+      # DNS resolution in the probe hot path.
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8080/healthz"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
     restart: unless-stopped
     deploy:
       resources:
@@ -204,11 +218,14 @@ services:
         max-file: "3"
 {{- if distributedEnabled}}
 
-  # DHI NATS: distroless, runs as nonroot (65532). Healthcheck via sidecar
-  # because there is no shell or HTTP client inside the distroless image.
-  # Configuration comes from a bind-mounted nats.conf written next to
-  # compose.yml by the CLI -- NATS 2.12 has no `--max_payload` CLI flag,
-  # so settings that diverge from defaults must come from a config file.
+  # DHI NATS: distroless, runs as nonroot (65532). No in-container
+  # healthcheck (no shell/wget inside DHI by design). Liveness is
+  # surfaced at the application layer: ``NatsBus.health_check`` does a
+  # live PING/PONG round-trip and the backend's /api/v1/health reports
+  # the result. Configuration comes from a bind-mounted nats.conf
+  # written next to compose.yml by the CLI -- NATS 2.12 has no
+  # ``--max_payload`` CLI flag, so settings that diverge from defaults
+  # must come from a config file.
   nats:
     # renovate: datasource=docker depName=dhi.io/nats
     image: {{.DHIRegistry}}/nats:{{.NATSImageTag}}{{if .NATSDigest}}@{{.NATSDigest}}{{end}}
@@ -236,38 +253,11 @@ services:
           memory: 256M
           cpus: "0.5"
           pids: 64
-  nats-healthcheck:
-    # renovate: datasource=docker depName=busybox
-    image: busybox:1.37-musl@sha256:19b646668802469d968a05342a601e78da4322a414a7c09b1c9ee25165042138
-    depends_on:
-      nats:
-        condition: service_started
-    healthcheck:
-      # ``nats`` is the docker-compose service DNS name; 8222 is the
-      # NATS HTTP monitoring port (not exposed to the host). Both are
-      # container-internal and intentionally not operator-tunable.
-      test: ["CMD", "wget", "-qO-", "http://nats:8222/healthz"]
-      interval: 10s
-      timeout: 3s
-      retries: 3
-      start_period: 10s
-    entrypoint: ["sleep", "infinity"]
-    user: "65532:65532"
-    read_only: true
-    cap_drop:
-      - ALL
-    restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 8M
-          cpus: "0.05"
-          pids: 4
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+  # NATS health is surfaced via the backend's /api/v1/health endpoint.
+  # ``NatsBus.health_check`` performs a live PING/PONG round-trip, so
+  # shipping a busybox sidecar purely to produce a green dot in
+  # ``docker ps`` added a container for zero dependency value -- nothing
+  # in compose ever consumed the sidecar's ``service_healthy`` state.
 {{- end}}
 
 networks:

--- a/cli/internal/compose/compose.yml.tmpl
+++ b/cli/internal/compose/compose.yml.tmpl
@@ -253,6 +253,11 @@ services:
           memory: 256M
           cpus: "0.5"
           pids: 64
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
   # NATS health is surfaced via the backend's /api/v1/health endpoint.
   # ``NatsBus.health_check`` performs a live PING/PONG round-trip, so
   # shipping a busybox sidecar purely to produce a green dot in

--- a/cli/internal/compose/generate_test.go
+++ b/cli/internal/compose/generate_test.go
@@ -52,10 +52,12 @@ func TestGenerateDefault(t *testing.T) {
 		t.Error("default output should not contain SETTINGS_KEY")
 	}
 
-	// Compose must not override Dockerfile healthchecks.
-	if strings.Contains(yaml, "healthcheck:") {
-		t.Error("compose output must not override healthcheck (defined in Dockerfile)")
-	}
+	// Web service carries a compose-level healthcheck because its apko
+	// image intentionally ships no Dockerfile HEALTHCHECK; backend and
+	// postgres own their probes at the image layer. Absence would
+	// mean `docker ps` reports no health for the web container, which
+	// is the bug this block guards against regressing.
+	assertContains(t, yaml, "http://127.0.0.1:8080/healthz")
 
 	compareGolden(t, "compose_default.yml", out)
 }
@@ -132,10 +134,10 @@ func TestGenerateWithSandbox(t *testing.T) {
 	// Hardening still present on backend.
 	assertContains(t, yaml, "no-new-privileges:true")
 
-	// Compose must not override Dockerfile healthchecks.
-	if strings.Contains(yaml, "healthcheck:") {
-		t.Error("compose output must not override healthcheck (defined in Dockerfile)")
-	}
+	// Web service carries a compose-level healthcheck (apko image
+	// ships no Dockerfile HEALTHCHECK). Guards against regressing to
+	// the previous "no health status for web" behaviour.
+	assertContains(t, yaml, "http://127.0.0.1:8080/healthz")
 
 	// DockerSockGID is -1 (detection failed), so no group_add block should render.
 	if strings.Contains(yaml, "group_add:") {

--- a/cli/testdata/compose_custom_ports.yml
+++ b/cli/testdata/compose_custom_ports.yml
@@ -29,8 +29,11 @@ services:
       data-init:
         condition: service_completed_successfully
     environment:
-      SYNTHORG_HOST: "0.0.0.0"
-      SYNTHORG_PORT: "3001"
+      # SYNTHORG_HOST/SYNTHORG_PORT/UVICORN_HOST/UVICORN_PORT are baked
+      # into the backend image ENV -- see docker/backend/Dockerfile.
+      # Setting them here only duplicates the defaults; operators who
+      # need to override still do so via env_file / shell env, which
+      # docker-compose forwards into the container.
       SYNTHORG_DB_PATH: "/data/synthorg.db"
       SYNTHORG_MEMORY_DIR: "/data/memory"
       SYNTHORG_PERSISTENCE_BACKEND: "sqlite"
@@ -42,7 +45,8 @@ services:
       SYNTHORG_LOG_LEVEL: "debug"
       SYNTHORG_JWT_SECRET: "test-secret-value"
       SYNTHORG_SETTINGS_KEY: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-    user: "65532:65532"
+    # Image sets USER 65532 (docker/backend/Dockerfile); no compose
+    # override needed.
     # CIS Docker Benchmark v1.6.0 hardening (5.3, 5.12, 5.25, 5.28)
     security_opt:
       - no-new-privileges:true
@@ -72,7 +76,8 @@ services:
     depends_on:
       backend:
         condition: service_healthy
-    user: "65532:65532"
+    # apko image sets run-as: "65532" (docker/web/apko.yaml); no
+    # compose override needed.
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -82,6 +87,15 @@ services:
       - /tmp:noexec,nosuid,nodev,size=16m
       - /config/caddy:noexec,nosuid,nodev,size=8m
       - /data/caddy:noexec,nosuid,nodev,size=16m
+    healthcheck:
+      # Caddy serves a plain "ok" 200 at /healthz; the apko image
+      # includes wget solely for this probe. Target 127.0.0.1 to avoid
+      # DNS resolution in the probe hot path.
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8080/healthz"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
     restart: unless-stopped
     deploy:
       resources:

--- a/cli/testdata/compose_default.yml
+++ b/cli/testdata/compose_default.yml
@@ -29,8 +29,11 @@ services:
       data-init:
         condition: service_completed_successfully
     environment:
-      SYNTHORG_HOST: "0.0.0.0"
-      SYNTHORG_PORT: "3001"
+      # SYNTHORG_HOST/SYNTHORG_PORT/UVICORN_HOST/UVICORN_PORT are baked
+      # into the backend image ENV -- see docker/backend/Dockerfile.
+      # Setting them here only duplicates the defaults; operators who
+      # need to override still do so via env_file / shell env, which
+      # docker-compose forwards into the container.
       SYNTHORG_DB_PATH: "/data/synthorg.db"
       SYNTHORG_MEMORY_DIR: "/data/memory"
       SYNTHORG_PERSISTENCE_BACKEND: "sqlite"
@@ -40,7 +43,8 @@ services:
       MEM0_TELEMETRY: "false"
       SYNTHORG_TELEMETRY: "false"
       SYNTHORG_LOG_LEVEL: "info"
-    user: "65532:65532"
+    # Image sets USER 65532 (docker/backend/Dockerfile); no compose
+    # override needed.
     # CIS Docker Benchmark v1.6.0 hardening (5.3, 5.12, 5.25, 5.28)
     security_opt:
       - no-new-privileges:true
@@ -70,7 +74,8 @@ services:
     depends_on:
       backend:
         condition: service_healthy
-    user: "65532:65532"
+    # apko image sets run-as: "65532" (docker/web/apko.yaml); no
+    # compose override needed.
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -80,6 +85,15 @@ services:
       - /tmp:noexec,nosuid,nodev,size=16m
       - /config/caddy:noexec,nosuid,nodev,size=8m
       - /data/caddy:noexec,nosuid,nodev,size=16m
+    healthcheck:
+      # Caddy serves a plain "ok" 200 at /healthz; the apko image
+      # includes wget solely for this probe. Target 127.0.0.1 to avoid
+      # DNS resolution in the probe hot path.
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8080/healthz"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
     restart: unless-stopped
     deploy:
       resources:

--- a/cli/testdata/compose_digest_pins.yml
+++ b/cli/testdata/compose_digest_pins.yml
@@ -29,8 +29,11 @@ services:
       data-init:
         condition: service_completed_successfully
     environment:
-      SYNTHORG_HOST: "0.0.0.0"
-      SYNTHORG_PORT: "3001"
+      # SYNTHORG_HOST/SYNTHORG_PORT/UVICORN_HOST/UVICORN_PORT are baked
+      # into the backend image ENV -- see docker/backend/Dockerfile.
+      # Setting them here only duplicates the defaults; operators who
+      # need to override still do so via env_file / shell env, which
+      # docker-compose forwards into the container.
       SYNTHORG_DB_PATH: "/data/synthorg.db"
       SYNTHORG_MEMORY_DIR: "/data/memory"
       SYNTHORG_PERSISTENCE_BACKEND: "sqlite"
@@ -40,7 +43,8 @@ services:
       MEM0_TELEMETRY: "false"
       SYNTHORG_TELEMETRY: "false"
       SYNTHORG_LOG_LEVEL: "info"
-    user: "65532:65532"
+    # Image sets USER 65532 (docker/backend/Dockerfile); no compose
+    # override needed.
     # CIS Docker Benchmark v1.6.0 hardening (5.3, 5.12, 5.25, 5.28)
     security_opt:
       - no-new-privileges:true
@@ -70,7 +74,8 @@ services:
     depends_on:
       backend:
         condition: service_healthy
-    user: "65532:65532"
+    # apko image sets run-as: "65532" (docker/web/apko.yaml); no
+    # compose override needed.
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -80,6 +85,15 @@ services:
       - /tmp:noexec,nosuid,nodev,size=16m
       - /config/caddy:noexec,nosuid,nodev,size=8m
       - /data/caddy:noexec,nosuid,nodev,size=16m
+    healthcheck:
+      # Caddy serves a plain "ok" 200 at /healthz; the apko image
+      # includes wget solely for this probe. Target 127.0.0.1 to avoid
+      # DNS resolution in the probe hot path.
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8080/healthz"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
     restart: unless-stopped
     deploy:
       resources:

--- a/cli/testdata/compose_sandbox.yml
+++ b/cli/testdata/compose_sandbox.yml
@@ -34,8 +34,11 @@ services:
       data-init:
         condition: service_completed_successfully
     environment:
-      SYNTHORG_HOST: "0.0.0.0"
-      SYNTHORG_PORT: "3001"
+      # SYNTHORG_HOST/SYNTHORG_PORT/UVICORN_HOST/UVICORN_PORT are baked
+      # into the backend image ENV -- see docker/backend/Dockerfile.
+      # Setting them here only duplicates the defaults; operators who
+      # need to override still do so via env_file / shell env, which
+      # docker-compose forwards into the container.
       SYNTHORG_DB_PATH: "/data/synthorg.db"
       SYNTHORG_MEMORY_DIR: "/data/memory"
       SYNTHORG_PERSISTENCE_BACKEND: "sqlite"
@@ -47,7 +50,8 @@ services:
       SYNTHORG_LOG_LEVEL: "info"
       SYNTHORG_SANDBOX_IMAGE: "ghcr.io/aureliolo/synthorg-sandbox:latest"
       SYNTHORG_SIDECAR_IMAGE: "ghcr.io/aureliolo/synthorg-sidecar:latest"
-    user: "65532:65532"
+    # Image sets USER 65532 (docker/backend/Dockerfile); no compose
+    # override needed.
     # CIS Docker Benchmark v1.6.0 hardening (5.3, 5.12, 5.25, 5.28)
     security_opt:
       - no-new-privileges:true
@@ -77,7 +81,8 @@ services:
     depends_on:
       backend:
         condition: service_healthy
-    user: "65532:65532"
+    # apko image sets run-as: "65532" (docker/web/apko.yaml); no
+    # compose override needed.
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -87,6 +92,15 @@ services:
       - /tmp:noexec,nosuid,nodev,size=16m
       - /config/caddy:noexec,nosuid,nodev,size=8m
       - /data/caddy:noexec,nosuid,nodev,size=16m
+    healthcheck:
+      # Caddy serves a plain "ok" 200 at /healthz; the apko image
+      # includes wget solely for this probe. Target 127.0.0.1 to avoid
+      # DNS resolution in the probe hot path.
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8080/healthz"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
     restart: unless-stopped
     deploy:
       resources:

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -11,9 +11,7 @@
 # top. No setup stage needed -- the symlink fix is done in the builder itself.
 # =============================================================================
 
-# CI always passes ``--build-arg BASE_IMAGE=...`` (digest-pinned);
-# the default here makes the Dockerfile buildable standalone for
-# local dev without tripping InvalidDefaultArgInFrom.
+# CI overrides with digest-pinned ref; default keeps standalone builds working.
 ARG BASE_IMAGE=ghcr.io/aureliolo/synthorg-backend-base:latest
 
 # ---------------------------------------------------------------------------
@@ -130,6 +128,9 @@ RUN set -eu; \
 # ---------------------------------------------------------------------------
 FROM ${BASE_IMAGE}
 
+# Optional build-time telemetry write token. Empty default disables delivery.
+ARG LOGFIRE_PROJECT_TOKEN=""
+
 LABEL org.opencontainers.image.title="synthorg-backend" \
       org.opencontainers.image.description="SynthOrg orchestration backend" \
       org.opencontainers.image.url="https://github.com/Aureliolo/synthorg" \
@@ -162,6 +163,7 @@ ENV PATH="/app/.venv/bin:/usr/local/bin:$PATH" \
     SYNTHORG_PORT="3001" \
     UVICORN_HOST="0.0.0.0" \
     UVICORN_PORT="3001" \
+    SYNTHORG_LOGFIRE_PROJECT_TOKEN=${LOGFIRE_PROJECT_TOKEN} \
     PYTHONWARNINGS="ignore::UserWarning:litestar.plugins.pydantic.utils"
 
 USER 65532

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -31,19 +31,22 @@ WORKDIR /app
 
 COPY --chown=65532:65532 pyproject.toml uv.lock ./
 USER build
-# Install the `postgres` and `distributed` extras unconditionally: both
-# are runtime-selectable via `synthorg init --persistence-backend` and
-# `--bus-backend`, so the image must carry psycopg and nats-py whether
-# or not the user has chosen them yet. `fine-tune` lives in the
-# dedicated synthorg-fine-tune-gpu / -cpu images (large, torch inside);
-# `telemetry` stays opt-in to avoid pulling logfire on default installs.
+# Install the `postgres`, `distributed`, and `telemetry` extras
+# unconditionally. `postgres` and `distributed` are runtime-selectable
+# via `synthorg init --persistence-backend` and `--bus-backend`, so the
+# image must carry psycopg and nats-py whether or not the user has
+# chosen them yet. `telemetry` ships the logfire SDK so the opt-in
+# project telemetry signal actually reaches Logfire when operators flip
+# `SYNTHORG_TELEMETRY=true` -- shipping the image without it would make
+# the opt-in a silent noop. `fine-tune` lives in the dedicated
+# synthorg-fine-tune-gpu / -cpu images (large, torch inside).
 RUN --mount=type=cache,target=/home/build/.cache/uv,uid=65532,gid=65532 \
-    uv sync --frozen --no-dev --no-install-project --extra postgres --extra distributed
+    uv sync --frozen --no-dev --no-install-project --extra postgres --extra distributed --extra telemetry
 
 RUN touch README.md
 COPY --chown=65532:65532 src/ src/
 RUN --mount=type=cache,target=/home/build/.cache/uv,uid=65532,gid=65532 \
-    uv sync --frozen --no-dev --extra postgres --extra distributed
+    uv sync --frozen --no-dev --extra postgres --extra distributed --extra telemetry
 
 RUN find /app/src -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -11,7 +11,10 @@
 # top. No setup stage needed -- the symlink fix is done in the builder itself.
 # =============================================================================
 
-ARG BASE_IMAGE
+# CI always passes ``--build-arg BASE_IMAGE=...`` (digest-pinned);
+# the default here makes the Dockerfile buildable standalone for
+# local dev without tripping InvalidDefaultArgInFrom.
+ARG BASE_IMAGE=ghcr.io/aureliolo/synthorg-backend-base:latest
 
 # ---------------------------------------------------------------------------
 # Stage 1 -- Builder (ephemeral: compiles deps, fixes venv symlink)

--- a/docker/compose.distributed.yml
+++ b/docker/compose.distributed.yml
@@ -14,16 +14,21 @@
 # Without this overlay, `--profile distributed` still starts the `nats`
 # container, but `SYNTHORG_BUS_BACKEND` stays at its default of
 # `internal` and the backend never publishes to JetStream.
+#
+# We intentionally do NOT gate backend startup on a `nats` health
+# status here: DHI NATS is distroless and exposes no in-container
+# probe. Instead, `NatsBus.health_check` performs a live round-trip
+# from the backend at request time, and the backend's own
+# `/api/v1/health` surfaces the result. Backend startup uses a normal
+# retrying connect in `NatsBus.start`, so there is no benefit from a
+# compose-level readiness gate that would hang forever when no
+# healthcheck can be defined.
 
 services:
   backend:
     environment:
       SYNTHORG_BUS_BACKEND: "nats"
       SYNTHORG_NATS_URL: "${SYNTHORG_NATS_URL:-nats://nats:4222}"
-    # The `nats` service is a DHI distroless image with no shell/wget, so its
-    # healthcheck lives on the `nats-healthcheck` sidecar. Depending directly
-    # on `nats: service_healthy` would hang forever because Compose cannot
-    # satisfy `service_healthy` for a service without a healthcheck.
     depends_on:
-      nats-healthcheck:
-        condition: service_healthy
+      nats:
+        condition: service_started

--- a/docker/compose.fine-tuning-cpu.yml
+++ b/docker/compose.fine-tuning-cpu.yml
@@ -25,12 +25,12 @@ services:
       - synthorg-data:/data:ro
     depends_on:
       backend:
-        # The base backend service has no healthcheck, so Docker Compose
-        # would never satisfy ``service_healthy`` and the sidecar would
-        # stall forever. ``service_started`` gives correct boot ordering
-        # without fabricating a liveness signal we do not actually probe.
-        condition: service_started
-    user: "10003:10003"
+        # Gate the sidecar on the backend's image-level HEALTHCHECK
+        # (python-urllib probe against /api/v1/health in
+        # ``docker/backend/Dockerfile``) so fine-tune does not start
+        # talking to a backend that is still running migrations or
+        # wiring dependents.
+        condition: service_healthy
     group_add:
       - "65532"
     security_opt:

--- a/docker/compose.fine-tuning-gpu.yml
+++ b/docker/compose.fine-tuning-gpu.yml
@@ -30,12 +30,12 @@ services:
       - synthorg-data:/data:ro
     depends_on:
       backend:
-        # The base backend service has no healthcheck, so Docker Compose
-        # would never satisfy ``service_healthy`` and the sidecar would
-        # stall forever. ``service_started`` gives correct boot ordering
-        # without fabricating a liveness signal we do not actually probe.
-        condition: service_started
-    user: "10003:10003"
+        # Gate the sidecar on the backend's image-level HEALTHCHECK
+        # (python-urllib probe against /api/v1/health in
+        # ``docker/backend/Dockerfile``) so fine-tune does not start
+        # talking to a backend that is still running migrations or
+        # wiring dependents.
+        condition: service_healthy
     group_add:
       - "65532"
     security_opt:

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -82,8 +82,13 @@ services:
         condition: service_healthy
     env_file: .env
     environment:
-      SYNTHORG_HOST: "${SYNTHORG_HOST:-0.0.0.0}"
-      SYNTHORG_PORT: "${SYNTHORG_PORT:-3001}"
+      # Only set values that are deployment-specific (DB URL, bus
+      # backend, NATS URL, memory/log dirs, log level, third-party
+      # telemetry toggles). SYNTHORG_HOST / SYNTHORG_PORT / UVICORN_HOST
+      # / UVICORN_PORT already carry correct defaults from the image
+      # ENV (see docker/backend/Dockerfile); setting them here just
+      # duplicates the baseline without offering operator control that
+      # docker-compose run-time env files do not already provide.
       SYNTHORG_DATABASE_URL: "postgresql://synthorg:${POSTGRES_PASSWORD}@postgres:5432/synthorg"
       # Local docker-network postgres runs plaintext inside the bridge.
       # For production, override to `verify-full` with proper certs.
@@ -95,9 +100,8 @@ services:
       SYNTHORG_LOG_DIR: "${SYNTHORG_LOG_DIR:-/data/logs}"
       SYNTHORG_LOG_LEVEL: "${SYNTHORG_LOG_LEVEL:-info}"
       MEM0_TELEMETRY: "${MEM0_TELEMETRY:-false}"
-      UVICORN_HOST: "${SYNTHORG_HOST:-0.0.0.0}"
-      UVICORN_PORT: "${SYNTHORG_PORT:-3001}"
-    user: "65532:65532"
+    # Image sets USER 65532 in the Dockerfile; no compose override
+    # needed.
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -121,7 +125,8 @@ services:
     depends_on:
       backend:
         condition: service_healthy
-    user: "65532:65532"
+    # apko sets run-as: "65532" in docker/web/apko.yaml; no compose
+    # override needed.
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -131,6 +136,15 @@ services:
       - /tmp:noexec,nosuid,nodev,size=16m
       - /config/caddy:noexec,nosuid,nodev,size=8m
       - /data/caddy:noexec,nosuid,nodev,size=16m
+    healthcheck:
+      # Caddy serves a plain "ok" 200 at /healthz; wget is installed in
+      # the apko image specifically for this probe. Target 127.0.0.1 to
+      # avoid pulling in external DNS resolution.
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8080/healthz"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
     restart: unless-stopped
     deploy:
       resources:
@@ -173,33 +187,11 @@ services:
           pids: 64
     logging: *logging
 
-  # Healthcheck sidecar for distroless NATS (no shell/wget inside).
-  # Probes NATS monitoring endpoint via Docker network DNS.
-  nats-healthcheck:
-    # renovate: datasource=docker depName=busybox
-    image: busybox:1.37-musl@sha256:19b646668802469d968a05342a601e78da4322a414a7c09b1c9ee25165042138
-    depends_on:
-      nats:
-        condition: service_started
-    healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://nats:8222/healthz"]
-      interval: 10s
-      timeout: 3s
-      retries: 3
-      start_period: 10s
-    entrypoint: ["sleep", "infinity"]
-    user: "65532:65532"
-    read_only: true
-    cap_drop:
-      - ALL
-    restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 8M
-          cpus: "0.05"
-          pids: 4
-    logging: *logging
+  # NATS health is surfaced via the backend's /api/v1/health endpoint.
+  # `NatsBus.health_check` performs a live PING/PONG round-trip, so
+  # shipping a busybox sidecar purely to produce a green dot in
+  # `docker ps` added a container for zero dependency value -- nothing
+  # in compose ever consumed the sidecar's `service_healthy` state.
 
   # Fine-tuning sidecar (~4 GB GPU variant / ~1.7 GB CPU-only).
   #

--- a/docker/web/apko.yaml
+++ b/docker/web/apko.yaml
@@ -4,6 +4,7 @@
 # Contents:
 #   - caddy (Wolfi package, static binary, memory-safe Go)
 #   - ca-certificates-bundle, tzdata
+#   - wget (HTTP client used by the Docker HEALTHCHECK to probe /healthz)
 #   - synthorg-web-assets (melange-built apk from docker/web/melange.yaml,
 #     carrying the Vite SPA bundle, zensical docs output, pre-gzipped siblings,
 #     and the Caddyfile)
@@ -24,6 +25,7 @@ contents:
     - ca-certificates-bundle
     - tzdata
     - caddy
+    - wget
     - synthorg-web-assets@local
 
 accounts:

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -103,7 +103,7 @@ After the containers are running, open `http://localhost:3000`. The setup wizard
 
 - **Base image**: Pure apko Wolfi (Caddy + melange-packaged static assets, no Dockerfile)
 - **User**: UID 65532 (caddy)
-- **Health check**: none (stateless static server; container readiness determined by TCP port availability)
+- **Health check**: `GET /healthz` via Caddy (compose-level probe using `wget`; 10s interval, 3s timeout, 3 retries, 10s start period). The apko image intentionally ships no Dockerfile `HEALTHCHECK`, so the probe is declared alongside the service and targets `127.0.0.1` to avoid Docker DNS.
 - **Routing**: SPA routing (`try_files {path} /index.html`), API proxy to backend, WebSocket proxy, per-request CSP nonce via Caddy `templates` directive
 - **Caching**: `/index.html` is no-cache; `/assets/*` is immutable with 1-year max-age (content-hashed filenames)
 - **Static compression**: pre-compressed `.gz` files served via `file_server { precompressed gzip }`

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -1378,21 +1378,23 @@ def _build_default_trust_service() -> TrustService:
 _DEFAULT_MEMORY_DIR = Path("/data/memory")
 
 
-def _allowed_memory_dir_roots() -> tuple[Path, ...]:
-    r"""Return the roots a resolved memory dir must live inside.
+def _allowed_memory_dir_roots() -> tuple[str, ...]:
+    r"""Return the string roots a memory dir must begin with.
 
-    Production containers mount the data volume at ``/data``, so
-    that path's parent is the only legitimate runtime base. Tests
-    exercise the builder with ``tmp_path`` fixtures, which land
-    under the OS temp dir -- resolved here so Windows CI
-    (``C:\Users\...``) and POSIX runners (``/tmp``, ``/var/tmp``)
-    both pass validation. Resolving eagerly canonicalises symlinks
-    (e.g. macOS ``/var -> /private/var``) so prefix comparison is
-    meaningful.
+    Production containers mount the data volume at ``/data``, which
+    is the only legitimate runtime base. Tests drive the builder
+    with ``tmp_path``, so :func:`tempfile.gettempdir` is also
+    admitted -- covering POSIX (``/tmp``, ``/var/tmp``) and Windows
+    (``C:\Users\...\AppData\Local\Temp``) runners without special
+    casing. Returned as plain strings so the caller can use
+    explicit :py:meth:`str.startswith` checks, which CodeQL's
+    ``py/path-injection`` query recognises as a sanitiser for
+    tainted-path dataflow (``Path.is_relative_to`` / ``.resolve``
+    do not register with the query).
     """
-    roots: list[Path] = [Path("/data").resolve(strict=False)]
+    roots: list[str] = [str(Path("/data"))]
     try:
-        tmp_root = Path(tempfile.gettempdir()).resolve(strict=False)
+        tmp_root: str | None = str(Path(tempfile.gettempdir()))
     except OSError, RuntimeError:
         tmp_root = None
     if tmp_root is not None:
@@ -1404,12 +1406,13 @@ def _resolve_memory_dir() -> Path:
     """Read and validate ``SYNTHORG_MEMORY_DIR`` for derived paths.
 
     The value is operator-controlled (container runtime env), so it
-    is treated as untrusted input for path-injection purposes: the
-    raw string is stripped, must be absolute, canonicalised via
-    :meth:`Path.resolve`, and must land under one of the roots
-    returned by :func:`_allowed_memory_dir_roots` (container volume
-    ``/data``, or the OS temp dir for tests). Any failure falls
-    back to :data:`_DEFAULT_MEMORY_DIR` and logs the reason so
+    is treated as untrusted input for path-injection purposes. The
+    string is stripped, rejected if empty, rejected if any path
+    segment equals ``..`` (traversal attempt), rejected if not
+    absolute, and rejected if the resulting path string does not
+    begin with one of the roots returned by
+    :func:`_allowed_memory_dir_roots`. Failures fall back to
+    :data:`_DEFAULT_MEMORY_DIR` and log the reason so
     misconfiguration is observable, never silent.
     """
     raw = os.environ.get("SYNTHORG_MEMORY_DIR")
@@ -1423,7 +1426,17 @@ def _resolve_memory_dir() -> Path:
             reason="empty_or_whitespace",
         )
         return _DEFAULT_MEMORY_DIR
+    # Explicit ``..`` guard: reject traversal attempts up front so
+    # the string-prefix check below cannot be bypassed with
+    # ``/data/../etc``-style inputs.
     path = Path(candidate)
+    if ".." in path.parts:
+        logger.warning(
+            API_APP_STARTUP,
+            detail="memory_dir_traversal",
+            value=candidate,
+        )
+        return _DEFAULT_MEMORY_DIR
     if not path.is_absolute():
         logger.warning(
             API_APP_STARTUP,
@@ -1431,23 +1444,25 @@ def _resolve_memory_dir() -> Path:
             value=candidate,
         )
         return _DEFAULT_MEMORY_DIR
-    # Canonicalise: eliminates ``..`` segments and resolves symlinks
-    # so the allow-list check below can rely on simple prefix
-    # comparison. ``strict=False`` tolerates paths that do not yet
-    # exist (first-boot of a fresh data volume).
-    canonical = path.resolve(strict=False)
+    # String-based ``startswith`` allow-list -- the pattern CodeQL
+    # ``py/path-injection`` recognises as a sanitiser. Normalise
+    # through ``str(Path(...))`` on both sides so platform
+    # separators line up on Windows. Appending ``os.sep`` on the
+    # root avoids ``/data-evil`` matching ``/data`` by prefix.
+    candidate_str = str(path)
     allowed_roots = _allowed_memory_dir_roots()
     if not any(
-        canonical == root or canonical.is_relative_to(root) for root in allowed_roots
+        candidate_str == root or candidate_str.startswith(root + os.sep)
+        for root in allowed_roots
     ):
         logger.warning(
             API_APP_STARTUP,
             detail="memory_dir_outside_allowed_roots",
-            value=str(canonical),
-            allowed=[str(r) for r in allowed_roots],
+            value=candidate_str,
+            allowed=list(allowed_roots),
         )
         return _DEFAULT_MEMORY_DIR
-    return canonical
+    return path
 
 
 def _build_telemetry_collector() -> TelemetryCollector:

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -1470,20 +1470,28 @@ def _resolve_memory_dir() -> Path:
     return path
 
 
-def _build_telemetry_collector() -> TelemetryCollector:
+def _build_telemetry_collector(
+    telemetry_cfg: TelemetryConfig | None = None,
+) -> TelemetryCollector:
     """Build the project telemetry collector.
 
-    ``TelemetryConfig()`` defaults to ``enabled=False``;
-    :class:`TelemetryCollector` reads ``SYNTHORG_TELEMETRY`` inside
-    its own ``__init__`` (``true``/``1``/``yes`` to enable) and
-    overrides the config accordingly, so the env var wins over the
-    config file. The data directory stores the anonymous deployment
-    ID -- placed under the same base as ``SYNTHORG_MEMORY_DIR`` so
-    the container volume holds it.
+    Takes the parsed :class:`TelemetryConfig` from the app's
+    :class:`RootConfig` so config-file settings (e.g.
+    ``telemetry.backend``, ``telemetry.heartbeat_interval_hours``)
+    survive wiring -- passing ``None`` falls back to defaults
+    (``enabled=False``) for callers without a parsed config, like
+    early-boot helpers.  :class:`TelemetryCollector` reads
+    ``SYNTHORG_TELEMETRY`` inside its own ``__init__``
+    (``true``/``1``/``yes`` to enable) and overrides the config's
+    ``enabled`` flag, so the env var still wins over the config
+    file. The data directory stores the anonymous deployment ID --
+    placed under the same base as ``SYNTHORG_MEMORY_DIR`` so the
+    container volume holds it.
     """
     memory_dir = _resolve_memory_dir()
     telemetry_dir = memory_dir.parent / "telemetry"
-    return TelemetryCollector(config=TelemetryConfig(), data_dir=telemetry_dir)
+    config = telemetry_cfg if telemetry_cfg is not None else TelemetryConfig()
+    return TelemetryCollector(config=config, data_dir=telemetry_dir)
 
 
 def _build_performance_tracker(
@@ -2393,7 +2401,7 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
     # by ``telemetry_collector.shutdown`` reflects final state, and so
     # a hanging Logfire flush never blocks cleanup of load-bearing
     # resources.
-    telemetry_collector = _build_telemetry_collector()
+    telemetry_collector = _build_telemetry_collector(effective_config.telemetry)
     app_state.set_telemetry_collector(telemetry_collector)
     startup = [*startup, telemetry_collector.start]
     shutdown = [*shutdown, telemetry_collector.shutdown]

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -1374,17 +1374,54 @@ def _build_default_trust_service() -> TrustService:
     )
 
 
+_DEFAULT_MEMORY_DIR = Path("/data/memory")
+
+
+def _resolve_memory_dir() -> Path:
+    """Read and validate ``SYNTHORG_MEMORY_DIR`` for derived paths.
+
+    Rejects empty, whitespace-only, and relative values -- those
+    would resolve ``memory_dir.parent / "telemetry"`` to a
+    path outside the container volume (e.g. ``./telemetry`` or
+    ``/telemetry``) instead of the intended
+    ``/data/telemetry``. Logs a warning and falls back to
+    ``/data/memory`` in each failure mode so misconfiguration is
+    observable.
+    """
+    raw = os.environ.get("SYNTHORG_MEMORY_DIR")
+    if raw is None:
+        return _DEFAULT_MEMORY_DIR
+    candidate = raw.strip()
+    if not candidate:
+        logger.warning(
+            API_APP_STARTUP,
+            detail="memory_dir_blank",
+            reason="empty_or_whitespace",
+        )
+        return _DEFAULT_MEMORY_DIR
+    path = Path(candidate)
+    if not path.is_absolute():
+        logger.warning(
+            API_APP_STARTUP,
+            detail="memory_dir_not_absolute",
+            value=candidate,
+        )
+        return _DEFAULT_MEMORY_DIR
+    return path
+
+
 def _build_telemetry_collector() -> TelemetryCollector:
     """Build the project telemetry collector.
 
-    ``TelemetryConfig()`` defaults to ``enabled=False``; the
-    ``TelemetryCollector`` constructor honours the
-    ``SYNTHORG_TELEMETRY`` env var (``true``/``1``/``yes`` to
-    enable). The data directory stores the anonymous deployment
-    ID -- placed under the same base as
-    ``SYNTHORG_MEMORY_DIR`` so the container volume holds it.
+    ``TelemetryConfig()`` defaults to ``enabled=False``;
+    :class:`TelemetryCollector` reads ``SYNTHORG_TELEMETRY`` inside
+    its own ``__init__`` (``true``/``1``/``yes`` to enable) and
+    overrides the config accordingly, so the env var wins over the
+    config file. The data directory stores the anonymous deployment
+    ID -- placed under the same base as ``SYNTHORG_MEMORY_DIR`` so
+    the container volume holds it.
     """
-    memory_dir = Path(os.environ.get("SYNTHORG_MEMORY_DIR", "/data/memory"))
+    memory_dir = _resolve_memory_dir()
     telemetry_dir = memory_dir.parent / "telemetry"
     return TelemetryCollector(config=TelemetryConfig(), data_dir=telemetry_dir)
 
@@ -2289,10 +2326,17 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
     # Litestar lifespan. Telemetry is SynthOrg-owned and silent on
     # failure: a broken reporter falls back to noop and never affects
     # the app.
+    #
+    # Shutdown is appended (runs LAST), not prepended: critical
+    # infrastructure (task engine drain, persistence disconnect, bus
+    # stop) must complete first so the session-summary event emitted
+    # by ``telemetry_collector.shutdown`` reflects final state, and so
+    # a hanging Logfire flush never blocks cleanup of load-bearing
+    # resources.
     telemetry_collector = _build_telemetry_collector()
     app_state.set_telemetry_collector(telemetry_collector)
     startup = [*startup, telemetry_collector.start]
-    shutdown = [telemetry_collector.shutdown, *shutdown]
+    shutdown = [*shutdown, telemetry_collector.shutdown]
 
     if _skip_lifecycle_shutdown:
         shutdown = []

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -155,6 +155,7 @@ from synthorg.settings.subscribers import (
     ObservabilitySettingsSubscriber,
     ProviderSettingsSubscriber,
 )
+from synthorg.telemetry import TelemetryCollector, TelemetryConfig
 from synthorg.tools.invocation_tracker import ToolInvocationTracker  # noqa: TC001
 from synthorg.versioning import VersioningService
 
@@ -1373,6 +1374,21 @@ def _build_default_trust_service() -> TrustService:
     )
 
 
+def _build_telemetry_collector() -> TelemetryCollector:
+    """Build the project telemetry collector.
+
+    ``TelemetryConfig()`` defaults to ``enabled=False``; the
+    ``TelemetryCollector`` constructor honours the
+    ``SYNTHORG_TELEMETRY`` env var (``true``/``1``/``yes`` to
+    enable). The data directory stores the anonymous deployment
+    ID -- placed under the same base as
+    ``SYNTHORG_MEMORY_DIR`` so the container volume holds it.
+    """
+    memory_dir = Path(os.environ.get("SYNTHORG_MEMORY_DIR", "/data/memory"))
+    telemetry_dir = memory_dir.parent / "telemetry"
+    return TelemetryCollector(config=TelemetryConfig(), data_dir=telemetry_dir)
+
+
 def _build_performance_tracker(
     *,
     cost_tracker: CostTracker | None = None,
@@ -2266,6 +2282,18 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
         should_auto_wire_settings=_should_auto_wire,
         effective_config=effective_config,
     )
+
+    # Project telemetry: build collector (reads SYNTHORG_TELEMETRY env for
+    # opt-in, defaults to disabled). Attach to app_state so the health
+    # endpoint can report the state, and hook start()/shutdown() into the
+    # Litestar lifespan. Telemetry is SynthOrg-owned and silent on
+    # failure: a broken reporter falls back to noop and never affects
+    # the app.
+    telemetry_collector = _build_telemetry_collector()
+    app_state.set_telemetry_collector(telemetry_collector)
+    startup = [*startup, telemetry_collector.start]
+    shutdown = [telemetry_collector.shutdown, *shutdown]
+
     if _skip_lifecycle_shutdown:
         shutdown = []
 

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -10,6 +10,7 @@ import contextlib
 import functools
 import os
 import sys
+import tempfile
 import time
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -1377,16 +1378,39 @@ def _build_default_trust_service() -> TrustService:
 _DEFAULT_MEMORY_DIR = Path("/data/memory")
 
 
+def _allowed_memory_dir_roots() -> tuple[Path, ...]:
+    r"""Return the roots a resolved memory dir must live inside.
+
+    Production containers mount the data volume at ``/data``, so
+    that path's parent is the only legitimate runtime base. Tests
+    exercise the builder with ``tmp_path`` fixtures, which land
+    under the OS temp dir -- resolved here so Windows CI
+    (``C:\Users\...``) and POSIX runners (``/tmp``, ``/var/tmp``)
+    both pass validation. Resolving eagerly canonicalises symlinks
+    (e.g. macOS ``/var -> /private/var``) so prefix comparison is
+    meaningful.
+    """
+    roots: list[Path] = [Path("/data").resolve(strict=False)]
+    try:
+        tmp_root = Path(tempfile.gettempdir()).resolve(strict=False)
+    except OSError, RuntimeError:
+        tmp_root = None
+    if tmp_root is not None:
+        roots.append(tmp_root)
+    return tuple(roots)
+
+
 def _resolve_memory_dir() -> Path:
     """Read and validate ``SYNTHORG_MEMORY_DIR`` for derived paths.
 
-    Rejects empty, whitespace-only, and relative values -- those
-    would resolve ``memory_dir.parent / "telemetry"`` to a
-    path outside the container volume (e.g. ``./telemetry`` or
-    ``/telemetry``) instead of the intended
-    ``/data/telemetry``. Logs a warning and falls back to
-    ``/data/memory`` in each failure mode so misconfiguration is
-    observable.
+    The value is operator-controlled (container runtime env), so it
+    is treated as untrusted input for path-injection purposes: the
+    raw string is stripped, must be absolute, canonicalised via
+    :meth:`Path.resolve`, and must land under one of the roots
+    returned by :func:`_allowed_memory_dir_roots` (container volume
+    ``/data``, or the OS temp dir for tests). Any failure falls
+    back to :data:`_DEFAULT_MEMORY_DIR` and logs the reason so
+    misconfiguration is observable, never silent.
     """
     raw = os.environ.get("SYNTHORG_MEMORY_DIR")
     if raw is None:
@@ -1407,7 +1431,23 @@ def _resolve_memory_dir() -> Path:
             value=candidate,
         )
         return _DEFAULT_MEMORY_DIR
-    return path
+    # Canonicalise: eliminates ``..`` segments and resolves symlinks
+    # so the allow-list check below can rely on simple prefix
+    # comparison. ``strict=False`` tolerates paths that do not yet
+    # exist (first-boot of a fresh data volume).
+    canonical = path.resolve(strict=False)
+    allowed_roots = _allowed_memory_dir_roots()
+    if not any(
+        canonical == root or canonical.is_relative_to(root) for root in allowed_roots
+    ):
+        logger.warning(
+            API_APP_STARTUP,
+            detail="memory_dir_outside_allowed_roots",
+            value=str(canonical),
+            allowed=[str(r) for r in allowed_roots],
+        )
+        return _DEFAULT_MEMORY_DIR
+    return canonical
 
 
 def _build_telemetry_collector() -> TelemetryCollector:

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -1445,20 +1445,25 @@ def _resolve_memory_dir() -> Path:
         )
         return _DEFAULT_MEMORY_DIR
     # String-based ``startswith`` allow-list -- the pattern CodeQL
-    # ``py/path-injection`` recognises as a sanitiser. Normalise
-    # through ``str(Path(...))`` on both sides so platform
-    # separators line up on Windows. Appending ``os.sep`` on the
-    # root avoids ``/data-evil`` matching ``/data`` by prefix.
-    candidate_str = str(path)
+    # ``py/path-injection`` recognises as a sanitiser. ``normcase``
+    # lower-cases and normalises separators on Windows so the
+    # prefix check is case-insensitive there and unchanged on
+    # POSIX. The equality case (``candidate_str == root``) is
+    # deliberately NOT accepted: ``_build_telemetry_collector``
+    # derives ``memory_dir.parent / "telemetry"``, so if the env
+    # var points exactly at a root (``/data``) the telemetry dir
+    # would escape to ``/telemetry``. Requiring ``root + os.sep``
+    # means the memory dir must be a strict descendant.
+    candidate_str = os.path.normcase(str(path))
     allowed_roots = _allowed_memory_dir_roots()
     if not any(
-        candidate_str == root or candidate_str.startswith(root + os.sep)
+        candidate_str.startswith(os.path.normcase(root) + os.sep)
         for root in allowed_roots
     ):
         logger.warning(
             API_APP_STARTUP,
             detail="memory_dir_outside_allowed_roots",
-            value=candidate_str,
+            value=str(path),
             allowed=list(allowed_roots),
         )
         return _DEFAULT_MEMORY_DIR

--- a/src/synthorg/api/controllers/health.py
+++ b/src/synthorg/api/controllers/health.py
@@ -28,6 +28,22 @@ class ServiceStatus(StrEnum):
     DOWN = "down"
 
 
+class TelemetryStatus(StrEnum):
+    """Project telemetry runtime state.
+
+    ``enabled`` means the collector is configured to send events to
+    the SynthOrg Logfire project (``SYNTHORG_TELEMETRY=true`` plus the
+    ``telemetry`` extra installed). ``disabled`` covers every other
+    case: opt-out, noop reporter, missing ``logfire`` package, or
+    construction failure. Reflects the reporter class, not delivery
+    confirmation -- the collector itself is fire-and-forget and
+    never signals send failure upstream.
+    """
+
+    ENABLED = "enabled"
+    DISABLED = "disabled"
+
+
 class HealthStatus(BaseModel):
     """Health check response payload.
 
@@ -35,6 +51,8 @@ class HealthStatus(BaseModel):
         status: Overall health status.
         persistence: True if healthy, False if unhealthy, None if not configured.
         message_bus: True if running, False if stopped, None if not configured.
+        telemetry: ``enabled`` when the collector is actively sending
+            anonymous project telemetry, ``disabled`` otherwise.
         version: Application version.
         uptime_seconds: Seconds since application startup.
     """
@@ -47,6 +65,9 @@ class HealthStatus(BaseModel):
     )
     message_bus: bool | None = Field(
         description="Message bus running (None if not configured)",
+    )
+    telemetry: TelemetryStatus = Field(
+        description="Project telemetry delivery state",
     )
     version: str = Field(description="Application version")
     uptime_seconds: float = Field(
@@ -70,20 +91,21 @@ async def _probe_service(
         return False
 
 
-def _probe_sync_service(
-    *,
-    configured: bool,
-    probe: Callable[[], bool],
-    component: str,
-) -> bool | None:
-    """Probe a synchronous service, returning None if not configured."""
-    if not configured:
-        return None
-    try:
-        return probe()
-    except Exception:
-        logger.warning(API_HEALTH_CHECK, component=component, exc_info=True)
-        return False
+def _resolve_telemetry_status(app_state: AppState) -> TelemetryStatus:
+    """Read the telemetry collector and map to a public status.
+
+    Returns ``disabled`` when no collector is attached (test harness)
+    or when the collector reports itself disabled (opt-out, missing
+    logfire extra, or reporter init failure -- the factory degrades
+    to ``NoopReporter`` silently in all three cases).
+    """
+    if not app_state.has_telemetry_collector:
+        return TelemetryStatus.DISABLED
+    return (
+        TelemetryStatus.ENABLED
+        if app_state.telemetry_collector.enabled
+        else TelemetryStatus.DISABLED
+    )
 
 
 class HealthController(Controller):
@@ -112,11 +134,12 @@ class HealthController(Controller):
             probe=lambda: app_state.persistence.health_check(),  # noqa: PLW0108
             component="persistence",
         )
-        bus_ok = _probe_sync_service(
+        bus_ok = await _probe_service(
             configured=app_state.has_message_bus,
-            probe=lambda: app_state.message_bus.is_running,
+            probe=lambda: app_state.message_bus.health_check(),  # noqa: PLW0108
             component="message_bus",
         )
+        telemetry_status = _resolve_telemetry_status(app_state)
 
         checks = [v for v in (persistence_ok, bus_ok) if v is not None]
         if not checks or all(checks):
@@ -133,6 +156,7 @@ class HealthController(Controller):
             status=status.value,
             persistence=persistence_ok,
             message_bus=bus_ok,
+            telemetry=telemetry_status.value,
         )
 
         return ApiResponse(
@@ -140,6 +164,7 @@ class HealthController(Controller):
                 status=status,
                 persistence=persistence_ok,
                 message_bus=bus_ok,
+                telemetry=telemetry_status,
                 version=__version__,
                 uptime_seconds=uptime,
             ),

--- a/src/synthorg/api/controllers/health.py
+++ b/src/synthorg/api/controllers/health.py
@@ -1,5 +1,6 @@
 """Health check controller."""
 
+import asyncio
 import time
 from enum import StrEnum
 from typing import TYPE_CHECKING
@@ -31,13 +32,16 @@ class ServiceStatus(StrEnum):
 class TelemetryStatus(StrEnum):
     """Project telemetry runtime state.
 
-    ``enabled`` means the collector is configured to send events to
-    the SynthOrg Logfire project (``SYNTHORG_TELEMETRY=true`` plus the
-    ``telemetry`` extra installed). ``disabled`` covers every other
-    case: opt-out, noop reporter, missing ``logfire`` package, or
-    construction failure. Reflects the reporter class, not delivery
-    confirmation -- the collector itself is fire-and-forget and
-    never signals send failure upstream.
+    ``enabled`` means the collector is opted in AND the reporter can
+    deliver events (``SYNTHORG_TELEMETRY=true`` plus the ``telemetry``
+    extra installed and :func:`create_reporter` returning a live
+    backend). ``disabled`` covers every other case: opt-out, noop
+    reporter, missing ``logfire`` package, or reporter construction
+    failure -- the factory degrades to :class:`NoopReporter` in the
+    latter three, and the collector's ``is_functional`` property
+    reflects that. The collector itself is still fire-and-forget:
+    this field reflects the reporter's ability to deliver, not
+    post-send delivery confirmation.
     """
 
     ENABLED = "enabled"
@@ -94,16 +98,19 @@ async def _probe_service(
 def _resolve_telemetry_status(app_state: AppState) -> TelemetryStatus:
     """Read the telemetry collector and map to a public status.
 
-    Returns ``disabled`` when no collector is attached (test harness)
-    or when the collector reports itself disabled (opt-out, missing
-    logfire extra, or reporter init failure -- the factory degrades
-    to ``NoopReporter`` silently in all three cases).
+    Returns ``disabled`` when no collector is attached (test harness),
+    when the operator opted out, or when the reporter silently
+    degraded to :class:`NoopReporter` (missing ``logfire`` extra,
+    reporter construction failure, or explicit ``noop`` backend).
+    Uses ``collector.is_functional`` instead of ``enabled`` so the
+    health endpoint reflects delivery capability, not just the
+    config opt-in flag.
     """
     if not app_state.has_telemetry_collector:
         return TelemetryStatus.DISABLED
     return (
         TelemetryStatus.ENABLED
-        if app_state.telemetry_collector.enabled
+        if app_state.telemetry_collector.is_functional
         else TelemetryStatus.DISABLED
     )
 
@@ -129,16 +136,31 @@ class HealthController(Controller):
         """
         app_state: AppState = state.app_state
 
-        persistence_ok = await _probe_service(
-            configured=app_state.has_persistence,
-            probe=lambda: app_state.persistence.health_check(),  # noqa: PLW0108
-            component="persistence",
-        )
-        bus_ok = await _probe_service(
-            configured=app_state.has_message_bus,
-            probe=lambda: app_state.message_bus.health_check(),  # noqa: PLW0108
-            component="message_bus",
-        )
+        # Probe persistence and the message bus in parallel: the two
+        # checks are independent and each may wait on a round-trip
+        # (e.g. NATS PING/PONG), so sequential awaits add their
+        # latencies. TaskGroup gives structured concurrency with
+        # proper cancellation propagation if one probe raises (the
+        # ``_probe_service`` wrapper already swallows expected
+        # failures into ``False``, so only truly unexpected errors
+        # -- e.g. MemoryError -- propagate here).
+        async with asyncio.TaskGroup() as tg:
+            persistence_task = tg.create_task(
+                _probe_service(
+                    configured=app_state.has_persistence,
+                    probe=lambda: app_state.persistence.health_check(),  # noqa: PLW0108
+                    component="persistence",
+                ),
+            )
+            bus_task = tg.create_task(
+                _probe_service(
+                    configured=app_state.has_message_bus,
+                    probe=lambda: app_state.message_bus.health_check(),  # noqa: PLW0108
+                    component="message_bus",
+                ),
+            )
+        persistence_ok = persistence_task.result()
+        bus_ok = bus_task.result()
         telemetry_status = _resolve_telemetry_status(app_state)
 
         checks = [v for v in (persistence_ok, bus_ok) if v is not None]

--- a/src/synthorg/api/state.py
+++ b/src/synthorg/api/state.py
@@ -88,6 +88,7 @@ from synthorg.security.timeout.scheduler import ApprovalTimeoutScheduler  # noqa
 from synthorg.security.trust.service import TrustService  # noqa: TC001
 from synthorg.settings.resolver import ConfigResolver
 from synthorg.settings.service import SettingsService  # noqa: TC001
+from synthorg.telemetry.collector import TelemetryCollector  # noqa: TC001
 from synthorg.tools.invocation_tracker import ToolInvocationTracker  # noqa: TC001
 
 if TYPE_CHECKING:
@@ -174,6 +175,7 @@ class AppState:
         "_session_store",
         "_settings_service",
         "_task_engine",
+        "_telemetry_collector",
         "_ticket_store",
         "_tool_invocation_tracker",
         "_trace_handler",
@@ -256,6 +258,7 @@ class AppState:
         self._agent_registry = agent_registry
         self._performance_tracker = performance_tracker
         self._trust_service = trust_service
+        self._telemetry_collector: TelemetryCollector | None = None
         self._meeting_orchestrator = meeting_orchestrator
         self._meeting_scheduler = meeting_scheduler
         self._ceremony_scheduler = ceremony_scheduler
@@ -653,6 +656,23 @@ class AppState:
     def has_trust_service(self) -> bool:
         """Check whether the trust service is configured."""
         return self._trust_service is not None
+
+    @property
+    def has_telemetry_collector(self) -> bool:
+        """Check whether the project telemetry collector is configured."""
+        return self._telemetry_collector is not None
+
+    @property
+    def telemetry_collector(self) -> TelemetryCollector:
+        """Return project telemetry collector or raise 503."""
+        return self._require_service(
+            self._telemetry_collector,
+            "telemetry_collector",
+        )
+
+    def set_telemetry_collector(self, collector: TelemetryCollector) -> None:
+        """Attach the project telemetry collector (once-only)."""
+        self._set_once("_telemetry_collector", collector, "telemetry collector")
 
     @property
     def coordination_metrics_store(self) -> CoordinationMetricsStore:

--- a/src/synthorg/communication/bus/memory.py
+++ b/src/synthorg/communication/bus/memory.py
@@ -115,7 +115,21 @@ class InMemoryMessageBus:
 
     @property
     def is_running(self) -> bool:
-        """Whether the bus is currently running."""
+        """Whether the bus client thinks it is running.
+
+        Local state check: flipped by :meth:`start` / :meth:`stop`.
+        Tracks the same bit as :meth:`health_check` for the
+        in-process backend -- there is no external broker to race.
+        """
+        return self._running
+
+    async def health_check(self) -> bool:
+        """Liveness probe for the in-process bus.
+
+        No external transport to round-trip; the bus is healthy
+        when it reports itself running. Async matches the
+        :class:`MessageBus` protocol.
+        """
         return self._running
 
     async def start(self) -> None:

--- a/src/synthorg/communication/bus/nats.py
+++ b/src/synthorg/communication/bus/nats.py
@@ -42,6 +42,7 @@ from synthorg.communication.subscription import (  # noqa: TC001
 from synthorg.observability import get_logger
 from synthorg.observability.events.communication import (
     COMM_BUS_ALREADY_RUNNING,
+    COMM_BUS_HEALTH_CHECK_FAILED,
     COMM_BUS_STARTED,
     COMM_BUS_STREAM_SCAN_FAILED,
 )
@@ -113,8 +114,10 @@ class JetStreamMessageBus:
         Checks that the client is both locally marked running and
         actually connected, then performs a PING/PONG round-trip
         via ``nc.flush()`` with a short timeout. Returns ``False``
-        rather than raising when the probe fails, so the caller
+        rather than raising when the probe fails so the caller
         treats the bus as degraded without a ``try``/``except``.
+        Flush exceptions are logged at WARNING so operators can
+        distinguish broker-unreachable from client-logic bugs.
         """
         state = self._state
         if not state.running:
@@ -126,7 +129,13 @@ class JetStreamMessageBus:
             await client.flush(timeout=2)
         except MemoryError, RecursionError:
             raise
-        except Exception:
+        except Exception as exc:
+            logger.warning(
+                COMM_BUS_HEALTH_CHECK_FAILED,
+                phase="flush",
+                error_type=type(exc).__name__,
+                exc_info=True,
+            )
             return False
         return True
 

--- a/src/synthorg/communication/bus/nats.py
+++ b/src/synthorg/communication/bus/nats.py
@@ -112,11 +112,15 @@ class JetStreamMessageBus:
         """Live probe against the NATS server.
 
         Checks that the client is both locally marked running and
-        actually connected, then performs a PING/PONG round-trip
-        via ``nc.flush()`` with a short timeout. Returns ``False``
-        rather than raising when the probe fails so the caller
-        treats the bus as degraded without a ``try``/``except``.
-        Flush exceptions are logged at WARNING so operators can
+        actually connected, then calls ``nc.flush(timeout=2)`` --
+        which waits for any pending publishes to ack and, when the
+        queue is empty, resolves to a broker round-trip. The
+        2-second budget is deliberately tight so a stuck probe
+        fails fast rather than blocking the health endpoint.
+        Returns ``False`` instead of raising when the probe fails
+        so the caller can treat the bus as degraded without its
+        own ``try``/``except``. Flush exceptions are logged at
+        WARNING with exception type and traceback so operators can
         distinguish broker-unreachable from client-logic bugs.
         """
         state = self._state

--- a/src/synthorg/communication/bus/nats.py
+++ b/src/synthorg/communication/bus/nats.py
@@ -99,8 +99,36 @@ class JetStreamMessageBus:
 
     @property
     def is_running(self) -> bool:
-        """Whether the bus is currently running."""
+        """Whether the bus client thinks it is running.
+
+        Local state check: flipped by :meth:`start` / :meth:`stop`.
+        Does not reflect live server reachability -- use
+        :meth:`health_check` for that.
+        """
         return self._state.running
+
+    async def health_check(self) -> bool:
+        """Live probe against the NATS server.
+
+        Checks that the client is both locally marked running and
+        actually connected, then performs a PING/PONG round-trip
+        via ``nc.flush()`` with a short timeout. Returns ``False``
+        rather than raising when the probe fails, so the caller
+        treats the bus as degraded without a ``try``/``except``.
+        """
+        state = self._state
+        if not state.running:
+            return False
+        client = state.client
+        if client is None or not client.is_connected:
+            return False
+        try:
+            await client.flush(timeout=2)
+        except MemoryError, RecursionError:
+            raise
+        except Exception:
+            return False
+        return True
 
     async def start(self) -> None:
         """Connect to NATS, create the stream, and register channels.

--- a/src/synthorg/communication/bus_protocol.py
+++ b/src/synthorg/communication/bus_protocol.py
@@ -43,7 +43,23 @@ class MessageBus(Protocol):
 
     @property
     def is_running(self) -> bool:
-        """Whether the bus is currently running."""
+        """Whether the bus client thinks it is running.
+
+        Local state check: flipped by :meth:`start` / :meth:`stop`.
+        Does not reflect live server reachability -- use
+        :meth:`health_check` for that.
+        """
+        ...
+
+    async def health_check(self) -> bool:
+        """Live liveness probe against the underlying transport.
+
+        Unlike :attr:`is_running`, this performs an actual
+        round-trip to confirm the broker is reachable and the
+        connection is healthy. Implementations return ``False``
+        rather than raising when the probe fails, so the caller
+        can treat the bus as degraded without a try/except.
+        """
         ...
 
     async def publish(

--- a/src/synthorg/observability/events/communication.py
+++ b/src/synthorg/observability/events/communication.py
@@ -7,6 +7,7 @@ COMM_BUS_STARTED: Final[str] = "communication.bus.started"
 COMM_BUS_STOPPED: Final[str] = "communication.bus.stopped"
 COMM_BUS_ALREADY_RUNNING: Final[str] = "communication.bus.already_running"
 COMM_BUS_NOT_RUNNING: Final[str] = "communication.bus.not_running"
+COMM_BUS_HEALTH_CHECK_FAILED: Final[str] = "communication.bus.health_check_failed"
 
 # Bus connection lifecycle (distributed backends only)
 COMM_BUS_CONNECTED: Final[str] = "communication.bus.connected"

--- a/src/synthorg/telemetry/collector.py
+++ b/src/synthorg/telemetry/collector.py
@@ -5,10 +5,12 @@ import contextlib
 import os
 import platform
 import sys
+import tempfile
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from synthorg.observability import get_logger
@@ -29,8 +31,6 @@ from synthorg.telemetry.reporters import create_reporter
 from synthorg.telemetry.reporters.noop import NoopReporter
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from synthorg.telemetry.config import TelemetryConfig
 
 logger = get_logger(__name__)
@@ -411,8 +411,39 @@ class TelemetryCollector:
         """Load deployment ID from file or create a new UUID.
 
         Returns a valid UUID string in all cases (never raises).
-        Logs warnings on I/O errors.
+        Logs warnings on I/O errors. Performs a local path-injection
+        sanitiser (startswith allow-list) immediately before the
+        filesystem operations so CodeQL's ``py/path-injection``
+        query sees the guard adjacent to the sinks -- the same
+        validation in :func:`synthorg.api.app._resolve_memory_dir`
+        does not register with the dataflow tracker across the
+        caller/callee boundary.
         """
+        # Local sanitiser: verify ``self._data_dir`` is under a
+        # trusted root before any file operation below. Mirrors the
+        # builder's allow-list (``/data`` + OS temp dir) and falls
+        # back to an in-memory UUID when the path is outside the
+        # allow-list, so a misconfigured env var can never steer
+        # writes to an operator-sensitive location.
+        data_dir_str = str(self._data_dir)
+        trusted_roots: tuple[str, ...] = (str(Path("/data")),)
+        try:
+            tmp_root = str(Path(tempfile.gettempdir()))
+        except OSError, RuntimeError:
+            tmp_root = None
+        if tmp_root is not None:
+            trusted_roots = (*trusted_roots, tmp_root)
+        if not any(
+            data_dir_str == root or data_dir_str.startswith(root + os.sep)
+            for root in trusted_roots
+        ):
+            logger.warning(
+                TELEMETRY_REPORT_FAILED,
+                detail="data_dir_not_trusted",
+                value=data_dir_str,
+            )
+            return str(uuid.uuid4())
+
         id_file = self._data_dir / "telemetry_id"
         try:
             if id_file.exists():

--- a/src/synthorg/telemetry/collector.py
+++ b/src/synthorg/telemetry/collector.py
@@ -26,6 +26,7 @@ from synthorg.observability.events.telemetry import (
 from synthorg.telemetry.privacy import PrivacyScrubber, PrivacyViolationError
 from synthorg.telemetry.protocol import TelemetryEvent, TelemetryReporter
 from synthorg.telemetry.reporters import create_reporter
+from synthorg.telemetry.reporters.noop import NoopReporter
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -149,6 +150,23 @@ class TelemetryCollector:
         """Whether telemetry is enabled."""
         return self._config.enabled
 
+    @property
+    def is_functional(self) -> bool:
+        """Whether telemetry is both opted in AND the reporter can deliver.
+
+        Returns ``False`` when telemetry is opt-out, and also when the
+        operator opted in but :func:`create_reporter` fell back to
+        :class:`NoopReporter` (missing ``logfire`` extra, reporter
+        construction failure, or explicit ``TelemetryBackend.NOOP``).
+        This is what the health endpoint surfaces: ``enabled`` alone
+        would lie about delivery whenever the reporter silently
+        degraded to noop.
+        """
+        return self._config.enabled and not isinstance(
+            self._reporter,
+            NoopReporter,
+        )
+
     async def start(self) -> None:
         """Start the periodic heartbeat if telemetry is enabled.
 
@@ -191,6 +209,7 @@ class TelemetryCollector:
                             TELEMETRY_REPORT_FAILED,
                             detail="session_summary_snapshot_failed",
                             error_type=type(exc).__name__,
+                            exc_info=True,
                         )
 
                 try:
@@ -200,6 +219,7 @@ class TelemetryCollector:
                         TELEMETRY_REPORT_FAILED,
                         detail="send_session_summary_failed",
                         error_type=type(exc).__name__,
+                        exc_info=True,
                     )
 
                 try:
@@ -209,6 +229,7 @@ class TelemetryCollector:
                         TELEMETRY_REPORT_FAILED,
                         detail="send_shutdown_event_failed",
                         error_type=type(exc).__name__,
+                        exc_info=True,
                     )
 
             try:
@@ -218,6 +239,7 @@ class TelemetryCollector:
                     TELEMETRY_REPORT_FAILED,
                     detail="reporter_shutdown_failed",
                     error_type=type(exc).__name__,
+                    exc_info=True,
                 )
 
     async def send_heartbeat(

--- a/src/synthorg/telemetry/collector.py
+++ b/src/synthorg/telemetry/collector.py
@@ -411,43 +411,67 @@ class TelemetryCollector:
         """Load deployment ID from file or create a new UUID.
 
         Returns a valid UUID string in all cases (never raises).
-        Logs warnings on I/O errors. Performs a local path-injection
-        sanitiser (startswith allow-list) immediately before the
-        filesystem operations so CodeQL's ``py/path-injection``
-        query sees the guard adjacent to the sinks -- the same
-        validation in :func:`synthorg.api.app._resolve_memory_dir`
-        does not register with the dataflow tracker across the
-        caller/callee boundary.
+        Logs warnings on I/O errors.
+
+        Applies the OWASP path-injection recipe (:func:`os.path.normpath`
+        + :py:meth:`str.startswith` on the normalised full path +
+        trusted-root allow-list) immediately before the filesystem
+        operations. The duplicate of
+        :func:`synthorg.api.app._resolve_memory_dir` is deliberate
+        defense-in-depth: ``normpath`` collapses ``..``/redundant
+        separators that a caller constructing ``TelemetryCollector``
+        directly could otherwise smuggle past ``self._data_dir``,
+        and the startswith check is the sanitiser CodeQL's
+        ``py/path-injection`` query tracks across the sinks below.
         """
-        # Local sanitiser: verify ``self._data_dir`` is under a
-        # trusted root before any file operation below. Mirrors the
-        # builder's allow-list (``/data`` + OS temp dir) and falls
-        # back to an in-memory UUID when the path is outside the
-        # allow-list, so a misconfigured env var can never steer
-        # writes to an operator-sensitive location.
-        data_dir_str = str(self._data_dir)
-        trusted_roots: tuple[str, ...] = (str(Path("/data")),)
+        # Build the full target path as a normalised string: this is
+        # the ``str(os.path.normpath(os.path.join(base, name)))``
+        # recipe from OWASP / CodeQL. ``normpath`` collapses ``..``
+        # and redundant ``/`` so the prefix check below cannot be
+        # bypassed with ``/data/../etc/telemetry_id``. The ``PTH*``
+        # ruff lints (prefer ``Path``) are intentionally suppressed
+        # here: CodeQL's ``py/path-injection`` query only recognises
+        # string-based ``normpath``/``startswith`` + ``os.path``/
+        # builtin I/O as a sanitiser + sink pair; the equivalent
+        # ``Path`` methods leave the sinks flagged even with a
+        # valid guard.
+        id_path_str = os.path.normpath(
+            os.path.join(os.fspath(self._data_dir), "telemetry_id"),  # noqa: PTH118
+        )
+        data_root = os.path.normpath(str(Path("/data")))
         try:
-            tmp_root = str(Path(tempfile.gettempdir()))
+            tmp_root: str | None = os.path.normpath(str(Path(tempfile.gettempdir())))
         except OSError, RuntimeError:
             tmp_root = None
-        if tmp_root is not None:
-            trusted_roots = (*trusted_roots, tmp_root)
-        if not any(
-            data_dir_str == root or data_dir_str.startswith(root + os.sep)
-            for root in trusted_roots
-        ):
+        # Require a strict descendant of a trusted root (``root +
+        # sep``). Equality (``path == root``) is rejected because
+        # the caller would still derive ``parent / "telemetry"``
+        # above this function, and a path equal to the root would
+        # escape one level up (``/data`` -> ``/telemetry``).
+        # ``normcase`` lower-cases on Windows and is a no-op on
+        # POSIX -- pairing it with normpath keeps the comparison
+        # case-insensitive where the filesystem is.
+        candidate_norm = os.path.normcase(id_path_str)
+        allowed = candidate_norm.startswith(os.path.normcase(data_root) + os.sep) or (
+            tmp_root is not None
+            and candidate_norm.startswith(os.path.normcase(tmp_root) + os.sep)
+        )
+        if not allowed:
             logger.warning(
                 TELEMETRY_REPORT_FAILED,
                 detail="data_dir_not_trusted",
-                value=data_dir_str,
+                value=id_path_str,
             )
             return str(uuid.uuid4())
 
-        id_file = self._data_dir / "telemetry_id"
+        # Use the sanitised string with plain ``os`` / builtin I/O
+        # so the sanitiser and each sink sit on adjacent lines --
+        # the pattern CodeQL's static dataflow query matches on.
+        # ``# noqa: PTH*`` rationale above applies here too.
         try:
-            if id_file.exists():
-                stored = id_file.read_text(encoding="utf-8").strip()
+            if os.path.exists(id_path_str):  # noqa: PTH110
+                with open(id_path_str, encoding="utf-8") as fh:  # noqa: PTH123
+                    stored = fh.read().strip()
                 if stored:
                     try:
                         uuid.UUID(stored)
@@ -468,9 +492,13 @@ class TelemetryCollector:
 
         new_id = str(uuid.uuid4())
         try:
-            id_file.parent.mkdir(parents=True, exist_ok=True)
-            id_file.write_text(new_id, encoding="utf-8")
-            id_file.chmod(0o600)
+            os.makedirs(  # noqa: PTH103
+                os.path.dirname(id_path_str),  # noqa: PTH120
+                exist_ok=True,
+            )
+            with open(id_path_str, "w", encoding="utf-8") as fh:  # noqa: PTH123
+                fh.write(new_id)
+            os.chmod(id_path_str, 0o600)  # noqa: PTH101
         except OSError as exc:
             logger.warning(
                 TELEMETRY_REPORT_FAILED,

--- a/src/synthorg/telemetry/collector.py
+++ b/src/synthorg/telemetry/collector.py
@@ -407,7 +407,7 @@ class TelemetryCollector:
                     error_type=type(exc).__name__,
                 )
 
-    def _load_or_create_deployment_id(self) -> str:
+    def _load_or_create_deployment_id(self) -> str:  # noqa: C901
         """Load deployment ID from file or create a new UUID.
 
         Returns a valid UUID string in all cases (never raises).
@@ -424,39 +424,47 @@ class TelemetryCollector:
         and the startswith check is the sanitiser CodeQL's
         ``py/path-injection`` query tracks across the sinks below.
         """
-        # Build the full target path as a normalised string: this is
-        # the ``str(os.path.normpath(os.path.join(base, name)))``
-        # recipe from OWASP / CodeQL. ``normpath`` collapses ``..``
-        # and redundant ``/`` so the prefix check below cannot be
-        # bypassed with ``/data/../etc/telemetry_id``. The ``PTH*``
-        # ruff lints (prefer ``Path``) are intentionally suppressed
-        # here: CodeQL's ``py/path-injection`` query only recognises
+        # Build the full target path as a normalised, case-folded
+        # string: the ``str(os.path.normcase(os.path.normpath(
+        # os.path.join(base, name))))`` recipe from OWASP / CodeQL.
+        # ``normpath`` collapses ``..`` and redundant ``/`` so the
+        # prefix check below cannot be bypassed with
+        # ``/data/../etc/telemetry_id``; ``normcase`` lower-cases on
+        # Windows (no-op on POSIX) so the comparison is
+        # case-insensitive where the filesystem is. The ``PTH*``
+        # ruff lints (prefer ``Path``) are intentionally suppressed:
+        # CodeQL's ``py/path-injection`` query only recognises
         # string-based ``normpath``/``startswith`` + ``os.path``/
         # builtin I/O as a sanitiser + sink pair; the equivalent
         # ``Path`` methods leave the sinks flagged even with a
         # valid guard.
-        id_path_str = os.path.normpath(
-            os.path.join(os.fspath(self._data_dir), "telemetry_id"),  # noqa: PTH118
+        id_path_str = os.path.normcase(
+            os.path.normpath(
+                os.path.join(  # noqa: PTH118
+                    os.fspath(self._data_dir),
+                    "telemetry_id",
+                ),
+            ),
         )
-        data_root = os.path.normpath(str(Path("/data")))
+        data_root = os.path.normcase(os.path.normpath(str(Path("/data"))))
         try:
-            tmp_root: str | None = os.path.normpath(str(Path(tempfile.gettempdir())))
+            tmp_root: str | None = os.path.normcase(
+                os.path.normpath(str(Path(tempfile.gettempdir()))),
+            )
         except OSError, RuntimeError:
             tmp_root = None
         # Require a strict descendant of a trusted root (``root +
         # sep``). Equality (``path == root``) is rejected because
         # the caller would still derive ``parent / "telemetry"``
         # above this function, and a path equal to the root would
-        # escape one level up (``/data`` -> ``/telemetry``).
-        # ``normcase`` lower-cases on Windows and is a no-op on
-        # POSIX -- pairing it with normpath keeps the comparison
-        # case-insensitive where the filesystem is.
-        candidate_norm = os.path.normcase(id_path_str)
-        allowed = candidate_norm.startswith(os.path.normcase(data_root) + os.sep) or (
-            tmp_root is not None
-            and candidate_norm.startswith(os.path.normcase(tmp_root) + os.sep)
-        )
-        if not allowed:
+        # escape one level up (``/data`` -> ``/telemetry``). The
+        # checks here use ``id_path_str`` directly (the same
+        # variable read at every sink below) so CodeQL's dataflow
+        # query sees the sanitiser on the exact value it tracks.
+        if not (
+            id_path_str.startswith(data_root + os.sep)
+            or (tmp_root is not None and id_path_str.startswith(tmp_root + os.sep))
+        ):
             logger.warning(
                 TELEMETRY_REPORT_FAILED,
                 detail="data_dir_not_trusted",
@@ -467,7 +475,8 @@ class TelemetryCollector:
         # Use the sanitised string with plain ``os`` / builtin I/O
         # so the sanitiser and each sink sit on adjacent lines --
         # the pattern CodeQL's static dataflow query matches on.
-        # ``# noqa: PTH*`` rationale above applies here too.
+        # The inline PTH-rule suppressions below carry the same
+        # rationale as the builder above.
         try:
             if os.path.exists(id_path_str):  # noqa: PTH110
                 with open(id_path_str, encoding="utf-8") as fh:  # noqa: PTH123
@@ -496,9 +505,44 @@ class TelemetryCollector:
                 os.path.dirname(id_path_str),  # noqa: PTH120
                 exist_ok=True,
             )
-            with open(id_path_str, "w", encoding="utf-8") as fh:  # noqa: PTH123
-                fh.write(new_id)
-            os.chmod(id_path_str, 0o600)  # noqa: PTH101
+            # Atomic exclusive create: under concurrent startups
+            # (e.g. two backend replicas mounting the same ``/data``
+            # volume) the prior ``exists`` + ``open("w")`` pair
+            # could overwrite a peer's freshly-written UUID and
+            # leave each replica with a different deployment ID.
+            # ``O_CREAT | O_EXCL`` with the final mode bits set
+            # atomically wins-or-loses the race; if a peer wrote
+            # first we re-read and reuse its UUID so the persisted
+            # ID stays stable.
+            fd = os.open(
+                id_path_str,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    fh.write(new_id)
+            except BaseException:
+                # ``fdopen`` owns the fd on success; close it
+                # ourselves if construction raised.
+                os.close(fd)
+                raise
+        except FileExistsError:
+            # A peer wrote first. Re-read; fall back to our own
+            # freshly-minted UUID if their file is unreadable or
+            # corrupt (same contract as the read path above).
+            try:
+                with open(id_path_str, encoding="utf-8") as fh:  # noqa: PTH123
+                    stored = fh.read().strip()
+                uuid.UUID(stored)
+            except (OSError, ValueError) as exc:
+                logger.warning(
+                    TELEMETRY_REPORT_FAILED,
+                    detail="deployment_id_peer_read",
+                    error_type=type(exc).__name__,
+                )
+            else:
+                return stored
         except OSError as exc:
             logger.warning(
                 TELEMETRY_REPORT_FAILED,

--- a/src/synthorg/telemetry/config.py
+++ b/src/synthorg/telemetry/config.py
@@ -4,8 +4,6 @@ from enum import StrEnum, unique
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from synthorg.core.types import NotBlankStr  # noqa: TC001 -- Pydantic needs at runtime
-
 
 @unique
 class TelemetryBackend(StrEnum):
@@ -16,29 +14,29 @@ class TelemetryBackend(StrEnum):
 
 
 class TelemetryConfig(BaseModel):
-    """Configuration for opt-in anonymous product telemetry.
+    """Configuration for opt-in anonymous project telemetry.
 
-    Telemetry is **disabled by default**.  When enabled, only
+    Telemetry is **disabled by default**. When enabled, only
     aggregate usage metrics are sent -- never API keys, chat
-    content, or personal data.
+    content, or personal data. Telemetry is SynthOrg-owned and
+    project-scoped: the write token is embedded in source and
+    cannot be redirected to a different backend. Operators that
+    need their own observability stack use the Postgres +
+    Prometheus + audit-chain path, not this module.
 
     Attributes:
-        enabled: Master switch (default ``False``).  Can be
-            overridden by ``SYNTHORG_TELEMETRY`` env var.
+        enabled: Master switch (default ``False``). Can be
+            overridden by the ``SYNTHORG_TELEMETRY`` env var.
         backend: Reporter backend to use.
         heartbeat_interval_hours: Hours between periodic heartbeat
             events.
-        token: Write token for the telemetry backend.  When
-            ``None``, the embedded default project token is used.
-            Can be overridden by ``SYNTHORG_TELEMETRY_TOKEN`` env
-            var (useful for self-hosted backends).
     """
 
-    model_config = ConfigDict(frozen=True, allow_inf_nan=False)
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False, extra="forbid")
 
     enabled: bool = Field(
         default=False,
-        description="Enable anonymous product telemetry (default: off)",
+        description="Enable anonymous project telemetry (default: off)",
     )
     backend: TelemetryBackend = Field(
         default=TelemetryBackend.LOGFIRE,
@@ -49,9 +47,4 @@ class TelemetryConfig(BaseModel):
         gt=0.0,
         le=168.0,
         description="Hours between heartbeat events (1h--168h)",
-    )
-    token: NotBlankStr | None = Field(
-        default=None,
-        repr=False,
-        description="Backend write token override (None = embedded default)",
     )

--- a/src/synthorg/telemetry/reporters/__init__.py
+++ b/src/synthorg/telemetry/reporters/__init__.py
@@ -39,7 +39,7 @@ def create_reporter(config: TelemetryConfig) -> TelemetryReporter:
                 LogfireReporter,
             )
 
-            return LogfireReporter(token=config.token)
+            return LogfireReporter()
         except Exception as exc:
             logger.warning(
                 TELEMETRY_REPORT_FAILED,

--- a/src/synthorg/telemetry/reporters/logfire.py
+++ b/src/synthorg/telemetry/reporters/logfire.py
@@ -76,6 +76,7 @@ class LogfireReporter:
                 TELEMETRY_REPORT_FAILED,
                 detail="logfire_configure_failed",
                 error_type=type(exc).__name__,
+                exc_info=True,
             )
             raise
 
@@ -104,6 +105,7 @@ class LogfireReporter:
                 TELEMETRY_REPORT_FAILED,
                 event_type=event.event_type,
                 error_type=type(exc).__name__,
+                exc_info=True,
             )
 
     async def flush(self) -> None:
@@ -115,6 +117,7 @@ class LogfireReporter:
                 TELEMETRY_REPORT_FAILED,
                 detail="flush",
                 error_type=type(exc).__name__,
+                exc_info=True,
             )
 
     async def shutdown(self) -> None:
@@ -127,6 +130,7 @@ class LogfireReporter:
                 TELEMETRY_REPORT_FAILED,
                 detail="shutdown",
                 error_type=type(exc).__name__,
+                exc_info=True,
             )
 
 

--- a/src/synthorg/telemetry/reporters/logfire.py
+++ b/src/synthorg/telemetry/reporters/logfire.py
@@ -86,32 +86,23 @@ class LogfireReporter:
         """Send a telemetry event to Logfire.
 
         Offloads the synchronous SDK call to a thread to avoid
-        blocking the event loop. Logs at WARNING and re-raises so
-        :meth:`TelemetryCollector._send` returns ``False`` and does
-        not emit a misleading ``*_SENT`` success event for an
-        undelivered write. The outer collector already swallows
-        this exception, keeping telemetry fire-and-forget at the
-        application boundary.
+        blocking the event loop. Lets backend exceptions propagate
+        so :meth:`TelemetryCollector._send` returns ``False`` and
+        skips the misleading ``*_SENT`` success event for an
+        undelivered write. :meth:`TelemetryCollector._send` owns
+        the ``TELEMETRY_REPORT_FAILED`` alert -- no log here
+        avoids duplicating the same metric per failure.
         """
-        try:
-            await asyncio.to_thread(
-                self._logfire.info,
-                event.event_type,
-                event_timestamp=event.timestamp,
-                deployment_id=event.deployment_id,
-                synthorg_version=event.synthorg_version,
-                python_version=event.python_version,
-                os_platform=event.os_platform,
-                **event.properties,
-            )
-        except Exception as exc:
-            logger.warning(
-                TELEMETRY_REPORT_FAILED,
-                event_type=event.event_type,
-                error_type=type(exc).__name__,
-                exc_info=True,
-            )
-            raise
+        await asyncio.to_thread(
+            self._logfire.info,
+            event.event_type,
+            event_timestamp=event.timestamp,
+            deployment_id=event.deployment_id,
+            synthorg_version=event.synthorg_version,
+            python_version=event.python_version,
+            os_platform=event.os_platform,
+            **event.properties,
+        )
 
     async def flush(self) -> None:
         """Flush the Logfire exporter."""

--- a/src/synthorg/telemetry/reporters/logfire.py
+++ b/src/synthorg/telemetry/reporters/logfire.py
@@ -1,16 +1,22 @@
 """Logfire telemetry reporter.
 
-Sends curated, privacy-validated telemetry events to a Logfire
-project via the Logfire SDK (OpenTelemetry-compatible).
+Sends curated, privacy-validated telemetry events to the
+SynthOrg project on Logfire via the Logfire SDK (OpenTelemetry
+compatible).
 
-The ``logfire`` package is an optional dependency.  This module
+The ``logfire`` package is an optional dependency. This module
 is only imported when ``TelemetryBackend.LOGFIRE`` is selected,
 so the import is deferred to avoid loading logfire when telemetry
 is disabled.
+
+The Logfire write token is project-owned and compiled in: it is
+the only source, and cannot be overridden at runtime. Telemetry
+is a SynthOrg product signal, not a user-facing observability
+channel. Operators who need their own metrics pipeline use the
+Postgres + Prometheus + audit-chain stack.
 """
 
 import asyncio
-import os
 from typing import TYPE_CHECKING
 
 from synthorg.observability import get_logger
@@ -24,29 +30,24 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-_TOKEN_ENV = "SYNTHORG_TELEMETRY_TOKEN"  # noqa: S105
-
 # Write-only token for the SynthOrg project on Logfire.
-# This token can ONLY send data -- it cannot read telemetry,
-# access the account, or perform any other operation.  Safe to
+# This token can ONLY send data: it cannot read telemetry,
+# access the account, or perform any other operation. Safe to
 # embed in source (same pattern as Sentry DSNs, PostHog keys).
-# Override via SYNTHORG_TELEMETRY_TOKEN env var for self-hosted.
-_DEFAULT_TOKEN = "pylf_v1_eu_BMgmPmm3hLxdSz2fRQkpL0l62rYzvRJBbScQddH2wB7n"  # noqa: S105
+# Runtime override is intentionally not supported -- see module
+# docstring for rationale.
+_PROJECT_TOKEN = "pylf_v1_eu_BMgmPmm3hLxdSz2fRQkpL0l62rYzvRJBbScQddH2wB7n"  # noqa: S105
 
 
 class LogfireReporter:
     """Logfire SDK-based telemetry reporter.
 
-    Initializes ``logfire.configure()`` with the project write token.
-    Events are sent as Logfire log records with structured properties.
-
-    Args:
-        token: Logfire write token.  When ``None``, uses the
-            ``SYNTHORG_TELEMETRY_TOKEN`` env var or the embedded
-            default project token.
+    Initializes ``logfire.configure()`` with the compiled-in
+    project write token. Events are sent as Logfire log records
+    with structured properties.
     """
 
-    def __init__(self, token: str | None = None) -> None:
+    def __init__(self) -> None:
         try:
             import logfire as _logfire  # type: ignore[import-not-found]  # noqa: PLC0415
         except ImportError as exc:
@@ -63,12 +64,9 @@ class LogfireReporter:
 
         self._logfire = _logfire
 
-        has_custom_token = token is not None or os.environ.get(_TOKEN_ENV) is not None
-        resolved_token = token or os.environ.get(_TOKEN_ENV) or _DEFAULT_TOKEN
-
         try:
             self._logfire.configure(
-                token=resolved_token,
+                token=_PROJECT_TOKEN,
                 send_to_logfire="if-token-present",
                 service_name="synthorg-telemetry",
                 service_version=_get_synthorg_version(),
@@ -81,17 +79,13 @@ class LogfireReporter:
             )
             raise
 
-        logger.info(
-            TELEMETRY_REPORTER_INITIALIZED,
-            backend="logfire",
-            has_custom_token=has_custom_token,
-        )
+        logger.info(TELEMETRY_REPORTER_INITIALIZED, backend="logfire")
 
     async def report(self, event: TelemetryEvent) -> None:
         """Send a telemetry event to Logfire.
 
         Offloads the synchronous SDK call to a thread to avoid
-        blocking the event loop.  Catches and logs all exceptions
+        blocking the event loop. Catches and logs all exceptions
         (telemetry must never affect the main application).
         """
         try:

--- a/src/synthorg/telemetry/reporters/logfire.py
+++ b/src/synthorg/telemetry/reporters/logfire.py
@@ -2,21 +2,11 @@
 
 Sends curated, privacy-validated telemetry events to the
 SynthOrg project on Logfire via the Logfire SDK (OpenTelemetry
-compatible).
-
-The ``logfire`` package is an optional dependency. This module
-is only imported when ``TelemetryBackend.LOGFIRE`` is selected,
-so the import is deferred to avoid loading logfire when telemetry
-is disabled.
-
-The Logfire write token is project-owned and compiled in: it is
-the only source, and cannot be overridden at runtime. Telemetry
-is a SynthOrg product signal, not a user-facing observability
-channel. Operators who need their own metrics pipeline use the
-Postgres + Prometheus + audit-chain stack.
+compatible). The ``logfire`` package is an optional dependency.
 """
 
 import asyncio
+import os
 from typing import TYPE_CHECKING
 
 from synthorg.observability import get_logger
@@ -30,21 +20,16 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-# Write-only token for the SynthOrg project on Logfire.
-# This token can ONLY send data: it cannot read telemetry,
-# access the account, or perform any other operation. Safe to
-# embed in source (same pattern as Sentry DSNs, PostHog keys).
-# Runtime override is intentionally not supported -- see module
-# docstring for rationale.
-_PROJECT_TOKEN = "pylf_v1_eu_BMgmPmm3hLxdSz2fRQkpL0l62rYzvRJBbScQddH2wB7n"  # noqa: S105
+_PROJECT_TOKEN_ENV = "SYNTHORG_LOGFIRE_PROJECT_TOKEN"  # noqa: S105
 
 
 class LogfireReporter:
     """Logfire SDK-based telemetry reporter.
 
-    Initializes ``logfire.configure()`` with the compiled-in
-    project write token. Events are sent as Logfire log records
-    with structured properties.
+    Events are sent as Logfire log records with structured
+    properties. A missing or empty project token disables
+    delivery by raising :class:`ImportError` so the reporter
+    factory falls back to :class:`NoopReporter`.
     """
 
     def __init__(self) -> None:
@@ -62,11 +47,22 @@ class LogfireReporter:
             )
             raise ImportError(msg) from exc
 
+        token = os.environ.get(_PROJECT_TOKEN_ENV, "").strip()
+        if not token:
+            logger.warning(
+                TELEMETRY_REPORT_FAILED,
+                detail="logfire_token_missing",
+                error_type="ValueError",
+                env_var=_PROJECT_TOKEN_ENV,
+            )
+            msg = f"{_PROJECT_TOKEN_ENV} is not set; telemetry disabled."
+            raise ImportError(msg)
+
         self._logfire = _logfire
 
         try:
             self._logfire.configure(
-                token=_PROJECT_TOKEN,
+                token=token,
                 send_to_logfire="if-token-present",
                 service_name="synthorg-telemetry",
                 service_version=_get_synthorg_version(),

--- a/src/synthorg/telemetry/reporters/logfire.py
+++ b/src/synthorg/telemetry/reporters/logfire.py
@@ -86,8 +86,12 @@ class LogfireReporter:
         """Send a telemetry event to Logfire.
 
         Offloads the synchronous SDK call to a thread to avoid
-        blocking the event loop. Catches and logs all exceptions
-        (telemetry must never affect the main application).
+        blocking the event loop. Logs at WARNING and re-raises so
+        :meth:`TelemetryCollector._send` returns ``False`` and does
+        not emit a misleading ``*_SENT`` success event for an
+        undelivered write. The outer collector already swallows
+        this exception, keeping telemetry fire-and-forget at the
+        application boundary.
         """
         try:
             await asyncio.to_thread(
@@ -107,6 +111,7 @@ class LogfireReporter:
                 error_type=type(exc).__name__,
                 exc_info=True,
             )
+            raise
 
     async def flush(self) -> None:
         """Flush the Logfire exporter."""

--- a/tests/unit/api/fakes.py
+++ b/tests/unit/api/fakes.py
@@ -644,6 +644,9 @@ class FakeMessageBus:
     def is_running(self) -> bool:
         return self._running
 
+    async def health_check(self) -> bool:
+        return self._running
+
     async def publish(
         self,
         message: Message,

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -194,16 +194,34 @@ class TestResolveTelemetryStatus:
         app_state.has_telemetry_collector = False
         assert _resolve_telemetry_status(app_state) is TelemetryStatus.DISABLED
 
-    def test_enabled_when_collector_enabled(self) -> None:
+    def test_enabled_when_collector_is_functional(self) -> None:
         app_state = MagicMock()
         app_state.has_telemetry_collector = True
-        app_state.telemetry_collector.enabled = True
+        app_state.telemetry_collector.is_functional = True
         assert _resolve_telemetry_status(app_state) is TelemetryStatus.ENABLED
 
-    def test_disabled_when_collector_disabled(self) -> None:
+    def test_disabled_when_collector_opted_out(self) -> None:
         app_state = MagicMock()
         app_state.has_telemetry_collector = True
-        app_state.telemetry_collector.enabled = False
+        app_state.telemetry_collector.is_functional = False
+        assert _resolve_telemetry_status(app_state) is TelemetryStatus.DISABLED
+
+    def test_disabled_when_enabled_but_reporter_is_noop(self) -> None:
+        """Enabled config + noop reporter must surface as ``disabled``.
+
+        Regression guard: ``_resolve_telemetry_status`` previously read
+        ``collector.enabled`` (config opt-in only), so the endpoint lied
+        whenever ``create_reporter`` degraded to ``NoopReporter``
+        (missing ``logfire`` extra, reporter init failure). The
+        ``is_functional`` property collapses "opted in but not
+        delivering" to ``False`` so the surfaced status matches reality.
+        """
+        app_state = MagicMock()
+        app_state.has_telemetry_collector = True
+        # Simulate the "opted in but reporter degraded to noop" case:
+        # ``enabled`` reports True, ``is_functional`` reports False.
+        app_state.telemetry_collector.enabled = True
+        app_state.telemetry_collector.is_functional = False
         assert _resolve_telemetry_status(app_state) is TelemetryStatus.DISABLED
 
 

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -1,7 +1,7 @@
 """Tests for health check endpoint."""
 
 from typing import Any
-from unittest.mock import PropertyMock, patch
+from unittest.mock import patch
 
 import pytest
 from litestar.testing import TestClient
@@ -146,8 +146,8 @@ class TestHealthCheckExceptionPaths:
                     "factory": FakeMessageBus,
                     "init": "start",
                     "kwarg": "message_bus",
-                    "attr": "is_running",
-                    "patch_kw": {"new_callable": PropertyMock},
+                    "attr": "health_check",
+                    "patch_kw": {},
                 },
                 "message_bus",
                 id="message_bus_exception",

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -1,12 +1,16 @@
 """Tests for health check endpoint."""
 
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from litestar.testing import TestClient
 
 from synthorg.api.app import create_app
+from synthorg.api.controllers.health import (
+    TelemetryStatus,
+    _resolve_telemetry_status,
+)
 from tests.unit.api.fakes import FakeMessageBus, FakePersistenceBackend
 
 
@@ -20,6 +24,7 @@ class TestHealthCheck:
         assert body["data"]["status"] == "ok"
         assert body["data"]["persistence"] is True
         assert body["data"]["message_bus"] is True
+        assert body["data"]["telemetry"] in {"enabled", "disabled"}
         assert "version" in body["data"]
         assert body["data"]["uptime_seconds"] >= 0
 
@@ -178,3 +183,39 @@ class TestHealthCheckExceptionPaths:
             assert body["data"][response_key] is False
             expected_status = service_spec.get("expected_status", "down")
             assert body["data"]["status"] == expected_status
+
+
+@pytest.mark.unit
+class TestResolveTelemetryStatus:
+    """Branch coverage for the health controller helper."""
+
+    def test_disabled_when_no_collector(self) -> None:
+        app_state = MagicMock()
+        app_state.has_telemetry_collector = False
+        assert _resolve_telemetry_status(app_state) is TelemetryStatus.DISABLED
+
+    def test_enabled_when_collector_enabled(self) -> None:
+        app_state = MagicMock()
+        app_state.has_telemetry_collector = True
+        app_state.telemetry_collector.enabled = True
+        assert _resolve_telemetry_status(app_state) is TelemetryStatus.ENABLED
+
+    def test_disabled_when_collector_disabled(self) -> None:
+        app_state = MagicMock()
+        app_state.has_telemetry_collector = True
+        app_state.telemetry_collector.enabled = False
+        assert _resolve_telemetry_status(app_state) is TelemetryStatus.DISABLED
+
+
+@pytest.mark.unit
+class TestHealthTelemetryField:
+    """The /health endpoint always surfaces a telemetry status."""
+
+    def test_disabled_by_default(self, test_client: TestClient[Any]) -> None:
+        response = test_client.get("/api/v1/health")
+        assert response.status_code == 200
+        body = response.json()
+        # Default TelemetryConfig has enabled=False and nothing flips the
+        # SYNTHORG_TELEMETRY env var in the test fixture, so the collector
+        # is created but stays disabled.
+        assert body["data"]["telemetry"] == "disabled"

--- a/tests/unit/api/test_telemetry_builder.py
+++ b/tests/unit/api/test_telemetry_builder.py
@@ -3,7 +3,8 @@
 ``_build_telemetry_collector`` builds a :class:`TelemetryCollector`
 wired against the memory-dir env var. The collector respects
 ``SYNTHORG_TELEMETRY`` internally; this module verifies the path
-derivation and env-var handling around construction.
+derivation, env-var handling, and memory-dir validation around
+construction.
 """
 
 from pathlib import Path
@@ -51,3 +52,53 @@ class TestBuildTelemetryCollector:
         assert collector.enabled is True
         # Deployment ID gets persisted under the derived telemetry dir.
         assert (tmp_path / "telemetry").exists()
+
+
+@pytest.mark.unit
+class TestMemoryDirValidation:
+    """Reject junk ``SYNTHORG_MEMORY_DIR`` values before deriving paths.
+
+    ``memory_dir.parent / "telemetry"`` is only meaningful when the
+    env var is an absolute container path; empty, whitespace-only,
+    or relative values would land the deployment ID under
+    ``/telemetry`` or a cwd-relative directory and silently miss
+    the data volume. The builder falls back to ``/data/memory``
+    (its default) in each of those cases so misconfiguration is
+    observable via logs but does not poison persistence.
+    """
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            pytest.param("", id="empty_string"),
+            pytest.param("   ", id="whitespace_only"),
+            pytest.param("\t\n", id="tabs_and_newlines"),
+            pytest.param("relative/path", id="relative_subdir"),
+            pytest.param("./memory", id="dot_relative"),
+            pytest.param("memory", id="bare_name"),
+        ],
+    )
+    def test_invalid_values_fall_back_to_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        bad_value: str,
+    ) -> None:
+        monkeypatch.setenv("SYNTHORG_MEMORY_DIR", bad_value)
+        monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
+        collector = _build_telemetry_collector()
+        # Falls back to ``/data/memory`` -> ``/data/telemetry``.
+        assert collector._data_dir == Path("/data/telemetry")
+
+    def test_absolute_path_with_whitespace_is_trimmed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.setenv(
+            "SYNTHORG_MEMORY_DIR",
+            f"  {tmp_path / 'memory'}  ",
+        )
+        monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
+        collector = _build_telemetry_collector()
+        # Surrounding whitespace is stripped before path resolution.
+        assert collector._data_dir == tmp_path / "telemetry"

--- a/tests/unit/api/test_telemetry_builder.py
+++ b/tests/unit/api/test_telemetry_builder.py
@@ -39,7 +39,10 @@ class TestBuildTelemetryCollector:
         monkeypatch.setenv("SYNTHORG_MEMORY_DIR", str(memory_dir))
         monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
         collector = _build_telemetry_collector()
-        assert collector._data_dir == tmp_path / "telemetry"
+        # Builder canonicalises via ``Path.resolve`` to satisfy the
+        # path-injection sanitiser; compare against the resolved form
+        # so macOS (``/var -> /private/var``) passes like Linux.
+        assert collector._data_dir == (tmp_path / "telemetry").resolve()
 
     def test_opt_in_flips_enabled_via_env(
         self,
@@ -51,7 +54,7 @@ class TestBuildTelemetryCollector:
         collector = _build_telemetry_collector()
         assert collector.enabled is True
         # Deployment ID gets persisted under the derived telemetry dir.
-        assert (tmp_path / "telemetry").exists()
+        assert (tmp_path / "telemetry").resolve().exists()
 
 
 @pytest.mark.unit
@@ -100,5 +103,38 @@ class TestMemoryDirValidation:
         )
         monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
         collector = _build_telemetry_collector()
-        # Surrounding whitespace is stripped before path resolution.
-        assert collector._data_dir == tmp_path / "telemetry"
+        # Whitespace is stripped before path resolution; the result
+        # is the canonicalised form (matches Linux and macOS).
+        assert collector._data_dir == (tmp_path / "telemetry").resolve()
+
+    def test_path_outside_allowed_roots_falls_back(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Absolute paths outside ``/data`` + temp dir are rejected.
+
+        CodeQL's ``py/path-injection`` rule treats the env var as
+        untrusted input; the builder caps the allow-list to the
+        container data volume and the OS temp dir so a hostile or
+        typo'd value (e.g. ``/etc``) cannot steer deployment-ID
+        writes outside the intended surface.
+        """
+        monkeypatch.setenv("SYNTHORG_MEMORY_DIR", "/etc/synthorg")
+        monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
+        collector = _build_telemetry_collector()
+        assert collector._data_dir == Path("/data/telemetry")
+
+    def test_traversal_via_dotdot_is_canonicalised_and_checked(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`/data/../etc` gets canonicalised to `/etc` and rejected.
+
+        ``Path.resolve`` collapses ``..`` segments before the
+        allow-list check runs, so traversal tricks cannot smuggle
+        paths past the prefix comparison.
+        """
+        monkeypatch.setenv("SYNTHORG_MEMORY_DIR", "/data/../etc/memory")
+        monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
+        collector = _build_telemetry_collector()
+        assert collector._data_dir == Path("/data/telemetry")

--- a/tests/unit/api/test_telemetry_builder.py
+++ b/tests/unit/api/test_telemetry_builder.py
@@ -1,0 +1,53 @@
+"""Tests for the app-level telemetry collector factory.
+
+``_build_telemetry_collector`` builds a :class:`TelemetryCollector`
+wired against the memory-dir env var. The collector respects
+``SYNTHORG_TELEMETRY`` internally; this module verifies the path
+derivation and env-var handling around construction.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from synthorg.api.app import _build_telemetry_collector
+from synthorg.telemetry.collector import TelemetryCollector
+
+
+@pytest.mark.unit
+class TestBuildTelemetryCollector:
+    """Env-var handling and data-dir derivation."""
+
+    def test_defaults_to_container_path_when_env_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("SYNTHORG_MEMORY_DIR", raising=False)
+        monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
+        collector = _build_telemetry_collector()
+        assert isinstance(collector, TelemetryCollector)
+        assert collector._data_dir == Path("/data/telemetry")
+        assert collector.enabled is False
+
+    def test_derives_sibling_dir_from_memory_dir(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        memory_dir = tmp_path / "memory"
+        monkeypatch.setenv("SYNTHORG_MEMORY_DIR", str(memory_dir))
+        monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
+        collector = _build_telemetry_collector()
+        assert collector._data_dir == tmp_path / "telemetry"
+
+    def test_opt_in_flips_enabled_via_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.setenv("SYNTHORG_MEMORY_DIR", str(tmp_path / "memory"))
+        monkeypatch.setenv("SYNTHORG_TELEMETRY", "true")
+        collector = _build_telemetry_collector()
+        assert collector.enabled is True
+        # Deployment ID gets persisted under the derived telemetry dir.
+        assert (tmp_path / "telemetry").exists()

--- a/tests/unit/api/test_telemetry_builder.py
+++ b/tests/unit/api/test_telemetry_builder.py
@@ -39,10 +39,7 @@ class TestBuildTelemetryCollector:
         monkeypatch.setenv("SYNTHORG_MEMORY_DIR", str(memory_dir))
         monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
         collector = _build_telemetry_collector()
-        # Builder canonicalises via ``Path.resolve`` to satisfy the
-        # path-injection sanitiser; compare against the resolved form
-        # so macOS (``/var -> /private/var``) passes like Linux.
-        assert collector._data_dir == (tmp_path / "telemetry").resolve()
+        assert collector._data_dir == tmp_path / "telemetry"
 
     def test_opt_in_flips_enabled_via_env(
         self,
@@ -54,7 +51,7 @@ class TestBuildTelemetryCollector:
         collector = _build_telemetry_collector()
         assert collector.enabled is True
         # Deployment ID gets persisted under the derived telemetry dir.
-        assert (tmp_path / "telemetry").resolve().exists()
+        assert (tmp_path / "telemetry").exists()
 
 
 @pytest.mark.unit
@@ -103,9 +100,8 @@ class TestMemoryDirValidation:
         )
         monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
         collector = _build_telemetry_collector()
-        # Whitespace is stripped before path resolution; the result
-        # is the canonicalised form (matches Linux and macOS).
-        assert collector._data_dir == (tmp_path / "telemetry").resolve()
+        # Surrounding whitespace is stripped before the prefix check.
+        assert collector._data_dir == tmp_path / "telemetry"
 
     def test_path_outside_allowed_roots_falls_back(
         self,

--- a/tests/unit/api/test_telemetry_builder.py
+++ b/tests/unit/api/test_telemetry_builder.py
@@ -124,13 +124,31 @@ class TestMemoryDirValidation:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """`/data/../etc` gets canonicalised to `/etc` and rejected.
+        """`/data/../etc` gets rejected via the ``..`` traversal guard.
 
-        ``Path.resolve`` collapses ``..`` segments before the
-        allow-list check runs, so traversal tricks cannot smuggle
-        paths past the prefix comparison.
+        The explicit ``Path.parts`` check catches traversal attempts
+        before the prefix check, so ``/data/../etc`` cannot smuggle
+        past the allow-list by starting with ``/data``.
         """
         monkeypatch.setenv("SYNTHORG_MEMORY_DIR", "/data/../etc/memory")
+        monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
+        collector = _build_telemetry_collector()
+        assert collector._data_dir == Path("/data/telemetry")
+
+    def test_path_equal_to_root_is_rejected(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``SYNTHORG_MEMORY_DIR=/data`` must fall back to the default.
+
+        Regression guard: ``_build_telemetry_collector`` derives
+        ``memory_dir.parent / "telemetry"``. If the memory dir
+        equals a root (``/data``), the parent is ``/`` and the
+        telemetry dir would escape to ``/telemetry``. The
+        allow-list therefore requires the memory dir to be a
+        *strict* descendant of a root.
+        """
+        monkeypatch.setenv("SYNTHORG_MEMORY_DIR", "/data")
         monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
         collector = _build_telemetry_collector()
         assert collector._data_dir == Path("/data/telemetry")

--- a/tests/unit/communication/test_bus_memory.py
+++ b/tests/unit/communication/test_bus_memory.py
@@ -98,6 +98,15 @@ class TestBusLifecycle:
         assert bus.is_running is False
 
     @pytest.mark.unit
+    async def test_health_check_tracks_running(self) -> None:
+        bus = InMemoryMessageBus(config=_make_config())
+        assert await bus.health_check() is False
+        await bus.start()
+        assert await bus.health_check() is True
+        await bus.stop()
+        assert await bus.health_check() is False
+
+    @pytest.mark.unit
     async def test_publish_on_stopped_bus_raises(self) -> None:
         bus = InMemoryMessageBus(config=_make_config())
         msg = _make_message(channel="#general")

--- a/tests/unit/communication/test_bus_nats_health.py
+++ b/tests/unit/communication/test_bus_nats_health.py
@@ -1,0 +1,88 @@
+"""Unit tests for ``JetStreamMessageBus.health_check``.
+
+Exercises the four degraded-probe branches plus the happy path.
+Tests avoid a real NATS connection by mutating the bus's internal
+``_state`` directly -- the method only reads ``state.running`` and
+``state.client`` attributes and awaits ``client.flush``.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from synthorg.communication.bus.nats import JetStreamMessageBus
+from synthorg.communication.config import MessageBusConfig, NatsConfig
+from synthorg.communication.enums import MessageBusBackend
+from synthorg.observability.events.communication import COMM_BUS_HEALTH_CHECK_FAILED
+
+
+def _make_bus() -> JetStreamMessageBus:
+    """Build a JetStreamMessageBus without connecting to NATS."""
+    config = MessageBusConfig(
+        backend=MessageBusBackend.NATS,
+        nats=NatsConfig(url="nats://localhost:4222"),
+    )
+    return JetStreamMessageBus(config=config)
+
+
+@pytest.mark.unit
+class TestNatsBusHealthCheck:
+    """Branch coverage for ``JetStreamMessageBus.health_check``."""
+
+    async def test_returns_false_when_not_running(self) -> None:
+        bus = _make_bus()
+        bus._state.running = False
+        assert await bus.health_check() is False
+
+    async def test_returns_false_when_client_none(self) -> None:
+        bus = _make_bus()
+        bus._state.running = True
+        bus._state.client = None
+        assert await bus.health_check() is False
+
+    async def test_returns_false_when_not_connected(self) -> None:
+        bus = _make_bus()
+        bus._state.running = True
+        client = MagicMock()
+        client.is_connected = False
+        client.flush = AsyncMock()
+        bus._state.client = client
+        assert await bus.health_check() is False
+        client.flush.assert_not_called()
+
+    async def test_returns_false_and_logs_when_flush_raises(self) -> None:
+        bus = _make_bus()
+        bus._state.running = True
+        client = MagicMock()
+        client.is_connected = True
+        client.flush = AsyncMock(side_effect=TimeoutError("simulated"))
+        bus._state.client = client
+        with patch("synthorg.communication.bus.nats.logger") as mock_logger:
+            result = await bus.health_check()
+        assert result is False
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert call_args.args[0] == COMM_BUS_HEALTH_CHECK_FAILED
+        assert call_args.kwargs["phase"] == "flush"
+        assert call_args.kwargs["error_type"] == "TimeoutError"
+        assert call_args.kwargs["exc_info"] is True
+
+    async def test_returns_true_when_flush_succeeds(self) -> None:
+        bus = _make_bus()
+        bus._state.running = True
+        client = MagicMock()
+        client.is_connected = True
+        client.flush = AsyncMock()
+        bus._state.client = client
+        assert await bus.health_check() is True
+        client.flush.assert_awaited_once_with(timeout=2)
+
+    async def test_memory_error_is_reraised(self) -> None:
+        bus = _make_bus()
+        bus._state.running = True
+        client = MagicMock()
+        client.is_connected = True
+        client.flush = AsyncMock(side_effect=MemoryError())
+        bus._state.client = client
+        with pytest.raises(MemoryError):
+            await bus.health_check()

--- a/tests/unit/engine/task_engine_helpers.py
+++ b/tests/unit/engine/task_engine_helpers.py
@@ -78,6 +78,9 @@ class FakeMessageBus:
     def is_running(self) -> bool:
         return self._running
 
+    async def health_check(self) -> bool:
+        return self._running
+
     async def publish(
         self,
         message: object,

--- a/tests/unit/hr/test_offboarding_service.py
+++ b/tests/unit/hr/test_offboarding_service.py
@@ -128,6 +128,9 @@ class FakeMessageBus:
     def is_running(self) -> bool:
         return self._running
 
+    async def health_check(self) -> bool:
+        return self._running
+
     async def publish(
         self,
         message: Message,

--- a/tests/unit/settings/test_dispatcher.py
+++ b/tests/unit/settings/test_dispatcher.py
@@ -100,6 +100,9 @@ class _FakeBus:
     def is_running(self) -> bool:
         return self._running
 
+    async def health_check(self) -> bool:
+        return self._running
+
     async def start(self) -> None:
         self._running = True
 

--- a/tests/unit/telemetry/reporters/test_logfire_reporter.py
+++ b/tests/unit/telemetry/reporters/test_logfire_reporter.py
@@ -37,13 +37,21 @@ class TestLogfireReporterReportRaises:
     """``report()`` must propagate backend failures, not swallow them."""
 
     @pytest.fixture
-    def reporter(self) -> Any:
+    def reporter(self, monkeypatch: pytest.MonkeyPatch) -> Any:
         pytest.importorskip(
             "logfire",
             reason="logfire extra not installed in this environment",
         )
         from synthorg.telemetry.reporters.logfire import LogfireReporter
 
+        # Reporter refuses to initialise without a token; a dummy
+        # value exercises the construction path without enabling
+        # delivery (the SDK handles an unauthenticated token by
+        # dropping events).
+        monkeypatch.setenv(
+            "SYNTHORG_LOGFIRE_PROJECT_TOKEN",
+            "pylf_v1_test_000000000000000000000000000000000000000000",
+        )
         return LogfireReporter()
 
     async def test_backend_exception_propagates(

--- a/tests/unit/telemetry/reporters/test_logfire_reporter.py
+++ b/tests/unit/telemetry/reporters/test_logfire_reporter.py
@@ -1,0 +1,69 @@
+"""Regression tests for ``LogfireReporter``.
+
+The collector's ``_send`` helper only flips the "delivered" return
+value to ``False`` when ``report()`` raises. Earlier revisions of
+the Logfire reporter logged and swallowed backend exceptions, so
+failed writes surfaced as successful deliveries (``*_SENT``
+debug events fired regardless). These tests lock in the re-raise
+contract so that regression cannot sneak back in.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from synthorg.observability.events.telemetry import TELEMETRY_REPORT_FAILED
+from synthorg.telemetry.protocol import TelemetryEvent
+
+
+def _event() -> TelemetryEvent:
+    return TelemetryEvent(
+        event_type="deployment.heartbeat",
+        deployment_id="00000000-0000-0000-0000-000000000001",
+        synthorg_version="test",
+        python_version="3.14.0",
+        os_platform="Linux",
+        timestamp=datetime.now(UTC),
+        properties={},
+    )
+
+
+@pytest.mark.unit
+class TestLogfireReporterReportRaises:
+    """``report()`` must re-raise backend failures after logging."""
+
+    @pytest.fixture
+    def reporter(self) -> Any:
+        pytest.importorskip(
+            "logfire",
+            reason="logfire extra not installed in this environment",
+        )
+        from synthorg.telemetry.reporters.logfire import LogfireReporter
+
+        return LogfireReporter()
+
+    async def test_backend_exception_is_logged_and_reraised(
+        self,
+        reporter: Any,
+    ) -> None:
+        event = _event()
+        with (
+            patch.object(
+                reporter._logfire,
+                "info",
+                side_effect=RuntimeError("backend down"),
+            ),
+            patch(
+                "synthorg.telemetry.reporters.logfire.logger",
+            ) as mock_logger,
+            pytest.raises(RuntimeError, match="backend down"),
+        ):
+            await reporter.report(event)
+        mock_logger.warning.assert_called_once()
+        call = mock_logger.warning.call_args
+        assert call.args[0] == TELEMETRY_REPORT_FAILED
+        assert call.kwargs["event_type"] == event.event_type
+        assert call.kwargs["error_type"] == "RuntimeError"
+        assert call.kwargs["exc_info"] is True

--- a/tests/unit/telemetry/reporters/test_logfire_reporter.py
+++ b/tests/unit/telemetry/reporters/test_logfire_reporter.py
@@ -4,8 +4,11 @@ The collector's ``_send`` helper only flips the "delivered" return
 value to ``False`` when ``report()`` raises. Earlier revisions of
 the Logfire reporter logged and swallowed backend exceptions, so
 failed writes surfaced as successful deliveries (``*_SENT``
-debug events fired regardless). These tests lock in the re-raise
-contract so that regression cannot sneak back in.
+debug events fired regardless). These tests lock in the
+propagate-don't-swallow contract so that regression cannot sneak
+back in. The reporter does **not** log ``TELEMETRY_REPORT_FAILED``
+itself -- :meth:`TelemetryCollector._send` owns that alert and
+duplicate logs would double-count failures.
 """
 
 from datetime import UTC, datetime
@@ -14,7 +17,6 @@ from unittest.mock import patch
 
 import pytest
 
-from synthorg.observability.events.telemetry import TELEMETRY_REPORT_FAILED
 from synthorg.telemetry.protocol import TelemetryEvent
 
 
@@ -32,7 +34,7 @@ def _event() -> TelemetryEvent:
 
 @pytest.mark.unit
 class TestLogfireReporterReportRaises:
-    """``report()`` must re-raise backend failures after logging."""
+    """``report()`` must propagate backend failures, not swallow them."""
 
     @pytest.fixture
     def reporter(self) -> Any:
@@ -44,7 +46,7 @@ class TestLogfireReporterReportRaises:
 
         return LogfireReporter()
 
-    async def test_backend_exception_is_logged_and_reraised(
+    async def test_backend_exception_propagates(
         self,
         reporter: Any,
     ) -> None:
@@ -55,15 +57,26 @@ class TestLogfireReporterReportRaises:
                 "info",
                 side_effect=RuntimeError("backend down"),
             ),
-            patch(
-                "synthorg.telemetry.reporters.logfire.logger",
-            ) as mock_logger,
             pytest.raises(RuntimeError, match="backend down"),
         ):
             await reporter.report(event)
-        mock_logger.warning.assert_called_once()
-        call = mock_logger.warning.call_args
-        assert call.args[0] == TELEMETRY_REPORT_FAILED
-        assert call.kwargs["event_type"] == event.event_type
-        assert call.kwargs["error_type"] == "RuntimeError"
-        assert call.kwargs["exc_info"] is True
+
+    async def test_reporter_does_not_emit_report_failed_alert(
+        self,
+        reporter: Any,
+    ) -> None:
+        """The collector owns ``TELEMETRY_REPORT_FAILED``; reporter stays quiet."""
+        event = _event()
+        with (
+            patch.object(
+                reporter._logfire,
+                "info",
+                side_effect=RuntimeError("backend down"),
+            ),
+            patch(
+                "synthorg.telemetry.reporters.logfire.logger",
+            ) as mock_logger,
+            pytest.raises(RuntimeError),
+        ):
+            await reporter.report(event)
+        mock_logger.warning.assert_not_called()

--- a/tests/unit/telemetry/test_collector.py
+++ b/tests/unit/telemetry/test_collector.py
@@ -89,15 +89,18 @@ class TestTelemetryCollector:
         probe) instead of ``Path.exists``; ``_load_or_create_deployment_id``
         uses the ``os`` / builtin I/O pair so the CodeQL
         path-injection sanitiser sits on the same lines as the
-        filesystem sinks.
+        filesystem sinks. Matching the sanitised form
+        (``normcase``+``normpath``) makes the patch cross-platform.
         """
         config = TelemetryConfig(enabled=True, backend=TelemetryBackend.NOOP)
-        deployment_file_str = str(tmp_path / "telemetry_id")
+        deployment_file_str = os.path.normcase(
+            os.path.normpath(str(tmp_path / "telemetry_id")),
+        )
         read_error = OSError("permission denied")
         original_exists = os.path.exists
 
         def exists_side_effect(path: str) -> bool:
-            if path == deployment_file_str:
+            if os.path.normcase(os.path.normpath(path)) == deployment_file_str:
                 raise read_error
             return original_exists(path)
 
@@ -110,36 +113,79 @@ class TestTelemetryCollector:
             assert len(collector.deployment_id) == 36  # UUID4 with hyphens: 8-4-4-4-12
 
     def test_deployment_id_write_error_still_returns(self, tmp_path: Path) -> None:
-        """OSError on write still returns the generated ID.
+        """OSError on the atomic create still returns the generated ID.
 
-        Patches the builtin :func:`open` (the post-sanitiser writer)
-        instead of ``Path.write_text``; the collector now uses
-        ``open()`` directly so the sanitiser and sink are textually
-        adjacent for CodeQL.
+        Patches :func:`os.open` (the ``O_CREAT | O_EXCL`` sink used
+        by the atomic write path) instead of ``Path.write_text``;
+        the collector now wins-or-loses the write race with
+        :func:`os.open` so the sanitiser and sink stay textually
+        adjacent for CodeQL and the ID survives a concurrent peer.
         """
         config = TelemetryConfig(enabled=True, backend=TelemetryBackend.NOOP)
-        deployment_file_str = str(tmp_path / "telemetry_id")
+        deployment_file_str = os.path.normcase(
+            os.path.normpath(str(tmp_path / "telemetry_id")),
+        )
         write_error = OSError("disk full")
-        original_open = open
+        original_os_open = os.open
 
-        def open_side_effect(
-            file: str,
-            mode: str = "r",
-            *args: object,
-            **kwargs: object,
-        ) -> object:
-            if file == deployment_file_str and "w" in mode:
+        def os_open_side_effect(
+            path: str,
+            flags: int,
+            mode: int = 0o777,
+        ) -> int:
+            if (
+                os.path.normcase(os.path.normpath(path)) == deployment_file_str
+                and flags & os.O_EXCL
+            ):
                 raise write_error
-            return original_open(file, mode, *args, **kwargs)  # type: ignore[call-overload]
+            return original_os_open(path, flags, mode)
 
         with patch(
-            "synthorg.telemetry.collector.open",
-            side_effect=open_side_effect,
-            create=True,
+            "synthorg.telemetry.collector.os.open",
+            side_effect=os_open_side_effect,
         ):
             collector = TelemetryCollector(config=config, data_dir=tmp_path)
             assert collector.deployment_id is not None
             assert len(collector.deployment_id) == 36  # UUID4 with hyphens: 8-4-4-4-12
+
+    def test_deployment_id_concurrent_peer_wins_race(self, tmp_path: Path) -> None:
+        """``FileExistsError`` on atomic create reuses the peer's UUID.
+
+        Regression guard for the TOCTOU race: two replicas racing
+        against the same ``/data`` volume must converge on one
+        deployment ID instead of each clobbering the other. Simulated
+        by making ``os.open`` with ``O_CREAT|O_EXCL`` raise
+        ``FileExistsError`` while the peer file's UUID is pre-written
+        on disk -- the collector reads that and uses it.
+        """
+        config = TelemetryConfig(enabled=True, backend=TelemetryBackend.NOOP)
+        deployment_file = tmp_path / "telemetry_id"
+        deployment_file_str = os.path.normcase(
+            os.path.normpath(str(deployment_file)),
+        )
+        peer_uuid = "12345678-1234-5678-1234-567812345678"
+        original_os_open = os.open
+
+        def os_open_side_effect(
+            path: str,
+            flags: int,
+            mode: int = 0o777,
+        ) -> int:
+            if (
+                os.path.normcase(os.path.normpath(path)) == deployment_file_str
+                and flags & os.O_EXCL
+            ):
+                # Peer wrote between our ``exists`` check and ``os.open``.
+                deployment_file.write_text(peer_uuid, encoding="utf-8")
+                raise FileExistsError(17, "File exists", path)
+            return original_os_open(path, flags, mode)
+
+        with patch(
+            "synthorg.telemetry.collector.os.open",
+            side_effect=os_open_side_effect,
+        ):
+            collector = TelemetryCollector(config=config, data_dir=tmp_path)
+        assert collector.deployment_id == peer_uuid
 
     async def test_send_heartbeat_disabled(self, tmp_path: Path) -> None:
         """Heartbeat should be a no-op when disabled."""

--- a/tests/unit/telemetry/test_collector.py
+++ b/tests/unit/telemetry/test_collector.py
@@ -50,11 +50,16 @@ class TestTelemetryCollector:
     def test_is_functional_true_when_logfire_reporter_built(
         self,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Functional is True when opted in and a non-noop reporter is wired."""
         pytest.importorskip(
             "logfire",
             reason="logfire extra not installed in this environment",
+        )
+        monkeypatch.setenv(
+            "SYNTHORG_LOGFIRE_PROJECT_TOKEN",
+            "pylf_v1_test_000000000000000000000000000000000000000000",
         )
         config = TelemetryConfig(
             enabled=True,

--- a/tests/unit/telemetry/test_collector.py
+++ b/tests/unit/telemetry/test_collector.py
@@ -29,7 +29,38 @@ class TestTelemetryCollector:
         config = TelemetryConfig()
         collector = TelemetryCollector(config=config, data_dir=tmp_path)
         assert collector.enabled is False
+        assert collector.is_functional is False
         assert collector.deployment_id is None
+
+    def test_is_functional_false_when_reporter_is_noop(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Opted in + noop reporter collapses to ``is_functional=False``.
+
+        Covers the "enabled in config but reporter degraded to noop"
+        case that the health endpoint used to mis-report as enabled.
+        """
+        config = TelemetryConfig(enabled=True, backend=TelemetryBackend.NOOP)
+        collector = TelemetryCollector(config=config, data_dir=tmp_path)
+        assert collector.enabled is True
+        assert collector.is_functional is False
+
+    def test_is_functional_true_when_logfire_reporter_built(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Functional is True when opted in and a non-noop reporter is wired."""
+        pytest.importorskip(
+            "logfire",
+            reason="logfire extra not installed in this environment",
+        )
+        config = TelemetryConfig(
+            enabled=True,
+            backend=TelemetryBackend.LOGFIRE,
+        )
+        collector = TelemetryCollector(config=config, data_dir=tmp_path)
+        assert collector.is_functional is True
 
     def test_generates_deployment_id(self, tmp_path: Path) -> None:
         config = TelemetryConfig(enabled=True, backend=TelemetryBackend.NOOP)

--- a/tests/unit/telemetry/test_collector.py
+++ b/tests/unit/telemetry/test_collector.py
@@ -1,5 +1,6 @@
 """Tests for the telemetry collector."""
 
+import os
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -82,40 +83,59 @@ class TestTelemetryCollector:
         assert id_file.read_text(encoding="utf-8").strip() == collector.deployment_id
 
     def test_deployment_id_read_error_generates_new(self, tmp_path: Path) -> None:
-        """OSError on read falls back to generating a new ID."""
+        """OSError on read falls back to generating a new ID.
+
+        Patches :func:`os.path.exists` (the post-sanitiser read
+        probe) instead of ``Path.exists``; ``_load_or_create_deployment_id``
+        uses the ``os`` / builtin I/O pair so the CodeQL
+        path-injection sanitiser sits on the same lines as the
+        filesystem sinks.
+        """
         config = TelemetryConfig(enabled=True, backend=TelemetryBackend.NOOP)
-        deployment_file = tmp_path / "telemetry_id"
-        original_exists = Path.exists
+        deployment_file_str = str(tmp_path / "telemetry_id")
         read_error = OSError("permission denied")
+        original_exists = os.path.exists
 
-        def exists_side_effect(self: Path) -> bool:
-            if self == deployment_file:
+        def exists_side_effect(path: str) -> bool:
+            if path == deployment_file_str:
                 raise read_error
-            return original_exists(self)
+            return original_exists(path)
 
-        with patch.object(
-            Path, "exists", autospec=True, side_effect=exists_side_effect
+        with patch(
+            "synthorg.telemetry.collector.os.path.exists",
+            side_effect=exists_side_effect,
         ):
             collector = TelemetryCollector(config=config, data_dir=tmp_path)
             assert collector.deployment_id is not None
             assert len(collector.deployment_id) == 36  # UUID4 with hyphens: 8-4-4-4-12
 
     def test_deployment_id_write_error_still_returns(self, tmp_path: Path) -> None:
-        """OSError on write still returns the generated ID."""
+        """OSError on write still returns the generated ID.
+
+        Patches the builtin :func:`open` (the post-sanitiser writer)
+        instead of ``Path.write_text``; the collector now uses
+        ``open()`` directly so the sanitiser and sink are textually
+        adjacent for CodeQL.
+        """
         config = TelemetryConfig(enabled=True, backend=TelemetryBackend.NOOP)
-        deployment_file = tmp_path / "telemetry_id"
-        original_write_text = Path.write_text
+        deployment_file_str = str(tmp_path / "telemetry_id")
         write_error = OSError("disk full")
+        original_open = open
 
-        def write_text_side_effect(
-            self: Path, data: str, encoding: str | None = None, **kwargs: object
-        ) -> int:
-            if self == deployment_file:
+        def open_side_effect(
+            file: str,
+            mode: str = "r",
+            *args: object,
+            **kwargs: object,
+        ) -> object:
+            if file == deployment_file_str and "w" in mode:
                 raise write_error
-            return original_write_text(self, data, encoding=encoding, **kwargs)  # type: ignore[arg-type]
+            return original_open(file, mode, *args, **kwargs)  # type: ignore[call-overload]
 
-        with patch.object(
-            Path, "write_text", autospec=True, side_effect=write_text_side_effect
+        with patch(
+            "synthorg.telemetry.collector.open",
+            side_effect=open_side_effect,
+            create=True,
         ):
             collector = TelemetryCollector(config=config, data_dir=tmp_path)
             assert collector.deployment_id is not None

--- a/tests/unit/telemetry/test_config.py
+++ b/tests/unit/telemetry/test_config.py
@@ -1,6 +1,7 @@
 """Tests for telemetry configuration."""
 
 import pytest
+from pydantic import ValidationError
 
 from synthorg.telemetry.config import TelemetryBackend, TelemetryConfig
 
@@ -14,15 +15,10 @@ class TestTelemetryConfig:
         assert config.enabled is False
         assert config.backend == TelemetryBackend.LOGFIRE
         assert config.heartbeat_interval_hours == 6.0
-        assert config.token is None
 
-    def test_enabled_with_token(self) -> None:
-        config = TelemetryConfig(
-            enabled=True,
-            token="test-token-123",
-        )
+    def test_enabled(self) -> None:
+        config = TelemetryConfig(enabled=True)
         assert config.enabled is True
-        assert config.token == "test-token-123"
 
     def test_noop_backend(self) -> None:
         config = TelemetryConfig(
@@ -35,6 +31,10 @@ class TestTelemetryConfig:
         config = TelemetryConfig()
         with pytest.raises(Exception, match="frozen"):
             config.enabled = True  # type: ignore[misc]
+
+    def test_token_field_is_removed(self) -> None:
+        with pytest.raises(ValidationError):
+            TelemetryConfig(token="anything")  # type: ignore[call-arg]
 
     @pytest.mark.parametrize("hours", [0.0, -1.0])
     def test_rejects_non_positive_heartbeat(self, hours: float) -> None:

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -72,6 +72,16 @@
 :8080 {
 	root * /usr/share/caddy/html
 
+	# --- Container health probe: plain-text 200 for Docker HEALTHCHECK.
+	# Served before any static-asset handling so the probe stays cheap
+	# and independent of SPA bundle state. No security headers -- the
+	# response body is a literal "ok" with no user content. log_skip
+	# keeps the access log quiet under a 10s probe interval.
+	handle /healthz {
+		log_skip
+		respond "ok" 200
+	}
+
 	# --- WebSocket proxy: must precede /api/* so it matches first ---
 	@ws path /api/v1/ws
 	handle @ws {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1097,10 +1097,13 @@ export interface Channel {
 
 // ── Health ───────────────────────────────────────────────────
 
+export type TelemetryStatus = 'enabled' | 'disabled'
+
 export interface HealthStatus {
   status: 'ok' | 'degraded' | 'down'
   persistence: boolean | null
   message_bus: boolean | null
+  telemetry: TelemetryStatus
   version: string
   uptime_seconds: number
 }


### PR DESCRIPTION
## Summary

Three container-health / telemetry bugs plus audit-driven cleanups, discovered while debugging a running stack:

- `SYNTHORG_TELEMETRY=true` was a lie: the backend image shipped without the `logfire` extra, the collector was never instantiated, and there was no way to tell. Now the extra is installed, `TelemetryCollector` is wired into the Litestar lifespan, and the health endpoint + CLI status surface the delivery state.
- The `nats-healthcheck` busybox sidecar was decorative -- nothing in compose consumed its `service_healthy` signal, and backend's self-reported `is_running` was a stale local bool. Replaced with a live `MessageBus.health_check()` that performs a real PING/PONG round-trip on `NatsBus`; sidecar dropped.
- The web container had no healthcheck because apko doesn't support `HEALTHCHECK` at the image layer. Added one at the compose layer via `wget` + a Caddy `/healthz` handler.
- Audit pass: fine-tune overlays now gate on `service_healthy` (backend HAS a Dockerfile HEALTHCHECK, contrary to the stale comment); redundant `user:` directives on our-owned images removed; redundant default env on backend removed.

## What changed

### Telemetry (fixes: broken opt-in, token-override footgun, no delivery signal)
- `docker/backend/Dockerfile` -- added `--extra telemetry` to both `uv sync` calls
- `src/synthorg/telemetry/reporters/logfire.py` -- removed `SYNTHORG_TELEMETRY_TOKEN` env override; write token is now compile-time-only (project-owned, write-only; same pattern as Sentry DSN / PostHog key). Users who need their own observability use the Postgres + Prometheus + audit-chain stack, not this module.
- `src/synthorg/telemetry/config.py` -- dropped the `token` field; `extra="forbid"` so stray config catches early
- `src/synthorg/api/app.py` -- new `_build_telemetry_collector()` helper; instantiated in `create_app`, attached via `AppState.set_telemetry_collector()`, start/shutdown hooked into the Litestar lifespan
- `src/synthorg/api/controllers/health.py` -- new `TelemetryStatus` enum + `telemetry` field on `HealthStatus`. Also: `message_bus` probe is now async (`health_check()`) to match the new protocol
- `cli/cmd/status.go` -- reads and renders `Telemetry` in the health section
- `web/src/api/types.ts` -- `HealthStatus.telemetry: TelemetryStatus` added so the dashboard type matches the backend contract
- Failures log but never propagate: reporter fallback to noop is deliberate (telemetry must not affect the app), but `NatsBus.health_check` now logs `communication.bus.health_check_failed` with phase/error_type/traceback instead of silently returning False.

### NATS health (replaces decorative sidecar with real probe)
- `src/synthorg/communication/bus_protocol.py` -- new `async health_check() -> bool`
- `src/synthorg/communication/bus/nats.py` -- live probe: checks `state.running`, `client.is_connected`, then `await client.flush(timeout=2)` for a PING/PONG round-trip
- `src/synthorg/communication/bus/memory.py` -- trivial: returns `_running`
- `docker/compose.yml` + `cli/internal/compose/compose.yml.tmpl` -- removed `nats-healthcheck` service
- `docker/compose.distributed.yml` -- depends_on changed from `nats-healthcheck: service_healthy` to `nats: service_started` (sidecar is gone; backend does the live probe itself)
- `cli/cmd/start.go` -- removed busybox-sidecar entry from `thirdPartyImages`

### Web healthcheck
- `docker/web/apko.yaml` -- added `wget` package (apko has no HEALTHCHECK field; wget is the smallest HTTP client that satisfies Docker's `CMD` form)
- `web/Caddyfile` -- new `handle /healthz { respond "ok" 200 }` before the SPA fallback
- `docker/compose.yml` + template -- `healthcheck:` block targeting `http://127.0.0.1:8080/healthz` (loopback inside the container, avoiding Docker DNS)

### Audit cleanups
- `docker/compose.fine-tuning-{cpu,gpu}.yml` -- `depends_on: backend: condition: service_healthy` (was `service_started` with a now-stale comment claiming backend had no healthcheck). Removes a real startup race where fine-tune could start talking to a backend mid-migration.
- `docker/compose.yml` + template -- removed redundant `user: "65532:65532"` on backend and web (Dockerfile has `USER 65532`, apko has `run-as: "65532"`); removed redundant `SYNTHORG_HOST/PORT/UVICORN_*` env defaults (they're baked into the Dockerfile ENV; operators still override via `.env`).

## Test plan

- Unit suite: 21,656 tests passing (incl. new tests below)
- Go CLI: `go test ./...` green; golden fixtures regenerated
- New tests:
  - `tests/unit/communication/test_bus_nats_health.py` -- 6 cases covering all four degraded branches + happy path + `MemoryError` re-raise + logging assertion
  - `tests/unit/communication/test_bus_memory.py::test_health_check_tracks_running`
  - `tests/unit/api/test_health.py::TestResolveTelemetryStatus` -- 3 cases (no collector, collector enabled, collector disabled)
  - `tests/unit/api/test_health.py::TestHealthTelemetryField` -- asserts the `telemetry` field surfaces in `/api/v1/health`
  - `tests/unit/api/test_telemetry_builder.py` -- env-var path derivation + opt-in behavior for `_build_telemetry_collector`
- Protocol conformance: 5 `FakeMessageBus` classes across `tests/` updated with the new `async health_check`

## Review coverage

14 review agents ran in parallel (docs-consistency, code-reviewer, python-reviewer, pr-test-analyzer, silent-failure-hunter, logging-audit, resilience-audit, conventions-enforcer, security-reviewer, infra-reviewer, api-contract-drift, test-quality-reviewer, async-concurrency-reviewer, go-reviewer, go-conventions-enforcer). 7 valid findings addressed (frontend type drift, docs wording, 5 test-coverage gaps). 4 false positives rejected with reasoning (PEP 758 except syntax is correct per CLAUDE.md, healthcheck 127.0.0.1 is intentional for container-self-probe, broad `except` in health paths is by design, `_build_telemetry_collector` dir creation is handled internally by `TelemetryCollector`).
