### PR TITLE
fix(ci): set GH_REPO env in release-events to fix chronic post-merge failure

### DIFF
--- a/.github/actions/post-tracking-issue/action.yml
+++ b/.github/actions/post-tracking-issue/action.yml
@@ -61,6 +61,12 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.gh-token }}
+        # `gh issue list` etc. infer the repo from git remote when
+        # neither `--repo` nor `GH_REPO` is set; in a job that does
+        # not check out the source this fails with `fatal: not a git
+        # repository`. Set `GH_REPO` explicitly so the composite
+        # action works whether or not the caller checked out.
+        GH_REPO: ${{ github.repository }}
         TITLE: ${{ inputs.title }}
         LABELS: ${{ inputs.labels }}
         BODY: ${{ inputs.body }}

--- a/.github/workflows/release-events.yml
+++ b/.github/workflows/release-events.yml
@@ -87,6 +87,16 @@ jobs:
       - name: Compose + post event
         env:
           GH_TOKEN: ${{ github.token }}
+          # ``gh issue list`` / ``gh issue create`` infer the target
+          # repo from the current git remote when neither ``--repo``
+          # nor ``GH_REPO`` is set, falling back to a hard ``fatal:
+          # not a git repository`` error in workflows that do not
+          # check out the source. This job intentionally does not
+          # check out (it only manipulates issues), so we set
+          # ``GH_REPO`` explicitly to skip the git probe. Without it,
+          # every Auto Rollover / Test Signing completion that
+          # triggers this fan-in fails at the first gh call.
+          GH_REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
           SERVER_URL: ${{ github.server_url }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
## Why

Post-merge of PR #1576, the **Release Events** workflow failed (run `24931462842`). Looking back, this workflow has been failing **on every run all day** — every Auto Rollover and Test Signing completion has been hitting the same error and silently going red in the Actions tab. Pre-existing bug; surfaced now because we just made these failures more visible via the new commit-status reporting.

## Root cause

The `Compose + post event` step calls `gh issue list` / `gh issue create` without a `--repo` flag, in a job that does **not** check out the source. `gh` CLI's repo-resolution falls back to running `git config --get remote.origin.url` to infer the target repo, which in a no-checkout job exits with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The first `gh` call exits non-zero under `set -e` and the workflow aborts before any event is posted to the rolling tracking issue.

## Fix

Set `GH_REPO: ${{ github.repository }}` in the step env so `gh` skips the git-repo probe and uses the explicit repo name. One line.

Same fix applied defensively to the `post-tracking-issue` composite action (today every caller checks out, but the action shouldn't silently depend on that contract).

## Verification

After merge, the next Auto Rollover or Test Signing completion will trigger Release Events. It should now post to the rolling-events tracking issue successfully (creating it on first run since the issue doesn't exist yet).

## Out of scope

A broader audit of `gh` CLI usage across other workflows that don't checkout — none currently fail this way (verified via Actions tab), but the same pattern could regress elsewhere. Consider documenting the `GH_REPO` env requirement in the project's CI guidelines as a follow-up.