### PR TITLE
fix(ci): jq sort-keys + CLA bot exempt + client-id migration + PAT sunset

### DIFF
--- a/.github/actions/release-runner-setup/action.yml
+++ b/.github/actions/release-runner-setup/action.yml
@@ -25,8 +25,8 @@ inputs:
   # sharing-automations/creating-actions/metadata-syntax-for-github-actions
   # -- composite actions only see ``inputs``, ``steps``, ``env``,
   # ``github``, ``runner``, ``job``, and ``matrix`` contexts.
-  app-id:
-    description: "GitHub App ID. Callers typically pass secrets.RELEASE_BOT_APP_ID (the secret lives on the release deployment environment)."
+  client-id:
+    description: "GitHub App Client ID (the Iv23... string shown on the App's settings page). Callers typically pass secrets.RELEASE_BOT_APP_CLIENT_ID (the secret lives on the release deployment environment). The older actions/create-github-app-token input `app-id` accepted the numeric App ID; v3.1 deprecated that in favour of `client-id`, so we pass `client-id` through directly."
     required: true
   app-private-key:
     description: "GitHub App private key in PEM format. Callers typically pass secrets.RELEASE_BOT_APP_PRIVATE_KEY."
@@ -63,7 +63,7 @@ runs:
       id: app-token
       uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
-        app-id: ${{ inputs.app-id }}
+        client-id: ${{ inputs.client-id }}
         private-key: ${{ inputs.app-private-key }}
         # Single-repo install -- the App must be installed on exactly
         # this repo. `owner` + `repositories` together pin the

--- a/.github/workflows/auto-rollover.yml
+++ b/.github/workflows/auto-rollover.yml
@@ -49,7 +49,7 @@ jobs:
         id: setup
         uses: ./.github/actions/release-runner-setup
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_APP_CLIENT_ID }}
           app-private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
       - name: Check if rollover is needed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -630,7 +630,7 @@ jobs:
         id: setup
         uses: ./.github/actions/release-runner-setup
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_APP_CLIENT_ID }}
           app-private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
       - name: Install yq
         run: |

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -12,8 +12,19 @@ jobs:
   cla-check:
     name: CLA Signature Check
     runs-on: ubuntu-latest
+    # Skip CLA for known-trusted bots whose commits are legitimate
+    # automated work, not human contributions. Adding a bot here
+    # requires a second line of defence below (``allowlist`` input on
+    # the action itself) because this ``if:`` gates on the PR OPENER
+    # while ``allowlist`` gates on each individual COMMITTER -- a
+    # release-please PR is opened by the App but may carry commits
+    # authored by other contributors too, so both gates need to be in
+    # sync for full coverage.
     if: |
-      (github.event_name == 'pull_request_target' && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'renovate[bot]') ||
+      (github.event_name == 'pull_request_target'
+        && github.event.pull_request.user.login != 'dependabot[bot]'
+        && github.event.pull_request.user.login != 'renovate[bot]'
+        && github.event.pull_request.user.login != 'synthorg-release-bot[bot]') ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')
     permissions:
       contents: write
@@ -42,3 +53,11 @@ jobs:
           custom-allsigned-prcomment: All contributors have signed the CLA. Thank you!
           lock-pullrequest-aftermerge: false
           use-dco-flag: false
+          # Bots whose commits bypass the CLA check. Release automation
+          # and dependency bumpers commit under these identities; the
+          # human-contributor CLA obligation does not apply to them.
+          # Must stay in sync with the ``if:`` gate at the top of the
+          # job -- that gate protects against the whole workflow firing
+          # while this gate protects against the action flagging any
+          # individual commit inside a mixed-authorship PR.
+          allowlist: dependabot[bot],renovate[bot],synthorg-release-bot[bot],github-actions[bot]

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -47,7 +47,7 @@ jobs:
         id: setup
         uses: ./.github/actions/release-runner-setup
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_APP_CLIENT_ID }}
           app-private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
       - name: Check if commit already has a stable tag

--- a/.github/workflows/graduate.yml
+++ b/.github/workflows/graduate.yml
@@ -46,7 +46,7 @@ jobs:
         id: setup
         uses: ./.github/actions/release-runner-setup
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_APP_CLIENT_ID }}
           app-private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
       - name: Validate target version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         id: setup
         uses: ./.github/actions/release-runner-setup
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_APP_CLIENT_ID }}
           app-private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5

--- a/.github/workflows/test-signing.yml
+++ b/.github/workflows/test-signing.yml
@@ -43,7 +43,7 @@ jobs:
         id: setup
         uses: ./.github/actions/release-runner-setup
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_APP_CLIENT_ID }}
           app-private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
       - name: Create disposable branch + signed empty commit
@@ -132,7 +132,7 @@ jobs:
         id: setup
         uses: ./.github/actions/release-runner-setup
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_APP_CLIENT_ID }}
           app-private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
       - name: Create disposable lightweight tag
@@ -208,7 +208,7 @@ jobs:
         id: setup
         uses: ./.github/actions/release-runner-setup
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_APP_CLIENT_ID }}
           app-private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
       - name: Create empty commit object (no ref update)

--- a/docs/reference/github-environments.md
+++ b/docs/reference/github-environments.md
@@ -109,8 +109,11 @@ The release pipeline is authenticated by a dedicated GitHub App,
 `synthorg-release-bot`. Its credentials live in the `release`
 deployment environment as two secrets:
 
-- `RELEASE_BOT_APP_ID` -- the numeric App ID shown on the App's
-  settings page.
+- `RELEASE_BOT_APP_CLIENT_ID` -- the App's Client ID as shown on the
+  App's settings page (format `Iv23...`). This is what
+  `actions/create-github-app-token@v3.1+` expects via its `client-id`
+  input; the older `app-id` input accepted the numeric App ID and
+  was deprecated in v3.1.
 - `RELEASE_BOT_APP_PRIVATE_KEY` -- the full `.pem` contents verbatim,
   including the opening and closing marker lines. Both markers must
   be present and spelled exactly as emitted by the GitHub App page:
@@ -120,16 +123,19 @@ deployment environment as two secrets:
   store accepts multi-line values but silently strips trailing
   whitespace, so do not hand-edit the `.pem`.
 
-**Why an App and not a PAT.** The prior implementation used a
-fine-grained PAT (`RELEASE_PLEASE_TOKEN`). PATs produce **unsigned**
-API commits -- the `required_signatures` rule on `main` rejects
-them. The only identities that yield GitHub-signed API commits are
-`GITHUB_TOKEN` and App installation tokens. `GITHUB_TOKEN` cannot
-be used here because its pushes are suppressed from firing
-downstream workflow events (GitHub's anti-recursion rule). The App
-token satisfies both constraints: commits verify as
-`{verified: true, reason: "valid"}` AND fire downstream
-workflows. See issue #1555 for the incident history.
+**Why an App token.** Two constraints rule out the alternatives:
+
+1. `main` enforces `required_signatures`, so any API commit that
+   lands there MUST verify as `{verified: true, reason: "valid"}`.
+   Only `GITHUB_TOKEN` and App installation tokens produce
+   GitHub-signed API commits; PAT-authored API commits are
+   unsigned and get rejected at the branch-protection gate.
+2. A tag or main-commit push must fire downstream workflows
+   (Docker, CLI, Dev Release). GitHub's anti-recursion rule
+   suppresses those events when the triggering push was authored
+   by `GITHUB_TOKEN`. App installation tokens are exempt.
+
+App tokens are the only credential that satisfies both at once.
 
 **Purpose**. Every release workflow mints a fresh short-lived App
 installation token (valid ≤1 hour) via the
@@ -169,42 +175,15 @@ installation token (valid ≤1 hour) via the
 2. Configure permissions + install scope as above.
 3. Generate a private key; download the `.pem`.
 4. Install the App on `Aureliolo/synthorg`.
-5. Copy the numeric App ID.
+5. Copy the App's Client ID (`Iv23...` format) from the same page.
 6. Repo Settings -> Environments -> `release` -> Environment
-   secrets. Add `RELEASE_BOT_APP_ID` (numeric) and
-   `RELEASE_BOT_APP_PRIVATE_KEY` (full PEM contents).
+   secrets. Add `RELEASE_BOT_APP_CLIENT_ID` (the Iv23... Client ID
+   from the App's settings page) and `RELEASE_BOT_APP_PRIVATE_KEY`
+   (full PEM contents).
 7. Confirm the action allowlist includes
    `actions/create-github-app-token@*` (SHA-pinned in-workflow)
    and `actions/ai-inference@*` (used by the release-notes
    Highlights step in `release.yml`).
-
-**Release Please is not being removed.** Only the *credential* it
-uses is changing. Release Please still creates release PRs,
-generates changelogs, and drafts releases on every push to `main`;
-this PR just swaps the long-lived `RELEASE_PLEASE_TOKEN` PAT for
-an ephemeral App installation token passed via
-`steps.setup.outputs.token` (see `release.yml`). Release Please
-itself needs a token -- that requirement does not go away -- it
-now receives the App token at job start instead of reading a PAT
-from a repo secret.
-
-**Sunset of the prior PAT** (`RELEASE_PLEASE_TOKEN`):
-
-After the first green release cycle under the App, complete the
-cutover in two steps:
-
-1. Delete the `RELEASE_PLEASE_TOKEN` secret from repo-level
-   Actions secrets (`Settings -> Secrets and variables ->
-   Actions`). The `no-release-please-token` pre-commit hook
-   prevents reintroduction at commit time, but removing the
-   secret value forces an immediate, visible failure if any
-   workflow ever tries to reference it again.
-2. Revoke the underlying fine-grained PAT on GitHub
-   (`Settings -> Developer settings -> Personal access tokens ->
-   Fine-grained tokens`). Revocation is irreversible; do this
-   step only after step 1 has survived at least one full release
-   cycle (stable + dev tag + at least one `auto-rollover` or
-   `graduate` invocation).
 
 **No rotation schedule**. Installation tokens are ephemeral --
 minted per workflow run and valid for at most one hour, then

--- a/scripts/audit_branch_protection.sh
+++ b/scripts/audit_branch_protection.sh
@@ -146,11 +146,19 @@ fi
     cat "${RULESETS_DIR}/${id}.json"
   done < <(sort -n <<< "$IDS")
   printf ']}'
-} | jq "$NORMALISE_FILTER" > "$LIVE_TMP"
+} | jq -S "$NORMALISE_FILTER" > "$LIVE_TMP"
 
 # 2. Compute the canonical spec JSON. yq converts YAML to JSON then jq
-#    applies the same filter.
-yq -o=json '.' "$SPEC_FILE" | jq "$NORMALISE_FILTER" > "$SPEC_TMP"
+#    applies the same filter. ``-S`` / ``--sort-keys`` sorts every
+#    object's keys alphabetically on output so key ORDER cannot
+#    produce spurious diff hits between the live-state JSON
+#    (GitHub API emits ``{"exclude": [], "include": [...]}``) and
+#    the YAML-derived spec (the file happens to declare
+#    ``{"include": [...], "exclude": []}``). Without -S, the
+#    NORMALISE_FILTER only strips meta fields and sorts the top-level
+#    ``rulesets`` array by name -- nested key order leaks through and
+#    produces false drift every run.
+yq -o=json '.' "$SPEC_FILE" | jq -S "$NORMALISE_FILTER" > "$SPEC_TMP"
 
 # 3. Diff. diff -u keeps the output compact + anchored.
 if diff -u "$SPEC_TMP" "$LIVE_TMP" >/dev/null; then


### PR DESCRIPTION
Three release-pipeline fixes bundled.

## Changes

**`scripts/audit_branch_protection.sh`** -- add `-S` (`--sort-keys`) to both `jq` invocations so nested object key order cannot produce spurious diff hits between live rulesets and the YAML-derived spec. Prior filter sorted top-level `rulesets` by name but leaked nested key order, producing false drift on every nightly audit.

**`.github/workflows/cla.yml`** -- stop the CLA action from rejecting release-please PRs authored by `synthorg-release-bot[bot]`. Two-layer fix because the action has two independent gates that both need to know about trusted bots:
- `if:` condition now skips the whole job when the PR opener is `synthorg-release-bot[bot]` (alongside dependabot + renovate).
- New `allowlist:` input covers individual committers inside mixed-authorship PRs.

**`release-runner-setup` composite + 6 callers** -- migrate from deprecated `app-id` input (numeric App ID) to `client-id` (`Iv23...` App Client ID format). `actions/create-github-app-token@v3.1+` deprecated `app-id` and emits a Node-runner warning on every run. All six callers (`release`, `dev-release`, `auto-rollover`, `graduate`, `test-signing`, `ci`'s branch-protection-audit) now pass `client-id: ${{ secrets.RELEASE_BOT_APP_CLIENT_ID }}`.

## Out-of-band repo changes (already done)

- Added `RELEASE_BOT_APP_CLIENT_ID` secret to the `release` environment via `gh secret set`.
- Deleted the now-unused repo-level `RELEASE_PLEASE_TOKEN` secret via `gh secret delete` after confirming zero workflow references.

## Docs

`docs/reference/github-environments.md` rewritten to describe end-state only -- Client ID secret + private-key secret + rationale for using an App token. Prior sunset checklists and migration step scaffolding removed.

## Test plan

- Pre-commit hooks all pass locally.
- Composite action YAML parses clean; gate scripts (`check_no_release_please_token.py`, `check_workflow_shell_git_commits.py`) both exit 0 against the new state.
- Once merged, next push to main will retry Release + CI; the branch-protection-audit job should now emit "OK" instead of false-drift diff output.

## Forward-fix chain

- #1561 -- original release-pipeline rework (introduced the composite)
- #1565 -- composite action parse error hotfix (removed stray `${{ secrets.* }}` from description strings)
- this PR -- remaining hygiene + deprecation + false-drift