### PR TITLE
fix(cli): render update walk as inline section, not full screen

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,3 +31,9 @@ Dockerfile text eol=lf
 
 # PowerShell scripts -- Windows expects CRLF.
 *.ps1 text eol=crlf
+
+# Web dashboard -- Node, Vitest, MSW, and Caddy all expect LF.
+# Without this pin, core.autocrlf=true on Windows produces CRLF in worktrees
+# while the index stores LF, creating phantom `git status` diffs in
+# generated/checked-in files like web/public/mockServiceWorker.js.
+web/** text=auto eol=lf

--- a/cli/internal/ui/walk.go
+++ b/cli/internal/ui/walk.go
@@ -44,6 +44,13 @@ const (
 	viewCommits    changelogView = "commits"
 )
 
+// maxWalkContentHeight caps the viewport's content rows so the changelog
+// walk renders as a fixed-size inline section instead of inflating to fill
+// the entire terminal. Picked so a typical batch fits "above the fold"
+// without dwarfing the surrounding `synthorg update` output. Larger ranges
+// stay scrollable via j/k and pgup/pgdn.
+const maxWalkContentHeight = 14
+
 // WalkBatchInput drives RunWalkBatch.
 type WalkBatchInput struct {
 	// Versions is the batch -- typically 1 to 3 entries.
@@ -188,13 +195,14 @@ func initialDimensions(w, h int) (int, int) {
 
 // viewportHeightForChrome reserves chrome lines for renderView's surrounding
 // layout (header + trailing newline + footer, plus any optional fallback /
-// flash rows the caller knows about). Falls back to 1 when the terminal is
-// too small to render anything meaningful.
+// flash rows the caller knows about), then caps the result at
+// maxWalkContentHeight. Falls back to 1 when the terminal is too small to
+// render anything meaningful.
 func viewportHeightForChrome(termHeight, chrome int) int {
 	if termHeight <= chrome+1 {
 		return 1
 	}
-	return termHeight - chrome
+	return min(termHeight-chrome, maxWalkContentHeight)
 }
 
 // wrappedLines returns the number of terminal rows a string of the given


### PR DESCRIPTION
## Summary

- Cap the bubbletea viewport in `viewportHeightForChrome` to a 14-row content max so `synthorg update`'s changelog walk renders as a fixed-size inline section (~17-19 lines total: header + content + footer) instead of inflating to fill the entire terminal.
- Fixes both walks driven by `synthorg update`:
  - `walkModel` (stable channel, per-release Highlights walk)
  - `commitWalkModel` (dev channel, single combined commit list)
- Larger ranges stay fully scrollable via `j/k`, `pgup/pgdn`, and `g/G`.

Bonus hygiene fix bundled in:

- Pin `web/**` to `text=auto eol=lf` in `.gitattributes` so worktree checkouts on Windows (`core.autocrlf=true`) stop producing phantom CRLF diffs against the LF-stored index. Most visible on `web/public/mockServiceWorker.js`, which kept showing as modified after every fresh worktree.

## Before / after

Before: walk fills `terminal_height - chrome` rows on every invocation, dwarfing the surrounding `synthorg update` output and feeling like a screen takeover.

After: walk renders as a ~17-19-line section regardless of terminal size; the surrounding CLI output stays visible above the walk.

## Test plan

- `go -C cli vet ./...` — clean
- `go -C cli test ./internal/ui/... ./cmd/...` — all 38 UI tests + cmd tests pass
- `go -C cli build ./...` — clean
- Manually verified `viewportHeightForChrome` correctness across edge cases:
  - Very small terminals (`termHeight <= chrome+1`) → falls back to 1 row (unchanged)
  - Moderate terminals (e.g. height 20, chrome 5) → returns `min(15, 14) = 14`
  - Large terminals (e.g. height 100, chrome 5) → returns `min(95, 14) = 14`

## Review coverage

Pre-reviewed by 5 agents (go-reviewer, go-conventions-enforcer, go-security-reviewer, infra-reviewer, docs-consistency).

- 1 finding addressed: relocated `maxWalkContentHeight` constant to the top-of-file const group near `viewHighlights`/`viewCommits`.
- 1 finding skipped (invalid): `web/** text=auto eol=lf` over-match concern — verified all tracked files in `web/` are text (css, html, js, json, md, svg, ts, tsx, .npmrc, Caddyfile, .example) and `text=auto` performs binary detection per Git's documentation.
