### PR TITLE
fix(ci): quote hex colors in labels.yml + make sync-labels manual-only

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -5,41 +5,48 @@
 # labels (type:*, prio:*, spec:*, scope:*) are managed via the GitHub UI
 # and are not synced from here.
 #
-# Synced by .github/workflows/sync-labels.yml on push to main when this
-# file changes, plus manual workflow_dispatch. Forks should run the
-# manual dispatch once after creation to bootstrap the label set.
+# Synced by .github/workflows/sync-labels.yml -- manual workflow_dispatch
+# only. Run it from Actions -> Sync Labels -> Run workflow whenever this
+# file changes. Forks should also run it once after creation to bootstrap
+# the label set.
 #
 # The sync uses EndBug/label-sync with delete: false, so labels not
 # listed here are left untouched.
 
+# Quote every color code as a string. Hex codes that match YAML
+# 1.1 scientific-notation syntax (e.g. `5319e7` = 5319 * 10^7) are
+# otherwise parsed as floats by yq, then re-stringified to the
+# decimal value, then rejected by `gh label create --color` with
+# `Label.color is invalid`. Quoting forces string parsing.
+
 - name: automation:ci-health
-  color: B60205
+  color: "B60205"
   description: CI / scheduled-job health regression
 
 - name: automation:ci-preflight
-  color: B60205
+  color: "B60205"
   description: Fork / repo-setup preflight tracker (created by ci-preflight workflow)
 
 - name: automation:release-events
-  color: B60205
+  color: "B60205"
   description: Release pipeline events log + signing / health regressions
 
 - name: type:ci
-  color: 5319e7
+  color: "5319e7"
   description: CI / build / release tooling
 
 - name: prio:low
-  color: c2e0c6
+  color: "c2e0c6"
   description: Nice to have, can defer
 
 - name: prio:medium
-  color: fbca04
+  color: "fbca04"
   description: Should do, but not blocking
 
 - name: prio:high
-  color: d93f0b
+  color: "d93f0b"
   description: Important, should be prioritized
 
 - name: "autorelease: pending"
-  color: ededed
+  color: "ededed"
   description: Release-please pending-release marker

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,11 +1,11 @@
 name: Sync Labels
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - .github/labels.yml
-      - .github/workflows/sync-labels.yml
+  # Manual-only. Edits to .github/labels.yml do NOT auto-sync; the
+  # operator runs this workflow from Actions -> Sync Labels -> Run
+  # workflow when they want the change to land. Keeps label
+  # mutations explicit and reviewable instead of riding any merge
+  # to main that touches the file.
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
## Summary

Two changes batched as one fix because the auto-sync trigger is what made the YAML parsing bug visible on a merge no one had explicitly asked for.

**Hex bug.** In YAML 1.1 (which yq still uses) `5319e7` is a valid float literal in scientific notation, so yq parses the unquoted hex code as `5319 * 10^7 = 53190000000`. `jq -r '.color'` then stringifies the float and `gh label create --color 53190000000` is rejected with HTTP 422 `Label.color is invalid`. Other hex codes happened to parse as strings (start with a letter, or have a non-digit between a digit and `e`), so only `type:ci` hit it. Quote every color literal so YAML always parses them as strings, plus a comment above the list explaining why.

**Trigger change.** Drop `push: branches: [main]` from `sync-labels.yml`. Editing `labels.yml` shouldn't auto-mutate the live label set on every merge to main; the operator runs the workflow manually from Actions -> Sync Labels -> Run workflow when they want the change to land. The `labels.yml` header comment is updated accordingly. The fork-setup guide and the preflight tracking-issue template already documented the manual-only path, so no doc changes there.

## Test plan

- Pre-commit hooks: passed (yaml lint, secrets scan, no-em-dashes).
- After merge: run Sync Labels manually -- the previously-failing `type:ci` label should now create cleanly with color `5319e7`. Subsequent preflight runs see all 8 labels and close issue #1587 with a `Preflight passed` comment.
- No source code changed; no unit / integration test relevant.

## Issue

Surfaces from the Sync Labels failure on the squash-merge of #1586. Closes #1587 indirectly (the preflight will close it once labels are bootstrapped).