### PR TITLE
chore: skills audit, async-leak gate hardening, web HTTP adapter design spec

### DIFF
--- a/.claude/skills/codebase-audit/SKILL.md
+++ b/.claude/skills/codebase-audit/SKILL.md
@@ -1,12 +1,12 @@
 ---
-description: "Full codebase audit: launches 75 specialized agents to find issues across Python/React/Go/docs/website, writes findings to _audit/findings/, then triages with user"
+description: "Full codebase audit: launches 123 specialized agents to find issues across Python/React/Go/docs/website, writes findings to _audit/findings/, then triages with user"
 argument-hint: "<scope: full | src/ | web/ | cli/ | docs/> [--report-only] [--quick]"
 allowed-tools: ["Agent", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion", "mcp__github__issue_write", "mcp__github__issue_read", "mcp__github__list_issues", "mcp__github__search_issues"]
 ---
 
 # /codebase-audit -- Full Codebase Audit
 
-Launch 75 specialized agents to audit the entire codebase (or a targeted scope), write findings to `_audit/findings/`, build an index, and triage with the user.
+Launch 123 specialized agents to audit the entire codebase (or a targeted scope), write findings to `_audit/findings/`, build an index, and triage with the user.
 
 ## Key Principles
 
@@ -23,13 +23,13 @@ Launch 75 specialized agents to audit the entire codebase (or a targeted scope),
 
 ### Parse scope
 
-| Argument | Directories | Agent Waves |
+| Argument | Directories | Agents |
 |----------|-------------|-------------|
-| `full` (default) | All | All 13 waves (75 agents) |
-| `src/` | `src/synthorg/`, `tests/`, `web/src/types/`, `docs/design/` | 01-08, 11-16, 20-45, 51-54, 60, 62-63 |
-| `web/` | `web/src/`, `src/synthorg/api/controllers/` | 09-10, 15, 17-19, 33, 36, 46-50, 59-61, 67-69, 72-74 |
-| `cli/` | `cli/` | 22, 33, 55-58, 71 |
-| `docs/` | `docs/`, `site/`, `src/synthorg/` | 22, 25, 54, 62-66, 70, 75 |
+| `full` (default) | All | 1-123 |
+| `src/` | `src/synthorg/`, `tests/`, `web/src/types/`, `docs/design/` | 01-06, 09-16, 18-34, 39-42, 48-51, 55, 58-80, 87-100, 102-106, 110-114, 120-121 |
+| `web/` | `web/src/`, `src/synthorg/api/controllers/` | 07-08, 13, 15, 35-38, 45-47, 52-54, 57-59, 97, 100-101, 109, 111-112, 120-121 |
+| `cli/` | `cli/` | 18, 43-44, 56, 67, 78, 89, 115-119, 122 |
+| `docs/` | `docs/`, `site/`, `src/synthorg/` | 20, 42, 48-51, 73-86, 103-104, 108, 123 |
 
 Flags:
 - `--report-only` -- skip issue creation, findings files only
@@ -142,26 +142,31 @@ Rules:
 
 ### Batch Execution
 
-Launch agents in 8 batches of ~10 each. All agents within a batch run in parallel (`run_in_background: true`). Wait for each batch to complete before launching the next.
+Launch agents in 13 batches of ~10 each. All agents within a batch run in parallel (`run_in_background: true`). Wait for each batch to complete before launching the next.
 
-| Batch | Agent #s | Count |
-|-------|----------|-------|
-| A | 01-10 | 10 |
-| B | 11-20 | 10 |
-| C | 21-30 | 10 |
-| D | 31-40 | 10 |
-| E | 41-50 | 10 |
-| F | 51-58 | 8 |
-| G | 59-65 | 7 |
-| H | 66-75 | 10 |
+| Batch | Agents |
+|-------|----------|
+| A | 01-10 |
+| B | 11-20 |
+| C | 21-30 |
+| D | 31-40 |
+| E | 41-50 |
+| F | 51-60 |
+| G | 61-70 |
+| H | 71-80 |
+| I | 81-90 |
+| J | 91-100 |
+| K | 101-110 |
+| L | 111-120 |
+| M | 121-123 |
 
-Report to user after each batch: "Batch X complete (N/75 agents done)."
+Report to user after each batch: "Batch X complete (N/123 agents done)."
 
 ---
 
 ## Agent Roster
 
-### Wave 1: Observability & Logging (7 agents)
+### Wave 1: Observability & Logging (5 agents)
 
 **Agent 01 -- missing-logger** (haiku)
 File: `_audit/findings/01-missing-logger.md`
@@ -179,25 +184,8 @@ If a file has business logic (functions with if/try/for/while, service methods,
 handlers) but no logger, that's a finding.
 ```
 
-**Agent 02 -- wrong-logger-pattern** (haiku)
-File: `_audit/findings/02-wrong-logger-pattern.md`
-```text
-Search ALL .py files in src/synthorg/ and tests/ for forbidden logging patterns:
-
-1. `import logging` (except in observability/setup.py, observability/sinks.py,
-   observability/syslog_handler.py, observability/http_handler.py,
-   observability/otlp_handler.py)
-2. `logging.getLogger` (same exceptions)
-3. `print(` in application code (except observability/ exceptions above and
-   tests/). print() in test helpers is fine.
-4. Logger variable named anything other than `logger` (e.g. `_logger`, `log`,
-   `LOG`)
-
-Severity: medium for app code, low for test code.
-```
-
-**Agent 03 -- missing-event-constants** (sonnet)
-File: `_audit/findings/03-missing-event-constants.md`
+**Agent 02 -- missing-event-constants** (sonnet)
+File: `_audit/findings/02-missing-event-constants.md`
 ```text
 The project requires all logger calls to use event constants from
 src/synthorg/observability/events/ modules (e.g. API_REQUEST_STARTED from
@@ -217,24 +205,8 @@ what's available. Then check every logger call.
 Severity: low.
 ```
 
-**Agent 04 -- unstructured-logging** (haiku)
-File: `_audit/findings/04-unstructured-logging.md`
-```text
-Search ALL logger calls in src/synthorg/ for unstructured formatting:
-
-WRONG: logger.info("Processing user %s", user_id)
-WRONG: logger.info(f"Processing user {user_id}")
-WRONG: logger.info("Processing user " + user_id)
-RIGHT: logger.info(EVENT_CONSTANT, user_id=user_id)
-
-Flag any logger.info/warning/error/debug call that uses %s, %d, %f formatting,
-f-strings, or string concatenation as arguments.
-
-Severity: low.
-```
-
-**Agent 05 -- missing-error-logging** (sonnet)
-File: `_audit/findings/05-missing-error-logging.md`
+**Agent 03 -- missing-error-logging** (sonnet)
+File: `_audit/findings/03-missing-error-logging.md`
 ```text
 Project convention: "All error paths must log at WARNING or ERROR with context
 before raising."
@@ -254,8 +226,8 @@ Exceptions to skip:
 Severity: medium for service/engine code, low for model validation.
 ```
 
-**Agent 06 -- missing-state-transition-log** (sonnet)
-File: `_audit/findings/06-missing-state-transition-log.md`
+**Agent 04 -- missing-state-transition-log** (sonnet)
+File: `_audit/findings/04-missing-state-transition-log.md`
 ```text
 Project convention: "All state transitions must log at INFO."
 
@@ -276,8 +248,8 @@ For each domain, find where status/state fields are modified and check if
 there's an INFO-level log call nearby. Missing transitions are severity=medium.
 ```
 
-**Agent 07 -- observability-completeness** (sonnet)
-File: `_audit/findings/07-observability-completeness.md`
+**Agent 05 -- observability-completeness** (sonnet)
+File: `_audit/findings/05-observability-completeness.md`
 ```text
 Check whether key operations have full observability coverage:
 
@@ -300,33 +272,33 @@ low for nice-to-have.
 
 ### Wave 2: Wiring & Integration (8 agents)
 
-**Agent 08 -- unwired-api-controllers** (sonnet)
-File: `_audit/findings/08-unwired-api-controllers.md`
+**Agent 06 -- unwired-api-controllers** (sonnet)
+File: `_audit/findings/06-unwired-api-controllers.md`
 ```text
 Check api/controllers/ for controller classes not registered in auto_wire.py
 or app.py. Also check for route handler methods that exist but are not mapped
-to any HTTP route. Do NOT check frontend-to-backend connectivity (Agent 15
+to any HTTP route. Do NOT check frontend-to-backend connectivity (Agent 13
 owns that). Severity: high (unreachable code).
 ```
 
-**Agent 09 -- unwired-web-stores** (sonnet)
-File: `_audit/findings/09-unwired-web-stores.md`
+**Agent 07 -- unwired-web-stores** (sonnet)
+File: `_audit/findings/07-unwired-web-stores.md`
 ```text
 Check every Zustand store file in web/src/stores/. For each store, grep the
 entire web/src/ directory for imports of that store. If a store is imported by
 zero pages or components, it's dead. Severity: medium.
 ```
 
-**Agent 10 -- unwired-web-pages** (sonnet)
-File: `_audit/findings/10-unwired-web-pages.md`
+**Agent 08 -- unwired-web-pages** (sonnet)
+File: `_audit/findings/08-unwired-web-pages.md`
 ```text
 Find all .tsx files in web/src/pages/ that are NOT imported by any other file
 (not by routes.ts, not by another page as a nested layout). Pages with no
 route AND no parent import are unreachable. Severity: medium.
 ```
 
-**Agent 11 -- unwired-settings** (sonnet)
-File: `_audit/findings/11-unwired-settings.md`
+**Agent 09 -- unwired-settings** (sonnet)
+File: `_audit/findings/09-unwired-settings.md`
 ```text
 Check settings/definitions/ for setting definitions. For each, check if it is:
 (a) subscribed to via settings/subscribers/, AND
@@ -334,16 +306,16 @@ Check settings/definitions/ for setting definitions. For each, check if it is:
 Settings defined but never consumed are dead config. Severity: medium.
 ```
 
-**Agent 12 -- unwired-tools** (sonnet)
-File: `_audit/findings/12-unwired-tools.md`
+**Agent 10 -- unwired-tools** (sonnet)
+File: `_audit/findings/10-unwired-tools.md`
 ```text
 Check tool classes in tools/ subdirectories. For each tool class that extends
 BaseTool, verify it is registered in tools/factory.py or tools/registry.py.
 Unregistered tools are dead code. Severity: medium.
 ```
 
-**Agent 13 -- unwired-protocols** (sonnet)
-File: `_audit/findings/13-unwired-protocols.md`
+**Agent 11 -- unwired-protocols** (sonnet)
+File: `_audit/findings/11-unwired-protocols.md`
 ```text
 Find all Protocol classes in src/synthorg/. For each, find concrete
 implementations (classes that implement the protocol). Then check if those
@@ -352,8 +324,8 @@ implementations are registered in their factory. Report:
 - Implementations not registered in any factory (severity: medium)
 ```
 
-**Agent 14 -- unwired-notifications** (sonnet)
-File: `_audit/findings/14-unwired-notifications.md`
+**Agent 12 -- unwired-notifications** (sonnet)
+File: `_audit/findings/12-unwired-notifications.md`
 ```text
 Check notifications/adapters/ for adapter classes. Verify each is registered
 in notifications/factory.py. Also check if notification events are dispatched
@@ -361,8 +333,8 @@ from business logic. Report adapters with no factory registration and
 notification types never dispatched. Severity: medium.
 ```
 
-**Agent 15 -- frontend-backend-mismatch** (sonnet)
-File: `_audit/findings/15-frontend-backend-mismatch.md`
+**Agent 13 -- frontend-backend-mismatch** (sonnet)
+File: `_audit/findings/13-frontend-backend-mismatch.md`
 ```text
 Cross-reference web/src/api/ and web/src/services/ API calls with backend
 api/controllers/ endpoints. Report:
@@ -370,10 +342,10 @@ api/controllers/ endpoints. Report:
 - Backend endpoints with zero frontend consumers (low -- may be API-only)
 ```
 
-### Wave 3: Dead Code & Unused (6 agents)
+### Wave 3: Dead Code & Unused (3 agents)
 
-**Agent 16 -- unused-python-exports** (sonnet)
-File: `_audit/findings/16-unused-python-exports.md`
+**Agent 14 -- unused-python-exports** (sonnet)
+File: `_audit/findings/14-unused-python-exports.md`
 ```text
 Find public functions and classes in src/synthorg/ that are not imported by
 any other module, not re-exported in __init__.py, and not referenced in tests/.
@@ -381,30 +353,8 @@ Exclude: __init__ methods, property descriptors, __repr__/__str__, metaclass
 methods, enum members, Pydantic field definitions. Severity: medium.
 ```
 
-**Agent 17 -- unused-web-components** (sonnet)
-File: `_audit/findings/17-unused-web-components.md`
-```text
-Check every component file in web/src/components/ (excluding .stories.tsx).
-Grep web/src/ for imports of each component. Components imported by zero
-consumers are dead code. Severity: medium.
-```
-
-**Agent 18 -- unused-web-hooks** (haiku)
-File: `_audit/findings/18-unused-web-hooks.md`
-```text
-Check every hook file in web/src/hooks/. Grep web/src/ for imports of each
-hook. Hooks imported by zero files are dead code. Severity: medium.
-```
-
-**Agent 19 -- unused-web-utils** (haiku)
-File: `_audit/findings/19-unused-web-utils.md`
-```text
-Check exported functions in web/src/utils/ and web/src/lib/. Grep web/src/
-for imports. Unused exports are dead code. Severity: low.
-```
-
-**Agent 20 -- unused-dto-fields** (sonnet)
-File: `_audit/findings/20-unused-dto-fields.md`
+**Agent 15 -- unused-dto-fields** (sonnet)
+File: `_audit/findings/15-unused-dto-fields.md`
 ```text
 Compare DTO classes in api/dto*.py with frontend TypeScript types in
 web/src/types/. Flag fields present in backend DTOs but absent from frontend
@@ -412,8 +362,8 @@ types (or vice versa). This suggests unused serialization. Severity: low.
 Only runs for `full` or `src/` scope (requires both backend and frontend).
 ```
 
-**Agent 21 -- orphan-test-helpers** (sonnet)
-File: `_audit/findings/21-orphan-test-helpers.md`
+**Agent 16 -- orphan-test-helpers** (sonnet)
+File: `_audit/findings/16-orphan-test-helpers.md`
 ```text
 Check all conftest.py files in tests/ for fixtures and helper functions.
 Grep tests/ for usage of each. Unused fixtures/helpers are dead test code.
@@ -422,42 +372,42 @@ Severity: low.
 
 ### Wave 4: TODOs & Deferred (4 agents)
 
-**Agent 22 -- todo-comments** (haiku)
-File: `_audit/findings/22-todo-comments.md`
+**Agent 17 -- todo-comments** (haiku)
+File: `_audit/findings/17-todo-comments.md`
 ```text
 Grep source files in the provided scope for TODO, FIXME, HACK,
 XXX, TEMPORARY, WORKAROUND comments. List each with file:line and the full
 comment text. Severity: info.
 ```
 
-**Agent 23 -- not-implemented** (haiku)
-File: `_audit/findings/23-not-implemented.md`
+**Agent 18 -- not-implemented** (haiku)
+File: `_audit/findings/18-not-implemented.md`
 ```text
 Grep src/synthorg/ and cli/ for: NotImplementedError, pass-only function
 bodies (def/async def with only pass), and Ellipsis (...) as sole function
 body. Severity: info for abstract methods, medium for concrete stubs.
 ```
 
-**Agent 24 -- placeholder-stubs** (sonnet)
-File: `_audit/findings/24-placeholder-stubs.md`
+**Agent 19 -- placeholder-stubs** (sonnet)
+File: `_audit/findings/19-placeholder-stubs.md`
 ```text
 Find functions that return hardcoded dummy values, empty lists/dicts, or have
 "placeholder", "stub", "temporary", "mock" in their comments/docstrings.
 These suggest incomplete implementations. Severity: medium.
 ```
 
-**Agent 25 -- deferred-features** (sonnet)
-File: `_audit/findings/25-deferred-features.md`
+**Agent 20 -- deferred-features** (sonnet)
+File: `_audit/findings/20-deferred-features.md`
 ```text
 Read docs/design/ pages and cross-reference with src/synthorg/. Find features
 described in the design spec that have no corresponding implementation.
 Focus on major features (not minor details). Severity: info.
 ```
 
-### Wave 5: Safety & Security (7 agents)
+### Wave 5: Safety & Security (6 agents)
 
-**Agent 26 -- silent-exception-swallow** (sonnet)
-File: `_audit/findings/26-silent-exception-swallow.md`
+**Agent 21 -- silent-exception-swallow** (sonnet)
+File: `_audit/findings/21-silent-exception-swallow.md`
 ```text
 Find except blocks that swallow exceptions silently: bare `except:`,
 `except Exception: pass`, `except Exception as e:` with only DEBUG logging
@@ -465,126 +415,82 @@ Find except blocks that swallow exceptions silently: bare `except:`,
 graceful shutdown cleanup. Severity: high for business logic, medium for cleanup.
 ```
 
-**Agent 27 -- input-validation-gaps** (sonnet)
-File: `_audit/findings/27-input-validation-gaps.md`
+**Agent 22 -- input-validation-gaps** (sonnet)
+File: `_audit/findings/22-input-validation-gaps.md`
 ```text
 Check API controller methods for user input that bypasses validation. Look for
 path/query parameters used directly without Pydantic validation, raw request
 body access, and missing type coercion. Severity: high.
 ```
 
-**Agent 28 -- sql-injection-risk** (sonnet)
-File: `_audit/findings/28-sql-injection-risk.md`
+**Agent 23 -- sql-injection-risk** (sonnet)
+File: `_audit/findings/23-sql-injection-risk.md`
 ```text
 Search persistence/ and any file using SQL for string concatenation or f-strings
 in SQL queries instead of parameterized queries. Severity: critical.
 ```
 
-**Agent 29 -- missing-auth-checks** (sonnet)
-File: `_audit/findings/29-missing-auth-checks.md`
+**Agent 24 -- missing-auth-checks** (sonnet)
+File: `_audit/findings/24-missing-auth-checks.md`
 ```text
 Check API controllers for endpoints missing auth guards. Compare with auth
 middleware/dependency injection. Public endpoints should be explicitly marked.
 Severity: high for data-mutating endpoints, medium for read-only.
 ```
 
-**Agent 30 -- unsafe-deserialization** (haiku)
-File: `_audit/findings/30-unsafe-deserialization.md`
+**Agent 25 -- unsafe-deserialization** (haiku)
+File: `_audit/findings/25-unsafe-deserialization.md`
 ```text
 Flag ANY use of yaml.load (even with Loader parameter -- verify SafeLoader),
 pickle.loads, eval(), exec(). Flag compile() ONLY if the argument contains a
 variable or function parameter (not a string literal). Severity: critical.
 ```
 
-**Agent 31 -- hardcoded-secrets** (haiku)
-File: `_audit/findings/31-hardcoded-secrets.md`
-```text
-Grep for patterns suggesting hardcoded secrets: password=", api_key=",
-token=", secret=", followed by string literals. Skip test files and .env
-examples. Severity: critical.
-```
-
-**Agent 32 -- missing-rate-limiting** (sonnet)
-File: `_audit/findings/32-missing-rate-limiting.md`
+**Agent 26 -- missing-rate-limiting** (sonnet)
+File: `_audit/findings/26-missing-rate-limiting.md`
 ```text
 Check public-facing API endpoints for rate limiting. Check expensive operations
 (LLM calls, bulk DB writes, file uploads) for throttling. Severity: medium.
 ```
 
-### Wave 6: Configuration & Hardcoding (6 agents)
+### Wave 6: Configuration & Hardcoding (4 agents)
 
-**Agent 33 -- hardcoded-urls-ports** (haiku)
-File: `_audit/findings/33-hardcoded-urls-ports.md`
+**Agent 27 -- hardcoded-urls-ports** (haiku)
+File: `_audit/findings/27-hardcoded-urls-ports.md`
 ```text
 Grep files in the provided scope for hardcoded URLs, ports, hostnames, IP
 addresses that should come from config or env vars. Skip test files and
 documentation. Severity: medium.
 ```
 
-**Agent 34 -- hardcoded-timeouts-limits** (haiku)
-File: `_audit/findings/34-hardcoded-timeouts-limits.md`
+**Agent 28 -- hardcoded-timeouts-limits** (haiku)
+File: `_audit/findings/28-hardcoded-timeouts-limits.md`
 ```text
 Grep src/synthorg/ for hardcoded timeout values (seconds/ms), retry counts,
 batch sizes, max limits that should be configurable. Look for bare numeric
 literals in asyncio.wait_for, sleep, timeout parameters. Severity: low.
 ```
 
-**Agent 35 -- hardcoded-magic-numbers** (haiku)
-File: `_audit/findings/35-hardcoded-magic-numbers.md`
+**Agent 29 -- hardcoded-magic-numbers** (haiku)
+File: `_audit/findings/29-hardcoded-magic-numbers.md`
 ```text
 Find magic numbers in business logic: bare numeric literals (not 0, 1, -1)
 without named constants. Focus on src/synthorg/ business logic, skip tests
 and config defaults. Severity: low.
 ```
 
-**Agent 36 -- vendor-name-leaks** (haiku)
-File: `_audit/findings/36-vendor-name-leaks.md`
-```text
-Grep files in the provided scope for real vendor names: Anthropic, OpenAI,
-Claude, GPT, Gemini, Mistral in project-owned code. ALLOWED exceptions (do
-NOT flag):
-- providers/presets.py (user-facing runtime data)
-- .claude/ directory files
-- Third-party import paths (litellm.types.llms.openai etc)
-- docs/design/operations.md provider list
-Everything else is a violation. Severity: low.
-```
-
-**Agent 37 -- hardcoded-display-values** (sonnet)
-File: `_audit/findings/37-hardcoded-display-values.md`
-```text
-Find hardcoded currencies (should default EUR not USD), date formats, number
-formats, locale-specific strings in both src/synthorg/ and web/src/.
-Severity: medium for USD defaults, low for format strings.
-```
-
-**Agent 38 -- missing-settings-bridge** (sonnet)
-File: `_audit/findings/38-missing-settings-bridge.md`
+**Agent 30 -- missing-settings-bridge** (sonnet)
+File: `_audit/findings/30-missing-settings-bridge.md`
 ```text
 Cross-reference hardcoded values in src/synthorg/ with settings definitions in
 settings/definitions/. Find values that SHOULD be configurable but are hardcoded,
 and settings defined but never consumed by any code. Severity: medium.
 ```
 
-### Wave 7: Code Quality & Conventions (7 agents)
+### Wave 7: Code Quality & Conventions (4 agents)
 
-**Agent 39 -- long-functions** (haiku)
-File: `_audit/findings/39-long-functions.md`
-```text
-Find functions exceeding line limits: Python over 50 lines, Go over 80 lines,
-TypeScript over 60 lines. Report file:line of function def and line count.
-Severity: low.
-```
-
-**Agent 40 -- long-files** (haiku)
-File: `_audit/findings/40-long-files.md`
-```text
-Find files exceeding size limits: Python over 800 lines, TypeScript over 600
-lines, Go over 1000 lines. Report file path and line count. Severity: low.
-```
-
-**Agent 41 -- model-convention-violations** (sonnet)
-File: `_audit/findings/41-model-convention-violations.md`
+**Agent 31 -- model-convention-violations** (sonnet)
+File: `_audit/findings/31-model-convention-violations.md`
 ```text
 Check Pydantic models in src/synthorg/ for convention violations:
 - Missing frozen=True in ConfigDict (config/identity models must be frozen)
@@ -594,8 +500,8 @@ Check Pydantic models in src/synthorg/ for convention violations:
 Severity: medium.
 ```
 
-**Agent 42 -- missing-immutability** (sonnet)
-File: `_audit/findings/42-missing-immutability.md`
+**Agent 32 -- missing-immutability** (sonnet)
+File: `_audit/findings/32-missing-immutability.md`
 ```text
 Find violations of immutability conventions:
 - dict/list exposed without MappingProxyType wrapping (non-Pydantic)
@@ -605,8 +511,8 @@ Find violations of immutability conventions:
 Severity: medium.
 ```
 
-**Agent 43 -- async-antipatterns** (sonnet)
-File: `_audit/findings/43-async-antipatterns.md`
+**Agent 33 -- async-antipatterns** (sonnet)
+File: `_audit/findings/33-async-antipatterns.md`
 ```text
 Find async antipatterns in src/synthorg/:
 - Bare asyncio.create_task without TaskGroup
@@ -617,8 +523,8 @@ Find async antipatterns in src/synthorg/:
 Severity: high for missing await, medium for others.
 ```
 
-**Agent 44 -- error-handling-consistency** (sonnet)
-File: `_audit/findings/44-error-handling-consistency.md`
+**Agent 34 -- error-handling-consistency** (sonnet)
+File: `_audit/findings/34-error-handling-consistency.md`
 ```text
 Check error handling conventions:
 - Custom exceptions not inheriting from project error hierarchy
@@ -628,17 +534,10 @@ Check error handling conventions:
 Severity: medium.
 ```
 
-**Agent 45 -- future-annotations-leak** (haiku)
-File: `_audit/findings/45-future-annotations-leak.md`
-```text
-Grep for "from __future__ import annotations" in ALL Python files. This is
-forbidden on Python 3.14 (PEP 649 native). Severity: low.
-```
+### Wave 8: Frontend Quality (4 agents)
 
-### Wave 8: Frontend Quality (5 agents)
-
-**Agent 46 -- missing-accessibility** (sonnet)
-File: `_audit/findings/46-missing-accessibility.md`
+**Agent 35 -- missing-accessibility** (sonnet)
+File: `_audit/findings/35-missing-accessibility.md`
 ```text
 Check web/src/components/ and web/src/pages/ for accessibility issues:
 missing aria-label on interactive elements, missing role attributes, missing
@@ -646,33 +545,24 @@ keyboard navigation (onKeyDown handlers), missing focus management after
 navigation, images without alt text. Severity: medium.
 ```
 
-**Agent 47 -- missing-loading-states** (sonnet)
-File: `_audit/findings/47-missing-loading-states.md`
+**Agent 36 -- missing-loading-states** (sonnet)
+File: `_audit/findings/36-missing-loading-states.md`
 ```text
 Check pages/components that fetch data (useQuery, useEffect with fetch) for
 missing loading skeletons/spinners, missing empty states when data is [],
 and missing error boundaries around async content. Severity: medium.
 ```
 
-**Agent 48 -- hardcoded-frontend-strings** (haiku)
-File: `_audit/findings/48-hardcoded-frontend-strings.md`
+**Agent 37 -- hardcoded-frontend-strings** (haiku)
+File: `_audit/findings/37-hardcoded-frontend-strings.md`
 ```text
 Find user-facing strings hardcoded directly in TSX files. Look for text
 content in JSX elements that should be centralized for i18n readiness.
 Skip component prop names and technical strings. Severity: info.
 ```
 
-**Agent 49 -- design-token-violations** (sonnet)
-File: `_audit/findings/49-design-token-violations.md`
-```text
-Check web/src/ for design system violations: hardcoded hex colors (#xxx),
-hardcoded px values for spacing/padding/margins, raw font-family declarations,
-raw CSS transition/animation values instead of @/lib/motion presets.
-Severity: medium.
-```
-
-**Agent 50 -- missing-error-handling-fe** (sonnet)
-File: `_audit/findings/50-missing-error-handling-fe.md`
+**Agent 38 -- missing-error-handling-fe** (sonnet)
+File: `_audit/findings/38-missing-error-handling-fe.md`
 ```text
 Check web/src/ for API calls without error handling: missing .catch() or
 try/catch, missing toast/notification on failure, optimistic updates without
@@ -681,65 +571,49 @@ rollback on error, console.error without user feedback. Severity: medium.
 
 ### Wave 9: Logic & Architecture (4 agents)
 
-**Agent 51 -- race-conditions** (sonnet)
-File: `_audit/findings/51-race-conditions.md`
+**Agent 39 -- race-conditions** (sonnet)
+File: `_audit/findings/39-race-conditions.md`
 ```text
 Find potential race conditions: shared mutable state without locks/mutexes,
 TOCTOU patterns (check-then-act without atomicity), concurrent dict/list
 modification, DB read-modify-write without transactions. Severity: high.
 ```
 
-**Agent 52 -- resource-leaks** (sonnet)
-File: `_audit/findings/52-resource-leaks.md`
+**Agent 40 -- resource-leaks** (sonnet)
+File: `_audit/findings/40-resource-leaks.md`
 ```text
 Find unclosed resources: HTTP clients/sessions not using async with,
 file handles not in with blocks, DB connections not properly returned to pool,
 aiohttp sessions created but not closed. Severity: high.
 ```
 
-**Agent 53 -- circular-dependencies** (sonnet)
-File: `_audit/findings/53-circular-dependencies.md`
+**Agent 41 -- circular-dependencies** (sonnet)
+File: `_audit/findings/41-circular-dependencies.md`
 ```text
 Find import cycles between src/synthorg/ packages. Check for circular
 references that could cause runtime ImportError or require deferred imports.
 Also check for TYPE_CHECKING guards that hide real circular deps. Severity: medium.
 ```
 
-**Agent 54 -- design-spec-drift** (sonnet)
-File: `_audit/findings/54-design-spec-drift.md`
+**Agent 42 -- design-spec-drift** (sonnet)
+File: `_audit/findings/42-design-spec-drift.md`
 ```text
 Compare implementation in src/synthorg/ with docs/design/ specs. Find
 behaviors, models, or flows that diverge from what the spec describes without
 documented rationale. Focus on major architectural decisions. Severity: medium.
 ```
 
-### Wave 10: Go CLI (4 agents)
+### Wave 10: Go CLI (2 agents)
 
-**Agent 55 -- go-error-handling** (sonnet)
-File: `_audit/findings/55-go-error-handling.md`
-```text
-Check cli/ Go code for: ignored error returns (assigned to _), missing error
-wrapping (fmt.Errorf with %w), bare log.Fatal instead of returning errors,
-os.Exit in non-main functions. Severity: medium.
-```
-
-**Agent 56 -- go-resource-leaks** (sonnet)
-File: `_audit/findings/56-go-resource-leaks.md`
-```text
-Check cli/ for unclosed resources: Docker clients without defer Close(),
-HTTP response bodies not closed, file handles without defer Close(),
-context cancellation not propagated. Severity: high.
-```
-
-**Agent 57 -- go-hardcoded-values** (haiku)
-File: `_audit/findings/57-go-hardcoded-values.md`
+**Agent 43 -- go-hardcoded-values** (haiku)
+File: `_audit/findings/43-go-hardcoded-values.md`
 ```text
 Grep cli/ for hardcoded Docker image tags, ports, paths, timeouts that should
 be configurable via flags or config. Severity: low.
 ```
 
-**Agent 58 -- go-cli-wiring** (sonnet)
-File: `_audit/findings/58-go-cli-wiring.md`
+**Agent 44 -- go-cli-wiring** (sonnet)
+File: `_audit/findings/44-go-cli-wiring.md`
 ```text
 Check cobra command registration in cli/cmd/. Find commands registered but
 non-functional, flags defined but never read, subcommands with no RunE.
@@ -748,8 +622,8 @@ Severity: medium.
 
 ### Wave 11: Dashboard Completeness (3 agents)
 
-**Agent 59 -- dashboard-api-coverage** (sonnet)
-File: `_audit/findings/59-dashboard-api-coverage.md`
+**Agent 45 -- dashboard-api-coverage** (sonnet)
+File: `_audit/findings/45-dashboard-api-coverage.md`
 ```text
 Cross-reference every backend API endpoint (from all controllers in
 api/controllers/) with the web dashboard. For each endpoint, check whether
@@ -758,8 +632,8 @@ a button, a settings panel, a dialog, etc. Report endpoints that exist in
 the backend but have no corresponding UI surface. Severity: medium.
 ```
 
-**Agent 60 -- dashboard-settings-completeness** (sonnet)
-File: `_audit/findings/60-dashboard-settings-completeness.md`
+**Agent 46 -- dashboard-settings-completeness** (sonnet)
+File: `_audit/findings/46-dashboard-settings-completeness.md`
 ```text
 Cross-reference every setting definition in src/synthorg/settings/definitions/ with the
 Settings page in the dashboard (web/src/pages/settings/). For each setting,
@@ -768,8 +642,8 @@ in src/synthorg/config/ that are user-facing but have no settings UI.
 Report settings that exist but are not exposed. Severity: medium.
 ```
 
-**Agent 61 -- dashboard-ux-improvements** (sonnet)
-File: `_audit/findings/61-dashboard-ux-improvements.md`
+**Agent 47 -- dashboard-ux-improvements** (sonnet)
+File: `_audit/findings/47-dashboard-ux-improvements.md`
 ```text
 Review the web dashboard pages for UX improvement opportunities. Look for:
 - Pages with no sorting/filtering when data lists can grow large
@@ -786,10 +660,10 @@ Focus on the most impactful improvements. Severity: medium for missing
 core UX patterns, low for polish.
 ```
 
-### Wave 12: Documentation Quality (5 agents)
+### Wave 12: Documentation Quality (4 agents)
 
-**Agent 62 -- docs-accuracy** (sonnet)
-File: `_audit/findings/62-docs-accuracy.md`
+**Agent 48 -- docs-accuracy** (sonnet)
+File: `_audit/findings/48-docs-accuracy.md`
 ```text
 Check docs/ pages for factual accuracy. Read key documentation pages
 (architecture, tech-stack, decisions, design pages) and verify claims
@@ -802,8 +676,8 @@ against actual code. Look for:
 Severity: medium for misleading docs, low for minor inaccuracies.
 ```
 
-**Agent 63 -- docs-completeness** (sonnet)
-File: `_audit/findings/63-docs-completeness.md`
+**Agent 49 -- docs-completeness** (sonnet)
+File: `_audit/findings/49-docs-completeness.md`
 ```text
 Check for documentation gaps. Look for:
 - Major features with no documentation page
@@ -816,17 +690,8 @@ Cross-reference docs/design/ index with actual pages.
 Severity: medium for missing feature docs, low for missing examples.
 ```
 
-**Agent 64 -- docs-links-refs** (haiku)
-File: `_audit/findings/64-docs-links-refs.md`
-```text
-Check all markdown files in docs/ for broken internal links. Verify that
-every [text](path) reference points to an existing file. Also check for
-anchor references (#section) that don't match actual headings. Check
-mkdocs.yml nav structure matches actual file layout. Severity: medium.
-```
-
-**Agent 65 -- readme-website-accuracy** (sonnet)
-File: `_audit/findings/65-readme-website-accuracy.md`
+**Agent 50 -- readme-website-accuracy** (sonnet)
+File: `_audit/findings/50-readme-website-accuracy.md`
 ```text
 Check README.md and any public-facing content (landing page content in
 docs/, comparison page, etc.) for:
@@ -839,8 +704,8 @@ docs/, comparison page, etc.) for:
 Severity: medium for public-facing inaccuracies.
 ```
 
-**Agent 66 -- docs-diagram-quality** (sonnet)
-File: `_audit/findings/66-docs-diagram-quality.md`
+**Agent 51 -- docs-diagram-quality** (sonnet)
+File: `_audit/findings/51-docs-diagram-quality.md`
 ```text
 Check all D2 and Mermaid diagrams in docs/ for:
 - Diagrams that reference modules/classes that no longer exist
@@ -852,10 +717,10 @@ Cross-reference diagram content with actual source structure.
 Severity: low.
 ```
 
-### Wave 13: UX & Content Quality (9 agents)
+### Wave 13: UX & Content Quality (8 agents)
 
-**Agent 67 -- ux-consistency** (sonnet)
-File: `_audit/findings/67-ux-consistency.md`
+**Agent 52 -- ux-consistency** (sonnet)
+File: `_audit/findings/52-ux-consistency.md`
 ```text
 Check dashboard pages for visual and interaction consistency:
 - Pages using different card layouts for similar data
@@ -868,8 +733,8 @@ Check dashboard pages for visual and interaction consistency:
 Severity: medium for jarring inconsistencies, low for minor.
 ```
 
-**Agent 68 -- ux-responsiveness** (sonnet)
-File: `_audit/findings/68-ux-responsiveness.md`
+**Agent 53 -- ux-responsiveness** (sonnet)
+File: `_audit/findings/53-ux-responsiveness.md`
 ```text
 Check dashboard for responsive design issues. The dashboard shows a
 MobileUnsupportedOverlay below the 768px breakpoint, but check for:
@@ -881,8 +746,8 @@ MobileUnsupportedOverlay below the 768px breakpoint, but check for:
 Severity: medium.
 ```
 
-**Agent 69 -- ux-performance-patterns** (sonnet)
-File: `_audit/findings/69-ux-performance-patterns.md`
+**Agent 54 -- ux-performance-patterns** (sonnet)
+File: `_audit/findings/54-ux-performance-patterns.md`
 ```text
 Check dashboard for performance antipatterns:
 - Large component re-renders (components that subscribe to entire store
@@ -895,8 +760,8 @@ Check dashboard for performance antipatterns:
 Severity: medium.
 ```
 
-**Agent 70 -- api-docs-openapi** (sonnet)
-File: `_audit/findings/70-api-docs-openapi.md`
+**Agent 55 -- api-docs-openapi** (sonnet)
+File: `_audit/findings/55-api-docs-openapi.md`
 ```text
 Check the OpenAPI/Scalar API documentation for completeness:
 - Endpoints missing descriptions or summaries
@@ -908,8 +773,8 @@ Check by reading controller decorators and Pydantic model docstrings.
 Severity: low.
 ```
 
-**Agent 71 -- cli-docs-help** (haiku)
-File: `_audit/findings/71-cli-docs-help.md`
+**Agent 56 -- cli-docs-help** (haiku)
+File: `_audit/findings/56-cli-docs-help.md`
 ```text
 Check Go CLI commands for documentation completeness:
 - Commands missing Long descriptions
@@ -920,8 +785,8 @@ Check Go CLI commands for documentation completeness:
 Check cli/cmd/*.go for cobra.Command fields. Severity: low.
 ```
 
-**Agent 72 -- storybook-coverage** (sonnet)
-File: `_audit/findings/72-storybook-coverage.md`
+**Agent 57 -- storybook-coverage** (sonnet)
+File: `_audit/findings/57-storybook-coverage.md`
 ```text
 Check web/src/components/ui/ for Storybook story coverage. Every shared
 component should have a .stories.tsx file. For existing stories, check:
@@ -932,8 +797,8 @@ Severity: low for missing stories, medium for shared components with
 zero coverage.
 ```
 
-**Agent 73 -- error-messages-ux** (sonnet)
-File: `_audit/findings/73-error-messages-ux.md`
+**Agent 58 -- error-messages-ux** (sonnet)
+File: `_audit/findings/58-error-messages-ux.md`
 ```text
 Check error messages shown to users (toast notifications, error states,
 API error responses, form validation messages) for quality:
@@ -947,8 +812,8 @@ Check both frontend toast calls and backend API error messages.
 Severity: medium for unhelpful errors, low for tone inconsistencies.
 ```
 
-**Agent 74 -- onboarding-flow** (sonnet)
-File: `_audit/findings/74-onboarding-flow.md`
+**Agent 59 -- onboarding-flow** (sonnet)
+File: `_audit/findings/59-onboarding-flow.md`
 ```text
 Check the setup wizard and first-run experience:
 - Setup steps that can fail silently
@@ -961,17 +826,875 @@ Check web/src/pages/setup/ and src/synthorg/api/controllers/setup.py.
 Severity: medium.
 ```
 
-**Agent 75 -- changelog-release-notes** (haiku)
-File: `_audit/findings/75-changelog-release-notes.md`
+### Wave 14: Abstraction Boundaries & Backend Parity (13 agents)
+
+**Agent 60 -- dual-backend-protocol-parity** (sonnet)
+File: `_audit/findings/60-dual-backend-protocol-parity.md`
 ```text
-Check for changelog/release notes completeness:
-- CHANGELOG.md missing or outdated
-- GitHub releases with missing or generic descriptions
-- Version bumps without corresponding release notes
-- Breaking changes not documented
-Check CHANGELOG.md, GitHub releases via gh, and pyproject.toml version.
+Every repository Protocol in src/synthorg/persistence/*_protocol.py must have
+concrete implementations in BOTH src/synthorg/persistence/sqlite/ AND
+src/synthorg/persistence/postgres/. For each Protocol, verify both impls exist
+and implement every method with matching signatures.
+
+Flag:
+- Protocols with SQLite-only or Postgres-only impls
+- Methods present on one backend but not the other
+- Signature drift (parameter names, types, return types diverging)
+
+Severity: high for missing impl, medium for signature drift.
+```
+
+**Agent 61 -- migration-parity** (sonnet)
+File: `_audit/findings/61-migration-parity.md`
+```text
+Migrations in src/synthorg/persistence/sqlite/revisions/ and
+src/synthorg/persistence/postgres/revisions/ must stay in semantic parity.
+
+For each recent migration, verify the same schema change exists in the other
+backend. Compare schema.sql files in both backends for table/column drift.
+
+Flag:
+- Migrations added to one backend only
+- Tables/columns in one schema but not the other
+- Column type mismatches (TEXT vs VARCHAR, INTEGER vs BIGINT) implying drift
+
+Severity: high.
+```
+
+**Agent 62 -- dual-backend-test-parity** (sonnet)
+File: `_audit/findings/62-dual-backend-test-parity.md`
+```text
+Every repository implementation in src/synthorg/persistence/sqlite/ and
+src/synthorg/persistence/postgres/ must have test coverage on BOTH backends
+(parametrized fixtures or mirrored test files).
+
+Flag:
+- Repo impls with tests on only one backend
+- Integration suites that don't run against both backends
+- Conftest fixtures defaulting to one backend with no parametrized counterpart
+
+Severity: medium.
+```
+
+**Agent 63 -- persistence-boundary-deep** (sonnet)
+File: `_audit/findings/63-persistence-boundary-deep.md`
+```text
+scripts/check_persistence_boundary.py (PreToolUse hook) catches import-level
+leaks. This agent does deeper analysis.
+
+Outside src/synthorg/persistence/ and the allowlisted exceptions in the hook's
+_ALLOWLIST, find:
+- Raw SQL DDL/DML in multi-line strings (CREATE TABLE, INSERT INTO, UPDATE,
+  DELETE, ALTER, DROP)
+- f-string or template-rendered SQL
+- Dynamic query builders
+- ORM session or transaction boundary management
+
+Severity: high.
+```
+
+**Agent 64 -- provider-boundary-leaks** (sonnet)
+File: `_audit/findings/64-provider-boundary-leaks.md`
+```text
+All LLM calls must go through BaseCompletionProvider in src/synthorg/providers/.
+
+Outside src/synthorg/providers/, find:
+- Direct litellm.completion / litellm.acompletion calls
+- Raw openai / anthropic / mistralai / google.generativeai SDK imports or instantiation
+- HTTP calls to /v1/chat/completions or similar provider endpoints
+- Anything bypassing the retry + rate-limit + fallback infrastructure
+
+Severity: high.
+```
+
+**Agent 65 -- memory-boundary-leaks** (sonnet)
+File: `_audit/findings/65-memory-boundary-leaks.md`
+```text
+All memory/recall operations must go through src/synthorg/memory/.
+
+Outside src/synthorg/memory/, find:
+- Direct mem0 SDK calls
+- qdrant_client imports or usage
+- Raw vector store client instantiation
+- Embedding API calls bypassing the memory abstraction
+
+Severity: medium.
+```
+
+**Agent 66 -- queue-boundary-leaks** (sonnet)
+File: `_audit/findings/66-queue-boundary-leaks.md`
+```text
+Inter-component messaging must go through the project's event bus / message
+bus abstraction.
+
+Find:
+- Direct nats / nats.aio client usage outside the messaging module
+- Bare asyncio.Queue used for cross-subsystem communication (single-function
+  use is fine)
+- Redis pub/sub or similar bypassing the abstraction
+
+Severity: medium.
+```
+
+**Agent 67 -- process-spawn-leaks** (sonnet)
+File: `_audit/findings/67-process-spawn-leaks.md`
+```text
+Process spawning and container orchestration must go through the sandbox /
+orchestration layer.
+
+Outside sandbox / execution / CLI orchestrator modules, find:
+- subprocess.run / Popen
+- asyncio.create_subprocess_exec / asyncio.create_subprocess_shell
+- docker.DockerClient / aiodocker.Docker instantiation
+- os.system or similar shell-outs
+
+Severity: high for arbitrary code paths, medium for admin tools.
+```
+
+**Agent 68 -- state-mutation-leaks** (sonnet)
+File: `_audit/findings/68-state-mutation-leaks.md`
+```text
+API controllers should delegate to service-layer methods, not reach into
+persistence internals.
+
+In src/synthorg/api/controllers/, find:
+- Direct repository method calls for write operations (should go through a service)
+- Raw DB session access
+- Transaction management inside controllers
+- Anything bypassing the service layer to mutate state
+
+Severity: medium.
+```
+
+**Agent 69 -- hardcoded-backend-selection** (haiku)
+File: `_audit/findings/69-hardcoded-backend-selection.md`
+```text
+Backend choices must be driven by config factories, not hardcoded in business
+logic.
+
+Outside config/, settings/, and factory modules, grep for string literals used
+in branching logic: "sqlite", "postgres", "nats", "mem0", "qdrant",
+"in_memory", "in-process". Flag patterns like `if backend == "sqlite":` in
+business code.
+
+Severity: medium.
+```
+
+**Agent 70 -- pluggable-impl-coverage** (sonnet)
+File: `_audit/findings/70-pluggable-impl-coverage.md`
+```text
+Per CLAUDE.md, every pluggable subsystem uses Protocol + concrete strategies +
+factory + config discriminator.
+
+For every *_protocol.py, *_factory.py, and *_config.py discriminator in
+src/synthorg/:
+1. Enumerate all discriminator values (enum members or Literal types)
+2. Verify each value has a registered factory mapping
+3. Verify each value has at least one test case
+4. Verify the discriminator is documented
+
+Flag:
+- Discriminator values with no factory entry
+- Factory entries with no impl
+- Impls with no test
+
+Severity: medium.
+```
+
+**Agent 71 -- abstraction-swap-readiness** (sonnet)
+File: `_audit/findings/71-abstraction-swap-readiness.md`
+```text
+Adding a new backend should require zero changes outside the owning module.
+
+Find code that would break that invariant:
+- isinstance() checks against concrete backend classes in business logic
+- `if backend_type == "X":` branches outside factories
+- Concrete impl type hints (e.g. SQLiteRepo) leaking into public APIs where
+  the Protocol type should be used
+- Direct instantiation of concrete impls outside factories
+
+Severity: medium.
+```
+
+**Agent 72 -- dependency-inversion-violations** (sonnet)
+File: `_audit/findings/72-dependency-inversion-violations.md`
+```text
+High-level modules (engine, api, communication) should depend on Protocol
+types, not concrete impls.
+
+For each imported symbol in src/synthorg/engine/, src/synthorg/api/, and
+src/synthorg/communication/, check if it's a concrete class when a Protocol
+exists for the same role. Flag imports of concrete classes where a Protocol
+type is available and would satisfy the call site.
+
 Severity: low.
 ```
+
+### Wave 15: Documentation Truth & Freshness (9 agents)
+
+**Agent 73 -- roadmap-currency** (sonnet)
+File: `_audit/findings/73-roadmap-currency.md`
+```text
+Cross-reference roadmap.md / docs/roadmap*.md with `gh issue list` (open +
+closed by version label) and `gh release list`.
+
+Flag:
+- Version themes listing issues already closed as open work
+- Shipped work still described as future
+- Version numbers on the roadmap not matching released tags in pyproject.toml
+- Missing entries for versions that have shipped
+
+Severity: medium.
+```
+
+**Agent 74 -- comparison-page-accuracy** (sonnet)
+File: `_audit/findings/74-comparison-page-accuracy.md`
+```text
+Read docs/comparison*.md and scripts/generate_comparison.py. For every feature
+we claim to support, verify the claim against actual code in src/synthorg/.
+
+Flag:
+- Checkmarks for features with no implementation
+- Missing checkmarks for features we do implement
+- Competitor feature claims without cited sources
+- "We support X" statements without the supporting code
+
+Severity: medium for inaccurate self-claims, low for competitor drift.
+```
+
+**Agent 75 -- landing-page-metrics** (sonnet)
+File: `_audit/findings/75-landing-page-metrics.md`
+```text
+Check numeric claims on public-facing pages (README, landing, comparison,
+docs index). For each number, verify against live source:
+- Test count via pytest --collect-only
+- Provider count via providers/presets.py
+- Backend count via persistence/ subdirectories
+- Tool count via tools/registry.py
+- Supported model count
+- Line count / file count claims
+
+Flag every stale number.
+
+Severity: medium.
+```
+
+**Agent 76 -- superseded-decisions** (sonnet)
+File: `_audit/findings/76-superseded-decisions.md`
+```text
+Read docs/decisions*.md, ADR files, and docs/design/ pages. For each accepted
+decision, check: was it later reversed or superseded?
+
+Flag:
+- Decisions marked "accepted" that code no longer follows
+- ADRs without status updates (missing "Superseded by" cross-link)
+- "Decided to use X" claims where code now uses Y
+- Contradicting decisions across multiple ADRs with no resolution
+
+Severity: medium.
+```
+
+**Agent 77 -- config-reference-drift** (sonnet)
+File: `_audit/findings/77-config-reference-drift.md`
+```text
+Compare docs/reference/*.md env var / settings reference against
+src/synthorg/settings/definitions/ and src/synthorg/config/.
+
+Flag:
+- Documented settings that don't exist in code
+- Real settings with no doc entry
+- Default values in docs that disagree with code defaults
+- Type / validation mismatches
+
+Severity: medium.
+```
+
+**Agent 78 -- cli-reference-drift** (sonnet)
+File: `_audit/findings/78-cli-reference-drift.md`
+```text
+Compare CLI reference pages in docs/reference/ (and cli/CLAUDE.md command
+listings) against actual cobra definitions in cli/cmd/*.go.
+
+Flag:
+- Documented flags or commands that don't exist
+- Real flags or commands with no docs entry
+- Description drift between docs and cobra Long / Short fields
+
+Severity: medium.
+```
+
+**Agent 79 -- api-reference-drift** (sonnet)
+File: `_audit/findings/79-api-reference-drift.md`
+```text
+Compare API reference pages (docs/reference/api*.md, if present) against
+actual Litestar routes in src/synthorg/api/controllers/.
+
+Flag:
+- Documented endpoints not registered in code
+- Registered endpoints with no reference docs
+- Request / response shape drift between docs and DTOs
+
+Severity: medium.
+```
+
+**Agent 80 -- example-config-validity** (sonnet)
+File: `_audit/findings/80-example-config-validity.md`
+```text
+For every fenced code block in docs/ tagged yaml / toml / json / env / dotenv
+that looks like a config example, validate it against the current Pydantic
+schema.
+
+Flag:
+- Snippets with deprecated keys
+- Missing required fields
+- Type mismatches
+- Keys no longer recognized by the schema
+
+Severity: medium.
+```
+
+**Agent 81 -- design-spec-contradictions** (sonnet)
+File: `_audit/findings/81-design-spec-contradictions.md`
+```text
+Cross-reference pages in docs/design/. Find internal contradictions.
+
+Flag:
+- Two pages making contradictory claims about the same subsystem (e.g. page A
+  says "all writes go through the engine", page B says "workers write directly")
+- Terminology drift (same concept named differently across pages)
+- `§cross-references` to sections that no longer exist
+
+Severity: medium.
+```
+
+### Wave 16: Docs Scope & Rot (5 agents)
+
+**Agent 82 -- docs-scope-creep** (sonnet)
+File: `_audit/findings/82-docs-scope-creep.md`
+```text
+Read each docs/ page and assess whether it has grown beyond its stated purpose.
+
+Flag:
+- Pages whose scope (as described in their intro) doesn't match the actual
+  content (e.g. architecture page full of HR details)
+- Topics that should live on a dedicated page
+- Pages over 800 lines mixing unrelated subjects
+
+Severity: low.
+```
+
+**Agent 83 -- stale-code-examples** (sonnet)
+File: `_audit/findings/83-stale-code-examples.md`
+```text
+For every fenced code block in docs/ tagged python / typescript / javascript /
+go / bash that calls project code, verify the APIs referenced still exist
+with the same signatures.
+
+Flag:
+- Renamed functions or classes
+- Moved imports
+- Changed parameter names or types
+- Removed methods
+
+Severity: medium.
+```
+
+**Agent 84 -- removed-features-still-mentioned** (sonnet)
+File: `_audit/findings/84-removed-features-still-mentioned.md`
+```text
+Read docs/ narrative prose for feature / module / concept names. For each
+reference, verify the named thing still exists in code.
+
+Flag:
+- "How it works" sections describing subsystems that have been deleted
+- Feature walkthroughs for removed capabilities
+- Prose referencing renamed modules by their old names
+
+Severity: medium.
+```
+
+**Agent 85 -- docs-seo-freshness** (haiku)
+File: `_audit/findings/85-docs-seo-freshness.md`
+```text
+Check page titles, meta descriptions (front matter), and opening paragraphs
+in docs/ for:
+- Outdated version numbers (e.g. "as of v0.5")
+- Dates that have passed (e.g. "coming in Q1 2026")
+- "Latest version" claims pointing to a version no longer latest
+
+Severity: low.
+```
+
+**Agent 86 -- issue-pr-link-rot** (haiku)
+File: `_audit/findings/86-issue-pr-link-rot.md`
+```text
+Grep docs/ for `#NNN` references to GitHub issues / PRs. For each, verify via
+`gh issue view` / `gh pr view` that the reference is still valid.
+
+Flag:
+- Deleted issues / PRs
+- Renamed issues where the cited title no longer matches
+- Links to issues reassigned under a different scope
+
+Severity: low.
+```
+
+### Wave 17: Security Deep-Dive (6 agents)
+
+**Agent 87 -- http-security-headers** (sonnet)
+File: `_audit/findings/87-http-security-headers.md`
+```text
+Check HTTP responses for missing security headers: Content-Security-Policy,
+Strict-Transport-Security (HSTS), X-Frame-Options, X-Content-Type-Options,
+Referrer-Policy, Permissions-Policy.
+
+Scope: api/app.py middleware, Litestar response plugins, reverse proxy configs.
+
+Severity: medium.
+```
+
+**Agent 88 -- cookie-auth-security** (sonnet)
+File: `_audit/findings/88-cookie-auth-security.md`
+```text
+Audit authentication and cookie hygiene:
+- Cookies without HttpOnly / Secure / SameSite flags
+- JWT usage without alg/exp/iss/aud validation
+- OAuth flows missing state/nonce parameters
+- CSRF protection gaps on state-mutating endpoints
+
+Severity: high.
+```
+
+**Agent 89 -- crypto-hygiene** (sonnet)
+File: `_audit/findings/89-crypto-hygiene.md`
+```text
+Find cryptographic anti-patterns:
+- `random` / `random.choice` for security-sensitive randomness (should be `secrets`)
+- `==` comparison on secrets/tokens (should use `hmac.compare_digest`)
+- Weak hash algorithms (MD5, SHA-1) for security
+- Hardcoded IVs / nonces
+
+Severity: high.
+```
+
+**Agent 90 -- secrets-in-logs** (sonnet)
+File: `_audit/findings/90-secrets-in-logs.md`
+```text
+Check the telemetry privacy allowlist in `src/synthorg/telemetry/privacy.py`
+against actual `logger.*` calls. Flag:
+- Logger kwargs that could leak PII, tokens, passwords, API keys
+- Field names matching forbidden patterns (key, token, secret, password,
+  bearer, auth, credential) being logged without scrubbing
+- Exception messages that may contain sensitive context logged verbatim
+
+Severity: high.
+```
+
+**Agent 91 -- path-traversal-ssrf-xxe-redos** (sonnet)
+File: `_audit/findings/91-path-traversal-ssrf-xxe-redos.md`
+```text
+Find injection-class vulnerabilities:
+- Path traversal: user input passed to `open()` / `Path()` without sanitization
+- SSRF: user-supplied URLs fetched without an allowlist
+- XXE: XML parsing with external entity resolution enabled
+- ReDoS: user-supplied strings matched against catastrophic-backtracking regexes
+
+Severity: high.
+```
+
+**Agent 92 -- prompt-injection-defenses** (sonnet)
+File: `_audit/findings/92-prompt-injection-defenses.md`
+```text
+Audit LLM prompt handling:
+- System prompts concatenated with user input without delimiters/tagging
+- LLM output used as tool arguments without schema validation
+- Agent-to-agent message content treated as trusted
+- Missing `<untrusted-*>` tag wrapping for external content in prompts
+- Output schema validation on LLM responses
+
+Severity: high.
+```
+
+### Wave 18: Performance & Resource Efficiency (5 agents)
+
+**Agent 93 -- n-plus-one-queries** (sonnet)
+File: `_audit/findings/93-n-plus-one-queries.md`
+```text
+Find N+1 query patterns in persistence and service layers: loops that call
+repository methods per item instead of batch loads, per-row fetches in render
+paths, missing eager-load joins for related entities.
+
+Severity: high.
+```
+
+**Agent 94 -- missing-indices** (sonnet)
+File: `_audit/findings/94-missing-indices.md`
+```text
+Cross-reference WHERE / JOIN / ORDER BY columns in persistence queries with
+schema indices. Flag query patterns that would benefit from an index that
+doesn't exist. Check both SQLite and Postgres schemas.
+
+Severity: medium.
+```
+
+**Agent 95 -- missing-pagination** (sonnet)
+File: `_audit/findings/95-missing-pagination.md`
+```text
+Find API endpoints and repository methods that return unbounded lists.
+Everything that can grow should accept cursor/offset+limit parameters.
+
+Severity: medium.
+```
+
+**Agent 96 -- blocking-io-hot-paths** (sonnet)
+File: `_audit/findings/96-blocking-io-hot-paths.md`
+```text
+Find blocking I/O inside async hot paths:
+- Sync `open()` / `requests.*` / `subprocess.run` in async functions
+- CPU-bound work without `run_in_executor`
+- Missing gzip/brotli compression on large payload endpoints
+- Missing ETag / Cache-Control on cacheable responses
+
+Severity: high.
+```
+
+**Agent 97 -- memory-leak-patterns** (sonnet)
+File: `_audit/findings/97-memory-leak-patterns.md`
+```text
+Find leak patterns:
+- Event listeners / subscriptions added without teardown
+- Zustand stores scheduling timers without cleanup
+- Closures holding references to large objects
+- Unclosed async generators / contextvars
+
+Scope: src/synthorg/ AND web/src/.
+
+Severity: high.
+```
+
+### Wave 19: Test Quality (4 agents)
+
+**Agent 98 -- tests-without-assertions** (sonnet)
+File: `_audit/findings/98-tests-without-assertions.md`
+```text
+Find test functions in tests/ (Python) and web/src/__tests__/ (TS) that have
+no assert / expect / raises call. These "tests" pass regardless of behavior
+and give false coverage confidence.
+
+Severity: high.
+```
+
+**Agent 99 -- tests-with-sleeps** (haiku)
+File: `_audit/findings/99-tests-with-sleeps.md`
+```text
+Grep tests/ and web/src/__tests__/ for hardcoded sleeps / setTimeout /
+asyncio.sleep in tests. These indicate timing-dependent tests that should
+use deterministic waits (Event, condition variables, fake clocks).
+
+Severity: medium.
+```
+
+**Agent 100 -- mock-drift** (sonnet)
+File: `_audit/findings/100-mock-drift.md`
+```text
+Compare mock shapes (MagicMock, unittest.mock patches, vi.mock) against the
+real interfaces they stand in for. Flag method names, signatures, or return
+types on mocks that don't match the real class/function today.
+
+Severity: medium.
+```
+
+**Agent 101 -- e2e-critical-flow-gaps** (sonnet)
+File: `_audit/findings/101-e2e-critical-flow-gaps.md`
+```text
+Identify critical user flows (setup wizard, agent creation, workflow run,
+budget check, approval, memory recall) and verify each has at least one E2E
+test in web/e2e/ or tests/e2e/. Flag missing coverage.
+
+Severity: medium.
+```
+
+### Wave 20: Operational & Data Readiness (5 agents)
+
+**Agent 102 -- graceful-shutdown** (sonnet)
+File: `_audit/findings/102-graceful-shutdown.md`
+```text
+Check shutdown path:
+- SIGTERM handler installed?
+- In-flight HTTP requests drained?
+- Background tasks cancelled with timeout?
+- Provider / DB connections closed cleanly?
+- Atlas/Postgres connection pools shutdown?
+
+Severity: high.
+```
+
+**Agent 103 -- data-retention-gdpr** (sonnet)
+File: `_audit/findings/103-data-retention-gdpr.md`
+```text
+Find PII/user-data fields in Pydantic models and persistence schemas and
+check:
+- Retention policy documented?
+- Deletion flow exists?
+- Audit trail for PII reads?
+
+Severity: medium.
+```
+
+**Agent 104 -- monitoring-dashboards** (sonnet)
+File: `_audit/findings/104-monitoring-dashboards.md`
+```text
+Check Prometheus metrics emitted by the code against documented Grafana /
+Logfire dashboards. Flag metrics without dashboards and dashboards referring
+to metrics that no longer exist.
+
+Severity: medium.
+```
+
+**Agent 105 -- prompt-eval-coverage** (sonnet)
+File: `_audit/findings/105-prompt-eval-coverage.md`
+```text
+List LLM prompts in src/synthorg/ (agents, tools, quality graders, etc.) and
+check each has:
+- An eval suite with before/after examples
+- Explicit model version pinning
+- Temperature / top_p set explicitly (not model default)
+
+Severity: medium.
+```
+
+**Agent 106 -- health-readiness-probes** (sonnet)
+File: `_audit/findings/106-health-readiness-probes.md`
+```text
+Verify the API exposes `/healthz` (liveness) and `/readyz` (readiness) with
+distinct semantics. Readiness should check DB / provider / queue connectivity;
+liveness should only confirm the process is alive.
+
+Severity: medium.
+```
+
+### Wave 21: Developer Experience & Reproducibility (2 agents)
+
+**Agent 107 -- slow-precommit-hooks** (haiku)
+File: `_audit/findings/107-slow-precommit-hooks.md`
+```text
+Profile `.pre-commit-config.yaml` hooks by measuring runtime. Flag hooks
+taking >3s on a typical `git commit`. Suggest moving expensive ones to
+pre-push or CI.
+
+Severity: low.
+```
+
+**Agent 108 -- claude-md-reproducibility** (sonnet)
+File: `_audit/findings/108-claude-md-reproducibility.md`
+```text
+For every fenced command in CLAUDE.md, web/CLAUDE.md, cli/CLAUDE.md, and
+`.claude/skills/*/SKILL.md`, verify the command actually works today. Flag
+commands referencing removed scripts, changed flag names, or missing tools.
+
+Severity: medium.
+```
+
+### Wave 22: Code Quality & Duplication (6 agents)
+
+**Agent 109 -- typescript-strictness** (sonnet)
+File: `_audit/findings/109-typescript-strictness.md`
+```text
+In web/src/, count and flag: `any` type usage, `@ts-ignore` / `@ts-expect-error`
+comments, non-null assertions (`!`), and type assertions (`as X`) where a type
+guard would be safer. Verify tsconfig `strict` is fully enabled.
+
+Severity: medium.
+```
+
+**Agent 110 -- duplicate-business-logic** (sonnet)
+File: `_audit/findings/110-duplicate-business-logic.md`
+```text
+Find blocks of business logic duplicated across 2+ modules. Focus on
+substantive duplication (>10 lines of non-trivial code), not boilerplate.
+
+Severity: medium.
+```
+
+**Agent 111 -- duplicate-types** (sonnet)
+File: `_audit/findings/111-duplicate-types.md`
+```text
+Find types defined on both backend (Pydantic models / dataclasses) and
+frontend (TypeScript types / interfaces) that should be generated from a
+single source instead. Focus on DTOs, API request/response shapes, and
+shared enums.
+
+Severity: medium.
+```
+
+**Agent 112 -- duplicate-error-codes** (sonnet)
+File: `_audit/findings/112-duplicate-error-codes.md`
+```text
+Cross-reference custom exception names, RFC 9457 error `type` fields, and
+frontend error code enums. Flag the same conceptual error defined in multiple
+places.
+
+Severity: medium.
+```
+
+**Agent 113 -- feature-flag-coverage** (sonnet)
+File: `_audit/findings/113-feature-flag-coverage.md`
+```text
+Find feature flags / settings that gate risky behavior. Flag:
+- Risky features with no kill-switch
+- Flags that are always-on or always-off (dead flags)
+- Flags referenced in code but not defined in settings
+
+Severity: medium.
+```
+
+**Agent 114 -- default-config-sanity** (sonnet)
+File: `_audit/findings/114-default-config-sanity.md`
+```text
+Review default values across `src/synthorg/config/` and
+`settings/definitions/`. Flag defaults that are unsafe for production or
+surprise the user (debug=True, verbose logging, open CORS, etc.).
+
+Severity: medium.
+```
+
+### Wave 23: CI & Supply Chain (5 agents)
+
+**Agent 115 -- workflow-permissions** (sonnet)
+File: `_audit/findings/115-workflow-permissions.md`
+```text
+Audit `.github/workflows/*.yml` for:
+- Over-broad `GITHUB_TOKEN` permissions (should be least-privilege per job)
+- Missing `permissions:` block (inherits repo default, usually too broad)
+- Missing environment protection rules on prod deploys
+
+Severity: high.
+```
+
+**Agent 116 -- ci-flakiness** (sonnet)
+File: `_audit/findings/116-ci-flakiness.md`
+```text
+Analyze recent CI run history (via `gh run list`) for patterns:
+- Tests failing intermittently on unchanged code
+- Jobs hitting timeout consistently
+- Cache misses that slow runs significantly
+
+Severity: medium.
+```
+
+**Agent 117 -- unused-deps** (sonnet)
+File: `_audit/findings/117-unused-deps.md`
+```text
+Cross-reference dependencies declared in `pyproject.toml`, `web/package.json`,
+and `cli/go.mod` with actual import statements. Flag deps that are declared
+but never imported anywhere.
+
+Severity: medium.
+```
+
+**Agent 118 -- duplicate-deps** (sonnet)
+File: `_audit/findings/118-duplicate-deps.md`
+```text
+Find redundant libraries doing the same job (e.g. lodash + ramda, axios +
+fetch wrappers, multiple date libraries). Recommend consolidation.
+
+Severity: low.
+```
+
+**Agent 119 -- license-compat** (sonnet)
+File: `_audit/findings/119-license-compat.md`
+```text
+Check dependency licenses against project BUSL-1.1 license. Flag deps with
+GPL, AGPL, or other copyleft licenses that conflict with the project license
+grant.
+
+Severity: high.
+```
+
+### Wave 24: Client Robustness (2 agents)
+
+**Agent 120 -- rate-limit-client** (sonnet)
+File: `_audit/findings/120-rate-limit-client.md`
+```text
+Audit client-side handling of HTTP 429 responses:
+- Web dashboard: retry-with-backoff on API calls?
+- Python SDK / provider clients: retry-after header respected?
+- CLI: graceful degradation on rate-limited endpoints?
+
+Severity: medium.
+```
+
+**Agent 121 -- ws-sse-robustness** (sonnet)
+File: `_audit/findings/121-ws-sse-robustness.md`
+```text
+Check WebSocket and Server-Sent Events implementations:
+- Reconnection logic with exponential backoff
+- Heartbeat / ping-pong to detect stalled connections
+- Backpressure handling when client can't keep up
+- Message schema versioning
+- Graceful fallback if WS/SSE is blocked by proxies
+
+Severity: medium.
+```
+
+### Wave 25: Git History & Drift (2 agents)
+
+**Agent 122 -- git-history-secrets-and-bloat** (sonnet)
+File: `_audit/findings/122-git-history-secrets-and-bloat.md`
+```text
+Two narrow checks on full git history (not just current tree):
+1. Run `gitleaks detect --log-opts=--all` over full history. Pre-commit
+   gitleaks only covers the current commit; this catches secrets that slipped
+   in before the hook existed.
+2. List top-20 largest blobs in git via
+   `git rev-list --objects --all | git cat-file --batch-check='%(objectsize) %(objectname) %(rest)' | sort -rn | head -20`.
+   Flag blobs >1MB that should be in LFS or removed.
+
+Severity: critical for secrets, medium for bloat.
+```
+
+**Agent 123 -- temporal-drift-wording** (sonnet)
+File: `_audit/findings/123-temporal-drift-wording.md`
+```text
+Scan docs/, CLAUDE.md, web/CLAUDE.md, cli/CLAUDE.md, README.md, and
+.claude/skills/*/SKILL.md for temporal / reference-drift wording that will
+go stale or is already stale:
+- "new in vX.Y", "added in version X", "recently added"
+- "as of <date>", "as of <version>"
+- "coming soon", "in the next release"
+- "the new X" when X is now baseline
+- "legacy" markers for code that's now the only implementation
+- "temporary" / "workaround" that persisted
+- "TODO: remove after <date>" where date has passed
+- Positional references like "above", "below", "this here" that rot after reorganisation
+- `#NNN` issue references that no longer match the cited topic
+
+Severity: low for stylistic drift, medium for misleading claims.
+```
+
+### Retired Agents
+
+These concerns are now enforced by hooks, linters, or external tooling instead of an audit agent. Do NOT launch them; check the "Now enforced by" column if a related concern needs attention.
+
+| Retired agent | Now enforced by |
+|---|---|
+| wrong-logger-pattern | Custom ruff rule or pre-commit regex hook (TODO: add) |
+| unstructured-logging | Custom ruff rule (TODO: add) |
+| unused-web-components | `knip` in CI (TODO: wire) |
+| unused-web-hooks | `knip` in CI (TODO: wire) |
+| unused-web-utils | `knip` / `ts-prune` in CI (TODO: wire) |
+| hardcoded-secrets | `gitleaks` pre-commit + CI |
+| vendor-name-leaks | Extend `scripts/check_forbidden_literals.py` (TODO) |
+| hardcoded-display-values | `scripts/check_web_design_system.py` + `scripts/check_backend_regional_defaults.py` PostToolUse hooks |
+| long-functions | Ruff `C901` / `PLR0915` + eslint `max-lines-per-function` (TODO: enable) |
+| long-files | Ruff + eslint `max-lines` (TODO: enable) |
+| future-annotations-leak | Ruff `FA100` / `FA102` (TODO: enable) |
+| design-token-violations | `scripts/check_web_design_system.py` PostToolUse hook |
+| go-error-handling | `golangci-lint` (errcheck, wrapcheck, errorlint) pre-commit + CI |
+| go-resource-leaks | `golangci-lint` + `go vet` pre-commit + CI |
+| docs-links-refs | `lychee` in CI (TODO: wire) |
+| changelog-release-notes | `release-please` (automated) |
+| changelog-releases-parity | `release-please` (automated) |
 
 ---
 
@@ -979,7 +1702,7 @@ Severity: low.
 
 **Required for standard runs.** For `--quick` runs or when fewer than 5 critical+high findings exist, validation may be skipped.
 
-After all launched audit agents complete, launch validation agents to verify findings. The number of agents depends on scope (75 for `full`, fewer for scoped runs).
+After all launched audit agents complete, launch validation agents to verify findings. The number of agents depends on scope (123 for `full`, fewer for scoped runs).
 
 ### Process
 

--- a/.claude/skills/codebase-audit/SKILL.md
+++ b/.claude/skills/codebase-audit/SKILL.md
@@ -25,11 +25,11 @@ Launch 123 specialized agents to audit the entire codebase (or a targeted scope)
 
 | Argument | Directories | Agents |
 |----------|-------------|-------------|
-| `full` (default) | All | 1-123 |
-| `src/` | `src/synthorg/`, `tests/`, `web/src/types/`, `docs/design/` | 01-06, 09-16, 18-34, 39-42, 48-51, 55, 58-80, 87-100, 102-106, 110-114, 120-121 |
-| `web/` | `web/src/`, `src/synthorg/api/controllers/` | 07-08, 13, 15, 35-38, 45-47, 52-54, 57-59, 97, 100-101, 109, 111-112, 120-121 |
-| `cli/` | `cli/` | 18, 43-44, 56, 67, 78, 89, 115-119, 122 |
-| `docs/` | `docs/`, `site/`, `src/synthorg/` | 20, 42, 48-51, 73-86, 103-104, 108, 123 |
+| `full` (default) | All | 01-123 |
+| `src/` | `src/synthorg/`, `tests/`, `web/src/types/`, `docs/design/` | 01-06, 09-14, 16-34, 39-42, 48-51, 55, 58-80, 87-100, 102-108, 110-123 |
+| `web/` | `web/src/`, `src/synthorg/api/controllers/` | 07-08, 13, 17, 35-38, 45-47, 52-54, 57-59, 97, 100-101, 107-109, 111-112, 120-121, 123 |
+| `cli/` | `cli/` | 17, 18, 43-44, 56, 67, 78, 89, 107-108, 115-119, 122-123 |
+| `docs/` | `docs/`, `site/`, `src/synthorg/` | 17, 20, 42, 48-51, 73-86, 103-104, 107-108, 123 |
 
 Flags:
 - `--report-only` -- skip issue creation, findings files only
@@ -182,6 +182,7 @@ Skip these (they legitimately don't need loggers):
 For each missing logger, report severity=low with the file path.
 If a file has business logic (functions with if/try/for/while, service methods,
 handlers) but no logger, that's a finding.
+
 ```
 
 **Agent 02 -- missing-event-constants** (sonnet)
@@ -203,6 +204,7 @@ First, list all event constant modules in observability/events/ to understand
 what's available. Then check every logger call.
 
 Severity: low.
+
 ```
 
 **Agent 03 -- missing-error-logging** (sonnet)
@@ -224,6 +226,7 @@ Exceptions to skip:
 - `raise StopIteration` / `raise StopAsyncIteration`
 
 Severity: medium for service/engine code, low for model validation.
+
 ```
 
 **Agent 04 -- missing-state-transition-log** (sonnet)
@@ -246,6 +249,7 @@ If you find state machines in other modules, include them too.
 
 For each domain, find where status/state fields are modified and check if
 there's an INFO-level log call nearby. Missing transitions are severity=medium.
+
 ```
 
 **Agent 05 -- observability-completeness** (sonnet)
@@ -268,6 +272,7 @@ Check whether key operations have full observability coverage:
 For each gap, describe what operation is missing coverage and suggest which
 metric/trace/event to add. Severity: medium for missing metrics on key paths,
 low for nice-to-have.
+
 ```
 
 ### Wave 2: Wiring & Integration (8 agents)
@@ -279,6 +284,7 @@ Check api/controllers/ for controller classes not registered in auto_wire.py
 or app.py. Also check for route handler methods that exist but are not mapped
 to any HTTP route. Do NOT check frontend-to-backend connectivity (Agent 13
 owns that). Severity: high (unreachable code).
+
 ```
 
 **Agent 07 -- unwired-web-stores** (sonnet)
@@ -287,6 +293,7 @@ File: `_audit/findings/07-unwired-web-stores.md`
 Check every Zustand store file in web/src/stores/. For each store, grep the
 entire web/src/ directory for imports of that store. If a store is imported by
 zero pages or components, it's dead. Severity: medium.
+
 ```
 
 **Agent 08 -- unwired-web-pages** (sonnet)
@@ -295,6 +302,7 @@ File: `_audit/findings/08-unwired-web-pages.md`
 Find all .tsx files in web/src/pages/ that are NOT imported by any other file
 (not by routes.ts, not by another page as a nested layout). Pages with no
 route AND no parent import are unreachable. Severity: medium.
+
 ```
 
 **Agent 09 -- unwired-settings** (sonnet)
@@ -304,6 +312,7 @@ Check settings/definitions/ for setting definitions. For each, check if it is:
 (a) subscribed to via settings/subscribers/, AND
 (b) exposed via an API endpoint in api/controllers/settings.py.
 Settings defined but never consumed are dead config. Severity: medium.
+
 ```
 
 **Agent 10 -- unwired-tools** (sonnet)
@@ -312,6 +321,7 @@ File: `_audit/findings/10-unwired-tools.md`
 Check tool classes in tools/ subdirectories. For each tool class that extends
 BaseTool, verify it is registered in tools/factory.py or tools/registry.py.
 Unregistered tools are dead code. Severity: medium.
+
 ```
 
 **Agent 11 -- unwired-protocols** (sonnet)
@@ -322,6 +332,7 @@ implementations (classes that implement the protocol). Then check if those
 implementations are registered in their factory. Report:
 - Protocols with zero implementations (severity: medium)
 - Implementations not registered in any factory (severity: medium)
+
 ```
 
 **Agent 12 -- unwired-notifications** (sonnet)
@@ -331,6 +342,7 @@ Check notifications/adapters/ for adapter classes. Verify each is registered
 in notifications/factory.py. Also check if notification events are dispatched
 from business logic. Report adapters with no factory registration and
 notification types never dispatched. Severity: medium.
+
 ```
 
 **Agent 13 -- frontend-backend-mismatch** (sonnet)
@@ -340,6 +352,7 @@ Cross-reference web/src/api/ and web/src/services/ API calls with backend
 api/controllers/ endpoints. Report:
 - Frontend calls targeting endpoints that don't exist in backend (high)
 - Backend endpoints with zero frontend consumers (low -- may be API-only)
+
 ```
 
 ### Wave 3: Dead Code & Unused (3 agents)
@@ -351,6 +364,7 @@ Find public functions and classes in src/synthorg/ that are not imported by
 any other module, not re-exported in __init__.py, and not referenced in tests/.
 Exclude: __init__ methods, property descriptors, __repr__/__str__, metaclass
 methods, enum members, Pydantic field definitions. Severity: medium.
+
 ```
 
 **Agent 15 -- unused-dto-fields** (sonnet)
@@ -359,7 +373,8 @@ File: `_audit/findings/15-unused-dto-fields.md`
 Compare DTO classes in api/dto*.py with frontend TypeScript types in
 web/src/types/. Flag fields present in backend DTOs but absent from frontend
 types (or vice versa). This suggests unused serialization. Severity: low.
-Only runs for `full` or `src/` scope (requires both backend and frontend).
+Runs for `full`, `src/`, or `web/` scope (requires both backend and frontend).
+
 ```
 
 **Agent 16 -- orphan-test-helpers** (sonnet)
@@ -368,6 +383,7 @@ File: `_audit/findings/16-orphan-test-helpers.md`
 Check all conftest.py files in tests/ for fixtures and helper functions.
 Grep tests/ for usage of each. Unused fixtures/helpers are dead test code.
 Severity: low.
+
 ```
 
 ### Wave 4: TODOs & Deferred (4 agents)
@@ -378,6 +394,7 @@ File: `_audit/findings/17-todo-comments.md`
 Grep source files in the provided scope for TODO, FIXME, HACK,
 XXX, TEMPORARY, WORKAROUND comments. List each with file:line and the full
 comment text. Severity: info.
+
 ```
 
 **Agent 18 -- not-implemented** (haiku)
@@ -386,6 +403,7 @@ File: `_audit/findings/18-not-implemented.md`
 Grep src/synthorg/ and cli/ for: NotImplementedError, pass-only function
 bodies (def/async def with only pass), and Ellipsis (...) as sole function
 body. Severity: info for abstract methods, medium for concrete stubs.
+
 ```
 
 **Agent 19 -- placeholder-stubs** (sonnet)
@@ -394,6 +412,7 @@ File: `_audit/findings/19-placeholder-stubs.md`
 Find functions that return hardcoded dummy values, empty lists/dicts, or have
 "placeholder", "stub", "temporary", "mock" in their comments/docstrings.
 These suggest incomplete implementations. Severity: medium.
+
 ```
 
 **Agent 20 -- deferred-features** (sonnet)
@@ -402,6 +421,7 @@ File: `_audit/findings/20-deferred-features.md`
 Read docs/design/ pages and cross-reference with src/synthorg/. Find features
 described in the design spec that have no corresponding implementation.
 Focus on major features (not minor details). Severity: info.
+
 ```
 
 ### Wave 5: Safety & Security (6 agents)
@@ -413,6 +433,7 @@ Find except blocks that swallow exceptions silently: bare `except:`,
 `except Exception: pass`, `except Exception as e:` with only DEBUG logging
 (should be WARNING+), catching too broadly. Skip intentional patterns like
 graceful shutdown cleanup. Severity: high for business logic, medium for cleanup.
+
 ```
 
 **Agent 22 -- input-validation-gaps** (sonnet)
@@ -421,6 +442,7 @@ File: `_audit/findings/22-input-validation-gaps.md`
 Check API controller methods for user input that bypasses validation. Look for
 path/query parameters used directly without Pydantic validation, raw request
 body access, and missing type coercion. Severity: high.
+
 ```
 
 **Agent 23 -- sql-injection-risk** (sonnet)
@@ -428,6 +450,7 @@ File: `_audit/findings/23-sql-injection-risk.md`
 ```text
 Search persistence/ and any file using SQL for string concatenation or f-strings
 in SQL queries instead of parameterized queries. Severity: critical.
+
 ```
 
 **Agent 24 -- missing-auth-checks** (sonnet)
@@ -436,6 +459,7 @@ File: `_audit/findings/24-missing-auth-checks.md`
 Check API controllers for endpoints missing auth guards. Compare with auth
 middleware/dependency injection. Public endpoints should be explicitly marked.
 Severity: high for data-mutating endpoints, medium for read-only.
+
 ```
 
 **Agent 25 -- unsafe-deserialization** (haiku)
@@ -444,6 +468,7 @@ File: `_audit/findings/25-unsafe-deserialization.md`
 Flag ANY use of yaml.load (even with Loader parameter -- verify SafeLoader),
 pickle.loads, eval(), exec(). Flag compile() ONLY if the argument contains a
 variable or function parameter (not a string literal). Severity: critical.
+
 ```
 
 **Agent 26 -- missing-rate-limiting** (sonnet)
@@ -451,6 +476,7 @@ File: `_audit/findings/26-missing-rate-limiting.md`
 ```text
 Check public-facing API endpoints for rate limiting. Check expensive operations
 (LLM calls, bulk DB writes, file uploads) for throttling. Severity: medium.
+
 ```
 
 ### Wave 6: Configuration & Hardcoding (4 agents)
@@ -461,6 +487,7 @@ File: `_audit/findings/27-hardcoded-urls-ports.md`
 Grep files in the provided scope for hardcoded URLs, ports, hostnames, IP
 addresses that should come from config or env vars. Skip test files and
 documentation. Severity: medium.
+
 ```
 
 **Agent 28 -- hardcoded-timeouts-limits** (haiku)
@@ -477,6 +504,7 @@ File: `_audit/findings/29-hardcoded-magic-numbers.md`
 Find magic numbers in business logic: bare numeric literals (not 0, 1, -1)
 without named constants. Focus on src/synthorg/ business logic, skip tests
 and config defaults. Severity: low.
+
 ```
 
 **Agent 30 -- missing-settings-bridge** (sonnet)
@@ -485,6 +513,7 @@ File: `_audit/findings/30-missing-settings-bridge.md`
 Cross-reference hardcoded values in src/synthorg/ with settings definitions in
 settings/definitions/. Find values that SHOULD be configurable but are hardcoded,
 and settings defined but never consumed by any code. Severity: medium.
+
 ```
 
 ### Wave 7: Code Quality & Conventions (4 agents)
@@ -498,6 +527,7 @@ Check Pydantic models in src/synthorg/ for convention violations:
 - Identifier/name fields not using NotBlankStr type
 - Mutable runtime fields mixed with config fields in one model
 Severity: medium.
+
 ```
 
 **Agent 32 -- missing-immutability** (sonnet)
@@ -509,6 +539,7 @@ Find violations of immutability conventions:
 - In-place mutations of frozen model instances
 - Missing copy.deepcopy at system boundaries
 Severity: medium.
+
 ```
 
 **Agent 33 -- async-antipatterns** (sonnet)
@@ -521,6 +552,7 @@ Find async antipatterns in src/synthorg/:
 - Fire-and-forget tasks with no error handling
 - sync sleep() in async context
 Severity: high for missing await, medium for others.
+
 ```
 
 **Agent 34 -- error-handling-consistency** (sonnet)
@@ -532,6 +564,7 @@ Check error handling conventions:
 - Missing error mapping in controllers (raw exceptions leaking to clients)
 - Inconsistent error response shapes across endpoints
 Severity: medium.
+
 ```
 
 ### Wave 8: Frontend Quality (4 agents)
@@ -543,6 +576,7 @@ Check web/src/components/ and web/src/pages/ for accessibility issues:
 missing aria-label on interactive elements, missing role attributes, missing
 keyboard navigation (onKeyDown handlers), missing focus management after
 navigation, images without alt text. Severity: medium.
+
 ```
 
 **Agent 36 -- missing-loading-states** (sonnet)
@@ -551,6 +585,7 @@ File: `_audit/findings/36-missing-loading-states.md`
 Check pages/components that fetch data (useQuery, useEffect with fetch) for
 missing loading skeletons/spinners, missing empty states when data is [],
 and missing error boundaries around async content. Severity: medium.
+
 ```
 
 **Agent 37 -- hardcoded-frontend-strings** (haiku)
@@ -559,6 +594,7 @@ File: `_audit/findings/37-hardcoded-frontend-strings.md`
 Find user-facing strings hardcoded directly in TSX files. Look for text
 content in JSX elements that should be centralized for i18n readiness.
 Skip component prop names and technical strings. Severity: info.
+
 ```
 
 **Agent 38 -- missing-error-handling-fe** (sonnet)
@@ -567,6 +603,7 @@ File: `_audit/findings/38-missing-error-handling-fe.md`
 Check web/src/ for API calls without error handling: missing .catch() or
 try/catch, missing toast/notification on failure, optimistic updates without
 rollback on error, console.error without user feedback. Severity: medium.
+
 ```
 
 ### Wave 9: Logic & Architecture (4 agents)
@@ -577,6 +614,7 @@ File: `_audit/findings/39-race-conditions.md`
 Find potential race conditions: shared mutable state without locks/mutexes,
 TOCTOU patterns (check-then-act without atomicity), concurrent dict/list
 modification, DB read-modify-write without transactions. Severity: high.
+
 ```
 
 **Agent 40 -- resource-leaks** (sonnet)
@@ -585,6 +623,7 @@ File: `_audit/findings/40-resource-leaks.md`
 Find unclosed resources: HTTP clients/sessions not using async with,
 file handles not in with blocks, DB connections not properly returned to pool,
 aiohttp sessions created but not closed. Severity: high.
+
 ```
 
 **Agent 41 -- circular-dependencies** (sonnet)
@@ -593,6 +632,7 @@ File: `_audit/findings/41-circular-dependencies.md`
 Find import cycles between src/synthorg/ packages. Check for circular
 references that could cause runtime ImportError or require deferred imports.
 Also check for TYPE_CHECKING guards that hide real circular deps. Severity: medium.
+
 ```
 
 **Agent 42 -- design-spec-drift** (sonnet)
@@ -601,6 +641,7 @@ File: `_audit/findings/42-design-spec-drift.md`
 Compare implementation in src/synthorg/ with docs/design/ specs. Find
 behaviors, models, or flows that diverge from what the spec describes without
 documented rationale. Focus on major architectural decisions. Severity: medium.
+
 ```
 
 ### Wave 10: Go CLI (2 agents)
@@ -610,6 +651,7 @@ File: `_audit/findings/43-go-hardcoded-values.md`
 ```text
 Grep cli/ for hardcoded Docker image tags, ports, paths, timeouts that should
 be configurable via flags or config. Severity: low.
+
 ```
 
 **Agent 44 -- go-cli-wiring** (sonnet)
@@ -618,6 +660,7 @@ File: `_audit/findings/44-go-cli-wiring.md`
 Check cobra command registration in cli/cmd/. Find commands registered but
 non-functional, flags defined but never read, subcommands with no RunE.
 Severity: medium.
+
 ```
 
 ### Wave 11: Dashboard Completeness (3 agents)
@@ -630,6 +673,7 @@ api/controllers/) with the web dashboard. For each endpoint, check whether
 the dashboard exposes the functionality to the user in SOME way -- a page,
 a button, a settings panel, a dialog, etc. Report endpoints that exist in
 the backend but have no corresponding UI surface. Severity: medium.
+
 ```
 
 **Agent 46 -- dashboard-settings-completeness** (sonnet)
@@ -640,6 +684,7 @@ Settings page in the dashboard (web/src/pages/settings/). For each setting,
 check whether it is editable/visible in the UI. Also check ConfigDict fields
 in src/synthorg/config/ that are user-facing but have no settings UI.
 Report settings that exist but are not exposed. Severity: medium.
+
 ```
 
 **Agent 47 -- dashboard-ux-improvements** (sonnet)
@@ -674,6 +719,7 @@ against actual code. Look for:
 - Removed features still documented
 - Incorrect file paths or module references
 Severity: medium for misleading docs, low for minor inaccuracies.
+
 ```
 
 **Agent 49 -- docs-completeness** (sonnet)
@@ -688,6 +734,7 @@ Check for documentation gaps. Look for:
 - Design pages referenced in DESIGN_SPEC.md that don't exist
 Cross-reference docs/design/ index with actual pages.
 Severity: medium for missing feature docs, low for missing examples.
+
 ```
 
 **Agent 50 -- readme-website-accuracy** (sonnet)
@@ -702,6 +749,7 @@ docs/, comparison page, etc.) for:
 - Missing or incorrect installation instructions
 - Outdated screenshots or diagrams
 Severity: medium for public-facing inaccuracies.
+
 ```
 
 **Agent 51 -- docs-diagram-quality** (sonnet)
@@ -715,6 +763,7 @@ Check all D2 and Mermaid diagrams in docs/ for:
 - Missing diagrams for complex subsystems that would benefit from visuals
 Cross-reference diagram content with actual source structure.
 Severity: low.
+
 ```
 
 ### Wave 13: UX & Content Quality (8 agents)
@@ -731,6 +780,7 @@ Check dashboard pages for visual and interaction consistency:
 - Inconsistent empty state messaging tone/style
 - Inconsistent date/time display formats across pages
 Severity: medium for jarring inconsistencies, low for minor.
+
 ```
 
 **Agent 53 -- ux-responsiveness** (sonnet)
@@ -744,6 +794,7 @@ MobileUnsupportedOverlay below the 768px breakpoint, but check for:
 - Charts/graphs that don't resize properly
 - Modals/drawers that overflow on smaller screens
 Severity: medium.
+
 ```
 
 **Agent 54 -- ux-performance-patterns** (sonnet)
@@ -758,6 +809,7 @@ Check dashboard for performance antipatterns:
 - Large bundle imports that should be lazy-loaded
 - Images without width/height (causing layout shift)
 Severity: medium.
+
 ```
 
 **Agent 55 -- api-docs-openapi** (sonnet)
@@ -771,6 +823,7 @@ Check the OpenAPI/Scalar API documentation for completeness:
 - Missing authentication requirements in endpoint docs
 Check by reading controller decorators and Pydantic model docstrings.
 Severity: low.
+
 ```
 
 **Agent 56 -- cli-docs-help** (haiku)
@@ -783,6 +836,7 @@ Check Go CLI commands for documentation completeness:
 - Inconsistent flag naming conventions
 - Commands without --help output verification
 Check cli/cmd/*.go for cobra.Command fields. Severity: low.
+
 ```
 
 **Agent 57 -- storybook-coverage** (sonnet)
@@ -795,6 +849,7 @@ component should have a .stories.tsx file. For existing stories, check:
 - Components in ui/ without any story file
 Severity: low for missing stories, medium for shared components with
 zero coverage.
+
 ```
 
 **Agent 58 -- error-messages-ux** (sonnet)
@@ -810,6 +865,7 @@ API error responses, form validation messages) for quality:
 - Error messages that don't tell the user what to do next
 Check both frontend toast calls and backend API error messages.
 Severity: medium for unhelpful errors, low for tone inconsistencies.
+
 ```
 
 **Agent 59 -- onboarding-flow** (sonnet)
@@ -824,6 +880,7 @@ Check the setup wizard and first-run experience:
 - Missing guidance on what to do after setup completes
 Check web/src/pages/setup/ and src/synthorg/api/controllers/setup.py.
 Severity: medium.
+
 ```
 
 ### Wave 14: Abstraction Boundaries & Backend Parity (13 agents)
@@ -842,6 +899,7 @@ Flag:
 - Signature drift (parameter names, types, return types diverging)
 
 Severity: high for missing impl, medium for signature drift.
+
 ```
 
 **Agent 61 -- migration-parity** (sonnet)
@@ -859,6 +917,7 @@ Flag:
 - Column type mismatches (TEXT vs VARCHAR, INTEGER vs BIGINT) implying drift
 
 Severity: high.
+
 ```
 
 **Agent 62 -- dual-backend-test-parity** (sonnet)
@@ -874,6 +933,7 @@ Flag:
 - Conftest fixtures defaulting to one backend with no parametrized counterpart
 
 Severity: medium.
+
 ```
 
 **Agent 63 -- persistence-boundary-deep** (sonnet)
@@ -891,6 +951,7 @@ _ALLOWLIST, find:
 - ORM session or transaction boundary management
 
 Severity: high.
+
 ```
 
 **Agent 64 -- provider-boundary-leaks** (sonnet)
@@ -919,6 +980,7 @@ Outside src/synthorg/memory/, find:
 - Embedding API calls bypassing the memory abstraction
 
 Severity: medium.
+
 ```
 
 **Agent 66 -- queue-boundary-leaks** (sonnet)
@@ -934,6 +996,7 @@ Find:
 - Redis pub/sub or similar bypassing the abstraction
 
 Severity: medium.
+
 ```
 
 **Agent 67 -- process-spawn-leaks** (sonnet)
@@ -949,6 +1012,7 @@ Outside sandbox / execution / CLI orchestrator modules, find:
 - os.system or similar shell-outs
 
 Severity: high for arbitrary code paths, medium for admin tools.
+
 ```
 
 **Agent 68 -- state-mutation-leaks** (sonnet)
@@ -1060,6 +1124,7 @@ Flag:
 - "We support X" statements without the supporting code
 
 Severity: medium for inaccurate self-claims, low for competitor drift.
+
 ```
 
 **Agent 75 -- landing-page-metrics** (sonnet)
@@ -1670,6 +1735,7 @@ go stale or is already stale:
 - `#NNN` issue references that no longer match the cited topic
 
 Severity: low for stylistic drift, medium for misleading claims.
+
 ```
 
 ### Retired Agents

--- a/.claude/skills/codebase-audit/SKILL.md
+++ b/.claude/skills/codebase-audit/SKILL.md
@@ -26,7 +26,7 @@ Launch 123 specialized agents to audit the entire codebase (or a targeted scope)
 | Argument | Directories | Agents |
 |----------|-------------|-------------|
 | `full` (default) | All | 01-123 |
-| `src/` | `src/synthorg/`, `tests/`, `web/src/types/`, `docs/design/` | 01-06, 09-14, 16-34, 39-42, 48-51, 55, 58-80, 87-100, 102-108, 110-123 |
+| `src/` | `src/synthorg/`, `tests/`, `web/src/types/`, `docs/design/` | 01-06, 09-15, 16-34, 39-42, 48-51, 55, 58-80, 87-100, 102-108, 110-123 |
 | `web/` | `web/src/`, `src/synthorg/api/controllers/` | 07-08, 13, 17, 35-38, 45-47, 52-54, 57-59, 97, 100-101, 107-109, 111-112, 120-121, 123 |
 | `cli/` | `cli/` | 17, 18, 43-44, 56, 67, 78, 89, 107-108, 115-119, 122-123 |
 | `docs/` | `docs/`, `site/`, `src/synthorg/` | 17, 20, 42, 48-51, 73-86, 103-104, 107-108, 123 |
@@ -160,7 +160,7 @@ Launch agents in 13 batches of ~10 each. All agents within a batch run in parall
 | L | 111-120 |
 | M | 121-123 |
 
-Report to user after each batch: "Batch X complete (N/123 agents done)."
+Report to user after each batch: "Batch X complete (N/{AGENTS_LAUNCHED} agents done)." where `{AGENTS_LAUNCHED}` is the total number of agents launched for the current scope (123 for `full`, fewer for scoped runs).
 
 ---
 
@@ -170,6 +170,7 @@ Report to user after each batch: "Batch X complete (N/123 agents done)."
 
 **Agent 01 -- missing-logger** (haiku)
 File: `_audit/findings/01-missing-logger.md`
+
 ```text
 Search every .py file in src/synthorg/ for modules that contain business logic
 but do NOT have `logger = get_logger(__name__)`.
@@ -187,6 +188,7 @@ handlers) but no logger, that's a finding.
 
 **Agent 02 -- missing-event-constants** (sonnet)
 File: `_audit/findings/02-missing-event-constants.md`
+
 ```text
 The project requires all logger calls to use event constants from
 src/synthorg/observability/events/ modules (e.g. API_REQUEST_STARTED from
@@ -209,6 +211,7 @@ Severity: low.
 
 **Agent 03 -- missing-error-logging** (sonnet)
 File: `_audit/findings/03-missing-error-logging.md`
+
 ```text
 Project convention: "All error paths must log at WARNING or ERROR with context
 before raising."
@@ -231,6 +234,7 @@ Severity: medium for service/engine code, low for model validation.
 
 **Agent 04 -- missing-state-transition-log** (sonnet)
 File: `_audit/findings/04-missing-state-transition-log.md`
+
 ```text
 Project convention: "All state transitions must log at INFO."
 
@@ -254,6 +258,7 @@ there's an INFO-level log call nearby. Missing transitions are severity=medium.
 
 **Agent 05 -- observability-completeness** (sonnet)
 File: `_audit/findings/05-observability-completeness.md`
+
 ```text
 Check whether key operations have full observability coverage:
 
@@ -279,6 +284,7 @@ low for nice-to-have.
 
 **Agent 06 -- unwired-api-controllers** (sonnet)
 File: `_audit/findings/06-unwired-api-controllers.md`
+
 ```text
 Check api/controllers/ for controller classes not registered in auto_wire.py
 or app.py. Also check for route handler methods that exist but are not mapped
@@ -289,6 +295,7 @@ owns that). Severity: high (unreachable code).
 
 **Agent 07 -- unwired-web-stores** (sonnet)
 File: `_audit/findings/07-unwired-web-stores.md`
+
 ```text
 Check every Zustand store file in web/src/stores/. For each store, grep the
 entire web/src/ directory for imports of that store. If a store is imported by
@@ -298,6 +305,7 @@ zero pages or components, it's dead. Severity: medium.
 
 **Agent 08 -- unwired-web-pages** (sonnet)
 File: `_audit/findings/08-unwired-web-pages.md`
+
 ```text
 Find all .tsx files in web/src/pages/ that are NOT imported by any other file
 (not by routes.ts, not by another page as a nested layout). Pages with no
@@ -307,6 +315,7 @@ route AND no parent import are unreachable. Severity: medium.
 
 **Agent 09 -- unwired-settings** (sonnet)
 File: `_audit/findings/09-unwired-settings.md`
+
 ```text
 Check settings/definitions/ for setting definitions. For each, check if it is:
 (a) subscribed to via settings/subscribers/, AND
@@ -317,6 +326,7 @@ Settings defined but never consumed are dead config. Severity: medium.
 
 **Agent 10 -- unwired-tools** (sonnet)
 File: `_audit/findings/10-unwired-tools.md`
+
 ```text
 Check tool classes in tools/ subdirectories. For each tool class that extends
 BaseTool, verify it is registered in tools/factory.py or tools/registry.py.
@@ -326,6 +336,7 @@ Unregistered tools are dead code. Severity: medium.
 
 **Agent 11 -- unwired-protocols** (sonnet)
 File: `_audit/findings/11-unwired-protocols.md`
+
 ```text
 Find all Protocol classes in src/synthorg/. For each, find concrete
 implementations (classes that implement the protocol). Then check if those
@@ -337,6 +348,7 @@ implementations are registered in their factory. Report:
 
 **Agent 12 -- unwired-notifications** (sonnet)
 File: `_audit/findings/12-unwired-notifications.md`
+
 ```text
 Check notifications/adapters/ for adapter classes. Verify each is registered
 in notifications/factory.py. Also check if notification events are dispatched
@@ -347,6 +359,7 @@ notification types never dispatched. Severity: medium.
 
 **Agent 13 -- frontend-backend-mismatch** (sonnet)
 File: `_audit/findings/13-frontend-backend-mismatch.md`
+
 ```text
 Cross-reference web/src/api/ and web/src/services/ API calls with backend
 api/controllers/ endpoints. Report:
@@ -359,6 +372,7 @@ api/controllers/ endpoints. Report:
 
 **Agent 14 -- unused-python-exports** (sonnet)
 File: `_audit/findings/14-unused-python-exports.md`
+
 ```text
 Find public functions and classes in src/synthorg/ that are not imported by
 any other module, not re-exported in __init__.py, and not referenced in tests/.
@@ -369,6 +383,7 @@ methods, enum members, Pydantic field definitions. Severity: medium.
 
 **Agent 15 -- unused-dto-fields** (sonnet)
 File: `_audit/findings/15-unused-dto-fields.md`
+
 ```text
 Compare DTO classes in api/dto*.py with frontend TypeScript types in
 web/src/types/. Flag fields present in backend DTOs but absent from frontend
@@ -379,6 +394,7 @@ Runs for `full`, `src/`, or `web/` scope (requires both backend and frontend).
 
 **Agent 16 -- orphan-test-helpers** (sonnet)
 File: `_audit/findings/16-orphan-test-helpers.md`
+
 ```text
 Check all conftest.py files in tests/ for fixtures and helper functions.
 Grep tests/ for usage of each. Unused fixtures/helpers are dead test code.
@@ -390,6 +406,7 @@ Severity: low.
 
 **Agent 17 -- todo-comments** (haiku)
 File: `_audit/findings/17-todo-comments.md`
+
 ```text
 Grep source files in the provided scope for TODO, FIXME, HACK,
 XXX, TEMPORARY, WORKAROUND comments. List each with file:line and the full
@@ -399,6 +416,7 @@ comment text. Severity: info.
 
 **Agent 18 -- not-implemented** (haiku)
 File: `_audit/findings/18-not-implemented.md`
+
 ```text
 Grep src/synthorg/ and cli/ for: NotImplementedError, pass-only function
 bodies (def/async def with only pass), and Ellipsis (...) as sole function
@@ -408,6 +426,7 @@ body. Severity: info for abstract methods, medium for concrete stubs.
 
 **Agent 19 -- placeholder-stubs** (sonnet)
 File: `_audit/findings/19-placeholder-stubs.md`
+
 ```text
 Find functions that return hardcoded dummy values, empty lists/dicts, or have
 "placeholder", "stub", "temporary", "mock" in their comments/docstrings.
@@ -417,6 +436,7 @@ These suggest incomplete implementations. Severity: medium.
 
 **Agent 20 -- deferred-features** (sonnet)
 File: `_audit/findings/20-deferred-features.md`
+
 ```text
 Read docs/design/ pages and cross-reference with src/synthorg/. Find features
 described in the design spec that have no corresponding implementation.
@@ -428,6 +448,7 @@ Focus on major features (not minor details). Severity: info.
 
 **Agent 21 -- silent-exception-swallow** (sonnet)
 File: `_audit/findings/21-silent-exception-swallow.md`
+
 ```text
 Find except blocks that swallow exceptions silently: bare `except:`,
 `except Exception: pass`, `except Exception as e:` with only DEBUG logging
@@ -438,6 +459,7 @@ graceful shutdown cleanup. Severity: high for business logic, medium for cleanup
 
 **Agent 22 -- input-validation-gaps** (sonnet)
 File: `_audit/findings/22-input-validation-gaps.md`
+
 ```text
 Check API controller methods for user input that bypasses validation. Look for
 path/query parameters used directly without Pydantic validation, raw request
@@ -447,6 +469,7 @@ body access, and missing type coercion. Severity: high.
 
 **Agent 23 -- sql-injection-risk** (sonnet)
 File: `_audit/findings/23-sql-injection-risk.md`
+
 ```text
 Search persistence/ and any file using SQL for string concatenation or f-strings
 in SQL queries instead of parameterized queries. Severity: critical.
@@ -455,6 +478,7 @@ in SQL queries instead of parameterized queries. Severity: critical.
 
 **Agent 24 -- missing-auth-checks** (sonnet)
 File: `_audit/findings/24-missing-auth-checks.md`
+
 ```text
 Check API controllers for endpoints missing auth guards. Compare with auth
 middleware/dependency injection. Public endpoints should be explicitly marked.
@@ -464,6 +488,7 @@ Severity: high for data-mutating endpoints, medium for read-only.
 
 **Agent 25 -- unsafe-deserialization** (haiku)
 File: `_audit/findings/25-unsafe-deserialization.md`
+
 ```text
 Flag ANY use of yaml.load (even with Loader parameter -- verify SafeLoader),
 pickle.loads, eval(), exec(). Flag compile() ONLY if the argument contains a
@@ -473,6 +498,7 @@ variable or function parameter (not a string literal). Severity: critical.
 
 **Agent 26 -- missing-rate-limiting** (sonnet)
 File: `_audit/findings/26-missing-rate-limiting.md`
+
 ```text
 Check public-facing API endpoints for rate limiting. Check expensive operations
 (LLM calls, bulk DB writes, file uploads) for throttling. Severity: medium.
@@ -483,6 +509,7 @@ Check public-facing API endpoints for rate limiting. Check expensive operations
 
 **Agent 27 -- hardcoded-urls-ports** (haiku)
 File: `_audit/findings/27-hardcoded-urls-ports.md`
+
 ```text
 Grep files in the provided scope for hardcoded URLs, ports, hostnames, IP
 addresses that should come from config or env vars. Skip test files and
@@ -492,6 +519,7 @@ documentation. Severity: medium.
 
 **Agent 28 -- hardcoded-timeouts-limits** (haiku)
 File: `_audit/findings/28-hardcoded-timeouts-limits.md`
+
 ```text
 Grep src/synthorg/ for hardcoded timeout values (seconds/ms), retry counts,
 batch sizes, max limits that should be configurable. Look for bare numeric
@@ -500,6 +528,7 @@ literals in asyncio.wait_for, sleep, timeout parameters. Severity: low.
 
 **Agent 29 -- hardcoded-magic-numbers** (haiku)
 File: `_audit/findings/29-hardcoded-magic-numbers.md`
+
 ```text
 Find magic numbers in business logic: bare numeric literals (not 0, 1, -1)
 without named constants. Focus on src/synthorg/ business logic, skip tests
@@ -509,6 +538,7 @@ and config defaults. Severity: low.
 
 **Agent 30 -- missing-settings-bridge** (sonnet)
 File: `_audit/findings/30-missing-settings-bridge.md`
+
 ```text
 Cross-reference hardcoded values in src/synthorg/ with settings definitions in
 settings/definitions/. Find values that SHOULD be configurable but are hardcoded,
@@ -520,6 +550,7 @@ and settings defined but never consumed by any code. Severity: medium.
 
 **Agent 31 -- model-convention-violations** (sonnet)
 File: `_audit/findings/31-model-convention-violations.md`
+
 ```text
 Check Pydantic models in src/synthorg/ for convention violations:
 - Missing frozen=True in ConfigDict (config/identity models must be frozen)
@@ -532,6 +563,7 @@ Severity: medium.
 
 **Agent 32 -- missing-immutability** (sonnet)
 File: `_audit/findings/32-missing-immutability.md`
+
 ```text
 Find violations of immutability conventions:
 - dict/list exposed without MappingProxyType wrapping (non-Pydantic)
@@ -544,6 +576,7 @@ Severity: medium.
 
 **Agent 33 -- async-antipatterns** (sonnet)
 File: `_audit/findings/33-async-antipatterns.md`
+
 ```text
 Find async antipatterns in src/synthorg/:
 - Bare asyncio.create_task without TaskGroup
@@ -557,6 +590,7 @@ Severity: high for missing await, medium for others.
 
 **Agent 34 -- error-handling-consistency** (sonnet)
 File: `_audit/findings/34-error-handling-consistency.md`
+
 ```text
 Check error handling conventions:
 - Custom exceptions not inheriting from project error hierarchy
@@ -571,6 +605,7 @@ Severity: medium.
 
 **Agent 35 -- missing-accessibility** (sonnet)
 File: `_audit/findings/35-missing-accessibility.md`
+
 ```text
 Check web/src/components/ and web/src/pages/ for accessibility issues:
 missing aria-label on interactive elements, missing role attributes, missing
@@ -581,6 +616,7 @@ navigation, images without alt text. Severity: medium.
 
 **Agent 36 -- missing-loading-states** (sonnet)
 File: `_audit/findings/36-missing-loading-states.md`
+
 ```text
 Check pages/components that fetch data (useQuery, useEffect with fetch) for
 missing loading skeletons/spinners, missing empty states when data is [],
@@ -590,6 +626,7 @@ and missing error boundaries around async content. Severity: medium.
 
 **Agent 37 -- hardcoded-frontend-strings** (haiku)
 File: `_audit/findings/37-hardcoded-frontend-strings.md`
+
 ```text
 Find user-facing strings hardcoded directly in TSX files. Look for text
 content in JSX elements that should be centralized for i18n readiness.
@@ -599,6 +636,7 @@ Skip component prop names and technical strings. Severity: info.
 
 **Agent 38 -- missing-error-handling-fe** (sonnet)
 File: `_audit/findings/38-missing-error-handling-fe.md`
+
 ```text
 Check web/src/ for API calls without error handling: missing .catch() or
 try/catch, missing toast/notification on failure, optimistic updates without
@@ -610,6 +648,7 @@ rollback on error, console.error without user feedback. Severity: medium.
 
 **Agent 39 -- race-conditions** (sonnet)
 File: `_audit/findings/39-race-conditions.md`
+
 ```text
 Find potential race conditions: shared mutable state without locks/mutexes,
 TOCTOU patterns (check-then-act without atomicity), concurrent dict/list
@@ -619,6 +658,7 @@ modification, DB read-modify-write without transactions. Severity: high.
 
 **Agent 40 -- resource-leaks** (sonnet)
 File: `_audit/findings/40-resource-leaks.md`
+
 ```text
 Find unclosed resources: HTTP clients/sessions not using async with,
 file handles not in with blocks, DB connections not properly returned to pool,
@@ -628,6 +668,7 @@ aiohttp sessions created but not closed. Severity: high.
 
 **Agent 41 -- circular-dependencies** (sonnet)
 File: `_audit/findings/41-circular-dependencies.md`
+
 ```text
 Find import cycles between src/synthorg/ packages. Check for circular
 references that could cause runtime ImportError or require deferred imports.
@@ -637,6 +678,7 @@ Also check for TYPE_CHECKING guards that hide real circular deps. Severity: medi
 
 **Agent 42 -- design-spec-drift** (sonnet)
 File: `_audit/findings/42-design-spec-drift.md`
+
 ```text
 Compare implementation in src/synthorg/ with docs/design/ specs. Find
 behaviors, models, or flows that diverge from what the spec describes without
@@ -648,6 +690,7 @@ documented rationale. Focus on major architectural decisions. Severity: medium.
 
 **Agent 43 -- go-hardcoded-values** (haiku)
 File: `_audit/findings/43-go-hardcoded-values.md`
+
 ```text
 Grep cli/ for hardcoded Docker image tags, ports, paths, timeouts that should
 be configurable via flags or config. Severity: low.
@@ -656,6 +699,7 @@ be configurable via flags or config. Severity: low.
 
 **Agent 44 -- go-cli-wiring** (sonnet)
 File: `_audit/findings/44-go-cli-wiring.md`
+
 ```text
 Check cobra command registration in cli/cmd/. Find commands registered but
 non-functional, flags defined but never read, subcommands with no RunE.
@@ -667,6 +711,7 @@ Severity: medium.
 
 **Agent 45 -- dashboard-api-coverage** (sonnet)
 File: `_audit/findings/45-dashboard-api-coverage.md`
+
 ```text
 Cross-reference every backend API endpoint (from all controllers in
 api/controllers/) with the web dashboard. For each endpoint, check whether
@@ -678,6 +723,7 @@ the backend but have no corresponding UI surface. Severity: medium.
 
 **Agent 46 -- dashboard-settings-completeness** (sonnet)
 File: `_audit/findings/46-dashboard-settings-completeness.md`
+
 ```text
 Cross-reference every setting definition in src/synthorg/settings/definitions/ with the
 Settings page in the dashboard (web/src/pages/settings/). For each setting,
@@ -689,6 +735,7 @@ Report settings that exist but are not exposed. Severity: medium.
 
 **Agent 47 -- dashboard-ux-improvements** (sonnet)
 File: `_audit/findings/47-dashboard-ux-improvements.md`
+
 ```text
 Review the web dashboard pages for UX improvement opportunities. Look for:
 - Pages with no sorting/filtering when data lists can grow large
@@ -709,6 +756,7 @@ core UX patterns, low for polish.
 
 **Agent 48 -- docs-accuracy** (sonnet)
 File: `_audit/findings/48-docs-accuracy.md`
+
 ```text
 Check docs/ pages for factual accuracy. Read key documentation pages
 (architecture, tech-stack, decisions, design pages) and verify claims
@@ -724,6 +772,7 @@ Severity: medium for misleading docs, low for minor inaccuracies.
 
 **Agent 49 -- docs-completeness** (sonnet)
 File: `_audit/findings/49-docs-completeness.md`
+
 ```text
 Check for documentation gaps. Look for:
 - Major features with no documentation page
@@ -739,6 +788,7 @@ Severity: medium for missing feature docs, low for missing examples.
 
 **Agent 50 -- readme-website-accuracy** (sonnet)
 File: `_audit/findings/50-readme-website-accuracy.md`
+
 ```text
 Check README.md and any public-facing content (landing page content in
 docs/, comparison page, etc.) for:
@@ -754,6 +804,7 @@ Severity: medium for public-facing inaccuracies.
 
 **Agent 51 -- docs-diagram-quality** (sonnet)
 File: `_audit/findings/51-docs-diagram-quality.md`
+
 ```text
 Check all D2 and Mermaid diagrams in docs/ for:
 - Diagrams that reference modules/classes that no longer exist
@@ -770,6 +821,7 @@ Severity: low.
 
 **Agent 52 -- ux-consistency** (sonnet)
 File: `_audit/findings/52-ux-consistency.md`
+
 ```text
 Check dashboard pages for visual and interaction consistency:
 - Pages using different card layouts for similar data
@@ -785,6 +837,7 @@ Severity: medium for jarring inconsistencies, low for minor.
 
 **Agent 53 -- ux-responsiveness** (sonnet)
 File: `_audit/findings/53-ux-responsiveness.md`
+
 ```text
 Check dashboard for responsive design issues. The dashboard shows a
 MobileUnsupportedOverlay below the 768px breakpoint, but check for:
@@ -799,6 +852,7 @@ Severity: medium.
 
 **Agent 54 -- ux-performance-patterns** (sonnet)
 File: `_audit/findings/54-ux-performance-patterns.md`
+
 ```text
 Check dashboard for performance antipatterns:
 - Large component re-renders (components that subscribe to entire store
@@ -814,6 +868,7 @@ Severity: medium.
 
 **Agent 55 -- api-docs-openapi** (sonnet)
 File: `_audit/findings/55-api-docs-openapi.md`
+
 ```text
 Check the OpenAPI/Scalar API documentation for completeness:
 - Endpoints missing descriptions or summaries
@@ -828,6 +883,7 @@ Severity: low.
 
 **Agent 56 -- cli-docs-help** (haiku)
 File: `_audit/findings/56-cli-docs-help.md`
+
 ```text
 Check Go CLI commands for documentation completeness:
 - Commands missing Long descriptions
@@ -841,6 +897,7 @@ Check cli/cmd/*.go for cobra.Command fields. Severity: low.
 
 **Agent 57 -- storybook-coverage** (sonnet)
 File: `_audit/findings/57-storybook-coverage.md`
+
 ```text
 Check web/src/components/ui/ for Storybook story coverage. Every shared
 component should have a .stories.tsx file. For existing stories, check:
@@ -854,6 +911,7 @@ zero coverage.
 
 **Agent 58 -- error-messages-ux** (sonnet)
 File: `_audit/findings/58-error-messages-ux.md`
+
 ```text
 Check error messages shown to users (toast notifications, error states,
 API error responses, form validation messages) for quality:
@@ -870,6 +928,7 @@ Severity: medium for unhelpful errors, low for tone inconsistencies.
 
 **Agent 59 -- onboarding-flow** (sonnet)
 File: `_audit/findings/59-onboarding-flow.md`
+
 ```text
 Check the setup wizard and first-run experience:
 - Setup steps that can fail silently
@@ -887,6 +946,7 @@ Severity: medium.
 
 **Agent 60 -- dual-backend-protocol-parity** (sonnet)
 File: `_audit/findings/60-dual-backend-protocol-parity.md`
+
 ```text
 Every repository Protocol in src/synthorg/persistence/*_protocol.py must have
 concrete implementations in BOTH src/synthorg/persistence/sqlite/ AND
@@ -904,6 +964,7 @@ Severity: high for missing impl, medium for signature drift.
 
 **Agent 61 -- migration-parity** (sonnet)
 File: `_audit/findings/61-migration-parity.md`
+
 ```text
 Migrations in src/synthorg/persistence/sqlite/revisions/ and
 src/synthorg/persistence/postgres/revisions/ must stay in semantic parity.
@@ -922,6 +983,7 @@ Severity: high.
 
 **Agent 62 -- dual-backend-test-parity** (sonnet)
 File: `_audit/findings/62-dual-backend-test-parity.md`
+
 ```text
 Every repository implementation in src/synthorg/persistence/sqlite/ and
 src/synthorg/persistence/postgres/ must have test coverage on BOTH backends
@@ -938,6 +1000,7 @@ Severity: medium.
 
 **Agent 63 -- persistence-boundary-deep** (sonnet)
 File: `_audit/findings/63-persistence-boundary-deep.md`
+
 ```text
 scripts/check_persistence_boundary.py (PreToolUse hook) catches import-level
 leaks. This agent does deeper analysis.
@@ -956,6 +1019,7 @@ Severity: high.
 
 **Agent 64 -- provider-boundary-leaks** (sonnet)
 File: `_audit/findings/64-provider-boundary-leaks.md`
+
 ```text
 All LLM calls must go through BaseCompletionProvider in src/synthorg/providers/.
 
@@ -970,6 +1034,7 @@ Severity: high.
 
 **Agent 65 -- memory-boundary-leaks** (sonnet)
 File: `_audit/findings/65-memory-boundary-leaks.md`
+
 ```text
 All memory/recall operations must go through src/synthorg/memory/.
 
@@ -985,6 +1050,7 @@ Severity: medium.
 
 **Agent 66 -- queue-boundary-leaks** (sonnet)
 File: `_audit/findings/66-queue-boundary-leaks.md`
+
 ```text
 Inter-component messaging must go through the project's event bus / message
 bus abstraction.
@@ -1001,6 +1067,7 @@ Severity: medium.
 
 **Agent 67 -- process-spawn-leaks** (sonnet)
 File: `_audit/findings/67-process-spawn-leaks.md`
+
 ```text
 Process spawning and container orchestration must go through the sandbox /
 orchestration layer.
@@ -1017,6 +1084,7 @@ Severity: high for arbitrary code paths, medium for admin tools.
 
 **Agent 68 -- state-mutation-leaks** (sonnet)
 File: `_audit/findings/68-state-mutation-leaks.md`
+
 ```text
 API controllers should delegate to service-layer methods, not reach into
 persistence internals.
@@ -1032,6 +1100,7 @@ Severity: medium.
 
 **Agent 69 -- hardcoded-backend-selection** (haiku)
 File: `_audit/findings/69-hardcoded-backend-selection.md`
+
 ```text
 Backend choices must be driven by config factories, not hardcoded in business
 logic.
@@ -1046,6 +1115,7 @@ Severity: medium.
 
 **Agent 70 -- pluggable-impl-coverage** (sonnet)
 File: `_audit/findings/70-pluggable-impl-coverage.md`
+
 ```text
 Per CLAUDE.md, every pluggable subsystem uses Protocol + concrete strategies +
 factory + config discriminator.
@@ -1067,6 +1137,7 @@ Severity: medium.
 
 **Agent 71 -- abstraction-swap-readiness** (sonnet)
 File: `_audit/findings/71-abstraction-swap-readiness.md`
+
 ```text
 Adding a new backend should require zero changes outside the owning module.
 
@@ -1082,6 +1153,7 @@ Severity: medium.
 
 **Agent 72 -- dependency-inversion-violations** (sonnet)
 File: `_audit/findings/72-dependency-inversion-violations.md`
+
 ```text
 High-level modules (engine, api, communication) should depend on Protocol
 types, not concrete impls.
@@ -1098,6 +1170,7 @@ Severity: low.
 
 **Agent 73 -- roadmap-currency** (sonnet)
 File: `_audit/findings/73-roadmap-currency.md`
+
 ```text
 Cross-reference roadmap.md / docs/roadmap*.md with `gh issue list` (open +
 closed by version label) and `gh release list`.
@@ -1113,6 +1186,7 @@ Severity: medium.
 
 **Agent 74 -- comparison-page-accuracy** (sonnet)
 File: `_audit/findings/74-comparison-page-accuracy.md`
+
 ```text
 Read docs/comparison*.md and scripts/generate_comparison.py. For every feature
 we claim to support, verify the claim against actual code in src/synthorg/.
@@ -1129,6 +1203,7 @@ Severity: medium for inaccurate self-claims, low for competitor drift.
 
 **Agent 75 -- landing-page-metrics** (sonnet)
 File: `_audit/findings/75-landing-page-metrics.md`
+
 ```text
 Check numeric claims on public-facing pages (README, landing, comparison,
 docs index). For each number, verify against live source:
@@ -1146,6 +1221,7 @@ Severity: medium.
 
 **Agent 76 -- superseded-decisions** (sonnet)
 File: `_audit/findings/76-superseded-decisions.md`
+
 ```text
 Read docs/decisions*.md, ADR files, and docs/design/ pages. For each accepted
 decision, check: was it later reversed or superseded?
@@ -1161,6 +1237,7 @@ Severity: medium.
 
 **Agent 77 -- config-reference-drift** (sonnet)
 File: `_audit/findings/77-config-reference-drift.md`
+
 ```text
 Compare docs/reference/*.md env var / settings reference against
 src/synthorg/settings/definitions/ and src/synthorg/config/.
@@ -1176,6 +1253,7 @@ Severity: medium.
 
 **Agent 78 -- cli-reference-drift** (sonnet)
 File: `_audit/findings/78-cli-reference-drift.md`
+
 ```text
 Compare CLI reference pages in docs/reference/ (and cli/CLAUDE.md command
 listings) against actual cobra definitions in cli/cmd/*.go.
@@ -1190,6 +1268,7 @@ Severity: medium.
 
 **Agent 79 -- api-reference-drift** (sonnet)
 File: `_audit/findings/79-api-reference-drift.md`
+
 ```text
 Compare API reference pages (docs/reference/api*.md, if present) against
 actual Litestar routes in src/synthorg/api/controllers/.
@@ -1204,6 +1283,7 @@ Severity: medium.
 
 **Agent 80 -- example-config-validity** (sonnet)
 File: `_audit/findings/80-example-config-validity.md`
+
 ```text
 For every fenced code block in docs/ tagged yaml / toml / json / env / dotenv
 that looks like a config example, validate it against the current Pydantic
@@ -1220,6 +1300,7 @@ Severity: medium.
 
 **Agent 81 -- design-spec-contradictions** (sonnet)
 File: `_audit/findings/81-design-spec-contradictions.md`
+
 ```text
 Cross-reference pages in docs/design/. Find internal contradictions.
 
@@ -1236,6 +1317,7 @@ Severity: medium.
 
 **Agent 82 -- docs-scope-creep** (sonnet)
 File: `_audit/findings/82-docs-scope-creep.md`
+
 ```text
 Read each docs/ page and assess whether it has grown beyond its stated purpose.
 
@@ -1250,6 +1332,7 @@ Severity: low.
 
 **Agent 83 -- stale-code-examples** (sonnet)
 File: `_audit/findings/83-stale-code-examples.md`
+
 ```text
 For every fenced code block in docs/ tagged python / typescript / javascript /
 go / bash that calls project code, verify the APIs referenced still exist
@@ -1266,6 +1349,7 @@ Severity: medium.
 
 **Agent 84 -- removed-features-still-mentioned** (sonnet)
 File: `_audit/findings/84-removed-features-still-mentioned.md`
+
 ```text
 Read docs/ narrative prose for feature / module / concept names. For each
 reference, verify the named thing still exists in code.
@@ -1280,6 +1364,7 @@ Severity: medium.
 
 **Agent 85 -- docs-seo-freshness** (haiku)
 File: `_audit/findings/85-docs-seo-freshness.md`
+
 ```text
 Check page titles, meta descriptions (front matter), and opening paragraphs
 in docs/ for:
@@ -1292,6 +1377,7 @@ Severity: low.
 
 **Agent 86 -- issue-pr-link-rot** (haiku)
 File: `_audit/findings/86-issue-pr-link-rot.md`
+
 ```text
 Grep docs/ for `#NNN` references to GitHub issues / PRs. For each, verify via
 `gh issue view` / `gh pr view` that the reference is still valid.
@@ -1308,6 +1394,7 @@ Severity: low.
 
 **Agent 87 -- http-security-headers** (sonnet)
 File: `_audit/findings/87-http-security-headers.md`
+
 ```text
 Check HTTP responses for missing security headers: Content-Security-Policy,
 Strict-Transport-Security (HSTS), X-Frame-Options, X-Content-Type-Options,
@@ -1320,6 +1407,7 @@ Severity: medium.
 
 **Agent 88 -- cookie-auth-security** (sonnet)
 File: `_audit/findings/88-cookie-auth-security.md`
+
 ```text
 Audit authentication and cookie hygiene:
 - Cookies without HttpOnly / Secure / SameSite flags
@@ -1332,6 +1420,7 @@ Severity: high.
 
 **Agent 89 -- crypto-hygiene** (sonnet)
 File: `_audit/findings/89-crypto-hygiene.md`
+
 ```text
 Find cryptographic anti-patterns:
 - `random` / `random.choice` for security-sensitive randomness (should be `secrets`)
@@ -1344,6 +1433,7 @@ Severity: high.
 
 **Agent 90 -- secrets-in-logs** (sonnet)
 File: `_audit/findings/90-secrets-in-logs.md`
+
 ```text
 Check the telemetry privacy allowlist in `src/synthorg/telemetry/privacy.py`
 against actual `logger.*` calls. Flag:
@@ -1357,6 +1447,7 @@ Severity: high.
 
 **Agent 91 -- path-traversal-ssrf-xxe-redos** (sonnet)
 File: `_audit/findings/91-path-traversal-ssrf-xxe-redos.md`
+
 ```text
 Find injection-class vulnerabilities:
 - Path traversal: user input passed to `open()` / `Path()` without sanitization
@@ -1369,6 +1460,7 @@ Severity: high.
 
 **Agent 92 -- prompt-injection-defenses** (sonnet)
 File: `_audit/findings/92-prompt-injection-defenses.md`
+
 ```text
 Audit LLM prompt handling:
 - System prompts concatenated with user input without delimiters/tagging
@@ -1384,6 +1476,7 @@ Severity: high.
 
 **Agent 93 -- n-plus-one-queries** (sonnet)
 File: `_audit/findings/93-n-plus-one-queries.md`
+
 ```text
 Find N+1 query patterns in persistence and service layers: loops that call
 repository methods per item instead of batch loads, per-row fetches in render
@@ -1394,6 +1487,7 @@ Severity: high.
 
 **Agent 94 -- missing-indices** (sonnet)
 File: `_audit/findings/94-missing-indices.md`
+
 ```text
 Cross-reference WHERE / JOIN / ORDER BY columns in persistence queries with
 schema indices. Flag query patterns that would benefit from an index that
@@ -1404,6 +1498,7 @@ Severity: medium.
 
 **Agent 95 -- missing-pagination** (sonnet)
 File: `_audit/findings/95-missing-pagination.md`
+
 ```text
 Find API endpoints and repository methods that return unbounded lists.
 Everything that can grow should accept cursor/offset+limit parameters.
@@ -1413,6 +1508,7 @@ Severity: medium.
 
 **Agent 96 -- blocking-io-hot-paths** (sonnet)
 File: `_audit/findings/96-blocking-io-hot-paths.md`
+
 ```text
 Find blocking I/O inside async hot paths:
 - Sync `open()` / `requests.*` / `subprocess.run` in async functions
@@ -1425,6 +1521,7 @@ Severity: high.
 
 **Agent 97 -- memory-leak-patterns** (sonnet)
 File: `_audit/findings/97-memory-leak-patterns.md`
+
 ```text
 Find leak patterns:
 - Event listeners / subscriptions added without teardown
@@ -1441,6 +1538,7 @@ Severity: high.
 
 **Agent 98 -- tests-without-assertions** (sonnet)
 File: `_audit/findings/98-tests-without-assertions.md`
+
 ```text
 Find test functions in tests/ (Python) and web/src/__tests__/ (TS) that have
 no assert / expect / raises call. These "tests" pass regardless of behavior
@@ -1451,6 +1549,7 @@ Severity: high.
 
 **Agent 99 -- tests-with-sleeps** (haiku)
 File: `_audit/findings/99-tests-with-sleeps.md`
+
 ```text
 Grep tests/ and web/src/__tests__/ for hardcoded sleeps / setTimeout /
 asyncio.sleep in tests. These indicate timing-dependent tests that should
@@ -1461,6 +1560,7 @@ Severity: medium.
 
 **Agent 100 -- mock-drift** (sonnet)
 File: `_audit/findings/100-mock-drift.md`
+
 ```text
 Compare mock shapes (MagicMock, unittest.mock patches, vi.mock) against the
 real interfaces they stand in for. Flag method names, signatures, or return
@@ -1471,6 +1571,7 @@ Severity: medium.
 
 **Agent 101 -- e2e-critical-flow-gaps** (sonnet)
 File: `_audit/findings/101-e2e-critical-flow-gaps.md`
+
 ```text
 Identify critical user flows (setup wizard, agent creation, workflow run,
 budget check, approval, memory recall) and verify each has at least one E2E
@@ -1483,6 +1584,7 @@ Severity: medium.
 
 **Agent 102 -- graceful-shutdown** (sonnet)
 File: `_audit/findings/102-graceful-shutdown.md`
+
 ```text
 Check shutdown path:
 - SIGTERM handler installed?
@@ -1496,6 +1598,7 @@ Severity: high.
 
 **Agent 103 -- data-retention-gdpr** (sonnet)
 File: `_audit/findings/103-data-retention-gdpr.md`
+
 ```text
 Find PII/user-data fields in Pydantic models and persistence schemas and
 check:
@@ -1508,6 +1611,7 @@ Severity: medium.
 
 **Agent 104 -- monitoring-dashboards** (sonnet)
 File: `_audit/findings/104-monitoring-dashboards.md`
+
 ```text
 Check Prometheus metrics emitted by the code against documented Grafana /
 Logfire dashboards. Flag metrics without dashboards and dashboards referring
@@ -1518,6 +1622,7 @@ Severity: medium.
 
 **Agent 105 -- prompt-eval-coverage** (sonnet)
 File: `_audit/findings/105-prompt-eval-coverage.md`
+
 ```text
 List LLM prompts in src/synthorg/ (agents, tools, quality graders, etc.) and
 check each has:
@@ -1530,6 +1635,7 @@ Severity: medium.
 
 **Agent 106 -- health-readiness-probes** (sonnet)
 File: `_audit/findings/106-health-readiness-probes.md`
+
 ```text
 Verify the API exposes `/healthz` (liveness) and `/readyz` (readiness) with
 distinct semantics. Readiness should check DB / provider / queue connectivity;
@@ -1542,6 +1648,7 @@ Severity: medium.
 
 **Agent 107 -- slow-precommit-hooks** (haiku)
 File: `_audit/findings/107-slow-precommit-hooks.md`
+
 ```text
 Profile `.pre-commit-config.yaml` hooks by measuring runtime. Flag hooks
 taking >3s on a typical `git commit`. Suggest moving expensive ones to
@@ -1552,6 +1659,7 @@ Severity: low.
 
 **Agent 108 -- claude-md-reproducibility** (sonnet)
 File: `_audit/findings/108-claude-md-reproducibility.md`
+
 ```text
 For every fenced command in CLAUDE.md, web/CLAUDE.md, cli/CLAUDE.md, and
 `.claude/skills/*/SKILL.md`, verify the command actually works today. Flag
@@ -1564,6 +1672,7 @@ Severity: medium.
 
 **Agent 109 -- typescript-strictness** (sonnet)
 File: `_audit/findings/109-typescript-strictness.md`
+
 ```text
 In web/src/, count and flag: `any` type usage, `@ts-ignore` / `@ts-expect-error`
 comments, non-null assertions (`!`), and type assertions (`as X`) where a type
@@ -1574,6 +1683,7 @@ Severity: medium.
 
 **Agent 110 -- duplicate-business-logic** (sonnet)
 File: `_audit/findings/110-duplicate-business-logic.md`
+
 ```text
 Find blocks of business logic duplicated across 2+ modules. Focus on
 substantive duplication (>10 lines of non-trivial code), not boilerplate.
@@ -1583,6 +1693,7 @@ Severity: medium.
 
 **Agent 111 -- duplicate-types** (sonnet)
 File: `_audit/findings/111-duplicate-types.md`
+
 ```text
 Find types defined on both backend (Pydantic models / dataclasses) and
 frontend (TypeScript types / interfaces) that should be generated from a
@@ -1594,6 +1705,7 @@ Severity: medium.
 
 **Agent 112 -- duplicate-error-codes** (sonnet)
 File: `_audit/findings/112-duplicate-error-codes.md`
+
 ```text
 Cross-reference custom exception names, RFC 9457 error `type` fields, and
 frontend error code enums. Flag the same conceptual error defined in multiple
@@ -1604,6 +1716,7 @@ Severity: medium.
 
 **Agent 113 -- feature-flag-coverage** (sonnet)
 File: `_audit/findings/113-feature-flag-coverage.md`
+
 ```text
 Find feature flags / settings that gate risky behavior. Flag:
 - Risky features with no kill-switch
@@ -1615,6 +1728,7 @@ Severity: medium.
 
 **Agent 114 -- default-config-sanity** (sonnet)
 File: `_audit/findings/114-default-config-sanity.md`
+
 ```text
 Review default values across `src/synthorg/config/` and
 `settings/definitions/`. Flag defaults that are unsafe for production or
@@ -1627,6 +1741,7 @@ Severity: medium.
 
 **Agent 115 -- workflow-permissions** (sonnet)
 File: `_audit/findings/115-workflow-permissions.md`
+
 ```text
 Audit `.github/workflows/*.yml` for:
 - Over-broad `GITHUB_TOKEN` permissions (should be least-privilege per job)
@@ -1638,6 +1753,7 @@ Severity: high.
 
 **Agent 116 -- ci-flakiness** (sonnet)
 File: `_audit/findings/116-ci-flakiness.md`
+
 ```text
 Analyze recent CI run history (via `gh run list`) for patterns:
 - Tests failing intermittently on unchanged code
@@ -1649,6 +1765,7 @@ Severity: medium.
 
 **Agent 117 -- unused-deps** (sonnet)
 File: `_audit/findings/117-unused-deps.md`
+
 ```text
 Cross-reference dependencies declared in `pyproject.toml`, `web/package.json`,
 and `cli/go.mod` with actual import statements. Flag deps that are declared
@@ -1659,6 +1776,7 @@ Severity: medium.
 
 **Agent 118 -- duplicate-deps** (sonnet)
 File: `_audit/findings/118-duplicate-deps.md`
+
 ```text
 Find redundant libraries doing the same job (e.g. lodash + ramda, axios +
 fetch wrappers, multiple date libraries). Recommend consolidation.
@@ -1668,6 +1786,7 @@ Severity: low.
 
 **Agent 119 -- license-compat** (sonnet)
 File: `_audit/findings/119-license-compat.md`
+
 ```text
 Check dependency licenses against project BUSL-1.1 license. Flag deps with
 GPL, AGPL, or other copyleft licenses that conflict with the project license
@@ -1680,6 +1799,7 @@ Severity: high.
 
 **Agent 120 -- rate-limit-client** (sonnet)
 File: `_audit/findings/120-rate-limit-client.md`
+
 ```text
 Audit client-side handling of HTTP 429 responses:
 - Web dashboard: retry-with-backoff on API calls?
@@ -1691,6 +1811,7 @@ Severity: medium.
 
 **Agent 121 -- ws-sse-robustness** (sonnet)
 File: `_audit/findings/121-ws-sse-robustness.md`
+
 ```text
 Check WebSocket and Server-Sent Events implementations:
 - Reconnection logic with exponential backoff
@@ -1706,6 +1827,7 @@ Severity: medium.
 
 **Agent 122 -- git-history-secrets-and-bloat** (sonnet)
 File: `_audit/findings/122-git-history-secrets-and-bloat.md`
+
 ```text
 Two narrow checks on full git history (not just current tree):
 1. Run `gitleaks detect --log-opts=--all` over full history. Pre-commit
@@ -1720,6 +1842,7 @@ Severity: critical for secrets, medium for bloat.
 
 **Agent 123 -- temporal-drift-wording** (sonnet)
 File: `_audit/findings/123-temporal-drift-wording.md`
+
 ```text
 Scan docs/, CLAUDE.md, web/CLAUDE.md, cli/CLAUDE.md, README.md, and
 .claude/skills/*/SKILL.md for temporal / reference-drift wording that will
@@ -1740,27 +1863,34 @@ Severity: low for stylistic drift, medium for misleading claims.
 
 ### Retired Agents
 
-These concerns are now enforced by hooks, linters, or external tooling instead of an audit agent. Do NOT launch them; check the "Now enforced by" column if a related concern needs attention.
+These concerns are already enforced by hooks, linters, or external tooling today instead of an audit agent. Do NOT launch these agents; check the "Now enforced by" column if a related concern needs attention.
 
 | Retired agent | Now enforced by |
+|---|---|
+| hardcoded-secrets | `gitleaks` pre-commit + CI |
+| hardcoded-display-values | `scripts/check_web_design_system.py` + `scripts/check_backend_regional_defaults.py` PostToolUse hooks |
+| design-token-violations | `scripts/check_web_design_system.py` PostToolUse hook |
+| go-error-handling | `golangci-lint` (errcheck, wrapcheck, errorlint) pre-commit + CI |
+| go-resource-leaks | `golangci-lint` + `go vet` pre-commit + CI |
+| changelog-release-notes | `release-please` (automated) |
+| changelog-releases-parity | `release-please` (automated) |
+
+### Planned Retirements
+
+These concerns have a planned hook, linter, or external-tool replacement, but the enforcement is not fully wired yet. Keep launching these audit agents until the replacement is enabled; once the TODO ships, move the row up to the Retired Agents table.
+
+| Agent to keep active for now | Planned enforcement |
 |---|---|
 | wrong-logger-pattern | Custom ruff rule or pre-commit regex hook (TODO: add) |
 | unstructured-logging | Custom ruff rule (TODO: add) |
 | unused-web-components | `knip` in CI (TODO: wire) |
 | unused-web-hooks | `knip` in CI (TODO: wire) |
 | unused-web-utils | `knip` / `ts-prune` in CI (TODO: wire) |
-| hardcoded-secrets | `gitleaks` pre-commit + CI |
 | vendor-name-leaks | Extend `scripts/check_forbidden_literals.py` (TODO) |
-| hardcoded-display-values | `scripts/check_web_design_system.py` + `scripts/check_backend_regional_defaults.py` PostToolUse hooks |
 | long-functions | Ruff `C901` / `PLR0915` + eslint `max-lines-per-function` (TODO: enable) |
 | long-files | Ruff + eslint `max-lines` (TODO: enable) |
 | future-annotations-leak | Ruff `FA100` / `FA102` (TODO: enable) |
-| design-token-violations | `scripts/check_web_design_system.py` PostToolUse hook |
-| go-error-handling | `golangci-lint` (errcheck, wrapcheck, errorlint) pre-commit + CI |
-| go-resource-leaks | `golangci-lint` + `go vet` pre-commit + CI |
 | docs-links-refs | `lychee` in CI (TODO: wire) |
-| changelog-release-notes | `release-please` (automated) |
-| changelog-releases-parity | `release-please` (automated) |
 
 ---
 

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -236,7 +236,7 @@ Directory suffix is auto-derived from the branch name:
    ## Quality Standards (MANDATORY)
    - Build BEST IN CLASS. No shortcuts, no "good enough", no "we can improve later".
    - NEVER defer anything. If a finding says "fix X", fix X completely. No TODOs, no stubs, no "phase 2" thinking.
-   - Still alpha: breaking API/interface changes are fine, no backward compatibility shims. BUT schema changes MUST ship proper Atlas migrations (never edit an existing migration; always generate a new one via `atlas migrate diff --env <sqlite|postgres> <name>`) so migration paths stay testable.
+   - Still alpha: breaking API/interface changes are fine, no backward compatibility shims. BUT schema changes MUST ship proper Atlas migrations (never edit an existing migration; always generate a new one -- for SQLite: `atlas migrate diff <migration_name> --env sqlite`; for Postgres: `atlas migrate diff <migration_name> --env postgres`) so migration paths stay testable.
    - Every piece of work must meet the highest standard of security, UX, maintainability, and correctness.
    ~~~
 

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -236,7 +236,7 @@ Directory suffix is auto-derived from the branch name:
    ## Quality Standards (MANDATORY)
    - Build BEST IN CLASS. No shortcuts, no "good enough", no "we can improve later".
    - NEVER defer anything. If a finding says "fix X", fix X completely. No TODOs, no stubs, no "phase 2" thinking.
-   - NEVER add backward compatibility shims -- break things properly (pre-alpha).
+   - Still alpha: breaking API/interface changes are fine, no backward compatibility shims. BUT schema changes MUST ship proper Atlas migrations (never edit an existing migration; always generate a new one via `atlas migrate diff --env <sqlite|postgres> <name>`) so migration paths stay testable.
    - Every piece of work must meet the highest standard of security, UX, maintainability, and correctness.
    ~~~
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,8 +350,9 @@ jobs:
           # GitHub runners; contributors run jsdom under Windows/macOS).
           # The ceiling is 70 -- the CI baseline plus a small run-to-run
           # variance buffer -- so the gate actually fires on regressions
-          # instead of silently reporting 0 like the legacy parser did. The structural 50-leak floor is still the local
-          # target and comes from MSW 2.x's own CookieStore (tough-cookie),
+          # instead of silently reporting 0 like the legacy parser did.
+          # The structural 50-leak floor is still the local target and
+          # comes from MSW 2.x's own CookieStore (tough-cookie),
           # the MSW XHR interceptor's `queueMicrotask` dispatch, and
           # axios's internal interceptor `promise.then` chain -- none
           # reachable from `test-setup.tsx`. Further reduction requires

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,13 +344,13 @@ jobs:
           # always reported 0 leaks regardless of reality. Vitest honors
           # `NO_COLOR` via chalk.
           NO_COLOR: '1'
-          # Structural ceiling: the post-shim leak count is ~50 locally and
-          # ~64 in CI. The delta is platform-level event-loop timing (CI is
-          # ubuntu-latest on GitHub runners; contributors run jsdom under
-          # Windows/macOS). The ceiling is 70 -- the CI baseline plus a
-          # small run-to-run variance buffer -- so the gate actually fires
-          # on regressions instead of silently reporting 0 like the legacy
-          # parser did. The structural 50-leak floor is still the local
+          # Structural ceiling: the post-shim leak count measured
+          # 2026-04-19 is ~50 locally and ~64 in CI. The delta is
+          # platform-level event-loop timing (CI is ubuntu-latest on
+          # GitHub runners; contributors run jsdom under Windows/macOS).
+          # The ceiling is 70 -- the CI baseline plus a small run-to-run
+          # variance buffer -- so the gate actually fires on regressions
+          # instead of silently reporting 0 like the legacy parser did. The structural 50-leak floor is still the local
           # target and comes from MSW 2.x's own CookieStore (tough-cookie),
           # the MSW XHR interceptor's `queueMicrotask` dispatch, and
           # axios's internal interceptor `promise.then` chain -- none
@@ -383,10 +383,13 @@ jobs:
           # naive `tail -n 200` cuts the summary off. Anchor the match
           # to the whole line instead: a test's `console.log('Reporter:
           # Leaks 50 leaks detected')` (or any substring containing the
-          # phrase) will not satisfy the gate, and `tail -1` keeps the
-          # last match so repeated summaries favor the real one. The
-          # count is extracted with a bash regex capture group so extra
-          # digits elsewhere on the line cannot bleed in.
+          # phrase) will not satisfy the gate, and `tail -1` picks the
+          # final match -- defensive guard against any rare case where
+          # grep returns multiple anchored lines (e.g. Vitest reruns
+          # emitting two summary blocks); the last line is the reporter's
+          # authoritative total. The count is extracted with a bash
+          # regex capture group so extra digits elsewhere on the line
+          # cannot bleed in.
           leaks_line=$(grep -E '^[[:space:]]*Leaks +[0-9]+ leaks[[:space:]]*$' vitest-output.log | tail -1 || true)
           if [ -z "$leaks_line" ]; then
             echo "::error::Could not locate 'Leaks N leaks' line in Vitest output tail."

--- a/.opencode/commands/codebase-audit.md
+++ b/.opencode/commands/codebase-audit.md
@@ -1,5 +1,5 @@
 ---
-description: "Full codebase audit: launches 58 specialized agents to find issues across Python/React/Go, writes findings to _audit/findings/, then triages with user"
+description: "Full codebase audit: launches 123 specialized agents to find issues across Python/React/Go/docs/website, writes findings to _audit/findings/, then triages with user"
 ---
 
 # OpenCode Adapter (read this FIRST, before the skill below)
@@ -8,7 +8,7 @@ You are running in **OpenCode**, not Claude Code. Apply these overrides:
 
 ### Subagent spawning
 
-The rewritten skill launches 58 audit agents with custom embedded prompts via the `Agent` tool. These are NOT mapped to `.opencode/agents/` -- they use inline prompts defined in the skill itself. Spawn each agent with its prompt from the skill's Agent Roster section.
+The rewritten skill launches 123 audit agents with custom embedded prompts via the `Agent` tool. These are NOT mapped to `.opencode/agents/` -- they use inline prompts defined in the skill itself. Spawn each agent with its prompt from the skill's Agent Roster section.
 
 ### Scope changes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 
 ## Design Spec (MANDATORY)
 
-- **ALWAYS read the relevant `docs/design/` page** before implementing any feature or planning any issue. [DESIGN_SPEC.md](docs/DESIGN_SPEC.md) is a pointer file linking to the 19 design pages.
+- **ALWAYS read the relevant `docs/design/` page** before implementing any feature or planning any issue. [DESIGN_SPEC.md](docs/DESIGN_SPEC.md) is a pointer file linking to the 20 design pages.
 - The design spec is the **starting point** for architecture, data models, and behavior
 - If implementation deviates from the spec (better approach found, scope evolved, etc.), **alert the user and explain why** -- user decides whether to proceed or update the spec
 - Do NOT silently diverge -- every deviation needs explicit user approval

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ SynthOrg vs [44 agent frameworks](https://synthorg.io/compare/) across 14 dimens
 |---------|-------------|
 | [User Guide](https://synthorg.io/docs/user_guide/) | Install, configure, run, customize |
 | [Guides](https://synthorg.io/docs/guides/) | Quickstart, company config, agents, budget, security, MCP tools, deployment, logging, memory |
-| [Design Specification](https://synthorg.io/docs/design/) | Agents, org structure, communication, engine, memory, operations, brand & UX, strategy (19 pages) |
+| [Design Specification](https://synthorg.io/docs/design/) | Agents, org structure, communication, engine, memory, operations, brand & UX, strategy (20 pages) |
 | [Architecture](https://synthorg.io/docs/architecture/) | System overview, tech stack, decision log |
 | [REST API](https://synthorg.io/docs/rest-api/) | Scalar/OpenAPI reference |
 | [Library Reference](https://synthorg.io/docs/api/) | Auto-generated from docstrings (14 modules) |

--- a/docs/DESIGN_SPEC.md
+++ b/docs/DESIGN_SPEC.md
@@ -21,6 +21,7 @@ The design specification has been split into focused documentation pages for bet
 | [Multi-Agent Memory Consistency](design/memory-consistency.md) | Consistency Model | Append-only writes, MVCC snapshot reads, conflict handling, deployment rollout |
 | [Semantic Ontology](design/ontology.md) | Entity Definitions, Versioning, Drift | Shared vocabulary, decorator, backend, bootstrap, drift detection |
 | [Operations](design/operations.md) | Providers, Budget, Tools, Security, Human Interaction | Provider layer, cost management, sandboxing, security, API |
+| [Web HTTP Adapter](design/web-http-adapter.md) | HTTP Transport, Async Leaks, CI Gate | Axios XHR vs fetch, MSW interceptor async-leak investigation, test teardown contract, CI leak-gate ceiling |
 | [Brand Identity & UX](design/brand-and-ux.md) | Brand, Themes, Colors, Typography, Density, Animation | Visual identity, semantic color system, theme architecture |
 | [Page Structure & IA](design/page-structure.md) | Pages, Navigation, Routing, WebSocket, Responsive | Page list, sidebar hierarchy, URL routing map, WS subscriptions |
 | [UX Design Guidelines](design/ux-guidelines.md) | Color System, Components, Interaction, Animation, Accessibility, Responsive | Implementable specs for all v0.5.0 dashboard pages |

--- a/web/src/test-setup.tsx
+++ b/web/src/test-setup.tsx
@@ -49,7 +49,13 @@ if (typeof document !== 'undefined') {
       if (eq === -1) return
       const name = pair.slice(0, eq).trim()
       const value = pair.slice(eq + 1).trim()
-      if (!name || name === '__proto__' || name === 'constructor') return
+      if (
+        !name ||
+        name === '__proto__' ||
+        name === 'constructor' ||
+        name === 'prototype'
+      )
+        return
       const isDelete = segments.slice(1).some((segment) => {
         const attr = segment.trim().toLowerCase()
         if (attr === 'max-age=0') return true

--- a/web/src/test-setup.tsx
+++ b/web/src/test-setup.tsx
@@ -49,6 +49,14 @@ if (typeof document !== 'undefined') {
       if (eq === -1) return
       const name = pair.slice(0, eq).trim()
       const value = pair.slice(eq + 1).trim()
+      // Belt-and-suspenders prototype-pollution guard. The jar uses
+      // `Object.create(null)` (no prototype chain), so none of these names
+      // can actually pollute `Object.prototype` through `cookieJar[name] =
+      // value`. We still reject them so the shim never stores a key that a
+      // future refactor (spread, `Object.assign`, iteration into a
+      // prototype-carrying object) could weaponise. Diverging from RFC 6265
+      // is acceptable here because production code never emits these names
+      // as cookies.
       if (
         !name ||
         name === '__proto__' ||


### PR DESCRIPTION
## Summary

Three focused streams bundled together:

**1. Claude skills audit & revision**

- `.claude/skills/codebase-audit/SKILL.md`: major revision (75 -> 123 agents, 8 -> 13 batches, reorganized roster, split retired vs planned-retirement enforcement tables)
- `.claude/skills/worktree/SKILL.md`: quality-standards wording refresh — alpha breaking changes are fine without back-compat shims, but schema changes MUST ship proper Atlas migrations (never edit an existing migration)
- `.opencode/commands/codebase-audit.md`: parity update — agent count bumped 58 -> 123

**2. Async-leak CI gate comments**

The hardening itself (NO_COLOR=1, strict parser, `MAX_ASYNC_LEAKS=70` ceiling) landed in #1469. This PR only touches the comments around it:

- Add measurement date (2026-04-19) to the ceiling rationale so the "~50 local / ~64 CI" baseline stays attributable
- Expand the `tail -1` comment to explain why picking the final match is a defensive guard against Vitest retry summaries

**3. `web/src/test-setup.tsx` cookie shim guard**

- Add `'prototype'` to the cookie setter's rejection list alongside `'__proto__'` and `'constructor'` for belt-and-suspenders prototype-pollution defense
- Document why the guard is redundant-but-retained (the jar uses `Object.create(null)` so there's no active exploit path, but rejecting these names keeps future refactors safe if the jar ever gets spread into a prototype-carrying object)

**4. Supporting docs updates**

- `CLAUDE.md`: design-pages count 19 -> 20 (the new `docs/design/web-http-adapter.md` page was added in #1469)
- `docs/DESIGN_SPEC.md`: index table gets the `web-http-adapter.md` row
- `README.md`: matching 19 -> 20 update in the docs section

## Test plan

- `npm --prefix web run lint` — passes (zero warnings)
- `npm --prefix web run type-check` — passes
- `npm --prefix web run test` — 215 files / 2592 tests pass in 29s
- CI `Dashboard Test` job exercises the strict parser against the post-shim leak count against the 70 ceiling on ubuntu-latest

No Python, Go, Docker, or persistence changes in this PR — corresponding checks skipped.

## Review coverage

Addressed in this branch from automated reviewers (gemini-code-assist, CodeRabbit, Copilot) and local agents:

- CRITICAL (tool-parity-checker): `.opencode/commands/codebase-audit.md` description was stuck at 58 agents; updated to 123 to match the skill
- CRITICAL (docs-consistency): `README.md` still said "19 pages"; bumped to 20
- MAJOR (gemini-code-assist): Agent 15 (`unused-dto-fields`) was missing from the `src/` scope mapping; range expanded from `09-14` to `09-15`
- MAJOR (CodeRabbit): Hardcoded `N/123` progress message would misreport on scoped runs; replaced with `{AGENTS_LAUNCHED}` placeholder + explanation
- MAJOR (CodeRabbit): MD031 markdown-lint violations across all 123 agent prompt fences; added the required blank line between every `File:` line and its opening fence
- MAJOR (Copilot): "Retired Agents" table conflated "enforced today" with "TODO: wire" entries, which would silently drop audit coverage; split into two tables with explicit guidance to keep the TODO agents active until enforcement lands
- MEDIUM (Copilot + CodeRabbit): Awkward mid-paragraph hard line break in the `MAX_ASYNC_LEAKS` rationale comment; reflowed so "The structural 50-leak floor is still the local target" reads as one phrase
- MEDIUM (Copilot): The new `'prototype'` guard in `test-setup.tsx` is redundant on a null-prototype jar; kept the guard but added an inline comment explaining the belt-and-suspenders rationale

## Notes

The previous revision of this PR description mistakenly took credit for the `docs/design/web-http-adapter.md` page, `mkdocs.yml` nav, and `web/CLAUDE.md` "Async-leak ceiling" section — all of which actually landed in #1469 (already merged to main) before this branch rebased on top. The body above reflects only what this PR's diff changes.
