### PR TITLE
fix(ci): drop stale release-please ruleset exclusion

### DIFF
--- a/.github/branch_protection.yml
+++ b/.github/branch_protection.yml
@@ -26,7 +26,6 @@ rulesets:
       ref_name:
         include: ["~ALL"]
         exclude:
-          - refs/heads/release-please--*
           - refs/heads/cla-signatures
     rules:
       - type: code_quality


### PR DESCRIPTION
## Summary

Aligns `.github/branch_protection.yml` with the live default ruleset on `Aureliolo/synthorg` so `scripts/audit_branch_protection.sh` stops flagging drift on every run.

The spec excluded `refs/heads/release-please--*` from the default ruleset; the live ruleset has not carried that exclusion since the GitHub App release-pipeline rework (#1561). Release automation now mints signed commits as `synthorg-repo-bot` via the Git Data API, which satisfies `required_signatures` without needing a ref-name carve-out.

## Diff

```diff
       ref_name:
         include: ["~ALL"]
         exclude:
-          - refs/heads/release-please--*
           - refs/heads/cla-signatures
```

## Test plan

- `bash scripts/audit_branch_protection.sh --repo Aureliolo/synthorg` exits 0 locally with this change applied.
- No code, tests, or other config touched.

## Follow-up

#1633 tracks doing the same for `cla-signatures` so the entire `exclude:` list can disappear (requires migrating the CLA Assistant action away from unsigned `git push` to App-token Git Data API mints).
