### PR TITLE
chore: consolidate Renovate lock-file PRs and delete orphan root package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "synthorg-wt-budget-panel-page",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/renovate.json
+++ b/renovate.json
@@ -99,32 +99,13 @@
       "labels": ["dependencies", "type:chore", "scope:docker"]
     },
     {
-      "description": "Route Python lock file maintenance into Python group",
+      "description": "Combine all lock-file maintenance (pep621, pre-commit, npm, gomod) into a single weekly PR so the refresh cycle surfaces as one unit instead of 2-3 parallel branches",
       "matchUpdateTypes": ["lockFileMaintenance"],
-      "matchManagers": ["pep621", "pre-commit"],
-      "groupName": "Python dependencies",
-      "groupSlug": "python",
+      "groupName": "Lock file maintenance",
+      "groupSlug": "lock-files",
       "additionalBranchPrefix": "",
       "commitMessagePrefix": "chore:",
       "labels": ["dependencies", "type:chore"]
-    },
-    {
-      "description": "Route npm lock file maintenance into Web group",
-      "matchUpdateTypes": ["lockFileMaintenance"],
-      "matchManagers": ["npm"],
-      "groupName": "Web dependencies",
-      "groupSlug": "web",
-      "commitMessagePrefix": "chore:",
-      "labels": ["dependencies", "type:chore", "scope:web"]
-    },
-    {
-      "description": "Route Go lock file maintenance into CLI group",
-      "matchUpdateTypes": ["lockFileMaintenance"],
-      "matchManagers": ["gomod"],
-      "groupName": "CLI dependencies",
-      "groupSlug": "cli",
-      "commitMessagePrefix": "chore:",
-      "labels": ["dependencies", "type:chore", "scope:cli"]
     },
     {
       "description": "Do not pin requires-python -- it is a compatibility range, not a dependency",


### PR DESCRIPTION
## Summary

Two small maintenance changes so weekly Renovate runs produce less PR churn and so the repo doesn't carry an orphan lockfile at the root.

**`renovate.json` -- consolidate lock-file maintenance**

Collapse the three per-ecosystem `lockFileMaintenance` routing rules (Python / Web / CLI) into one rule that puts every `matchUpdateTypes: ["lockFileMaintenance"]` update into a single `lock-files` group. Next Monday's refresh cycle will surface as **one combined PR** (`chore/Renovate/lock-files`) instead of the current 2-3 parallel branches (`renovate/lock-file-maintenance-python`, `renovate/lock-file-maintenance-web`, `renovate/lock-file-maintenance-cli`).

Tradeoff acknowledged: if one ecosystem's lock regeneration fails CI, it blocks the others. The Monday cadence is low-frequency enough that this is acceptable; a failure can be unblocked manually or split back out via the Renovate UI if needed.

**`package-lock.json` -- delete orphan**

Root-level `package-lock.json` (114 bytes, empty `packages: {}`) was committed in `b63b0f16` as collateral from a now-merged worktree. No corresponding root `package.json` exists, so the file was never tracked by any manager (Renovate included). Removing it prevents accidental `npm install` in the repo root from re-populating a phantom lockfile.

## Test plan

- `node -e "JSON.parse(readFileSync('renovate.json'))"` -- JSON validates
- Renovate's config-migration bot will auto-validate the semantic change on the next scheduled run; no local dry-run tool available for lockFileMaintenance grouping

## Review coverage

- `/pre-pr-review quick`: no code changes (config + lockfile deletion), so agents were skipped per quick-mode rules
- No Python / Go / web source files touched, so Phase 2 automated checks had nothing to run
- JSON validated via `node -e`
