### PR TITLE
fix(docker): drop ':latest' default on backend BASE_IMAGE ARG

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -11,8 +11,10 @@
 # top. No setup stage needed -- the symlink fix is done in the builder itself.
 # =============================================================================
 
-# CI overrides with digest-pinned ref; default keeps standalone builds working.
-ARG BASE_IMAGE=ghcr.io/aureliolo/synthorg-backend-base:latest
+# CI must provide a digest-pinned ref. No default: standalone builds without
+# an explicit --build-arg BASE_IMAGE=... fail fast instead of silently pulling
+# a mutable :latest tag (Scorecard Pinned-Dependencies).
+ARG BASE_IMAGE
 
 # ---------------------------------------------------------------------------
 # Stage 1 -- Builder (ephemeral: compiles deps, fixes venv symlink)

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -11,9 +11,10 @@
 # top. No setup stage needed -- the symlink fix is done in the builder itself.
 # =============================================================================
 
-# CI must provide a digest-pinned ref. No default: standalone builds without
-# an explicit --build-arg BASE_IMAGE=... fail fast instead of silently pulling
-# a mutable :latest tag (Scorecard Pinned-Dependencies).
+# CI always provides BASE_IMAGE explicitly and uses a digest-pinned ref when
+# available (otherwise a tag/local artifact tag). No default: standalone
+# builds without an explicit --build-arg BASE_IMAGE=... fail fast instead of
+# silently pulling a mutable :latest tag (Scorecard Pinned-Dependencies).
 ARG BASE_IMAGE
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #1464. Drops the `:latest` default on `docker/backend/Dockerfile:15`'s `ARG BASE_IMAGE`, adopting Option 1 from the issue.

Scorecard code-scanning alert #228 flagged the `BASE_IMAGE=ghcr.io/aureliolo/synthorg-backend-base:latest` default against the Pinned-Dependencies rule. In CI it was a false positive -- `.github/workflows/docker.yml` always overrides `BASE_IMAGE` with a digest-pinned form (`synthorg-backend-base@sha256:...`) whenever the base-image build step emits a digest. But a standalone `docker build docker/backend/` without an explicit `--build-arg BASE_IMAGE=...` would silently pull the mutable `:latest` tag -- the real footgun the rule catches.

Dropping the default makes standalone builds fail fast (`ARG BASE_IMAGE ... FROM ${BASE_IMAGE}` with an empty value is a hard error), which matches the existing pattern in `docker/sandbox/Dockerfile`, `docker/sidecar/Dockerfile`, and `docker/fine-tune/Dockerfile`.

## What changed

- `docker/backend/Dockerfile:15` -- `ARG BASE_IMAGE=ghcr.io/aureliolo/synthorg-backend-base:latest` -> `ARG BASE_IMAGE` (+ updated the adjacent comment to explain the contract).

## Test plan

- Pre-commit hooks pass (hadolint, gitleaks, check-added-large-files, etc.).
- No CI behavior change: every `BASE_IMAGE=` assignment in `.github/workflows/docker.yml` already uses the digest-pinned ternary (lines 409, 483, 888, 960, 1092, 1159, 1313, 1381), so CI continues to build with a digest-pinned base.
- Standalone `docker build docker/backend/` now fails fast instead of silently pulling `:latest` -- this is the intended behavior.

## Review coverage

Quick pre-PR pass: one-line Dockerfile hygiene change; automated checks (Python/web/Go) all skipped because only `docker/backend/Dockerfile` changed. No agent review needed for this scope.

Closes #1464