### PR TITLE
chore(ci): audit PR-gated workflows + fix 282 web async leaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,15 +36,24 @@ jobs:
             python:
               - 'src/**'
               - 'tests/**'
+              - 'scripts/**'
               - 'pyproject.toml'
               - 'uv.lock'
               - '.github/actions/**'
+              - '.github/workflows/ci.yml'
               - 'atlas.hcl'
             dashboard:
               - 'web/**'
+              - 'src/synthorg/api/schemas/**'
+              - 'scripts/export_openapi.py'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.github/actions/**'
+              - '.github/workflows/ci.yml'
             docker:
               - 'docker/**'
               - '.dockerignore'
+              - '.github/workflows/ci.yml'
 
   # ── Python: Lint ──
   lint:

--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -15,6 +15,7 @@ on:
       - "scripts/**"
       - "cli/scripts/install.sh"
       - "cli/scripts/install.ps1"
+      - ".github/actions/**"
       - ".github/workflows/pages-preview.yml"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,6 +14,7 @@ on:
       - "scripts/**"
       - "cli/scripts/install.sh"
       - "cli/scripts/install.ps1"
+      - ".github/actions/**"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ PYTHONPATH=. uv run zensical serve          # local docs preview (http://127.0.0
 
 ### Web Dashboard
 
-See `web/CLAUDE.md` for commands, design system, and component inventory.
+See `web/CLAUDE.md` for commands, design system, and component inventory. The CI-matching full-suite leak check is `npm --prefix web run test -- --coverage --detect-async-leaks` (must exit 0; any new store that schedules timers must expose a teardown hook per `web/CLAUDE.md`).
 
 ### CLI (Go Binary)
 

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -83,7 +83,7 @@ All Zustand store **mutation** actions (create/update/delete) MUST follow the `s
 | `StatPill` | `@/components/ui/stat-pill` | Compact inline label + value pair |
 | `Avatar` | `@/components/ui/avatar` | Circular initials avatar with optional `borderColor?` prop |
 | `Button` | `@/components/ui/button` | Standard button (shadcn) |
-| `Toast` / `ToastContainer` | `@/components/ui/toast` | Success/error/warning/info notifications with auto-dismiss queue (mount `ToastContainer` once in AppLayout). Store exposes `dismissAll()` (timers + toasts) and `cancelAllPending()` (timers only, preserves toasts) for test teardown -- the global `afterEach` in `test-setup.tsx` uses `dismissAll()`. |
+| `Toast` / `ToastContainer` | `@/components/ui/toast` | Success/error/warning/info notifications with auto-dismiss queue (mount `ToastContainer` once in AppLayout). Store exposes `dismissAll()` (timers + toasts) and `cancelAllPending()` (timers only, preserves toasts) for test teardown -- the global `afterEach` in `web/src/test-setup.tsx` uses `dismissAll()`. |
 | `Skeleton` / `SkeletonCard` / `SkeletonMetric` / `SkeletonTable` / `SkeletonText` | `@/components/ui/skeleton` | Loading placeholders matching component shapes (shimmer animation, respects `prefers-reduced-motion`) |
 | `EmptyState` | `@/components/ui/empty-state` | No-data / no-results placeholder with icon, title, description, optional action button |
 | `ErrorBoundary` | `@/components/ui/error-boundary` | React error boundary with retry -- `level` prop: `page` / `section` / `component` |

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -13,6 +13,7 @@ npm --prefix web run build                 # production build
 npm --prefix web run lint                  # ESLint (zero warnings enforced)
 npm --prefix web run type-check            # TypeScript type checking
 npm --prefix web run test                  # Vitest unit tests (coverage scoped to files changed vs origin/main)
+npm --prefix web run test -- --coverage --detect-async-leaks  # Full suite + unhandled-handle detection (matches CI)
 npm --prefix web run analyze               # bundle size treemap (opens stats.html)
 npm --prefix web run e2e                   # Playwright visual regression tests
 npm --prefix web run e2e:update            # update Playwright screenshot baselines
@@ -60,6 +61,8 @@ All Zustand store **mutation** actions (create/update/delete) MUST follow the `s
 
 **List reads** (`fetch*`) follow the same pattern for logging but set `error: string | null` on the store instead of toasting -- the UI surface (usually a page-level error banner) consumes the error state.
 
+**Test teardown**: `web/src/test-setup.tsx` registers a global `afterEach` that calls `useToastStore.getState().cancelAllPending()` + resets `toasts` state, and invokes `cancelPendingPersist()` on the notifications store. `cancelAllPending()` clears pending `setTimeout` handles used for auto-dismiss without mutating the toast list, so per-test assertions against `toasts` still work. This contract is required for `npm run test -- --detect-async-leaks` to exit 0; any new store that schedules timers must expose an equivalent cleanup hook.
+
 ## Design System (MANDATORY)
 
 ### Component Reuse
@@ -78,7 +81,7 @@ All Zustand store **mutation** actions (create/update/delete) MUST follow the `s
 | `StatPill` | `@/components/ui/stat-pill` | Compact inline label + value pair |
 | `Avatar` | `@/components/ui/avatar` | Circular initials avatar with optional `borderColor?` prop |
 | `Button` | `@/components/ui/button` | Standard button (shadcn) |
-| `Toast` / `ToastContainer` | `@/components/ui/toast` | Success/error/warning/info notifications with auto-dismiss queue (mount `ToastContainer` once in AppLayout) |
+| `Toast` / `ToastContainer` | `@/components/ui/toast` | Success/error/warning/info notifications with auto-dismiss queue (mount `ToastContainer` once in AppLayout). Store exposes `cancelAllPending()` for test teardown -- called from the global `afterEach` in `test-setup.tsx`. |
 | `Skeleton` / `SkeletonCard` / `SkeletonMetric` / `SkeletonTable` / `SkeletonText` | `@/components/ui/skeleton` | Loading placeholders matching component shapes (shimmer animation, respects `prefers-reduced-motion`) |
 | `EmptyState` | `@/components/ui/empty-state` | No-data / no-results placeholder with icon, title, description, optional action button |
 | `ErrorBoundary` | `@/components/ui/error-boundary` | React error boundary with retry -- `level` prop: `page` / `section` / `component` |

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -61,7 +61,9 @@ All Zustand store **mutation** actions (create/update/delete) MUST follow the `s
 
 **List reads** (`fetch*`) follow the same pattern for logging but set `error: string | null` on the store instead of toasting -- the UI surface (usually a page-level error banner) consumes the error state.
 
-**Test teardown**: `web/src/test-setup.tsx` registers a global `afterEach` that calls `useToastStore.getState().cancelAllPending()` + resets `toasts` state, and invokes `cancelPendingPersist()` on the notifications store. `cancelAllPending()` clears pending `setTimeout` handles used for auto-dismiss without mutating the toast list, so per-test assertions against `toasts` still work. This contract is required for `npm run test -- --detect-async-leaks` to exit 0; any new store that schedules timers must expose an equivalent cleanup hook.
+**Test teardown**: `web/src/test-setup.tsx` registers a global `afterEach` that calls `useToastStore.getState().dismissAll()` (clears pending auto-dismiss timers + the toasts array in one idiomatic call) and invokes `cancelPendingPersist()` on the notifications store. Tests that need to inspect the toasts list *after* timers drain can call `useToastStore.getState().cancelAllPending()` directly in their own teardown -- it clears timers without mutating `toasts`. This contract is required for `npm run test -- --detect-async-leaks` to exit 0; any new store that schedules timers must expose an equivalent cleanup hook.
+
+**WS payload sanitization**: `sanitizeWsString()` (internal to `web/src/stores/notifications.ts`) normalizes every string field received from WebSocket events before it reaches storage or display. It strips C0 control characters and DELETE (except common whitespace `\t` / `\n` / `\r`), strips bidi-override characters (CVE-2021-42574 class), trims, and caps length at `MAX_STRING_LEN` (128) at code-point boundaries so surrogate pairs are not split. Any new WS payload handler in the notifications store (or a sibling store that ingests untrusted strings) MUST route string fields through this sanitizer.
 
 ## Design System (MANDATORY)
 
@@ -81,7 +83,7 @@ All Zustand store **mutation** actions (create/update/delete) MUST follow the `s
 | `StatPill` | `@/components/ui/stat-pill` | Compact inline label + value pair |
 | `Avatar` | `@/components/ui/avatar` | Circular initials avatar with optional `borderColor?` prop |
 | `Button` | `@/components/ui/button` | Standard button (shadcn) |
-| `Toast` / `ToastContainer` | `@/components/ui/toast` | Success/error/warning/info notifications with auto-dismiss queue (mount `ToastContainer` once in AppLayout). Store exposes `cancelAllPending()` for test teardown -- called from the global `afterEach` in `test-setup.tsx`. |
+| `Toast` / `ToastContainer` | `@/components/ui/toast` | Success/error/warning/info notifications with auto-dismiss queue (mount `ToastContainer` once in AppLayout). Store exposes `dismissAll()` (timers + toasts) and `cancelAllPending()` (timers only, preserves toasts) for test teardown -- the global `afterEach` in `test-setup.tsx` uses `dismissAll()`. |
 | `Skeleton` / `SkeletonCard` / `SkeletonMetric` / `SkeletonTable` / `SkeletonText` | `@/components/ui/skeleton` | Loading placeholders matching component shapes (shimmer animation, respects `prefers-reduced-motion`) |
 | `EmptyState` | `@/components/ui/empty-state` | No-data / no-results placeholder with icon, title, description, optional action button |
 | `ErrorBoundary` | `@/components/ui/error-boundary` | React error boundary with retry -- `level` prop: `page` / `section` / `component` |

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -4,6 +4,12 @@ import { useSetupStore } from '@/stores/setup'
 import { router } from '@/router'
 import App from '../App'
 
+// Note: `@/api/endpoints/settings` is mocked globally in
+// `src/test-setup.tsx`. Do NOT override it here with a partial shape --
+// per-file overrides replace the global mock entirely, so any test that
+// runs after a partial override inherits the missing exports. Extend
+// the global mock in `test-setup.tsx` if more endpoints are needed.
+
 // Mock the setup API (used by SetupGuard)
 vi.mock('@/api/endpoints/setup', () => ({
   getSetupStatus: vi.fn().mockResolvedValue({

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -30,22 +30,9 @@ vi.mock('@/hooks/useGlobalNotifications', () => ({
   useGlobalNotifications: vi.fn(),
 }))
 
-// AuthGuard fires `useSettingsStore.getState().fetchLocale()` when the user
-// is authenticated; that hits `/settings/display`, which returns 401 in the
-// jsdom test environment. The axios 401 interceptor then flips auth state
-// back to 'unauthenticated', which bounces the router to /login. Stub the
-// settings endpoint to return an empty list so the locale fetch is a no-op.
-vi.mock('@/api/endpoints/settings', () => ({
-  getSchema: vi.fn().mockResolvedValue([]),
-  getNamespaceSchema: vi.fn().mockResolvedValue([]),
-  getAllSettings: vi.fn().mockResolvedValue([]),
-  getNamespaceSettings: vi.fn().mockResolvedValue([]),
-  updateSetting: vi.fn().mockResolvedValue(undefined),
-  deleteSetting: vi.fn().mockResolvedValue(undefined),
-  restartServer: vi.fn().mockResolvedValue(undefined),
-  listSinks: vi.fn().mockResolvedValue([]),
-  testSink: vi.fn().mockResolvedValue({ ok: true } satisfies { ok: boolean }),
-}))
+// AuthGuard's `fetchLocale()` call is neutralized by the global mock of
+// `@/api/endpoints/settings` in `src/test-setup.tsx`; no per-file override
+// is needed.
 
 // AppLayout + LoginPage are React.lazy() imports that transitively pull in
 // motion, cmdk, Base UI, and every lazy route module. Under vitest with

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { useAuthStore } from '@/stores/auth'
 import { useSetupStore } from '@/stores/setup'
+import { router } from '@/router'
 import App from '../App'
 
 // Mock the setup API (used by SetupGuard)
@@ -21,6 +22,45 @@ vi.mock('@/api/endpoints/setup', () => ({
 // EnvironmentTeardownError when the worker unmounts.
 vi.mock('@/hooks/useGlobalNotifications', () => ({
   useGlobalNotifications: vi.fn(),
+}))
+
+// AuthGuard fires `useSettingsStore.getState().fetchLocale()` when the user
+// is authenticated; that hits `/settings/display`, which returns 401 in the
+// jsdom test environment. The axios 401 interceptor then flips auth state
+// back to 'unauthenticated', which bounces the router to /login. Stub the
+// settings endpoint to return an empty list so the locale fetch is a no-op.
+vi.mock('@/api/endpoints/settings', () => ({
+  getSchema: vi.fn().mockResolvedValue([]),
+  getNamespaceSchema: vi.fn().mockResolvedValue([]),
+  getAllSettings: vi.fn().mockResolvedValue([]),
+  getNamespaceSettings: vi.fn().mockResolvedValue([]),
+  updateSetting: vi.fn().mockResolvedValue(undefined),
+  deleteSetting: vi.fn().mockResolvedValue(undefined),
+  restartServer: vi.fn().mockResolvedValue(undefined),
+  listSinks: vi.fn().mockResolvedValue([]),
+  testSink: vi.fn().mockResolvedValue({ ok: true } satisfies { ok: boolean }),
+}))
+
+// AppLayout + LoginPage are React.lazy() imports that transitively pull in
+// motion, cmdk, Base UI, and every lazy route module. Under vitest with
+// --coverage and --detect-async-leaks, that import chain can take 5-9s and
+// race vitest's worker teardown (EnvironmentTeardownError: closing RPC while
+// onUserConsoleLog was pending). This test only asserts the router-guard
+// routing behavior, so we stub the lazy modules with minimal shells that
+// render the landmarks the assertions check (nav + main, sign-in heading).
+// Full AppLayout / LoginPage coverage is exercised by Storybook stories
+// and the Playwright e2e suite.
+vi.mock('@/components/layout/AppLayout', () => ({
+  default: () => (
+    <>
+      <nav aria-label="Main navigation">Nav</nav>
+      <main>Content</main>
+    </>
+  ),
+}))
+
+vi.mock('@/pages/LoginPage', () => ({
+  default: () => <h1>Sign in</h1>,
 }))
 
 // Prevent window.location side effects from auth store
@@ -55,40 +95,26 @@ describe('App', () => {
   })
 
   it('redirects unauthenticated users to login', async () => {
+    // Auth state is already 'unauthenticated' from beforeEach.
+    await router.navigate('/')
     render(<App />)
-    // Login page is lazy-loaded and calls getSetupStatus on mount,
-    // so we need extra time for: Suspense resolve + useEffect + mock.
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: /sign in/i })).toBeInTheDocument()
-    }, { timeout: 5000 })
+    })
   })
 
-  it(
-    'renders app shell for authenticated users with setup complete',
-    async () => {
+  it('renders app shell for authenticated users with setup complete', async () => {
     useAuthStore.setState({
       authStatus: 'authenticated',
       user: { id: '1', username: 'admin', role: 'ceo', must_change_password: false, org_roles: [], scoped_departments: [] },
     })
     useSetupStore.setState({ setupComplete: true })
+    await router.navigate('/')
 
     render(<App />)
-    // Wait for lazy-loaded layout to render.  On CI with
-    // `--detect-async-leaks` + coverage enabled, the initial import of
-    // AppLayout (which transitively pulls in motion, cmdk-base,
-    // Base UI primitives, and every lazy page) can take 5-9s before the
-    // Suspense fallback resolves -- the 8000ms budget below has margin
-    // over observed CI timings while staying under the outer 15s cap.
-    await waitFor(
-      () => {
-        // Verify sidebar navigation is present
-        expect(screen.getByRole('navigation', { name: /main navigation/i })).toBeInTheDocument()
-      },
-      { timeout: 8000 },
-    )
-    // Verify main content area exists
+    await waitFor(() => {
+      expect(screen.getByRole('navigation', { name: /main navigation/i })).toBeInTheDocument()
+    })
     expect(screen.getByRole('main')).toBeInTheDocument()
-  },
-    15_000,
-  )
+  })
 })

--- a/web/src/__tests__/api/client.test.ts
+++ b/web/src/__tests__/api/client.test.ts
@@ -187,48 +187,63 @@ function getRequestInterceptor(): (config: Record<string, unknown>) => Record<st
   return fulfilled as (config: Record<string, unknown>) => Record<string, unknown>
 }
 
+// Spy on getCsrfToken rather than setting `document.cookie` -- jsdom's
+// tough-cookie backed `document.cookie` setter creates a Promise via
+// `createPromiseCallback` that leaks past test teardown under
+// --detect-async-leaks. Mocking the reader is a narrower, leak-free path
+// to the same coverage.
+vi.mock('@/utils/csrf', () => ({
+  getCsrfToken: vi.fn(),
+}))
+
 describe('apiClient request interceptor (CSRF)', () => {
+  let csrfMock: ReturnType<typeof vi.fn>
+
+  beforeAll(async () => {
+    const mod = await import('@/utils/csrf')
+    csrfMock = vi.mocked(mod.getCsrfToken) as ReturnType<typeof vi.fn>
+  })
+
+  beforeEach(() => {
+    csrfMock.mockReturnValue('test-csrf-token')
+  })
+
   afterEach(() => {
-    // Clear any test cookies
-    document.cookie = 'csrf_token=; Max-Age=0'
+    csrfMock.mockReset()
   })
 
   it('attaches CSRF token on POST requests when cookie present', () => {
-    document.cookie = 'csrf_token=test-csrf-token'
     const fulfilled = getRequestInterceptor()
     const result = fulfilled({ method: 'post', headers: {} }) as { headers: Record<string, string> }
     expect(result.headers['X-CSRF-Token']).toBe('test-csrf-token')
   })
 
   it('attaches CSRF token on PUT requests when cookie present', () => {
-    document.cookie = 'csrf_token=test-csrf-token'
     const fulfilled = getRequestInterceptor()
     const result = fulfilled({ method: 'put', headers: {} }) as { headers: Record<string, string> }
     expect(result.headers['X-CSRF-Token']).toBe('test-csrf-token')
   })
 
   it('attaches CSRF token on PATCH requests when cookie present', () => {
-    document.cookie = 'csrf_token=test-csrf-token'
     const fulfilled = getRequestInterceptor()
     const result = fulfilled({ method: 'patch', headers: {} }) as { headers: Record<string, string> }
     expect(result.headers['X-CSRF-Token']).toBe('test-csrf-token')
   })
 
   it('attaches CSRF token on DELETE requests when cookie present', () => {
-    document.cookie = 'csrf_token=test-csrf-token'
     const fulfilled = getRequestInterceptor()
     const result = fulfilled({ method: 'delete', headers: {} }) as { headers: Record<string, string> }
     expect(result.headers['X-CSRF-Token']).toBe('test-csrf-token')
   })
 
   it('does not attach CSRF token on GET requests', () => {
-    document.cookie = 'csrf_token=test-csrf-token'
     const fulfilled = getRequestInterceptor()
     const result = fulfilled({ method: 'get', headers: {} }) as { headers: Record<string, string> }
     expect(result.headers['X-CSRF-Token']).toBeUndefined()
   })
 
   it('does not attach CSRF token when cookie is absent', () => {
+    csrfMock.mockReturnValue(null)
     const fulfilled = getRequestInterceptor()
     const result = fulfilled({ method: 'post', headers: {} }) as { headers: Record<string, string> }
     expect(result.headers['X-CSRF-Token']).toBeUndefined()

--- a/web/src/__tests__/api/client.test.ts
+++ b/web/src/__tests__/api/client.test.ts
@@ -191,7 +191,14 @@ function getRequestInterceptor(): (config: Record<string, unknown>) => Record<st
 // tough-cookie backed `document.cookie` setter creates a Promise via
 // `createPromiseCallback` that leaks past test teardown under
 // --detect-async-leaks. Mocking the reader is a narrower, leak-free path
-// to the same coverage.
+// to the interceptor's behavior; the cookie-parsing logic inside
+// `csrf.ts` itself is covered directly by `__tests__/utils/csrf.test.ts`.
+// Compile-time guard: if `@/utils/csrf` gains new exports, the type
+// import below will error until this mock is extended.
+import type * as CsrfModule from '@/utils/csrf'
+type CsrfExports = keyof typeof CsrfModule
+const _csrfMockExports: Record<CsrfExports, unknown> = { getCsrfToken: true }
+void _csrfMockExports
 vi.mock('@/utils/csrf', () => ({
   getCsrfToken: vi.fn(),
 }))
@@ -267,5 +274,50 @@ describe('apiClient 401 response interceptor', () => {
     )
 
     await expect(apiClient.interceptors.response.handlers?.[0]?.rejected?.(error)).rejects.toBeDefined()
+  })
+
+  it('flips auth to unauthenticated on 401 (integration)', async () => {
+    const { AxiosError } = await import('axios')
+    const { useAuthStore } = await import('@/stores/auth')
+
+    // Seed an authenticated session so we can observe the flip.
+    useAuthStore.setState({
+      authStatus: 'authenticated',
+      user: {
+        id: '1',
+        username: 'admin',
+        role: 'ceo',
+        must_change_password: false,
+        org_roles: [],
+        scoped_departments: [],
+      },
+      loading: false,
+    })
+
+    const error = new AxiosError(
+      'Unauthorized',
+      'ERR_BAD_RESPONSE',
+      undefined,
+      undefined,
+      {
+        status: 401,
+        data: {},
+        headers: {},
+        statusText: 'Unauthorized',
+        config: {} as AxiosResponse['config'],
+      } as AxiosResponse,
+    )
+
+    // The interceptor re-throws after triggering handleUnauthorized.
+    await expect(
+      apiClient.interceptors.response.handlers?.[0]?.rejected?.(error),
+    ).rejects.toBeDefined()
+
+    // Dynamic import chain inside the interceptor resolves on a microtask;
+    // wait for the flip rather than assuming synchronous execution.
+    await vi.waitFor(() => {
+      expect(useAuthStore.getState().authStatus).toBe('unauthenticated')
+      expect(useAuthStore.getState().user).toBeNull()
+    })
   })
 })

--- a/web/src/__tests__/components/layout/Sidebar.test.tsx
+++ b/web/src/__tests__/components/layout/Sidebar.test.tsx
@@ -1,5 +1,6 @@
 import { act, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import fc from 'fast-check'
 import { useAuthStore } from '@/stores/auth'
 import { useThemeStore } from '@/stores/theme'
 import { Sidebar } from '@/components/layout/Sidebar'
@@ -335,12 +336,14 @@ describe('Sidebar', () => {
       expect(onOverlayClose).toHaveBeenCalledOnce()
     })
 
-    // Property: navigating to any different static route while overlay is open triggers exactly one close.
     // Each iteration mounts a tablet-sized Sidebar with a Base UI Drawer; the Drawer's
     // `useTransitionStatus` schedules requestAnimationFrame callbacks (jsdom emulates rAF via
-    // setInterval) that leak past unmount under `--detect-async-leaks`. Using `it.each` instead of
-    // fast-check lets us cover every static route deterministically while keeping iteration count
-    // low enough that any residual rAF handle is flushed within the 15s test budget.
+    // setInterval) that would previously leak past unmount under `--detect-async-leaks`.
+    // The rAF shim in `test-setup.tsx` keeps these tests leak-free.
+    //
+    // Coverage strategy: `it.each` enumerates every route exactly once (deterministic coverage,
+    // stable CI timing), and a low-iteration `fast-check` property test shuffles ordering to
+    // catch cross-render state leaks that a fixed order would miss.
     const staticRoutes = Object.values(ROUTES).filter((r) => !r.includes(':') && r !== '/')
     it.each(staticRoutes)(
       'close-on-navigate fires exactly once when navigating to %s',
@@ -350,6 +353,26 @@ describe('Sidebar', () => {
         await act(() => router.navigate(route))
         expect(onOverlayClose).toHaveBeenCalledOnce()
         unmount()
+      },
+    )
+
+    it(
+      'close-on-navigate is independent of route order (property)',
+      { timeout: 15_000 },
+      async () => {
+        await fc.assert(
+          fc.asyncProperty(
+            fc.constantFrom(...staticRoutes),
+            async (route) => {
+              const onOverlayClose = vi.fn()
+              const { router, unmount } = setupTablet(true, onOverlayClose)
+              await act(() => router.navigate(route))
+              expect(onOverlayClose).toHaveBeenCalledOnce()
+              unmount()
+            },
+          ),
+          { numRuns: 10 },
+        )
       },
     )
   })

--- a/web/src/__tests__/components/layout/Sidebar.test.tsx
+++ b/web/src/__tests__/components/layout/Sidebar.test.tsx
@@ -356,19 +356,33 @@ describe('Sidebar', () => {
       },
     )
 
+    // Permutation coverage: each iteration navigates a random ordered subset
+    // of routes inside the SAME Drawer mount. The subset size is bounded
+    // (max 3) because React Router's `navigate` schedules a setImmediate
+    // per call that only drains on unmount -- sweeping every route inside
+    // one iteration would tip the test over the --detect-async-leaks
+    // threshold. 3 routes per iteration x 10 runs gives 30 ordered-pair
+    // navigations per CI run, which is enough to exercise cross-render
+    // state leaks without reintroducing the leak this PR is fixing.
+    const PERMUTATION_SIZE = Math.min(3, staticRoutes.length)
     it(
       'close-on-navigate is independent of route order (property)',
       { timeout: 15_000 },
       async () => {
         await fc.assert(
           fc.asyncProperty(
-            fc.constantFrom(...staticRoutes),
-            async (route) => {
-              const onOverlayClose = vi.fn()
-              const { router, unmount } = setupTablet(true, onOverlayClose)
-              await act(() => router.navigate(route))
-              expect(onOverlayClose).toHaveBeenCalledOnce()
-              unmount()
+            fc.shuffledSubarray(staticRoutes, {
+              minLength: PERMUTATION_SIZE,
+              maxLength: PERMUTATION_SIZE,
+            }),
+            async (routesInRandomOrder) => {
+              for (const route of routesInRandomOrder) {
+                const onOverlayClose = vi.fn()
+                const { router, unmount } = setupTablet(true, onOverlayClose)
+                await act(() => router.navigate(route))
+                expect(onOverlayClose).toHaveBeenCalledOnce()
+                unmount()
+              }
             },
           ),
           { numRuns: 10 },

--- a/web/src/__tests__/components/layout/Sidebar.test.tsx
+++ b/web/src/__tests__/components/layout/Sidebar.test.tsx
@@ -1,6 +1,5 @@
 import { act, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import fc from 'fast-check'
 import { useAuthStore } from '@/stores/auth'
 import { useThemeStore } from '@/stores/theme'
 import { Sidebar } from '@/components/layout/Sidebar'
@@ -336,18 +335,22 @@ describe('Sidebar', () => {
       expect(onOverlayClose).toHaveBeenCalledOnce()
     })
 
-    // Property: navigating to any different static route while overlay is open triggers exactly one close
+    // Property: navigating to any different static route while overlay is open triggers exactly one close.
+    // Each iteration mounts a tablet-sized Sidebar with a Base UI Drawer; the Drawer's
+    // `useTransitionStatus` schedules requestAnimationFrame callbacks (jsdom emulates rAF via
+    // setInterval) that leak past unmount under `--detect-async-leaks`. Using `it.each` instead of
+    // fast-check lets us cover every static route deterministically while keeping iteration count
+    // low enough that any residual rAF handle is flushed within the 15s test budget.
     const staticRoutes = Object.values(ROUTES).filter((r) => !r.includes(':') && r !== '/')
-    it('close-on-navigate fires exactly once for any static route (property)', { timeout: 15000 }, async () => {
-      await fc.assert(
-        fc.asyncProperty(fc.constantFrom(...staticRoutes), async (route) => {
-          const onOverlayClose = vi.fn()
-          const { router, unmount } = setupTablet(true, onOverlayClose)
-          await act(() => router.navigate(route))
-          expect(onOverlayClose).toHaveBeenCalledOnce()
-          unmount()
-        }),
-      )
-    })
+    it.each(staticRoutes)(
+      'close-on-navigate fires exactly once when navigating to %s',
+      async (route) => {
+        const onOverlayClose = vi.fn()
+        const { router, unmount } = setupTablet(true, onOverlayClose)
+        await act(() => router.navigate(route))
+        expect(onOverlayClose).toHaveBeenCalledOnce()
+        unmount()
+      },
+    )
   })
 })

--- a/web/src/__tests__/components/layout/Sidebar.test.tsx
+++ b/web/src/__tests__/components/layout/Sidebar.test.tsx
@@ -356,14 +356,20 @@ describe('Sidebar', () => {
       },
     )
 
-    // Permutation coverage: each iteration navigates a random ordered subset
-    // of routes inside the SAME Drawer mount. The subset size is bounded
-    // (max 3) because React Router's `navigate` schedules a setImmediate
-    // per call that only drains on unmount -- sweeping every route inside
-    // one iteration would tip the test over the --detect-async-leaks
-    // threshold. 3 routes per iteration x 10 runs gives 30 ordered-pair
-    // navigations per CI run, which is enough to exercise cross-render
-    // state leaks without reintroducing the leak this PR is fixing.
+    // Permutation coverage: each iteration mounts ONE Drawer and navigates
+    // a random ordered subset of routes through it, so route-order
+    // interactions on a shared component instance are actually exercised
+    // (not masked by per-iteration remount). Cumulative call assertions
+    // (toHaveBeenCalledTimes(index + 1)) verify every navigation fires
+    // close-on-navigate rather than just the last one.
+    //
+    // The subset size is bounded (max 3) because React Router's `navigate`
+    // schedules a setImmediate per call that only drains on unmount --
+    // sweeping every route inside one mount would tip the test over the
+    // --detect-async-leaks threshold. 3 routes per iteration x 10 runs
+    // gives 30 ordered-pair navigations per CI run, which is enough to
+    // exercise cross-render state leaks without reintroducing the leak
+    // this PR is fixing.
     const PERMUTATION_SIZE = Math.min(3, staticRoutes.length)
     it(
       'close-on-navigate is independent of route order (property)',
@@ -376,11 +382,14 @@ describe('Sidebar', () => {
               maxLength: PERMUTATION_SIZE,
             }),
             async (routesInRandomOrder) => {
-              for (const route of routesInRandomOrder) {
-                const onOverlayClose = vi.fn()
-                const { router, unmount } = setupTablet(true, onOverlayClose)
-                await act(() => router.navigate(route))
-                expect(onOverlayClose).toHaveBeenCalledOnce()
+              const onOverlayClose = vi.fn()
+              const { router, unmount } = setupTablet(true, onOverlayClose)
+              try {
+                for (const [index, route] of routesInRandomOrder.entries()) {
+                  await act(() => router.navigate(route))
+                  expect(onOverlayClose).toHaveBeenCalledTimes(index + 1)
+                }
+              } finally {
                 unmount()
               }
             },

--- a/web/src/__tests__/hooks/usePolling.test.ts
+++ b/web/src/__tests__/hooks/usePolling.test.ts
@@ -146,6 +146,15 @@ describe('usePolling', () => {
 
     // setTimeout-based scheduling prevents overlap
     expect(maxConcurrent).toBeLessThanOrEqual(1)
+
+    // Stop polling and let any in-flight fn() settle so its internal
+    // setTimeout(r, 2000) Promise resolves before teardown.  Without
+    // this, the pending fake-timer-backed promise leaks past the test
+    // boundary under `--detect-async-leaks`.
+    await act(async () => {
+      result.current.stop()
+      await vi.advanceTimersByTimeAsync(5000)
+    })
   })
 
   it('ignores duplicate start calls', async () => {

--- a/web/src/__tests__/pages/AgentDetailPage.test.tsx
+++ b/web/src/__tests__/pages/AgentDetailPage.test.tsx
@@ -39,6 +39,12 @@ vi.mock('@/pages/agents/ActivityLog', () => ({
 vi.mock('@/pages/agents/TrainingSection', () => ({
   TrainingSection: () => <div data-testid="training-section" />,
 }))
+// QualityScoreOverride fires a `getQualityOverride` axios GET in a
+// useEffect on mount. Without a mock the request hits the real client,
+// UNDICI leaks the pending fetch past teardown.
+vi.mock('@/pages/agents/QualityScoreOverride', () => ({
+  QualityScoreOverride: () => <div data-testid="quality-score-override" />,
+}))
 
 
 const defaultHookReturn: UseAgentDetailDataReturn = {

--- a/web/src/__tests__/pages/LoginPage.test.tsx
+++ b/web/src/__tests__/pages/LoginPage.test.tsx
@@ -282,8 +282,15 @@ describe('LoginPage', () => {
 
   it('disables inputs during submission', async () => {
     mockGetSetupStatus.mockResolvedValue(setupStatusResponse())
-    // Never resolves -- stays in submitting state.
-    mockLogin.mockReturnValue(new Promise(() => {}))
+    // Deferred promise rather than ``new Promise(() => {})`` so
+    // --detect-async-leaks doesn't flag the intentionally-pending
+    // submission state as a leak: we resolve it at the end of the
+    // test so the login store's promise chain settles before teardown.
+    let resolveLogin: () => void
+    const loginDeferred = new Promise<void>((resolve) => {
+      resolveLogin = resolve
+    })
+    mockLogin.mockReturnValue(loginDeferred)
     const user = userEvent.setup()
 
     renderLogin()
@@ -298,6 +305,11 @@ describe('LoginPage', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Signing In...' })).toBeDisabled()
     })
+
+    // Settle the deferred so the in-flight login promise resolves
+    // before the worker tears down.
+    resolveLogin!()
+    await loginDeferred
   })
 
   it('shows lockout warning when locked', async () => {

--- a/web/src/__tests__/pages/LoginPage.test.tsx
+++ b/web/src/__tests__/pages/LoginPage.test.tsx
@@ -73,7 +73,7 @@ describe('LoginPage', () => {
     // pending state as a leak: the assertion runs while the promise
     // is still pending, then we resolve + await it in teardown so
     // no promise outlives the test.
-    let resolveSetup: (value: ReturnType<typeof setupStatusResponse>) => void
+    let resolveSetup: ((value: ReturnType<typeof setupStatusResponse>) => void) | undefined
     const deferred = new Promise<ReturnType<typeof setupStatusResponse>>(
       (resolve) => {
         resolveSetup = resolve
@@ -82,7 +82,8 @@ describe('LoginPage', () => {
     mockGetSetupStatus.mockReturnValue(deferred)
     renderLogin()
     expect(screen.getByText('Checking setup status...')).toBeInTheDocument()
-    resolveSetup!(setupStatusResponse({ needs_admin: false }))
+    if (!resolveSetup) throw new Error('deferred resolver was never assigned')
+    resolveSetup(setupStatusResponse({ needs_admin: false }))
     await waitFor(() => {
       expect(
         screen.queryByText('Checking setup status...'),
@@ -286,7 +287,7 @@ describe('LoginPage', () => {
     // --detect-async-leaks doesn't flag the intentionally-pending
     // submission state as a leak: we resolve it at the end of the
     // test so the login store's promise chain settles before teardown.
-    let resolveLogin: () => void
+    let resolveLogin: (() => void) | undefined
     const loginDeferred = new Promise<void>((resolve) => {
       resolveLogin = resolve
     })
@@ -308,7 +309,8 @@ describe('LoginPage', () => {
 
     // Settle the deferred so the in-flight login promise resolves
     // before the worker tears down.
-    resolveLogin!()
+    if (!resolveLogin) throw new Error('deferred resolver was never assigned')
+    resolveLogin()
     await loginDeferred
   })
 
@@ -341,6 +343,57 @@ describe('LoginPage', () => {
 
     await waitFor(() => {
       expect(mockLogin).toHaveBeenCalledWith('admin', 'secret123456')
+    })
+  })
+
+  describe('XSS safety', () => {
+    const XSS_PAYLOAD = '<script>window.__xss_fired__ = true</script>'
+
+    beforeEach(() => {
+      // Remove the flag in case a prior test set it.
+      delete (globalThis as { __xss_fired__?: boolean }).__xss_fired__
+    })
+
+    it('renders username input as text, not executable HTML', async () => {
+      mockGetSetupStatus.mockResolvedValue(setupStatusResponse())
+      const user = userEvent.setup()
+
+      renderLogin()
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: 'Sign In' })).toBeInTheDocument()
+      })
+
+      const username = screen.getByLabelText('Username') as HTMLInputElement
+      await user.type(username, XSS_PAYLOAD)
+
+      // The input `value` preserves the payload as a literal string.
+      expect(username.value).toBe(XSS_PAYLOAD)
+      // No script element was added to the DOM.
+      expect(document.querySelector('script[data-xss], body script')).toBeNull()
+      // The payload did not execute in the test realm.
+      expect((globalThis as { __xss_fired__?: boolean }).__xss_fired__).toBeUndefined()
+    })
+
+    it('forwards XSS payload to the login action as a plain string', async () => {
+      mockGetSetupStatus.mockResolvedValue(setupStatusResponse())
+      mockLogin.mockResolvedValue(undefined)
+      const user = userEvent.setup()
+
+      renderLogin()
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: 'Sign In' })).toBeInTheDocument()
+      })
+
+      await user.type(screen.getByLabelText('Username'), XSS_PAYLOAD)
+      await user.type(screen.getByLabelText('Password'), 'password12345')
+      await user.click(screen.getByRole('button', { name: 'Sign In' }))
+
+      await waitFor(() => {
+        expect(mockLogin).toHaveBeenCalledWith(XSS_PAYLOAD, 'password12345')
+      })
+
+      // The payload was never executed as HTML during render.
+      expect((globalThis as { __xss_fired__?: boolean }).__xss_fired__).toBeUndefined()
     })
   })
 })

--- a/web/src/__tests__/pages/TaskDetailPage.test.tsx
+++ b/web/src/__tests__/pages/TaskDetailPage.test.tsx
@@ -67,21 +67,38 @@ async function renderDetailPage() {
 }
 
 describe('TaskDetailPage', () => {
+  // Controllable pending promises let loading-state tests simulate an
+  // in-flight fetch without leaving a never-settled promise past teardown.
+  // Each test appends its pending resolver to this list; afterEach
+  // resolves them all so --detect-async-leaks sees a clean slate.
+  const pendingResolvers: Array<() => void> = []
+  function pendingPromise<T>(): Promise<T> {
+    return new Promise<T>((resolve) => {
+      pendingResolvers.push(() => resolve(undefined as T))
+    })
+  }
+
   beforeEach(() => {
     resetStore()
     vi.clearAllMocks()
     mockGetTask.mockResolvedValue(mockTask)
   })
 
+  afterEach(() => {
+    while (pendingResolvers.length > 0) {
+      pendingResolvers.pop()?.()
+    }
+  })
+
   it('renders loading spinner when loadingDetail is true', async () => {
-    mockGetTask.mockReturnValue(new Promise(() => {}))
+    mockGetTask.mockReturnValue(pendingPromise())
     resetStore({ loadingDetail: true })
     await renderDetailPage()
     expect(screen.queryByText('Test task')).not.toBeInTheDocument()
   })
 
   it('renders loading spinner when task is null', async () => {
-    mockGetTask.mockReturnValue(new Promise(() => {}))
+    mockGetTask.mockReturnValue(pendingPromise())
     resetStore({ selectedTask: null, loadingDetail: false })
     await renderDetailPage()
     // Should show spinner since task is null (fetch is pending)

--- a/web/src/__tests__/pages/TaskDetailPage.test.tsx
+++ b/web/src/__tests__/pages/TaskDetailPage.test.tsx
@@ -106,6 +106,11 @@ describe('TaskDetailPage', () => {
     mockGetTask.mockReturnValue(pendingPromise())
     resetStore({ loadingDetail: true })
     await renderDetailPage()
+    // Positive assertion: the loading UI (role="status", aria-label="Loading task")
+    // must be rendered. Asserting presence -- not just absence of the loaded
+    // content -- catches regressions where the page renders nothing or an
+    // error state instead of the spinner.
+    expect(screen.getByRole('status', { name: 'Loading task' })).toBeInTheDocument()
     expect(screen.queryByText('Test task')).not.toBeInTheDocument()
   })
 
@@ -113,7 +118,7 @@ describe('TaskDetailPage', () => {
     mockGetTask.mockReturnValue(pendingPromise())
     resetStore({ selectedTask: null, loadingDetail: false })
     await renderDetailPage()
-    // Should show spinner since task is null (fetch is pending)
+    expect(screen.getByRole('status', { name: 'Loading task' })).toBeInTheDocument()
     expect(screen.queryByText('Test task')).not.toBeInTheDocument()
   })
 

--- a/web/src/__tests__/pages/TaskDetailPage.test.tsx
+++ b/web/src/__tests__/pages/TaskDetailPage.test.tsx
@@ -69,13 +69,20 @@ async function renderDetailPage() {
 describe('TaskDetailPage', () => {
   // Controllable pending promises let loading-state tests simulate an
   // in-flight fetch without leaving a never-settled promise past teardown.
-  // Each test appends its pending resolver to this list; afterEach
-  // resolves them all so --detect-async-leaks sees a clean slate.
-  const pendingResolvers: Array<() => void> = []
-  function pendingPromise<T>(): Promise<T> {
-    return new Promise<T>((resolve) => {
-      pendingResolvers.push(() => resolve(undefined as T))
+  // Each test appends its pending promise to this list; afterEach resolves
+  // every pending promise with a valid `mockTask` (never `undefined`, which
+  // would drive the real `fetchTask` continuation to set `selectedTask =
+  // undefined` and cross-test-interfere with the next test) and then awaits
+  // the microtask chain so the continuation settles before the test
+  // boundary -- --detect-async-leaks sees a clean slate either way.
+  const pendingPromises: Array<{ resolve: () => void; settled: Promise<unknown> }> = []
+  function pendingPromise<T>(resolveValue: T = mockTask as T): Promise<T> {
+    let resolveFn!: (value: T) => void
+    const p = new Promise<T>((resolve) => {
+      resolveFn = resolve
     })
+    pendingPromises.push({ resolve: () => resolveFn(resolveValue), settled: p })
+    return p
   }
 
   beforeEach(() => {
@@ -84,10 +91,15 @@ describe('TaskDetailPage', () => {
     mockGetTask.mockResolvedValue(mockTask)
   })
 
-  afterEach(() => {
-    while (pendingResolvers.length > 0) {
-      pendingResolvers.pop()?.()
+  afterEach(async () => {
+    const outstanding = pendingPromises.splice(0, pendingPromises.length)
+    for (const { resolve } of outstanding) {
+      resolve()
     }
+    // Await each promise so its continuation runs inside the test boundary
+    // (otherwise the microtask could land in the next test's beforeEach
+    // and briefly set invalid store state before resetStore wipes it).
+    await Promise.all(outstanding.map((p) => p.settled))
   })
 
   it('renders loading spinner when loadingDetail is true', async () => {

--- a/web/src/__tests__/stores/auth.test.ts
+++ b/web/src/__tests__/stores/auth.test.ts
@@ -15,10 +15,12 @@ vi.mock('@/api/endpoints/auth', () => ({
 
 // `handleUnauthorized` dynamically imports `@/stores/websocket` and calls
 // `disconnect()`. Without a mock, the dynamic import + `.then().catch()`
-// chain outlives the test body and leaks as PROMISEs. Stub the module.
+// chain outlives the test body and leaks as PROMISEs. Stub the module
+// with a stable spy so tests can assert `disconnect` was called.
+const mockDisconnect = vi.fn()
 vi.mock('@/stores/websocket', () => ({
   useWebSocketStore: {
-    getState: () => ({ disconnect: vi.fn() }),
+    getState: () => ({ disconnect: mockDisconnect }),
   },
 }))
 
@@ -75,6 +77,19 @@ describe('auth store', () => {
 
       expect(useAuthStore.getState().authStatus).toBe('unauthenticated')
       expect(useAuthStore.getState().user).toBeNull()
+    })
+
+    it('tears down the WebSocket transport', async () => {
+      const { vi: viLocal } = await import('vitest')
+      useAuthStore.setState({ authStatus: 'authenticated', user: mockUser })
+
+      useAuthStore.getState().handleUnauthorized()
+
+      // `handleUnauthorized` uses a dynamic import + .then() to call
+      // disconnect. Wait for the chain to resolve before asserting.
+      await viLocal.waitFor(() => {
+        expect(mockDisconnect).toHaveBeenCalled()
+      })
     })
 
     it('redirects to /login when not already there', () => {

--- a/web/src/__tests__/stores/auth.test.ts
+++ b/web/src/__tests__/stores/auth.test.ts
@@ -13,6 +13,15 @@ vi.mock('@/api/endpoints/auth', () => ({
   changePassword: vi.fn(),
 }))
 
+// `handleUnauthorized` dynamically imports `@/stores/websocket` and calls
+// `disconnect()`. Without a mock, the dynamic import + `.then().catch()`
+// chain outlives the test body and leaks as PROMISEs. Stub the module.
+vi.mock('@/stores/websocket', () => ({
+  useWebSocketStore: {
+    getState: () => ({ disconnect: vi.fn() }),
+  },
+}))
+
 // Prevent actual navigation in tests
 const originalLocation = window.location
 beforeAll(() => {

--- a/web/src/__tests__/stores/notifications.test.ts
+++ b/web/src/__tests__/stores/notifications.test.ts
@@ -1,0 +1,146 @@
+import { useNotificationsStore, cancelPendingPersist } from '@/stores/notifications'
+import type { WsEvent } from '@/api/types'
+
+/**
+ * Focused unit tests for the module-level `cancelPendingPersist` helper.
+ *
+ * `notifications.ts` debounces localStorage persistence with a 300ms
+ * `setTimeout`. Tests that enqueue notifications but finish before the
+ * debounce elapses would otherwise leak the pending timer past the test
+ * boundary and trip vitest --detect-async-leaks. `cancelPendingPersist`
+ * drops the pending handle without flushing; the global `afterEach` in
+ * `test-setup.tsx` calls it unconditionally.
+ */
+describe('cancelPendingPersist', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    useNotificationsStore.getState().clearAll()
+    localStorage.clear()
+    // Invoking clearAll() can itself schedule a persist timer; cancel it
+    // so every test starts from a deterministic no-timer baseline.
+    cancelPendingPersist()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('suppresses the pending persist after an enqueue', () => {
+    useNotificationsStore.getState().enqueue({
+      category: 'approvals.pending',
+      title: 'Pending work item',
+    })
+
+    // Baseline: without cancellation the debounce would fire after 300ms
+    // and write to localStorage.
+    cancelPendingPersist()
+
+    vi.advanceTimersByTime(5_000)
+
+    expect(localStorage.getItem('so_notifications')).toBeNull()
+  })
+
+  it('is a no-op when no timer is pending', () => {
+    // Called at a clean slate -- must not throw.
+    expect(() => cancelPendingPersist()).not.toThrow()
+    cancelPendingPersist()
+    cancelPendingPersist()
+  })
+
+  it('does not prevent a follow-up persist from being scheduled', () => {
+    useNotificationsStore.getState().enqueue({
+      category: 'approvals.pending',
+      title: 'First',
+    })
+    cancelPendingPersist()
+
+    // A subsequent enqueue must still schedule its own persist.
+    useNotificationsStore.getState().enqueue({
+      category: 'approvals.pending',
+      title: 'Second',
+    })
+
+    vi.advanceTimersByTime(400)
+
+    const persisted = localStorage.getItem('so_notifications')
+    expect(persisted).not.toBeNull()
+    const parsed = JSON.parse(persisted!) as Array<{ title: string }>
+    const titles = parsed.map((i) => i.title)
+    expect(titles).toContain('Second')
+  })
+})
+
+describe('handleWsEvent payload sanitization', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    useNotificationsStore.getState().clearAll()
+    localStorage.clear()
+    cancelPendingPersist()
+  })
+
+  function makeEvent(eventType: string, payload: Record<string, unknown>): WsEvent {
+    return {
+      event_type: eventType,
+      payload,
+      timestamp: new Date().toISOString(),
+    } as WsEvent
+  }
+
+  it('strips C0 control characters from description fields', () => {
+    useNotificationsStore.getState().handleWsEvent(
+      makeEvent('approval.submitted', {
+        approval_id: 'a-1',
+        title: 'Normal\u0000title\u001Bwith\u0007controls',
+      }),
+    )
+
+    const items = useNotificationsStore.getState().items
+    expect(items).toHaveLength(1)
+    expect(items[0]!.description).toBe('Normaltitlewithcontrols')
+  })
+
+  it('strips bidi-override characters from description fields', () => {
+    useNotificationsStore.getState().handleWsEvent(
+      makeEvent('system.error', {
+        message: '\u202EHidden reversal payload\u202C hidden',
+      }),
+    )
+
+    const items = useNotificationsStore.getState().items
+    expect(items).toHaveLength(1)
+    expect(items[0]!.description).toBe('Hidden reversal payload hidden')
+  })
+
+  it('clamps description length to 128 characters', () => {
+    const huge = 'x'.repeat(500)
+    useNotificationsStore.getState().handleWsEvent(
+      makeEvent('system.error', { message: huge }),
+    )
+
+    const items = useNotificationsStore.getState().items
+    expect(items).toHaveLength(1)
+    expect(items[0]!.description).toHaveLength(128)
+  })
+
+  it('returns undefined for non-string payload fields (type guard)', () => {
+    useNotificationsStore.getState().handleWsEvent(
+      makeEvent('system.error', {
+        message: { nested: 'object' },
+      }),
+    )
+
+    const items = useNotificationsStore.getState().items
+    expect(items).toHaveLength(1)
+    expect(items[0]!.description).toBeUndefined()
+  })
+
+  it('treats whitespace-only strings as absent to avoid blank descriptions', () => {
+    useNotificationsStore.getState().handleWsEvent(
+      makeEvent('system.error', { message: '   \n\t  ' }),
+    )
+
+    const items = useNotificationsStore.getState().items
+    expect(items).toHaveLength(1)
+    expect(items[0]!.description).toBeUndefined()
+  })
+})

--- a/web/src/__tests__/stores/notifications.test.ts
+++ b/web/src/__tests__/stores/notifications.test.ts
@@ -143,4 +143,39 @@ describe('handleWsEvent payload sanitization', () => {
     expect(items).toHaveLength(1)
     expect(items[0]!.description).toBeUndefined()
   })
+
+  it('preserves common whitespace (TAB, LF, CR) in multi-line messages', () => {
+    useNotificationsStore.getState().handleWsEvent(
+      makeEvent('system.error', {
+        message: 'line1\nline2\r\nindented:\tvalue',
+      }),
+    )
+
+    const items = useNotificationsStore.getState().items
+    expect(items).toHaveLength(1)
+    // Whitespace in the interior survives; leading/trailing trim still applies
+    // (none in this input).
+    expect(items[0]!.description).toBe('line1\nline2\r\nindented:\tvalue')
+  })
+
+  it('truncates at code-point boundaries so surrogate pairs are not split', () => {
+    // Each "🌟" is a 2-code-unit surrogate pair. 200 stars = 400 UTF-16 units
+    // (200 code points), well over the 128-code-point cap. Naive
+    // `.slice(0, 128)` would return 64 whole stars followed by a LONE HIGH
+    // SURROGATE from star #65 -- that lone surrogate serializes to U+FFFD
+    // and leaks a bad character into storage. The code-point-aware slice
+    // returns exactly 128 whole stars with no orphans.
+    const stars = '\u{1F31F}'.repeat(200)
+    useNotificationsStore.getState().handleWsEvent(
+      makeEvent('system.error', { message: stars }),
+    )
+
+    const items = useNotificationsStore.getState().items
+    expect(items).toHaveLength(1)
+    const description = items[0]!.description
+    expect(description).toBeDefined()
+    // Must contain exactly 128 whole emojis -- no more, no fewer, no lone surrogates.
+    expect([...description!]).toHaveLength(128)
+    expect([...description!].every((c) => c === '\u{1F31F}')).toBe(true)
+  })
 })

--- a/web/src/__tests__/stores/toast.test.ts
+++ b/web/src/__tests__/stores/toast.test.ts
@@ -52,6 +52,21 @@ describe('toast store', () => {
     expect(useToastStore.getState().toasts).toHaveLength(0)
   })
 
+  it('cancelAllPending() clears pending auto-dismiss timers but preserves toasts', () => {
+    useToastStore.getState().add({ variant: 'info', title: 'Keep me' })
+    useToastStore.getState().add({ variant: 'success', title: 'Keep me too' })
+    expect(useToastStore.getState().toasts).toHaveLength(2)
+
+    useToastStore.getState().cancelAllPending()
+
+    // Toasts remain in state -- only timers are cleared.
+    expect(useToastStore.getState().toasts).toHaveLength(2)
+
+    // Advancing past the longest auto-dismiss duration must not remove anything.
+    vi.advanceTimersByTime(60_000)
+    expect(useToastStore.getState().toasts).toHaveLength(2)
+  })
+
   it('auto-dismisses after default duration', () => {
     useToastStore.getState().add({ variant: 'info', title: 'Auto' })
     expect(useToastStore.getState().toasts).toHaveLength(1)

--- a/web/src/__tests__/utils/csrf.test.ts
+++ b/web/src/__tests__/utils/csrf.test.ts
@@ -1,0 +1,82 @@
+import { getCsrfToken } from '@/utils/csrf'
+
+/**
+ * Direct unit tests for the cookie-parsing path in `getCsrfToken`.
+ *
+ * The CSRF interceptor tests in `__tests__/api/client.test.ts` mock
+ * `getCsrfToken` to avoid jsdom's tough-cookie Promise leak when
+ * `document.cookie` is mutated. That leaves the cookie-parsing logic
+ * itself untested, so these tests exercise it directly by swapping
+ * `document.cookie` with a property-descriptor override -- no actual
+ * jsdom cookie-jar writes, no leaks.
+ */
+describe('getCsrfToken', () => {
+  let originalDescriptor: PropertyDescriptor | undefined
+
+  beforeAll(() => {
+    originalDescriptor = Object.getOwnPropertyDescriptor(
+      Document.prototype,
+      'cookie',
+    )
+  })
+
+  afterEach(() => {
+    if (originalDescriptor) {
+      Object.defineProperty(Document.prototype, 'cookie', originalDescriptor)
+    }
+  })
+
+  function mockCookie(value: string): void {
+    Object.defineProperty(Document.prototype, 'cookie', {
+      configurable: true,
+      get: () => value,
+    })
+  }
+
+  it('returns the token when csrf_token cookie is present', () => {
+    mockCookie('session=abc; csrf_token=xyz123; path=/')
+    expect(getCsrfToken()).toBe('xyz123')
+  })
+
+  it('returns the token when it is the only cookie', () => {
+    mockCookie('csrf_token=only-one')
+    expect(getCsrfToken()).toBe('only-one')
+  })
+
+  it('returns null when cookie jar is empty', () => {
+    mockCookie('')
+    expect(getCsrfToken()).toBeNull()
+  })
+
+  it('returns null when csrf_token cookie is absent', () => {
+    mockCookie('session=abc; other=value')
+    expect(getCsrfToken()).toBeNull()
+  })
+
+  it('trims surrounding whitespace around cookie entries', () => {
+    mockCookie('session=abc ;  csrf_token=spaced ; path=/')
+    expect(getCsrfToken()).toBe('spaced')
+  })
+
+  it('decodes URL-encoded token values', () => {
+    mockCookie('csrf_token=a%2Fb%3Fc%3Dd')
+    expect(getCsrfToken()).toBe('a/b?c=d')
+  })
+
+  it('returns null on malformed URL-encoded token', () => {
+    mockCookie('csrf_token=%FF%FF')
+    expect(getCsrfToken()).toBeNull()
+  })
+
+  it('returns empty string when token value is empty (indexOf returns valid position)', () => {
+    mockCookie('csrf_token=')
+    expect(getCsrfToken()).toBe('')
+  })
+
+  it('does not match a cookie whose name is a superstring of csrf_token', () => {
+    // ``csrf_token_other`` should not be treated as ``csrf_token``; the
+    // `startsWith('csrf_token=')` check enforces an exact-name match.
+    mockCookie('csrf_token_other=wrong; other=value')
+    expect(getCsrfToken()).toBeNull()
+  })
+})

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -102,7 +102,11 @@ export default function TaskDetailPage() {
 
   if (loadingDetail || !task) {
     return (
-      <div className="flex items-center justify-center py-20">
+      <div
+        className="flex items-center justify-center py-20"
+        role="status"
+        aria-label="Loading task"
+      >
         <Loader2 className="size-8 animate-spin text-text-muted" />
       </div>
     )

--- a/web/src/stores/notifications.ts
+++ b/web/src/stores/notifications.ts
@@ -164,6 +164,19 @@ function debouncedPersist(state: NotificationsState): void {
   }, PERSIST_DEBOUNCE_MS)
 }
 
+/**
+ * Clear the pending debounce timer without flushing. Intended for tests
+ * that enqueue notifications but finish before the persist interval
+ * elapses; without this the timer outlives the test boundary and vitest's
+ * --detect-async-leaks flags it.
+ */
+export function cancelPendingPersist(): void {
+  if (persistTimer !== null) {
+    clearTimeout(persistTimer)
+    persistTimer = null
+  }
+}
+
 function countUnread(items: readonly NotificationItem[]): number {
   return items.filter((i) => !i.read).length
 }

--- a/web/src/stores/notifications.ts
+++ b/web/src/stores/notifications.ts
@@ -191,9 +191,13 @@ const MAX_STRING_LEN = 128
  * non-presentational paths:
  *  - strips C0 controls and DELETE (U+0000..U+001F, U+007F) that would
  *    corrupt log lines, terminal output, and notification tooltips,
+ *    except the common whitespace set (TAB U+0009, LF U+000A, CR U+000D)
+ *    so multi-line messages retain their line structure,
  *  - strips bidi-override characters (U+202A..U+202E, U+2066..U+2069)
  *    that can flip on-screen token order in sensitive UI (CVE-2021-42574),
- *  - trims surrounding whitespace and caps length at `maxLen`.
+ *  - trims surrounding whitespace and caps length at `maxLen`. The length
+ *    cap iterates by Unicode code points so surrogate pairs (emojis, rare
+ *    CJK) are never split mid-character.
  *
  * Returns `undefined` for non-strings so callers can pass the result
  * directly into an optional field without widening the type.
@@ -202,11 +206,13 @@ function sanitizeWsString(value: unknown, maxLen: number = MAX_STRING_LEN): stri
   if (typeof value !== 'string') return undefined
   const stripped = value
     // eslint-disable-next-line no-control-regex
-    .replace(/[\u0000-\u001F\u007F]/g, '')
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '')
     .replace(/[\u202A-\u202E\u2066-\u2069]/g, '')
     .trim()
   if (stripped.length === 0) return undefined
-  return stripped.slice(0, maxLen)
+  const codePoints = [...stripped]
+  if (codePoints.length <= maxLen) return stripped
+  return codePoints.slice(0, maxLen).join('')
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/stores/notifications.ts
+++ b/web/src/stores/notifications.ts
@@ -181,6 +181,34 @@ function countUnread(items: readonly NotificationItem[]): number {
   return items.filter((i) => !i.read).length
 }
 
+const MAX_STRING_LEN = 128
+
+/**
+ * Clamp a WS-supplied string for safe storage and display.
+ *
+ * React escapes HTML at render time, so XSS via the default text path is
+ * already covered. This helper adds defense-in-depth for the
+ * non-presentational paths:
+ *  - strips C0 controls and DELETE (U+0000..U+001F, U+007F) that would
+ *    corrupt log lines, terminal output, and notification tooltips,
+ *  - strips bidi-override characters (U+202A..U+202E, U+2066..U+2069)
+ *    that can flip on-screen token order in sensitive UI (CVE-2021-42574),
+ *  - trims surrounding whitespace and caps length at `maxLen`.
+ *
+ * Returns `undefined` for non-strings so callers can pass the result
+ * directly into an optional field without widening the type.
+ */
+function sanitizeWsString(value: unknown, maxLen: number = MAX_STRING_LEN): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const stripped = value
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001F\u007F]/g, '')
+    .replace(/[\u202A-\u202E\u2066-\u2069]/g, '')
+    .trim()
+  if (stripped.length === 0) return undefined
+  return stripped.slice(0, maxLen)
+}
+
 // ---------------------------------------------------------------------------
 // Store
 // ---------------------------------------------------------------------------
@@ -395,9 +423,9 @@ export const useNotificationsStore = create<NotificationsState>()((set, get) => 
           enqueue({
             category: 'approvals.pending',
             title: 'Approval requested',
-            description: typeof payload.title === 'string' ? payload.title.slice(0, 128) : undefined,
+            description: sanitizeWsString(payload.title),
             href: typeof payload.approval_id === 'string' ? `/approvals` : undefined,
-            entityId: typeof payload.approval_id === 'string' ? payload.approval_id : undefined,
+            entityId: sanitizeWsString(payload.approval_id),
           })
           break
 
@@ -405,7 +433,7 @@ export const useNotificationsStore = create<NotificationsState>()((set, get) => 
           enqueue({
             category: 'approvals.expiring',
             title: 'Approval expiring',
-            entityId: typeof payload.approval_id === 'string' ? payload.approval_id : undefined,
+            entityId: sanitizeWsString(payload.approval_id),
           })
           break
 
@@ -413,7 +441,7 @@ export const useNotificationsStore = create<NotificationsState>()((set, get) => 
           enqueue({
             category: 'approvals.decided',
             title: 'Approval approved',
-            entityId: typeof payload.approval_id === 'string' ? payload.approval_id : undefined,
+            entityId: sanitizeWsString(payload.approval_id),
           })
           break
 
@@ -421,7 +449,7 @@ export const useNotificationsStore = create<NotificationsState>()((set, get) => 
           enqueue({
             category: 'approvals.decided',
             title: 'Approval rejected',
-            entityId: typeof payload.approval_id === 'string' ? payload.approval_id : undefined,
+            entityId: sanitizeWsString(payload.approval_id),
           })
           break
 
@@ -431,7 +459,7 @@ export const useNotificationsStore = create<NotificationsState>()((set, get) => 
           enqueue({
             category: isExhausted ? 'budget.exhausted' : 'budget.threshold',
             title: isExhausted ? 'Budget exhausted' : 'Budget threshold crossed',
-            description: typeof payload.message === 'string' ? payload.message.slice(0, 128) : undefined,
+            description: sanitizeWsString(payload.message),
             severity: isExhausted ? 'critical' : 'warning',
           })
           break
@@ -441,7 +469,7 @@ export const useNotificationsStore = create<NotificationsState>()((set, get) => 
           enqueue({
             category: 'system.error',
             title: 'System error',
-            description: typeof payload.message === 'string' ? payload.message.slice(0, 128) : undefined,
+            description: sanitizeWsString(payload.message),
           })
           break
 
@@ -452,23 +480,23 @@ export const useNotificationsStore = create<NotificationsState>()((set, get) => 
           })
           break
 
-        case 'personality.trimmed':
+        case 'personality.trimmed': {
+          const agentName = sanitizeWsString(payload.agent_name, 64)
           enqueue({
             category: 'agents.personality_trimmed',
             title: 'Personality trimmed',
-            description: typeof payload.agent_name === 'string'
-              ? `${payload.agent_name.slice(0, 64)} personality was trimmed`
-              : undefined,
-            entityId: typeof payload.agent_id === 'string' ? payload.agent_id : undefined,
+            description: agentName ? `${agentName} personality was trimmed` : undefined,
+            entityId: sanitizeWsString(payload.agent_id),
           })
           break
+        }
 
         case 'agent.hired':
           enqueue({
             category: 'agents.hired',
             title: 'Agent hired',
-            description: typeof payload.agent_name === 'string' ? payload.agent_name.slice(0, 64) : undefined,
-            entityId: typeof payload.agent_id === 'string' ? payload.agent_id : undefined,
+            description: sanitizeWsString(payload.agent_name, 64),
+            entityId: sanitizeWsString(payload.agent_id),
           })
           break
 
@@ -476,27 +504,29 @@ export const useNotificationsStore = create<NotificationsState>()((set, get) => 
           enqueue({
             category: 'agents.fired',
             title: 'Agent fired',
-            description: typeof payload.agent_name === 'string' ? payload.agent_name.slice(0, 64) : undefined,
-            entityId: typeof payload.agent_id === 'string' ? payload.agent_id : undefined,
+            description: sanitizeWsString(payload.agent_name, 64),
+            entityId: sanitizeWsString(payload.agent_id),
           })
           break
 
         case 'task.status_changed': {
           const status = typeof payload.status === 'string' ? payload.status : ''
+          const taskId = sanitizeWsString(payload.task_id)
+          const title = sanitizeWsString(payload.title)
           if (status === 'failed') {
             enqueue({
               category: 'tasks.failed',
               title: 'Task failed',
-              description: typeof payload.title === 'string' ? payload.title.slice(0, 128) : undefined,
-              entityId: typeof payload.task_id === 'string' ? payload.task_id : undefined,
-              href: typeof payload.task_id === 'string' ? `/tasks` : undefined,
+              description: title,
+              entityId: taskId,
+              href: taskId ? `/tasks` : undefined,
             })
           } else if (status === 'blocked') {
             enqueue({
               category: 'tasks.blocked',
               title: 'Task blocked',
-              description: typeof payload.title === 'string' ? payload.title.slice(0, 128) : undefined,
-              entityId: typeof payload.task_id === 'string' ? payload.task_id : undefined,
+              description: title,
+              entityId: taskId,
             })
           }
           break

--- a/web/src/stores/toast.ts
+++ b/web/src/stores/toast.ts
@@ -18,6 +18,13 @@ interface ToastState {
   add: (toast: Omit<ToastItem, 'id'>) => string
   dismiss: (id: string) => void
   dismissAll: () => void
+  /**
+   * Clear all pending auto-dismiss timers without mutating the toasts array.
+   * Intended for test teardown where the toast list is still needed for
+   * assertions but pending setTimeout handles would otherwise leak past the
+   * test boundary.
+   */
+  cancelAllPending: () => void
 }
 
 /** Variant-specific auto-dismiss durations. Warning/error are persistent (no auto-dismiss). */
@@ -79,5 +86,12 @@ export const useToastStore = create<ToastState>((set, get) => ({
     timers.clear()
 
     set({ toasts: [] })
+  },
+
+  cancelAllPending() {
+    for (const timer of timers.values()) {
+      clearTimeout(timer)
+    }
+    timers.clear()
   },
 }))

--- a/web/src/test-setup.ts
+++ b/web/src/test-setup.ts
@@ -1,1 +1,0 @@
-import '@testing-library/jest-dom/vitest'

--- a/web/src/test-setup.tsx
+++ b/web/src/test-setup.tsx
@@ -107,6 +107,13 @@ vi.mock('motion/react', async () => {
 // --detect-async-leaks flags it as a Timeout leak. Replace rAF with
 // `setTimeout(cb, 0)` so each frame is a discrete macrotask that drains
 // cleanly between tests.
+//
+// We intentionally do NOT drain pending rAF callbacks in the global
+// afterEach: d3-timer (used by d3-force in `pages/org/force-layout.ts`)
+// binds `setFrame` to our shim at module load time and relies on its
+// wake() callback firing to clear its internal `setInterval(poke)` after
+// `simulation.stop()`. Clearing the shim's setTimeout handles before
+// wake() can run strands that interval and reintroduces a leak.
 if (typeof window !== 'undefined') {
   const timers = new Set<ReturnType<typeof setTimeout>>()
   window.requestAnimationFrame = (callback: FrameRequestCallback): number => {

--- a/web/src/test-setup.tsx
+++ b/web/src/test-setup.tsx
@@ -23,10 +23,9 @@ vi.mock('@/api/endpoints/settings', async () => {
     getAllSettings: vi.fn().mockResolvedValue([]),
     getNamespaceSettings: vi.fn().mockResolvedValue([]),
     updateSetting: vi.fn().mockResolvedValue(undefined),
-    deleteSetting: vi.fn().mockResolvedValue(undefined),
-    restartServer: vi.fn().mockResolvedValue(undefined),
+    resetSetting: vi.fn().mockResolvedValue(undefined),
     listSinks: vi.fn().mockResolvedValue([]),
-    testSink: vi.fn().mockResolvedValue({ ok: true }),
+    testSinkConfig: vi.fn().mockResolvedValue({ ok: true }),
   }
 })
 
@@ -150,8 +149,10 @@ if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
 
 // Toast store schedules a `setTimeout` per auto-dismiss (success / info toasts
 // with a real timer). Without a global teardown hook these timers survive the
-// test boundary and vitest flags them as leaked. `cancelAllPending()` clears
-// the handles; resetting `toasts` keeps subsequent tests isolated.
+// test boundary and vitest flags them as leaked. `dismissAll()` clears both
+// the pending handles and the toasts array in one idiomatic call; tests that
+// need to inspect the toasts list after pending timers drain can instead call
+// `cancelAllPending()` directly in their own teardown.
 //
 // We run this in `afterEach` (not `beforeEach`) deliberately: the test body's
 // assertions on toast state complete *before* the afterEach fires, so
@@ -160,8 +161,7 @@ if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
 // still visible after a dialog closes) should inline its own assertion
 // within the test body, never rely on post-teardown state.
 afterEach(() => {
-  useToastStore.getState().cancelAllPending()
-  useToastStore.setState({ toasts: [] })
+  useToastStore.getState().dismissAll()
   // Notifications store debounces localStorage persistence with a 300ms
   // setTimeout; drop any pending handle so it does not outlive the test.
   cancelPendingPersist()

--- a/web/src/test-setup.tsx
+++ b/web/src/test-setup.tsx
@@ -152,6 +152,13 @@ if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
 // with a real timer). Without a global teardown hook these timers survive the
 // test boundary and vitest flags them as leaked. `cancelAllPending()` clears
 // the handles; resetting `toasts` keeps subsequent tests isolated.
+//
+// We run this in `afterEach` (not `beforeEach`) deliberately: the test body's
+// assertions on toast state complete *before* the afterEach fires, so
+// resetting here does not mask in-test assertions. A test that needs toast
+// state to persist across a teardown boundary (e.g. asserting a toast is
+// still visible after a dialog closes) should inline its own assertion
+// within the test body, never rely on post-teardown state.
 afterEach(() => {
   useToastStore.getState().cancelAllPending()
   useToastStore.setState({ toasts: [] })

--- a/web/src/test-setup.tsx
+++ b/web/src/test-setup.tsx
@@ -1,0 +1,161 @@
+import '@testing-library/jest-dom/vitest'
+import { createElement } from 'react'
+import type { ComponentProps, ReactNode, Ref } from 'react'
+import { afterEach, vi } from 'vitest'
+import { MotionGlobalConfig } from 'motion/react'
+import { useToastStore } from '@/stores/toast'
+import { cancelPendingPersist } from '@/stores/notifications'
+
+// AuthGuard calls `useSettingsStore.getState().fetchLocale()` from a
+// `useEffect` whenever the user becomes authenticated. Without a global
+// mock that call reaches the real axios client, returns 401 (no backend
+// in jsdom), and leaks as an UNDICI_REQUEST + PROMISE past test teardown.
+// Individual tests can still override these endpoints with their own
+// `vi.mock('@/api/endpoints/settings', ...)` call.
+vi.mock('@/api/endpoints/settings', async () => {
+  const actual = await vi.importActual<typeof import('@/api/endpoints/settings')>(
+    '@/api/endpoints/settings',
+  )
+  return {
+    ...actual,
+    getSchema: vi.fn().mockResolvedValue([]),
+    getNamespaceSchema: vi.fn().mockResolvedValue([]),
+    getAllSettings: vi.fn().mockResolvedValue([]),
+    getNamespaceSettings: vi.fn().mockResolvedValue([]),
+    updateSetting: vi.fn().mockResolvedValue(undefined),
+    deleteSetting: vi.fn().mockResolvedValue(undefined),
+    restartServer: vi.fn().mockResolvedValue(undefined),
+    listSinks: vi.fn().mockResolvedValue([]),
+    testSink: vi.fn().mockResolvedValue({ ok: true }),
+  }
+})
+
+// Short-circuit every Motion animation so framer-motion does not leave
+// `AnimationComplete` promise chains pending past test teardown. This is
+// the canonical test hook documented at https://motion.dev/docs/testing
+// and resolves animation promises instantly instead of via rAF.
+MotionGlobalConfig.skipAnimations = true
+
+// Even with `skipAnimations`, framer-motion still creates a Promise in
+// `MotionValue.start` and schedules its resolution through the next frame
+// (rAF, polyfilled by jsdom as setInterval). Under vitest with
+// `--detect-async-leaks` those promises are flagged. Replacing `motion.*`
+// with plain host elements and `AnimatePresence` with a passthrough removes
+// the animation code path entirely. Tests that assert on motion-specific
+// behavior can still opt out via their own `vi.mock('motion/react', ...)`.
+vi.mock('motion/react', async () => {
+  const actual = await vi.importActual<typeof import('motion/react')>('motion/react')
+
+  type MotionStubProps = ComponentProps<'div'> & {
+    ref?: Ref<HTMLElement>
+    children?: ReactNode
+  } & Record<string, unknown>
+
+  const MOTION_ONLY_PROPS = new Set([
+    'animate', 'initial', 'exit', 'transition', 'variants', 'whileHover',
+    'whileTap', 'whileFocus', 'whileDrag', 'whileInView', 'layout',
+    'layoutId', 'layoutDependency', 'layoutScroll', 'drag', 'dragConstraints',
+    'dragElastic', 'dragMomentum', 'dragTransition', 'dragSnapToOrigin',
+    'dragControls', 'dragListener', 'onAnimationStart', 'onAnimationComplete',
+    'onUpdate', 'onDragStart', 'onDrag', 'onDragEnd', 'onDirectionLock',
+    'onHoverStart', 'onHoverEnd', 'onTapStart', 'onTap', 'onTapCancel',
+    'onViewportEnter', 'onViewportLeave', 'viewport', 'custom', 'inherit',
+  ])
+
+  const makeMotionComponent = (tag: string) => {
+    return function MotionStub({ children, ref, style, ...rest }: MotionStubProps) {
+      const domProps: Record<string, unknown> = {}
+      for (const [key, value] of Object.entries(rest)) {
+        if (!MOTION_ONLY_PROPS.has(key)) domProps[key] = value
+      }
+      // Preserve plain-object style values; drop motion-value-backed entries.
+      const plainStyle =
+        style && typeof style === 'object'
+          ? Object.fromEntries(
+              Object.entries(style).filter(
+                ([, v]) =>
+                  v === null
+                  || ['string', 'number', 'boolean'].includes(typeof v),
+              ),
+            )
+          : undefined
+      return createElement(
+        tag,
+        { ref, style: plainStyle, ...domProps },
+        children,
+      )
+    }
+  }
+
+  const motionProxy = new Proxy({} as typeof actual.motion, {
+    get(_target, prop) {
+      if (typeof prop !== 'string') return undefined
+      return makeMotionComponent(prop)
+    },
+  })
+
+  return {
+    ...actual,
+    motion: motionProxy,
+    AnimatePresence: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  }
+})
+
+// jsdom polyfills `requestAnimationFrame` with a shared `setInterval` that
+// only clears when every registered callback has fired. Recharts's
+// `ZIndexPortal` registers rAF callbacks via @reduxjs/toolkit that keep
+// getting re-scheduled, so the interval outlives the test and
+// --detect-async-leaks flags it as a Timeout leak. Replace rAF with
+// `setTimeout(cb, 0)` so each frame is a discrete macrotask that drains
+// cleanly between tests.
+if (typeof window !== 'undefined') {
+  const timers = new Set<ReturnType<typeof setTimeout>>()
+  window.requestAnimationFrame = (callback: FrameRequestCallback): number => {
+    const handle = setTimeout(() => {
+      timers.delete(handle)
+      callback(performance.now())
+    }, 0)
+    timers.add(handle)
+    return handle as unknown as number
+  }
+  window.cancelAnimationFrame = (handle: number) => {
+    clearTimeout(handle as unknown as ReturnType<typeof setTimeout>)
+    timers.delete(handle as unknown as ReturnType<typeof setTimeout>)
+  }
+}
+
+// jsdom does not implement matchMedia; several components (the breakpoint
+// hook, the theme store, a few prefers-* consumers) call it during render.
+// Provide a no-op shim that reports `matches: false` for every query so the
+// default render path is used. Motion's animation short-circuit is handled
+// by the mock above; we explicitly do NOT force reduced-motion here because
+// hook tests (useFlash, useCountAnimation) pin their behavior to the
+// non-reduced branch.
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  })
+}
+
+// Toast store schedules a `setTimeout` per auto-dismiss (success / info toasts
+// with a real timer). Without a global teardown hook these timers survive the
+// test boundary and vitest flags them as leaked. `cancelAllPending()` clears
+// the handles; resetting `toasts` keeps subsequent tests isolated.
+afterEach(() => {
+  useToastStore.getState().cancelAllPending()
+  useToastStore.setState({ toasts: [] })
+  // Notifications store debounces localStorage persistence with a 300ms
+  // setTimeout; drop any pending handle so it does not outlive the test.
+  cancelPendingPersist()
+})

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: ['./src/test-setup.ts'],
+    setupFiles: ['./src/test-setup.tsx'],
     exclude: [...configDefaults.exclude, '**/e2e/**'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
Closes #1455

## What changed

### Web async leaks (`npm run test -- --coverage --detect-async-leaks`)
Local repro on main hit **279 leaks + 2 failing tests**. After this PR: **0 leaks, 2569/2569 tests pass, exit 0**.

The issue body named toast timers as the root cause; local repro showed the dominant category (~260 leaks) was framer-motion animation `AnimationComplete` PROMISEs, with additional Timeout/UNDICI_REQUEST/Microtask leaks from Recharts rAF, unmocked settings API, tough-cookie jsdom internals, and dynamic websocket imports.

**Store-level teardown contracts:**
- `web/src/stores/toast.ts` gains `cancelAllPending()` — clears pending auto-dismiss `setTimeout` handles without mutating `toasts`.
- `web/src/stores/notifications.ts` exports `cancelPendingPersist()` — clears the 300ms debounce timer.

**Global test setup (`web/src/test-setup.ts` → `test-setup.tsx`):**
- `MotionGlobalConfig.skipAnimations = true` + `vi.mock('motion/react')` replaces `motion.<tag>` + `AnimatePresence` with host-element passthroughs (eliminates ~260 PROMISE leaks).
- `vi.mock('@/api/endpoints/settings')` prevents `AuthGuard.fetchLocale()` from hitting a real 401 that flips auth state mid-test (UNDICI leaks).
- `window.requestAnimationFrame` shimmed to `setTimeout(cb, 0)` so Recharts/ZIndexPortal rAF callbacks drain cleanly.
- `window.matchMedia` shim returns `matches: false` for jsdom.
- Global `afterEach` calls `cancelAllPending()` + `cancelPendingPersist()` + resets `toasts` state.

**Per-file test fixes:**
- `App.test.tsx` — mocks lazy `AppLayout` + `LoginPage`, resets router history via `router.navigate('/')` in each test.
- `guards.test.tsx` — inherits global settings mock (no file change required).
- `TaskDetailPage.test.tsx` — replaces `new Promise(() => {})` with a `pendingPromise()` helper + `afterEach` resolver drain.
- `LoginPage.test.tsx` — deferred-resolver pattern with explicit init guards (no `!` non-null asserts).
- `api/client.test.ts` — spies `getCsrfToken` instead of mutating `document.cookie` (avoids tough-cookie Promise leak).
- `Sidebar.test.tsx` — swaps `fc.asyncProperty(100 runs)` for deterministic `it.each(routes)` + low-iteration `fc.asyncProperty(10 runs)` for permutation coverage.
- `auth.test.ts` — mocks `@/stores/websocket` to neutralize `handleUnauthorized`'s dynamic-import chain.
- `AgentDetailPage.test.tsx` — mocks `QualityScoreOverride` (fires unmocked `getQualityOverride`).
- `usePolling.test.ts` — adds `stop()` + timer advance to drain slow-fn promises.

### CI path-filter audit (per issue)

| Workflow | Change | Rationale |
|---|---|---|
| `ci.yml::dashboard` | += `src/synthorg/api/schemas/**`, `scripts/export_openapi.py`, `pyproject.toml`, `uv.lock`, `.github/actions/**`, `.github/workflows/ci.yml` | Dashboard job depends on backend DTOs + OpenAPI exporter + shared Python/composite-action config |
| `ci.yml::python` | += `scripts/**`, `.github/workflows/ci.yml` | `check_forbidden_literals.py` runs in lint; self-reference |
| `ci.yml::docker` | += `.github/workflows/ci.yml` | Self-reference |
| `pages.yml`, `pages-preview.yml` | += `.github/actions/**` | Builds use `./.github/actions/setup-python-uv` |
| `cli.yml`, `docker.yml`, `dependency-review.yml`, `zizmor.yml` | No change | Already self-referential and scoped correctly (docker.yml::web already includes `src/synthorg/api/**` + `scripts/export_openapi.py`; dependency-review has no path filter by design; zizmor covers `.github/workflows/**` recursively) |
| Periodic scans (`apko-lock`, `dast`, `evals`, `python-audit`, `scorecard`, `secret-scan`) | Out of scope | Explicitly excluded by the issue |

**No new schedule-triggered workflow added** (issue mandate).

### Pre-PR review findings addressed

7 review agents ran (docs-consistency, frontend-reviewer, test-quality-reviewer, design-token-audit, security-reviewer, infra-reviewer, issue-resolution-verifier). 12 valid findings triaged; **all 12 fixed** in commit `0831fc21`:

**Test quality:**
- Replaced `resolveSetup!()` / `resolveLogin!()` non-null asserts in `LoginPage.test.tsx` with explicit init-checks that throw if the Promise constructor never ran.
- Restored fast-check property coverage in `Sidebar.test.tsx` alongside `it.each` (low `numRuns: 10` to stay inside the 15s budget).
- Documented mock-override inheritance risk in `App.test.tsx`; compile-time type-import guard on the `@/utils/csrf` mock.
- Inline comment on `test-setup.tsx` explaining `afterEach` (not `beforeEach`) for toast reset.

**Security:**
- New `__tests__/utils/csrf.test.ts` covers the cookie-parsing path that the `getCsrfToken` mock bypasses (valid, missing, URL-encoded, malformed, empty, superstring-name-collision).
- Added `tears down the WebSocket transport` assertion in `auth.test.ts` — verifies `handleUnauthorized` actually calls `disconnect()` via the dynamic-import chain.
- New integration test `flips auth to unauthenticated on 401` in `api/client.test.ts` exercises the interceptor → `handleUnauthorized` → state-flip chain end-to-end.
- New `XSS safety` describe block in `LoginPage.test.tsx` verifies React's default text escaping handles `<script>` payloads as plain strings.
- `notifications.ts` gains `sanitizeWsString(value, maxLen)` — strips C0 controls, DELETE, bidi-override characters (CVE-2021-42574 class), trims whitespace, clamps length. Applied to every WS-payload string field (`approval_id`, `agent_id`, `agent_name`, `task_id`, `title`, `message`). 5 new tests cover the sanitizer.

**Docs:**
- `web/CLAUDE.md` Quick Commands — added `--detect-async-leaks` invocation.
- `web/CLAUDE.md` Zustand Store Error Handling — documents the test-teardown contract (`cancelAllPending()` + `cancelPendingPersist()`).
- `web/CLAUDE.md` Toast component row — references the teardown hook.

**Unit-test coverage for new helpers:**
- New `__tests__/stores/notifications.test.ts` covers `cancelPendingPersist()` (3 tests).
- Existing `__tests__/stores/toast.test.ts` already covers `cancelAllPending()`.

## Verification

```
cd web && npm run test -- --coverage --detect-async-leaks
→ Test Files  213 passed (213)
  Tests       2569 passed (2569)
  exit 0
```

```
npm --prefix web run lint       # zero warnings
npm --prefix web run type-check # zero errors
```

## Commits

1. `030773a7` chore(web): add cancelAllPending/cancelPendingPersist and wire global test teardown
2. `3f0ecc7e` test(web): fix 282 async leaks + 1 unhandled rejection in dashboard tests
3. `7e94e049` chore(ci): widen PR-gated path filters to cover cross-domain inputs
4. `0831fc21` fix(web): address pre-PR agent findings (tests, docs, WS sanitization)

## Review coverage

- 7 specialised review agents run over 3 domains (docs, web, CI).
- 12 valid findings surfaced, 12 fixed in-branch. 0 deferred.
- 22 new tests added (CSRF parsing, notifications persist/sanitization, WebSocket disconnect, 401 auth-flip integration, LoginPage XSS).