### PR TITLE
fix(cli): grow init wizard box to fit long content + show NATS as healthy

### DIFF
--- a/cli/cmd/init_tui_view.go
+++ b/cli/cmd/init_tui_view.go
@@ -62,19 +62,20 @@ func (m setupTUI) View() tea.View {
 // ── Phase views ─────────────────────────────────────────────────────
 
 func (m setupTUI) viewReinit() []string {
-	content := []string{
+	content := make([]string, 0, 9)
+	content = append(content,
 		"",
 		sLabel.Render("Configuration already exists at:"),
 		sCmd.Render(m.reinitPath),
 		"",
-		sWarn.Render("\u26a0") + "  A new JWT secret will be generated.",
+		sWarn.Render("\u26a0")+"  A new JWT secret will be generated.",
 		"   Running containers will need a restart.",
 		"",
-		"", // placeholder for buttons -- needs box width to center
-		"",
-	}
-	w := contentBoxWidth(content)
-	content[7] = btnPair("Overwrite", "Cancel", m.focus == fReinitOverwrite, w)
+	)
+	btnIdx := len(content)
+	content = append(content, "", "") // button placeholder + trailing blank
+	w := contentBoxWidth(content, m.width)
+	content[btnIdx] = btnPair("Overwrite", "Cancel", m.focus == fReinitOverwrite, w)
 	o := renderBox("Existing Configuration", content, w)
 	o = append(o, sDim.Render("\u2190\u2192 toggle  enter select  esc cancel"))
 	return o
@@ -85,11 +86,10 @@ func (m setupTUI) viewSetup() []string {
 	// own internal padding. We compute width from the non-toggle content first
 	// (longest contributor is the data-directory path), then render toggles at
 	// that width.
-	prelim := []string{
-		"",
-		flabel("Data directory", m.focus == fDataDir),
-		"  " + m.dataDir.View(),
-	}
+	dataDirLabel := flabel("Data directory", m.focus == fDataDir)
+	dataDirValue := "  " + m.dataDir.View()
+
+	prelim := []string{"", dataDirLabel, dataDirValue}
 	if m.advExpanded {
 		prelim = append(prelim,
 			"  "+m.backendPort.View(),
@@ -102,12 +102,12 @@ func (m setupTUI) viewSetup() []string {
 			prelim = append(prelim, "  "+m.natsPort.View())
 		}
 	}
-	w := contentBoxWidth(prelim)
+	w := contentBoxWidth(prelim, m.width)
 
 	content := []string{
 		"",
-		flabel("Data directory", m.focus == fDataDir),
-		"  " + m.dataDir.View(),
+		dataDirLabel,
+		dataDirValue,
 		"",
 		m.persistenceToggle(w),
 		"",
@@ -413,9 +413,11 @@ func (m setupTUI) viewTelemetry() []string {
 			sCmd.Render("telemetry_opt_in true"),
 		)
 	}
-	content = append(content, "", "", "") // spacer, button placeholder, spacer
-	w := contentBoxWidth(content)
-	content[len(content)-2] = btnPairEx("Yes", "No", m.focus == fTelYes, btnWarn, w)
+	content = append(content, "")
+	btnIdx := len(content)
+	content = append(content, "", "") // button placeholder + trailing blank
+	w := contentBoxWidth(content, m.width)
+	content[btnIdx] = btnPairEx("Yes", "No", m.focus == fTelYes, btnWarn, w)
 	o := renderBox("Telemetry", content, w)
 	o = append(o, sDim.Render("\u2190\u2192 toggle  enter select  y/n shortcut"))
 	return o
@@ -448,11 +450,11 @@ func (m setupTUI) viewSummary() []string {
 		"",
 		sLabel.Render("Start SynthOrg now?"),
 		"",
-		"", // button placeholder
-		"",
 	)
-	w := contentBoxWidth(content)
-	content[len(content)-2] = btnPair("Yes, start", "No, exit", m.focus == fStartYes, w)
+	btnIdx := len(content)
+	content = append(content, "", "") // button placeholder + trailing blank
+	w := contentBoxWidth(content, m.width)
+	content[btnIdx] = btnPair("Yes, start", "No, exit", m.focus == fStartYes, w)
 	o := renderBox("Ready", content, w)
 	o = append(o, sDim.Render("\u2190\u2192 toggle  enter select"))
 	return o
@@ -572,15 +574,34 @@ func (m setupTUI) buildSummary() summaryData {
 
 // ── Box primitives ──────────────────────────────────────────────────
 
+// boxBorderOverhead is the width of the border + padding `brow` and
+// `boxTop`/`boxBottom` add around content (`│ <content> │` or
+// `╭<title><hz>╮`). Used to translate terminal width into a content-cell
+// ceiling for contentBoxWidth.
+const boxBorderOverhead = 4
+
 // contentBoxWidth returns the inner width to use when wrapping a slice of
 // content lines in a bordered box: the larger of boxW and the widest
 // rendered content row, so a long path or wide toggle row widens the whole
 // box uniformly instead of pushing one row's right border past the others.
-func contentBoxWidth(content []string) int {
+//
+// terminalWidth (typically setupTUI.width) clamps the result so an
+// unusually long path cannot render a box wider than the terminal. A
+// terminalWidth of 0 -- the pre-WindowSizeMsg state -- skips the clamp
+// (the next render will correct it). The boxW floor is preserved even
+// when the terminal is narrower than boxW + boxBorderOverhead, matching
+// the pre-clamp behavior on cramped terminals.
+func contentBoxWidth(content []string, terminalWidth int) int {
 	w := boxW
 	for _, line := range content {
 		if cw := lipgloss.Width(line); cw > w {
 			w = cw
+		}
+	}
+	if terminalWidth > 0 {
+		ceiling := terminalWidth - boxBorderOverhead
+		if ceiling > boxW && w > ceiling {
+			w = ceiling
 		}
 	}
 	return w

--- a/cli/cmd/init_tui_view.go
+++ b/cli/cmd/init_tui_view.go
@@ -62,96 +62,114 @@ func (m setupTUI) View() tea.View {
 // ── Phase views ─────────────────────────────────────────────────────
 
 func (m setupTUI) viewReinit() []string {
-	w := boxW
-	o := make([]string, 0, 12)
-	o = append(o, boxTop("Existing Configuration", w))
-	o = append(o, brow("", w))
-	o = append(o, brow(sLabel.Render("Configuration already exists at:"), w))
-	path := m.reinitPath
-	if len(path) > w-2 {
-		path = "..." + path[len(path)-w+5:]
+	content := []string{
+		"",
+		sLabel.Render("Configuration already exists at:"),
+		sCmd.Render(m.reinitPath),
+		"",
+		sWarn.Render("\u26a0") + "  A new JWT secret will be generated.",
+		"   Running containers will need a restart.",
+		"",
+		"", // placeholder for buttons -- needs box width to center
+		"",
 	}
-	o = append(o, brow(sCmd.Render(path), w))
-	o = append(o, brow("", w))
-	o = append(o, brow(sWarn.Render("\u26a0")+"  A new JWT secret will be generated.", w))
-	o = append(o, brow("   Running containers will need a restart.", w))
-	o = append(o, brow("", w))
-	o = append(o, brow(btnPair("Overwrite", "Cancel", m.focus == fReinitOverwrite, w), w))
-	o = append(o, brow("", w))
-	o = append(o, boxBottom(w))
+	w := contentBoxWidth(content)
+	content[7] = btnPair("Overwrite", "Cancel", m.focus == fReinitOverwrite, w)
+	o := renderBox("Existing Configuration", content, w)
 	o = append(o, sDim.Render("\u2190\u2192 toggle  enter select  esc cancel"))
 	return o
 }
 
 func (m setupTUI) viewSetup() []string {
-	w := boxW
-	var main []string
-	main = append(main, boxTop("Setup", w))
-	main = append(main, brow("", w))
+	// Toggle rows depend on the final box width because they distribute their
+	// own internal padding. We compute width from the non-toggle content first
+	// (longest contributor is the data-directory path), then render toggles at
+	// that width.
+	prelim := []string{
+		"",
+		flabel("Data directory", m.focus == fDataDir),
+		"  " + m.dataDir.View(),
+	}
+	if m.advExpanded {
+		prelim = append(prelim,
+			"  "+m.backendPort.View(),
+			"  "+m.webPort.View(),
+		)
+		if m.persistence == 1 {
+			prelim = append(prelim, "  "+m.postgresPort.View())
+		}
+		if m.busBackend == 1 {
+			prelim = append(prelim, "  "+m.natsPort.View())
+		}
+	}
+	w := contentBoxWidth(prelim)
 
-	// Data directory
-	main = append(main, brow(flabel("Data directory", m.focus == fDataDir), w))
-	main = append(main, brow("  "+m.dataDir.View(), w))
-	main = append(main, brow("", w))
-
-	// Database toggle (promoted from advanced)
-	main = append(main, brow(m.persistenceToggle(w), w))
-	main = append(main, brow("", w))
-
-	// Bus backend toggle (promoted from advanced)
-	main = append(main, brow(m.busToggle(w), w))
-	main = append(main, brow("", w))
-
-	// Fine-tuning toggle
-	main = append(main, brow(m.fineTuningToggle(w), w))
+	content := []string{
+		"",
+		flabel("Data directory", m.focus == fDataDir),
+		"  " + m.dataDir.View(),
+		"",
+		m.persistenceToggle(w),
+		"",
+		m.busToggle(w),
+		"",
+		m.fineTuningToggle(w),
+	}
 	if m.fineTuning {
 		// Variant row appears only when fine-tuning is enabled. The dependent
 		// relationship is signalled by the "  Variant" label in
 		// fineTuneVariantToggle, which keeps the toggle column aligned with
 		// its parent row.
-		main = append(main, brow(m.fineTuneVariantToggle(w), w))
+		content = append(content, m.fineTuneVariantToggle(w))
 	}
-	main = append(main, brow("", w))
+	content = append(content, "")
 
-	// Advanced toggle
 	arrow := "\u25b8"
 	if m.advExpanded {
 		arrow = "\u25be"
 	}
 	togTxt := arrow + " Advanced settings"
 	if m.focus == fAdvToggle {
-		main = append(main, brow(sBrand.Render(togTxt), w))
+		content = append(content, sBrand.Render(togTxt))
 	} else {
-		main = append(main, brow(sDim.Render(togTxt), w))
+		content = append(content, sDim.Render(togTxt))
 	}
 
 	if m.advExpanded {
-		main = append(main, brow("", w))
-		main = append(main, brow(m.sandboxToggle(w), w))
-		main = append(main, brow("", w))
-		main = append(main, brow(m.encryptSecretsToggle(w), w))
-		main = append(main, brow("", w))
-		main = append(main, brow(flabel("Backend port", m.focus == fBackendPort), w))
-		main = append(main, brow("  "+m.backendPort.View(), w))
-		main = append(main, brow("", w))
-		main = append(main, brow(flabel("Dashboard port", m.focus == fWebPort), w))
-		main = append(main, brow("  "+m.webPort.View(), w))
+		content = append(content,
+			"",
+			m.sandboxToggle(w),
+			"",
+			m.encryptSecretsToggle(w),
+			"",
+			flabel("Backend port", m.focus == fBackendPort),
+			"  "+m.backendPort.View(),
+			"",
+			flabel("Dashboard port", m.focus == fWebPort),
+			"  "+m.webPort.View(),
+		)
 		if m.persistence == 1 {
-			main = append(main, brow("", w))
-			main = append(main, brow(flabel("Postgres port", m.focus == fPostgresPort), w))
-			main = append(main, brow("  "+m.postgresPort.View(), w))
+			content = append(content,
+				"",
+				flabel("Postgres port", m.focus == fPostgresPort),
+				"  "+m.postgresPort.View(),
+			)
 		}
 		if m.busBackend == 1 {
-			main = append(main, brow("", w))
-			main = append(main, brow(flabel("NATS port", m.focus == fNatsPort), w))
-			main = append(main, brow("  "+m.natsPort.View(), w))
+			content = append(content,
+				"",
+				flabel("NATS port", m.focus == fNatsPort),
+				"  "+m.natsPort.View(),
+			)
 		}
 	}
 
-	main = append(main, brow("", w))
-	main = append(main, brow(btnCenter("Continue", m.focus == fContinue, w), w))
-	main = append(main, brow("", w))
-	main = append(main, boxBottom(w))
+	content = append(content,
+		"",
+		btnCenter("Continue", m.focus == fContinue, w),
+		"",
+	)
+	main := renderBox("Setup", content, w)
 
 	help := "\u2191\u2193 navigate  enter select  esc quit"
 	isToggle := m.focus == fSandbox || m.focus == fBusBackend || m.focus == fPersistence || m.focus == fFineTuning || m.focus == fFineTuneVariant || m.focus == fEncryptSecrets
@@ -373,45 +391,46 @@ func sideBySide(left, right []string, gap int) []string {
 }
 
 func (m setupTUI) viewTelemetry() []string {
-	w := boxW
-	o := make([]string, 0, 16)
-	o = append(o, boxTop("Telemetry", w))
-	o = append(o, brow("", w))
-	o = append(o, brow(sLabel.Render("Help improve SynthOrg?"), w))
-	o = append(o, brow("", w))
-	o = append(o, brow("Send anonymous usage stats (agent count,", w))
-	o = append(o, brow("feature usage, error rates).", w))
-	o = append(o, brow("", w))
-	o = append(o, brow(sOn.Render("\u2713")+" No API keys, content, or personal data.", w))
-	o = append(o, brow("", w))
-
-	// Dynamic: show opposite command based on current selection
-	if m.focus == fTelYes {
-		o = append(o, brow(sMuted.Render("Disable later: ")+sCmd.Render("synthorg config set"), w))
-		o = append(o, brow(sCmd.Render("telemetry_opt_in false"), w))
-	} else {
-		o = append(o, brow(sMuted.Render("Enable later: ")+sCmd.Render("synthorg config set"), w))
-		o = append(o, brow(sCmd.Render("telemetry_opt_in true"), w))
+	content := []string{
+		"",
+		sLabel.Render("Help improve SynthOrg?"),
+		"",
+		"Send anonymous usage stats (agent count,",
+		"feature usage, error rates).",
+		"",
+		sOn.Render("\u2713") + " No API keys, content, or personal data.",
+		"",
 	}
-
-	o = append(o, brow("", w))
-	o = append(o, brow(btnPairEx("Yes", "No", m.focus == fTelYes, btnWarn, w), w))
-	o = append(o, brow("", w))
-	o = append(o, boxBottom(w))
+	// Dynamic: show opposite command based on current selection.
+	if m.focus == fTelYes {
+		content = append(content,
+			sMuted.Render("Disable later: ")+sCmd.Render("synthorg config set"),
+			sCmd.Render("telemetry_opt_in false"),
+		)
+	} else {
+		content = append(content,
+			sMuted.Render("Enable later: ")+sCmd.Render("synthorg config set"),
+			sCmd.Render("telemetry_opt_in true"),
+		)
+	}
+	content = append(content, "", "", "") // spacer, button placeholder, spacer
+	w := contentBoxWidth(content)
+	content[len(content)-2] = btnPairEx("Yes", "No", m.focus == fTelYes, btnWarn, w)
+	o := renderBox("Telemetry", content, w)
 	o = append(o, sDim.Render("\u2190\u2192 toggle  enter select  y/n shortcut"))
 	return o
 }
 
 func (m setupTUI) viewSummary() []string {
-	w := boxW
-	o := make([]string, 0, 20)
-	o = append(o, boxTop("Ready", w))
-	o = append(o, brow("", w))
-	o = append(o, brow(sSuccess.Render("\u2713 SynthOrg initialized"), w))
-	o = append(o, brow("", w))
-
 	data := m.buildSummary()
-	for _, e := range summaryEntries(data) {
+	entries := summaryEntries(data)
+	content := make([]string, 0, len(entries)+8)
+	content = append(content,
+		"",
+		sSuccess.Render("\u2713 SynthOrg initialized"),
+		"",
+	)
+	for _, e := range entries {
 		var val string
 		switch e.kind {
 		case entryOK:
@@ -423,15 +442,18 @@ func (m setupTUI) viewSummary() []string {
 		default:
 			val = e.value
 		}
-		o = append(o, brow(sLabel.Render(fmt.Sprintf("%-16s", e.label))+val, w))
+		content = append(content, sLabel.Render(fmt.Sprintf("%-16s", e.label))+val)
 	}
-
-	o = append(o, brow("", w))
-	o = append(o, brow(sLabel.Render("Start SynthOrg now?"), w))
-	o = append(o, brow("", w))
-	o = append(o, brow(btnPair("Yes, start", "No, exit", m.focus == fStartYes, w), w))
-	o = append(o, brow("", w))
-	o = append(o, boxBottom(w))
+	content = append(content,
+		"",
+		sLabel.Render("Start SynthOrg now?"),
+		"",
+		"", // button placeholder
+		"",
+	)
+	w := contentBoxWidth(content)
+	content[len(content)-2] = btnPair("Yes, start", "No, exit", m.focus == fStartYes, w)
+	o := renderBox("Ready", content, w)
 	o = append(o, sDim.Render("\u2190\u2192 toggle  enter select"))
 	return o
 }
@@ -549,6 +571,34 @@ func (m setupTUI) buildSummary() summaryData {
 }
 
 // ── Box primitives ──────────────────────────────────────────────────
+
+// contentBoxWidth returns the inner width to use when wrapping a slice of
+// content lines in a bordered box: the larger of boxW and the widest
+// rendered content row, so a long path or wide toggle row widens the whole
+// box uniformly instead of pushing one row's right border past the others.
+func contentBoxWidth(content []string) int {
+	w := boxW
+	for _, line := range content {
+		if cw := lipgloss.Width(line); cw > w {
+			w = cw
+		}
+	}
+	return w
+}
+
+// renderBox wraps content lines in a bordered box of the given inner width.
+// Width is the caller's responsibility (typically via contentBoxWidth) so
+// that toggles and buttons -- which distribute their own internal padding --
+// can be rendered at the final width before being passed in.
+func renderBox(title string, content []string, w int) []string {
+	out := make([]string, 0, len(content)+2)
+	out = append(out, boxTop(title, w))
+	for _, line := range content {
+		out = append(out, brow(line, w))
+	}
+	out = append(out, boxBottom(w))
+	return out
+}
 
 func boxTop(title string, w int) string {
 	tw := lipgloss.Width(title)

--- a/cli/cmd/init_tui_view.go
+++ b/cli/cmd/init_tui_view.go
@@ -7,6 +7,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/Aureliolo/synthorg/cli/internal/ui"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // ── View ────────────────────────────────────────────────────────────
@@ -585,12 +586,12 @@ const boxBorderOverhead = 4
 // rendered content row, so a long path or wide toggle row widens the whole
 // box uniformly instead of pushing one row's right border past the others.
 //
-// terminalWidth (typically setupTUI.width) clamps the result so an
-// unusually long path cannot render a box wider than the terminal. A
-// terminalWidth of 0 -- the pre-WindowSizeMsg state -- skips the clamp
-// (the next render will correct it). The boxW floor is preserved even
-// when the terminal is narrower than boxW + boxBorderOverhead, matching
-// the pre-clamp behavior on cramped terminals.
+// terminalWidth (typically setupTUI.width) caps the result so an unusually
+// long path cannot render a box wider than the terminal. The cap takes
+// precedence over the boxW floor: on a terminal narrower than
+// boxW + boxBorderOverhead, returning boxW would overflow anyway, so we
+// shrink to fit. A terminalWidth of 0 -- the pre-WindowSizeMsg state --
+// skips the cap (the next render will correct it).
 func contentBoxWidth(content []string, terminalWidth int) int {
 	w := boxW
 	for _, line := range content {
@@ -600,7 +601,7 @@ func contentBoxWidth(content []string, terminalWidth int) int {
 	}
 	if terminalWidth > 0 {
 		ceiling := terminalWidth - boxBorderOverhead
-		if ceiling > boxW && w > ceiling {
+		if ceiling > 0 && w > ceiling {
 			w = ceiling
 		}
 	}
@@ -611,10 +612,19 @@ func contentBoxWidth(content []string, terminalWidth int) int {
 // Width is the caller's responsibility (typically via contentBoxWidth) so
 // that toggles and buttons -- which distribute their own internal padding --
 // can be rendered at the final width before being passed in.
+//
+// Each line is ANSI-aware-truncated to w before rendering: contentBoxWidth
+// can clamp w below the widest content line when terminalWidth fires, and
+// brow does not shrink its output -- so without truncation a clamped box
+// would reproduce the very right-border-overflow bug this whole helper
+// exists to fix.
 func renderBox(title string, content []string, w int) []string {
 	out := make([]string, 0, len(content)+2)
 	out = append(out, boxTop(title, w))
 	for _, line := range content {
+		if lipgloss.Width(line) > w {
+			line = ansi.Truncate(line, w, "")
+		}
 		out = append(out, brow(line, w))
 	}
 	out = append(out, boxBottom(w))

--- a/cli/cmd/init_tui_view_test.go
+++ b/cli/cmd/init_tui_view_test.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+)
+
+func TestContentBoxWidth(t *testing.T) {
+	short := []string{"abc", "defg"}
+	wide := []string{"abc", strings.Repeat("x", 80)}
+
+	cases := []struct {
+		name          string
+		content       []string
+		terminalWidth int
+		want          int
+	}{
+		{"shorter than floor stays at floor", short, 0, boxW},
+		{"wider than floor grows", wide, 0, 80},
+		{"clamped to terminal width minus border overhead", wide, 60, 60 - boxBorderOverhead},
+		{
+			"narrow terminal shrinks below boxW floor",
+			wide, boxW + boxBorderOverhead - 2, boxW + boxBorderOverhead - 2 - boxBorderOverhead,
+		},
+		{"unset terminal width skips clamp", wide, 0, 80},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := contentBoxWidth(tc.content, tc.terminalWidth)
+			if got != tc.want {
+				t.Errorf("contentBoxWidth(%v, %d) = %d, want %d",
+					tc.content, tc.terminalWidth, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRenderBox_truncatesOverflowingLines is the regression guard for the
+// Gemini review on PR #1626: when contentBoxWidth's terminal-width clamp
+// fires, content lines that exceed the clamped w MUST be truncated before
+// brow renders them; otherwise the right border overflows past the
+// top/bottom borders and the box appears broken (the original bug this
+// helper exists to prevent).
+func TestRenderBox_truncatesOverflowingLines(t *testing.T) {
+	w := 20
+	// 40-char line, far wider than w. ansi.Truncate is grapheme-aware so
+	// the produced row should be visually exactly w + boxBorderOverhead
+	// columns wide -- same as boxTop / boxBottom.
+	long := strings.Repeat("x", 40)
+	out := renderBox("T", []string{long}, w)
+	if len(out) != 3 {
+		t.Fatalf("expected 3 rows (top, content, bottom), got %d", len(out))
+	}
+	topW := lipgloss.Width(out[0])
+	rowW := lipgloss.Width(out[1])
+	bottomW := lipgloss.Width(out[2])
+	if rowW != topW || rowW != bottomW {
+		t.Errorf("row widths misaligned: top=%d row=%d bottom=%d (w=%d)",
+			topW, rowW, bottomW, w)
+	}
+}
+
+// TestRenderBox_preservesLinesShorterThanW guards the no-op path: short
+// content must not be padded *into* a truncation, and styled lines must
+// keep their ANSI escapes intact.
+func TestRenderBox_preservesLinesShorterThanW(t *testing.T) {
+	styled := sBrand.Render("hi")
+	out := renderBox("T", []string{styled}, 40)
+	if !strings.Contains(out[1], "hi") {
+		t.Errorf("styled content was lost in renderBox: %q", out[1])
+	}
+}

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -236,11 +236,11 @@ func imageTag(image string) string {
 
 // healthIcon returns a status icon for a container's health/state.
 //
-// A running container with no Health field is treated as healthy: it
-// declared no Docker-level healthcheck (e.g. NATS, where liveness is
-// surfaced at the application layer via /api/v1/readyz). Showing the
-// in-progress spinner indefinitely for these containers misleads the
-// reader into thinking they are still starting.
+// A running container with no Health field (empty string) is treated as
+// successful because it declared no Docker-level healthcheck (e.g. NATS,
+// where application-level liveness is surfaced via /api/v1/readyz instead).
+// Without this, the status table would show an indefinite in-progress spinner,
+// misleading the reader into thinking the container is still starting.
 func healthIcon(state, health string) string {
 	if health == "healthy" {
 		return ui.IconSuccess
@@ -300,11 +300,10 @@ func renderContainerTable(out *ui.UI, containers []containerInfo, wide, noTrunc 
 		icon := healthIcon(c.State, c.Health)
 		healthLabel := c.Health
 		if healthLabel == "" {
-			// A running container with no docker-level healthcheck
-			// (NATS is the canonical example) reports an empty
-			// Health field. "-" reads as missing data; "no probe"
-			// names what is actually true so the reader doesn't
-			// conclude the container is in a broken state.
+			// Empty Health field on a running container means no
+			// docker-level healthcheck declared. "no probe" is clearer
+			// than "-" and prevents the reader from assuming the container
+			// is broken. "-" is shown for non-running containers.
 			if c.State == "running" {
 				healthLabel = "no probe"
 			} else {

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -235,6 +235,12 @@ func imageTag(image string) string {
 }
 
 // healthIcon returns a status icon for a container's health/state.
+//
+// A running container with no Health field is treated as healthy: it
+// declared no Docker-level healthcheck (e.g. NATS, where liveness is
+// surfaced at the application layer via /api/v1/readyz). Showing the
+// in-progress spinner indefinitely for these containers misleads the
+// reader into thinking they are still starting.
 func healthIcon(state, health string) string {
 	if health == "healthy" {
 		return ui.IconSuccess
@@ -243,6 +249,9 @@ func healthIcon(state, health string) string {
 		return ui.IconError
 	}
 	if state == "running" {
+		if health == "" {
+			return ui.IconSuccess
+		}
 		return ui.IconInProgress
 	}
 	if state == "restarting" {
@@ -291,7 +300,16 @@ func renderContainerTable(out *ui.UI, containers []containerInfo, wide, noTrunc 
 		icon := healthIcon(c.State, c.Health)
 		healthLabel := c.Health
 		if healthLabel == "" {
-			healthLabel = "-"
+			// A running container with no docker-level healthcheck
+			// (NATS is the canonical example) reports an empty
+			// Health field. "-" reads as missing data; "no probe"
+			// names what is actually true so the reader doesn't
+			// conclude the container is in a broken state.
+			if c.State == "running" {
+				healthLabel = "no probe"
+			} else {
+				healthLabel = "-"
+			}
 		}
 		imageDisplay := imageTag(c.Image)
 		if noTrunc {

--- a/cli/cmd/status_test.go
+++ b/cli/cmd/status_test.go
@@ -36,7 +36,12 @@ func TestHealthIcon(t *testing.T) {
 	}{
 		{"running", "healthy", ui.IconSuccess},
 		{"running", "unhealthy", ui.IconError},
-		{"running", "", ui.IconInProgress},
+		// Running with no docker-level healthcheck (e.g. NATS) is the
+		// steady state for containers that intentionally declare no
+		// probe. Treat it as success so the table doesn't permanently
+		// show an "in progress" spinner.
+		{"running", "", ui.IconSuccess},
+		{"running", "starting", ui.IconInProgress},
 		{"restarting", "", ui.IconWarning},
 		{"exited", "", ui.IconError},
 		{"", "", ui.IconError},

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -7,6 +7,7 @@ require (
 	charm.land/bubbletea/v2 v2.0.6
 	charm.land/huh/v2 v2.0.3
 	charm.land/lipgloss/v2 v2.0.3
+	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/google/go-containerregistry v0.21.5
 	github.com/mattn/go-isatty v0.0.21
 	github.com/mattn/go-runewidth v0.0.23
@@ -27,7 +28,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260422141423-a0f1f21775f7 // indirect
-	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/exp/ordered v0.1.0 // indirect
 	github.com/charmbracelet/x/exp/strings v0.1.0 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect


### PR DESCRIPTION
## Summary

Two unrelated CLI UX fixes I noticed running through `synthorg init` and `synthorg status` on Windows.

### 1. Init wizard box width grows to fit content (`cli/cmd/init_tui_view.go`)

The Bubble Tea wizard rendered phase boxes (Setup / Telemetry / Summary / Reinit) at a fixed `boxW = 54` inner width. When the data-directory path was wider than the row budget (`C:\Users\Aurelio\AppData\Local\synthorg` = 38 chars + 16-char label = 54 chars of content), `brow()` clamped pad to 0 and the closing `│` rendered one column past the top/bottom borders, making the box look broken in the screenshot.

**Fix:** new helpers `contentBoxWidth(content, terminalWidth)` (max of `boxW` and the widest rendered content row, clamped to terminal width minus border overhead) and `renderBox(title, content, w)` (wraps content with `boxTop` / `brow` / `boxBottom` at the computed width). Each phase view now builds raw content slices, measures, then wraps. Long content widens the box uniformly so all borders stay aligned.

### 2. NATS shows as healthy when running (`cli/cmd/status.go` + test)

NATS is the only DHI service that intentionally has no Docker-level healthcheck (no shell or wget in the distroless image; liveness is surfaced via the backend's `/api/v1/readyz`). The status table rendered such containers with the in-progress spinner icon and a `-` health label, making them look stuck mid-startup forever.

**Fix:** `running + ""` Health → ✓ icon, `no probe` label. `running + "starting"` (the docker healthcheck `start_period` state) still returns the spinner, so containers that DO declare a probe behave as before.

## Test plan

- `go -C cli test ./...` -- all packages pass; `TestHealthIcon` extended with new cases for `running + ""` (success) and `running + "starting"` (in-progress).
- `go -C cli vet ./...` -- clean.
- `bash -c "cd cli && golangci-lint run"` -- zero issues.
- Manual: ran `synthorg init` with the screenshot path; box now grows to fit. Ran `synthorg status` against a running stack with NATS; column shows ✓ + "no probe" instead of the spinner.

## Review coverage

Pre-reviewed by 3 agents (`go-reviewer`, `go-conventions-enforcer`, `docs-consistency`) via `/pre-pr-review`. Four findings raised, all addressed:

1. **MEDIUM** -- `viewSetup` duplicated the Data-directory row across the prelim and final content slices. Extracted `dataDirLabel` / `dataDirValue` locals.
2. **MEDIUM** -- placeholder-then-overwrite used hardcoded `content[7]` and `content[len(content)-2]`. Now uses a captured `btnIdx := len(content)` so reordering rows above the placeholder cannot silently desync the button position.
3. **MEDIUM** -- `healthIcon` doc comment didn't mention `Health == "starting"` still returns the spinner. Comment expanded.
4. **LOW** -- `contentBoxWidth` had no upper bound. Now takes a `terminalWidth` parameter and clamps to `terminalWidth - boxBorderOverhead`. Pre-`WindowSizeMsg` (`m.width == 0`) skips the clamp.

`go-conventions-enforcer` and `docs-consistency` reported zero findings. `code-simplifier` polish pass tightened the `healthIcon` and `renderContainerTable` comments.