### PR TITLE
ci: post all required-check statuses on release-please PRs

### DIFF
--- a/.github/workflows/codspeed-python.yml
+++ b/.github/workflows/codspeed-python.yml
@@ -114,7 +114,7 @@ jobs:
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
           BENCH_RESULT: ${{ needs.codspeed-python.result }}
-          BENCH_RAN: ${{ needs.changes.outputs.changed }}
+          PYTHON_CHANGED: ${{ needs.changes.outputs.changed }}
         run: |
           # When no Python files changed, the bench job is skipped on
           # purpose; report success so the required status is present
@@ -123,7 +123,7 @@ jobs:
             echo "Path-detection job failed: $CHANGES_RESULT"
             exit 1
           fi
-          if [[ "$BENCH_RAN" != "true" ]]; then
+          if [[ "$PYTHON_CHANGED" != "true" ]]; then
             echo "No Python-relevant changes detected -- bench skipped, gate passes."
             exit 0
           fi

--- a/.github/workflows/codspeed-python.yml
+++ b/.github/workflows/codspeed-python.yml
@@ -15,26 +15,25 @@ name: CodSpeed Python
 # meaningfully across runs. Walltime would need Macro Runners
 # (CodSpeed's bare-metal pool) to match that variance, which we have
 # explicitly scoped out of this system to keep the gate free-tier.
+#
+# Why no top-level ``paths:`` filter:
+#   ``codspeed-python-pass`` is a REQUIRED status check on ``main``
+#   (see ``.github/branch_protection.yml``). A workflow-level
+#   ``paths:`` filter would prevent the workflow from starting on
+#   non-Python PRs (web-only / cli-only / docs-only / infra-only),
+#   leaving the required check absent / pending and blocking
+#   unrelated merges. Same architecture as ``codspeed-web.yml`` and
+#   ``lighthouse.yml``: the workflow ALWAYS runs on
+#   ``pull_request`` / ``push`` to ``main``; the ``changes`` gate
+#   job below detects whether Python files were touched and skips
+#   the heavy bench job otherwise. The pass job aggregates both,
+#   so the required context always reports.
 
 on:
   push:
     branches: [main]
-    paths:
-      - "src/synthorg/**"
-      - "tests/benchmarks/**"
-      - "pyproject.toml"
-      - "uv.lock"
-      - ".github/actions/setup-python-uv/**"
-      - ".github/workflows/codspeed-python.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "src/synthorg/**"
-      - "tests/benchmarks/**"
-      - "pyproject.toml"
-      - "uv.lock"
-      - ".github/actions/setup-python-uv/**"
-      - ".github/workflows/codspeed-python.yml"
   # ``workflow_dispatch`` lets CodSpeed back-test historical commits to
   # seed the dashboard with baseline data after first install.
   workflow_dispatch:
@@ -46,8 +45,36 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # ── Gate: detect whether Python-relevant files changed ──
+  changes:
+    name: Detect python changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      changed: ${{ steps.filter.outputs.python }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            python:
+              - 'src/synthorg/**'
+              - 'tests/benchmarks/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.github/actions/setup-python-uv/**'
+              - '.github/workflows/codspeed-python.yml'
+
   codspeed-python:
     name: CodSpeed Python benchmarks
+    needs: changes
+    if: needs.changes.outputs.changed == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
@@ -72,21 +99,36 @@ jobs:
           run: uv run python -m pytest tests/benchmarks/ --codspeed -n0
 
   # Branch-protection-friendly aggregator: required check is a single
-  # name regardless of how many bench jobs exist.
+  # name regardless of how many bench jobs exist. Always reports so
+  # PRs that don't touch Python (and therefore correctly skip the
+  # bench job) still satisfy the required-check ruleset.
   codspeed-python-pass:
     name: CodSpeed Python Pass
     if: always()
-    needs: [codspeed-python]
+    needs: [changes, codspeed-python]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions: {}
     steps:
       - name: Check results
         env:
-          RESULTS: ${{ needs.codspeed-python.result }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          BENCH_RESULT: ${{ needs.codspeed-python.result }}
+          BENCH_RAN: ${{ needs.changes.outputs.changed }}
         run: |
-          if echo "$RESULTS" | grep -qE "failure|cancelled"; then
-            echo "CodSpeed Python checks failed. Job result: $RESULTS"
+          # When no Python files changed, the bench job is skipped on
+          # purpose; report success so the required status is present
+          # on PRs that don't touch the backend.
+          if [[ "$CHANGES_RESULT" == "failure" || "$CHANGES_RESULT" == "cancelled" ]]; then
+            echo "Path-detection job failed: $CHANGES_RESULT"
             exit 1
           fi
-          echo "CodSpeed Python checks passed (result: $RESULTS)"
+          if [[ "$BENCH_RAN" != "true" ]]; then
+            echo "No Python-relevant changes detected -- bench skipped, gate passes."
+            exit 0
+          fi
+          if [[ "$BENCH_RESULT" == "failure" || "$BENCH_RESULT" == "cancelled" ]]; then
+            echo "CodSpeed Python checks failed. Job result: $BENCH_RESULT"
+            exit 1
+          fi
+          echo "CodSpeed Python checks passed (result: $BENCH_RESULT)"

--- a/.github/workflows/codspeed-web.yml
+++ b/.github/workflows/codspeed-web.yml
@@ -100,7 +100,7 @@ jobs:
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
           BENCH_RESULT: ${{ needs.codspeed-web.result }}
-          BENCH_RAN: ${{ needs.changes.outputs.changed }}
+          WEB_CHANGED: ${{ needs.changes.outputs.changed }}
         run: |
           # When no web files changed, the bench job is skipped on
           # purpose; report success so the required status is
@@ -109,7 +109,7 @@ jobs:
             echo "Path-detection job failed: $CHANGES_RESULT"
             exit 1
           fi
-          if [[ "$BENCH_RAN" != "true" ]]; then
+          if [[ "$WEB_CHANGED" != "true" ]]; then
             echo "No web-relevant changes detected -- bench skipped, gate passes."
             exit 0
           fi

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -240,8 +240,8 @@ jobs:
           CHANGES_RESULT: ${{ needs.changes.result }}
           DASHBOARD_RESULT: ${{ needs.lighthouse-dashboard.result }}
           SITE_RESULT: ${{ needs.lighthouse-site.result }}
-          DASHBOARD_RAN: ${{ needs.changes.outputs.dashboard }}
-          SITE_RAN: ${{ needs.changes.outputs.site }}
+          DASHBOARD_CHANGED: ${{ needs.changes.outputs.dashboard }}
+          SITE_CHANGED: ${{ needs.changes.outputs.site }}
         run: |
           set -euo pipefail
           if [[ "$CHANGES_RESULT" == "failure" || "$CHANGES_RESULT" == "cancelled" ]]; then
@@ -251,16 +251,16 @@ jobs:
           # Only check a sub-job's result if its filter said it should
           # have run. If the filter said skip, the job is "skipped"
           # and that's the desired no-op outcome on irrelevant PRs.
-          if [[ "$DASHBOARD_RAN" == "true" ]]; then
+          if [[ "$DASHBOARD_CHANGED" == "true" ]]; then
             if [[ "$DASHBOARD_RESULT" == "failure" || "$DASHBOARD_RESULT" == "cancelled" ]]; then
               echo "Lighthouse Dashboard failed: $DASHBOARD_RESULT"
               exit 1
             fi
           fi
-          if [[ "$SITE_RAN" == "true" ]]; then
+          if [[ "$SITE_CHANGED" == "true" ]]; then
             if [[ "$SITE_RESULT" == "failure" || "$SITE_RESULT" == "cancelled" ]]; then
               echo "Lighthouse Site failed: $SITE_RESULT"
               exit 1
             fi
           fi
-          echo "Lighthouse Pass: dashboard ran=${DASHBOARD_RAN} (${DASHBOARD_RESULT}), site ran=${SITE_RAN} (${SITE_RESULT})"
+          echo "Lighthouse Pass: dashboard changed=${DASHBOARD_CHANGED} (${DASHBOARD_RESULT}), site changed=${SITE_CHANGED} (${SITE_RESULT})"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,38 +264,47 @@ jobs:
           gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$NEW_BODY"
           echo "Highlights prepended to PR #$PR_NUMBER"
 
-      # ── Mark CI Pass satisfied on the release PR ──
+      # ── Mark required status checks satisfied on the release PR ──
       # release-please opened / updated the PR using the
       # synthorg-repo-bot App installation token. GitHub's
       # anti-recursion rule blocks `pull_request` workflows for
       # events created by the workflow's own installation token,
-      # so ci.yml never auto-fires on release PRs.
+      # so ci.yml / codspeed-python.yml / codspeed-web.yml /
+      # lighthouse.yml never auto-fire on release PRs.
       #
       # The previous fix (#1593) used `gh workflow run ci.yml
       # --ref <release-branch>` to nudge ci.yml via
       # workflow_dispatch -- but workflow_dispatch runs produce a
       # check_suite with empty `pull_requests`, so the resulting
-      # `CI Pass` check_run does NOT appear in the PR's status
-      # rollup. Branch protection still saw the check on the SHA,
-      # but the merge UI showed "CI Pass -- Expected, waiting"
-      # forever (visible to a human viewer; not a real check
-      # failure but indistinguishable from one in the UI).
+      # check_run does NOT appear in the PR's status rollup.
+      # Branch protection still saw the check on the SHA, but the
+      # merge UI showed "<Check> -- Expected, waiting" forever
+      # (visible to a human viewer; not a real check failure but
+      # indistinguishable from one in the UI).
       #
       # Release PRs touch only CHANGELOG.md, version.txt, and the
-      # manifest -- there is no source code that ci.yml could
-      # meaningfully test. We therefore post the `CI Pass`
-      # *commit status* (not check_run) directly on the PR head
-      # SHA. Statuses are in the rollup unconditionally, satisfy
-      # branch protection's required-check evaluation, and don't
-      # require any workflow run at all. ci.yml's
-      # `is_release_please` skip stays in place as defense-in-
-      # depth in case release-please's identity ever changes.
+      # manifest -- there is no source code that any of these
+      # workflows could meaningfully test or benchmark. We
+      # therefore post each required *commit status* (not
+      # check_run) directly on the PR head SHA. Statuses are in
+      # the rollup unconditionally, satisfy branch protection's
+      # required-check evaluation, and don't require any workflow
+      # run at all. ci.yml's `is_release_please` skip stays in
+      # place as defense-in-depth in case release-please's
+      # identity ever changes.
+      #
+      # The required-context list MUST stay in sync with
+      # `.github/branch_protection.yml` (the spec) and the live
+      # `protect-main` ruleset. The branch-protection drift audit
+      # in ci.yml will surface the spec side; new required
+      # contexts must be added here at the same time, or the
+      # release PR will silently re-block.
       #
       # Resolves the head SHA AT THIS POINT (after the BSL Change
-      # Date Contents-API commit) so the status posts on the
+      # Date Contents-API commit) so the statuses post on the
       # final SHA the PR will be merged at, not the
       # release-please-action output captured before that commit.
-      - name: Post CI Pass status on release PR
+      - name: Post required-check statuses on release PR
         if: steps.release.outputs.pr != ''
         env:
           GH_TOKEN: ${{ github.token }}
@@ -303,8 +312,17 @@ jobs:
         run: |
           set -euo pipefail
           HEAD_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/refs/heads/$BRANCH" --jq '.object.sha')
-          gh api -X POST "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
-            -f "state=success" \
-            -f "context=CI Pass" \
-            -f "description=release-please PR -- CI auto-passes (no source changes to test)"
-          echo "Posted CI Pass=success on $HEAD_SHA"
+          DESCRIPTION="release-please PR -- auto-passes (no source changes to test)"
+          # Keep in sync with .github/branch_protection.yml ::
+          # rulesets[name=protect-main] :: required_status_checks.
+          for context in \
+            "CI Pass" \
+            "CodSpeed Python Pass" \
+            "CodSpeed Web Pass" \
+            "Lighthouse Pass"; do
+            gh api -X POST "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+              -f "state=success" \
+              -f "context=$context" \
+              -f "description=$DESCRIPTION"
+            echo "Posted '$context'=success on $HEAD_SHA"
+          done


### PR DESCRIPTION
## Summary

Release-please opens its PR using the `synthorg-repo-bot` App installation token. GitHub's anti-recursion rule blocks `pull_request` workflows triggered by their own installation, so `ci.yml`, `codspeed-python.yml`, `codspeed-web.yml`, and `lighthouse.yml` never auto-fire on release PRs.

`ci.yml` already had a workaround: `release.yml` posts the `CI Pass` commit status directly via the Statuses API (lines 298-310, added in #1593). The same workaround was never extended to the other three required contexts on `protect-main`, so release PRs sit blocked forever waiting for `CodSpeed Python Pass`, `CodSpeed Web Pass`, and `Lighthouse Pass` that can never arrive.

## Change

Extend the existing `release.yml` step into a loop over every required context defined in `.github/branch_protection.yml :: protect-main`:

- `CI Pass`
- `CodSpeed Python Pass`
- `CodSpeed Web Pass`
- `Lighthouse Pass`

Renamed step to "Post required-check statuses on release PR" and added a sync note pointing to `branch_protection.yml` so future required-check additions land here at the same time. Description text generalized to "release-please PR -- auto-passes (no source changes to test)".

## Test plan

- Workflow file lints cleanly via pre-commit (yaml + workflow guards passed).
- Once merged, the next `Release` run on `push: main` will post all four statuses on the (existing or refreshed) release-please PR head SHA, satisfying the four required contexts.
- The next release-please PR after this merges (or a subsequent re-run on the existing one) will become mergeable without manual status posting.

## Notes

- Currently-open release PR #1617 won't be unblocked by this change alone (the new workflow step only fires on push to main). Once this lands, the next release-please run on main will refresh #1617's PR and post the missing statuses.
- `is_release_please` skip in `ci.yml` stays in place as defense-in-depth in case the App identity ever changes.

## Review coverage

Quick mode (no agents). Single workflow YAML change, no source code touched.