### PR TITLE
fix(ci): use GITHUB_TOKEN for BSL Change Date commit so it is signed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,13 @@ jobs:
       - name: Update BSL Change Date (release + 3 years)
         if: steps.release.outputs.pr != ''
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # GITHUB_TOKEN (not the PAT) so the Contents API commit ships
+          # with a GitHub-signed verification -- PAT-authored API commits
+          # are unsigned, while GITHUB_TOKEN commits are signed by GitHub
+          # and attributed to github-actions[bot]. Workflow recursion is
+          # not a concern here because the commit lands on the release PR
+          # branch, not main.
+          GH_TOKEN: ${{ github.token }}
           BRANCH: release-please--branches--main--components--synthorg
         run: |
           set -euo pipefail
@@ -62,11 +68,11 @@ jobs:
             exit 0
           fi
 
-          # Commit via the GitHub Contents API so the commit is verified
-          # in the release PR UI -- matches release-please's own commits
-          # on the same PR and avoids Unverified badges mid-review.
-          # (The eventual squash-merge produces a fresh GitHub-signed
-          # commit on main regardless of this step's signature.)
+          # Commit via the GitHub Contents API with GITHUB_TOKEN. The
+          # resulting commit is signed by GitHub and authored by
+          # github-actions[bot], appearing as Verified in the release PR
+          # UI. (The eventual squash-merge produces a separate GitHub-
+          # signed commit on main regardless of this step's signature.)
           BLOB_SHA=$(git rev-parse HEAD:LICENSE)
           jq -n \
             --arg msg "chore: update BSL Change Date to $new_date" \

--- a/docs/reference/github-environments.md
+++ b/docs/reference/github-environments.md
@@ -110,11 +110,13 @@ under the `release` deployment environment.
 
 **Purpose**:
 
-- `release.yml` uses it for the `googleapis/release-please-action` step
-  and the BSL Change Date Contents API update (`PUT
-  /repos/.../contents/LICENSE`) against the release-please PR branch.
-  Both writes flow through the GitHub REST API, which signs the
-  resulting commits on behalf of the PAT owner.
+- `release.yml` uses it only for the `googleapis/release-please-action`
+  step. Release Please needs a PAT so that its tag push on release-PR
+  merge triggers the downstream Docker + CLI build pipelines (tag
+  pushes from the default `GITHUB_TOKEN` are suppressed by GitHub's
+  anti-recursion rule). The BSL Change Date Contents API update uses
+  the default `GITHUB_TOKEN` instead, since it commits to the release
+  PR branch and does not need to trigger any workflow.
 - `dev-release.yml` uses it to create dev pre-release tags (e.g.
   `v0.7.2-dev.3`). Unlike the default `GITHUB_TOKEN`, a PAT-authored tag
   push triggers downstream workflows (docker.yml, cli.yml, etc.), which is


### PR DESCRIPTION
## Summary

In PR #1553 I claimed the BSL Change Date commit would be signed because it was created via the GitHub Contents API. **That was wrong** — `RELEASE_PLEASE_TOKEN` is a fine-grained PAT, and PAT-authored API commits are unsigned regardless of vigilant mode. Observed on the v0.7.2 release PR: the BSL commit showed as `verified: false, reason: "unsigned"` per `gh api`.

**Real rule**:
- `GITHUB_TOKEN` + GitHub API → commit authored by `github-actions[bot]` → **signed by GitHub** → Verified.
- GitHub App installation token + API → **signed** (authored by app's bot identity).
- **PAT + API → unsigned, period.** Vigilant mode only labels unsigned commits as Unverified; it doesn't sign anything.

## Changes

- `.github/workflows/release.yml`: `GH_TOKEN` on the BSL Change Date step switches from `${{ secrets.RELEASE_PLEASE_TOKEN }}` to `${{ github.token }}`. The commit lands on the release-please PR branch (not main), so workflow-trigger recursion isn't a concern — `GITHUB_TOKEN` is the correct minimum privilege for a PR-branch file edit.
- `docs/reference/github-environments.md`: `RELEASE_PLEASE_TOKEN` Purpose section updated — the BSL step no longer consumes the PAT. Release Please still needs the PAT because tag pushes from `GITHUB_TOKEN` are suppressed by GitHub's anti-recursion rule.

## Auto-rollover still has the same underlying problem

`auto-rollover.yml` commits directly to `main`, which requires signed commits via branch protection. It also needs a PAT so its commit triggers downstream Release Please + dev-release workflows. These two requirements conflict under the current PAT setup — the eventual PAT-authored commit will be rejected by branch protection when the rule actually fires (patch is currently 1, so latent).

This is tracked as a separate follow-up (see conversation — the clean fix is a GitHub App, which produces signed commits AND triggers workflows). Not blocking this PR.

## Test plan

- Cannot unit-test workflow YAML. Verification is next release cut: the BSL commit on the release PR should now show the green Verified badge in the GitHub UI (and `gh api .../commits/<sha> --jq '.commit.verification'` should return `{verified: true, reason: "valid", ...}`).

## Review coverage

`/pre-pr-review quick` — automated checks skipped (no Python/web/Go files), agents skipped per quick mode. Narrow, 2-file config+docs change.