### PR TITLE
fix(ci): pin wrangler commit metadata for PR previews

### DIFF
--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -278,9 +278,15 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PR_NUMBER: ${{ needs.build.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.build.outputs.head_sha }}
         run: |
           npm ci --ignore-scripts --prefix .github
-          npx --prefix .github wrangler pages deploy _site --project-name=synthorg-pr-preview --branch="pr-${PR_NUMBER}"
+          npx --prefix .github wrangler pages deploy _site \
+            --project-name=synthorg-pr-preview \
+            --branch="pr-${PR_NUMBER}" \
+            --commit-hash="${HEAD_SHA}" \
+            --commit-message="PR #${PR_NUMBER} preview" \
+            --commit-dirty=true
 
       - name: Comment preview URL
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
## Summary

Unblocks the Cloudflare Pages Deploy Preview job. CFG-1 (#1512) failed with `Invalid commit message, it must be a valid UTF-8 string. [code: 8000111]`.

## Root cause

`pages-preview.yml`'s `Checkout CI tooling` step sparse-checks out `ref: main` to fetch the wrangler lockfile. This parks `HEAD` on main's tip, currently `28339565` — a Renovate "Update Python dependencies (#1483)" commit whose body is ~9.3 KB and contains multi-byte UTF-8 characters (en-dashes, right arrows, recycle glyph, emojis 📅 🚦 👻) inside the renovate markdown table.

Wrangler auto-detects git metadata from CWD, reads that HEAD commit, and forwards it to Cloudflare Pages API. Cloudflare rejects — either wrangler byte-truncates the body mid-multi-byte-sequence, or Cloudflare has a size ceiling that refuses the payload. Either way, every PR preview after #1483 merged would keep failing.

Verified the CFG-1 branch commits and the synthetic PR merge commit are all clean ASCII — the culprit is the inherited HEAD from the sparse checkout of main.

## Fix

Pass commit metadata explicitly so wrangler stops deriving it from whatever happens to be at main's HEAD:

```yaml
npx --prefix .github wrangler pages deploy _site \
  --project-name=synthorg-pr-preview \
  --branch="pr-${PR_NUMBER}" \
  --commit-hash="${HEAD_SHA}" \
  --commit-message="PR #${PR_NUMBER} preview" \
  --commit-dirty=true
```

`HEAD_SHA` is already exposed by the `build` job's outputs (used by the Comment preview URL step below) — just wire it into this step's env.

## Test plan

- Merge, then re-run CFG-1's (#1512) Deploy Preview. The wrangler step should now send a short ASCII commit message and succeed.
- Verify the preview URL comment still lands correctly on subsequent PRs.

## Review coverage

Quick mode: CI-only change, no agents run.
