### PR TITLE
fix(ci): skip release-please CI + apko web config + copilot drift noise

### DIFF
--- a/.github/branch_protection.yml
+++ b/.github/branch_protection.yml
@@ -7,6 +7,12 @@
 #   - Strips id, node_id, created_at, updated_at
 #   - Strips bypass_actors (owner-private; different accounts have
 #     different admin setups)
+#   - Strips copilot_code_review rule entries on BOTH sides -- Copilot
+#     review is a UI-managed convenience that GitHub toggles when it
+#     adjusts review-rate-limit policies, so treating its drift as
+#     alertable produces noise on every policy change. Do NOT add
+#     copilot_code_review entries to this spec; the audit will silently
+#     drop them on the spec side as well.
 #   - Sorts `rules` alphabetically by `type`
 #
 # A mismatch fails the audit, signalling drift between the committed

--- a/.github/branch_protection.yml
+++ b/.github/branch_protection.yml
@@ -26,10 +26,6 @@ rulesets:
       - type: code_quality
         parameters:
           severity: all
-      - type: copilot_code_review
-        parameters:
-          review_on_push: false
-          review_draft_pull_requests: false
       - type: required_signatures
 
   - name: protect-main

--- a/.github/workflows/apko-lock.yml
+++ b/.github/workflows/apko-lock.yml
@@ -34,6 +34,15 @@ jobs:
       - name: Update lockfiles
         run: |
           for config in docker/*/apko.yaml; do
+            # docker/web/apko.yaml depends on synthorg-web-assets@local --
+            # a melange-built apk produced fresh per docker.yml run, with
+            # no stable upstream to lock against. Skipping cleanly avoids
+            # `failed to read apk key: melange.rsa.pub` when apko looks
+            # for the workflow-build-time keyring outside docker.yml.
+            if [ "${config}" = "docker/web/apko.yaml" ]; then
+              echo "Skipping ${config} (workflow-build-time @local deps)"
+              continue
+            fi
             echo "Updating lockfile for ${config}..."
             apko lock "${config}"
           done
@@ -41,7 +50,11 @@ jobs:
       - name: Check for changes
         id: diff
         run: |
-          if git diff --quiet -- 'docker/*/apko.lock.json'; then
+          # `git diff --quiet` only catches modifications to tracked
+          # files; `apko lock` writes brand-new `<config>.apko.lock.json`
+          # files on first run that are still untracked. `git status
+          # --porcelain` covers both cases.
+          if [ -z "$(git status --porcelain -- 'docker/*/apko.lock.json')" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,19 @@ jobs:
       # release-please PRs only touch CHANGELOG.md, version.txt, and
       # the manifest. There is no source code to test, so every heavy
       # job below short-circuits on this flag and ci-pass posts success
-      # immediately. Detect via both `github.ref` (covers push +
-      # workflow_dispatch from release.yml's nudge) and
-      # `github.head_ref` (covers pull_request from main, if anti-
-      # recursion ever lifts).
-      is_release_please: ${{ startsWith(github.ref, 'refs/heads/release-please--') || startsWith(github.head_ref, 'release-please--') }}
+      # immediately.
+      #
+      # SECURITY: branch names alone are NOT sufficient -- on a
+      # `pull_request` event from a fork, `github.head_ref` is the
+      # source ref name, which is fully attacker-controlled. A fork PR
+      # named `release-please--evil` would otherwise short-circuit CI
+      # and post a green CI Pass with no real testing. We therefore
+      # gate the pull_request arm on the PR author identity (set by
+      # GitHub at PR creation, not bypassable via branch naming) and
+      # only fall back to ref-name detection for push / dispatch
+      # events, where pushing `refs/heads/release-please--*` already
+      # requires push access to the upstream.
+      is_release_please: ${{ (github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'synthorg-release-bot[bot]') || (github.event_name != 'pull_request' && startsWith(github.ref, 'refs/heads/release-please--')) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,14 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
       dashboard: ${{ steps.filter.outputs.dashboard }}
       docker: ${{ steps.filter.outputs.docker }}
+      # release-please PRs only touch CHANGELOG.md, version.txt, and
+      # the manifest. There is no source code to test, so every heavy
+      # job below short-circuits on this flag and ci-pass posts success
+      # immediately. Detect via both `github.ref` (covers push +
+      # workflow_dispatch from release.yml's nudge) and
+      # `github.head_ref` (covers pull_request from main, if anti-
+      # recursion ever lifts).
+      is_release_please: ${{ startsWith(github.ref, 'refs/heads/release-please--') || startsWith(github.head_ref, 'release-please--') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -64,7 +72,7 @@ jobs:
   lint:
     name: Lint
     needs: changes
-    if: needs.changes.outputs.python == 'true' || github.event_name == 'workflow_dispatch'
+    if: (needs.changes.outputs.python == 'true' || github.event_name == 'workflow_dispatch') && needs.changes.outputs.is_release_please != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -93,7 +101,7 @@ jobs:
   schema-validate:
     name: Schema Validation
     needs: changes
-    if: needs.changes.outputs.python == 'true' || github.event_name == 'workflow_dispatch'
+    if: (needs.changes.outputs.python == 'true' || github.event_name == 'workflow_dispatch') && needs.changes.outputs.is_release_please != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: atlas
@@ -151,7 +159,7 @@ jobs:
   type-check:
     name: Type Check
     needs: changes
-    if: needs.changes.outputs.python == 'true' || github.event_name == 'workflow_dispatch'
+    if: (needs.changes.outputs.python == 'true' || github.event_name == 'workflow_dispatch') && needs.changes.outputs.is_release_please != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -169,7 +177,7 @@ jobs:
   openapi-liveness:
     name: OpenAPI Liveness
     needs: changes
-    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.dashboard == 'true' || github.event_name == 'workflow_dispatch'
+    if: (needs.changes.outputs.python == 'true' || needs.changes.outputs.dashboard == 'true' || github.event_name == 'workflow_dispatch') && needs.changes.outputs.is_release_please != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -187,7 +195,7 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
     needs: changes
-    if: needs.changes.outputs.python == 'true' || github.event_name == 'workflow_dispatch'
+    if: (needs.changes.outputs.python == 'true' || github.event_name == 'workflow_dispatch') && needs.changes.outputs.is_release_please != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -252,7 +260,7 @@ jobs:
   python-audit:
     name: Python Security Audit
     needs: changes
-    if: needs.changes.outputs.python == 'true' || github.event_name == 'workflow_dispatch'
+    if: (needs.changes.outputs.python == 'true' || github.event_name == 'workflow_dispatch') && needs.changes.outputs.is_release_please != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -278,7 +286,7 @@ jobs:
   dockerfile-lint:
     name: Dockerfile Lint
     needs: changes
-    if: needs.changes.outputs.docker == 'true' || github.event_name == 'workflow_dispatch'
+    if: (needs.changes.outputs.docker == 'true' || github.event_name == 'workflow_dispatch') && needs.changes.outputs.is_release_please != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -302,7 +310,7 @@ jobs:
   dashboard-lint:
     name: Dashboard Lint
     needs: changes
-    if: needs.changes.outputs.dashboard == 'true' || github.event_name == 'workflow_dispatch'
+    if: (needs.changes.outputs.dashboard == 'true' || github.event_name == 'workflow_dispatch') && needs.changes.outputs.is_release_please != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -325,7 +333,7 @@ jobs:
   dashboard-type-check:
     name: Dashboard Type Check
     needs: changes
-    if: needs.changes.outputs.dashboard == 'true' || github.event_name == 'workflow_dispatch'
+    if: (needs.changes.outputs.dashboard == 'true' || github.event_name == 'workflow_dispatch') && needs.changes.outputs.is_release_please != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -352,7 +360,7 @@ jobs:
   dashboard-test:
     name: Dashboard Test
     needs: changes
-    if: needs.changes.outputs.dashboard == 'true' || github.event_name == 'workflow_dispatch'
+    if: (needs.changes.outputs.dashboard == 'true' || github.event_name == 'workflow_dispatch') && needs.changes.outputs.is_release_please != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -505,7 +513,7 @@ jobs:
   dashboard-build:
     name: Dashboard Build
     needs: changes
-    if: needs.changes.outputs.dashboard == 'true' || github.event_name == 'workflow_dispatch'
+    if: (needs.changes.outputs.dashboard == 'true' || github.event_name == 'workflow_dispatch') && needs.changes.outputs.is_release_please != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -533,7 +541,7 @@ jobs:
   dashboard-audit:
     name: Dashboard Security Audit
     needs: changes
-    if: needs.changes.outputs.dashboard == 'true' || github.event_name == 'workflow_dispatch'
+    if: (needs.changes.outputs.dashboard == 'true' || github.event_name == 'workflow_dispatch') && needs.changes.outputs.is_release_please != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -557,7 +565,7 @@ jobs:
   dashboard-storybook-build:
     name: Dashboard Storybook Build
     needs: changes
-    if: needs.changes.outputs.dashboard == 'true' || github.event_name == 'workflow_dispatch'
+    if: (needs.changes.outputs.dashboard == 'true' || github.event_name == 'workflow_dispatch') && needs.changes.outputs.is_release_please != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/docs/design/deployment.md
+++ b/docs/design/deployment.md
@@ -33,7 +33,7 @@ Reconciliation mechanisms:
 | Mechanism | Target | Cadence |
 |-----------|--------|---------|
 | Renovate (Docker ecosystem + digest pinning) | Thin Dockerfile `FROM` lines (apko-base digest) | Daily |
-| `apko lock` cron (`.github/workflows/apko-lock.yml`) | `docker/*/apko.lock.json` (backend, sandbox, sidecar, fine-tune, web) | Weekly (Mon 06:00 UTC) -- the single `fine-tune` apko base is shared by both `-gpu` and `-cpu` runtime images |
+| `apko lock` cron (`.github/workflows/apko-lock.yml`) | `docker/*/apko.lock.json` (backend, sandbox, sidecar, fine-tune). `docker/web/apko.yaml` is intentionally skipped: it depends on the workflow-build-time `synthorg-web-assets@local` melange package, which has no stable upstream to lock against | Weekly (Mon 06:00 UTC) -- the single `fine-tune` apko base is shared by both `-gpu` and `-cpu` runtime images |
 
 ## Image verification at launch
 

--- a/scripts/audit_branch_protection.sh
+++ b/scripts/audit_branch_protection.sh
@@ -74,6 +74,11 @@ echo
 # API or from yq's YAML -> JSON conversion) into the canonical shape:
 #   - Strip id, node_id, created_at, updated_at, bypass_actors,
 #     current_user_can_bypass, source, source_type, _links, node_id
+#   - Drop `copilot_code_review` rule entries -- Copilot review is a
+#     UI-managed convenience that gets toggled off when GitHub changes
+#     its review-rate-limit policies, so treating its presence as drift
+#     produces noise on every policy adjustment. Both sides have it
+#     stripped, so the audit is silent on this rule by design.
 #   - Sort .rules by .type (ascending) so diff is order-independent
 #   - Remove null `parameters` objects (YAML spec omits; API may emit)
 #
@@ -84,12 +89,14 @@ NORMALISE_FILTER='
     del(.id, .node_id, .created_at, .updated_at,
         .bypass_actors, .current_user_can_bypass,
         .source, .source_type, ._links);
+  def drop_ignored_rules:
+    if .rules then .rules |= map(select(.type != "copilot_code_review")) else . end;
   def sort_rules:
     if .rules then .rules |= sort_by(.type) else . end;
   def drop_null_params:
     if .rules then .rules |= map(if has("parameters") and .parameters == null then del(.parameters) else . end) else . end;
   {
-    rulesets: (.rulesets | map(strip_meta | sort_rules | drop_null_params) | sort_by(.name))
+    rulesets: (.rulesets | map(strip_meta | drop_ignored_rules | sort_rules | drop_null_params) | sort_by(.name))
   }
 '
 


### PR DESCRIPTION
## Summary

Three independent CI fixes that surfaced while validating the recent `apko-lock` and `release.yml` work in #1593.

### 1. release-please PRs run a full CI suite for nothing

release-please only modifies `CHANGELOG.md`, `version.txt`, and the manifest -- there is no source code to test, but `ci.yml` was running every heavy job (`lint`, `test`, `dashboard-*`, `type-check`, `python-audit`, etc.) on every release PR.

- **`ci.yml`**: add an `is_release_please` output to the `changes` job; gate every heavy job's `if:` on `&& needs.changes.outputs.is_release_please != 'true'`. The existing `ci-pass` job already runs with `if: always()` and treats `skipped` results as success, so all heavy jobs short-circuit to `skipped` and `CI Pass` posts `success` in seconds. The `workflow_dispatch` nudge from `release.yml` continues to fire `ci.yml`, but it now resolves immediately instead of running a full suite.

**Security hardening (CRITICAL):** the first cut of the gate used `startsWith(github.head_ref, 'release-please--')`, but on a `pull_request` event from a fork, `github.head_ref` is the source-branch name -- attacker-controlled. A fork PR named `release-please--evil` would have skipped every gate and posted a green `CI Pass` with zero real testing, leaving merge gated only on maintainer review (a viable social-engineering vector: "approve my urgent release-please fix"). The detection now also requires `github.event.pull_request.user.login == 'synthorg-release-bot[bot]'` on the `pull_request` arm. Push / dispatch events keep ref-name detection because pushing `refs/heads/release-please--*` already requires push access to the upstream.

**Out-of-band follow-up:** the user is separately adding `synthorg-release-bot` as a `bypass_actors` entry on the `protect-main` ruleset (via `gh api` or Settings -> Rules). With both pieces in place, release PRs neither run heavy CI nor require `CI Pass` -- and even if the bypass entry is later removed, the `is_release_please` gate keeps `CI Pass` auto-passing on legitimate release PRs (defense-in-depth).

### 2. `apko-lock.yml` was broken even after the `--update` fix in #1593

The first run of the workflow after #1593 landed surfaced a second, independent failure mode:

```
Error: initializing apk: failed to initialize apk keyring: failed to read apk key:
open /work/melange.rsa.pub: no such file or directory
```

`docker/web/apko.yaml` depends on `synthorg-web-assets@local` -- a melange-built apk produced fresh per `docker.yml` run, with no stable upstream and a workflow-build-time keyring (`melange.rsa.pub`) that doesn't exist outside `docker.yml`'s build context. `apko lock` couldn't read the keyring and `set -e` aborted the whole loop after locking only the first 4 (`backend`, `fine-tune`, `sandbox`, `sidecar`).

- **`apko-lock.yml`**: skip `docker/web/apko.yaml` cleanly with an explicit comment explaining why.
- **Diff-detection bug:** the existing `git diff --quiet -- 'docker/*/apko.lock.json'` only catches modifications to **tracked** files. The very first lockfile-generating run produces brand-new untracked files, which `git diff --quiet` reports as identical, so the workflow's "Create PR" step would have been gated to `false` on first run anyway. Replaced with `[ -z "$(git status --porcelain -- 'docker/*/apko.lock.json')" ]` which catches both modifications and new files.

### 3. `copilot_code_review` ruleset drift produces noise

GitHub adjusted Copilot review rate limits, so the live `default` ruleset has the rule removed but the spec still has it. The audit script (`scripts/audit_branch_protection.sh`) flags this as drift on every run, and it would do so again on every future GitHub policy adjustment.

- **`branch_protection.yml`**: drop the `copilot_code_review` rule from the `default` ruleset; document the strip in the header comment so future maintainers don't re-add it.
- **`scripts/audit_branch_protection.sh`**: add a `drop_ignored_rules` step to `NORMALISE_FILTER` that strips `copilot_code_review` entries from BOTH the live and spec sides before diffing. The audit is now silent on this rule by design.

Plus the docs sync:

- **`docs/design/deployment.md`** reconciliation table: drop `web` from the apko-lock target list and explain the skip.

## Why now

The `apko lock` workflow_dispatch run done immediately after #1593 merged failed at the `Update lockfiles` step, exposing the `melange.rsa.pub` issue (the `--update` fix had unblocked the loop only enough to reveal the next bug). Same dispatch run was the prompt to investigate why release-please PR #1592 was sitting on a `BLOCKED` merge state -- which led to the realisation that the `protect-main` ruleset's `CI Pass` requirement was the gate, and that a single `is_release_please` flag in `ci.yml` would let release PRs short-circuit cleanly.

## Test plan

- **`apko-lock.yml`**: next manual dispatch (or weekly cron) runs `apko lock` across the 4 lockable configs, skips `docker/web/apko.yaml` with a clear log line, and either opens `ci/apko-lock-update` if Wolfi indices have moved or no-ops cleanly. Output of the failed run prior to this PR is the proof of the regression.
- **`ci.yml`**: the very PR you're reading -- ci.yml fires on this PR; it touches workflow files (matches the `python` path filter via `.github/workflows/ci.yml` itself) so the heavy jobs DO run for this commit. The is_release_please flag is `false` here. The next release-please PR will be the live test of the skip.
- **`branch_protection.yml` + audit script**: `bash scripts/audit_branch_protection.sh --repo Aureliolo/synthorg` exits 0 with "OK: live rulesets match" instead of the prior `copilot_code_review`-driven 1.

## Review coverage

Pre-reviewed by 3 agents (`infra-reviewer`, `docs-consistency`, `security-reviewer`).

- **security-reviewer** flagged a CRITICAL exploitable path on the original `is_release_please` detection (attacker-controlled `github.head_ref` in fork PRs). Fixed in the second commit on this branch by adding the PR-author identity check.
- **docs-consistency** flagged stale `web` reference in `docs/design/deployment.md` apko-lock target table. Fixed.
- **infra-reviewer** flagged the same `github.head_ref` concern (independent of security-reviewer) plus a MEDIUM "spec lacks comment about copilot strip" -- both fixed.