### PR TITLE
fix(ci): clean up fine-tune matrix job names

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -969,8 +969,14 @@ jobs:
   #   - cpu  -> ghcr.io/aureliolo/synthorg-fine-tune-cpu  (CPU torch, ~1.7 GB)
   # The variant is driven by the FINE_TUNE_EXTRA build-arg; uv routes torch to
   # PyPI (CUDA) or pytorch.org/whl/cpu via [tool.uv.sources] in pyproject.toml.
+  # Use a static job name. GitHub normally appends `(variant)` to each
+  # matrix leg, so expanded jobs still read "Build Fine-Tune (gpu)" /
+  # "(cpu)" in the UI. A `name:` that interpolates `${{ matrix.* }}`
+  # leaves the raw template visible when a matrix is skipped *before*
+  # expansion (the `if:` evaluates false), producing ugly check-run
+  # entries like "Build Fine-Tune (${{ matrix.variant }})".
   build-fine-tune:
-    name: Build Fine-Tune (${{ matrix.variant }})
+    name: Build Fine-Tune
     needs: [version, build-fine-tune-base, build-fine-tune-base-publish]
     if: >-
       !cancelled() &&
@@ -1014,7 +1020,7 @@ jobs:
           free-disk-space: "true"
 
   build-fine-tune-publish:
-    name: Publish Fine-Tune (${{ matrix.variant }})
+    name: Publish Fine-Tune
     needs: [version, build-fine-tune]
     if: >-
       !cancelled() &&


### PR DESCRIPTION
## Summary

Cosmetic follow-up to #1542. The `build-fine-tune` and `build-fine-tune-publish` jobs used `name: Build Fine-Tune (${{ matrix.variant }})` / `Publish Fine-Tune (${{ matrix.variant }})`. When a matrix job is *skipped before expansion* (the job-level `if:` evaluates false, as happens on PR refs where the publish path is gated out), GitHub leaves the raw template string in the check-run list — producing ugly entries like:

```
Build Fine-Tune (${{ matrix.variant }})
Publish Fine-Tune (${{ matrix.variant }})
```

Appeared in the post-merge Docker run UI alongside the real expanded `(gpu)` / `(cpu)` legs.

## Change

Static job `name:`; GitHub appends `(gpu)` / `(cpu)` automatically on the expanded legs, and there is no raw template to leak when the matrix is skipped.

```diff
  build-fine-tune:
-    name: Build Fine-Tune (${{ matrix.variant }})
+    name: Build Fine-Tune

  build-fine-tune-publish:
-    name: Publish Fine-Tune (${{ matrix.variant }})
+    name: Publish Fine-Tune
```

Plus a comment block above `build-fine-tune:` explaining why.

No identifier, artifact name, cache scope, `needs:` reference, or env gate changes — `name:` is UI display only. `image-name`, `cache-scope`, artifact `fine-tune-<variant>-digest`, etc. still interpolate `matrix.variant` where needed.

## Test plan

- Pre-commit hooks: passed on `.github/workflows/docker.yml`.
- Expanded matrix legs still display as `Build Fine-Tune (gpu)` / `(cpu)` (GitHub default).
- Skipped-before-expansion entries now read `Build Fine-Tune` / `Publish Fine-Tune` instead of the raw template.
- No branch protection rule referenced the old template-bearing check name (verified).

## Review coverage

Pre-reviewed by 2 agents (`docs-consistency`, `infra-reviewer`). Zero findings — no doc drift, no dependency/artifact side effects, no security regression.

## Operational note

On a separate track during this session: the `image-push` environment's deployment branch policy was migrated from `branch:v*` to `tag:v*` via `scripts/configure_environments.sh --apply`, and a new `release-tags` env (`tag:v*`, no secrets) was created. That reconciles the live GitHub config with the script shipped in #1542 — the 5 `Publish *` failures on the `v0.7.2-dev.27` auto-tag right after merge were caused by the pre-migration `branch:v*` rules not matching tag refs. Re-run of those jobs is in flight.

Related: #1535, #1542.