### PR TITLE
refactor: decouple engine/tools/approval + abstraction-swap readiness (ARC-1)

### DIFF
--- a/docs/design/persistence.md
+++ b/docs/design/persistence.md
@@ -65,8 +65,10 @@ one level up in `src/synthorg/persistence/`:
 | Protocol module                        | Concerns |
 |----------------------------------------|-----------|
 | `protocol.py` (`PersistenceBackend`)   | Backend aggregate: connect / disconnect, migrate, and accessors for every repository below |
+| `approval_protocol.py`                 | `ApprovalRepository` -- human-in-the-loop decision queue |
 | `auth_protocol.py`                     | `SessionRepository`, `RefreshTokenRepository`, `LockoutRepository` |
 | `escalation_protocol.py`               | Conflict-resolution escalation queue |
+| `fine_tune_protocol.py`                | `FineTuneRunRepository`, `FineTuneCheckpointRepository` |
 | `mcp_protocol.py`                      | MCP catalog installation repository |
 | `memory_protocol.py`                   | Org-memory fact repository with MVCC log + snapshot |
 | `ontology_protocol.py`                 | Ontology entity + drift-report repositories |
@@ -97,6 +99,20 @@ TRIGGER`s enforce "exactly one CEO" and "at least one owner" invariants across
 concurrent writers, and optional capability protocols surface Postgres-native
 features (JSONB analytics, TimescaleDB hypertables) that SQLite callers
 simply do not see.
+
+### Backend capability methods
+
+When an application service needs a subsystem whose construction differs
+between backends -- e.g. ontology versioning that wraps an
+``aiosqlite.Connection`` for SQLite but an ``AsyncConnectionPool`` for
+Postgres -- the pattern is a ``build_*()`` method on ``PersistenceBackend``
+instead of an ``isinstance(persistence, ConcreteBackend)`` branch at the
+call site.  Current examples include ``build_lockouts(auth_config)``,
+``build_escalations(notify_channel)``, and ``build_ontology_versioning()``.
+Callers always type against the protocol; the factory hides the dialect
+choice.  This matches the "no ``isinstance`` against concrete persistence
+backends outside ``persistence/`` or its factory" rule enforced by the
+code audit (ARC-1, #1491).
 
 ## Schema patterns
 

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -333,8 +333,10 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
 
     channels_plugin = create_channels_plugin()
     expire_callback = _make_expire_callback(channels_plugin)
-    effective_approval_store = approval_store or ApprovalStore(
-        on_expire=expire_callback,
+    effective_approval_store: ApprovalStoreProtocol = (
+        approval_store
+        if approval_store is not None
+        else ApprovalStore(on_expire=expire_callback)
     )
 
     # Wire meeting event publisher to the meetings WS channel.

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -53,6 +53,7 @@ from synthorg.api.middleware_factory import _build_middleware
 from synthorg.api.rate_limits import build_sliding_window_store
 from synthorg.api.rate_limits.protocol import SlidingWindowStore  # noqa: TC001
 from synthorg.api.state import AppState
+from synthorg.approval.protocol import ApprovalStoreProtocol  # noqa: TC001
 from synthorg.backup.factory import build_backup_service
 from synthorg.budget.coordination_store import (
     CoordinationMetricsStore,
@@ -127,7 +128,7 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
     persistence: PersistenceBackend | None = None,
     message_bus: MessageBus | None = None,
     cost_tracker: CostTracker | None = None,
-    approval_store: ApprovalStore | None = None,
+    approval_store: ApprovalStoreProtocol | None = None,
     auth_service: AuthService | None = None,
     task_engine: TaskEngine | None = None,
     coordinator: MultiAgentCoordinator | None = None,

--- a/src/synthorg/api/approval_store.py
+++ b/src/synthorg/api/approval_store.py
@@ -54,9 +54,7 @@ from synthorg.observability.events.api import (
 from synthorg.persistence.errors import ConstraintViolationError
 
 if TYPE_CHECKING:
-    from synthorg.persistence.sqlite.approval_repo import (
-        SQLiteApprovalRepository,
-    )
+    from synthorg.persistence.approval_protocol import ApprovalRepository
 
 logger = get_logger(__name__)
 
@@ -81,7 +79,7 @@ class ApprovalStore:
         self,
         *,
         on_expire: Callable[[ApprovalItem], None] | None = None,
-        repo: SQLiteApprovalRepository | None = None,
+        repo: ApprovalRepository | None = None,
     ) -> None:
         self._items: dict[str, ApprovalItem] = {}
         self._on_expire = on_expire

--- a/src/synthorg/api/approval_store.py
+++ b/src/synthorg/api/approval_store.py
@@ -155,7 +155,7 @@ class ApprovalStore:
                     raise ConflictError(msg) from None
             self._items[item.id] = item
 
-    async def get(self, approval_id: str) -> ApprovalItem | None:
+    async def get(self, approval_id: NotBlankStr) -> ApprovalItem | None:
         """Get an approval item by ID, applying lazy expiration.
 
         Falls through to the repository on cache miss when a repo is

--- a/src/synthorg/api/approval_store.py
+++ b/src/synthorg/api/approval_store.py
@@ -1,9 +1,10 @@
-"""Approval store with optional SQLite persistence.
+"""Approval store with optional durable persistence.
 
 Provides async CRUD operations for ``ApprovalItem`` instances.
-Designed to be attached to ``AppState``.  When a
-``SQLiteApprovalRepository`` is provided, mutations are persisted
-to the database while the in-memory dict serves as a read cache.
+Designed to be attached to ``AppState``.  When an
+``ApprovalRepository`` (protocol-typed; backend-agnostic) is
+provided, mutations are persisted to the database while the in-memory
+dict serves as a read cache.
 
 Concurrency model
 -----------------
@@ -43,7 +44,8 @@ from synthorg.core.enums import (
     ApprovalRiskLevel,
     ApprovalStatus,
 )
-from synthorg.observability import get_logger
+from synthorg.core.types import NotBlankStr  # noqa: TC001
+from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.api import (
     API_APPROVAL_CONFLICT,
     API_APPROVAL_EXPIRE_CALLBACK_FAILED,
@@ -60,7 +62,7 @@ logger = get_logger(__name__)
 
 
 class ApprovalStore:
-    """Approval store with in-memory cache and optional SQLite persistence.
+    """Approval store with in-memory cache and optional durable persistence.
 
     Uses a plain ``dict`` for O(1) lookups by ID.  A single instance
     ``asyncio.Lock`` serialises all mutation paths so read-then-write
@@ -72,7 +74,8 @@ class ApprovalStore:
 
     Args:
         on_expire: Optional callback for expired items.
-        repo: Optional SQLite repository for persistence.
+        repo: Optional durable repository for persistence
+            (protocol-typed; backend-agnostic).
     """
 
     def __init__(
@@ -179,7 +182,7 @@ class ApprovalStore:
         *,
         status: ApprovalStatus | None = None,
         risk_level: ApprovalRiskLevel | None = None,
-        action_type: str | None = None,
+        action_type: NotBlankStr | None = None,
     ) -> tuple[ApprovalItem, ...]:
         """List approval items with optional filters.
 
@@ -409,10 +412,11 @@ class ApprovalStore:
                     # failure must not unwind the expiration itself.
                     # Emit a dedicated event so operators can filter
                     # callback failures from successful expirations.
-                    logger.exception(
+                    logger.warning(
                         API_APPROVAL_EXPIRE_CALLBACK_FAILED,
                         approval_id=item.id,
-                        error=type(exc).__name__,
+                        error_type=type(exc).__name__,
+                        error=safe_error_description(exc),
                     )
             return expired
         return item

--- a/src/synthorg/api/auto_wire.py
+++ b/src/synthorg/api/auto_wire.py
@@ -788,13 +788,6 @@ async def auto_wire_ontology(
         ONTOLOGY_AUTO_WIRE_FAILED,
     )
     from synthorg.ontology.service import OntologyService  # noqa: PLC0415
-    from synthorg.ontology.versioning import (  # noqa: PLC0415
-        create_ontology_versioning,
-        create_postgres_ontology_versioning,
-    )
-    from synthorg.persistence.postgres.backend import (  # noqa: PLC0415
-        PostgresPersistenceBackend,
-    )
 
     ontology_config = effective_config.ontology
     if persistence is None or not getattr(persistence, "is_connected", False):
@@ -808,15 +801,13 @@ async def auto_wire_ontology(
     # Ontology runs on the shared persistence backend (#1457 A5): the
     # entity repository and versioning service both take the backend's
     # active DB handle, so schema migrations (Atlas) and connection
-    # lifecycle are owned by PersistenceBackend.  SQLite hands back an
-    # aiosqlite connection, Postgres hands back an AsyncConnectionPool --
-    # pick the matching versioning factory.
+    # lifecycle are owned by PersistenceBackend.  The backend's
+    # ``build_ontology_versioning`` factory selects the correct
+    # versioning service (SQLite aiosqlite vs Postgres pool) without
+    # leaking concrete-backend identity to this call site.
     backend = persistence.ontology_entities
     try:
-        if isinstance(persistence, PostgresPersistenceBackend):
-            versioning = create_postgres_ontology_versioning(persistence.get_db())
-        else:
-            versioning = create_ontology_versioning(persistence.get_db())
+        versioning = persistence.build_ontology_versioning()
         service = OntologyService(
             backend=backend,
             versioning=versioning,

--- a/src/synthorg/api/controllers/memory.py
+++ b/src/synthorg/api/controllers/memory.py
@@ -74,8 +74,8 @@ def _build_memory_service(app_state: AppState) -> MemoryService:
     except NotImplementedError as exc:
         raise ClientException(
             detail=(
-                "Fine-tune admin endpoints require an SQLite persistence "
-                "backend; the current backend does not implement them."
+                "Fine-tune admin endpoints are not supported by the "
+                "active persistence backend."
             ),
             status_code=HTTP_501_NOT_IMPLEMENTED,
         ) from exc

--- a/src/synthorg/api/state.py
+++ b/src/synthorg/api/state.py
@@ -7,13 +7,13 @@ Holds typed references to core services, injected into
 
 from typing import TYPE_CHECKING
 
-from synthorg.api.approval_store import ApprovalStore  # noqa: TC001
 from synthorg.api.auth.presence import UserPresence
 from synthorg.api.auth.service import AuthService  # noqa: TC001
 from synthorg.api.auth.ticket_store import WsTicketStore
 from synthorg.api.errors import ServiceUnavailableError
 from synthorg.api.services.org_mutations import OrgMutationService
 from synthorg.api.state_services import AppStateServicesMixin
+from synthorg.approval.protocol import ApprovalStoreProtocol  # noqa: TC001
 from synthorg.backup.service import BackupService  # noqa: TC001
 from synthorg.budget.coordination_store import (
     CoordinationMetricsStore,  # noqa: TC001
@@ -202,7 +202,7 @@ class AppState(AppStateServicesMixin):
         self,
         *,
         config: RootConfig,
-        approval_store: ApprovalStore,
+        approval_store: ApprovalStoreProtocol,
         persistence: PersistenceBackend | None = None,
         message_bus: MessageBus | None = None,
         cost_tracker: CostTracker | None = None,

--- a/src/synthorg/approval/__init__.py
+++ b/src/synthorg/approval/__init__.py
@@ -3,7 +3,7 @@
 A neutral subsystem module so ``engine`` and ``tools`` can both depend on
 approval event models (``EscalationInfo``, ``ResumePayload``) and on the
 ``ApprovalStoreProtocol`` contract without either module importing the
-other.  This eliminates the cycle previously dodged by ``TYPE_CHECKING``
+other.  This avoids the former cycle that was dodged by ``TYPE_CHECKING``
 imports and deferred runtime imports inside function bodies.
 
 The concrete ``ApprovalStore`` implementation lives in

--- a/src/synthorg/approval/__init__.py
+++ b/src/synthorg/approval/__init__.py
@@ -1,0 +1,22 @@
+"""Shared approval types and protocols.
+
+A neutral subsystem module so ``engine`` and ``tools`` can both depend on
+approval event models (``EscalationInfo``, ``ResumePayload``) and on the
+``ApprovalStoreProtocol`` contract without either module importing the
+other.  This eliminates the cycle previously dodged by ``TYPE_CHECKING``
+imports and deferred runtime imports inside function bodies.
+
+The concrete ``ApprovalStore`` implementation lives in
+``synthorg.api.approval_store``; concrete ``ApprovalRepository``
+implementations live under ``synthorg.persistence.{sqlite,postgres}``.
+Callers depending on the protocol types here remain backend-agnostic.
+"""
+
+from synthorg.approval.models import EscalationInfo, ResumePayload
+from synthorg.approval.protocol import ApprovalStoreProtocol
+
+__all__ = [
+    "ApprovalStoreProtocol",
+    "EscalationInfo",
+    "ResumePayload",
+]

--- a/src/synthorg/approval/models.py
+++ b/src/synthorg/approval/models.py
@@ -1,8 +1,10 @@
-"""Approval gate models -- escalation info and resume payload.
+"""Approval event models shared between engine, tools, and api layers.
 
-These frozen Pydantic models carry escalation details from SecOps
-ESCALATE verdicts or ``request_human_approval`` tool calls, and
-approval decision payloads for resume injection.
+These frozen Pydantic models are emitted by ``ToolInvoker`` when a
+security ``ESCALATE`` verdict or a tool-reported ``requires_parking``
+metadata flag is observed, and consumed by ``ApprovalGate`` to decide
+parking.  Keeping them in a neutral module lets both subsystems depend
+on the types without forming an import cycle.
 """
 
 from pydantic import BaseModel, ConfigDict

--- a/src/synthorg/approval/protocol.py
+++ b/src/synthorg/approval/protocol.py
@@ -14,17 +14,17 @@ from synthorg.core.enums import (
     ApprovalRiskLevel,  # noqa: TC001
     ApprovalStatus,  # noqa: TC001
 )
+from synthorg.core.types import NotBlankStr  # noqa: TC001
 
 
 @runtime_checkable
 class ApprovalStoreProtocol(Protocol):
     """CRUD + lifecycle contract for an approval-item store.
 
-    Concrete implementations (currently ``synthorg.api.approval_store
-    .ApprovalStore``) provide an in-memory cache with optional
-    persistence-backed writes.  Consumers depend on this protocol so
-    the storage implementation can evolve without touching the engine,
-    security, or hr layers.
+    Concrete implementations (currently ``synthorg.api.approval_store.ApprovalStore``)
+    provide an in-memory cache with optional persistence-backed writes.
+    Consumers depend on this protocol so the storage implementation can
+    evolve without touching the engine, security, or hr layers.
 
     Methods mirror the public surface of ``ApprovalStore``; private
     helpers (cache invalidation, expiration checks) are not part of
@@ -46,7 +46,7 @@ class ApprovalStoreProtocol(Protocol):
         """
         ...
 
-    async def get(self, approval_id: str) -> ApprovalItem | None:
+    async def get(self, approval_id: NotBlankStr) -> ApprovalItem | None:
         """Get an approval item by ID, applying lazy expiration."""
         ...
 
@@ -55,7 +55,7 @@ class ApprovalStoreProtocol(Protocol):
         *,
         status: ApprovalStatus | None = None,
         risk_level: ApprovalRiskLevel | None = None,
-        action_type: str | None = None,
+        action_type: NotBlankStr | None = None,
     ) -> tuple[ApprovalItem, ...]:
         """List approval items with optional filters."""
         ...

--- a/src/synthorg/approval/protocol.py
+++ b/src/synthorg/approval/protocol.py
@@ -7,26 +7,24 @@ no caller needs to know the concrete ``ApprovalStore`` lives in
 ``synthorg.api.approval_store``.
 """
 
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-from synthorg.core.approval import ApprovalItem  # noqa: TC001
-from synthorg.core.enums import (
-    ApprovalRiskLevel,  # noqa: TC001
-    ApprovalStatus,  # noqa: TC001
-)
-from synthorg.core.types import NotBlankStr  # noqa: TC001
+if TYPE_CHECKING:
+    from synthorg.core.approval import ApprovalItem
+    from synthorg.core.enums import ApprovalRiskLevel, ApprovalStatus
+    from synthorg.core.types import NotBlankStr
 
 
 @runtime_checkable
 class ApprovalStoreProtocol(Protocol):
     """CRUD + lifecycle contract for an approval-item store.
 
-    Concrete implementations (currently ``synthorg.api.approval_store.ApprovalStore``)
-    provide an in-memory cache with optional persistence-backed writes.
-    Consumers depend on this protocol so the storage implementation can
-    evolve without touching the engine, security, or hr layers.
+    Implementations provide an in-memory cache with optional
+    persistence-backed writes. Consumers depend on this protocol so
+    the storage implementation can evolve without touching the
+    engine, security, or hr layers.
 
-    Methods mirror the public surface of ``ApprovalStore``; private
+    Methods mirror the public surface of the concrete store; private
     helpers (cache invalidation, expiration checks) are not part of
     the contract.
     """

--- a/src/synthorg/approval/protocol.py
+++ b/src/synthorg/approval/protocol.py
@@ -1,0 +1,72 @@
+"""``ApprovalStoreProtocol`` -- the approval-store contract shared across layers.
+
+``engine`` (agent execution), ``security`` (interceptors), ``hr``
+(hiring/promotion/pruning/training/scaling guards), and ``api`` all
+type their dependency on the approval store against this protocol so
+no caller needs to know the concrete ``ApprovalStore`` lives in
+``synthorg.api.approval_store``.
+"""
+
+from typing import Protocol, runtime_checkable
+
+from synthorg.core.approval import ApprovalItem  # noqa: TC001
+from synthorg.core.enums import (
+    ApprovalRiskLevel,  # noqa: TC001
+    ApprovalStatus,  # noqa: TC001
+)
+
+
+@runtime_checkable
+class ApprovalStoreProtocol(Protocol):
+    """CRUD + lifecycle contract for an approval-item store.
+
+    Concrete implementations (currently ``synthorg.api.approval_store
+    .ApprovalStore``) provide an in-memory cache with optional
+    persistence-backed writes.  Consumers depend on this protocol so
+    the storage implementation can evolve without touching the engine,
+    security, or hr layers.
+
+    Methods mirror the public surface of ``ApprovalStore``; private
+    helpers (cache invalidation, expiration checks) are not part of
+    the contract.
+    """
+
+    def clear(self) -> None:
+        """Reset all approval items for test isolation.
+
+        Test-only.  Production code uses the async CRUD methods.
+        """
+        ...
+
+    async def add(self, item: ApprovalItem) -> None:
+        """Add a new approval item.
+
+        Raises:
+            ConflictError: If an item with the same ID already exists.
+        """
+        ...
+
+    async def get(self, approval_id: str) -> ApprovalItem | None:
+        """Get an approval item by ID, applying lazy expiration."""
+        ...
+
+    async def list_items(
+        self,
+        *,
+        status: ApprovalStatus | None = None,
+        risk_level: ApprovalRiskLevel | None = None,
+        action_type: str | None = None,
+    ) -> tuple[ApprovalItem, ...]:
+        """List approval items with optional filters."""
+        ...
+
+    async def save(self, item: ApprovalItem) -> ApprovalItem | None:
+        """Update an existing approval item (first-writer-wins)."""
+        ...
+
+    async def save_if_pending(
+        self,
+        item: ApprovalItem,
+    ) -> ApprovalItem | None:
+        """Conditionally update an approval item if it is still pending."""
+        ...

--- a/src/synthorg/communication/conflict_resolution/escalation/notify.py
+++ b/src/synthorg/communication/conflict_resolution/escalation/notify.py
@@ -26,11 +26,11 @@ from synthorg.observability.events.conflict import (
 )
 
 if TYPE_CHECKING:
+    from synthorg.communication.conflict_resolution.escalation.protocol import (
+        EscalationQueueStore,
+    )
     from synthorg.communication.conflict_resolution.escalation.registry import (
         PendingFuturesRegistry,
-    )
-    from synthorg.persistence.postgres.escalation_repo import (
-        PostgresEscalationRepository,
     )
 
 logger = get_logger(__name__)
@@ -96,7 +96,7 @@ class PostgresEscalationNotifySubscriber:
 
     def __init__(
         self,
-        repo: PostgresEscalationRepository,
+        repo: EscalationQueueStore,
         registry: PendingFuturesRegistry,
         *,
         channel: str,
@@ -105,8 +105,12 @@ class PostgresEscalationNotifySubscriber:
         """Initialise the subscriber.
 
         Args:
-            repo: Postgres escalation repository; used to fetch the
-                decision payload when a ``DECIDED`` signal arrives.
+            repo: Escalation queue store (protocol-typed).  Postgres
+                implementations deliver real NOTIFY payloads; other
+                backends return a blocking-on-cancel iterator from
+                ``subscribe_notifications`` and so are used exclusively
+                in single-worker deployments where no real cross-instance
+                wake-up is needed.
             registry: Process-local registry whose futures should wake.
             channel: LISTEN/NOTIFY channel name.
             reconnect_delay_seconds: Seconds to wait before reconnecting

--- a/src/synthorg/communication/conflict_resolution/escalation/notify.py
+++ b/src/synthorg/communication/conflict_resolution/escalation/notify.py
@@ -106,11 +106,12 @@ class PostgresEscalationNotifySubscriber:
 
         Args:
             repo: Escalation queue store (protocol-typed).  Postgres
-                implementations deliver real NOTIFY payloads; other
-                backends return a blocking-on-cancel iterator from
-                ``subscribe_notifications`` and so are used exclusively
-                in single-worker deployments where no real cross-instance
-                wake-up is needed.
+                implementations deliver real NOTIFY payloads via
+                ``subscribe_notifications``; other backends either
+                return a backend-specific stream or raise
+                ``RuntimeError`` from ``subscribe_notifications`` when
+                subscriptions are unsupported (see the contract in
+                ``synthorg.communication.conflict_resolution.escalation.protocol``).
             registry: Process-local registry whose futures should wake.
             channel: LISTEN/NOTIFY channel name.
             reconnect_delay_seconds: Seconds to wait before reconnecting

--- a/src/synthorg/engine/__init__.py
+++ b/src/synthorg/engine/__init__.py
@@ -5,10 +5,10 @@ run results, system prompt construction, runtime execution state,
 execution loops, and engine errors.
 """
 
+from synthorg.approval.models import EscalationInfo, ResumePayload
 from synthorg.engine.agent_engine import AgentEngine
 from synthorg.engine.agent_state import AgentRuntimeState
 from synthorg.engine.approval_gate import ApprovalGate
-from synthorg.engine.approval_gate_models import EscalationInfo, ResumePayload
 from synthorg.engine.assignment import (
     STRATEGY_MAP,
     STRATEGY_NAME_AUCTION,

--- a/src/synthorg/engine/_security_factory.py
+++ b/src/synthorg/engine/_security_factory.py
@@ -33,7 +33,7 @@ from synthorg.security.timeout.risk_tier_classifier import DefaultRiskTierClassi
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from synthorg.api.approval_store import ApprovalStore
+    from synthorg.approval.protocol import ApprovalStoreProtocol
     from synthorg.config.schema import ProviderConfig
     from synthorg.core.agent import AgentIdentity
     from synthorg.providers.registry import ProviderRegistry
@@ -49,7 +49,7 @@ def make_security_interceptor(  # noqa: PLR0913
     security_config: SecurityConfig | None,
     audit_log: AuditLog,
     *,
-    approval_store: ApprovalStore | None = None,
+    approval_store: ApprovalStoreProtocol | None = None,
     effective_autonomy: EffectiveAutonomy | None = None,
     provider_registry: ProviderRegistry | None = None,
     provider_configs: Mapping[str, ProviderConfig] | None = None,
@@ -245,7 +245,7 @@ def _warn_disabled_features(cfg: SecurityConfig) -> None:
 
 def registry_with_approval_tool(
     tool_registry: ToolRegistry,
-    approval_store: ApprovalStore | None,
+    approval_store: ApprovalStoreProtocol | None,
     identity: AgentIdentity,
     task_id: str | None = None,
 ) -> ToolRegistry:

--- a/src/synthorg/engine/agent_engine.py
+++ b/src/synthorg/engine/agent_engine.py
@@ -53,7 +53,7 @@ from synthorg.security.audit import AuditLog
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from synthorg.api.approval_store import ApprovalStore
+    from synthorg.approval.protocol import ApprovalStoreProtocol
     from synthorg.budget.coordination_collector import CoordinationMetricsCollector
     from synthorg.budget.coordination_config import ErrorTaxonomyConfig
     from synthorg.budget.enforcer import BudgetEnforcer
@@ -101,7 +101,7 @@ if TYPE_CHECKING:
     from synthorg.security.config import SecurityConfig
     from synthorg.settings.resolver import ConfigResolver
     from synthorg.tools.invocation_tracker import ToolInvocationTracker
-    from synthorg.tools.invoker import ToolInvoker
+    from synthorg.tools.protocol import ToolInvokerProtocol
     from synthorg.tools.registry import ToolRegistry
 
 logger = get_logger(__name__)
@@ -151,7 +151,7 @@ class AgentEngine(
         error_taxonomy_config: ErrorTaxonomyConfig | None = None,
         budget_enforcer: BudgetEnforcer | None = None,
         security_config: SecurityConfig | None = None,
-        approval_store: ApprovalStore | None = None,
+        approval_store: ApprovalStoreProtocol | None = None,
         parked_context_repo: ParkedContextRepository | None = None,
         task_engine: TaskEngine | None = None,
         checkpoint_repo: CheckpointRepository | None = None,
@@ -504,7 +504,7 @@ class AgentEngine(
         system_prompt: SystemPrompt,
         start: float,
         timeout_seconds: float | None = None,
-        tool_invoker: ToolInvoker | None = None,
+        tool_invoker: ToolInvokerProtocol | None = None,
         effective_autonomy: EffectiveAutonomy | None = None,
         provider: CompletionProvider | None = None,
         project_budget: float = 0.0,

--- a/src/synthorg/engine/agent_engine_context.py
+++ b/src/synthorg/engine/agent_engine_context.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from synthorg.core.task import Task
     from synthorg.engine.prompt import SystemPrompt
     from synthorg.security.autonomy.models import EffectiveAutonomy
-    from synthorg.tools.invoker import ToolInvoker
+    from synthorg.tools.protocol import ToolInvokerProtocol
 
 logger = get_logger(__name__)
 
@@ -68,7 +68,7 @@ class AgentEngineContextMixin:
         task_id: str,
         max_turns: int,
         memory_messages: tuple[ChatMessage, ...],
-        tool_invoker: ToolInvoker | None = None,
+        tool_invoker: ToolInvokerProtocol | None = None,
         effective_autonomy: EffectiveAutonomy | None = None,
     ) -> tuple[AgentContext, SystemPrompt]:
         """Build system prompt and prepare execution context."""

--- a/src/synthorg/engine/agent_engine_factories.py
+++ b/src/synthorg/engine/agent_engine_factories.py
@@ -11,7 +11,6 @@ from synthorg.engine.loop_selector import (
     build_execution_loop,
     select_loop_type,
 )
-from synthorg.engine.react_loop import ReactLoop
 from synthorg.observability import get_logger
 from synthorg.observability.events.execution import (
     EXECUTION_LOOP_AUTO_SELECTED,
@@ -71,9 +70,10 @@ class AgentEngineFactoriesMixin:
             interrupt_store=self._interrupt_store,
         )
 
-    def _make_default_loop(self) -> ReactLoop:
-        """Build the default ReactLoop with approval gate and stagnation detector."""
-        return ReactLoop(
+    def _make_default_loop(self) -> ExecutionLoop:
+        """Build the default ``react`` loop via the shared factory."""
+        return build_execution_loop(
+            "react",
             approval_gate=self._approval_gate,
             stagnation_detector=self._stagnation_detector,
             compaction_callback=self._compaction_callback,

--- a/src/synthorg/engine/agent_engine_post_exec.py
+++ b/src/synthorg/engine/agent_engine_post_exec.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from synthorg.providers.models import CompletionConfig
     from synthorg.providers.protocol import CompletionProvider
     from synthorg.security.autonomy.models import EffectiveAutonomy
-    from synthorg.tools.invoker import ToolInvoker
+    from synthorg.tools.protocol import ToolInvokerProtocol
 
 logger = get_logger(__name__)
 
@@ -376,7 +376,7 @@ class AgentEnginePostExecMixin:
         task_id: str,
         completion_config: CompletionConfig | None,
         budget_checker: BudgetChecker | None,
-        tool_invoker: ToolInvoker | None,
+        tool_invoker: ToolInvokerProtocol | None,
         start: float,
         timeout_seconds: float | None,
         provider: CompletionProvider | None = None,

--- a/src/synthorg/engine/approval_gate.py
+++ b/src/synthorg/engine/approval_gate.py
@@ -16,6 +16,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
+from synthorg.approval.models import EscalationInfo  # noqa: TC001
 from synthorg.communication.event_stream.interrupt import (
     Interrupt,
     InterruptResolution,
@@ -42,8 +43,6 @@ from synthorg.observability.events.approval_gate import (
 from synthorg.persistence.repositories import ParkedContextRepository  # noqa: TC001
 from synthorg.security.timeout.park_service import ParkService  # noqa: TC001
 from synthorg.security.timeout.parked_context import ParkedContext  # noqa: TC001
-
-from .approval_gate_models import EscalationInfo  # noqa: TC001
 
 if TYPE_CHECKING:
     from synthorg.engine.context import AgentContext

--- a/src/synthorg/engine/hybrid_loop.py
+++ b/src/synthorg/engine/hybrid_loop.py
@@ -78,7 +78,7 @@ if TYPE_CHECKING:
     from synthorg.engine.stagnation.protocol import StagnationDetector
     from synthorg.providers.models import ToolDefinition
     from synthorg.providers.protocol import CompletionProvider
-    from synthorg.tools.invoker import ToolInvoker
+    from synthorg.tools.protocol import ToolInvokerProtocol
 
 logger = get_logger(__name__)
 
@@ -143,7 +143,7 @@ class HybridLoop:
         *,
         context: AgentContext,
         provider: CompletionProvider,
-        tool_invoker: ToolInvoker | None = None,
+        tool_invoker: ToolInvokerProtocol | None = None,
         budget_checker: BudgetChecker | None = None,
         shutdown_checker: ShutdownChecker | None = None,
         completion_config: CompletionConfig | None = None,
@@ -250,7 +250,7 @@ class HybridLoop:
         planner_model: str,
         config: CompletionConfig,
         tool_defs: list[ToolDefinition] | None,
-        tool_invoker: ToolInvoker | None,
+        tool_invoker: ToolInvokerProtocol | None,
         plan: ExecutionPlan,
         turns: list[TurnRecord],
         all_plans: list[ExecutionPlan],
@@ -585,7 +585,7 @@ class HybridLoop:
         executor_model: str,
         config: CompletionConfig,
         tool_defs: list[ToolDefinition] | None,
-        tool_invoker: ToolInvoker | None,
+        tool_invoker: ToolInvokerProtocol | None,
         step: PlanStep,
         turns: list[TurnRecord],
         budget_checker: BudgetChecker | None,
@@ -672,7 +672,7 @@ class HybridLoop:
         model: str,
         config: CompletionConfig,
         tool_defs: list[ToolDefinition] | None,
-        tool_invoker: ToolInvoker | None,
+        tool_invoker: ToolInvokerProtocol | None,
         turns: list[TurnRecord],
         budget_checker: BudgetChecker | None,
         shutdown_checker: ShutdownChecker | None,
@@ -755,7 +755,7 @@ class HybridLoop:
     async def _handle_step_tool_calls(  # noqa: PLR0913
         self,
         ctx: AgentContext,
-        tool_invoker: ToolInvoker | None,
+        tool_invoker: ToolInvokerProtocol | None,
         response: CompletionResponse,
         turn_number: int,
         turns: list[TurnRecord],

--- a/src/synthorg/engine/loop_helpers.py
+++ b/src/synthorg/engine/loop_helpers.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
     from synthorg.engine.context import AgentContext
     from synthorg.engine.stagnation.protocol import StagnationDetector
     from synthorg.providers.protocol import CompletionProvider
-    from synthorg.tools.invoker import ToolInvoker
+    from synthorg.tools.protocol import ToolInvokerProtocol
 
 logger = get_logger(__name__)
 
@@ -287,7 +287,7 @@ def check_response_errors(
 
 
 def get_tool_definitions(
-    tool_invoker: ToolInvoker | None,
+    tool_invoker: ToolInvokerProtocol | None,
     loaded_tools: frozenset[str] = frozenset(),
 ) -> list[ToolDefinition] | None:
     """Extract disclosure-aware tool definitions from the invoker.

--- a/src/synthorg/engine/loop_protocol.py
+++ b/src/synthorg/engine/loop_protocol.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from synthorg.engine.trajectory.efficiency_ratios import EfficiencyRatios
     from synthorg.providers.models import CompletionConfig
     from synthorg.providers.protocol import CompletionProvider
-    from synthorg.tools.invoker import ToolInvoker
+    from synthorg.tools.protocol import ToolInvokerProtocol
 
 
 class NodeType(StrEnum):
@@ -284,7 +284,7 @@ class ExecutionLoop(Protocol):
         *,
         context: AgentContext,
         provider: CompletionProvider,
-        tool_invoker: ToolInvoker | None = None,
+        tool_invoker: ToolInvokerProtocol | None = None,
         budget_checker: BudgetChecker | None = None,
         shutdown_checker: ShutdownChecker | None = None,
         completion_config: CompletionConfig | None = None,

--- a/src/synthorg/engine/loop_tool_execution.py
+++ b/src/synthorg/engine/loop_tool_execution.py
@@ -39,11 +39,11 @@ from synthorg.providers.enums import MessageRole
 from synthorg.providers.models import ChatMessage, ToolResult
 
 if TYPE_CHECKING:
+    from synthorg.approval.models import EscalationInfo
     from synthorg.engine.approval_gate import ApprovalGate
-    from synthorg.engine.approval_gate_models import EscalationInfo
     from synthorg.engine.context import AgentContext
     from synthorg.providers.models import CompletionResponse
-    from synthorg.tools.invoker import ToolInvoker
+    from synthorg.tools.protocol import ToolInvokerProtocol
 
 logger = get_logger(__name__)
 
@@ -200,7 +200,7 @@ async def _park_for_approval(
 
 async def execute_tool_calls(  # noqa: PLR0913, C901
     ctx: AgentContext,
-    tool_invoker: ToolInvoker | None,
+    tool_invoker: ToolInvokerProtocol | None,
     response: CompletionResponse,
     turn_number: int,
     turns: list[TurnRecord],

--- a/src/synthorg/engine/plan_execute_loop.py
+++ b/src/synthorg/engine/plan_execute_loop.py
@@ -75,7 +75,7 @@ if TYPE_CHECKING:
     from synthorg.engine.stagnation.protocol import StagnationDetector
     from synthorg.providers.models import ToolDefinition
     from synthorg.providers.protocol import CompletionProvider
-    from synthorg.tools.invoker import ToolInvoker
+    from synthorg.tools.protocol import ToolInvokerProtocol
 
 logger = get_logger(__name__)
 
@@ -145,7 +145,7 @@ class PlanExecuteLoop(PlanExecuteStepMixin):
         *,
         context: AgentContext,
         provider: CompletionProvider,
-        tool_invoker: ToolInvoker | None = None,
+        tool_invoker: ToolInvokerProtocol | None = None,
         budget_checker: BudgetChecker | None = None,
         shutdown_checker: ShutdownChecker | None = None,
         completion_config: CompletionConfig | None = None,
@@ -254,7 +254,7 @@ class PlanExecuteLoop(PlanExecuteStepMixin):
         executor_model: str,
         config: CompletionConfig,
         tool_defs: list[ToolDefinition] | None,
-        tool_invoker: ToolInvoker | None,
+        tool_invoker: ToolInvokerProtocol | None,
         plan: ExecutionPlan,
         turns: list[TurnRecord],
         all_plans: list[ExecutionPlan],
@@ -647,7 +647,7 @@ class PlanExecuteLoop(PlanExecuteStepMixin):
         executor_model: str,
         config: CompletionConfig,
         tool_defs: list[ToolDefinition] | None,
-        tool_invoker: ToolInvoker | None,
+        tool_invoker: ToolInvokerProtocol | None,
         step: PlanStep,
         turns: list[TurnRecord],
         budget_checker: BudgetChecker | None,

--- a/src/synthorg/engine/plan_execute_step_mixin.py
+++ b/src/synthorg/engine/plan_execute_step_mixin.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
         ToolDefinition,
     )
     from synthorg.providers.protocol import CompletionProvider
-    from synthorg.tools.invoker import ToolInvoker
+    from synthorg.tools.protocol import ToolInvokerProtocol
 
 logger = get_logger(__name__)
 
@@ -65,7 +65,7 @@ class PlanExecuteStepMixin:
         model: str,
         config: CompletionConfig,
         tool_defs: list[ToolDefinition] | None,
-        tool_invoker: ToolInvoker | None,
+        tool_invoker: ToolInvokerProtocol | None,
         turns: list[TurnRecord],
         budget_checker: BudgetChecker | None,
         shutdown_checker: ShutdownChecker | None,
@@ -150,7 +150,7 @@ class PlanExecuteStepMixin:
     async def _handle_step_tool_calls(  # noqa: PLR0913
         self,
         ctx: AgentContext,
-        tool_invoker: ToolInvoker | None,
+        tool_invoker: ToolInvokerProtocol | None,
         response: CompletionResponse,
         turn_number: int,
         turns: list[TurnRecord],

--- a/src/synthorg/engine/react_loop.py
+++ b/src/synthorg/engine/react_loop.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
     from synthorg.engine.stagnation.protocol import StagnationDetector
     from synthorg.providers.models import ToolDefinition
     from synthorg.providers.protocol import CompletionProvider
-    from synthorg.tools.invoker import ToolInvoker
+    from synthorg.tools.protocol import ToolInvokerProtocol
 
 logger = get_logger(__name__)
 
@@ -121,7 +121,7 @@ class ReactLoop:
         *,
         context: AgentContext,
         provider: CompletionProvider,
-        tool_invoker: ToolInvoker | None = None,
+        tool_invoker: ToolInvokerProtocol | None = None,
         budget_checker: BudgetChecker | None = None,
         shutdown_checker: ShutdownChecker | None = None,
         completion_config: CompletionConfig | None = None,
@@ -230,7 +230,7 @@ class ReactLoop:
         self,
         context: AgentContext,
         completion_config: CompletionConfig | None,
-        tool_invoker: ToolInvoker | None,
+        tool_invoker: ToolInvokerProtocol | None,
     ) -> tuple[str, CompletionConfig, list[ToolDefinition] | None, list[TurnRecord]]:
         """Log loop start and resolve config, model ID, and tool defs."""
         logger.info(
@@ -257,7 +257,7 @@ class ReactLoop:
         response: CompletionResponse,
         turn_number: int,
         turns: list[TurnRecord],
-        tool_invoker: ToolInvoker | None,
+        tool_invoker: ToolInvokerProtocol | None,
         shutdown_checker: ShutdownChecker | None = None,
     ) -> AgentContext | ExecutionResult:
         """Check errors, update context, handle completion or tool calls."""

--- a/src/synthorg/engine/task_sync.py
+++ b/src/synthorg/engine/task_sync.py
@@ -27,7 +27,7 @@ from synthorg.observability.events.execution import (
 )
 
 if TYPE_CHECKING:
-    from synthorg.api.approval_store import ApprovalStore
+    from synthorg.approval.protocol import ApprovalStoreProtocol
     from synthorg.engine.context import AgentContext
     from synthorg.engine.loop_protocol import ExecutionResult
     from synthorg.engine.task_engine import TaskEngine
@@ -178,7 +178,7 @@ async def apply_post_execution_transitions(
     agent_id: str,
     task_id: str,
     task_engine: TaskEngine | None,
-    approval_store: ApprovalStore | None = None,
+    approval_store: ApprovalStoreProtocol | None = None,
 ) -> ExecutionResult:
     """Apply post-execution task transitions based on termination reason.
 
@@ -284,7 +284,7 @@ async def _transition_and_sync(  # noqa: PLR0913
 
 
 async def _create_review_approval(
-    approval_store: ApprovalStore | None,
+    approval_store: ApprovalStoreProtocol | None,
     *,
     agent_id: str,
     task_id: str,

--- a/src/synthorg/hr/hiring_service.py
+++ b/src/synthorg/hr/hiring_service.py
@@ -41,7 +41,7 @@ from synthorg.observability.events.hr import (
 )
 
 if TYPE_CHECKING:
-    from synthorg.api.approval_store import ApprovalStore
+    from synthorg.approval.protocol import ApprovalStoreProtocol
     from synthorg.hr.onboarding_service import OnboardingService
 
 logger = get_logger(__name__)
@@ -67,7 +67,7 @@ class HiringService:
         self,
         *,
         registry: AgentRegistryService,
-        approval_store: ApprovalStore | None = None,
+        approval_store: ApprovalStoreProtocol | None = None,
         onboarding_service: OnboardingService | None = None,
         default_model_config: ModelConfig | None = None,
     ) -> None:

--- a/src/synthorg/hr/promotion/service.py
+++ b/src/synthorg/hr/promotion/service.py
@@ -45,7 +45,7 @@ from synthorg.observability.events.promotion import (
 if TYPE_CHECKING:
     from pydantic import AwareDatetime
 
-    from synthorg.api.approval_store import ApprovalStore
+    from synthorg.approval.protocol import ApprovalStoreProtocol
     from synthorg.hr.performance.tracker import PerformanceTracker
     from synthorg.hr.promotion.approval_protocol import (
         PromotionApprovalStrategy,
@@ -121,7 +121,7 @@ class PromotionService:
         registry: AgentRegistryService,
         tracker: PerformanceTracker,
         config: PromotionConfig,
-        approval_store: ApprovalStore | None = None,
+        approval_store: ApprovalStoreProtocol | None = None,
         trust_service: TrustService | None = None,
         on_notification: PromotionNotificationCallback | None = None,
     ) -> None:

--- a/src/synthorg/hr/pruning/service.py
+++ b/src/synthorg/hr/pruning/service.py
@@ -48,7 +48,7 @@ from synthorg.observability.events.hr import (
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
-    from synthorg.api.approval_store import ApprovalStore
+    from synthorg.approval.protocol import ApprovalStoreProtocol
     from synthorg.core.agent import AgentIdentity
     from synthorg.hr.models import OffboardingRecord
     from synthorg.hr.offboarding_service import OffboardingService
@@ -80,7 +80,7 @@ class PruningService:
         policies: tuple[PruningPolicy, ...],
         registry: AgentRegistryService,
         tracker: PerformanceTracker,
-        approval_store: ApprovalStore,
+        approval_store: ApprovalStoreProtocol,
         offboarding_service: OffboardingService,
         config: PruningServiceConfig | None = None,
         on_notification: (Callable[[PruningRecord], Awaitable[None]] | None) = None,

--- a/src/synthorg/hr/scaling/factory.py
+++ b/src/synthorg/hr/scaling/factory.py
@@ -31,7 +31,7 @@ from synthorg.observability.events.hr import HR_SCALING_FACTORY_ASSEMBLED
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
-    from synthorg.api.approval_store import ApprovalStore
+    from synthorg.approval.protocol import ApprovalStoreProtocol
     from synthorg.core.types import NotBlankStr
     from synthorg.hr.pruning.policy import PruningPolicy
     from synthorg.hr.scaling.config import ScalingConfig
@@ -111,7 +111,7 @@ def create_scaling_strategies(
 def create_scaling_guards(
     config: ScalingConfig,
     *,
-    approval_store: ApprovalStore | None = None,
+    approval_store: ApprovalStoreProtocol | None = None,
 ) -> ScalingGuard:
     """Create the guard chain from configuration.
 

--- a/src/synthorg/hr/scaling/guards/approval_gate.py
+++ b/src/synthorg/hr/scaling/guards/approval_gate.py
@@ -18,7 +18,7 @@ from synthorg.observability import get_logger
 from synthorg.observability.events.hr import HR_SCALING_GUARD_APPLIED
 
 if TYPE_CHECKING:
-    from synthorg.api.approval_store import ApprovalStore
+    from synthorg.approval.protocol import ApprovalStoreProtocol
     from synthorg.hr.scaling.models import ScalingDecision
 
 logger = get_logger(__name__)
@@ -45,7 +45,7 @@ class ApprovalGateGuard:
     def __init__(
         self,
         *,
-        approval_store: ApprovalStore,
+        approval_store: ApprovalStoreProtocol,
         expiry_days: int = 7,
     ) -> None:
         if expiry_days <= 0:

--- a/src/synthorg/hr/training/factory.py
+++ b/src/synthorg/hr/training/factory.py
@@ -6,7 +6,7 @@ from synthorg.hr.training.models import ContentType
 from synthorg.observability import get_logger
 
 if TYPE_CHECKING:
-    from synthorg.api.approval_store import ApprovalStore
+    from synthorg.approval.protocol import ApprovalStoreProtocol
     from synthorg.hr.performance.tracker import PerformanceTracker
     from synthorg.hr.registry import AgentRegistryService
     from synthorg.hr.training.config import TrainingConfig
@@ -72,7 +72,7 @@ def build_training_service(  # noqa: PLR0913
     memory_backend: MemoryBackend,
     tracker: PerformanceTracker,
     registry: AgentRegistryService,
-    approval_store: ApprovalStore,
+    approval_store: ApprovalStoreProtocol,
     tool_tracker: ToolInvocationTracker,
     provider: CompletionProvider | None = None,
 ) -> TrainingService:
@@ -235,7 +235,7 @@ def _build_curation(
 def _build_guards(
     config: TrainingConfig,
     *,
-    approval_store: ApprovalStore,
+    approval_store: ApprovalStoreProtocol,
 ) -> tuple[TrainingGuard, ...]:
     """Build guard chain from config.
 

--- a/src/synthorg/hr/training/guards/review_gate.py
+++ b/src/synthorg/hr/training/guards/review_gate.py
@@ -23,7 +23,7 @@ from synthorg.observability.events.training import (
 )
 
 if TYPE_CHECKING:
-    from synthorg.api.approval_store import ApprovalStore
+    from synthorg.approval.protocol import ApprovalStoreProtocol
     from synthorg.hr.training.models import TrainingPlan
 
 logger = get_logger(__name__)
@@ -44,7 +44,7 @@ class ReviewGateGuard:
         approval_store: Approval store for creating review items.
     """
 
-    def __init__(self, *, approval_store: ApprovalStore) -> None:
+    def __init__(self, *, approval_store: ApprovalStoreProtocol) -> None:
         self._approval_store = approval_store
 
     @property

--- a/src/synthorg/memory/embedding/fine_tune_orchestrator.py
+++ b/src/synthorg/memory/embedding/fine_tune_orchestrator.py
@@ -44,9 +44,9 @@ if TYPE_CHECKING:
     from synthorg.memory.embedding.fine_tune_models import (
         FineTuneRequest,
     )
-    from synthorg.persistence.sqlite.fine_tune_repo import (
-        SQLiteFineTuneCheckpointRepository,
-        SQLiteFineTuneRunRepository,
+    from synthorg.persistence.fine_tune_protocol import (
+        FineTuneCheckpointRepository,
+        FineTuneRunRepository,
     )
 
 logger = get_logger(__name__)
@@ -70,8 +70,8 @@ class FineTuneOrchestrator:
     cancel, and startup recovery.
 
     Args:
-        run_repo: SQLite repository for run state.
-        checkpoint_repo: SQLite repository for checkpoints.
+        run_repo: Repository for run state (protocol-typed; backend-agnostic).
+        checkpoint_repo: Repository for checkpoints (protocol-typed).
         settings_service: Runtime settings (for deploy stage).
         channels_plugin: WS plugin exposing ``publish(data, channels=...)``.
         llm_provider: Optional LLM provider for data generation.
@@ -80,8 +80,8 @@ class FineTuneOrchestrator:
     def __init__(
         self,
         *,
-        run_repo: SQLiteFineTuneRunRepository,
-        checkpoint_repo: SQLiteFineTuneCheckpointRepository,
+        run_repo: FineTuneRunRepository,
+        checkpoint_repo: FineTuneCheckpointRepository,
         settings_service: object | None = None,
         channels_plugin: ChannelsPlugin | None = None,
         llm_provider: object | None = None,

--- a/src/synthorg/meta/factory.py
+++ b/src/synthorg/meta/factory.py
@@ -56,6 +56,7 @@ from synthorg.observability.events.meta import (
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from synthorg.approval.protocol import ApprovalStoreProtocol
     from synthorg.meta.chief_of_staff.protocol import ConfidenceAdjuster
     from synthorg.meta.config import SelfImprovementConfig
     from synthorg.meta.protocol import (
@@ -174,6 +175,8 @@ def build_strategies(
 
 def build_guards(
     config: SelfImprovementConfig,
+    *,
+    approval_store: ApprovalStoreProtocol | None = None,
 ) -> tuple[ProposalGuard, ...]:
     """Build the proposal guard chain.
 
@@ -182,6 +185,12 @@ def build_guards(
 
     Args:
         config: Self-improvement configuration.
+        approval_store: Approval store routed into
+            :class:`ApprovalGateGuard` so proposals are durably
+            registered before proceeding.  When ``None`` the
+            approval gate fails closed -- every proposal is
+            rejected because the mandatory-review invariant
+            cannot be enforced.
 
     Returns:
         Tuple of guards in evaluation order.
@@ -193,7 +202,7 @@ def build_guards(
             max_proposals=config.guards.proposal_rate_limit,
             window_hours=config.guards.rate_limit_window_hours,
         ),
-        ApprovalGateGuard(),
+        ApprovalGateGuard(approval_store=approval_store),
     )
 
 

--- a/src/synthorg/meta/guards/approval_gate.py
+++ b/src/synthorg/meta/guards/approval_gate.py
@@ -1,14 +1,18 @@
 """Approval gate guard.
 
 Routes proposals to the ApprovalStore for mandatory human review.
-This guard always passes (it routes, not rejects) but records the
-proposal in the approval queue when a store is configured.
+The guard is the enforcement point for the ``requires_human_review``
+invariant: a proposal can only proceed if it is durably registered in
+the approval queue.  When the store is unavailable or a write fails,
+the guard rejects so the system fails closed instead of silently
+bypassing review.
 """
 
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 from uuid import NAMESPACE_URL, uuid5
 
+from synthorg.api.errors import ConflictError
 from synthorg.core.approval import ApprovalItem
 from synthorg.core.enums import ApprovalRiskLevel
 from synthorg.core.types import NotBlankStr
@@ -21,6 +25,7 @@ from synthorg.meta.models import (
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.meta import (
     META_PROPOSAL_GUARD_PASSED,
+    META_PROPOSAL_GUARD_REJECTED,
 )
 
 if TYPE_CHECKING:
@@ -41,14 +46,19 @@ _DEFAULT_EXPIRY_DAYS = 7
 class ApprovalGateGuard:
     """Routes proposals to the approval store for human review.
 
-    This guard always returns PASSED -- it does not reject proposals.
-    Its role is to ensure every proposal is registered in the
-    approval queue before proceeding.
+    ``evaluate()`` returns PASSED only when the proposal is durably
+    registered in the approval queue: on first evaluation via
+    ``ApprovalStoreProtocol.add()``, and on replay (same deterministic
+    ``approval_id``) via the ``ConflictError`` branch which treats the
+    duplicate as idempotent success.  When no store is configured, or
+    any non-duplicate write error surfaces, the guard returns
+    REJECTED so the meta loop fails closed instead of silently
+    bypassing mandatory human review.
 
     Args:
-        approval_store: The approval store instance (optional; when
-            ``None``, the guard still passes but does not persist
-            and logs a warning).
+        approval_store: The approval store instance.  When ``None``
+            the guard always rejects -- callers must wire a concrete
+            store before enabling the meta-loop pipeline.
         expiry_days: Days until approval items expire. Must be > 0.
     """
 
@@ -73,13 +83,16 @@ class ApprovalGateGuard:
         self,
         proposal: ImprovementProposal,
     ) -> GuardResult:
-        """Register proposal in approval store and pass.
+        """Register proposal in approval store.
 
         Args:
             proposal: The proposal to route for approval.
 
         Returns:
-            Guard result with PASSED verdict (always).
+            PASSED when the approval item is durably registered
+            (newly created, or already present from a replay);
+            REJECTED when no store is configured or the write fails
+            with a non-duplicate error.
         """
         risk = _ALTITUDE_RISK.get(
             proposal.altitude,
@@ -88,18 +101,22 @@ class ApprovalGateGuard:
         proposal_id_str = str(proposal.id)
 
         if self._store is None:
+            reason = (
+                "Approval store not configured; cannot register proposal "
+                "for mandatory human review."
+            )
             logger.warning(
-                META_PROPOSAL_GUARD_PASSED,
+                META_PROPOSAL_GUARD_REJECTED,
                 guard=self.name,
                 proposal_id=proposal_id_str,
                 risk_level=risk.value,
                 altitude=proposal.altitude.value,
-                persisted=False,
                 reason="approval_store_not_configured",
             )
             return GuardResult(
                 guard_name=self.name,
-                verdict=GuardVerdict.PASSED,
+                verdict=GuardVerdict.REJECTED,
+                reason=NotBlankStr(reason),
             )
 
         now = datetime.now(UTC)
@@ -130,21 +147,44 @@ class ApprovalGateGuard:
             await self._store.add(item)
         except MemoryError, RecursionError:
             raise
-        except Exception as exc:
-            logger.warning(
+        except ConflictError:
+            # Replay: the deterministic approval_id already exists, so
+            # the proposal is durably registered.  Treat as idempotent
+            # success -- not a silent bypass.
+            logger.info(
                 META_PROPOSAL_GUARD_PASSED,
                 guard=self.name,
                 proposal_id=proposal_id_str,
                 approval_id=approval_id,
                 risk_level=risk.value,
                 altitude=proposal.altitude.value,
-                persisted=False,
+                persisted=True,
+                replay=True,
+            )
+            return GuardResult(
+                guard_name=self.name,
+                verdict=GuardVerdict.PASSED,
+            )
+        except Exception as exc:
+            reason = (
+                f"Approval store write failed "
+                f"({type(exc).__name__}); proposal not persisted."
+            )
+            logger.warning(
+                META_PROPOSAL_GUARD_REJECTED,
+                guard=self.name,
+                proposal_id=proposal_id_str,
+                approval_id=approval_id,
+                risk_level=risk.value,
+                altitude=proposal.altitude.value,
+                reason="approval_store_write_failed",
                 error_type=type(exc).__name__,
                 error=safe_error_description(exc),
             )
             return GuardResult(
                 guard_name=self.name,
-                verdict=GuardVerdict.PASSED,
+                verdict=GuardVerdict.REJECTED,
+                reason=NotBlankStr(reason),
             )
 
         logger.info(

--- a/src/synthorg/meta/guards/approval_gate.py
+++ b/src/synthorg/meta/guards/approval_gate.py
@@ -1,12 +1,16 @@
 """Approval gate guard.
 
 Routes proposals to the ApprovalStore for mandatory human review.
-This guard always passes (it routes, not rejects) but records
-the proposal in the approval queue.
+This guard always passes (it routes, not rejects) but records the
+proposal in the approval queue when a store is configured.
 """
 
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
+from uuid import NAMESPACE_URL, uuid5
 
+from synthorg.core.approval import ApprovalItem
+from synthorg.core.enums import ApprovalRiskLevel
 from synthorg.core.types import NotBlankStr
 from synthorg.meta.models import (
     GuardResult,
@@ -14,20 +18,24 @@ from synthorg.meta.models import (
     ImprovementProposal,
     ProposalAltitude,
 )
-from synthorg.observability import get_logger
-from synthorg.observability.events.meta import META_PROPOSAL_GUARD_PASSED
+from synthorg.observability import get_logger, safe_error_description
+from synthorg.observability.events.meta import (
+    META_PROPOSAL_GUARD_PASSED,
+)
 
 if TYPE_CHECKING:
     from synthorg.approval.protocol import ApprovalStoreProtocol
 
 logger = get_logger(__name__)
 
-_ALTITUDE_RISK = {
-    ProposalAltitude.CONFIG_TUNING: "medium",
-    ProposalAltitude.ARCHITECTURE: "high",
-    ProposalAltitude.PROMPT_TUNING: "medium",
-    ProposalAltitude.CODE_MODIFICATION: "critical",
+_ALTITUDE_RISK: dict[ProposalAltitude, ApprovalRiskLevel] = {
+    ProposalAltitude.CONFIG_TUNING: ApprovalRiskLevel.MEDIUM,
+    ProposalAltitude.ARCHITECTURE: ApprovalRiskLevel.HIGH,
+    ProposalAltitude.PROMPT_TUNING: ApprovalRiskLevel.MEDIUM,
+    ProposalAltitude.CODE_MODIFICATION: ApprovalRiskLevel.CRITICAL,
 }
+
+_DEFAULT_EXPIRY_DAYS = 7
 
 
 class ApprovalGateGuard:
@@ -39,15 +47,22 @@ class ApprovalGateGuard:
 
     Args:
         approval_store: The approval store instance (optional; when
-            None, the guard still passes but does not persist).
+            ``None``, the guard still passes but does not persist
+            and logs a warning).
+        expiry_days: Days until approval items expire. Must be > 0.
     """
 
     def __init__(
         self,
         *,
         approval_store: ApprovalStoreProtocol | None = None,
+        expiry_days: int = _DEFAULT_EXPIRY_DAYS,
     ) -> None:
+        if expiry_days <= 0:
+            msg = f"expiry_days must be > 0, got {expiry_days}"
+            raise ValueError(msg)
         self._store = approval_store
+        self._expiry_days = expiry_days
 
     @property
     def name(self) -> NotBlankStr:
@@ -66,13 +81,80 @@ class ApprovalGateGuard:
         Returns:
             Guard result with PASSED verdict (always).
         """
-        risk = _ALTITUDE_RISK.get(proposal.altitude, "medium")
+        risk = _ALTITUDE_RISK.get(
+            proposal.altitude,
+            ApprovalRiskLevel.MEDIUM,
+        )
+        proposal_id_str = str(proposal.id)
+
+        if self._store is None:
+            logger.warning(
+                META_PROPOSAL_GUARD_PASSED,
+                guard=self.name,
+                proposal_id=proposal_id_str,
+                risk_level=risk.value,
+                altitude=proposal.altitude.value,
+                persisted=False,
+                reason="approval_store_not_configured",
+            )
+            return GuardResult(
+                guard_name=self.name,
+                verdict=GuardVerdict.PASSED,
+            )
+
+        now = datetime.now(UTC)
+        # Deterministic id from the proposal id so replays across
+        # evaluation cycles reuse the same approval entry rather than
+        # enqueueing duplicates.
+        approval_id = str(
+            uuid5(NAMESPACE_URL, f"proposal:{proposal_id_str}"),
+        )
+        item = ApprovalItem(
+            id=approval_id,
+            action_type=f"proposal:{proposal.altitude.value}",
+            title=proposal.title,
+            description=proposal.description,
+            requested_by="meta_improvement_service",
+            risk_level=risk,
+            created_at=now,
+            expires_at=now + timedelta(days=self._expiry_days),
+            metadata={
+                "proposal_id": proposal_id_str,
+                "altitude": proposal.altitude.value,
+                "source_rule": str(proposal.source_rule or ""),
+                "confidence": f"{proposal.confidence:.4f}",
+            },
+        )
+
+        try:
+            await self._store.add(item)
+        except MemoryError, RecursionError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                META_PROPOSAL_GUARD_PASSED,
+                guard=self.name,
+                proposal_id=proposal_id_str,
+                approval_id=approval_id,
+                risk_level=risk.value,
+                altitude=proposal.altitude.value,
+                persisted=False,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            return GuardResult(
+                guard_name=self.name,
+                verdict=GuardVerdict.PASSED,
+            )
+
         logger.info(
             META_PROPOSAL_GUARD_PASSED,
             guard=self.name,
-            proposal_id=str(proposal.id),
-            risk_level=risk,
+            proposal_id=proposal_id_str,
+            approval_id=approval_id,
+            risk_level=risk.value,
             altitude=proposal.altitude.value,
+            persisted=True,
         )
         return GuardResult(
             guard_name=self.name,

--- a/src/synthorg/meta/guards/approval_gate.py
+++ b/src/synthorg/meta/guards/approval_gate.py
@@ -18,7 +18,7 @@ from synthorg.observability import get_logger
 from synthorg.observability.events.meta import META_PROPOSAL_GUARD_PASSED
 
 if TYPE_CHECKING:
-    from synthorg.api.approval_store import ApprovalStore
+    from synthorg.approval.protocol import ApprovalStoreProtocol
 
 logger = get_logger(__name__)
 
@@ -45,7 +45,7 @@ class ApprovalGateGuard:
     def __init__(
         self,
         *,
-        approval_store: ApprovalStore | None = None,
+        approval_store: ApprovalStoreProtocol | None = None,
     ) -> None:
         self._store = approval_store
 

--- a/src/synthorg/meta/service.py
+++ b/src/synthorg/meta/service.py
@@ -56,6 +56,7 @@ from synthorg.observability.events.meta import (
 )
 
 if TYPE_CHECKING:
+    from synthorg.approval.protocol import ApprovalStoreProtocol
     from synthorg.memory.protocol import MemoryBackend
     from synthorg.meta.appliers.architecture_applier import (
         ArchitectureApplierContext,
@@ -138,11 +139,12 @@ class SelfImprovementService:
         roster: OrgRoster | None = None,
         snapshot_builder: SnapshotBuilder | None = None,
         group_aggregator: GroupSignalAggregator | None = None,
+        approval_store: ApprovalStoreProtocol | None = None,
     ) -> None:
         self._config = config
         self._rule_engine = build_rule_engine(config)
         self._strategies = build_strategies(config, provider=provider)
-        self._guards = build_guards(config)
+        self._guards = build_guards(config, approval_store=approval_store)
         self._appliers = build_appliers(
             config,
             config_provider=config_provider,

--- a/src/synthorg/meta/service.py
+++ b/src/synthorg/meta/service.py
@@ -141,6 +141,16 @@ class SelfImprovementService:
         group_aggregator: GroupSignalAggregator | None = None,
         approval_store: ApprovalStoreProtocol | None = None,
     ) -> None:
+        if config.enabled and approval_store is None:
+            # Fail-fast so callers notice at construction time rather
+            # than observing a silently no-op cycle when the approval
+            # gate rejects every proposal for lack of a store.
+            msg = (
+                "SelfImprovementService requires an approval_store when "
+                "config.enabled is True; the approval gate cannot enforce "
+                "mandatory human review without one."
+            )
+            raise ValueError(msg)
         self._config = config
         self._rule_engine = build_rule_engine(config)
         self._strategies = build_strategies(config, provider=provider)

--- a/src/synthorg/persistence/approval_protocol.py
+++ b/src/synthorg/persistence/approval_protocol.py
@@ -1,0 +1,74 @@
+"""Repository protocol for approval item persistence.
+
+Concrete implementation lives at
+``synthorg.persistence.sqlite.approval_repo.SQLiteApprovalRepository``.
+The :class:`ApprovalStore` (``synthorg.api.approval_store``) holds a
+reference typed against this protocol so the storage implementation
+can be swapped (e.g. a future Postgres backend) without changing the
+store itself.
+
+Mirrors the pattern of ``persistence/fine_tune_protocol.py`` and
+``persistence/escalation_protocol.py``.
+"""
+
+from typing import Protocol, runtime_checkable
+
+from synthorg.core.approval import ApprovalItem  # noqa: TC001
+from synthorg.core.enums import (
+    ApprovalRiskLevel,  # noqa: TC001
+    ApprovalStatus,  # noqa: TC001
+)
+from synthorg.core.types import NotBlankStr  # noqa: TC001
+
+
+@runtime_checkable
+class ApprovalRepository(Protocol):
+    """CRUD interface for durable approval-item storage.
+
+    All methods are async; non-recoverable errors (``MemoryError``,
+    ``RecursionError``) propagate to callers.  Constraint violations
+    raise :class:`ConstraintViolationError`; other DB errors raise
+    :class:`QueryError`.
+    """
+
+    async def save(self, item: ApprovalItem) -> None:
+        """Upsert an approval item.
+
+        Raises:
+            ConstraintViolationError: On constraint violations.
+            QueryError: On other database errors.
+        """
+        ...
+
+    async def get(self, approval_id: NotBlankStr) -> ApprovalItem | None:
+        """Get an approval item by ID, or ``None`` if not found.
+
+        Raises:
+            QueryError: If the database query fails.
+        """
+        ...
+
+    async def list_items(
+        self,
+        *,
+        status: ApprovalStatus | None = None,
+        risk_level: ApprovalRiskLevel | None = None,
+        action_type: NotBlankStr | None = None,
+    ) -> tuple[ApprovalItem, ...]:
+        """List approval items with optional filters.
+
+        Raises:
+            QueryError: If the database query fails.
+        """
+        ...
+
+    async def delete(self, approval_id: NotBlankStr) -> bool:
+        """Delete an approval item.
+
+        Returns:
+            ``True`` if a row was deleted, ``False`` if no match.
+
+        Raises:
+            QueryError: If the database query fails.
+        """
+        ...

--- a/src/synthorg/persistence/approval_protocol.py
+++ b/src/synthorg/persistence/approval_protocol.py
@@ -1,11 +1,11 @@
 """Repository protocol for approval item persistence.
 
-Concrete implementation lives at
-``synthorg.persistence.sqlite.approval_repo.SQLiteApprovalRepository``.
+Concrete implementations live in backend modules
+(``synthorg.persistence.sqlite.approval_repo.SQLiteApprovalRepository``
+and ``synthorg.persistence.postgres.approval_repo.PostgresApprovalRepository``).
 The :class:`ApprovalStore` (``synthorg.api.approval_store``) holds a
 reference typed against this protocol so the storage implementation
-can be swapped (e.g. a future Postgres backend) without changing the
-store itself.
+can be swapped without changing the store itself.
 
 Mirrors the pattern of ``persistence/fine_tune_protocol.py`` and
 ``persistence/escalation_protocol.py``.

--- a/src/synthorg/persistence/errors.py
+++ b/src/synthorg/persistence/errors.py
@@ -2,19 +2,40 @@
 
 All persistence-related errors inherit from ``PersistenceError`` so
 callers can catch the entire family with a single except clause.
+
+Each concrete exception carries an ``is_retryable`` class attribute
+mirroring the provider-layer convention in ``synthorg.providers.errors``.
+Callers that implement bounded retry/backoff (e.g. a repository
+middleware) can branch on this flag without string-matching the driver
+exception.  Default: ``False``.  Transient I/O failures override to
+``True``.
 """
 
 
 class PersistenceError(Exception):
     """Base exception for all persistence operations."""
 
+    is_retryable: bool = False
+
 
 class PersistenceConnectionError(PersistenceError):
-    """Raised when a backend connection cannot be established or is lost."""
+    """Raised when a backend connection cannot be established or is lost.
+
+    Network drops, pool exhaustion, and connect timeouts are transient
+    by default -- callers can retry with backoff.
+    """
+
+    is_retryable: bool = True
 
 
 class MigrationError(PersistenceError):
-    """Raised when a database migration fails."""
+    """Raised when a database migration fails.
+
+    Non-retryable: a failed migration indicates schema drift or a
+    logic bug, not a transient condition.
+    """
+
+    is_retryable: bool = False
 
 
 class RecordNotFoundError(PersistenceError):
@@ -25,13 +46,25 @@ class RecordNotFoundError(PersistenceError):
     return ``None`` on miss instead of raising.
     """
 
+    is_retryable: bool = False
+
 
 class DuplicateRecordError(PersistenceError):
     """Raised when inserting a record that already exists."""
 
+    is_retryable: bool = False
+
 
 class QueryError(PersistenceError):
-    """Raised when a query fails due to invalid parameters or backend issues."""
+    """Raised when a query fails due to invalid parameters or backend issues.
+
+    Transient by default: connection drops and deadlocks during a
+    query surface here and are safe to retry.  Deterministic failures
+    (bad SQL, invalid params) use :class:`ConstraintViolationError`
+    or :class:`VersionConflictError` which override to non-retryable.
+    """
+
+    is_retryable: bool = True
 
 
 class ConstraintViolationError(QueryError):
@@ -42,7 +75,12 @@ class ConstraintViolationError(QueryError):
     token parsed from the error message (for SQLite).  Callers can
     check this attribute to map the violation to a domain error
     without parsing error strings.
+
+    Non-retryable: constraint violations are deterministic for a
+    given input and will not succeed on a bare retry.
     """
+
+    is_retryable: bool = False
 
     def __init__(self, message: str, *, constraint: str) -> None:
         super().__init__(message)
@@ -50,12 +88,23 @@ class ConstraintViolationError(QueryError):
 
 
 class VersionConflictError(QueryError):
-    """Raised when an optimistic concurrency version check fails."""
+    """Raised when an optimistic concurrency version check fails.
+
+    Non-retryable at this layer: the caller must re-read, re-apply
+    its intended change, and resubmit with the fresh version.  A
+    blind retry would just lose the racing write.
+    """
+
+    is_retryable: bool = False
 
 
 class ArtifactTooLargeError(PersistenceError):
     """Raised when a single artifact exceeds the maximum allowed size."""
 
+    is_retryable: bool = False
+
 
 class ArtifactStorageFullError(PersistenceError):
     """Raised when total artifact storage exceeds capacity."""
+
+    is_retryable: bool = False

--- a/src/synthorg/persistence/postgres/approval_repo.py
+++ b/src/synthorg/persistence/postgres/approval_repo.py
@@ -1,0 +1,302 @@
+"""Postgres repository implementation for approval items.
+
+Sibling of :class:`SQLiteApprovalRepository` backed by
+``psycopg_pool.AsyncConnectionPool``.  Uses native ``JSONB`` for the
+``evidence_package`` and ``metadata`` columns and ``TIMESTAMPTZ`` for
+all timestamps -- matching the schema in
+``persistence/postgres/schema.sql``.
+
+Callers depend on the :class:`ApprovalRepository` Protocol from
+``persistence/approval_protocol.py``; this class satisfies it
+structurally.
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+import psycopg
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+
+from synthorg.core.approval import ApprovalItem
+from synthorg.core.enums import ApprovalRiskLevel, ApprovalStatus
+from synthorg.core.evidence import EvidencePackage
+from synthorg.core.types import NotBlankStr  # noqa: TC001
+from synthorg.observability import get_logger, safe_error_description
+from synthorg.observability.events.api import (
+    API_APPROVAL_REPO_DELETED,
+    API_APPROVAL_REPO_FAILED,
+    API_APPROVAL_REPO_FETCHED,
+    API_APPROVAL_REPO_LISTED,
+    API_APPROVAL_REPO_SAVED,
+)
+from synthorg.persistence.errors import ConstraintViolationError, QueryError
+
+if TYPE_CHECKING:
+    from psycopg_pool import AsyncConnectionPool
+
+logger = get_logger(__name__)
+
+_SELECT_COLS = (
+    "id, action_type, title, description, requested_by, risk_level, "
+    "status, created_at, expires_at, decided_at, decided_by, "
+    "decision_reason, task_id, evidence_package, metadata"
+)
+
+_APPROVALS_UPSERT_SQL = f"""
+    INSERT INTO approvals ({_SELECT_COLS})
+    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    ON CONFLICT (id) DO UPDATE SET
+        action_type = EXCLUDED.action_type,
+        title = EXCLUDED.title,
+        description = EXCLUDED.description,
+        requested_by = EXCLUDED.requested_by,
+        risk_level = EXCLUDED.risk_level,
+        status = EXCLUDED.status,
+        expires_at = EXCLUDED.expires_at,
+        decided_at = EXCLUDED.decided_at,
+        decided_by = EXCLUDED.decided_by,
+        decision_reason = EXCLUDED.decision_reason,
+        task_id = EXCLUDED.task_id,
+        evidence_package = EXCLUDED.evidence_package,
+        metadata = EXCLUDED.metadata
+"""  # noqa: S608 -- column list is compile-time constant
+
+
+def _row_to_item(row: dict[str, Any]) -> ApprovalItem:
+    """Convert a Postgres dict row into an :class:`ApprovalItem`.
+
+    Raises:
+        QueryError: If the row contains corrupt or unparseable data.
+    """
+    try:
+        metadata_raw = row["metadata"] or {}
+        # Postgres JSONB always deserializes to dict/list/primitive; if a
+        # legacy row stored a non-object value, ``ApprovalItem`` construction
+        # below will raise ``ValidationError`` and the outer except wraps it.
+        evidence_package = (
+            EvidencePackage.model_validate(row["evidence_package"])
+            if row["evidence_package"] is not None
+            else None
+        )
+        created_at = row["created_at"]
+        if isinstance(created_at, str):
+            created_at = datetime.fromisoformat(created_at)
+        expires_at = row["expires_at"]
+        if isinstance(expires_at, str):
+            expires_at = datetime.fromisoformat(expires_at)
+        decided_at = row["decided_at"]
+        if isinstance(decided_at, str):
+            decided_at = datetime.fromisoformat(decided_at)
+        return ApprovalItem(
+            id=str(row["id"]),
+            action_type=str(row["action_type"]),
+            title=str(row["title"]),
+            description=str(row["description"]),
+            requested_by=str(row["requested_by"]),
+            risk_level=ApprovalRiskLevel(str(row["risk_level"])),
+            status=ApprovalStatus(str(row["status"])),
+            created_at=created_at,
+            expires_at=expires_at,
+            decided_at=decided_at,
+            decided_by=(
+                str(row["decided_by"]) if row["decided_by"] is not None else None
+            ),
+            decision_reason=(
+                str(row["decision_reason"])
+                if row["decision_reason"] is not None
+                else None
+            ),
+            task_id=(str(row["task_id"]) if row["task_id"] is not None else None),
+            evidence_package=evidence_package,
+            metadata=metadata_raw,
+        )
+    except (ValueError, TypeError, KeyError) as exc:
+        try:
+            row_id = str(row["id"]) if row else "<unknown>"
+        except TypeError, KeyError:
+            row_id = "<unknown>"
+        msg = f"Failed to parse approval row {row_id!r}: {exc}"
+        logger.warning(
+            API_APPROVAL_REPO_FAILED,
+            row_id=row_id,
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
+        )
+        raise QueryError(msg) from exc
+
+
+class PostgresApprovalRepository:
+    """Postgres-backed approval item repository.
+
+    Provides CRUD operations for approval items using a shared
+    ``psycopg_pool.AsyncConnectionPool``.  Satisfies the
+    :class:`ApprovalRepository` protocol structurally.
+
+    Args:
+        pool: An open psycopg async connection pool.
+    """
+
+    def __init__(self, pool: AsyncConnectionPool) -> None:
+        self._pool = pool
+
+    async def save(self, item: ApprovalItem) -> None:
+        """Upsert an approval item.
+
+        Raises:
+            ConstraintViolationError: On constraint violations.
+            QueryError: On other database errors.
+        """
+        evidence_json = (
+            Jsonb(item.evidence_package.model_dump(mode="json"))
+            if item.evidence_package is not None
+            else None
+        )
+        params = (
+            item.id,
+            item.action_type,
+            item.title,
+            item.description,
+            item.requested_by,
+            item.risk_level.value,
+            item.status.value,
+            item.created_at,
+            item.expires_at,
+            item.decided_at,
+            item.decided_by,
+            item.decision_reason,
+            item.task_id,
+            evidence_json,
+            Jsonb(item.metadata),
+        )
+        try:
+            async with self._pool.connection() as conn, conn.cursor() as cur:
+                await cur.execute(_APPROVALS_UPSERT_SQL, params)
+        except psycopg.errors.IntegrityError as exc:
+            msg = f"Constraint violation saving approval {item.id!r}"
+            logger.warning(
+                API_APPROVAL_REPO_FAILED,
+                approval_id=item.id,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise ConstraintViolationError(msg, constraint=str(exc)) from exc
+        except psycopg.Error as exc:
+            msg = f"Failed to save approval {item.id!r}"
+            logger.warning(
+                API_APPROVAL_REPO_FAILED,
+                approval_id=item.id,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+        logger.info(
+            API_APPROVAL_REPO_SAVED,
+            approval_id=item.id,
+            status=item.status.value,
+        )
+
+    async def get(self, approval_id: NotBlankStr) -> ApprovalItem | None:
+        """Get an approval item by ID, or ``None`` if not found.
+
+        Raises:
+            QueryError: If the database query fails.
+        """
+        sql = f"SELECT {_SELECT_COLS} FROM approvals WHERE id = %s"  # noqa: S608
+        try:
+            async with (
+                self._pool.connection() as conn,
+                conn.cursor(row_factory=dict_row) as cur,
+            ):
+                await cur.execute(sql, (approval_id,))
+                row = await cur.fetchone()
+        except psycopg.Error as exc:
+            msg = f"Failed to fetch approval {approval_id!r}"
+            logger.warning(
+                API_APPROVAL_REPO_FAILED,
+                approval_id=approval_id,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+        if row is None:
+            return None
+        item = _row_to_item(row)
+        logger.debug(API_APPROVAL_REPO_FETCHED, approval_id=approval_id)
+        return item
+
+    async def list_items(
+        self,
+        *,
+        status: ApprovalStatus | None = None,
+        risk_level: ApprovalRiskLevel | None = None,
+        action_type: NotBlankStr | None = None,
+    ) -> tuple[ApprovalItem, ...]:
+        """List approval items with optional filters.
+
+        Raises:
+            QueryError: If the database query fails.
+        """
+        clauses: list[str] = []
+        params: list[str] = []
+        if status is not None:
+            clauses.append("status = %s")
+            params.append(status.value)
+        if risk_level is not None:
+            clauses.append("risk_level = %s")
+            params.append(risk_level.value)
+        if action_type is not None:
+            clauses.append("action_type = %s")
+            params.append(action_type)
+        where_sql = " AND ".join(clauses) if clauses else "TRUE"
+        try:
+            async with (
+                self._pool.connection() as conn,
+                conn.cursor(row_factory=dict_row) as cur,
+            ):
+                await cur.execute(
+                    f"SELECT {_SELECT_COLS} FROM approvals "  # noqa: S608
+                    f"WHERE {where_sql} ORDER BY created_at DESC",
+                    params,
+                )
+                rows = await cur.fetchall()
+                items = tuple(_row_to_item(r) for r in rows)
+        except QueryError:
+            raise
+        except psycopg.Error as exc:
+            msg = "Failed to list approvals"
+            logger.warning(
+                API_APPROVAL_REPO_FAILED,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+        logger.debug(API_APPROVAL_REPO_LISTED, count=len(items))
+        return items
+
+    async def delete(self, approval_id: NotBlankStr) -> bool:
+        """Delete an approval item; returns True when a row was removed.
+
+        Raises:
+            QueryError: If the database operation fails.
+        """
+        sql = "DELETE FROM approvals WHERE id = %s"
+        try:
+            async with self._pool.connection() as conn, conn.cursor() as cur:
+                await cur.execute(sql, (approval_id,))
+                deleted = cur.rowcount > 0
+        except psycopg.Error as exc:
+            msg = f"Failed to delete approval {approval_id!r}"
+            logger.warning(
+                API_APPROVAL_REPO_FAILED,
+                approval_id=approval_id,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+        logger.info(
+            API_APPROVAL_REPO_DELETED,
+            approval_id=approval_id,
+            deleted=deleted,
+        )
+        return deleted

--- a/src/synthorg/persistence/postgres/approval_repo.py
+++ b/src/synthorg/persistence/postgres/approval_repo.py
@@ -180,6 +180,14 @@ class PostgresApprovalRepository:
                 await cur.execute(_APPROVALS_UPSERT_SQL, params)
                 await conn.commit()
         except psycopg.errors.IntegrityError as exc:
+            # Extract the PostgreSQL constraint name so callers can
+            # dispatch reliably on
+            # :attr:`ConstraintViolationError.constraint` without
+            # parsing server error text.
+            constraint = (
+                getattr(getattr(exc, "diag", None), "constraint_name", None)
+                or "<unknown>"
+            )
             msg = f"Constraint violation saving approval {item.id!r}"
             logger.warning(
                 API_APPROVAL_REPO_FAILED,
@@ -187,7 +195,10 @@ class PostgresApprovalRepository:
                 error_type=type(exc).__name__,
                 error=safe_error_description(exc),
             )
-            raise ConstraintViolationError(msg, constraint=str(exc)) from exc
+            raise ConstraintViolationError(
+                msg,
+                constraint=constraint,
+            ) from exc
         except psycopg.Error as exc:
             msg = f"Failed to save approval {item.id!r}"
             logger.warning(

--- a/src/synthorg/persistence/postgres/approval_repo.py
+++ b/src/synthorg/persistence/postgres/approval_repo.py
@@ -71,7 +71,12 @@ def _row_to_item(row: dict[str, Any]) -> ApprovalItem:
         QueryError: If the row contains corrupt or unparseable data.
     """
     try:
-        metadata_raw = row["metadata"] or {}
+        # Normalise only NULL explicitly; preserve other falsy payloads
+        # (e.g. ``[]``, ``""``, ``0``, ``false``) so ``ApprovalItem``'s
+        # ``dict[str, str]`` validation rejects them via ``ValidationError``
+        # rather than masking corruption as an empty dict.
+        raw_metadata = row["metadata"]
+        metadata_raw = {} if raw_metadata is None else raw_metadata
         # Postgres JSONB always deserializes to dict/list/primitive; if a
         # legacy row stored a non-object value, ``ApprovalItem`` construction
         # below will raise ``ValidationError`` and the outer except wraps it.

--- a/src/synthorg/persistence/postgres/approval_repo.py
+++ b/src/synthorg/persistence/postgres/approval_repo.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 import psycopg
 from psycopg.rows import dict_row
 from psycopg.types.json import Jsonb
+from pydantic import ValidationError
 
 from synthorg.core.approval import ApprovalItem
 from synthorg.core.enums import ApprovalRiskLevel, ApprovalStatus
@@ -111,7 +112,7 @@ def _row_to_item(row: dict[str, Any]) -> ApprovalItem:
             evidence_package=evidence_package,
             metadata=metadata_raw,
         )
-    except (ValueError, TypeError, KeyError) as exc:
+    except (ValueError, TypeError, KeyError, ValidationError) as exc:
         try:
             row_id = str(row["id"]) if row else "<unknown>"
         except TypeError, KeyError:
@@ -172,6 +173,7 @@ class PostgresApprovalRepository:
         try:
             async with self._pool.connection() as conn, conn.cursor() as cur:
                 await cur.execute(_APPROVALS_UPSERT_SQL, params)
+                await conn.commit()
         except psycopg.errors.IntegrityError as exc:
             msg = f"Constraint violation saving approval {item.id!r}"
             logger.warning(
@@ -261,8 +263,6 @@ class PostgresApprovalRepository:
                 )
                 rows = await cur.fetchall()
                 items = tuple(_row_to_item(r) for r in rows)
-        except QueryError:
-            raise
         except psycopg.Error as exc:
             msg = "Failed to list approvals"
             logger.warning(
@@ -285,6 +285,7 @@ class PostgresApprovalRepository:
             async with self._pool.connection() as conn, conn.cursor() as cur:
                 await cur.execute(sql, (approval_id,))
                 deleted = cur.rowcount > 0
+                await conn.commit()
         except psycopg.Error as exc:
             msg = f"Failed to delete approval {approval_id!r}"
             logger.warning(

--- a/src/synthorg/persistence/postgres/backend.py
+++ b/src/synthorg/persistence/postgres/backend.py
@@ -138,6 +138,7 @@ if TYPE_CHECKING:
         LifecycleEventRepository,
         TaskMetricRepository,
     )
+    from synthorg.ontology.models import EntityDefinition
     from synthorg.persistence.auth_protocol import LockoutRepository
     from synthorg.persistence.circuit_breaker_repo import (
         CircuitBreakerStateRepository,
@@ -170,6 +171,7 @@ if TYPE_CHECKING:
     from synthorg.persistence.workflow_execution_repo import (
         WorkflowExecutionRepository,
     )
+    from synthorg.versioning.service import VersioningService
 
 logger = get_logger(__name__)
 
@@ -724,7 +726,9 @@ class PostgresPersistenceBackend(PostgresConnectionMixin, PostgresMigrationMixin
         pool = self.get_db()
         return PostgresEscalationRepository(pool, notify_channel=notify_channel)
 
-    def build_ontology_versioning(self) -> Any:
+    def build_ontology_versioning(
+        self,
+    ) -> VersioningService[EntityDefinition]:
         """Construct the ontology versioning service bound to this backend."""
         from synthorg.ontology.versioning import (  # noqa: PLC0415
             create_postgres_ontology_versioning,

--- a/src/synthorg/persistence/postgres/backend.py
+++ b/src/synthorg/persistence/postgres/backend.py
@@ -724,6 +724,14 @@ class PostgresPersistenceBackend(PostgresConnectionMixin, PostgresMigrationMixin
         pool = self.get_db()
         return PostgresEscalationRepository(pool, notify_channel=notify_channel)
 
+    def build_ontology_versioning(self) -> Any:
+        """Construct the ontology versioning service bound to this backend."""
+        from synthorg.ontology.versioning import (  # noqa: PLC0415
+            create_postgres_ontology_versioning,
+        )
+
+        return create_postgres_ontology_versioning(self.get_db())
+
     async def get_setting(self, key: NotBlankStr) -> str | None:
         """Retrieve a setting value by key from the ``_system`` namespace.
 

--- a/src/synthorg/persistence/postgres/revisions/20260422081439_add_approvals_task_id_index.sql
+++ b/src/synthorg/persistence/postgres/revisions/20260422081439_add_approvals_task_id_index.sql
@@ -1,0 +1,2 @@
+-- Create index "idx_approvals_task_id" to table: "approvals"
+CREATE INDEX "idx_approvals_task_id" ON "approvals" ("task_id");

--- a/src/synthorg/persistence/postgres/revisions/atlas.sum
+++ b/src/synthorg/persistence/postgres/revisions/atlas.sum
@@ -1,3 +1,4 @@
-h1:Hl2syg9fwWQ0WAs1ztAgq4Uds6O6+AGSw/+h7AenwfU=
+h1:dmK+MOU4yK4vWbu0kwqv/PEhbwiYNnokCOhKc90mkCM=
 00000000000000_baseline.sql h1:TFe+cyJnIUi99mruIQ2OukbFYT53VJAV04egAmJTqIA=
 20260421223602_pst1_parity_and_indices.sql h1:1TZHKK51bU9RZlV7mvrZ+dXPoHF+NO0i+VNkCBwb5js=
+20260422081439_add_approvals_task_id_index.sql h1:8P1EtN8n939/fe39nAUCwYAbMg6GVV4erh0c3CZJQQE=

--- a/src/synthorg/persistence/postgres/schema.sql
+++ b/src/synthorg/persistence/postgres/schema.sql
@@ -1112,6 +1112,7 @@ CREATE INDEX idx_approvals_action_type ON approvals(action_type);
 CREATE INDEX idx_approvals_risk_level ON approvals(risk_level);
 CREATE INDEX idx_approvals_requested_by_status ON approvals(requested_by, status);
 CREATE INDEX idx_approvals_status_expires_at ON approvals(status, expires_at);
+CREATE INDEX idx_approvals_task_id ON approvals(task_id);
 
 -- Org memory: MVCC operation log + materialized snapshot (#1457 A4).
 -- Tags are TEXT JSON to match the SQLite backend's serialization;

--- a/src/synthorg/persistence/protocol.py
+++ b/src/synthorg/persistence/protocol.py
@@ -4,7 +4,7 @@ Application code depends on this protocol for storage lifecycle
 management.  Repository protocols provide entity-level access.
 """
 
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from synthorg.api.auth.config import AuthConfig  # noqa: TC001
 from synthorg.budget.config import BudgetConfig  # noqa: TC001
@@ -97,6 +97,10 @@ from synthorg.persistence.workflow_definition_repo import (
 from synthorg.persistence.workflow_execution_repo import (
     WorkflowExecutionRepository,  # noqa: TC001
 )
+
+if TYPE_CHECKING:
+    from synthorg.ontology.models import EntityDefinition
+    from synthorg.versioning.service import VersioningService
 
 
 @runtime_checkable
@@ -484,15 +488,15 @@ class PersistenceBackend(Protocol):
         """
         ...
 
-    def build_ontology_versioning(self) -> Any:
+    def build_ontology_versioning(
+        self,
+    ) -> VersioningService[EntityDefinition]:
         """Construct the ontology versioning service bound to this backend.
 
-        Returns a ``VersioningService[EntityDefinition]`` wired to the
-        backend's active DB handle.  SQLite implementations pass their
-        ``aiosqlite.Connection``; Postgres implementations pass their
-        ``AsyncConnectionPool``.  Typed as :class:`Any` here to avoid
-        importing ontology/versioning types into the persistence
-        protocol.
+        Returns a versioning service wired to the backend's active DB
+        handle.  SQLite implementations bind the service to their
+        ``aiosqlite.Connection``; Postgres implementations bind to their
+        ``AsyncConnectionPool``.
 
         Raises:
             PersistenceConnectionError: If the backend is not connected.

--- a/src/synthorg/persistence/protocol.py
+++ b/src/synthorg/persistence/protocol.py
@@ -484,6 +484,21 @@ class PersistenceBackend(Protocol):
         """
         ...
 
+    def build_ontology_versioning(self) -> Any:
+        """Construct the ontology versioning service bound to this backend.
+
+        Returns a ``VersioningService[EntityDefinition]`` wired to the
+        backend's active DB handle.  SQLite implementations pass their
+        ``aiosqlite.Connection``; Postgres implementations pass their
+        ``AsyncConnectionPool``.  Typed as :class:`Any` here to avoid
+        importing ontology/versioning types into the persistence
+        protocol.
+
+        Raises:
+            PersistenceConnectionError: If the backend is not connected.
+        """
+        ...
+
     async def get_setting(self, key: NotBlankStr) -> str | None:
         """Retrieve a setting value by key.
 

--- a/src/synthorg/persistence/sqlite/approval_repo.py
+++ b/src/synthorg/persistence/sqlite/approval_repo.py
@@ -6,12 +6,13 @@ from datetime import datetime
 
 import aiosqlite
 from aiosqlite import Row
+from pydantic import ValidationError
 
 from synthorg.core.approval import ApprovalItem
 from synthorg.core.enums import ApprovalRiskLevel, ApprovalStatus
 from synthorg.core.evidence import EvidencePackage
 from synthorg.core.types import NotBlankStr  # noqa: TC001
-from synthorg.observability import get_logger
+from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.api import (
     API_APPROVAL_REPO_DELETED,
     API_APPROVAL_REPO_FAILED,
@@ -93,13 +94,24 @@ def _row_to_item(row: Row) -> ApprovalItem:
             ),
             metadata=metadata_raw,
         )
-    except (json.JSONDecodeError, ValueError, TypeError, KeyError) as exc:
+    except (
+        json.JSONDecodeError,
+        ValueError,
+        TypeError,
+        KeyError,
+        ValidationError,
+    ) as exc:
         try:
             row_id = str(row["id"]) if row else "<unknown>"
         except TypeError, KeyError:
             row_id = "<unknown>"
-        msg = f"Failed to parse approval row {row_id!r}: {exc}"
-        logger.exception(API_APPROVAL_REPO_FAILED, row_id=row_id, error=msg)
+        msg = f"Failed to parse approval row {row_id!r}"
+        logger.warning(
+            API_APPROVAL_REPO_FAILED,
+            row_id=row_id,
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
+        )
         raise QueryError(msg) from exc
 
 
@@ -154,16 +166,26 @@ class SQLiteApprovalRepository:
             await self._db.commit()
         except sqlite3.IntegrityError as exc:
             await self._db.rollback()
-            msg = f"Constraint violation saving approval {item.id!r}: {exc}"
-            logger.exception(API_APPROVAL_REPO_FAILED, approval_id=item.id, error=msg)
+            msg = f"Constraint violation saving approval {item.id!r}"
+            logger.warning(
+                API_APPROVAL_REPO_FAILED,
+                approval_id=item.id,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
             raise ConstraintViolationError(
                 msg,
                 constraint=str(exc),
             ) from exc
         except (sqlite3.Error, aiosqlite.Error) as exc:
             await self._db.rollback()
-            msg = f"Failed to save approval {item.id!r}: {exc}"
-            logger.exception(API_APPROVAL_REPO_FAILED, approval_id=item.id, error=msg)
+            msg = f"Failed to save approval {item.id!r}"
+            logger.warning(
+                API_APPROVAL_REPO_FAILED,
+                approval_id=item.id,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
             raise QueryError(msg) from exc
         logger.info(
             API_APPROVAL_REPO_SAVED,
@@ -194,11 +216,12 @@ class SQLiteApprovalRepository:
             cursor = await self._db.execute(sql, (approval_id,))
             row = await cursor.fetchone()
         except (sqlite3.Error, aiosqlite.Error) as exc:
-            msg = f"Failed to fetch approval {approval_id!r}: {exc}"
-            logger.exception(
+            msg = f"Failed to fetch approval {approval_id!r}"
+            logger.warning(
                 API_APPROVAL_REPO_FAILED,
                 approval_id=approval_id,
-                error=msg,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
             )
             raise QueryError(msg) from exc
         if row is None:
@@ -251,8 +274,12 @@ class SQLiteApprovalRepository:
         except QueryError:
             raise
         except (sqlite3.Error, aiosqlite.Error) as exc:
-            msg = f"Failed to list approvals: {exc}"
-            logger.exception(API_APPROVAL_REPO_FAILED, error=msg)
+            msg = "Failed to list approvals"
+            logger.warning(
+                API_APPROVAL_REPO_FAILED,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
             raise QueryError(msg) from exc
         logger.debug(API_APPROVAL_REPO_LISTED, count=len(items))
         return items
@@ -275,11 +302,12 @@ class SQLiteApprovalRepository:
             await self._db.commit()
         except (sqlite3.Error, aiosqlite.Error) as exc:
             await self._db.rollback()
-            msg = f"Failed to delete approval {approval_id!r}: {exc}"
-            logger.exception(
+            msg = f"Failed to delete approval {approval_id!r}"
+            logger.warning(
                 API_APPROVAL_REPO_FAILED,
                 approval_id=approval_id,
-                error=msg,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
             )
             raise QueryError(msg) from exc
         deleted = cursor.rowcount > 0

--- a/src/synthorg/persistence/sqlite/backend.py
+++ b/src/synthorg/persistence/sqlite/backend.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import sqlite3
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import aiosqlite
 from pydantic import BaseModel
@@ -140,6 +140,7 @@ from synthorg.persistence.sqlite.workflow_execution_repo import (
 
 if TYPE_CHECKING:
     from synthorg.api.auth.config import AuthConfig
+    from synthorg.ontology.models import EntityDefinition
     from synthorg.persistence.auth_protocol import LockoutRepository
     from synthorg.persistence.config import SQLiteConfig
     from synthorg.persistence.escalation_protocol import EscalationQueueRepository
@@ -148,6 +149,7 @@ if TYPE_CHECKING:
         FineTuneRunRepository,
     )
     from synthorg.persistence.version_repo import VersionRepository
+    from synthorg.versioning.service import VersioningService
 
 logger = get_logger(__name__)
 
@@ -882,7 +884,9 @@ class SQLitePersistenceBackend:
         db = self.get_db()
         return SQLiteEscalationRepository(db)
 
-    def build_ontology_versioning(self) -> Any:
+    def build_ontology_versioning(
+        self,
+    ) -> VersioningService[EntityDefinition]:
         """Construct the ontology versioning service bound to this backend."""
         from synthorg.ontology.versioning import (  # noqa: PLC0415
             create_ontology_versioning,

--- a/src/synthorg/persistence/sqlite/backend.py
+++ b/src/synthorg/persistence/sqlite/backend.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import sqlite3
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import aiosqlite
 from pydantic import BaseModel
@@ -143,6 +143,11 @@ if TYPE_CHECKING:
     from synthorg.persistence.auth_protocol import LockoutRepository
     from synthorg.persistence.config import SQLiteConfig
     from synthorg.persistence.escalation_protocol import EscalationQueueRepository
+    from synthorg.persistence.fine_tune_protocol import (
+        FineTuneCheckpointRepository,
+        FineTuneRunRepository,
+    )
+    from synthorg.persistence.version_repo import VersionRepository
 
 logger = get_logger(__name__)
 
@@ -185,18 +190,14 @@ class SQLitePersistenceBackend:
         self._workflow_definitions: SQLiteWorkflowDefinitionRepository | None = None
         self._workflow_executions: SQLiteWorkflowExecutionRepository | None = None
         self._subworkflows: SQLiteSubworkflowRepository | None = None
-        self._workflow_versions: SQLiteVersionRepository[WorkflowDefinition] | None = (
+        self._workflow_versions: VersionRepository[WorkflowDefinition] | None = None
+        self._identity_versions: VersionRepository[AgentIdentity] | None = None
+        self._evaluation_config_versions: VersionRepository[EvaluationConfig] | None = (
             None
         )
-        self._identity_versions: SQLiteVersionRepository[AgentIdentity] | None = None
-        self._evaluation_config_versions: (
-            SQLiteVersionRepository[EvaluationConfig] | None
-        ) = None
-        self._budget_config_versions: SQLiteVersionRepository[BudgetConfig] | None = (
-            None
-        )
-        self._company_versions: SQLiteVersionRepository[Company] | None = None
-        self._role_versions: SQLiteVersionRepository[Role] | None = None
+        self._budget_config_versions: VersionRepository[BudgetConfig] | None = None
+        self._company_versions: VersionRepository[Company] | None = None
+        self._role_versions: VersionRepository[Role] | None = None
         self._decision_records: SQLiteDecisionRepository | None = None
         self._risk_overrides: SQLiteRiskOverrideRepository | None = None
         self._ssrf_violations: SQLiteSsrfViolationRepository | None = None
@@ -204,8 +205,8 @@ class SQLitePersistenceBackend:
         self._project_cost_aggregates: SQLiteProjectCostAggregateRepository | None = (
             None
         )
-        self._fine_tune_checkpoints: SQLiteFineTuneCheckpointRepository | None = None
-        self._fine_tune_runs: SQLiteFineTuneRunRepository | None = None
+        self._fine_tune_checkpoints: FineTuneCheckpointRepository | None = None
+        self._fine_tune_runs: FineTuneRunRepository | None = None
         self._training_plans: SQLiteTrainingPlanRepository | None = None
         self._training_results: SQLiteTrainingResultRepository | None = None
         self._custom_rules: SQLiteCustomRuleRepository | None = None
@@ -359,7 +360,7 @@ class SQLitePersistenceBackend:
         def _ver_repo[T: BaseModel](
             table: str,
             model_cls: type[T],
-        ) -> SQLiteVersionRepository[T]:
+        ) -> VersionRepository[T]:
             assert self._db is not None  # noqa: S101
             return SQLiteVersionRepository(
                 self._db,
@@ -635,7 +636,7 @@ class SQLitePersistenceBackend:
         )
 
     @property
-    def fine_tune_checkpoints(self) -> SQLiteFineTuneCheckpointRepository:
+    def fine_tune_checkpoints(self) -> FineTuneCheckpointRepository:
         """Repository for fine-tune checkpoint persistence."""
         return self._require_connected(
             self._fine_tune_checkpoints,
@@ -643,7 +644,7 @@ class SQLitePersistenceBackend:
         )
 
     @property
-    def fine_tune_runs(self) -> SQLiteFineTuneRunRepository:
+    def fine_tune_runs(self) -> FineTuneRunRepository:
         """Repository for fine-tune pipeline run persistence."""
         return self._require_connected(
             self._fine_tune_runs,
@@ -680,7 +681,7 @@ class SQLitePersistenceBackend:
         )
 
     @property
-    def workflow_versions(self) -> SQLiteVersionRepository[WorkflowDefinition]:
+    def workflow_versions(self) -> VersionRepository[WorkflowDefinition]:
         """Repository for workflow definition version persistence."""
         return self._require_connected(
             self._workflow_versions,
@@ -688,7 +689,7 @@ class SQLitePersistenceBackend:
         )
 
     @property
-    def identity_versions(self) -> SQLiteVersionRepository[AgentIdentity]:
+    def identity_versions(self) -> VersionRepository[AgentIdentity]:
         """Repository for AgentIdentity version snapshot persistence."""
         return self._require_connected(
             self._identity_versions,
@@ -698,7 +699,7 @@ class SQLitePersistenceBackend:
     @property
     def evaluation_config_versions(
         self,
-    ) -> SQLiteVersionRepository[EvaluationConfig]:
+    ) -> VersionRepository[EvaluationConfig]:
         """Repository for EvaluationConfig version snapshot persistence."""
         return self._require_connected(
             self._evaluation_config_versions,
@@ -708,7 +709,7 @@ class SQLitePersistenceBackend:
     @property
     def budget_config_versions(
         self,
-    ) -> SQLiteVersionRepository[BudgetConfig]:
+    ) -> VersionRepository[BudgetConfig]:
         """Repository for BudgetConfig version snapshot persistence."""
         return self._require_connected(
             self._budget_config_versions,
@@ -718,7 +719,7 @@ class SQLitePersistenceBackend:
     @property
     def company_versions(
         self,
-    ) -> SQLiteVersionRepository[Company]:
+    ) -> VersionRepository[Company]:
         """Repository for Company version snapshot persistence."""
         return self._require_connected(
             self._company_versions,
@@ -728,7 +729,7 @@ class SQLitePersistenceBackend:
     @property
     def role_versions(
         self,
-    ) -> SQLiteVersionRepository[Role]:
+    ) -> VersionRepository[Role]:
         """Repository for Role version snapshot persistence."""
         return self._require_connected(
             self._role_versions,
@@ -880,6 +881,14 @@ class SQLitePersistenceBackend:
 
         db = self.get_db()
         return SQLiteEscalationRepository(db)
+
+    def build_ontology_versioning(self) -> Any:
+        """Construct the ontology versioning service bound to this backend."""
+        from synthorg.ontology.versioning import (  # noqa: PLC0415
+            create_ontology_versioning,
+        )
+
+        return create_ontology_versioning(self.get_db())
 
     async def get_setting(self, key: NotBlankStr) -> str | None:
         """Retrieve a setting value by key from the ``_system`` namespace.

--- a/src/synthorg/persistence/sqlite/revisions/20260422081430_add_approvals_task_id_index.sql
+++ b/src/synthorg/persistence/sqlite/revisions/20260422081430_add_approvals_task_id_index.sql
@@ -1,0 +1,2 @@
+-- Create index "idx_approvals_task_id" to table: "approvals"
+CREATE INDEX `idx_approvals_task_id` ON `approvals` (`task_id`);

--- a/src/synthorg/persistence/sqlite/revisions/atlas.sum
+++ b/src/synthorg/persistence/sqlite/revisions/atlas.sum
@@ -1,3 +1,4 @@
-h1:SlRtl1MZDHME3ThOgeCj2kzVX6ylrAHjV88Q2cMZ/c8=
+h1:Z0naWo6wrh/Kc642r9foDKbFWzdFuTkOPyhrc/I5Dz0=
 00000000000000_baseline.sql h1:iPb7ksO7gknp0bpuhi5BQ9+ZBqxHTUTp+ac0h+09Hbs=
 20260421184322_pst1_parity_and_indices.sql h1:6en6dccn5vUE2WGc8uzh+v63FGR0is0RBmh/ZNcWep0=
+20260422081430_add_approvals_task_id_index.sql h1:ToNSiidJVRigL2ASpnZ2IQEH+Bglh9rYo+Hf4Bl0BuI=

--- a/src/synthorg/persistence/sqlite/schema.sql
+++ b/src/synthorg/persistence/sqlite/schema.sql
@@ -1006,6 +1006,7 @@ CREATE INDEX idx_approvals_action_type ON approvals(action_type);
 CREATE INDEX idx_approvals_risk_level ON approvals(risk_level);
 CREATE INDEX idx_approvals_requested_by_status ON approvals(requested_by, status);
 CREATE INDEX idx_approvals_status_expires_at ON approvals(status, expires_at);
+CREATE INDEX idx_approvals_task_id ON approvals(task_id);
 
 -- Conflict escalations (#1418: human escalation approval queue).
 -- Persists one row per conflict awaiting a human decision so the

--- a/src/synthorg/security/service.py
+++ b/src/synthorg/security/service.py
@@ -60,7 +60,7 @@ from synthorg.security.service_safety import SecOpsServiceSafetyMixin
 from synthorg.security.timeout.protocol import RiskTierClassifier  # noqa: TC001
 
 if TYPE_CHECKING:
-    from synthorg.api.approval_store import ApprovalStore
+    from synthorg.approval.protocol import ApprovalStoreProtocol
     from synthorg.security.denial_tracker import (
         DenialTracker,
     )
@@ -96,7 +96,7 @@ class SecOpsService(SecOpsServiceSafetyMixin):
         rule_engine: RuleEngine,
         audit_log: AuditLog,
         output_scanner: OutputScanner,
-        approval_store: ApprovalStore | None = None,
+        approval_store: ApprovalStoreProtocol | None = None,
         effective_autonomy: EffectiveAutonomy | None = None,
         risk_classifier: RiskTierClassifier | None = None,
         output_scan_policy: OutputScanResponsePolicy | None = None,

--- a/src/synthorg/security/timeout/scheduler.py
+++ b/src/synthorg/security/timeout/scheduler.py
@@ -27,7 +27,7 @@ from synthorg.observability.events.timeout import (
 )
 
 if TYPE_CHECKING:
-    from synthorg.api.approval_store import ApprovalStore
+    from synthorg.approval.protocol import ApprovalStoreProtocol
     from synthorg.core.approval import ApprovalItem
     from synthorg.security.timeout.models import TimeoutAction
     from synthorg.security.timeout.timeout_checker import TimeoutChecker
@@ -55,7 +55,7 @@ class ApprovalTimeoutScheduler:
     def __init__(
         self,
         *,
-        approval_store: ApprovalStore,
+        approval_store: ApprovalStoreProtocol,
         timeout_checker: TimeoutChecker,
         interval_seconds: float = 60.0,
         on_timeout_resolve: (

--- a/src/synthorg/security/trust/service.py
+++ b/src/synthorg/security/trust/service.py
@@ -30,7 +30,7 @@ from synthorg.security.trust.models import (
 )
 
 if TYPE_CHECKING:
-    from synthorg.api.approval_store import ApprovalStore
+    from synthorg.approval.protocol import ApprovalStoreProtocol
     from synthorg.hr.performance.models import AgentPerformanceSnapshot
     from synthorg.security.trust.config import TrustConfig
     from synthorg.security.trust.protocol import TrustStrategy
@@ -56,7 +56,7 @@ class TrustService:
         *,
         strategy: TrustStrategy,
         config: TrustConfig,
-        approval_store: ApprovalStore | None = None,
+        approval_store: ApprovalStoreProtocol | None = None,
     ) -> None:
         self._strategy = strategy
         self._config = config

--- a/src/synthorg/tools/approval_tool.py
+++ b/src/synthorg/tools/approval_tool.py
@@ -23,7 +23,7 @@ from synthorg.observability.events.approval_gate import (
 from .base import BaseTool, ToolExecutionResult
 
 if TYPE_CHECKING:
-    from synthorg.api.approval_store import ApprovalStore
+    from synthorg.approval.protocol import ApprovalStoreProtocol
     from synthorg.security.timeout.risk_tier_classifier import (
         DefaultRiskTierClassifier,
     )
@@ -49,7 +49,7 @@ class RequestHumanApprovalTool(BaseTool):
     def __init__(
         self,
         *,
-        approval_store: ApprovalStore,
+        approval_store: ApprovalStoreProtocol,
         risk_classifier: DefaultRiskTierClassifier | None = None,
         agent_id: str,
         task_id: str | None = None,

--- a/src/synthorg/tools/invoker.py
+++ b/src/synthorg/tools/invoker.py
@@ -12,6 +12,7 @@ import copy
 from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
+from synthorg.approval.models import EscalationInfo
 from synthorg.core.enums import ApprovalRiskLevel
 from synthorg.observability import get_logger
 from synthorg.observability.events.security import (
@@ -45,7 +46,6 @@ from .scan_result_handler import handle_sensitive_scan
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from synthorg.engine.approval_gate_models import EscalationInfo
     from synthorg.security.protocol import SecurityInterceptionStrategy
     from synthorg.tools.html_parse_guard import HTMLParseGuard
 
@@ -182,10 +182,6 @@ class ToolInvoker(ToolInvokerDiscoveryMixin, ToolInvokerValidationMixin):
         if violation is None:
             return None
         if violation.requires_approval:
-            from synthorg.engine.approval_gate_models import (  # noqa: PLC0415
-                EscalationInfo,
-            )
-
             approval_id = f"sub-constraint-{tool_call.id}"
             self._pending_escalations.append(
                 EscalationInfo(
@@ -286,10 +282,6 @@ class ToolInvoker(ToolInvokerDiscoveryMixin, ToolInvokerValidationMixin):
                 approval_id=verdict.approval_id,
             )
             if verdict.approval_id is not None:
-                from synthorg.engine.approval_gate_models import (  # noqa: PLC0415
-                    EscalationInfo,
-                )
-
                 self._pending_escalations.append(
                     EscalationInfo(
                         approval_id=verdict.approval_id,
@@ -578,12 +570,8 @@ class ToolInvoker(ToolInvokerDiscoveryMixin, ToolInvokerValidationMixin):
                 is_error=True,
             )
         try:
-            from synthorg.engine.approval_gate_models import (  # noqa: PLC0415
-                EscalationInfo as _EscalationInfo,
-            )
-
             self._pending_escalations.append(
-                _EscalationInfo(
+                EscalationInfo(
                     approval_id=str(result.metadata["approval_id"]),
                     tool_call_id=tool_call.id,
                     tool_name=tool.name,

--- a/src/synthorg/tools/protocol.py
+++ b/src/synthorg/tools/protocol.py
@@ -39,7 +39,14 @@ class ToolInvokerProtocol(Protocol):
 
     @property
     def pending_escalations(self) -> tuple[EscalationInfo, ...]:
-        """Escalations detected during the most recent invoke/invoke_all."""
+        """Escalations detected during the most recent invoke/invoke_all.
+
+        Implementations reset this tuple at the start of every
+        ``invoke``/``invoke_all`` call so callers only ever see the
+        escalations from the latest tool batch.  The engine drains the
+        tuple between batches via ``ApprovalGate``, so accumulation
+        across calls is not required.
+        """
         ...
 
     async def invoke(self, tool_call: ToolCall) -> ToolResult:

--- a/src/synthorg/tools/protocol.py
+++ b/src/synthorg/tools/protocol.py
@@ -1,0 +1,78 @@
+"""``ToolInvokerProtocol`` -- the tool-invocation contract the engine depends on.
+
+``engine/loop_protocol.py``, ``engine/react_loop.py``,
+``engine/loop_tool_execution.py``, ``engine/agent_engine_context.py``,
+and ``engine/loop_helpers.py`` all consume a tool invoker. Typing them
+against this protocol lets the engine stay decoupled from the concrete
+``synthorg.tools.invoker.ToolInvoker`` implementation.
+
+``ToolInvoker`` satisfies this protocol structurally (it is
+``runtime_checkable``); a protocol-level test asserts conformance.
+"""
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from synthorg.approval.models import EscalationInfo
+    from synthorg.core.tool_disclosure import ToolL1Metadata
+    from synthorg.providers.models import ToolCall, ToolDefinition, ToolResult
+    from synthorg.tools.registry import ToolRegistry
+
+
+@runtime_checkable
+class ToolInvokerProtocol(Protocol):
+    """Validate, authorise, and execute LLM tool calls.
+
+    Implementations populate ``pending_escalations`` during
+    ``invoke``/``invoke_all`` when a SecOps ``ESCALATE`` verdict or a
+    ``requires_parking`` tool result is observed; the engine's
+    ``ApprovalGate`` consults this property after the tool batch to
+    decide whether to park the agent context.
+    """
+
+    @property
+    def registry(self) -> ToolRegistry:
+        """Read-only access to the underlying tool registry."""
+        ...
+
+    @property
+    def pending_escalations(self) -> tuple[EscalationInfo, ...]:
+        """Escalations detected during the most recent invoke/invoke_all."""
+        ...
+
+    async def invoke(self, tool_call: ToolCall) -> ToolResult:
+        """Execute a single tool call.
+
+        Recoverable errors are returned as ``ToolResult(is_error=True)``;
+        non-recoverable errors (``MemoryError``, ``RecursionError``) are
+        re-raised after logging.
+        """
+        ...
+
+    async def invoke_all(
+        self,
+        tool_calls: Iterable[ToolCall],
+        *,
+        max_concurrency: int | None = None,
+    ) -> tuple[ToolResult, ...]:
+        """Execute multiple tool calls concurrently.
+
+        Results are returned in input order.
+        """
+        ...
+
+    def get_l1_summaries(self) -> tuple[ToolL1Metadata, ...]:
+        """Return lightweight L1 metadata for permitted tools.
+
+        Used by the agent engine for system-prompt discovery injection.
+        """
+        ...
+
+    def get_loaded_definitions(
+        self,
+        loaded_tools: frozenset[str],
+    ) -> tuple[ToolDefinition, ...]:
+        """Return full definitions for loaded + discovery tools."""
+        ...

--- a/tests/integration/meta/test_code_modification_cycle.py
+++ b/tests/integration/meta/test_code_modification_cycle.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from synthorg.api.approval_store import ApprovalStore
 from synthorg.meta.config import CodeModificationConfig, SelfImprovementConfig
 from synthorg.meta.models import (
     OrgBudgetSummary,
@@ -105,6 +106,7 @@ class TestCodeModificationCycleIntegration:
                 code_modification=_CODE_MOD_CFG,
             ),
             provider=provider,
+            approval_store=ApprovalStore(),
         )
         proposals = await svc.run_cycle(_snap(quality=4.0))
 
@@ -130,6 +132,7 @@ class TestCodeModificationCycleIntegration:
                 code_modification_enabled=False,
             ),
             provider=provider,
+            approval_store=ApprovalStore(),
         )
         proposals = await svc.run_cycle(_snap(quality=4.0))
         for p in proposals:
@@ -149,6 +152,7 @@ class TestCodeModificationCycleIntegration:
                 code_modification=_CODE_MOD_CFG,
             ),
             provider=provider,
+            approval_store=ApprovalStore(),
         )
         proposals = await svc.run_cycle(
             _snap(error_findings=20),
@@ -169,6 +173,7 @@ class TestCodeModificationCycleIntegration:
                 code_modification=_CODE_MOD_CFG,
             ),
             provider=provider,
+            approval_store=ApprovalStore(),
         )
         proposals = await svc.run_cycle(_snap())
         code_proposals = [

--- a/tests/integration/meta/test_meta_cycle.py
+++ b/tests/integration/meta/test_meta_cycle.py
@@ -6,6 +6,7 @@ guards -> approval -> rollout -> regression detection.
 
 import pytest
 
+from synthorg.api.approval_store import ApprovalStore
 from synthorg.meta.config import SelfImprovementConfig
 from synthorg.meta.models import (
     OrgBudgetSummary,
@@ -74,6 +75,7 @@ class TestMetaCycleIntegration:
                 enabled=True,
                 config_tuning_enabled=True,
             ),
+            approval_store=ApprovalStore(),
         )
         proposals = await svc.run_cycle(_snap(quality=4.0))
 
@@ -97,6 +99,7 @@ class TestMetaCycleIntegration:
                 enabled=True,
                 config_tuning_enabled=True,
             ),
+            approval_store=ApprovalStore(),
         )
         proposals = await svc.run_cycle(_snap(days_left=7))
 
@@ -116,6 +119,7 @@ class TestMetaCycleIntegration:
             ),
             clock=FakeClock(),
             snapshot_builder=snapshot_builder,
+            approval_store=ApprovalStore(),
         )
         proposals = await svc.run_cycle(_snap(quality=4.0))
         assert len(proposals) >= 1
@@ -147,6 +151,7 @@ class TestMetaCycleIntegration:
                 config_tuning_enabled=True,
                 architecture_proposals_enabled=False,
             ),
+            approval_store=ApprovalStore(),
         )
         # Coordination cost ratio suggests both config and architecture.
         proposals = await svc.run_cycle(_snap(coord_ratio=0.5))
@@ -161,6 +166,7 @@ class TestMetaCycleIntegration:
                 enabled=True,
                 config_tuning_enabled=True,
             ),
+            approval_store=ApprovalStore(),
         )
         proposals = await svc.run_cycle(_snap())
         assert proposals == ()
@@ -174,6 +180,7 @@ class TestMetaCycleIntegration:
                 architecture_proposals_enabled=True,
                 prompt_tuning_enabled=True,
             ),
+            approval_store=ApprovalStore(),
         )
         proposals = await svc.run_cycle(_snap(quality=4.0))
         altitudes = {p.altitude for p in proposals}

--- a/tests/integration/persistence/test_postgres_approval_repo.py
+++ b/tests/integration/persistence/test_postgres_approval_repo.py
@@ -1,0 +1,351 @@
+"""Integration tests for :class:`PostgresApprovalRepository` (ARC-1).
+
+Requires a real Postgres via ``testcontainers``; runs under the
+``integration`` marker.  Uses the shared ``postgres_backend`` fixture
+from :mod:`tests.integration.persistence.conftest` so migrations are
+applied once per session.
+
+Mirrors the SQLite-side coverage in
+``tests/unit/api/test_approval_store.py`` and the
+``PostgresEscalationRepository`` integration suite so the dual-backend
+parity that ARC-1 establishes is actually exercised on real Postgres
+wire protocol (JSONB round-trips, TIMESTAMPTZ handling, commit
+semantics, constraint violations).
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import psycopg
+import pytest
+from psycopg.types.json import Jsonb
+
+from synthorg.core.approval import ApprovalItem
+from synthorg.core.enums import ApprovalRiskLevel, ApprovalStatus
+from synthorg.persistence.errors import ConstraintViolationError, QueryError
+from synthorg.persistence.postgres.approval_repo import (
+    PostgresApprovalRepository,
+)
+from synthorg.persistence.postgres.backend import PostgresPersistenceBackend
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+
+def _make_item(  # noqa: PLR0913 -- test factory with explicit knobs
+    *,
+    approval_id: str = "approval-pg-0001",
+    status: ApprovalStatus = ApprovalStatus.PENDING,
+    risk_level: ApprovalRiskLevel = ApprovalRiskLevel.HIGH,
+    action_type: str = "deploy:production",
+    task_id: str | None = None,
+    metadata: dict[str, str] | None = None,
+) -> ApprovalItem:
+    """Build an ApprovalItem with sensible defaults."""
+    now = datetime.now(UTC)
+    decided_at: datetime | None = None
+    decided_by: str | None = None
+    decision_reason: str | None = None
+    if status in {ApprovalStatus.APPROVED, ApprovalStatus.REJECTED}:
+        decided_at = now
+        decided_by = "operator-a"
+        if status == ApprovalStatus.REJECTED:
+            decision_reason = "Not authorised"
+    return ApprovalItem(
+        id=approval_id,
+        action_type=action_type,
+        title="Approve prod deploy",
+        description="Rolls service v2 to prod.",
+        requested_by="agent-eng-001",
+        risk_level=risk_level,
+        status=status,
+        created_at=now,
+        expires_at=now + timedelta(days=7),
+        task_id=task_id,
+        metadata=metadata or {},
+        decided_at=decided_at,
+        decided_by=decided_by,
+        decision_reason=decision_reason,
+    )
+
+
+@pytest.fixture
+def repo(
+    postgres_backend: PostgresPersistenceBackend,
+) -> PostgresApprovalRepository:
+    """Approval repository wired to the shared postgres backend pool."""
+    assert postgres_backend._pool is not None
+    return PostgresApprovalRepository(postgres_backend._pool)
+
+
+async def test_save_and_get_round_trip(
+    repo: PostgresApprovalRepository,
+) -> None:
+    """A pending item round-trips across the wire without drift."""
+    item = _make_item(
+        approval_id="approval-rt-001",
+        metadata={"source_rule": "rule-A", "confidence": "0.93"},
+    )
+    await repo.save(item)
+    fetched = await repo.get(item.id)
+    assert fetched is not None
+    assert fetched.id == item.id
+    assert fetched.status == ApprovalStatus.PENDING
+    assert fetched.action_type == item.action_type
+    assert fetched.metadata == item.metadata
+    # TIMESTAMPTZ round-trips preserve aware datetimes.
+    assert fetched.created_at.tzinfo is not None
+    assert fetched.expires_at is not None
+    assert fetched.expires_at.tzinfo is not None
+
+
+async def test_get_returns_none_when_absent(
+    repo: PostgresApprovalRepository,
+) -> None:
+    assert await repo.get("approval-missing-999") is None
+
+
+async def test_save_commits_survives_reconnect(
+    repo: PostgresApprovalRepository,
+    postgres_backend: PostgresPersistenceBackend,
+) -> None:
+    """Writes persist through a fresh connection -- guards against the
+    silent-rollback bug where missing ``await conn.commit()`` would
+    make writes vanish on pool return.
+    """
+    item = _make_item(approval_id="approval-commit-001")
+    await repo.save(item)
+
+    # Build a second repository around the same pool; if the first
+    # save didn't commit, this reader would see nothing.
+    assert postgres_backend._pool is not None
+    second_repo = PostgresApprovalRepository(postgres_backend._pool)
+    fetched = await second_repo.get(item.id)
+    assert fetched is not None
+    assert fetched.id == item.id
+
+
+async def test_list_items_filters(
+    repo: PostgresApprovalRepository,
+) -> None:
+    """Filter combinations drive WHERE clause construction correctly."""
+    pending = _make_item(
+        approval_id="approval-list-pending",
+        status=ApprovalStatus.PENDING,
+        risk_level=ApprovalRiskLevel.MEDIUM,
+        action_type="scaling:hire",
+    )
+    approved = _make_item(
+        approval_id="approval-list-approved",
+        status=ApprovalStatus.APPROVED,
+        risk_level=ApprovalRiskLevel.HIGH,
+        action_type="scaling:hire",
+    )
+    rejected = _make_item(
+        approval_id="approval-list-rejected",
+        status=ApprovalStatus.REJECTED,
+        risk_level=ApprovalRiskLevel.CRITICAL,
+        action_type="deploy:production",
+    )
+    await repo.save(pending)
+    await repo.save(approved)
+    await repo.save(rejected)
+
+    pending_only = await repo.list_items(status=ApprovalStatus.PENDING)
+    pending_ids = {i.id for i in pending_only}
+    assert pending.id in pending_ids
+    assert approved.id not in pending_ids
+
+    hires = await repo.list_items(action_type="scaling:hire")
+    hire_ids = {i.id for i in hires}
+    assert pending.id in hire_ids
+    assert approved.id in hire_ids
+    assert rejected.id not in hire_ids
+
+    crits = await repo.list_items(risk_level=ApprovalRiskLevel.CRITICAL)
+    crit_ids = {i.id for i in crits}
+    assert rejected.id in crit_ids
+
+
+async def test_delete_round_trip(
+    repo: PostgresApprovalRepository,
+) -> None:
+    """Delete returns True then False on repeat; the row is gone."""
+    item = _make_item(approval_id="approval-delete-001")
+    await repo.save(item)
+    assert await repo.get(item.id) is not None
+
+    deleted_first = await repo.delete(item.id)
+    assert deleted_first is True
+    assert await repo.get(item.id) is None
+
+    deleted_second = await repo.delete(item.id)
+    assert deleted_second is False
+
+
+async def test_save_update_overwrites(
+    repo: PostgresApprovalRepository,
+) -> None:
+    """Repeating save() upserts; status transitions are visible."""
+    item = _make_item(
+        approval_id="approval-upsert-001",
+        status=ApprovalStatus.PENDING,
+    )
+    await repo.save(item)
+    updated = item.model_copy(
+        update={
+            "status": ApprovalStatus.APPROVED,
+            "decided_at": datetime.now(UTC),
+            "decided_by": "operator-b",
+        },
+    )
+    await repo.save(updated)
+    fetched = await repo.get(item.id)
+    assert fetched is not None
+    assert fetched.status == ApprovalStatus.APPROVED
+    assert fetched.decided_by == "operator-b"
+
+
+async def test_corrupt_row_raises_query_error(
+    repo: PostgresApprovalRepository,
+    postgres_backend: PostgresPersistenceBackend,
+) -> None:
+    """Invalid enum values in the DB surface as ``QueryError`` with
+    the structured logging event, not a raw ``ValueError``.  This
+    exercises the _row_to_item error path with ``ValidationError``
+    now being part of the caught exception tuple.
+    """
+    assert postgres_backend._pool is not None
+    # Insert a row with an invalid enum value using raw SQL.
+    async with postgres_backend._pool.connection() as conn, conn.cursor() as cur:
+        await cur.execute(
+            "INSERT INTO approvals "
+            "(id, action_type, title, description, requested_by, "
+            " risk_level, status, created_at, expires_at, "
+            " decided_at, decided_by, decision_reason, task_id, "
+            " evidence_package, metadata) VALUES "
+            "(%s, %s, %s, %s, %s, %s, %s, %s, %s, "
+            " %s, %s, %s, %s, %s, %s)",
+            (
+                "approval-corrupt-001",
+                "deploy:production",
+                "Bad",
+                "Bad",
+                "agent-eng-001",
+                "NOT_A_RISK_LEVEL",  # invalid enum value
+                "pending",
+                datetime.now(UTC),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Jsonb({}),
+            ),
+        )
+        await conn.commit()
+
+    with pytest.raises(QueryError):
+        await repo.get("approval-corrupt-001")
+
+
+async def test_save_duplicate_primary_key_raises_constraint(
+    repo: PostgresApprovalRepository,
+    postgres_backend: PostgresPersistenceBackend,
+) -> None:
+    """A manually INSERTed duplicate id surfaces as
+    :class:`ConstraintViolationError`; the upsert path in ``save()``
+    handles legitimate updates without raising, so we force the
+    violation by directly inserting the second row via a raw
+    ``INSERT`` that bypasses ``ON CONFLICT``.
+    """
+    assert postgres_backend._pool is not None
+    item = _make_item(approval_id="approval-dup-001")
+    await repo.save(item)
+
+    async with postgres_backend._pool.connection() as conn, conn.cursor() as cur:
+        with pytest.raises(psycopg.errors.UniqueViolation):
+            await cur.execute(
+                "INSERT INTO approvals "
+                "(id, action_type, title, description, requested_by, "
+                " risk_level, status, created_at, expires_at, "
+                " decided_at, decided_by, decision_reason, task_id, "
+                " evidence_package, metadata) VALUES "
+                "(%s, %s, %s, %s, %s, %s, %s, %s, %s, "
+                " %s, %s, %s, %s, %s, %s)",
+                (
+                    item.id,
+                    item.action_type,
+                    item.title,
+                    item.description,
+                    item.requested_by,
+                    item.risk_level.value,
+                    item.status.value,
+                    item.created_at,
+                    item.expires_at,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Jsonb({}),
+                ),
+            )
+
+    # The legitimate upsert retry (same id, different payload) goes
+    # through ON CONFLICT and does NOT raise -- this documents the
+    # semantics for callers that were previously unsure.
+    updated = item.model_copy(update={"description": "Updated"})
+    await repo.save(updated)
+    fetched = await repo.get(item.id)
+    assert fetched is not None
+    assert fetched.description == "Updated"
+
+
+async def test_constraint_violation_surfaces_from_save(
+    repo: PostgresApprovalRepository,
+) -> None:
+    """A REJECTED item without a decision_reason fails at the DB CHECK
+    constraint and is surfaced as
+    :class:`ConstraintViolationError`.  We build an invalid row by
+    bypassing Pydantic validation via ``model_construct``.
+    """
+    # The Pydantic validator refuses to build this state directly, so
+    # use model_construct to bypass field validation and force the DB
+    # CHECK to surface the violation.
+    now = datetime.now(UTC)
+    bad_item = ApprovalItem.model_construct(
+        id="approval-ck-001",
+        action_type="deploy:production",
+        title="Rejected w/o reason",
+        description="Should not be storable.",
+        requested_by="agent-eng-001",
+        risk_level=ApprovalRiskLevel.HIGH,
+        status=ApprovalStatus.REJECTED,
+        created_at=now,
+        expires_at=now + timedelta(days=7),
+        decided_at=now,
+        decided_by="operator-a",
+        decision_reason=None,
+        task_id=None,
+        evidence_package=None,
+        metadata={},
+    )
+    with pytest.raises(ConstraintViolationError):
+        await repo.save(bad_item)
+
+
+async def test_build_ontology_versioning_returns_service(
+    postgres_backend: PostgresPersistenceBackend,
+) -> None:
+    """Postgres capability method yields a wired VersioningService.
+
+    Mirrors the SQLite-side unit test
+    (``tests/unit/persistence/test_backend_capability_methods.py``)
+    so the ARC-1 capability pattern is exercised on both backends.
+    """
+    from synthorg.versioning.service import VersioningService
+
+    service = postgres_backend.build_ontology_versioning()
+    assert isinstance(service, VersioningService)
+    for method_name in ("snapshot_if_changed", "force_snapshot", "get_latest"):
+        assert callable(getattr(service, method_name))

--- a/tests/integration/persistence/test_postgres_approval_repo.py
+++ b/tests/integration/persistence/test_postgres_approval_repo.py
@@ -204,17 +204,21 @@ async def test_save_update_overwrites(
     assert fetched.decided_by == "operator-b"
 
 
-async def test_corrupt_row_raises_query_error(
+async def test_pydantic_invalid_row_raises_query_error(
     repo: PostgresApprovalRepository,
     postgres_backend: PostgresPersistenceBackend,
 ) -> None:
-    """Invalid enum values in the DB surface as ``QueryError`` with
-    the structured logging event, not a raw ``ValueError``.  This
-    exercises the _row_to_item error path with ``ValidationError``
-    now being part of the caught exception tuple.
+    """A DB row that the DB accepts but Pydantic rejects surfaces as
+    :class:`QueryError` (wrapping the underlying ``ValidationError``),
+    exercising the ``_row_to_item`` error path with ``ValidationError``
+    in the caught exception tuple.
+
+    The schema's CHECK constraints block invalid enum values, so we
+    corrupt ``metadata`` to carry a non-string value -- permitted by
+    the ``JSONB`` column type but rejected by ``ApprovalItem``'s
+    ``dict[str, str]`` metadata field.
     """
     assert postgres_backend._pool is not None
-    # Insert a row with an invalid enum value using raw SQL.
     async with postgres_backend._pool.connection() as conn, conn.cursor() as cur:
         await cur.execute(
             "INSERT INTO approvals "
@@ -225,12 +229,12 @@ async def test_corrupt_row_raises_query_error(
             "(%s, %s, %s, %s, %s, %s, %s, %s, %s, "
             " %s, %s, %s, %s, %s, %s)",
             (
-                "approval-corrupt-001",
+                "approval-invalid-001",
                 "deploy:production",
-                "Bad",
-                "Bad",
+                "Invalid metadata",
+                "metadata dict carries a non-string value",
                 "agent-eng-001",
-                "NOT_A_RISK_LEVEL",  # invalid enum value
+                "high",
                 "pending",
                 datetime.now(UTC),
                 None,
@@ -239,13 +243,15 @@ async def test_corrupt_row_raises_query_error(
                 None,
                 None,
                 None,
-                Jsonb({}),
+                # Non-string value in metadata -- ApprovalItem
+                # requires dict[str, str] so Pydantic rejects.
+                Jsonb({"bad_field": 42}),
             ),
         )
         await conn.commit()
 
     with pytest.raises(QueryError):
-        await repo.get("approval-corrupt-001")
+        await repo.get("approval-invalid-001")
 
 
 async def test_save_duplicate_primary_key_raises_constraint(

--- a/tests/unit/api/fakes_backend.py
+++ b/tests/unit/api/fakes_backend.py
@@ -760,6 +760,12 @@ class FakePersistenceBackend:
 
         return AsyncMock()
 
+    def build_ontology_versioning(self) -> Any:
+        """Fake ontology versioning factory -- returns a mock service."""
+        from unittest.mock import AsyncMock
+
+        return AsyncMock()
+
     async def get_setting(self, key: str) -> str | None:
         return self._settings.get(key)
 

--- a/tests/unit/approval/test_protocol.py
+++ b/tests/unit/approval/test_protocol.py
@@ -39,6 +39,7 @@ class TestApprovalStoreProtocol:
         actual = {
             name for name in vars(ApprovalStoreProtocol) if not name.startswith("_")
         }
-        assert expected.issubset(actual), (
-            f"ApprovalStoreProtocol missing methods: {expected - actual}"
+        assert actual == expected, (
+            "ApprovalStoreProtocol surface changed: "
+            f"missing={expected - actual}, added={actual - expected}"
         )

--- a/tests/unit/approval/test_protocol.py
+++ b/tests/unit/approval/test_protocol.py
@@ -1,0 +1,44 @@
+"""Structural conformance tests for ``ApprovalStoreProtocol``.
+
+Locks the runtime-checkable contract against the concrete
+``ApprovalStore`` so a future method removal on the concrete fails CI
+instead of silently breaking the abstraction for engine, security, and
+hr callers.
+"""
+
+import pytest
+
+from synthorg.api.approval_store import ApprovalStore
+from synthorg.approval.protocol import ApprovalStoreProtocol
+
+pytestmark = pytest.mark.unit
+
+
+class TestApprovalStoreProtocol:
+    """``ApprovalStore`` must satisfy ``ApprovalStoreProtocol``."""
+
+    def test_concrete_satisfies_protocol(self) -> None:
+        """``isinstance(store, ApprovalStoreProtocol)`` is True.
+
+        Proves the runtime structural check binds: every method the
+        protocol declares exists on the concrete.
+        """
+        store = ApprovalStore()
+        assert isinstance(store, ApprovalStoreProtocol)
+
+    def test_protocol_surface_is_stable(self) -> None:
+        """The protocol's public method names are the agreed surface."""
+        expected = {
+            "add",
+            "clear",
+            "get",
+            "list_items",
+            "save",
+            "save_if_pending",
+        }
+        actual = {
+            name for name in vars(ApprovalStoreProtocol) if not name.startswith("_")
+        }
+        assert expected.issubset(actual), (
+            f"ApprovalStoreProtocol missing methods: {expected - actual}"
+        )

--- a/tests/unit/engine/approval_helpers.py
+++ b/tests/unit/engine/approval_helpers.py
@@ -14,8 +14,15 @@ from synthorg.core.enums import ApprovalRiskLevel
 def make_escalation(**overrides: Any) -> EscalationInfo:
     """Build an ``EscalationInfo`` with safe defaults.
 
-    Any field can be overridden via keyword arguments.
+    Any field can be overridden via keyword arguments.  Unknown keys
+    raise ``KeyError`` to catch typos -- Pydantic's default behaviour
+    is to silently ignore unknown fields, which would otherwise let a
+    misspelled override sneak through without taking effect.
     """
+    unknown = set(overrides) - set(EscalationInfo.model_fields)
+    if unknown:
+        msg = f"Unknown EscalationInfo override(s): {sorted(unknown)}"
+        raise KeyError(msg)
     defaults: dict[str, Any] = {
         "approval_id": "approval-1",
         "tool_call_id": "tc-1",

--- a/tests/unit/engine/approval_helpers.py
+++ b/tests/unit/engine/approval_helpers.py
@@ -1,0 +1,28 @@
+"""Shared helpers for approval-gate tests.
+
+The ``make_escalation`` factory is used by ``test_approval_gate.py``,
+``test_approval_gate_events.py``, and ``test_loop_helpers_approval.py``
+so each suite stays DRY without copy-pasting the same builder.
+"""
+
+from typing import Any
+
+from synthorg.approval.models import EscalationInfo
+from synthorg.core.enums import ApprovalRiskLevel
+
+
+def make_escalation(**overrides: Any) -> EscalationInfo:
+    """Build an ``EscalationInfo`` with safe defaults.
+
+    Any field can be overridden via keyword arguments.
+    """
+    defaults: dict[str, Any] = {
+        "approval_id": "approval-1",
+        "tool_call_id": "tc-1",
+        "tool_name": "deploy_to_prod",
+        "action_type": "deploy:production",
+        "risk_level": ApprovalRiskLevel.HIGH,
+        "reason": "Needs approval",
+    }
+    defaults.update(overrides)
+    return EscalationInfo(**defaults)

--- a/tests/unit/engine/test_approval_gate.py
+++ b/tests/unit/engine/test_approval_gate.py
@@ -4,31 +4,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from synthorg.approval.models import EscalationInfo
-from synthorg.core.enums import ApprovalRiskLevel
 from synthorg.engine.approval_gate import ApprovalGate
 from synthorg.persistence.repositories import ParkedContextRepository
 from synthorg.security.timeout.park_service import ParkService
+from tests.unit.engine.approval_helpers import make_escalation as _make_escalation
 
 pytestmark = pytest.mark.unit
-
-
-def _make_escalation(  # noqa: PLR0913
-    approval_id: str = "approval-1",
-    tool_call_id: str = "tc-1",
-    tool_name: str = "deploy_to_prod",
-    action_type: str = "deploy:production",
-    risk_level: ApprovalRiskLevel = ApprovalRiskLevel.HIGH,
-    reason: str = "Needs approval",
-) -> EscalationInfo:
-    return EscalationInfo(
-        approval_id=approval_id,
-        tool_call_id=tool_call_id,
-        tool_name=tool_name,
-        action_type=action_type,
-        risk_level=risk_level,
-        reason=reason,
-    )
 
 
 @pytest.fixture

--- a/tests/unit/engine/test_approval_gate.py
+++ b/tests/unit/engine/test_approval_gate.py
@@ -4,9 +4,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from synthorg.approval.models import EscalationInfo
 from synthorg.core.enums import ApprovalRiskLevel
 from synthorg.engine.approval_gate import ApprovalGate
-from synthorg.engine.approval_gate_models import EscalationInfo
 from synthorg.persistence.repositories import ParkedContextRepository
 from synthorg.security.timeout.park_service import ParkService
 

--- a/tests/unit/engine/test_approval_gate_events.py
+++ b/tests/unit/engine/test_approval_gate_events.py
@@ -1,12 +1,10 @@
 """Tests for ApprovalGate event stream integration."""
 
 from datetime import UTC, datetime
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from synthorg.approval.models import EscalationInfo
 from synthorg.communication.event_stream.interrupt import (
     Interrupt,
     InterruptStore,
@@ -14,24 +12,12 @@ from synthorg.communication.event_stream.interrupt import (
 )
 from synthorg.communication.event_stream.stream import EventStreamHub
 from synthorg.communication.event_stream.types import AgUiEventType
-from synthorg.core.enums import ApprovalRiskLevel
 from synthorg.engine.approval_gate import ApprovalGate
+from tests.unit.engine.approval_helpers import make_escalation as _make_escalation
+
+pytestmark = pytest.mark.unit
 
 
-def _make_escalation(**overrides: Any) -> EscalationInfo:
-    defaults: dict[str, Any] = {
-        "approval_id": "approval-001",
-        "tool_call_id": "tc-001",
-        "tool_name": "deploy_service",
-        "action_type": "deploy:production",
-        "risk_level": ApprovalRiskLevel.HIGH,
-        "reason": "Production deployment requires approval",
-    }
-    defaults.update(overrides)
-    return EscalationInfo(**defaults)
-
-
-@pytest.mark.unit
 class TestApprovalGateEventStream:
     async def test_park_publishes_approval_interrupt(self) -> None:
         park_service = MagicMock()
@@ -50,7 +36,11 @@ class TestApprovalGateEventStream:
         )
 
         context = MagicMock()
-        escalation = _make_escalation()
+        escalation = _make_escalation(
+            approval_id="approval-001",
+            tool_call_id="tc-001",
+            tool_name="deploy_service",
+        )
 
         await gate.park_context(
             escalation=escalation,
@@ -82,7 +72,7 @@ class TestApprovalGateEventStream:
         )
 
         context = MagicMock()
-        escalation = _make_escalation()
+        escalation = _make_escalation(tool_name="deploy_service")
 
         await gate.park_context(
             escalation=escalation,

--- a/tests/unit/engine/test_approval_gate_events.py
+++ b/tests/unit/engine/test_approval_gate_events.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from synthorg.approval.models import EscalationInfo
 from synthorg.communication.event_stream.interrupt import (
     Interrupt,
     InterruptStore,
@@ -15,7 +16,6 @@ from synthorg.communication.event_stream.stream import EventStreamHub
 from synthorg.communication.event_stream.types import AgUiEventType
 from synthorg.core.enums import ApprovalRiskLevel
 from synthorg.engine.approval_gate import ApprovalGate
-from synthorg.engine.approval_gate_models import EscalationInfo
 
 
 def _make_escalation(**overrides: Any) -> EscalationInfo:

--- a/tests/unit/engine/test_approval_gate_models.py
+++ b/tests/unit/engine/test_approval_gate_models.py
@@ -1,10 +1,10 @@
-"""Tests for approval gate models -- EscalationInfo and ResumePayload."""
+"""Tests for approval event models -- EscalationInfo and ResumePayload."""
 
 import pytest
 from pydantic import ValidationError
 
+from synthorg.approval.models import EscalationInfo, ResumePayload
 from synthorg.core.enums import ApprovalRiskLevel
-from synthorg.engine.approval_gate_models import EscalationInfo, ResumePayload
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/engine/test_loop_helpers_approval.py
+++ b/tests/unit/engine/test_loop_helpers_approval.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from synthorg.approval.models import EscalationInfo
-from synthorg.core.enums import ApprovalRiskLevel
 from synthorg.engine.approval_gate import ApprovalGate
 from synthorg.engine.loop_protocol import ExecutionResult, TerminationReason
 from synthorg.engine.loop_tool_execution import execute_tool_calls
@@ -16,21 +15,9 @@ from synthorg.providers.models import (
     ToolCall,
     ToolResult,
 )
+from tests.unit.engine.approval_helpers import make_escalation as _make_escalation
 
 pytestmark = pytest.mark.unit
-
-
-def _make_escalation(
-    approval_id: str = "approval-1",
-) -> EscalationInfo:
-    return EscalationInfo(
-        approval_id=approval_id,
-        tool_call_id="tc-1",
-        tool_name="deploy_to_prod",
-        action_type="deploy:production",
-        risk_level=ApprovalRiskLevel.HIGH,
-        reason="Needs approval",
-    )
 
 
 def _make_response_with_tool_calls() -> CompletionResponse:

--- a/tests/unit/engine/test_loop_helpers_approval.py
+++ b/tests/unit/engine/test_loop_helpers_approval.py
@@ -4,9 +4,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from synthorg.approval.models import EscalationInfo
 from synthorg.core.enums import ApprovalRiskLevel
 from synthorg.engine.approval_gate import ApprovalGate
-from synthorg.engine.approval_gate_models import EscalationInfo
 from synthorg.engine.loop_protocol import ExecutionResult, TerminationReason
 from synthorg.engine.loop_tool_execution import execute_tool_calls
 from synthorg.providers.enums import FinishReason

--- a/tests/unit/meta/test_guards.py
+++ b/tests/unit/meta/test_guards.py
@@ -232,17 +232,12 @@ class TestRateLimitGuard:
 class TestApprovalGateGuard:
     """Approval gate guard tests."""
 
-    async def test_always_passes(self) -> None:
-        guard = ApprovalGateGuard()
-        result = await guard.evaluate(_config_proposal())
-        assert result.verdict == GuardVerdict.PASSED
-
     async def test_guard_name(self) -> None:
         guard = ApprovalGateGuard()
         assert guard.name == "approval_gate"
 
-    async def test_persists_proposal_to_configured_store(self) -> None:
-        """Guard must route proposals to the approval store."""
+    async def test_persists_proposal_and_passes(self) -> None:
+        """Guard persists the proposal and passes on first evaluation."""
         from unittest.mock import AsyncMock
 
         from synthorg.approval.protocol import ApprovalStoreProtocol
@@ -262,14 +257,28 @@ class TestApprovalGateGuard:
         assert item.metadata["proposal_id"] == str(proposal.id)
         assert item.metadata["altitude"] == proposal.altitude.value
 
-    async def test_missing_store_still_passes(self) -> None:
-        """Without a configured store the guard still passes cleanly."""
-        guard = ApprovalGateGuard(approval_store=None)
+    async def test_replay_treated_as_idempotent_pass(self) -> None:
+        """ConflictError from replay is treated as idempotent PASSED."""
+        from unittest.mock import AsyncMock
+
+        from synthorg.api.errors import ConflictError
+        from synthorg.approval.protocol import ApprovalStoreProtocol
+
+        store = AsyncMock(spec=ApprovalStoreProtocol)
+        store.add.side_effect = ConflictError("already exists")
+        guard = ApprovalGateGuard(approval_store=store)
+
         result = await guard.evaluate(_config_proposal())
         assert result.verdict == GuardVerdict.PASSED
 
-    async def test_store_failure_is_non_fatal(self) -> None:
-        """Store errors must not fail the guard (still PASSED)."""
+    async def test_missing_store_rejects(self) -> None:
+        """Without a configured store the guard fails closed."""
+        guard = ApprovalGateGuard(approval_store=None)
+        result = await guard.evaluate(_config_proposal())
+        assert result.verdict == GuardVerdict.REJECTED
+
+    async def test_store_failure_rejects(self) -> None:
+        """Non-duplicate store write errors fail the guard closed."""
         from unittest.mock import AsyncMock
 
         from synthorg.approval.protocol import ApprovalStoreProtocol
@@ -279,7 +288,7 @@ class TestApprovalGateGuard:
         guard = ApprovalGateGuard(approval_store=store)
 
         result = await guard.evaluate(_config_proposal())
-        assert result.verdict == GuardVerdict.PASSED
+        assert result.verdict == GuardVerdict.REJECTED
 
     def test_invalid_expiry_days_raises(self) -> None:
         """Guard construction rejects non-positive expiry windows."""

--- a/tests/unit/meta/test_guards.py
+++ b/tests/unit/meta/test_guards.py
@@ -240,3 +240,48 @@ class TestApprovalGateGuard:
     async def test_guard_name(self) -> None:
         guard = ApprovalGateGuard()
         assert guard.name == "approval_gate"
+
+    async def test_persists_proposal_to_configured_store(self) -> None:
+        """Guard must route proposals to the approval store."""
+        from unittest.mock import AsyncMock
+
+        from synthorg.approval.protocol import ApprovalStoreProtocol
+
+        store = AsyncMock(spec=ApprovalStoreProtocol)
+        guard = ApprovalGateGuard(approval_store=store)
+        proposal = _config_proposal()
+
+        result = await guard.evaluate(proposal)
+        assert result.verdict == GuardVerdict.PASSED
+        store.add.assert_awaited_once()
+
+        # Inspect the persisted ApprovalItem
+        (item,) = store.add.await_args.args
+        assert item.action_type == f"proposal:{proposal.altitude.value}"
+        assert item.title == proposal.title
+        assert item.metadata["proposal_id"] == str(proposal.id)
+        assert item.metadata["altitude"] == proposal.altitude.value
+
+    async def test_missing_store_still_passes(self) -> None:
+        """Without a configured store the guard still passes cleanly."""
+        guard = ApprovalGateGuard(approval_store=None)
+        result = await guard.evaluate(_config_proposal())
+        assert result.verdict == GuardVerdict.PASSED
+
+    async def test_store_failure_is_non_fatal(self) -> None:
+        """Store errors must not fail the guard (still PASSED)."""
+        from unittest.mock import AsyncMock
+
+        from synthorg.approval.protocol import ApprovalStoreProtocol
+
+        store = AsyncMock(spec=ApprovalStoreProtocol)
+        store.add.side_effect = RuntimeError("boom")
+        guard = ApprovalGateGuard(approval_store=store)
+
+        result = await guard.evaluate(_config_proposal())
+        assert result.verdict == GuardVerdict.PASSED
+
+    def test_invalid_expiry_days_raises(self) -> None:
+        """Guard construction rejects non-positive expiry windows."""
+        with pytest.raises(ValueError, match="expiry_days"):
+            ApprovalGateGuard(expiry_days=0)

--- a/tests/unit/meta/test_service.py
+++ b/tests/unit/meta/test_service.py
@@ -69,7 +69,9 @@ class TestSelfImprovementService:
         architecture: bool = False,
         prompt_tuning: bool = False,
     ) -> SelfImprovementService:
-        from synthorg.api.approval_store import ApprovalStore
+        from unittest.mock import AsyncMock
+
+        from synthorg.approval.protocol import ApprovalStoreProtocol
 
         cfg = SelfImprovementConfig(
             enabled=True,
@@ -77,13 +79,15 @@ class TestSelfImprovementService:
             architecture_proposals_enabled=architecture,
             prompt_tuning_enabled=prompt_tuning,
         )
-        # ApprovalGateGuard now fails closed without a store; wire an
-        # in-memory ApprovalStore so proposals can surface in tests.
+        # ``ApprovalGateGuard`` now fails closed without a store; wire
+        # a protocol-shaped mock so the meta-layer test does not depend
+        # on the concrete API-layer ``ApprovalStore`` implementation.
+        approval_store = AsyncMock(spec=ApprovalStoreProtocol)
         return SelfImprovementService(
             config=cfg,
             clock=FakeClock(),
             snapshot_builder=_snapshot_builder,
-            approval_store=ApprovalStore(),
+            approval_store=approval_store,
         )
 
     async def test_no_triggers_returns_empty(self) -> None:

--- a/tests/unit/meta/test_service.py
+++ b/tests/unit/meta/test_service.py
@@ -69,16 +69,21 @@ class TestSelfImprovementService:
         architecture: bool = False,
         prompt_tuning: bool = False,
     ) -> SelfImprovementService:
+        from synthorg.api.approval_store import ApprovalStore
+
         cfg = SelfImprovementConfig(
             enabled=True,
             config_tuning_enabled=config_tuning,
             architecture_proposals_enabled=architecture,
             prompt_tuning_enabled=prompt_tuning,
         )
+        # ApprovalGateGuard now fails closed without a store; wire an
+        # in-memory ApprovalStore so proposals can surface in tests.
         return SelfImprovementService(
             config=cfg,
             clock=FakeClock(),
             snapshot_builder=_snapshot_builder,
+            approval_store=ApprovalStore(),
         )
 
     async def test_no_triggers_returns_empty(self) -> None:

--- a/tests/unit/persistence/test_approval_repository_protocol.py
+++ b/tests/unit/persistence/test_approval_repository_protocol.py
@@ -30,24 +30,29 @@ class TestApprovalRepositoryProtocol:
         finally:
             await db.close()
 
-    def test_postgres_impl_satisfies_protocol(self) -> None:
+    @pytest.mark.parametrize(
+        "method_name",
+        ["save", "get", "list_items", "delete"],
+    )
+    def test_postgres_impl_exposes_method(self, method_name: str) -> None:
         """``PostgresApprovalRepository`` exposes the protocol surface.
 
         We probe method presence on the class itself rather than
         constructing an instance -- opening a real pool belongs in the
         integration suite.  ``runtime_checkable`` matches on attribute
         presence, so class-level ``hasattr`` is sufficient to lock the
-        structural contract.
+        structural contract.  Parametrising makes a missing method
+        report as a single failing test rather than one loop iteration.
         """
-        for method_name in ("save", "get", "list_items", "delete"):
-            assert hasattr(PostgresApprovalRepository, method_name), (
-                f"PostgresApprovalRepository missing {method_name}"
-            )
+        assert hasattr(PostgresApprovalRepository, method_name), (
+            f"PostgresApprovalRepository missing {method_name}"
+        )
 
     def test_protocol_surface_is_stable(self) -> None:
-        """The protocol's public method names are the agreed surface."""
+        """The protocol's public method names are the exact surface."""
         expected = {"delete", "get", "list_items", "save"}
         actual = {name for name in vars(ApprovalRepository) if not name.startswith("_")}
-        assert expected.issubset(actual), (
-            f"ApprovalRepository missing methods: {expected - actual}"
+        assert actual == expected, (
+            "ApprovalRepository surface changed: "
+            f"missing={expected - actual}, added={actual - expected}"
         )

--- a/tests/unit/persistence/test_approval_repository_protocol.py
+++ b/tests/unit/persistence/test_approval_repository_protocol.py
@@ -1,0 +1,35 @@
+"""Structural conformance tests for ``ApprovalRepository``.
+
+Locks the runtime-checkable persistence contract against the SQLite
+concrete so a future schema/method change fails CI instead of silently
+breaking ``ApprovalStore``.
+"""
+
+import aiosqlite
+import pytest
+
+from synthorg.persistence.approval_protocol import ApprovalRepository
+from synthorg.persistence.sqlite.approval_repo import SQLiteApprovalRepository
+
+pytestmark = pytest.mark.unit
+
+
+class TestApprovalRepositoryProtocol:
+    """``SQLiteApprovalRepository`` must satisfy ``ApprovalRepository``."""
+
+    async def test_sqlite_impl_satisfies_protocol(self) -> None:
+        """``isinstance(repo, ApprovalRepository)`` is True."""
+        db = await aiosqlite.connect(":memory:")
+        try:
+            repo = SQLiteApprovalRepository(db)
+            assert isinstance(repo, ApprovalRepository)
+        finally:
+            await db.close()
+
+    def test_protocol_surface_is_stable(self) -> None:
+        """The protocol's public method names are the agreed surface."""
+        expected = {"delete", "get", "list_items", "save"}
+        actual = {name for name in vars(ApprovalRepository) if not name.startswith("_")}
+        assert expected.issubset(actual), (
+            f"ApprovalRepository missing methods: {expected - actual}"
+        )

--- a/tests/unit/persistence/test_approval_repository_protocol.py
+++ b/tests/unit/persistence/test_approval_repository_protocol.py
@@ -1,30 +1,48 @@
 """Structural conformance tests for ``ApprovalRepository``.
 
-Locks the runtime-checkable persistence contract against the SQLite
-concrete so a future schema/method change fails CI instead of silently
-breaking ``ApprovalStore``.
+Locks the runtime-checkable persistence contract against both the SQLite
+and Postgres concrete repositories so a future schema/method change
+fails CI instead of silently breaking ``ApprovalStore``.  The Postgres
+implementation is exercised structurally (method presence + class-level
+isinstance probe) without opening a real pool -- end-to-end Postgres
+behaviour lives in ``tests/integration/persistence``.
 """
 
 import aiosqlite
 import pytest
 
 from synthorg.persistence.approval_protocol import ApprovalRepository
+from synthorg.persistence.postgres.approval_repo import PostgresApprovalRepository
 from synthorg.persistence.sqlite.approval_repo import SQLiteApprovalRepository
 
 pytestmark = pytest.mark.unit
 
 
 class TestApprovalRepositoryProtocol:
-    """``SQLiteApprovalRepository`` must satisfy ``ApprovalRepository``."""
+    """Both backend repositories must satisfy ``ApprovalRepository``."""
 
     async def test_sqlite_impl_satisfies_protocol(self) -> None:
-        """``isinstance(repo, ApprovalRepository)`` is True."""
+        """``isinstance(SQLiteApprovalRepository(), ApprovalRepository)``."""
         db = await aiosqlite.connect(":memory:")
         try:
             repo = SQLiteApprovalRepository(db)
             assert isinstance(repo, ApprovalRepository)
         finally:
             await db.close()
+
+    def test_postgres_impl_satisfies_protocol(self) -> None:
+        """``PostgresApprovalRepository`` exposes the protocol surface.
+
+        We probe method presence on the class itself rather than
+        constructing an instance -- opening a real pool belongs in the
+        integration suite.  ``runtime_checkable`` matches on attribute
+        presence, so class-level ``hasattr`` is sufficient to lock the
+        structural contract.
+        """
+        for method_name in ("save", "get", "list_items", "delete"):
+            assert hasattr(PostgresApprovalRepository, method_name), (
+                f"PostgresApprovalRepository missing {method_name}"
+            )
 
     def test_protocol_surface_is_stable(self) -> None:
         """The protocol's public method names are the agreed surface."""

--- a/tests/unit/persistence/test_backend_capability_methods.py
+++ b/tests/unit/persistence/test_backend_capability_methods.py
@@ -4,8 +4,9 @@ Locks the contract of ``build_ontology_versioning()`` -- the
 capability method introduced by ARC-1 that replaces the
 ``isinstance(persistence, PostgresPersistenceBackend)`` check in
 ``api/auto_wire.py``.  Both the SQLite and Postgres backends must
-construct a versioning service with the expected surface (``save_version``,
-``list_versions``, ...) when invoked on a connected backend.
+construct a versioning service with the expected surface
+(``snapshot_if_changed``, ``force_snapshot``, ``get_latest``) when
+invoked on a connected backend.
 
 Postgres coverage lives alongside the existing integration-level
 persistence tests; here we exercise SQLite and verify the protocol

--- a/tests/unit/persistence/test_backend_capability_methods.py
+++ b/tests/unit/persistence/test_backend_capability_methods.py
@@ -1,0 +1,49 @@
+"""Tests for ``PersistenceBackend`` capability factory methods.
+
+Locks the contract of ``build_ontology_versioning()`` -- the
+capability method introduced by ARC-1 that replaces the
+``isinstance(persistence, PostgresPersistenceBackend)`` check in
+``api/auto_wire.py``.  Both the SQLite and Postgres backends must
+construct a versioning service with the expected surface (``save_version``,
+``list_versions``, ...) when invoked on a connected backend.
+
+Postgres coverage lives alongside the existing integration-level
+persistence tests; here we exercise SQLite and verify the protocol
+surface of the returned service so any signature drift in
+``create_ontology_versioning`` surfaces in unit CI.
+"""
+
+import pytest
+
+from synthorg.persistence.config import SQLiteConfig
+from synthorg.persistence.sqlite.backend import SQLitePersistenceBackend
+from synthorg.versioning.service import VersioningService
+
+pytestmark = pytest.mark.unit
+
+
+class TestBuildOntologyVersioning:
+    """``build_ontology_versioning()`` returns a wired versioning service."""
+
+    async def test_sqlite_returns_versioning_service(self) -> None:
+        """SQLite backend produces a ``VersioningService`` bound to its db."""
+        backend = SQLitePersistenceBackend(SQLiteConfig(path=":memory:"))
+        await backend.connect()
+        try:
+            service = backend.build_ontology_versioning()
+            assert isinstance(service, VersioningService)
+            # The service must expose the methods ``OntologyService``
+            # consumes -- any rename in the factory surfaces here.
+            assert hasattr(service, "snapshot_if_changed")
+            assert hasattr(service, "force_snapshot")
+            assert hasattr(service, "get_latest")
+        finally:
+            await backend.disconnect()
+
+    async def test_sqlite_factory_not_connected_raises(self) -> None:
+        """Calling the factory without ``connect()`` first raises cleanly."""
+        from synthorg.persistence.errors import PersistenceConnectionError
+
+        backend = SQLitePersistenceBackend(SQLiteConfig(path=":memory:"))
+        with pytest.raises(PersistenceConnectionError):
+            backend.build_ontology_versioning()

--- a/tests/unit/persistence/test_backend_capability_methods.py
+++ b/tests/unit/persistence/test_backend_capability_methods.py
@@ -13,6 +13,8 @@ surface of the returned service so any signature drift in
 ``create_ontology_versioning`` surfaces in unit CI.
 """
 
+import inspect
+
 import pytest
 
 from synthorg.persistence.config import SQLiteConfig
@@ -32,11 +34,28 @@ class TestBuildOntologyVersioning:
         try:
             service = backend.build_ontology_versioning()
             assert isinstance(service, VersioningService)
-            # The service must expose the methods ``OntologyService``
-            # consumes -- any rename in the factory surfaces here.
-            assert hasattr(service, "snapshot_if_changed")
-            assert hasattr(service, "force_snapshot")
-            assert hasattr(service, "get_latest")
+            # Each method ``OntologyService`` consumes must exist AND be
+            # callable with the expected async signature -- a property,
+            # a sync stub, or a renamed method would all fail this check
+            # rather than slipping through a bare ``hasattr`` probe.
+            for method_name in (
+                "snapshot_if_changed",
+                "force_snapshot",
+                "get_latest",
+            ):
+                method = getattr(service, method_name)
+                assert callable(method), (
+                    f"{method_name} must be callable on {service!r}"
+                )
+                assert inspect.iscoroutinefunction(method), (
+                    f"{method_name} must be async"
+                )
+                # Exercising the signature catches renames of the
+                # ``entity_id`` keyword that downstream callers depend on.
+                sig = inspect.signature(method)
+                assert "entity_id" in sig.parameters, (
+                    f"{method_name} must accept an 'entity_id' parameter"
+                )
         finally:
             await backend.disconnect()
 

--- a/tests/unit/persistence/test_protocol.py
+++ b/tests/unit/persistence/test_protocol.py
@@ -700,6 +700,9 @@ class _FakeBackend:
     def build_escalations(self, *, notify_channel: str | None = None) -> Any:
         return None
 
+    def build_ontology_versioning(self) -> Any:
+        return None
+
     async def get_setting(self, key: str) -> str | None:
         return None
 

--- a/tests/unit/tools/test_invoker_protocol.py
+++ b/tests/unit/tools/test_invoker_protocol.py
@@ -35,6 +35,7 @@ class TestToolInvokerProtocol:
         actual = {
             name for name in vars(ToolInvokerProtocol) if not name.startswith("_")
         }
-        assert expected.issubset(actual), (
-            f"ToolInvokerProtocol missing members: {expected - actual}"
+        assert actual == expected, (
+            "ToolInvokerProtocol surface changed: "
+            f"missing={expected - actual}, added={actual - expected}"
         )

--- a/tests/unit/tools/test_invoker_protocol.py
+++ b/tests/unit/tools/test_invoker_protocol.py
@@ -1,0 +1,40 @@
+"""Structural conformance tests for ``ToolInvokerProtocol``.
+
+Locks the runtime-checkable contract against the concrete ``ToolInvoker``
+so a future method removal on the concrete fails CI instead of silently
+breaking the abstraction for every execution loop.
+"""
+
+import pytest
+
+from synthorg.tools.invoker import ToolInvoker
+from synthorg.tools.protocol import ToolInvokerProtocol
+from synthorg.tools.registry import ToolRegistry
+
+pytestmark = pytest.mark.unit
+
+
+class TestToolInvokerProtocol:
+    """``ToolInvoker`` must satisfy ``ToolInvokerProtocol``."""
+
+    def test_concrete_satisfies_protocol(self) -> None:
+        """``isinstance(invoker, ToolInvokerProtocol)`` is True."""
+        invoker = ToolInvoker(ToolRegistry([]))
+        assert isinstance(invoker, ToolInvokerProtocol)
+
+    def test_protocol_surface_is_stable(self) -> None:
+        """The protocol's public method names are the agreed surface."""
+        expected = {
+            "get_l1_summaries",
+            "get_loaded_definitions",
+            "invoke",
+            "invoke_all",
+            "pending_escalations",
+            "registry",
+        }
+        actual = {
+            name for name in vars(ToolInvokerProtocol) if not name.startswith("_")
+        }
+        assert expected.issubset(actual), (
+            f"ToolInvokerProtocol missing members: {expected - actual}"
+        )


### PR DESCRIPTION
Closes #1491.

## Summary

Addresses audit finding ARC-1 on two fronts:

1. **Break hidden circular imports.** `tools/invoker.py` was dodging an `engine.approval_gate_models` import via three `# noqa: PLC0415` deferred imports inside function bodies; `engine/agent_engine.py` and ~15 other files typed against `api.approval_store.ApprovalStore` via `TYPE_CHECKING` to hide an engine→api layering violation. Extracted `EscalationInfo` / `ResumePayload` event models and `ApprovalStoreProtocol` into a new neutral `src/synthorg/approval/` subsystem package so both `engine/` and `tools/` can depend on the types without forming a cycle. Added `ToolInvokerProtocol` in new `tools/protocol.py` and `ApprovalRepository` in new `persistence/approval_protocol.py` (matching `fine_tune_protocol.py` / `escalation_protocol.py`). Deleted `src/synthorg/engine/approval_gate_models.py` (pre-alpha: no back-compat shim).

2. **Restore persistence abstraction.** `ApprovalStore` now holds an `ApprovalRepository` protocol (was `SQLiteApprovalRepository`). `SQLitePersistenceBackend` returns `VersionRepository[T]` / `FineTuneCheckpointRepository` / `FineTuneRunRepository` from 9 property accessors (was concrete `SQLite*` types). `FineTuneOrchestrator` accepts protocol types. `PostgresEscalationNotifySubscriber` accepts `EscalationQueueStore` (was `PostgresEscalationRepository`). `api/auto_wire.py` drops `isinstance(persistence, PostgresPersistenceBackend)` in favour of a new `PersistenceBackend.build_ontology_versioning()` capability method (mirrors existing `build_lockouts` / `build_escalations` pattern).

Plus full-parity `PostgresApprovalRepository` alongside the SQLite sibling so the approvals table is durably persistable on either backend (schema was already there).

## Acceptance criteria

- [x] `grep -r "TYPE_CHECKING" src/synthorg/engine/` returns only genuinely type-only imports (no `api.approval_store`, no `tools.invoker`, no `engine.approval_gate_models`).
- [x] Zero `isinstance(x, ConcretePersistenceImpl)` outside `persistence/` or its factory.
- [x] Adding a hypothetical new persistence backend requires zero changes outside `persistence/<newbackend>/` + `persistence/factory.py`.

## Files touched

- **Created (12)**: `src/synthorg/approval/{__init__,models,protocol}.py`, `src/synthorg/tools/protocol.py`, `src/synthorg/persistence/{approval_protocol,postgres/approval_repo}.py`, `tests/unit/{approval/{__init__,test_protocol},tools/test_invoker_protocol,persistence/{test_approval_repository_protocol,test_backend_capability_methods}}.py`
- **Deleted (1)**: `src/synthorg/engine/approval_gate_models.py`
- **Modified (~49)**: engine (`agent_engine`, `agent_engine_*`, `react_loop`, `loop_*`, `hybrid_loop`, `plan_execute_*`, `approval_gate`, `task_sync`, `_security_factory`), tools (`invoker`, `approval_tool`), api (`app`, `state`, `approval_store`, `auto_wire`, `controllers/memory`), hr (`hiring`, `promotion`, `pruning`, `scaling`, `training`), security (`service`, `timeout/scheduler`, `trust/service`), meta (`guards/approval_gate`), memory (`embedding/fine_tune_orchestrator`), communication (`conflict_resolution/escalation/notify`), persistence (`protocol`, `sqlite/backend`, `postgres/backend`), plus test-fake updates and 4 existing tests whose imports migrated.
- **Docs**: `docs/design/persistence.md` gains an `approval_protocol.py` row in the protocol inventory table and a new "Backend capability methods" subsection documenting the `build_*()` pattern.

## Test plan

- 22,018 unit tests green on Python 3.14 (~90s vs 186s baseline → well under the regression gate).
- 961 integration tests green (2:34).
- 3 new runtime-checkable protocol conformance tests lock the contracts: `ApprovalStore ⊨ ApprovalStoreProtocol`, `ToolInvoker ⊨ ToolInvokerProtocol`, `SQLiteApprovalRepository ⊨ ApprovalRepository` (plus class-level probe for `PostgresApprovalRepository`).
- New capability-method test exercises `build_ontology_versioning()` on SQLite: verifies the returned `VersioningService` has the expected surface and that calling on a disconnected backend raises `PersistenceConnectionError`.
- mypy strict clean (3,173 source files).
- ruff / ruff-format / pre-commit / persistence-boundary / forbidden-literal / regional-defaults gates all green.

## Review coverage

Pre-reviewed by 16 agents in parallel: docs-consistency, code-reviewer, python-reviewer, pr-test-analyzer, silent-failure-hunter, comment-analyzer, type-design-analyzer, logging-audit, resilience-audit, conventions-enforcer, security-reviewer, persistence-reviewer, test-quality-reviewer, async-concurrency-reviewer, issue-resolution-verifier, api-contract-drift. 9 findings addressed (3 critical, 3 medium, plus 3 valid out-of-scope items pulled in on request including the Postgres approval repo and capability-method return-type tightening). 10 findings verified invalid or pre-existing and skipped with rationale.

## Coordination

- **SEC-2** (#1489, in-progress): touches `api/controllers/memory.py` decorators. ARC-1's only edit on that file is a single HTTP 501 error-message string inside `_build_memory_service()`; rebase conflict should be trivial.
- **DOC-1** (#1497): already merged; this PR rebased cleanly on top.
- **WEB-2** (#1495): frontend-only, no overlap.