### PR TITLE
fix(ci): release-runner-setup composite action parse error (main hotfix)

### DIFF
--- a/.github/actions/release-runner-setup/action.yml
+++ b/.github/actions/release-runner-setup/action.yml
@@ -15,11 +15,21 @@ description: >-
   semantics), so this composite deliberately does not include one.
 
 inputs:
+  # IMPORTANT: input descriptions deliberately do NOT use ${{ ... }}
+  # syntax, even for documentation examples. GitHub Actions evaluates
+  # every expression in this file at template-load time -- composite
+  # actions cannot access the ``secrets`` context, so any stray
+  # ``${{ secrets.X }}`` in a description (even as a usage hint)
+  # fails the whole action with "Unrecognized named-value: 'secrets'"
+  # and breaks every caller. See https://docs.github.com/en/actions/
+  # sharing-automations/creating-actions/metadata-syntax-for-github-actions
+  # -- composite actions only see ``inputs``, ``steps``, ``env``,
+  # ``github``, ``runner``, ``job``, and ``matrix`` contexts.
   app-id:
-    description: "GitHub App ID (pass `${{ secrets.RELEASE_BOT_APP_ID }}`)."
+    description: "GitHub App ID. Callers typically pass secrets.RELEASE_BOT_APP_ID (the secret lives on the release deployment environment)."
     required: true
   app-private-key:
-    description: "GitHub App private key (pass `${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}`)."
+    description: "GitHub App private key in PEM format. Callers typically pass secrets.RELEASE_BOT_APP_PRIVATE_KEY."
     required: true
   validate-branch:
     description: "When 'true', assert $GITHUB_REF == 'refs/heads/main' before minting the token. Every current caller sets this implicitly to true; the input exists so a future workflow_dispatch-based caller can opt out."


### PR DESCRIPTION
## Why

`release-runner-setup/action.yml` (landed in #1561) failed template validation on every caller with:

```
Unrecognized named-value: 'secrets'.
Located at position 1 within expression: secrets.RELEASE_BOT_APP_ID
```

Root cause: GitHub Actions evaluates every `${{ ... }}` expression in an action manifest at template-load time -- **including expressions inside `inputs.*.description` strings**. Composite actions cannot access the `secrets` context (only `inputs`, `steps`, `env`, `github`, `runner`, `job`, `matrix`). The usage-hint expressions I embedded as `"pass ${{ secrets.RELEASE_BOT_APP_ID }}"` in the descriptions failed validation and broke the entire composite. Every workflow that depended on it then cascaded.

## What failed on main post-#1561 merge

- `Release` workflow -> release-please step never reached (parse error in composite)
- `CI` -> `branch-protection-audit` job -> same parse error
- Every other caller (`dev-release.yml`, `auto-rollover.yml`, `test-signing.yml`, `graduate.yml`) would hit the same error the next time they fire

## What this PR does

Rewrite the two input descriptions as plain English (`"Callers typically pass secrets.RELEASE_BOT_APP_ID"`) with **no `${{ ... }}` syntax**, plus an explanatory comment block above the `inputs:` section pointing at the [GHA composite-action context restrictions](https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions) so this does not regress.

The composite's step body (`inputs.app-id`, `inputs.app-private-key` references on the `create-github-app-token` step) is untouched -- those use the `inputs` context, which IS available in composite actions.

## Test plan

- 2-line description edit + explanatory comment block; no runtime behaviour changes.
- YAML parses clean (`check-yaml` pre-commit hook passed locally).
- Once merged, the next push to main will retry `Release` + `CI` automatically.
- `test-signing.yml` nightly cron (06:00 UTC) will confirm all three signing code paths still produce signed commits.
- Tomorrow's `release-pipeline-health.yml` (07:00 UTC) will exercise the full `git rev-list` + attestation path against v0.7.2.

## Scope

Single file, minimal diff -- deliberately surgical for a main hotfix.

## Linked issues

Forward-fix for a landed regression in #1561. No separate issue.