### PR TITLE
refactor(ci): fork-friendly CI + preflight setup checker

### DIFF
--- a/.github/actions/ci-preflight-check/action.yml
+++ b/.github/actions/ci-preflight-check/action.yml
@@ -28,7 +28,7 @@ outputs:
     description: '`true` if any check failed, `false` otherwise.'
     value: ${{ steps.check.outputs.gaps-found }}
   body:
-    description: 'Rendered Markdown body for the tracking issue. Empty when gaps-found is false.'
+    description: 'Rendered Markdown body for the tracking issue. Always populated -- on pass it shows the all-green summary, on gaps it lists each missing item.'
     value: ${{ steps.check.outputs.body }}
 
 runs:
@@ -46,7 +46,7 @@ runs:
 
         # ── Expectations (kept in sync with .github/labels.yml + the
         # workflow surface). Update both when new ones land. ──
-        EXPECTED_ENVS=(atlas release release-tags apko-lock cloudflare-preview image-push)
+        EXPECTED_ENVS=(atlas release release-tags apko-lock cloudflare-preview image-push github-pages)
         EXPECTED_LABELS=(
           "automation:ci-health"
           "automation:ci-preflight"
@@ -111,9 +111,17 @@ runs:
         fi
 
         # ── Branch protection on main ─────────────────────────────
+        # Distinguish 404 (no protection rule) from 403 / other errors
+        # (token lacks `administration: read` and similar). Mirroring
+        # the env / labels handling above, a permission error degrades
+        # to "Skipped" rather than falsely flagging missing rules.
         bp_block=""
         bp_gaps=()
-        if bp_json=$(gh api "repos/$GH_REPO/branches/main/protection" 2>/dev/null); then
+        bp_skipped=false
+        bp_status=$(gh api "repos/$GH_REPO/branches/main/protection" --include 2>&1 \
+          | head -n 1 || true)
+        if printf '%s' "$bp_status" | grep -qE 'HTTP/[0-9.]+ 200'; then
+          bp_json=$(gh api "repos/$GH_REPO/branches/main/protection")
           if ! jq -e '.required_signatures.enabled == true' <<<"$bp_json" >/dev/null; then
             bp_gaps+=("Required **signed commits** is not enabled. Enable at Settings -> Branches -> Branch protection rules -> main -> 'Require signed commits'.")
           fi
@@ -123,14 +131,18 @@ runs:
           if ! jq -e '[.required_status_checks.contexts[]?] | index("CI Pass") != null' <<<"$bp_json" >/dev/null; then
             bp_gaps+=("Required status check context \`CI Pass\` is not configured. Add it under 'Status checks that are required'.")
           fi
-        else
+        elif printf '%s' "$bp_status" | grep -qE 'HTTP/[0-9.]+ 404'; then
           bp_gaps+=("No branch protection rule on \`main\`. Create one at Settings -> Branches -> Add rule.")
+        else
+          bp_skipped=true
         fi
         default_branch=$(gh api "repos/$GH_REPO" --jq '.default_branch' 2>/dev/null || echo "")
         if [ "$default_branch" != "main" ] && [ -n "$default_branch" ]; then
           bp_gaps+=("Default branch is \`$default_branch\`, not \`main\`. Workflows assume \`main\`. Rename or update workflows.")
         fi
-        if [ "${#bp_gaps[@]}" -eq 0 ]; then
+        if [ "$bp_skipped" = true ] && [ "${#bp_gaps[@]}" -eq 0 ]; then
+          bp_block="_Could not enumerate branch protection (token lacks permission). Skipped._"
+        elif [ "${#bp_gaps[@]}" -eq 0 ]; then
           bp_block="Branch protection on \`main\` matches expectations."
         else
           gaps_found=true
@@ -155,8 +167,11 @@ runs:
         # marker on its own line cannot truncate the output. Per
         # GitHub Actions docs the delimiter must not appear in the
         # value; salting with a per-run random suffix makes that
-        # condition vacuous.
-        delim="PREFLIGHT_BODY_EOF_$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid)"
+        # condition vacuous. The triple fallback (uuidgen ->
+        # /proc/sys/kernel/random/uuid -> $RANDOM) keeps the
+        # subshell from ever exiting non-zero under `set -e` even
+        # on minimal or non-Linux runners.
+        delim="PREFLIGHT_BODY_EOF_$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid 2>/dev/null || echo $RANDOM)"
         echo "gaps-found=$gaps_found" >> "$GITHUB_OUTPUT"
         {
           printf 'body<<%s\n' "$delim"

--- a/.github/actions/ci-preflight-check/action.yml
+++ b/.github/actions/ci-preflight-check/action.yml
@@ -74,8 +74,14 @@ runs:
         envs_block=""
         envs_status="OK"
         envs_skipped=false
-        if existing_envs_json=$(gh api "repos/$GH_REPO/environments" --jq '[.environments[]?.name]' 2>/dev/null \
-            || (sleep 1 && gh api "repos/$GH_REPO/environments" --jq '[.environments[]?.name]')); then
+        # Paginate via `--paginate` so a repo with more than 30
+        # environments enumerates fully. Realistically this repo has
+        # 7, but a fork that has added custom environments should not
+        # see false-positive "missing" entries because we only saw
+        # the first page.
+        if existing_envs_json=$(gh api "repos/$GH_REPO/environments" --paginate --jq '[.environments[]?.name]' 2>/dev/null \
+            | jq -s 'add // []' \
+            || (sleep 1 && gh api "repos/$GH_REPO/environments" --paginate --jq '[.environments[]?.name]' | jq -s 'add // []')); then
           missing_envs=()
           for env in "${EXPECTED_ENVS[@]}"; do
             if jq -e --arg n "$env" 'index($n) != null' <<<"$existing_envs_json" >/dev/null; then
@@ -97,9 +103,15 @@ runs:
             envs_block+=$'\n'"See [Fork Setup Guide section 2](../blob/HEAD/docs/guides/fork-setup.md) for branch policies and which workflows consume each environment."
           fi
         else
+          # Skipping a blocking check is treated as inconclusive, not
+          # as passing: flip `gaps_found` to true so the tracking
+          # issue stays open and the caller knows the audit could not
+          # complete. Otherwise a permanently-permission-denied token
+          # would silently green-light a broken fork.
           envs_skipped=true
-          envs_status="skipped"
-          envs_block="_Could not enumerate environments (token lacks permission). Skipped._"
+          envs_status="skipped (cannot enumerate)"
+          envs_block="_Could not enumerate environments (token lacks permission). Inconclusive -- treated as a gap until verifiable._"
+          gaps_found=true
           # When we cannot enumerate, treat every env as "unknown" so
           # the conditional setup section below still renders -- a fork
           # without environments needs the instructions even if we
@@ -110,9 +122,15 @@ runs:
         fi
 
         # ── Labels ────────────────────────────────────────────────
+        # `gh label list` defaults to 30 results; this repo has 75+
+        # labels in production, so a default-limit call would silently
+        # drop the alphabetically-later ones (e.g. `type:ci`) and
+        # false-flag them as missing. Paginate via `gh api` to fetch
+        # every label regardless of total count.
         labels_block=""
         labels_status="OK"
-        if existing_labels_json=$(gh label list --json name --jq '[.[].name]' 2>/dev/null); then
+        if existing_labels_json=$(gh api "repos/$GH_REPO/labels" --paginate --jq '[.[].name]' 2>/dev/null \
+            | jq -s 'add // []'); then
           missing_labels=()
           for label in "${EXPECTED_LABELS[@]}"; do
             if ! jq -e --arg n "$label" 'index($n) != null' <<<"$existing_labels_json" >/dev/null; then
@@ -130,8 +148,10 @@ runs:
             done
           fi
         else
-          labels_status="skipped"
-          labels_block="_Could not enumerate labels (token lacks permission). Skipped._"
+          # Same inconclusive-is-a-gap rule as the environments check.
+          labels_status="skipped (cannot enumerate)"
+          labels_block="_Could not enumerate labels (token lacks permission). Inconclusive -- treated as a gap until verifiable._"
+          gaps_found=true
         fi
 
         # ── Branch protection on main (informational) ─────────────

--- a/.github/actions/ci-preflight-check/action.yml
+++ b/.github/actions/ci-preflight-check/action.yml
@@ -15,10 +15,12 @@ description: |
 
 inputs:
   gh-token:
-    description: |
-      GitHub token with `metadata: read` and access to the rulesets +
-      environments + labels APIs. The default `${{ github.token }}`
-      is sufficient.
+    description: >-
+      GitHub token with access to the environments, labels, and
+      branches/protection APIs. The workflow's default github.token
+      (passed via the `gh-token` input from the calling workflow) is
+      sufficient when the calling job declares `permissions: { contents:
+      read, issues: write }`.
     required: true
 
 outputs:

--- a/.github/actions/ci-preflight-check/action.yml
+++ b/.github/actions/ci-preflight-check/action.yml
@@ -62,9 +62,11 @@ runs:
         # Single-shot retry to absorb transient API hiccups; on a hard
         # failure (e.g. token can't read environments) we degrade to a
         # skipped check rather than flagging every env as missing.
+        # The `sleep 1` between attempts gives a transient rate-limit
+        # or brief outage a moment to clear before re-firing.
         envs_block=""
         if existing_envs_json=$(gh api "repos/$GH_REPO/environments" --jq '[.environments[]?.name]' 2>/dev/null \
-            || gh api "repos/$GH_REPO/environments" --jq '[.environments[]?.name]'); then
+            || (sleep 1 && gh api "repos/$GH_REPO/environments" --jq '[.environments[]?.name]')); then
           missing_envs=()
           for env in "${EXPECTED_ENVS[@]}"; do
             if ! jq -e --arg n "$env" 'index($n) != null' <<<"$existing_envs_json" >/dev/null; then
@@ -147,11 +149,17 @@ runs:
         body="${body//\{\{BRANCH_PROTECTION_BLOCK\}\}/$bp_block}"
 
         # ── Emit outputs ─────────────────────────────────────────
+        # Random delimiter so a body that happens to contain the
+        # marker on its own line cannot truncate the output. Per
+        # GitHub Actions docs the delimiter must not appear in the
+        # value; salting with a per-run random suffix makes that
+        # condition vacuous.
+        delim="PREFLIGHT_BODY_EOF_$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid)"
         echo "gaps-found=$gaps_found" >> "$GITHUB_OUTPUT"
         {
-          echo "body<<PREFLIGHT_BODY_EOF"
+          printf 'body<<%s\n' "$delim"
           printf '%s\n' "$body"
-          echo "PREFLIGHT_BODY_EOF"
+          printf '%s\n' "$delim"
         } >> "$GITHUB_OUTPUT"
 
         echo "::group::Preflight result"

--- a/.github/actions/ci-preflight-check/action.yml
+++ b/.github/actions/ci-preflight-check/action.yml
@@ -58,6 +58,10 @@ runs:
           "autorelease: pending"
         )
 
+        # `gaps_found` only flips for *blocking* checks (envs missing,
+        # labels missing). Branch protection is informational -- it can
+        # never be queried by the workflow's default token, so it is
+        # rendered as a status note rather than a blocker.
         gaps_found=false
 
         # ── Environments ──────────────────────────────────────────
@@ -66,30 +70,48 @@ runs:
         # skipped check rather than flagging every env as missing.
         # The `sleep 1` between attempts gives a transient rate-limit
         # or brief outage a moment to clear before re-firing.
+        declare -A env_exists
         envs_block=""
+        envs_status="OK"
+        envs_skipped=false
         if existing_envs_json=$(gh api "repos/$GH_REPO/environments" --jq '[.environments[]?.name]' 2>/dev/null \
             || (sleep 1 && gh api "repos/$GH_REPO/environments" --jq '[.environments[]?.name]')); then
           missing_envs=()
           for env in "${EXPECTED_ENVS[@]}"; do
-            if ! jq -e --arg n "$env" 'index($n) != null' <<<"$existing_envs_json" >/dev/null; then
+            if jq -e --arg n "$env" 'index($n) != null' <<<"$existing_envs_json" >/dev/null; then
+              env_exists[$env]=true
+            else
+              env_exists[$env]=false
               missing_envs+=("$env")
             fi
           done
           if [ "${#missing_envs[@]}" -eq 0 ]; then
-            envs_block="All expected environments exist."
+            envs_block="All ${#EXPECTED_ENVS[@]} expected environments exist."
           else
             gaps_found=true
-            envs_block="Missing environments (create at **Settings -> Environments -> New environment**):"$'\n'
+            envs_status="${#missing_envs[@]} of ${#EXPECTED_ENVS[@]} missing"
+            envs_block="Create at **Settings -> Environments -> New environment**:"$'\n\n'
             for env in "${missing_envs[@]}"; do
               envs_block+="- [ ] \`$env\`"$'\n'
             done
+            envs_block+=$'\n'"See [Fork Setup Guide section 2](../blob/HEAD/docs/guides/fork-setup.md) for branch policies and which workflows consume each environment."
           fi
         else
+          envs_skipped=true
+          envs_status="skipped"
           envs_block="_Could not enumerate environments (token lacks permission). Skipped._"
+          # When we cannot enumerate, treat every env as "unknown" so
+          # the conditional setup section below still renders -- a fork
+          # without environments needs the instructions even if we
+          # cannot positively confirm they are missing.
+          for env in "${EXPECTED_ENVS[@]}"; do
+            env_exists[$env]=false
+          done
         fi
 
         # ── Labels ────────────────────────────────────────────────
         labels_block=""
+        labels_status="OK"
         if existing_labels_json=$(gh label list --json name --jq '[.[].name]' 2>/dev/null); then
           missing_labels=()
           for label in "${EXPECTED_LABELS[@]}"; do
@@ -98,69 +120,143 @@ runs:
             fi
           done
           if [ "${#missing_labels[@]}" -eq 0 ]; then
-            labels_block="All expected labels exist."
+            labels_block="All ${#EXPECTED_LABELS[@]} expected labels exist."
           else
             gaps_found=true
-            labels_block="Missing labels. Run the **Sync Labels** workflow once (Actions -> Sync Labels -> Run workflow) to bootstrap from \`.github/labels.yml\`:"$'\n'
+            labels_status="${#missing_labels[@]} of ${#EXPECTED_LABELS[@]} missing"
+            labels_block="Run the **Sync Labels** workflow once (Actions -> Sync Labels -> Run workflow on \`main\`) to bootstrap from \`.github/labels.yml\`. Missing:"$'\n\n'
             for label in "${missing_labels[@]}"; do
               labels_block+="- [ ] \`$label\`"$'\n'
             done
           fi
         else
+          labels_status="skipped"
           labels_block="_Could not enumerate labels (token lacks permission). Skipped._"
         fi
 
-        # ── Branch protection on main ─────────────────────────────
-        # Distinguish 404 (no protection rule) from 403 / other errors
-        # (token lacks `administration: read` and similar). Mirroring
-        # the env / labels handling above, a permission error degrades
-        # to "Skipped" rather than falsely flagging missing rules.
+        # ── Branch protection on main (informational) ─────────────
+        # The workflow's default GITHUB_TOKEN cannot be granted the
+        # `administration: read` scope, so this section is purely
+        # informational: whatever can be inferred is reported, but
+        # never drives `gaps_found`. A fork operator follows the
+        # Fork Setup Guide manually for these items.
         bp_block=""
-        bp_gaps=()
-        bp_skipped=false
-        bp_status=$(gh api "repos/$GH_REPO/branches/main/protection" --include 2>&1 \
-          | head -n 1 || true)
-        if printf '%s' "$bp_status" | grep -qE 'HTTP/[0-9.]+ 200'; then
-          bp_json=$(gh api "repos/$GH_REPO/branches/main/protection")
-          if ! jq -e '.required_signatures.enabled == true' <<<"$bp_json" >/dev/null; then
-            bp_gaps+=("Required **signed commits** is not enabled. Enable at Settings -> Branches -> Branch protection rules -> main -> 'Require signed commits'.")
+        bp_status="info"
+        bp_notes=()
+        bp_response=$(gh api "repos/$GH_REPO/branches/main/protection" --include 2>&1 || true)
+        bp_status_line=$(printf '%s' "$bp_response" | head -n 1)
+        if printf '%s' "$bp_status_line" | grep -qE 'HTTP/[0-9.]+ 200'; then
+          bp_json=$(gh api "repos/$GH_REPO/branches/main/protection" 2>/dev/null || echo '{}')
+          if jq -e '.required_signatures.enabled == true' <<<"$bp_json" >/dev/null; then
+            bp_notes+=("Signed commits: enabled")
+          else
+            bp_notes+=("Signed commits: NOT enabled (recommended for production main)")
           fi
-          if ! jq -e '.required_status_checks.strict == true' <<<"$bp_json" >/dev/null; then
-            bp_gaps+=("Required status checks **strict policy** is off. Enable 'Require branches to be up to date before merging'.")
+          if jq -e '.required_status_checks.strict == true' <<<"$bp_json" >/dev/null; then
+            bp_notes+=("Strict status checks: on")
+          else
+            bp_notes+=("Strict status checks: off")
           fi
-          if ! jq -e '[.required_status_checks.contexts[]?] | index("CI Pass") != null' <<<"$bp_json" >/dev/null; then
-            bp_gaps+=("Required status check context \`CI Pass\` is not configured. Add it under 'Status checks that are required'.")
+          if jq -e '[.required_status_checks.contexts[]?] | index("CI Pass") != null' <<<"$bp_json" >/dev/null; then
+            bp_notes+=("Required check \`CI Pass\`: configured")
+          else
+            bp_notes+=("Required check \`CI Pass\`: NOT configured")
           fi
-        elif printf '%s' "$bp_status" | grep -qE 'HTTP/[0-9.]+ 404'; then
-          bp_gaps+=("No branch protection rule on \`main\`. Create one at Settings -> Branches -> Add rule.")
+          bp_status="visible"
+        elif printf '%s' "$bp_status_line" | grep -qE 'HTTP/[0-9.]+ 404'; then
+          bp_notes+=("No branch protection rule on \`main\` (or 404 from this token).")
+          bp_status="missing"
         else
-          bp_skipped=true
+          bp_notes+=("Cannot read branch protection from this workflow's token (the \`administration: read\` scope is not grantable to the default \`GITHUB_TOKEN\`).")
+          bp_status="opaque"
         fi
         default_branch=$(gh api "repos/$GH_REPO" --jq '.default_branch' 2>/dev/null || echo "")
-        if [ "$default_branch" != "main" ] && [ -n "$default_branch" ]; then
-          bp_gaps+=("Default branch is \`$default_branch\`, not \`main\`. Workflows assume \`main\`. Rename or update workflows.")
+        if [ -n "$default_branch" ] && [ "$default_branch" != "main" ]; then
+          bp_notes+=("Default branch is \`$default_branch\`, not \`main\`. Workflows assume \`main\`.")
         fi
-        if [ "$bp_skipped" = true ] && [ "${#bp_gaps[@]}" -eq 0 ]; then
-          bp_block="_Could not enumerate branch protection (token lacks permission). Skipped._"
-        elif [ "${#bp_gaps[@]}" -eq 0 ]; then
-          bp_block="Branch protection on \`main\` matches expectations."
-        else
-          gaps_found=true
-          bp_block=""
-          for gap in "${bp_gaps[@]}"; do
-            bp_block+="- [ ] $gap"$'\n'
-          done
+        for note in "${bp_notes[@]}"; do
+          bp_block+="- $note"$'\n'
+        done
+
+        # ── Setup instructions (only for missing environments) ────
+        # When an environment exists we hide its setup section; the
+        # signal "env exists" is a proxy for "operator reached this
+        # step in the guide". Env-scoped secret values cannot be
+        # introspected from this workflow's token, so secret presence
+        # is not auto-checked -- runtime workflow failures surface a
+        # missing secret loud enough on its own.
+        setup_block=""
+
+        if [ "${env_exists[atlas]}" != "true" ]; then
+          setup_block+=$'### `atlas`\n\n'
+          setup_block+=$'After creating the `atlas` environment, add this secret:\n\n'
+          setup_block+=$'- `ATLAS_TOKEN` -- Atlas Cloud API token for schema validation. Get one at https://atlasgo.cloud/. Free tier covers a single project. Used by `ci.yml` schema-validate.\n\n'
         fi
 
+        if [ "${env_exists[release]}" != "true" ] || [ "${env_exists[release-tags]}" != "true" ]; then
+          setup_block+=$'### `release` (and `release-tags` shares the same App)\n\n'
+          setup_block+=$'These two environments together gate the release pipeline. After creating them, add the following secrets to `release`:\n\n'
+          setup_block+=$'- `RELEASE_BOT_APP_CLIENT_ID` -- GitHub App **Client ID** for your release bot.\n'
+          setup_block+=$'- `RELEASE_BOT_APP_PRIVATE_KEY` -- the App\'s private key (full PEM contents, including `-----BEGIN ... PRIVATE KEY-----` headers).\n\n'
+          setup_block+=$'To create the release-bot App:\n\n'
+          setup_block+=$'1. Go to https://github.com/settings/apps/new (personal account) or your organization\'s "Developer settings -> GitHub Apps -> New GitHub App".\n'
+          setup_block+=$'2. **Name**: anything (e.g. `myorg-release-bot`). Webhook: uncheck "Active".\n'
+          setup_block+=$'3. **Repository permissions**: Contents Read & write, Pull requests Read & write, Metadata Read.\n'
+          setup_block+=$'4. **Install** the App on this repository.\n'
+          setup_block+=$'5. Generate a private key under "Private keys -> Generate private key" and save the PEM file.\n'
+          setup_block+=$'6. Copy the App\'s Client ID and PEM contents into the `release` environment as the two secrets above.\n\n'
+          setup_block+=$'The minted token is what mints signed bot commits on protected `main` and bypasses the GITHUB_TOKEN anti-recursion rule for tag-triggered downstream workflows. Without it, `release.yml`, `dev-release.yml`, `auto-rollover.yml`, `graduate.yml` and `test-signing.yml` skip cleanly (they are already gated on `!github.event.repository.fork`).\n\n'
+        fi
+
+        if [ "${env_exists[cloudflare-preview]}" != "true" ]; then
+          setup_block+=$'### `cloudflare-preview` _(optional -- PR docs previews)_\n\n'
+          setup_block+=$'After creating the environment, add:\n\n'
+          setup_block+=$'- `CLOUDFLARE_API_TOKEN` -- Pages-deploy-scoped API token from https://dash.cloudflare.com/profile/api-tokens.\n'
+          setup_block+=$'- `CLOUDFLARE_ACCOUNT_ID` -- account ID from the Cloudflare dashboard sidebar.\n\n'
+          setup_block+=$'`pages-preview.yml` is the only consumer; the deploy step skips when these secrets are unset.\n\n'
+        fi
+
+        if [ "${env_exists[apko-lock]}" != "true" ]; then
+          setup_block+=$'### `apko-lock` _(optional -- scheduled Wolfi base-image lock updates)_\n\n'
+          setup_block+=$'No secrets required. The environment exists for branch-policy gating only.\n\n'
+        fi
+
+        if [ "${env_exists[image-push]}" != "true" ]; then
+          setup_block+=$'### `image-push` _(optional -- publishes container images to GHCR)_\n\n'
+          setup_block+=$'No secrets required. Uses the auto-provided `github.token` against your fork\'s GHCR namespace. The environment exists for branch-policy gating only.\n\n'
+        fi
+
+        if [ "${env_exists[github-pages]}" != "true" ]; then
+          setup_block+=$'### `github-pages`\n\n'
+          setup_block+=$'No secrets required. The GitHub-managed Pages deployment uses the workflow token. The environment exists for branch-policy gating on the `main`-only Pages publish path. See `pages.yml`.\n\n'
+        fi
+
+        if [ -z "$setup_block" ]; then
+          setup_block=$'_All expected environments exist. Setup instructions hidden._'$'\n\n'
+          setup_block+=$'_The preflight cannot directly verify secret values inside each environment -- runtime workflow failures will surface a missing or invalid secret when the workflow next runs._'
+        fi
+
+        # ── Overview table + status line ─────────────────────────
+        if [ "$gaps_found" = true ]; then
+          status_line="**Action required.** Resolve the items checked below; the next preflight run will close this issue automatically."
+        else
+          status_line="**All blocking checks pass.** Branch protection notes below are informational only."
+        fi
+
+        overview_table=$'| Check | Status |\n'
+        overview_table+=$'|---|---|\n'
+        overview_table+="| GitHub environments | $envs_status |"$'\n'
+        overview_table+="| Labels | $labels_status |"$'\n'
+        overview_table+="| Branch protection on \`main\` | informational ($bp_status) |"$'\n'
+
         # ── Render the body from the template ────────────────────
-        # GitHub App installation is described in the body's `release`
-        # secrets section but not directly checked: the `repos/X/installation`
-        # endpoint requires App-JWT auth, not the workflow's GITHUB_TOKEN,
-        # so a check from here would 404 even on a correctly-installed App.
         body=$(cat "$TEMPLATE_PATH")
+        body="${body//\{\{STATUS_LINE\}\}/$status_line}"
+        body="${body//\{\{OVERVIEW_TABLE\}\}/$overview_table}"
         body="${body//\{\{ENVIRONMENTS_BLOCK\}\}/$envs_block}"
         body="${body//\{\{LABELS_BLOCK\}\}/$labels_block}"
         body="${body//\{\{BRANCH_PROTECTION_BLOCK\}\}/$bp_block}"
+        body="${body//\{\{SETUP_BLOCK\}\}/$setup_block}"
 
         # ── Emit outputs ─────────────────────────────────────────
         # Random delimiter so a body that happens to contain the

--- a/.github/actions/ci-preflight-check/action.yml
+++ b/.github/actions/ci-preflight-check/action.yml
@@ -1,0 +1,160 @@
+name: 'CI Preflight Check'
+description: |
+  Inspect the repository for the GitHub environments, labels, branch
+  protection rules, and App installation that the CI / automation
+  workflows assume. Returns a `gaps-found` boolean and a rendered
+  Markdown body that lists every missing item with how-to-fix
+  pointers, so the calling workflow can open or close a tracking
+  issue accordingly.
+
+  Does NOT verify environment-scoped secrets directly. The body it
+  produces lists the expected secrets per environment (informational)
+  and instructs the operator to populate them once the environments
+  are created. Real secret-presence is verified at runtime by the
+  workflows that consume the secrets.
+
+inputs:
+  gh-token:
+    description: |
+      GitHub token with `metadata: read` and access to the rulesets +
+      environments + labels APIs. The default `${{ github.token }}`
+      is sufficient.
+    required: true
+
+outputs:
+  gaps-found:
+    description: '`true` if any check failed, `false` otherwise.'
+    value: ${{ steps.check.outputs.gaps-found }}
+  body:
+    description: 'Rendered Markdown body for the tracking issue. Empty when gaps-found is false.'
+    value: ${{ steps.check.outputs.body }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Run preflight checks
+      id: check
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        GH_REPO: ${{ github.repository }}
+        TEMPLATE_PATH: ${{ github.action_path }}/checklist.md.tmpl
+      run: |
+        set -euo pipefail
+
+        # ── Expectations (kept in sync with .github/labels.yml + the
+        # workflow surface). Update both when new ones land. ──
+        EXPECTED_ENVS=(atlas release release-tags apko-lock cloudflare-preview image-push)
+        EXPECTED_LABELS=(
+          "automation:ci-health"
+          "automation:ci-preflight"
+          "automation:release-events"
+          "type:ci"
+          "prio:low"
+          "prio:medium"
+          "prio:high"
+          "autorelease: pending"
+        )
+
+        gaps_found=false
+
+        # ── Environments ──────────────────────────────────────────
+        # Single-shot retry to absorb transient API hiccups; on a hard
+        # failure (e.g. token can't read environments) we degrade to a
+        # skipped check rather than flagging every env as missing.
+        envs_block=""
+        if existing_envs_json=$(gh api "repos/$GH_REPO/environments" --jq '[.environments[]?.name]' 2>/dev/null \
+            || gh api "repos/$GH_REPO/environments" --jq '[.environments[]?.name]'); then
+          missing_envs=()
+          for env in "${EXPECTED_ENVS[@]}"; do
+            if ! jq -e --arg n "$env" 'index($n) != null' <<<"$existing_envs_json" >/dev/null; then
+              missing_envs+=("$env")
+            fi
+          done
+          if [ "${#missing_envs[@]}" -eq 0 ]; then
+            envs_block="All expected environments exist."
+          else
+            gaps_found=true
+            envs_block="Missing environments (create at **Settings -> Environments -> New environment**):"$'\n'
+            for env in "${missing_envs[@]}"; do
+              envs_block+="- [ ] \`$env\`"$'\n'
+            done
+          fi
+        else
+          envs_block="_Could not enumerate environments (token lacks permission). Skipped._"
+        fi
+
+        # ── Labels ────────────────────────────────────────────────
+        labels_block=""
+        if existing_labels_json=$(gh label list --json name --jq '[.[].name]' 2>/dev/null); then
+          missing_labels=()
+          for label in "${EXPECTED_LABELS[@]}"; do
+            if ! jq -e --arg n "$label" 'index($n) != null' <<<"$existing_labels_json" >/dev/null; then
+              missing_labels+=("$label")
+            fi
+          done
+          if [ "${#missing_labels[@]}" -eq 0 ]; then
+            labels_block="All expected labels exist."
+          else
+            gaps_found=true
+            labels_block="Missing labels. Run the **Sync Labels** workflow once (Actions -> Sync Labels -> Run workflow) to bootstrap from \`.github/labels.yml\`:"$'\n'
+            for label in "${missing_labels[@]}"; do
+              labels_block+="- [ ] \`$label\`"$'\n'
+            done
+          fi
+        else
+          labels_block="_Could not enumerate labels (token lacks permission). Skipped._"
+        fi
+
+        # ── Branch protection on main ─────────────────────────────
+        bp_block=""
+        bp_gaps=()
+        if bp_json=$(gh api "repos/$GH_REPO/branches/main/protection" 2>/dev/null); then
+          if ! jq -e '.required_signatures.enabled == true' <<<"$bp_json" >/dev/null; then
+            bp_gaps+=("Required **signed commits** is not enabled. Enable at Settings -> Branches -> Branch protection rules -> main -> 'Require signed commits'.")
+          fi
+          if ! jq -e '.required_status_checks.strict == true' <<<"$bp_json" >/dev/null; then
+            bp_gaps+=("Required status checks **strict policy** is off. Enable 'Require branches to be up to date before merging'.")
+          fi
+          if ! jq -e '[.required_status_checks.contexts[]?] | index("CI Pass") != null' <<<"$bp_json" >/dev/null; then
+            bp_gaps+=("Required status check context \`CI Pass\` is not configured. Add it under 'Status checks that are required'.")
+          fi
+        else
+          bp_gaps+=("No branch protection rule on \`main\`. Create one at Settings -> Branches -> Add rule.")
+        fi
+        default_branch=$(gh api "repos/$GH_REPO" --jq '.default_branch' 2>/dev/null || echo "")
+        if [ "$default_branch" != "main" ] && [ -n "$default_branch" ]; then
+          bp_gaps+=("Default branch is \`$default_branch\`, not \`main\`. Workflows assume \`main\`. Rename or update workflows.")
+        fi
+        if [ "${#bp_gaps[@]}" -eq 0 ]; then
+          bp_block="Branch protection on \`main\` matches expectations."
+        else
+          gaps_found=true
+          bp_block=""
+          for gap in "${bp_gaps[@]}"; do
+            bp_block+="- [ ] $gap"$'\n'
+          done
+        fi
+
+        # ── Render the body from the template ────────────────────
+        # GitHub App installation is described in the body's `release`
+        # secrets section but not directly checked: the `repos/X/installation`
+        # endpoint requires App-JWT auth, not the workflow's GITHUB_TOKEN,
+        # so a check from here would 404 even on a correctly-installed App.
+        body=$(cat "$TEMPLATE_PATH")
+        body="${body//\{\{ENVIRONMENTS_BLOCK\}\}/$envs_block}"
+        body="${body//\{\{LABELS_BLOCK\}\}/$labels_block}"
+        body="${body//\{\{BRANCH_PROTECTION_BLOCK\}\}/$bp_block}"
+
+        # ── Emit outputs ─────────────────────────────────────────
+        echo "gaps-found=$gaps_found" >> "$GITHUB_OUTPUT"
+        {
+          echo "body<<PREFLIGHT_BODY_EOF"
+          printf '%s\n' "$body"
+          echo "PREFLIGHT_BODY_EOF"
+        } >> "$GITHUB_OUTPUT"
+
+        echo "::group::Preflight result"
+        echo "gaps-found=$gaps_found"
+        printf '%s\n' "$body"
+        echo "::endgroup::"

--- a/.github/actions/ci-preflight-check/checklist.md.tmpl
+++ b/.github/actions/ci-preflight-check/checklist.md.tmpl
@@ -1,63 +1,41 @@
-CI in this repository is incomplete. The `ci-preflight` job detected one or more setup items missing. Follow the checklist below to make the release / automation workflows able to run.
+# CI Setup Tracking Issue
 
-This issue is auto-managed by `.github/workflows/ci-preflight.yml`. It will update automatically as you fix each item, and close itself with a comment once every check passes.
-
-For background, see [`docs/guides/fork-setup.md`](../blob/HEAD/docs/guides/fork-setup.md) which walks through each item end-to-end.
+This issue is auto-managed by [`ci-preflight.yml`](../blob/HEAD/.github/workflows/ci-preflight.yml). It refreshes on every push, opens when something blocking is missing, and closes itself with a `Preflight passed` comment once every blocking check passes. See the [Fork Setup Guide](../blob/HEAD/docs/guides/fork-setup.md) for the long-form walkthrough.
 
 ---
 
-## Missing GitHub environments
+## Overview
+
+{{OVERVIEW_TABLE}}
+
+{{STATUS_LINE}}
+
+---
+
+## GitHub environments
 
 {{ENVIRONMENTS_BLOCK}}
 
-## Missing labels
+---
+
+## Labels
 
 {{LABELS_BLOCK}}
 
-## Branch protection gaps on `main`
+---
+
+## Branch protection on `main` _(informational only)_
 
 {{BRANCH_PROTECTION_BLOCK}}
 
-## Required secrets per environment
-
-The preflight cannot verify environment-scoped secrets directly without running inside each environment. Once you have created the environments above, populate them with the following secrets. Every check that depends on a secret will surface as a real run failure later -- this section is informational.
-
-### `atlas`
-- `ATLAS_TOKEN` -- Atlas Cloud API token for schema validation. Get one at https://atlasgo.cloud/. Free tier covers a single project. Used by `ci.yml` schema-validate.
-
-### `release` (and `release-tags` shares the same App)
-- `RELEASE_BOT_APP_CLIENT_ID` -- GitHub App **Client ID** for your release bot.
-- `RELEASE_BOT_APP_PRIVATE_KEY` -- the App's private key (full PEM contents, including `-----BEGIN ... PRIVATE KEY-----` headers).
-
-To create the release bot App:
-
-1. Go to https://github.com/settings/apps/new (for a personal-account App) or your organization's "Developer settings -> GitHub Apps -> New GitHub App" (for an org App).
-2. **Name**: anything (e.g. `myorg-release-bot`). Webhook: uncheck "Active" (no webhook needed).
-3. **Repository permissions** the App needs:
-   - Contents: **Read & write** (mint signed commits + push tags).
-   - Pull requests: **Read & write** (open release PRs).
-   - Metadata: **Read** (always required).
-4. **Install** the App on this repository (after creation, "Install App" tab).
-5. Generate a private key under "Private keys -> Generate private key" and save the PEM file.
-6. Copy the App's **Client ID** (top of the App settings page) and the PEM contents into the `release` environment as the two secrets above.
-
-The minted token is what mints signed bot commits on protected `main` and bypasses the GITHUB_TOKEN anti-recursion rule for tag-triggered downstream workflows. Without it, `release.yml`, `dev-release.yml`, `auto-rollover.yml`, `graduate.yml` and `test-signing.yml` skip cleanly (they are already gated on `!github.event.repository.fork`).
-
-### `cloudflare-preview` (optional -- only if you want PR docs previews)
-- `CLOUDFLARE_API_TOKEN` -- Pages-deploy-scoped API token from https://dash.cloudflare.com/profile/api-tokens.
-- `CLOUDFLARE_ACCOUNT_ID` -- account ID from the Cloudflare dashboard sidebar.
-
-`pages-preview.yml` is the only consumer; if you do not need PR previews, you can leave `cloudflare-preview` empty and the workflow will skip its deploy step.
-
-### `apko-lock` (optional -- only if you want scheduled Wolfi base-image lock updates)
-No secrets required; the workflow uses `${{ github.token }}`. The environment exists for branch-policy gating.
-
-### `image-push` (optional -- only if you want to publish container images to GHCR)
-No secrets required; uses the auto-provided `github.token` against your fork's GHCR namespace. The environment exists for branch-policy gating.
-
-### `github-pages` (required for the docs site)
-No secrets required; the GitHub-managed Pages deployment uses the workflow token. The environment exists for branch-policy gating on the `main`-only Pages publish path. See `pages.yml`.
+> Branch protection cannot be queried by the workflow's default `GITHUB_TOKEN` (the `administration: read` scope is not grantable to the auto-provided token). This section reports what can be inferred and never opens or closes this issue. Configure the items above manually following [Fork Setup Guide section 5](../blob/HEAD/docs/guides/fork-setup.md).
 
 ---
 
-Once every box above is checked, the next push or workflow_dispatch run of `ci-preflight` will close this issue with a confirmation comment.
+## Setup instructions for missing environments
+
+{{SETUP_BLOCK}}
+
+---
+
+Once every blocking item is resolved, the next preflight run will close this issue with a confirmation comment. Re-runs are non-destructive: the body is regenerated from current state on every preflight run, so checking items off in the GitHub UI is purely cosmetic -- the source of truth is what the next run discovers.

--- a/.github/actions/ci-preflight-check/checklist.md.tmpl
+++ b/.github/actions/ci-preflight-check/checklist.md.tmpl
@@ -1,0 +1,60 @@
+CI in this repository is incomplete. The `ci-preflight` job detected one or more setup items missing. Follow the checklist below to make the release / automation workflows able to run.
+
+This issue is auto-managed by `.github/workflows/ci-preflight.yml`. It will update automatically as you fix each item, and close itself with a comment once every check passes.
+
+For background, see [`docs/contributing/fork-setup.md`](../blob/HEAD/docs/contributing/fork-setup.md) which walks through each item end-to-end.
+
+---
+
+## Missing GitHub environments
+
+{{ENVIRONMENTS_BLOCK}}
+
+## Missing labels
+
+{{LABELS_BLOCK}}
+
+## Branch protection gaps on `main`
+
+{{BRANCH_PROTECTION_BLOCK}}
+
+## Required secrets per environment
+
+The preflight cannot verify environment-scoped secrets directly without running inside each environment. Once you have created the environments above, populate them with the following secrets. Every check that depends on a secret will surface as a real run failure later -- this section is informational.
+
+### `atlas`
+- `ATLAS_TOKEN` -- Atlas Cloud API token for schema validation. Get one at https://atlasgo.cloud/. Free tier covers a single project. Used by `ci.yml` schema-validate.
+
+### `release` (and `release-tags` shares the same App)
+- `RELEASE_BOT_APP_CLIENT_ID` -- GitHub App **Client ID** for your release bot.
+- `RELEASE_BOT_APP_PRIVATE_KEY` -- the App's private key (full PEM contents, including `-----BEGIN ... PRIVATE KEY-----` headers).
+
+To create the release bot App:
+
+1. Go to https://github.com/settings/apps/new (for a personal-account App) or your organization's "Developer settings -> GitHub Apps -> New GitHub App" (for an org App).
+2. **Name**: anything (e.g. `myorg-release-bot`). Webhook: uncheck "Active" (no webhook needed).
+3. **Repository permissions** the App needs:
+   - Contents: **Read & write** (mint signed commits + push tags).
+   - Pull requests: **Read & write** (open release PRs).
+   - Metadata: **Read** (always required).
+4. **Install** the App on this repository (after creation, "Install App" tab).
+5. Generate a private key under "Private keys -> Generate private key" and save the PEM file.
+6. Copy the App's **Client ID** (top of the App settings page) and the PEM contents into the `release` environment as the two secrets above.
+
+The minted token is what mints signed bot commits on protected `main` and bypasses the GITHUB_TOKEN anti-recursion rule for tag-triggered downstream workflows. Without it, `release.yml`, `dev-release.yml`, `auto-rollover.yml`, `graduate.yml` and `test-signing.yml` skip cleanly (they are already gated on `!github.event.repository.fork`).
+
+### `cloudflare-preview` (optional -- only if you want PR docs previews)
+- `CLOUDFLARE_API_TOKEN` -- Pages-deploy-scoped API token from https://dash.cloudflare.com/profile/api-tokens.
+- `CLOUDFLARE_ACCOUNT_ID` -- account ID from the Cloudflare dashboard sidebar.
+
+`pages-preview.yml` is the only consumer; if you do not need PR previews, you can leave `cloudflare-preview` empty and the workflow will skip its deploy step.
+
+### `apko-lock` (optional -- only if you want scheduled Wolfi base-image lock updates)
+No secrets required; the workflow uses `${{ github.token }}`. The environment exists for branch-policy gating.
+
+### `image-push` (optional -- only if you want to publish container images to GHCR)
+No secrets required; uses the auto-provided `${{ github.token }}` against your fork's GHCR namespace. The environment exists for branch-policy gating.
+
+---
+
+Once every box above is checked, the next push or workflow_dispatch run of `ci-preflight` will close this issue with a confirmation comment.

--- a/.github/actions/ci-preflight-check/checklist.md.tmpl
+++ b/.github/actions/ci-preflight-check/checklist.md.tmpl
@@ -53,7 +53,10 @@ The minted token is what mints signed bot commits on protected `main` and bypass
 No secrets required; the workflow uses `${{ github.token }}`. The environment exists for branch-policy gating.
 
 ### `image-push` (optional -- only if you want to publish container images to GHCR)
-No secrets required; uses the auto-provided `${{ github.token }}` against your fork's GHCR namespace. The environment exists for branch-policy gating.
+No secrets required; uses the auto-provided `github.token` against your fork's GHCR namespace. The environment exists for branch-policy gating.
+
+### `github-pages` (required for the docs site)
+No secrets required; the GitHub-managed Pages deployment uses the workflow token. The environment exists for branch-policy gating on the `main`-only Pages publish path. See `pages.yml`.
 
 ---
 

--- a/.github/actions/ci-preflight-check/checklist.md.tmpl
+++ b/.github/actions/ci-preflight-check/checklist.md.tmpl
@@ -2,7 +2,7 @@ CI in this repository is incomplete. The `ci-preflight` job detected one or more
 
 This issue is auto-managed by `.github/workflows/ci-preflight.yml`. It will update automatically as you fix each item, and close itself with a comment once every check passes.
 
-For background, see [`docs/contributing/fork-setup.md`](../blob/HEAD/docs/contributing/fork-setup.md) which walks through each item end-to-end.
+For background, see [`docs/guides/fork-setup.md`](../blob/HEAD/docs/guides/fork-setup.md) which walks through each item end-to-end.
 
 ---
 

--- a/.github/actions/post-tracking-issue/action.yml
+++ b/.github/actions/post-tracking-issue/action.yml
@@ -8,17 +8,21 @@ description: |
   Behaviour:
     1. Search open issues by title alone (no label filter) so issues
        created via the label-less fallback below remain discoverable
-       and the next failure comments on them instead of opening a
+       and the next failure updates them instead of opening a
        duplicate tracker.
-    2. If a match is found -> append a comment with the supplied body.
+    2. If a match is found -> edit the body in place. The body is
+       authoritative state, so an edit avoids accumulating stale
+       snapshots in the comment chain.
     3. Otherwise -> create a new issue with the supplied labels. If the
        labelled create fails (e.g., a referenced label has been deleted
        from the repo), retry without labels and emit a workflow
        warning so the missing-label condition surfaces in the run UI.
-    4. If `pin: true` (default), best-effort pin the issue. Pin
-       failures (3-issue cap, race, permissions) emit a warning but do
-       NOT fail the action -- the comment / create above is the
-       primary signal.
+    4. If `pin: true` (default), best-effort pin the issue via the
+       GraphQL `pinIssue` mutation (GitHub never shipped a REST
+       endpoint for this). Pin failures (3-issue cap, race, "already
+       pinned", permissions) emit a warning with the actual GraphQL
+       error message but do NOT fail the action -- the create / edit
+       above is the primary signal.
 
   Caller contract:
     - The job invoking this action must declare `permissions:
@@ -42,23 +46,29 @@ inputs:
       labels so dedup works even if a label gets deleted.
     required: true
   body:
-    description: 'Issue body (on create) / comment body (on update). Markdown.'
+    description: 'Markdown body. On a fresh issue this is the initial body. On an existing match it overwrites the body in place.'
     required: true
   pin:
-    description: 'Pin the issue after create / comment. Best-effort -- failures degrade to a warning. default: true'
+    description: 'Pin the issue after create / edit. Best-effort -- failures degrade to a warning. default: true'
     required: false
     default: 'true'
   gh-token:
     description: >-
       GitHub token with `issues: write` scope on the workflow's own
       repository. The workflow's default github.token is sufficient
-      for every current caller. The action is single-repo: it always
+      for callers running on push, schedule, workflow_dispatch, or
+      same-repo pull_request events. It is NOT sufficient for
+      pull_request events whose head ref lives in a forked
+      repository -- GitHub silently downgrades GITHUB_TOKEN to
+      read-only for those runs regardless of what the workflow
+      declares under `permissions:`, and any issue-write call here
+      will 403. Callers that may run from fork PRs must gate this
+      step on `github.event.pull_request.head.repo.full_name ==
+      github.repository`. The action is single-repo: it always
       targets the calling workflow's github.repository for both
       issue lookup/create and pinning, which means it correctly
-      self-targets a fork when the workflow runs in a fork. To open
-      a tracking issue in a *different* repo, the action would need
-      a `repository` input plumbed through both `GH_REPO` and the
-      pin URL -- out of scope until a real cross-repo caller appears.
+      self-targets a fork when the workflow runs in the fork itself
+      (push events from the fork's own collaborators).
     required: true
 
 runs:
@@ -111,14 +121,20 @@ runs:
           ISSUE_NUMBER="${ISSUE_URL##*/}"
           echo "Created tracking issue #$ISSUE_NUMBER"
         else
-          gh issue comment "$ISSUE_NUMBER" --body "$BODY"
-          echo "Commented on tracking issue #$ISSUE_NUMBER"
+          # Edit the body in place rather than appending a comment.
+          # The body is regenerated from current state on every
+          # preflight run, so a comment chain would just accumulate
+          # stale snapshots of past gaps and pollute the issue feed.
+          # An edit keeps the issue clean: title is the dedup key,
+          # body always reflects current state.
+          gh issue edit "$ISSUE_NUMBER" --body "$BODY"
+          echo "Updated tracking issue #$ISSUE_NUMBER"
         fi
 
         if [ "$PIN" = "true" ]; then
           # Best-effort pin. A repo can hold at most 3 pinned issues;
           # quota / race / permission failures degrade to a warning so
-          # the comment / create above remains the primary signal.
+          # the create / edit above remains the primary signal.
           #
           # GitHub never shipped a REST endpoint for pinning -- the
           # `PUT /repos/.../issues/.../pin` URL the prior version used

--- a/.github/actions/post-tracking-issue/action.yml
+++ b/.github/actions/post-tracking-issue/action.yml
@@ -119,11 +119,53 @@ runs:
           # Best-effort pin. A repo can hold at most 3 pinned issues;
           # quota / race / permission failures degrade to a warning so
           # the comment / create above remains the primary signal.
-          if ! gh api --method PUT \
-              "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/pin" \
-              --silent 2>/dev/null; then
-            echo "::warning::could not pin tracking issue #$ISSUE_NUMBER (quota / race / permission)"
+          #
+          # GitHub never shipped a REST endpoint for pinning -- the
+          # `PUT /repos/.../issues/.../pin` URL the prior version used
+          # always returned 404, silently swallowed by `2>/dev/null`.
+          # The supported path is the GraphQL `pinIssue` mutation,
+          # which takes the issue's node ID. Resolve the node ID via
+          # GraphQL (the workflow's GITHUB_TOKEN has the necessary
+          # repository read scope), then fire the mutation and surface
+          # the actual error message on failure instead of guessing.
+          OWNER="${GITHUB_REPOSITORY%%/*}"
+          REPO_NAME="${GITHUB_REPOSITORY##*/}"
+          ISSUE_NODE_ID=$(gh api graphql \
+            -f query='query($owner: String!, $repo: String!, $number: Int!) {
+              repository(owner: $owner, name: $repo) {
+                issue(number: $number) { id }
+              }
+            }' \
+            -f owner="$OWNER" \
+            -f repo="$REPO_NAME" \
+            -F number="$ISSUE_NUMBER" \
+            --jq '.data.repository.issue.id' 2>/dev/null) || ISSUE_NODE_ID=""
+
+          if [ -z "$ISSUE_NODE_ID" ]; then
+            echo "::warning::could not resolve issue #$ISSUE_NUMBER node ID for pinning"
           else
-            echo "Pinned tracking issue #$ISSUE_NUMBER"
+            PIN_RESPONSE=$(gh api graphql \
+              -f query='mutation($id: ID!) {
+                pinIssue(input: {issueId: $id}) {
+                  issue { number }
+                }
+              }' \
+              -f id="$ISSUE_NODE_ID" 2>&1) || true
+
+            if printf '%s' "$PIN_RESPONSE" | grep -q '"errors"'; then
+              # GraphQL returns 200 with an `errors` array on
+              # business-rule failures (3-pin quota, race conditions,
+              # permission denied). Extract the first error message.
+              PIN_ERROR=$(printf '%s' "$PIN_RESPONSE" | jq -r '.errors[0].message // "unknown error"' 2>/dev/null || echo "unknown error")
+              echo "::warning::could not pin tracking issue #$ISSUE_NUMBER: $PIN_ERROR"
+            elif printf '%s' "$PIN_RESPONSE" | grep -q '"pinIssue"'; then
+              echo "Pinned tracking issue #$ISSUE_NUMBER"
+            else
+              # Network / auth failure -- gh api itself returned
+              # something that is not a recognisable GraphQL response.
+              # Trim to the first 200 chars to keep workflow logs clean.
+              PIN_ERROR=$(printf '%s' "$PIN_RESPONSE" | head -c 200)
+              echo "::warning::could not pin tracking issue #$ISSUE_NUMBER: $PIN_ERROR"
+            fi
           fi
         fi

--- a/.github/actions/post-tracking-issue/action.yml
+++ b/.github/actions/post-tracking-issue/action.yml
@@ -48,10 +48,15 @@ inputs:
     default: 'true'
   gh-token:
     description: |
-      GitHub token with `issues: write` scope. The default
-      `${{ github.token }}` works for repo-internal workflows; pass an
-      App installation token if write-on-fork or cross-repo behaviour
-      is needed.
+      GitHub token with `issues: write` scope on the workflow's own
+      repository. The default `${{ github.token }}` is sufficient for
+      every current caller. The action is single-repo: it always
+      targets `${{ github.repository }}` for both issue lookup/create
+      and pinning, which means it correctly self-targets a fork when
+      the workflow runs in a fork. To open a tracking issue in a
+      *different* repo, the action would need a `repository` input
+      plumbed through both `GH_REPO` and the pin URL -- out of scope
+      until a real cross-repo caller appears.
     required: true
 
 runs:

--- a/.github/actions/post-tracking-issue/action.yml
+++ b/.github/actions/post-tracking-issue/action.yml
@@ -23,8 +23,10 @@ description: |
   Caller contract:
     - The job invoking this action must declare `permissions:
       issues: write`.
-    - `gh-token` is a passthrough for `GH_TOKEN`; pass
-      `${{ github.token }}` unless a higher-permission token is needed.
+    - `gh-token` is a passthrough for `GH_TOKEN`; pass the workflow's
+      `github.token` (referenced as the GitHub Actions expression
+      `github.token` in the caller's YAML) unless a higher-permission
+      token is needed.
 
 inputs:
   title:
@@ -47,16 +49,16 @@ inputs:
     required: false
     default: 'true'
   gh-token:
-    description: |
+    description: >-
       GitHub token with `issues: write` scope on the workflow's own
-      repository. The default `${{ github.token }}` is sufficient for
-      every current caller. The action is single-repo: it always
-      targets `${{ github.repository }}` for both issue lookup/create
-      and pinning, which means it correctly self-targets a fork when
-      the workflow runs in a fork. To open a tracking issue in a
-      *different* repo, the action would need a `repository` input
-      plumbed through both `GH_REPO` and the pin URL -- out of scope
-      until a real cross-repo caller appears.
+      repository. The workflow's default github.token is sufficient
+      for every current caller. The action is single-repo: it always
+      targets the calling workflow's github.repository for both
+      issue lookup/create and pinning, which means it correctly
+      self-targets a fork when the workflow runs in a fork. To open
+      a tracking issue in a *different* repo, the action would need
+      a `repository` input plumbed through both `GH_REPO` and the
+      pin URL -- out of scope until a real cross-repo caller appears.
     required: true
 
 runs:

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,45 @@
+# Labels assumed by GitHub Actions workflows in this repo.
+#
+# This file is the source of truth for *workflow-asserted* labels only --
+# labels that the CI/automation surface relies on existing. Human-applied
+# labels (type:*, prio:*, spec:*, scope:*) are managed via the GitHub UI
+# and are not synced from here.
+#
+# Synced by .github/workflows/sync-labels.yml on push to main when this
+# file changes, plus manual workflow_dispatch. Forks should run the
+# manual dispatch once after creation to bootstrap the label set.
+#
+# The sync uses EndBug/label-sync with delete: false, so labels not
+# listed here are left untouched.
+
+- name: automation:ci-health
+  color: B60205
+  description: CI / scheduled-job health regression
+
+- name: automation:ci-preflight
+  color: B60205
+  description: Fork / repo-setup preflight tracker (created by ci-preflight workflow)
+
+- name: automation:release-events
+  color: B60205
+  description: Release pipeline events log + signing / health regressions
+
+- name: type:ci
+  color: 5319e7
+  description: CI / build / release tooling
+
+- name: prio:low
+  color: c2e0c6
+  description: Nice to have, can defer
+
+- name: prio:medium
+  color: fbca04
+  description: Should do, but not blocking
+
+- name: prio:high
+  color: d93f0b
+  description: Important, should be prioritized
+
+- name: "autorelease: pending"
+  color: ededed
+  description: Release-please pending-release marker

--- a/.github/workflows/apko-lock.yml
+++ b/.github/workflows/apko-lock.yml
@@ -66,7 +66,16 @@ jobs:
             dependencies
             type:ci
             scope:docker
-          reviewers: ${{ github.repository_owner }}
+          # peter-evans/create-pull-request' `reviewers` input only
+          # accepts user logins; passing an org name produces a 422
+          # "Could not resolve to a node" from GitHub's review-request
+          # API. Gate on owner.type == 'User' so an org-owned fork
+          # falls back to no reviewer assignment (the PR still opens,
+          # just without an automatic reviewer). User-owned repos --
+          # including the upstream `Aureliolo/synthorg` -- keep the
+          # existing behaviour. To request review from a team in an
+          # org-owned fork, change to `team-reviewers: <team-slug>` here.
+          reviewers: ${{ github.event.repository.owner.type == 'User' && github.repository_owner || '' }}
 
   report-failure:
     name: Open / update tracking issue on schedule failure

--- a/.github/workflows/apko-lock.yml
+++ b/.github/workflows/apko-lock.yml
@@ -66,7 +66,7 @@ jobs:
             dependencies
             type:ci
             scope:docker
-          reviewers: Aureliolo
+          reviewers: ${{ github.repository_owner }}
 
   report-failure:
     name: Open / update tracking issue on schedule failure

--- a/.github/workflows/auto-rollover.yml
+++ b/.github/workflows/auto-rollover.yml
@@ -21,8 +21,10 @@ jobs:
     name: Check Rollover
     # Skip on Release Please release commits and on commits that already
     # carry a Release-As trailer (including our own rollover commits).
+    # Skip in forks -- needs the upstream-only release-bot App token.
     if: >-
-      !startsWith(github.event.head_commit.message, 'chore(main): release')
+      !github.event.repository.fork
+      && !startsWith(github.event.head_commit.message, 'chore(main): release')
       && !contains(github.event.head_commit.message, 'Release-As:')
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/ci-preflight.yml
+++ b/.github/workflows/ci-preflight.yml
@@ -1,0 +1,92 @@
+name: CI Preflight
+
+# Detect missing repository setup (environments, labels, branch protection,
+# GitHub App installation) and surface it as a single tracking issue. Runs
+# in parallel with the rest of CI on every push and pull request, plus
+# manual dispatch. Hybrid blocking: warns on PR / non-main pushes, fails
+# the job on push to main so upstream stays loud about drift.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ci-preflight-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preflight:
+    name: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run preflight checks
+        id: check
+        uses: ./.github/actions/ci-preflight-check
+        with:
+          gh-token: ${{ github.token }}
+
+      - name: Open / update tracking issue
+        if: steps.check.outputs.gaps-found == 'true'
+        uses: ./.github/actions/post-tracking-issue
+        with:
+          title: "CI setup incomplete -- please configure the following"
+          labels: "automation:ci-preflight,type:ci,prio:high"
+          body: ${{ steps.check.outputs.body }}
+          pin: 'true'
+          gh-token: ${{ github.token }}
+
+      - name: Close tracking issue when all checks pass
+        if: steps.check.outputs.gaps-found == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PREFLIGHT_TITLE: "CI setup incomplete -- please configure the following"
+          COMMIT_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Search by title alone, same dedup key as post-tracking-issue.
+          # Use jq --arg so titles with shell metacharacters are safe.
+          ISSUE_NUMBER=$(gh issue list --state open \
+            --search "in:title \"$PREFLIGHT_TITLE\"" --json number,title \
+            | jq -r --arg title "$PREFLIGHT_TITLE" \
+              '[.[] | select(.title == $title)] | .[0].number // empty')
+
+          if [ -n "$ISSUE_NUMBER" ]; then
+            gh issue comment "$ISSUE_NUMBER" \
+              --body "Preflight passed at \`$COMMIT_SHA\`. Closing -- this issue will reopen automatically if a check regresses."
+            gh issue close "$ISSUE_NUMBER"
+            echo "Closed tracking issue #$ISSUE_NUMBER"
+          else
+            echo "No open preflight tracking issue to close."
+          fi
+
+      - name: Fail on push to main when gaps remain
+        if: >-
+          steps.check.outputs.gaps-found == 'true'
+          && github.event_name == 'push'
+          && github.ref == 'refs/heads/main'
+        shell: bash
+        run: |
+          echo "::error::CI setup gaps detected on a push to main. See the open tracking issue for the checklist."
+          exit 1
+
+      - name: Warn on non-main when gaps remain
+        if: >-
+          steps.check.outputs.gaps-found == 'true'
+          && (github.event_name != 'push' || github.ref != 'refs/heads/main')
+        shell: bash
+        run: |
+          echo "::warning::CI setup gaps detected. See the open tracking issue for the checklist. (Non-blocking on this trigger; this job blocks on push to main.)"

--- a/.github/workflows/ci-preflight.yml
+++ b/.github/workflows/ci-preflight.yml
@@ -37,8 +37,20 @@ jobs:
         with:
           gh-token: ${{ github.token }}
 
+      # Skip the issue-write paths on pull_request runs whose head
+      # branch lives in a forked repository. GitHub silently downgrades
+      # GITHUB_TOKEN to read-only for those runs regardless of what
+      # the workflow declares under `permissions:`, so any write API
+      # call would 403. Posting the tracking issue is also unhelpful
+      # in that context: the audit ran in upstream's repo, not the
+      # fork, and upstream is already configured. The fork's own runs
+      # (when the fork user pushes to their own fork) have full write
+      # perms and post normally.
       - name: Open / update tracking issue
-        if: steps.check.outputs.gaps-found == 'true'
+        if: >-
+          steps.check.outputs.gaps-found == 'true'
+          && (github.event_name != 'pull_request'
+              || github.event.pull_request.head.repo.full_name == github.repository)
         uses: ./.github/actions/post-tracking-issue
         with:
           title: "CI setup incomplete -- please configure the following"
@@ -48,7 +60,10 @@ jobs:
           gh-token: ${{ github.token }}
 
       - name: Close tracking issue when all checks pass
-        if: steps.check.outputs.gaps-found == 'false'
+        if: >-
+          steps.check.outputs.gaps-found == 'false'
+          && (github.event_name != 'pull_request'
+              || github.event.pull_request.head.repo.full_name == github.repository)
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -617,6 +617,10 @@ jobs:
     # Fork gate: skip in forks. The audit needs the release-bot App
     # token (env-scoped secret on `release`) and a fork won't have it.
     # ci-preflight reports the missing setup separately.
+    #
+    # Precedence: `&&` binds tighter than `||`, so the inner
+    # parentheses around `(push && main || dispatch)` are required
+    # to keep the trigger-OR group intact under the outer fork-AND.
     if: >-
       !github.event.repository.fork
       && ((github.event_name == 'push' && github.ref == 'refs/heads/main')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,9 +613,14 @@ jobs:
     # The ``release`` environment's branch policy still restricts both
     # paths to main -- a workflow_dispatch from a feature branch is
     # blocked at the environment gate, not by the if: check.
+    #
+    # Fork gate: skip in forks. The audit needs the release-bot App
+    # token (env-scoped secret on `release`) and a fork won't have it.
+    # ci-preflight reports the missing setup separately.
     if: >-
-      (github.event_name == 'push' && github.ref == 'refs/heads/main')
-      || github.event_name == 'workflow_dispatch'
+      !github.event.repository.fork
+      && ((github.event_name == 'push' && github.ref == 'refs/heads/main')
+          || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -21,9 +21,12 @@ jobs:
     name: Create Dev Pre-Release
     # Skip Release Please version-bump merges and tag pushes (handled by
     # the stable release pipeline). Also skip if a v* tag already points
-    # at this commit (the stable release just landed).
+    # at this commit (the stable release just landed). Skip in forks --
+    # the release-bot App token isn't available off the upstream release
+    # environment.
     if: >-
-      !startsWith(github.event.head_commit.message, 'chore(main): release')
+      !github.event.repository.fork
+      && !startsWith(github.event.head_commit.message, 'chore(main): release')
       && !contains(github.event.head_commit.message, 'Release-As:')
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/graduate.yml
+++ b/.github/workflows/graduate.yml
@@ -31,6 +31,12 @@ concurrency:
 jobs:
   graduate:
     name: Graduate to target version
+    # Fork gate: needs the upstream-only release-bot App token to mint
+    # the signed Release-As commit. The workflow_dispatch surface is
+    # also gated to the repo owner via repository_owner check.
+    if: >-
+      !github.event.repository.fork
+      && github.actor == github.repository_owner
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ permissions: {}
 jobs:
   release-please:
     name: Release Please
+    # Fork gate: release-please needs the synthorg-release-bot App token
+    # to mint signed commits + bypass GITHUB_TOKEN's anti-recursion rule.
+    # Forks don't have those env-scoped secrets; skip cleanly.
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,48 @@
+name: Sync Labels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/labels.yml
+      - .github/workflows/sync-labels.yml
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  sync:
+    name: sync
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Sync labels from .github/labels.yml
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # `yq -o=j -I=0 '.[]'` emits one compact JSON object per label so a
+          # while-read loop can iterate them. `gh label create --force` is
+          # upsert: it creates if missing and updates color/description if
+          # the label already exists. We never delete labels here -- humans
+          # may have added repo-specific ones we shouldn't touch.
+          yq -o=j -I=0 '.[]' .github/labels.yml | while IFS= read -r label_json; do
+            name=$(printf '%s' "$label_json" | jq -r '.name')
+            color=$(printf '%s' "$label_json" | jq -r '.color')
+            description=$(printf '%s' "$label_json" | jq -r '.description // ""')
+
+            echo "::group::sync $name"
+            gh label create "$name" \
+              --color "$color" \
+              --description "$description" \
+              --force
+            echo "::endgroup::"
+          done

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,6 +15,10 @@ jobs:
     name: sync
     runs-on: ubuntu-latest
     permissions:
+      # `issues: write` is the GitHub-side scope that covers
+      # `gh label create / edit / delete` on the repository.
+      # No `contents: write` is needed because we only mutate
+      # label metadata, not files.
       issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test-highlights.yml
+++ b/.github/workflows/test-highlights.yml
@@ -9,8 +9,10 @@ name: Test Highlights (dry-run)
 #
 # Scope discipline:
 #   - workflow_dispatch only (no schedule, no push, no PR trigger).
-#   - Gated to ``github.actor == 'Aureliolo'`` so additional
-#     collaborators with ``write`` access cannot invoke it.
+#   - Gated to ``github.actor == github.repository_owner`` so additional
+#     collaborators with ``write`` access cannot invoke it. Also makes
+#     the workflow fork-friendly: it skips silently in any fork whose
+#     owner isn't the user dispatching it.
 #   - Declares only ``models: read`` + ``contents: read`` -- no
 #     ``pull-requests: write`` and no App token, so it cannot mutate
 #     any repo state even if a bug or malicious input tried to.
@@ -43,7 +45,7 @@ jobs:
     # ``write`` access, but the extra explicit check forbids every
     # collaborator except the owner. Keeps the Copilot Pro quota under a
     # single, auditable trigger surface.
-    if: github.actor == 'Aureliolo'
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/test-signing.yml
+++ b/.github/workflows/test-signing.yml
@@ -27,6 +27,9 @@ concurrency:
 jobs:
   rp-release-commit-signature:
     name: RP release commit signature
+    # Fork gate: every job in this workflow mints the upstream-only
+    # release-bot App token. Skip cleanly in forks.
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: release
@@ -116,6 +119,9 @@ jobs:
 
   dev-release-tag-signature:
     name: Dev release tag signature
+    # Fork gate: every job in this workflow mints the upstream-only
+    # release-bot App token. Skip cleanly in forks.
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: release
@@ -192,6 +198,9 @@ jobs:
 
   auto-rollover-commit-signature:
     name: Auto-rollover commit signature (dry-run)
+    # Fork gate: every job in this workflow mints the upstream-only
+    # release-bot App token. Skip cleanly in forks.
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: release

--- a/.github/workflows/test-signing.yml
+++ b/.github/workflows/test-signing.yml
@@ -267,12 +267,20 @@ jobs:
     # Only the schedule path gets the issue sink. Manual `workflow_dispatch`
     # failures from a debugging branch shouldn't open repo-wide CI-health
     # issues; the operator already sees the run output directly.
+    #
+    # Skip in forks: signer jobs are gated on `!github.event.repository.fork`
+    # and resolve to `skipped` in forks. The condition below uses
+    # `== 'failure'` (rather than `!= 'success'`) so `skipped` does not
+    # masquerade as a regression and open a false tracking issue. The
+    # explicit fork gate is belt-and-braces -- redundant with the result
+    # check, but keeps the intent obvious.
     if: >-
       always()
+      && !github.event.repository.fork
       && github.event_name == 'schedule'
-      && (needs.rp-release-commit-signature.result != 'success'
-          || needs.dev-release-tag-signature.result != 'success'
-          || needs.auto-rollover-commit-signature.result != 'success')
+      && (needs.rp-release-commit-signature.result == 'failure'
+          || needs.dev-release-tag-signature.result == 'failure'
+          || needs.auto-rollover-commit-signature.result == 'failure')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ SynthOrg vs [44 agent frameworks](https://synthorg.io/compare/) across 14 dimens
 | [Roadmap](https://synthorg.io/docs/roadmap/) | Current status, open questions, future vision |
 
 > **Contributors:** Start with the [Design Specification](https://synthorg.io/docs/design/) before implementing any feature. See [`DESIGN_SPEC.md`](docs/DESIGN_SPEC.md) for the full design set.
+>
+> **Forking?** CI runs out of the box for code changes; the release pipeline needs setup (environments, labels, branch protection, a release-bot GitHub App). On your first push, the **CI Preflight** workflow opens a tracking issue listing exactly what is missing -- see [Fork Setup](https://synthorg.io/docs/guides/fork-setup/) for the long-form walkthrough.
 
 ## License
 

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -242,4 +242,5 @@ uv run zensical serve                      # preview at http://127.0.0.1:8000
 ## See Also
 
 - [Developer Setup](../getting_started.md) -- environment setup
+- [Fork Setup](fork-setup.md) -- configure CI on a fresh fork (environments, labels, branch protection, release-bot App)
 - [CONTRIBUTING.md](https://github.com/Aureliolo/synthorg/blob/main/.github/CONTRIBUTING.md) -- formal contributing guidelines

--- a/docs/guides/fork-setup.md
+++ b/docs/guides/fork-setup.md
@@ -19,20 +19,23 @@ After this, the `Missing labels` section of the preflight tracking issue should 
 
 ## 2. Create the GitHub environments
 
-CI uses six GitHub environments for branch-policy gating and to scope secrets. Most are required only for specific workflows; create them all even if you do not yet need every workflow, so the preflight passes.
+CI uses seven GitHub environments for branch-policy gating and to scope secrets. The preflight job audits all of them unconditionally, so create every one even if your fork does not yet exercise the corresponding workflow -- a missing environment will keep the preflight tracking issue open.
 
 Create at **Settings -> Environments -> New environment**:
 
-| Environment | Used by | Required for fork? |
+| Environment | Used by | Required to pass CI Preflight? |
 |-------------|---------|---------------------|
-| `atlas` | `ci.yml` schema-validate | Yes -- gates schema migrations |
-| `release` | `release.yml`, `dev-release.yml`, `auto-rollover.yml`, `graduate.yml`, `test-signing.yml`, `finalize-release.yml` | Only if you cut releases |
-| `release-tags` | `cli.yml`, `docker.yml` (tag pushes) | Only if you cut releases |
-| `apko-lock` | `apko-lock.yml` (scheduled lockfile updates) | Optional |
-| `cloudflare-preview` | `pages-preview.yml` | Optional, for PR docs previews |
-| `image-push` | `docker.yml` image push paths | Only if you publish images |
+| `atlas` | `ci.yml` schema-validate | Yes |
+| `release` | `release.yml`, `dev-release.yml`, `auto-rollover.yml`, `graduate.yml`, `test-signing.yml`, `finalize-release.yml` | Yes |
+| `release-tags` | `cli.yml`, `docker.yml` (tag pushes) | Yes |
+| `apko-lock` | `apko-lock.yml` (scheduled lockfile updates) | Yes |
+| `cloudflare-preview` | `pages-preview.yml` | Yes |
+| `image-push` | `docker.yml` image push paths | Yes |
+| `github-pages` | `pages.yml` push to main | Yes |
 
-For `release` and `release-tags`, configure a deployment branch policy of `main` (and `v*` for `release-tags`) so secrets only unlock for the intended refs.
+For `release` and `release-tags`, configure a deployment branch policy of `main` (and `v*` for `release-tags`) so secrets only unlock for the intended refs. See [`docs/reference/github-environments.md`](../reference/github-environments.md) for the full branch-policy matrix.
+
+Workflow consumers of each environment fall into two camps: required for any release activity (`release`, `release-tags`, `image-push`, `apko-lock`, `github-pages`), and optional capabilities you can leave un-credentialed if your fork does not need them (`cloudflare-preview` for PR docs previews, `apko-lock` if you skip scheduled Wolfi lock updates). The environment must still exist for the preflight to pass; the secrets inside can be empty until you actually use the workflow.
 
 ## 3. Create the release-bot GitHub App
 

--- a/docs/guides/fork-setup.md
+++ b/docs/guides/fork-setup.md
@@ -1,0 +1,82 @@
+---
+title: Fork setup
+description: Configure CI on a fresh fork or clone -- environments, labels, branch protection, and the release-bot GitHub App.
+---
+
+# Fork setup
+
+If you have just forked or cloned this repository, the CI workflows will not run cleanly until you create a small set of GitHub-side artifacts: environments, labels, branch protection on `main`, and a GitHub App for the release pipeline. Push any commit to your fork (or open a pull request) and the **CI Preflight** workflow opens a tracking issue in your fork listing exactly what is missing -- this page is the long-form companion to that checklist.
+
+The preflight is non-blocking on pull requests and feature branches; it only fails the job on push to `main`. So the path of least resistance is: push, read the tracking issue, work through this page, push again, watch the issue auto-close.
+
+## 1. Sync labels
+
+CI workflows reference a fixed set of automation labels (`automation:ci-health`, `automation:ci-preflight`, `automation:release-events`, `type:ci`, `prio:low`, `prio:medium`, `prio:high`, and `autorelease: pending`). The source of truth is `.github/labels.yml`.
+
+Bootstrap once: **Actions -> Sync Labels -> Run workflow** on `main`. The workflow reads `.github/labels.yml` and creates or updates each label via `gh label create --force`. It never deletes labels, so any repo-specific labels you add are safe.
+
+After this, the `Missing labels` section of the preflight tracking issue should clear on the next preflight run.
+
+## 2. Create the GitHub environments
+
+CI uses six GitHub environments for branch-policy gating and to scope secrets. Most are required only for specific workflows; create them all even if you do not yet need every workflow, so the preflight passes.
+
+Create at **Settings -> Environments -> New environment**:
+
+| Environment | Used by | Required for fork? |
+|-------------|---------|---------------------|
+| `atlas` | `ci.yml` schema-validate | Yes -- gates schema migrations |
+| `release` | `release.yml`, `dev-release.yml`, `auto-rollover.yml`, `graduate.yml`, `test-signing.yml`, `finalize-release.yml` | Only if you cut releases |
+| `release-tags` | `cli.yml`, `docker.yml` (tag pushes) | Only if you cut releases |
+| `apko-lock` | `apko-lock.yml` (scheduled lockfile updates) | Optional |
+| `cloudflare-preview` | `pages-preview.yml` | Optional, for PR docs previews |
+| `image-push` | `docker.yml` image push paths | Only if you publish images |
+
+For `release` and `release-tags`, configure a deployment branch policy of `main` (and `v*` for `release-tags`) so secrets only unlock for the intended refs.
+
+## 3. Create the release-bot GitHub App
+
+Stable, dev, rollover, graduate, and signing workflows mint installation tokens from a GitHub App with the right repository permissions. Without it, every commit those workflows produce on `main` would be unsigned and rejected by branch protection. The App is the single piece of state that makes the release pipeline able to write to a protected `main`.
+
+Steps:
+
+1. Go to **Settings -> Developer settings -> GitHub Apps -> New GitHub App** (or `https://github.com/settings/apps/new` for a personal-account App).
+2. Name the App something memorable (e.g. `myorg-release-bot`). Disable the webhook (uncheck "Active").
+3. Set **Repository permissions** to:
+    - Contents: **Read & write**
+    - Pull requests: **Read & write**
+    - Metadata: **Read-only** (always required)
+4. Save the App, then under **Install App** install it on your fork.
+5. Generate a private key under **Private keys -> Generate private key** and save the PEM file.
+6. Copy the App's **Client ID** (top of the App settings page).
+
+In your repository, go to **Settings -> Environments -> release** and add two secrets:
+
+- `RELEASE_BOT_APP_CLIENT_ID` -- the Client ID from step 6.
+- `RELEASE_BOT_APP_PRIVATE_KEY` -- the entire PEM file contents, including the `-----BEGIN ... PRIVATE KEY-----` header and `-----END ... PRIVATE KEY-----` footer.
+
+If you do not need the release pipeline at all (you are running a research fork and never cut releases), skip this section. The release workflows are gated on `!github.event.repository.fork` and skip cleanly.
+
+## 4. Populate the remaining environment secrets
+
+| Environment | Secret | Source |
+|-------------|--------|--------|
+| `atlas` | `ATLAS_TOKEN` | https://atlasgo.cloud/ -- free tier covers a single project |
+| `cloudflare-preview` | `CLOUDFLARE_API_TOKEN` | https://dash.cloudflare.com/profile/api-tokens -- Pages-deploy-scoped |
+| `cloudflare-preview` | `CLOUDFLARE_ACCOUNT_ID` | Cloudflare dashboard sidebar |
+
+`apko-lock` and `image-push` need no secrets -- the workflows use the auto-provided `${{ github.token }}` against your fork's resources. The environments exist purely for branch-policy gating.
+
+## 5. Branch protection on `main`
+
+The preflight checks for three things on `main`:
+
+- **Required signed commits** -- needed because the release pipeline produces commits, and branch protection rejects unsigned ones.
+- **Required status check `CI Pass`** -- the gate job that aggregates lint, type-check, and tests.
+- **Strict policy** ("Require branches to be up to date before merging") -- prevents stale PRs from merging.
+
+Configure at **Settings -> Branches -> Add rule** on `main`. The minimum to satisfy preflight is the three checkboxes above. Pull-request review counts and code-owner requirements are repository-policy decisions and not enforced by preflight.
+
+## When preflight passes
+
+Once every section above is checked off, the next preflight run finds the tracking issue by title, posts a `Preflight passed at <SHA>` comment, and closes it. If anything later regresses (a deleted environment, a missing label after manual cleanup), the next preflight run reopens or recreates the tracking issue with the updated diff. The issue body is regenerated from scratch on every run, so the checklist always reflects the current state.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,7 @@ nav:
       - Human Interaction & API: guides/human-interaction.md
       - Persistence Migrations: guides/persistence-migrations.md
       - Contributing: guides/contributing.md
+      - Fork Setup: guides/fork-setup.md
   - Design:
       - design/index.md
       - Agents: design/agents.md


### PR DESCRIPTION
## Summary

Closes #1579 (expanded scope, see issue body for the full landed list).

Make CI fork-friendly. A fresh fork now gets a single auto-managed tracking issue listing exactly what to set up, and CI works end-to-end once that checklist is completed.

What landed, by phase:

1. **`post-tracking-issue` docs fix.** `gh-token` description no longer claims cross-repo / write-on-fork support. The action's runtime is already correct (it self-targets via `${{ github.repository }}`); only the docs were lying.

2. **`ci-preflight` workflow + composite action.** New `.github/workflows/ci-preflight.yml` runs on push / pull_request / workflow_dispatch in parallel with the rest of CI. New composite `.github/actions/ci-preflight-check/` inspects environments, labels, branch protection on main, and default branch name. On gaps: opens or updates a tracking issue via `post-tracking-issue` with a body listing every missing item plus end-to-end setup instructions for the synthorg-release-bot GitHub App and per-environment secrets. On all-green: finds the issue by title and closes it with a `Preflight passed at <SHA>` comment. Hybrid blocking: warns on PR / non-main pushes, fails the job on push to main so upstream stays loud about drift.

3. **Fork-friendly release / automation gates.** Every job that mints the upstream-only `synthorg-release-bot` App token is gated on `!github.event.repository.fork` so it skips cleanly in forks: `ci.yml` branch-protection-audit, `release.yml` release-please, `dev-release.yml`, `auto-rollover.yml`, `graduate.yml`, `test-signing.yml` (all three jobs). Two literal upstream-owner references replaced with `github.repository_owner`: `apko-lock.yml` reviewer, `test-highlights.yml` actor gate.

4. **Labels-as-code.** New `.github/labels.yml` lists every workflow-asserted label (including the previously-missing `type:ci` that was silently falling through `post-tracking-issue`'s label-less fallback). New `.github/workflows/sync-labels.yml` syncs the file via `gh label create --force` (no third-party action -- avoids needing to expand the strict action allowlist).

5. **Fork-setup guide.** New `docs/guides/fork-setup.md` walks through every preflight item end-to-end, with explicit instructions for creating the release-bot GitHub App. Linked from the preflight tracking issue body, the contributing guide's See Also, the mkdocs nav, and a new Contributors note in the root README.

## Out of scope

- Templating `ghcr.io/aureliolo/synthorg-*` image namespaces in `docker.yml` release notes + `build-apko-base` / `build-scan-image` / `publish-apko-base` / `publish-image` / `cis-scan` composite actions + `sbom-diff.yml`, plus `synthorg.io` install URLs in `cli.yml` release notes. Substantial diff, coherent unit, no fork-publishing-images use case today. Tracked in #1585 with `backlog` label.
- True cross-repo `repository` input on `post-tracking-issue` (the original Option B). Not needed -- `${{ github.repository }}` already gives correct fork self-targeting.

## Test plan

- Pre-commit hooks: all passed (yaml, secrets scan, no-em-dashes, workflow-shell-git-commits guard, no-release-please-token).
- No Python / web / Go source touched -- unit tests not applicable.
- The new `ci-preflight` workflow and `sync-labels` workflow will run on this PR (and on merge) -- live smoke-test of the implementation.
- Per-step verification (manual, post-merge): trigger `Sync Labels` workflow on `main` once to bootstrap the `automation:ci-preflight` label upstream so the preflight job's `--label automation:ci-preflight,type:ci,prio:high` lands without falling through the label-less fallback.

## Review coverage

Pre-reviewed by 4 agents (docs-consistency, security-reviewer, infra-reviewer, issue-resolution-verifier). 6 findings surfaced:

- 4 implemented in commit `a0f5aa95`: random EOF delimiter for `$GITHUB_OUTPUT` heredoc, `sleep 1` between environments-API retry attempts, precedence-clarifying comment in `ci.yml` audit job's `if:`, `issues: write` justification comment in `sync-labels.yml`.
- 2 rejected as agent misreadings (rationale captured in `_audit/pre-pr-review/triage.md`): security-reviewer's bash parameter-expansion concern conflated sed semantics with bash; infra-reviewer's quoting suggestion for `github.repository_owner` would change GitHub Actions expression semantics, not improve safety.

issue-resolution-verifier: all 7 expanded-scope requirements RESOLVED at 100% confidence.

## Issue

Closes #1579
Tracked follow-up: #1585 (`backlog`)
