### PR TITLE
fix(ci): unblock release-PR CI + drop unsupported apko `--update` flag

### DIFF
--- a/.github/workflows/apko-lock.yml
+++ b/.github/workflows/apko-lock.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   update-lockfiles:
-    name: apko lock --update
+    name: apko lock
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Environment `apko-lock` carries a `main`-only branch allowlist so the
@@ -108,7 +108,7 @@ jobs:
           {
             echo 'body<<TRACKING_ISSUE_BODY_EOF'
             cat <<EOF
-          \`apko lock --update\` workflow failed at $(date -u +%Y-%m-%dT%H:%M:%SZ) with result \`$RESULT\`.
+          \`apko lock\` workflow failed at $(date -u +%Y-%m-%dT%H:%M:%SZ) with result \`$RESULT\`.
 
           Run: ${RUN_URL}
 

--- a/.github/workflows/apko-lock.yml
+++ b/.github/workflows/apko-lock.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           for config in docker/*/apko.yaml; do
             echo "Updating lockfile for ${config}..."
-            apko lock --update "${config}"
+            apko lock "${config}"
           done
 
       - name: Check for changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -608,23 +608,27 @@ jobs:
   # metadata read, which is sufficient for this read-only audit.
   branch-protection-audit:
     name: Branch-protection drift audit
-    # Accept push-to-main (informational) AND workflow_dispatch so the
-    # audit can be triggered ad-hoc from Actions -> "CI" -> Run workflow.
-    # The ``release`` environment's branch policy still restricts both
-    # paths to main -- a workflow_dispatch from a feature branch is
-    # blocked at the environment gate, not by the if: check.
+    # Accept push-to-main (informational) AND workflow_dispatch from
+    # main so the audit can be triggered ad-hoc from Actions -> "CI"
+    # -> Run workflow. The ``release`` environment's branch policy
+    # also restricts deploys to main, so allowing this job to attempt
+    # a deploy from a non-main ref would surface a noisy "deployment
+    # was rejected" annotation on every CI run dispatched against a
+    # release-please branch (the standard nudge used by release.yml
+    # to trigger CI on App-token-authored PRs). Gate at the if: check
+    # so non-main dispatches simply skip this job.
     #
     # Fork gate: skip in forks. The audit needs the release-bot App
     # token (env-scoped secret on `release`) and a fork won't have it.
     # ci-preflight reports the missing setup separately.
     #
     # Precedence: `&&` binds tighter than `||`, so the inner
-    # parentheses around `(push && main || dispatch)` are required
-    # to keep the trigger-OR group intact under the outer fork-AND.
+    # parentheses around `(push || dispatch)` are required to keep
+    # the trigger-OR group intact under the outer fork-AND-main-AND.
     if: >-
       !github.event.repository.fork
-      && ((github.event_name == 'push' && github.ref == 'refs/heads/main')
-          || github.event_name == 'workflow_dispatch')
+      && github.ref == 'refs/heads/main'
+      && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,15 @@ jobs:
       # inference is accessed via actions/ai-inference under the
       # `models: read` workflow-level permission. No new secret.
       models: read
+      # For the final "Trigger CI on release PR" step below: a
+      # workflow_dispatch against ci.yml is needed because
+      # release-please opens the PR using the synthorg-release-bot
+      # App installation token, and GitHub's anti-recursion rule
+      # suppresses pull_request workflow runs for events created
+      # by the App token that owns the running workflow. Without
+      # this nudge, ci.yml never fires on release PRs and the
+      # required "CI Pass" check waits forever.
+      actions: write
     steps:
       # Minimal checkout of main required so `./.github/actions/...`
       # paths resolve on the runner disk. `fetch-depth: 1` is enough;
@@ -258,3 +267,28 @@ jobs:
 
           gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$NEW_BODY"
           echo "Highlights prepended to PR #$PR_NUMBER"
+
+      # ── Trigger CI on the release PR ──
+      # release-please opened / updated the PR using the
+      # synthorg-release-bot App installation token. GitHub's
+      # anti-recursion rule blocks `pull_request` workflows for
+      # events created by the workflow's own installation token,
+      # so ci.yml never auto-fires on release PRs and the
+      # required "CI Pass" check would wait forever.
+      #
+      # workflow_dispatch is the documented exception to that
+      # rule (it can be invoked from GITHUB_TOKEN), and the
+      # resulting check_run posts against the dispatched ref's
+      # HEAD SHA -- which matches the PR's head SHA -- so the
+      # "CI Pass" gate resolves on the PR. Runs after the BSL
+      # Change Date update (which itself bumps the head SHA via
+      # the Contents API) so CI runs against the final SHA.
+      - name: Trigger CI on release PR
+        if: steps.release.outputs.pr != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: release-please--branches--main--components--synthorg
+        run: |
+          set -euo pipefail
+          gh workflow run ci.yml --repo "$GITHUB_REPOSITORY" --ref "$BRANCH"
+          echo "Dispatched ci.yml against $BRANCH"

--- a/docs/design/deployment.md
+++ b/docs/design/deployment.md
@@ -33,7 +33,7 @@ Reconciliation mechanisms:
 | Mechanism | Target | Cadence |
 |-----------|--------|---------|
 | Renovate (Docker ecosystem + digest pinning) | Thin Dockerfile `FROM` lines (apko-base digest) | Daily |
-| `apko lock --update` cron (`.github/workflows/apko-lock.yml`) | `docker/*/apko.lock.json` (backend, sandbox, sidecar, fine-tune, web) | Weekly (Mon 06:00 UTC) -- the single `fine-tune` apko base is shared by both `-gpu` and `-cpu` runtime images |
+| `apko lock` cron (`.github/workflows/apko-lock.yml`) | `docker/*/apko.lock.json` (backend, sandbox, sidecar, fine-tune, web) | Weekly (Mon 06:00 UTC) -- the single `fine-tune` apko base is shared by both `-gpu` and `-cpu` runtime images |
 
 ## Image verification at launch
 

--- a/docs/reference/github-environments.md
+++ b/docs/reference/github-environments.md
@@ -145,7 +145,23 @@ installation token (valid ≤1 hour) via the
 - `release.yml` -- `release-please-action` token input, so the RP
   tag push on release-PR merge triggers Docker + CLI builds. The
   BSL Change Date Contents API commit keeps `GITHUB_TOKEN` (lands
-  on the RP PR branch, not `main`; no recursion concern).
+  on the RP PR branch, not `main`; no recursion concern). One
+  side-effect of the App-token PR creation: GitHub's anti-recursion
+  rule blocks `pull_request` workflows for events created by the
+  workflow's own installation token, so `ci.yml` does not auto-fire
+  on the release PR. To unblock the required `CI Pass` check, the
+  job's final step issues `gh workflow run ci.yml --ref
+  release-please--branches--main--components--synthorg` with
+  `GITHUB_TOKEN` (which IS allowed to invoke `workflow_dispatch` --
+  the documented exception to the anti-recursion rule). The
+  resulting `ci.yml` run dispatches against the release branch's
+  HEAD, so its `CI Pass` check_run posts on the release PR's head
+  SHA and satisfies the `protect-main` ruleset. The
+  `branch-protection-audit` job inside `ci.yml` keeps a
+  `github.ref == 'refs/heads/main'` gate so non-main dispatches
+  skip cleanly instead of hitting the `release` environment's
+  branch allowlist and emitting a "deployment was rejected"
+  annotation on every release PR.
 - `dev-release.yml` -- tag creation for dev pre-releases via
   `gh api`.
 - `auto-rollover.yml` -- empty `Release-As:` commit via the Git

--- a/docs/reference/github-environments.md
+++ b/docs/reference/github-environments.md
@@ -150,10 +150,11 @@ installation token (valid ≤1 hour) via the
   rule blocks `pull_request` workflows for events created by the
   workflow's own installation token, so `ci.yml` does not auto-fire
   on the release PR. To unblock the required `CI Pass` check, the
-  job's final step issues `gh workflow run ci.yml --ref
-  release-please--branches--main--components--synthorg` with
-  `GITHUB_TOKEN` (which IS allowed to invoke `workflow_dispatch` --
-  the documented exception to the anti-recursion rule). The
+  job's final step issues
+  `gh workflow run ci.yml --ref release-please--branches--main--components--synthorg`
+  with `GITHUB_TOKEN` (which IS allowed to invoke
+  `workflow_dispatch` -- the documented exception to the
+  anti-recursion rule). The
   resulting `ci.yml` run dispatches against the release branch's
   HEAD, so its `CI Pass` check_run posts on the release PR's head
   SHA and satisfies the `protect-main` ruleset. The


### PR DESCRIPTION
## Summary

Three CI workflow fixes that surfaced together while debugging the manual `apko lock --update` dispatch failure and the stuck CI Pass on PR #1592:

- **`apko-lock.yml`**: drop unsupported `--update` flag. apko v1.2.7's `lock` subcommand has no `--update`; `apko lock <config>` regenerates the sibling lockfile in place by default. The workflow has been broken since landing -- the cron path would have failed the same way the recent manual dispatch did.
- **`release.yml`**: add a `Trigger CI on release PR` step that dispatches `ci.yml` against the release-please branch via `workflow_dispatch`. release-please now opens its PR using the synthorg-release-bot App installation token (since #1553 wired up signed-commit signing), and GitHub's anti-recursion rule suppresses `pull_request` workflow runs for events created by the workflow's own installation token. That left the required `CI Pass` check waiting forever -- the exact symptom on #1592. `workflow_dispatch` is the documented exception to that rule and CAN be invoked from `GITHUB_TOKEN`; the resulting check_run posts on the PR's head SHA. Adds the required `actions: write` permission scope.
- **`ci.yml`**: tighten `branch-protection-audit`'s `if:` so it only runs on main (regardless of trigger event). Without this, every release PR's `ci.yml` dispatch would emit a noisy "deployment was rejected" annotation when the audit job tries to deploy to the `release` environment from a non-main ref. The job is `continue-on-error: true` and not in `ci-pass.needs`, so this is purely cosmetic noise removal -- but the noise would have been on every release PR forever.

Plus the matching docs sync:

- `docs/design/deployment.md` reconciliation table: `apko lock --update` -> `apko lock`.
- `docs/reference/github-environments.md` release.yml consumer description: explain the App-token PR creation -> anti-recursion -> `workflow_dispatch` nudge mechanism, and the matching `branch-protection-audit` ref-gate.

## Why now

PR #1592 (the v0.7.3 release-please PR) was authored by `app/synthorg-release-bot` for the first time, exposing the anti-recursion gap. Previous release PRs were authored by the user account, so `pull_request` workflows fired normally. Manual nudge already unstuck #1592 (CI ran, all jobs green); this PR makes the unstick automatic for every future release PR.

## Test plan

- `apko-lock.yml`: next weekly cron (or any manual dispatch) runs `apko lock <config>` and either opens a "ci: update apko lockfiles" PR or no-ops if Wolfi indices haven't moved.
- `release.yml`: next push to main with conventional commits (this PR's squash-merge will do it) triggers `release.yml`, which now ends with `gh workflow run ci.yml --ref release-please-branch`, producing a `CI Pass` check_run on the release PR's head SHA.
- `ci.yml`: same dispatch path no longer surfaces the `branch-protection-audit` env-rejection annotation.

## Review coverage

Pre-reviewed by 3 agents (`infra-reviewer`, `docs-consistency`, `security-reviewer`).

- infra-reviewer: clean, no findings.
- docs-consistency: 2 valid drifts (deployment.md apko reference, github-environments.md anti-recursion explanation) -- both fixed in this PR.
- security-reviewer: 4 findings, all triaged invalid (full reasoning in `_audit/pre-pr-review/triage.md`):
  - The CRITICAL "actions: write overscope" inverts the requirement -- per the GitHub REST docs for the workflow-dispatch endpoint, `actions: write` IS required for `gh workflow run` from `GITHUB_TOKEN`. Removing it would break the fix.
  - The HIGH "gate dispatch on Highlights outcome" would be a regression -- Highlights is `continue-on-error` cosmetic polish; CI must run on every release PR regardless.
  - The MEDIUM "BRANCH could be a future injection point" is self-contradicting (the variable is already quoted at the suggested-fix line).
  - The MEDIUM "audit job comment is dense" is a maintainability suggestion with no code change.