### PR TITLE
fix(cli): use embedded build SHA as base ref for dev commit walk

### DIFF
--- a/cli/cmd/update_walk.go
+++ b/cli/cmd/update_walk.go
@@ -204,17 +204,18 @@ func normalizeVersionRef(v string) string {
 // Falls back to the tag for builds without a stamped commit, e.g. local
 // `go build` or `go run` where Commit is "none" / "dev".
 func effectiveBaseRef(tagRef, commitSHA string) string {
-	if isStableCommitSHA(commitSHA) {
+	if isLikelyCommitSHA(commitSHA) {
 		return commitSHA
 	}
 	return tagRef
 }
 
-// isStableCommitSHA reports whether s looks like a real git commit SHA
+// isLikelyCommitSHA reports whether s has the shape of a git commit SHA
 // (>= 7 hex chars). Sentinel ldflags values like "none", "dev", and the
 // empty string fail this check, which is the trigger for falling back to
-// the tag-based ref.
-func isStableCommitSHA(s string) bool {
+// the tag-based ref. The name avoids "stable" because that term is already
+// used in this file for the release channel (see runStableHighlightsWalk).
+func isLikelyCommitSHA(s string) bool {
 	if len(s) < 7 {
 		return false
 	}

--- a/cli/cmd/update_walk.go
+++ b/cli/cmd/update_walk.go
@@ -151,7 +151,15 @@ func runDevCommitWalk(ctx context.Context, cmd *cobra.Command, result selfupdate
 	apiBase := effectiveBaseRef(base, currentBuildCommit())
 	commitRange, err := commitsBetween(ctx, apiBase, head)
 	if err != nil {
-		out.Warn(fmt.Sprintf("Could not fetch commit list for %s..%s: %v", base, head, err))
+		// commitsBetween wraps its underlying error as
+		// "comparing <apiBase>...<head>: <inner>" -- when apiBase is the
+		// embedded build SHA that wrapper would leak the SHA into the
+		// warn line. Substitute it back to the user-facing version
+		// label before formatting. The inner cause (rate-limit, 404,
+		// etc.) is preserved because it is genuinely useful for
+		// self-diagnosis and contains no secret data.
+		errMsg := scrubAPIBase(err.Error(), apiBase, base)
+		out.Warn(fmt.Sprintf("Could not fetch commit list for %s..%s: %s", base, head, errMsg))
 		out.HintError(devCommitWalkErrorHint(apiBase != base))
 		printOfflineNotice(cmd, result)
 		return
@@ -220,6 +228,19 @@ func isStableCommitSHA(s string) bool {
 		}
 	}
 	return true
+}
+
+// scrubAPIBase replaces every occurrence of apiBase in errMsg with the
+// user-facing tagRef. Used to substitute the embedded build SHA back to
+// its version label in error strings sourced from the GitHub compare
+// path -- both the wrapper from commitsBetween and any inner error that
+// happens to include the request URL embed apiBase verbatim. No-op when
+// apiBase == tagRef (we never used the SHA on this call).
+func scrubAPIBase(errMsg, apiBase, tagRef string) string {
+	if apiBase == tagRef {
+		return errMsg
+	}
+	return strings.ReplaceAll(errMsg, apiBase, tagRef)
 }
 
 // devCommitWalkErrorHint returns the HintError body shown when the dev

--- a/cli/cmd/update_walk.go
+++ b/cli/cmd/update_walk.go
@@ -32,6 +32,11 @@ var (
 	commitsBetween  = selfupdate.CommitsBetween
 )
 
+// currentBuildCommit returns the commit SHA stamped into the running
+// binary by GoReleaser at build time. Wrapped in a function variable so
+// tests can stub it without touching the version package globals.
+var currentBuildCommit = func() string { return version.Commit }
+
 // runChangelogWalk renders the per-release Highlights walk (stable channel)
 // or the combined commit-list view (dev channel) before the install confirm
 // prompt in updateCLI. The walk is informational and never blocks the
@@ -123,26 +128,31 @@ func runStableHighlightsWalk(ctx context.Context, cmd *cobra.Command, result sel
 // so a per-release walk is uninformative -- a flat commit list is what the
 // user actually wants to see.
 //
-// The GitHub compare endpoint requires both refs to be exact tag names, so
-// we normalise the version strings (which may lack the leading "v" -- the
-// CLI's own version.Version is set without it) before calling out. When
-// compare fails (e.g. the installed dev pre-release tag was pruned from
-// the remote, or the network call errors) we ALWAYS surface the failure
-// with a warning explaining why the rich walk did not render -- silent
-// fallbacks have repeatedly bitten users who could not tell whether the
-// changelog was missing because of an empty range or a real error.
+// The GitHub compare endpoint accepts tags or commit SHAs on either side,
+// and we deliberately prefer the embedded build SHA over the installed tag
+// for the base ref: dev pre-release tags are auto-pruned from the remote
+// shortly after newer dev tags publish, so a tag-based base routinely 404s
+// once a few rollovers have happened. The embedded SHA, by contrast, is
+// permanent. We still normalise the version strings for the user-facing
+// labels (which may lack the leading "v" -- the CLI's own version.Version
+// is set without it) and for the head ref, which is the freshly-published
+// latest and unlikely to be pruned in the seconds between check and walk.
+//
+// When compare fails we ALWAYS surface the failure with a warning
+// explaining why the rich walk did not render -- silent fallbacks have
+// repeatedly bitten users who could not tell whether the changelog was
+// missing because of an empty range or a real error.
 func runDevCommitWalk(ctx context.Context, cmd *cobra.Command, result selfupdate.CheckResult) {
 	opts := GetGlobalOpts(ctx)
 	out := ui.NewUIWithOptions(cmd.OutOrStdout(), opts.UIOptions())
 
 	base := normalizeVersionRef(result.CurrentVersion)
 	head := normalizeVersionRef(result.LatestVersion)
-	commitRange, err := commitsBetween(ctx, base, head)
+	apiBase := effectiveBaseRef(base, currentBuildCommit())
+	commitRange, err := commitsBetween(ctx, apiBase, head)
 	if err != nil {
 		out.Warn(fmt.Sprintf("Could not fetch commit list for %s..%s: %v", base, head, err))
-		out.HintError(
-			"This usually means the installed dev pre-release tag was pruned from GitHub " +
-				"(dev releases are auto-rolled). Showing terse update notice instead.")
+		out.HintError(devCommitWalkErrorHint(apiBase != base))
 		printOfflineNotice(cmd, result)
 		return
 	}
@@ -177,6 +187,54 @@ func normalizeVersionRef(v string) string {
 		return v
 	}
 	return "v" + v
+}
+
+// effectiveBaseRef chooses which ref to pass to the GitHub compare API for
+// the "installed" side of the dev-channel commit walk. Prefers the embedded
+// build commit SHA (permanent on the remote) over the installed tag (which
+// is auto-pruned from the remote once a few newer dev releases roll over).
+// Falls back to the tag for builds without a stamped commit, e.g. local
+// `go build` or `go run` where Commit is "none" / "dev".
+func effectiveBaseRef(tagRef, commitSHA string) string {
+	if isStableCommitSHA(commitSHA) {
+		return commitSHA
+	}
+	return tagRef
+}
+
+// isStableCommitSHA reports whether s looks like a real git commit SHA
+// (>= 7 hex chars). Sentinel ldflags values like "none", "dev", and the
+// empty string fail this check, which is the trigger for falling back to
+// the tag-based ref.
+func isStableCommitSHA(s string) bool {
+	if len(s) < 7 {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		case r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// devCommitWalkErrorHint returns the HintError body shown when the dev
+// commit-walk compare API call fails. The wording differs based on whether
+// we already used the embedded commit SHA: with a SHA the tag-pruning
+// explanation no longer fits, so we name the more likely real causes
+// (network, rate limit) instead of misdirecting the user.
+func devCommitWalkErrorHint(usedCommitSHA bool) string {
+	if usedCommitSHA {
+		return "This is usually a transient network error or GitHub rate limit. " +
+			"Showing terse update notice instead."
+	}
+	return "This usually means the installed dev pre-release tag was pruned from GitHub " +
+		"(dev releases are auto-rolled), or this is a local build without an embedded " +
+		"commit SHA. Showing terse update notice instead."
 }
 
 // shouldShowWalk reports whether the walk UI should run for this invocation.

--- a/cli/cmd/update_walk_test.go
+++ b/cli/cmd/update_walk_test.go
@@ -475,7 +475,7 @@ func TestEffectiveBaseRef(t *testing.T) {
 	}
 }
 
-func TestIsStableCommitSHA(t *testing.T) {
+func TestIsLikelyCommitSHA(t *testing.T) {
 	tests := []struct {
 		in   string
 		want bool
@@ -494,8 +494,8 @@ func TestIsStableCommitSHA(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			if got := isStableCommitSHA(tt.in); got != tt.want {
-				t.Errorf("isStableCommitSHA(%q) = %v, want %v", tt.in, got, tt.want)
+			if got := isLikelyCommitSHA(tt.in); got != tt.want {
+				t.Errorf("isLikelyCommitSHA(%q) = %v, want %v", tt.in, got, tt.want)
 			}
 		})
 	}

--- a/cli/cmd/update_walk_test.go
+++ b/cli/cmd/update_walk_test.go
@@ -281,6 +281,13 @@ func TestRunStableHighlightsWalk_warnsOnEmptyRange(t *testing.T) {
 }
 
 func TestRunDevCommitWalk_warnsOnCompareError(t *testing.T) {
+	// Pin the build commit to a sentinel so this test deterministically
+	// exercises the tag-fallback branch even if a future test binary is
+	// ever built with real ldflags injection. The "tag was pruned" hint
+	// asserted below only fires on that branch -- on the SHA-base branch
+	// the hint reads "transient network error or GitHub rate limit"
+	// instead, which would silently break this assertion.
+	withCurrentBuildCommit(t, "none")
 	withCommitsBetween(t, func(_ context.Context, _, _ string) (selfupdate.CommitRange, error) {
 		return selfupdate.CommitRange{}, errors.New("404 Not Found")
 	})

--- a/cli/cmd/update_walk_test.go
+++ b/cli/cmd/update_walk_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -351,13 +352,20 @@ func TestRunDevCommitWalk_normalisesVersionRefs(t *testing.T) {
 // keeps working even after the installed tag has been auto-rolled off the
 // remote. The user-facing warn / offline-notice text must still show the
 // human-readable version label, not the raw SHA.
+//
+// The test stub wraps the simulated inner cause with the same prefix
+// production uses (selfupdate.commitsBetweenFromURL: "comparing
+// %s...%s: %w"), so err.Error() actually contains the SHA -- this is
+// what runDevCommitWalk has to scrub before formatting the warn line.
+// A plain errors.New() would never embed the SHA and the no-SHA-leak
+// assertion below would be vacuously true.
 func TestRunDevCommitWalk_usesEmbeddedCommitSHA(t *testing.T) {
 	const buildSHA = "deadbeefcafebabe1234567890abcdef12345678"
 	withCurrentBuildCommit(t, buildSHA)
 	var seenBase, seenHead string
 	withCommitsBetween(t, func(_ context.Context, base, head string) (selfupdate.CommitRange, error) {
 		seenBase, seenHead = base, head
-		return selfupdate.CommitRange{}, errors.New("simulated rate limit")
+		return selfupdate.CommitRange{}, fmt.Errorf("comparing %s...%s: %w", base, head, errors.New("simulated rate limit"))
 	})
 	cmd, buf := newWalkTestCmd(t)
 	result := selfupdate.CheckResult{CurrentVersion: "0.7.3-dev.20", LatestVersion: "0.7.3-dev.24"}
@@ -372,14 +380,19 @@ func TestRunDevCommitWalk_usesEmbeddedCommitSHA(t *testing.T) {
 	}
 
 	got := buf.String()
-	// Warn label uses the version refs, not the SHA.
+	// Warn label uses the version refs (with the production wrapper's
+	// SHA scrubbed back to the version label), and the inner cause is
+	// preserved so the user can self-diagnose rate-limit vs 404 vs
+	// network errors.
 	requireContains(t, got,
 		"Could not fetch commit list for v0.7.3-dev.20..v0.7.3-dev.24",
+		"comparing v0.7.3-dev.20...v0.7.3-dev.24", // wrapper rewritten back to tag form
 		"simulated rate limit",
 		"transient network error or GitHub rate limit",
 		"New version available: v0.7.3-dev.24",
 	)
-	// And critically, the SHA must NOT leak into the user-facing warn line.
+	// And critically, the SHA must NOT leak into the user-facing warn line --
+	// either as the bare SHA or as a substring of any wrapped error message.
 	if strings.Contains(got, buildSHA) {
 		t.Errorf("user-facing output should not contain raw build SHA\n--- got ---\n%s", got)
 	}
@@ -387,6 +400,54 @@ func TestRunDevCommitWalk_usesEmbeddedCommitSHA(t *testing.T) {
 	// it would misdirect the user about the actual cause.
 	if strings.Contains(got, "tag was pruned") {
 		t.Errorf("tag-pruned hint should not appear on the SHA-base path\n--- got ---\n%s", got)
+	}
+}
+
+func TestScrubAPIBase(t *testing.T) {
+	const sha = "deadbeefcafebabe1234567890abcdef12345678"
+	const tag = "v0.7.3-dev.20"
+	tests := []struct {
+		name    string
+		errMsg  string
+		apiBase string
+		tagRef  string
+		want    string
+	}{
+		{
+			name:    "rewrites compare wrapper containing the SHA",
+			errMsg:  fmt.Sprintf("comparing %s...v0.7.3-dev.24: github API returned 404", sha),
+			apiBase: sha,
+			tagRef:  tag,
+			want:    "comparing v0.7.3-dev.20...v0.7.3-dev.24: github API returned 404",
+		},
+		{
+			name:    "rewrites SHA inside an embedded compare URL",
+			errMsg:  fmt.Sprintf("querying GitHub releases: Get \"https://api.github.com/repos/x/y/compare/%s...v0.7.3-dev.24\": dial tcp: timeout", sha),
+			apiBase: sha,
+			tagRef:  tag,
+			want:    "querying GitHub releases: Get \"https://api.github.com/repos/x/y/compare/v0.7.3-dev.20...v0.7.3-dev.24\": dial tcp: timeout",
+		},
+		{
+			name:    "no-op when apiBase equals tagRef (tag-fallback path)",
+			errMsg:  "comparing v0.7.3-dev.20...v0.7.3-dev.24: github API returned 404",
+			apiBase: tag,
+			tagRef:  tag,
+			want:    "comparing v0.7.3-dev.20...v0.7.3-dev.24: github API returned 404",
+		},
+		{
+			name:    "leaves messages without the SHA untouched",
+			errMsg:  "github API rate-limited (HTTP 429) -- try again later",
+			apiBase: sha,
+			tagRef:  tag,
+			want:    "github API rate-limited (HTTP 429) -- try again later",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := scrubAPIBase(tt.errMsg, tt.apiBase, tt.tagRef); got != tt.want {
+				t.Errorf("scrubAPIBase()\n got: %q\nwant: %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cli/cmd/update_walk_test.go
+++ b/cli/cmd/update_walk_test.go
@@ -34,6 +34,16 @@ func withCommitsBetween(t *testing.T, stub func(ctx context.Context, base, head 
 	t.Cleanup(func() { commitsBetween = prev })
 }
 
+// withCurrentBuildCommit installs a stub for the package-level
+// currentBuildCommit var. Tests use it to drive runDevCommitWalk down the
+// "embedded SHA" branch without rebuilding the binary with custom ldflags.
+func withCurrentBuildCommit(t *testing.T, sha string) {
+	t.Helper()
+	prev := currentBuildCommit
+	currentBuildCommit = func() string { return sha }
+	t.Cleanup(func() { currentBuildCommit = prev })
+}
+
 // newWalkTestCmd returns a cobra.Command with a captured stdout/stderr
 // buffer and a non-prompting GlobalOpts that still carries Hints=always so
 // HintError lines render. Used by walk error-branch tests.
@@ -313,8 +323,10 @@ func TestRunDevCommitWalk_warnsOnEmptyRange(t *testing.T) {
 // the original user report: a dev-channel installed version stamped without
 // the "v" prefix MUST be normalised to "vX.Y.Z-dev.N" before reaching
 // commitsBetween, otherwise GitHub's compare API returns 404 for every
-// invocation.
+// invocation. This exercises the tag-fallback path where the embedded
+// commit SHA is a sentinel ("none") so effectiveBaseRef returns the tag.
 func TestRunDevCommitWalk_normalisesVersionRefs(t *testing.T) {
+	withCurrentBuildCommit(t, "none") // force the tag-fallback branch
 	var seenBase, seenHead string
 	withCommitsBetween(t, func(_ context.Context, base, head string) (selfupdate.CommitRange, error) {
 		seenBase, seenHead = base, head
@@ -330,6 +342,115 @@ func TestRunDevCommitWalk_normalisesVersionRefs(t *testing.T) {
 	}
 	if seenHead != "v0.7.3-dev.19" {
 		t.Errorf("head passed to commitsBetween = %q, want %q", seenHead, "v0.7.3-dev.19")
+	}
+}
+
+// TestRunDevCommitWalk_usesEmbeddedCommitSHA is the regression guard for
+// pruned-dev-tag 404s: when the binary has a real build commit SHA stamped
+// in, the compare API call must use the SHA as the base ref so the request
+// keeps working even after the installed tag has been auto-rolled off the
+// remote. The user-facing warn / offline-notice text must still show the
+// human-readable version label, not the raw SHA.
+func TestRunDevCommitWalk_usesEmbeddedCommitSHA(t *testing.T) {
+	const buildSHA = "deadbeefcafebabe1234567890abcdef12345678"
+	withCurrentBuildCommit(t, buildSHA)
+	var seenBase, seenHead string
+	withCommitsBetween(t, func(_ context.Context, base, head string) (selfupdate.CommitRange, error) {
+		seenBase, seenHead = base, head
+		return selfupdate.CommitRange{}, errors.New("simulated rate limit")
+	})
+	cmd, buf := newWalkTestCmd(t)
+	result := selfupdate.CheckResult{CurrentVersion: "0.7.3-dev.20", LatestVersion: "0.7.3-dev.24"}
+
+	runDevCommitWalk(cmd.Context(), cmd, result)
+
+	if seenBase != buildSHA {
+		t.Errorf("base passed to commitsBetween = %q, want embedded SHA %q", seenBase, buildSHA)
+	}
+	if seenHead != "v0.7.3-dev.24" {
+		t.Errorf("head passed to commitsBetween = %q, want %q", seenHead, "v0.7.3-dev.24")
+	}
+
+	got := buf.String()
+	// Warn label uses the version refs, not the SHA.
+	requireContains(t, got,
+		"Could not fetch commit list for v0.7.3-dev.20..v0.7.3-dev.24",
+		"simulated rate limit",
+		"transient network error or GitHub rate limit",
+		"New version available: v0.7.3-dev.24",
+	)
+	// And critically, the SHA must NOT leak into the user-facing warn line.
+	if strings.Contains(got, buildSHA) {
+		t.Errorf("user-facing output should not contain raw build SHA\n--- got ---\n%s", got)
+	}
+	// The tag-pruned hint must NOT show when we already used the SHA --
+	// it would misdirect the user about the actual cause.
+	if strings.Contains(got, "tag was pruned") {
+		t.Errorf("tag-pruned hint should not appear on the SHA-base path\n--- got ---\n%s", got)
+	}
+}
+
+func TestEffectiveBaseRef(t *testing.T) {
+	tests := []struct {
+		name      string
+		tagRef    string
+		commitSHA string
+		want      string
+	}{
+		{"prefers full SHA over tag", "v0.7.3-dev.20", "deadbeefcafebabe1234567890abcdef12345678", "deadbeefcafebabe1234567890abcdef12345678"},
+		{"prefers short SHA (>= 7 chars) over tag", "v0.7.3-dev.20", "deadbee", "deadbee"},
+		{"falls back to tag for none sentinel", "v0.7.3-dev.20", "none", "v0.7.3-dev.20"},
+		{"falls back to tag for dev sentinel", "v0.7.3-dev.20", "dev", "v0.7.3-dev.20"},
+		{"falls back to tag for empty SHA", "v0.7.3-dev.20", "", "v0.7.3-dev.20"},
+		{"falls back to tag for too-short SHA", "v0.7.3-dev.20", "abc123", "v0.7.3-dev.20"},
+		{"falls back to tag for non-hex SHA", "v0.7.3-dev.20", "notahexstring", "v0.7.3-dev.20"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := effectiveBaseRef(tt.tagRef, tt.commitSHA); got != tt.want {
+				t.Errorf("effectiveBaseRef(%q, %q) = %q, want %q", tt.tagRef, tt.commitSHA, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsStableCommitSHA(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"deadbeefcafebabe1234567890abcdef12345678", true}, // full 40-char SHA
+		{"DEADBEEFCAFEBABE1234567890ABCDEF12345678", true}, // uppercase hex
+		{"DeadBeef", true},       // mixed case, >= 7 chars
+		{"deadbee", true},        // exactly 7 chars
+		{"abc123", false},        // too short
+		{"", false},              // empty
+		{"none", false},          // GoReleaser default sentinel
+		{"dev", false},           // local-build sentinel
+		{"unknown", false},       // generic sentinel
+		{"deadbeefXXX", false},   // non-hex chars
+		{"v0.7.3-dev.20", false}, // version tag, not a SHA
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := isStableCommitSHA(tt.in); got != tt.want {
+				t.Errorf("isStableCommitSHA(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDevCommitWalkErrorHint(t *testing.T) {
+	tagHint := devCommitWalkErrorHint(false)
+	if !strings.Contains(tagHint, "tag was pruned") {
+		t.Errorf("tag-fallback hint should mention tag pruning, got %q", tagHint)
+	}
+	shaHint := devCommitWalkErrorHint(true)
+	if strings.Contains(shaHint, "tag was pruned") {
+		t.Errorf("SHA-base hint should NOT mention tag pruning, got %q", shaHint)
+	}
+	if !strings.Contains(shaHint, "rate limit") {
+		t.Errorf("SHA-base hint should mention transient network/rate limit, got %q", shaHint)
 	}
 }
 


### PR DESCRIPTION
## Summary

`synthorg update` on the dev channel routinely 404s the GitHub compare API once a few dev pre-releases have rolled over, because the **base** of the compare call is the installed dev tag (e.g. `v0.7.3-dev.20`) and dev pre-release tags get auto-pruned from the remote shortly after newer dev releases publish. Reproduced today on a `v0.7.3-dev.20` install updating to `v0.7.3-dev.24`:

```
! Could not fetch commit list for v0.7.3-dev.20..v0.7.3-dev.24: comparing v0.7.3-dev.20...v0.7.3-dev.24: github API returned 404
```

The compare endpoint accepts SHAs and tags interchangeably on either side, and the binary already carries a permanent commit SHA stamped in by GoReleaser (`-X .../version.Commit={{.Commit}}` in `cli/.goreleaser.yml`). So we now prefer that SHA as the base ref for the API call, falling back to the tag for builds without a stamped commit (local `go build`, `go run`, where `version.Commit` is `"none"` or `"dev"`).

Head stays as the freshly-published target tag — it is the just-resolved latest from the same `update` invocation, vanishingly unlikely to be pruned in the seconds between check and walk. Resolving an additional API call to a head SHA would buy almost nothing here and is intentionally left out.

## Changes

- `cli/cmd/update_walk.go`:
  - New `currentBuildCommit` function var (returns `version.Commit`) so tests can stub it without touching the version package globals.
  - New helpers `effectiveBaseRef(tagRef, commitSHA string) string` and `isStableCommitSHA(s string) bool`. The SHA check requires `len >= 7` and all-hex; sentinel values (`"none"`, `"dev"`, `"unknown"`, empty) fail and trigger tag fallback.
  - `runDevCommitWalk` now calls `commitsBetween(ctx, effectiveBaseRef(base, currentBuildCommit()), head)`. **User-facing labels in the warn / offline-notice text continue to show `vX.Y.Z-dev.N`** (not the raw SHA) — this is asserted in tests.
  - New `devCommitWalkErrorHint(usedCommitSHA bool)` splits the error hint: the "tag was pruned" explanation only fires when we actually fell back to the tag (local builds); the SHA-base path points at the real likely cause (transient network or GitHub rate limit). Misdirecting the user about the cause was a regression I wanted to avoid.

- `cli/cmd/update_walk_test.go`:
  - New helper `withCurrentBuildCommit(t, sha)` to drive the SHA-base branch.
  - New tests: `TestRunDevCommitWalk_usesEmbeddedCommitSHA` (asserts SHA passed to API, version label still in user-facing text, no SHA leak, no tag-pruned hint), `TestEffectiveBaseRef`, `TestIsStableCommitSHA`, `TestDevCommitWalkErrorHint`.
  - Existing `TestRunDevCommitWalk_normalisesVersionRefs` now explicitly stubs `currentBuildCommit` to `"none"` so it deterministically exercises the tag-fallback path even if a future build ever runs the test binary with ldflags injected.

## Test plan

```
go -C cli vet ./...                 # clean
go -C cli test ./...                # all packages pass
go -C cli build ./...               # builds clean
golangci-lint run ./cmd/...         # 0 issues
```

The new test `TestRunDevCommitWalk_usesEmbeddedCommitSHA` is the regression guard for the reported 404. It stubs the embedded commit to a fake 40-char hex SHA and asserts:
1. The base ref passed to the GitHub compare API is the SHA.
2. The head ref stays as the version tag.
3. The user-facing warn line shows `v0.7.3-dev.20..v0.7.3-dev.24` (not the SHA).
4. The raw SHA does not leak into the chat output.
5. The `tag was pruned` hint does NOT appear when the SHA was used (it would misdirect the user).

## Review coverage

Pre-PR pipeline ran in `quick` mode — automated checks only (vet, full Go test suite, build, golangci-lint, all pre-commit hooks). Agent review skipped per quick mode; change is a small, self-contained CLI fix with full test coverage on both branches (SHA preferred / tag fallback). No issue linkage — bug surfaced from user report in chat, not a tracked issue.
