### PR TITLE
fix(ci): deterministic manifest digest extraction + DAST base image build

### DIFF
--- a/.github/actions/publish-apko-base/action.yml
+++ b/.github/actions/publish-apko-base/action.yml
@@ -84,7 +84,12 @@ runs:
         # prior run leaves the manifest list present, and a plain `create` would
         # fail with "manifest already exists" before the idempotent push below.
         docker manifest create --amend "${REPO}:${TAG}" "${MANIFEST_ARGS[@]}"
-        DIGEST=$(docker manifest push "${REPO}:${TAG}")
+        docker manifest push "${REPO}:${TAG}"
+        # `docker manifest push` stdout is unreliable across Docker versions
+        # (some emit `sha256:<hex>`, some only `Created manifest list <ref>`).
+        # Read the canonical manifest digest back from the registry via
+        # buildx imagetools, which is deterministic.
+        DIGEST="$(docker buildx imagetools inspect "${REPO}:${TAG}" --format '{{.Manifest.Digest}}')"
         echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
     # GitHub releases occasionally 5xx; cosign-installer's internal retry (3

--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -127,17 +127,17 @@ runs:
             docker manifest create --amend "${REPO}:${t}" \
               "${REPO}:sha-${SHORT_SHA}-amd64"
           fi
-          PUSH_OUT=$(docker manifest push "${REPO}:${t}")
+          docker manifest push "${REPO}:${t}"
 
           # Capture the manifest digest of the sha-<short> tag as the
           # canonical output -- that is what cosign + attest will sign.
-          # `docker manifest push` may emit additional status lines
-          # alongside the digest on some Docker versions, so extract the
-          # last sha256 token explicitly -- a multiline DIGEST would
-          # silently corrupt cosign / attest-build-provenance subject
-          # refs downstream.
+          # `docker manifest push` stdout is unreliable across Docker
+          # versions: some print `sha256:<hex>`, some print only
+          # `Created manifest list <ref>` with no digest. Read it back
+          # from the registry via buildx imagetools, which always
+          # returns the canonical manifest digest.
           if [ "$t" = "sha-${SHORT_SHA}" ]; then
-            DIGEST="$(printf '%s\n' "$PUSH_OUT" | grep -Eo 'sha256:[0-9a-f]{64}' | tail -n1)"
+            DIGEST="$(docker buildx imagetools inspect "${REPO}:${t}" --format '{{.Manifest.Digest}}')"
           fi
         done <<< "$META_TAGS"
 

--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false  # Serialize: only one DAST scan at a time
 
+env:
+  TRIVY_VERSION: 0.70.0
+
 jobs:
   zap-scan:
     name: ZAP API Scan
@@ -21,6 +24,9 @@ jobs:
       # findings (not one per run). Removing issues:write would cause the action
       # to fail. The auto-created issue is updated in-place on subsequent runs.
       issues: write
+      # build-apko-base uploads a Trivy SARIF for the locally-built base
+      # image; this scope is required by that composite action.
+      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -36,8 +42,26 @@ jobs:
           echo "SYNTHORG_SETTINGS_KEY=$(python3 -c 'import base64, os; print(base64.urlsafe_b64encode(os.urandom(32)).decode())')" >> docker/.env
           echo "POSTGRES_PASSWORD=$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')" >> docker/.env
 
-      # Build backend image locally (no push, no registry credentials)
+      # Build the apko-composed Wolfi base image locally, mirroring CI's
+      # backend-base build. The backend Dockerfile has no default for
+      # `BASE_IMAGE` (PR #1465 / Scorecard Pinned-Dependencies), so the
+      # DAST workflow must supply a pinned reference. Building the base
+      # in-workflow yields a `sha-<short>` tag tied to the current commit
+      # -- no floating registry tag is consulted.
+      - name: Build apko base image
+        id: base
+        uses: ./.github/actions/build-apko-base
+        with:
+          image-name: backend
+          apko-yaml: docker/backend/apko.yaml
+          trivy-version: ${{ env.TRIVY_VERSION }}
+
+      # Build the backend application image. Compose passes the
+      # workflow-built `BASE_IMAGE` through to the Dockerfile via the
+      # backend.build.args mapping in docker/compose.yml.
       - name: Build backend image
+        env:
+          BASE_IMAGE: ghcr.io/aureliolo/synthorg-backend-base:${{ steps.base.outputs.tag }}
         run: docker compose -f docker/compose.yml build backend
 
       # Start backend only (no web/caddy needed for API scan)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -843,13 +843,14 @@ jobs:
             docker manifest create --amend "${REPO}:${t}" \
               "${REPO}:${SHA_TAG}-amd64" \
               "${REPO}:${SHA_TAG}-arm64"
-            PUSH_OUT=$(docker manifest push "${REPO}:${t}")
-            # Extract the sha256 digest explicitly; `docker manifest
-            # push` can emit extra status lines on some Docker versions,
-            # and a multiline DIGEST would silently corrupt cosign /
-            # attest-build-provenance subject refs below.
+            docker manifest push "${REPO}:${t}"
+            # `docker manifest push` stdout is unreliable across Docker
+            # versions: some emit `sha256:<hex>`, some only print
+            # `Created manifest list <ref>` with no digest. Read the
+            # canonical manifest digest back from the registry via
+            # buildx imagetools, which is deterministic.
             if [ "$t" = "${SHA_TAG}" ]; then
-              DIGEST="$(printf '%s\n' "$PUSH_OUT" | grep -Eo 'sha256:[0-9a-f]{64}' | tail -n1)"
+              DIGEST="$(docker buildx imagetools inspect "${REPO}:${t}" --format '{{.Manifest.Digest}}')"
             fi
           done
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -204,7 +204,13 @@ jobs:
 
       - name: Validate compose files
         run: |
-          echo "POSTGRES_PASSWORD=ci-validation-dummy" > docker/.env
+          # Placeholder values for compose interpolation. The Dockerfile is
+          # never built during `compose config`, so these values just need
+          # to silence "variable not set" warnings; they are not consumed.
+          {
+            echo "POSTGRES_PASSWORD=ci-validation-dummy"
+            echo "BASE_IMAGE=ci-validation-dummy:placeholder"
+          } > docker/.env
           docker compose -f docker/compose.yml config --quiet
           docker compose -f docker/compose.yml -f docker/compose.distributed.yml --profile distributed config --quiet
           docker compose -f docker/compose.yml -f docker/compose.override.yml config --quiet

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -71,6 +71,15 @@ services:
     build:
       context: ..
       dockerfile: docker/backend/Dockerfile
+      # BASE_IMAGE must come from the caller's environment (the
+      # backend Dockerfile has no default and a blank value is a
+      # hard error -- see docker/backend/Dockerfile and PR #1465 for
+      # the Pinned-Dependencies rationale). CI release builds set
+      # this to a digest-pinned `synthorg-backend-base@sha256:...`;
+      # the DAST workflow and local dev set it to a tag like
+      # `ghcr.io/aureliolo/synthorg-backend-base:main`.
+      args:
+        BASE_IMAGE: ${BASE_IMAGE}
     ports:
       - "${BACKEND_PORT:-3001}:3001"
     volumes:


### PR DESCRIPTION
## Summary

Two real CI regressions on the last 4 main commits, both rooted in changes that landed earlier this month and surfaced quietly. Plus the downstream cascade they caused.

### #1 — `Publish Fine-Tune (cpu)` digest-mismatch (commit `8178b500`)

`docker manifest push` stdout was being grepped for `sha256:[0-9a-f]{64}` to capture the manifest digest for cosign signing. That output is not stable across Docker versions: some emit the digest, some only print `Created manifest list <ref>`. On a runner whose Docker happened to print only the latter, the grep returned empty -> `DIGEST=""` -> the cosign sign step failed with `Push step did not produce a digest -- cannot sign image`.

**Regressed in PR #1542 (2026-04-24)** when `publish-image` was extracted into a composite action. Before then, the inline code in `docker.yml` did `DIGEST="$PUSH_OUT"` (capturing whole stdout). The grep extraction was a hardening attempt that became a foot-gun on Docker versions that don't emit the digest.

**Fix:** Switch all three manifest-push sites (`publish-image/action.yml`, `publish-apko-base/action.yml`, `docker.yml`) to read the digest back from the registry via `docker buildx imagetools inspect <ref> --format '{{.Manifest.Digest}}'`. That command is deterministic across Docker versions and returns the canonical manifest list digest -- exactly what cosign + attest-build-provenance expect. buildx is preinstalled on `ubuntu-latest` runners so no setup step is needed.

### #2 — DAST `ZAP API Scan` BASE_IMAGE blank (commit `8178b500`)

PR #1465 dropped the `:latest` default for `BASE_IMAGE` in `docker/backend/Dockerfile` to satisfy Scorecard Pinned-Dependencies, on the premise that "CI always provides BASE_IMAGE". DAST runs `docker compose -f docker/compose.yml build backend` without supplying it, and `compose.yml` had no `args:` mapping for `BASE_IMAGE`. The very next weekly DAST cron failed with `failed to solve: base name (${BASE_IMAGE}) should not be blank`.

**Fix:**
- `docker/compose.yml`: add `build.args.BASE_IMAGE: ${BASE_IMAGE}` pass-through to the backend service. Empty/unset still fails fast at Dockerfile parse, preserving the Pinned-Dependencies invariant -- no `:latest` default reintroduced.
- `.github/workflows/dast.yml`: build the apko-composed Wolfi base in-workflow via the existing `build-apko-base` composite action, then pass its `sha-<short>` tag (pinned by definition of the running commit, no floating registry tag) through the new compose `build.args` mapping. Adds the `security-events: write` scope required by `build-apko-base` for Trivy SARIF upload.
- `.github/workflows/docker.yml` (validate-compose): add `BASE_IMAGE=ci-validation-dummy:placeholder` to the dummy `docker/.env` so `docker compose config --quiet` doesn't emit a "variable not set" warning every CI run. The Dockerfile is never built during `compose config`, so the placeholder is never consumed.

### #3 — `Update Release Notes` cascade (commit `bba4aa37`)

Direct downstream of #1: fine-tune cpu/gpu publish failed -> dev release tag was never created -> the release-notes step couldn't find `v0.7.4-dev.15` after 6 attempts. Resolves automatically once #1 lands.

### #4 — CodSpeed neutral on `074a8f11`

Out of scope here. Already tracked as #1640 (investigation issue opened today).

## Test plan

- `docker buildx imagetools inspect --format '{{.Manifest.Digest}}'` is the documented way to read a manifest list digest from the registry, works for both single-arch (fine-tune-cpu) and multi-arch (backend, sandbox, sidecar, fine-tune-gpu) manifests.
- DAST workflow: the `build-apko-base` composite action does `docker load` of the built tarball and re-tags to `ghcr.io/aureliolo/synthorg-backend-base:sha-<short>`, so the subsequent `docker compose build backend` resolves `BASE_IMAGE` from the local Docker daemon without going to the registry. Same flow that backend / sandbox / sidecar / fine-tune builds already use in `docker.yml`.
- `validate-compose` job continues to pass; warning is silenced.
- Pre-commit hooks pass (no Python / Go / Dockerfile changes; YAML / commitizen / gitleaks / no-em-dashes all green).
- Pre-PR review: 2 agents (`docs-consistency`, `infra-reviewer`). 1 valid finding (validate-compose warning), addressed in the second commit.

## Review coverage

Pre-reviewed by 2 agents, 1 finding addressed.

## Files

- `.github/actions/publish-image/action.yml` — buildx imagetools digest read
- `.github/actions/publish-apko-base/action.yml` — buildx imagetools digest read
- `.github/workflows/docker.yml` — buildx imagetools digest read in inline manifest path; placeholder BASE_IMAGE in validate-compose
- `.github/workflows/dast.yml` — build apko base in-workflow, pass BASE_IMAGE through; add `security-events: write` scope; hoist `TRIVY_VERSION` to workflow env
- `docker/compose.yml` — `args.BASE_IMAGE: ${BASE_IMAGE}` pass-through on the backend service
