### PR TITLE
fix(ci): release-pipeline robustness — keep main pushes from cancelling each other + unstick finalize-release

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -12,9 +12,13 @@ on:
 
 permissions: {}
 
+# Serialize dev-release jobs across main pushes -- each commit must mint
+# its own per-SHA dev tag (v0.7.5-dev.N). Cancelling an in-flight run
+# would lose that commit's tag entirely (gap in version sequence, broken
+# per-commit traceability for downstream Docker / CLI / finalize-release).
 concurrency:
   group: dev-release
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   dev-release:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,9 +29,13 @@ on:
 
 permissions: {}
 
+# PR runs cancel each other (we don't care about intermediate PR-build
+# artifacts). Main pushes and tag pushes queue serially: cancelling
+# would drop per-SHA `:main` images, skip "Update Release Notes", and
+# leave finalize-release with an upstream conclusion of `cancelled`.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   # renovate: datasource=github-releases depName=aquasecurity/trivy

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -93,22 +93,55 @@ jobs:
             exit 0
           fi
 
-          # Check status of both workflows for this tag.
-          CLI_CONCLUSION=$(gh run list --repo "$GITHUB_REPOSITORY" \
-            --workflow cli.yml --branch "$TAG" --event push --commit "$HEAD_SHA" \
-            --limit 1 --status completed \
-            --json conclusion --jq '.[0].conclusion // "pending"')
-          DOCKER_CONCLUSION=$(gh run list --repo "$GITHUB_REPOSITORY" \
-            --workflow docker.yml --branch "$TAG" --event push --commit "$HEAD_SHA" \
-            --limit 1 --status completed \
-            --json conclusion --jq '.[0].conclusion // "pending"')
-          echo "CLI: $CLI_CONCLUSION"
-          echo "Docker: $DOCKER_CONCLUSION"
+          # The triggering workflow's conclusion is known directly from the
+          # event payload above -- never query it back, since the Actions
+          # search API has eventual-consistency lag (`gh run list --status
+          # completed` has been observed to miss runs that finished tens of
+          # minutes earlier under load) and would falsely report `pending`,
+          # leaving the commit's `finalize-release` status stuck.
+          #
+          # Query only the SIBLING (the workflow we did NOT just observe
+          # complete). Use the direct `actions/runs?head_sha=` endpoint
+          # instead of `gh run list` -- it is more reliable than the
+          # search-indexed listing -- and retry with backoff to absorb any
+          # residual lag from the indexer.
+          case "$WORKFLOW_NAME" in
+            Docker) SIBLING_NAME=CLI ;;
+            CLI) SIBLING_NAME=Docker ;;
+            *)
+              echo "::error::Unexpected triggering workflow: $WORKFLOW_NAME"
+              exit 1
+              ;;
+          esac
 
-          if [ "$CLI_CONCLUSION" != "success" ] || [ "$DOCKER_CONCLUSION" != "success" ]; then
-            echo "Not all workflows succeeded yet (CLI=$CLI_CONCLUSION, Docker=$DOCKER_CONCLUSION)."
-            echo "The other workflow's completion will trigger another attempt."
+          SIBLING_STATUS=missing
+          SIBLING_CONCLUSION=pending
+          for attempt in 1 2 3 4 5 6; do
+            SIBLING_JSON=$(gh api \
+              "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$HEAD_SHA&per_page=100" \
+              --jq "[.workflow_runs[] | select(.name == \"$SIBLING_NAME\" and .head_branch == \"$TAG\" and .event == \"push\")] | .[0] // {}")
+            SIBLING_STATUS=$(jq -r '.status // "missing"' <<< "$SIBLING_JSON")
+            SIBLING_CONCLUSION=$(jq -r '.conclusion // "pending"' <<< "$SIBLING_JSON")
+            if [ "$SIBLING_STATUS" = "completed" ]; then
+              break
+            fi
+            echo "Sibling $SIBLING_NAME status=$SIBLING_STATUS conclusion=$SIBLING_CONCLUSION (attempt $attempt/6); sleeping..."
+            sleep $((attempt * 10))
+          done
+
+          echo "$WORKFLOW_NAME (this trigger): $WORKFLOW_CONCLUSION"
+          echo "$SIBLING_NAME (sibling): status=$SIBLING_STATUS conclusion=$SIBLING_CONCLUSION"
+
+          if [ "$SIBLING_STATUS" != "completed" ]; then
+            echo "Sibling $SIBLING_NAME has not completed yet -- its workflow_run event will retrigger this run."
             echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$SIBLING_CONCLUSION" != "success" ]; then
+            echo "Sibling $SIBLING_NAME concluded $SIBLING_CONCLUSION -- release will not publish."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            echo "sibling_failed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -436,6 +469,7 @@ jobs:
           JOB_STATUS: ${{ job.status }}
           PROCEED: ${{ steps.preflight.outputs.proceed }}
           ALREADY_PUBLISHED: ${{ steps.preflight.outputs.already_published }}
+          SIBLING_FAILED: ${{ steps.preflight.outputs.sibling_failed }}
           PUBLISHED: ${{ steps.publish.outputs.published }}
           TRIGGER_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         run: |
@@ -451,6 +485,13 @@ jobs:
             # Triggering workflow (Docker/CLI) failed -- release will not publish.
             STATE=failure
             DESC="Upstream ${TRIGGER_CONCLUSION} blocked publish of ${TAG}"
+          elif [ "$PROCEED" != "true" ] && [ "$SIBLING_FAILED" = "true" ]; then
+            # Sibling workflow (the OTHER of Docker/CLI) failed/cancelled --
+            # release will never publish. Mark the commit red now rather
+            # than leaving a yellow dot waiting for a re-trigger that
+            # cannot succeed.
+            STATE=failure
+            DESC="Sibling workflow blocked publish of ${TAG}"
           elif [ "$PROCEED" != "true" ]; then
             # Sibling workflow (Docker / CLI) still pending; its
             # completion will retrigger this workflow and post the


### PR DESCRIPTION
## Summary

Two related release-pipeline bugs that compounded each other:

### Bug 1 (#1656) — `cancel-in-progress: true` on main pushes drops per-SHA artifacts

`docker.yml` and `dev-release.yml` had `cancel-in-progress: true` keyed on `${{ github.workflow }}-${{ github.ref }}`. Rapid main commits cancelled the previous run mid-flight:

- **`docker.yml`**: per-SHA `:main` images and "Update Release Notes" never landed for cancelled commits. Downstream `finalize-release` then saw `TRIGGER_CONCLUSION=cancelled` instead of `success`.
- **`dev-release.yml`**: the per-commit `v0.7.X-dev.N` tag was never minted when a second commit landed before the first dev-release job finished. Per-commit traceability lost.

**Fix**:
- `docker.yml`: switch to `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` (canonical pattern, matches `ci.yml` / `cli.yml` / `codspeed.yml` / `lighthouse.yml`). PR runs still cancel each other; main and tag pushes serialize.
- `dev-release.yml`: switch to `cancel-in-progress: false`. The workflow only triggers on `push: branches: [main]`, so the PR-conditional doesn't apply; plain `false` is correct.

### Bug 2 (#1657) — `finalize-release` status stuck on `pending`

The preflight step in `finalize-release.yml` queried both Docker and CLI conclusions via `gh run list --status completed`. The Actions search index has substantial eventual-consistency lag — observed >22 minutes for `afbdbcfa`/v0.7.5-dev.4: a CLI run that completed at 19:21:55 was still invisible to `--status completed` at 19:43:42 when Docker also completed and the second finalize-release fired. Both queries returned the jq fallback `"pending"`, so PROCEED=false and "Awaiting sibling workflow" was posted. No further `workflow_run` event followed, so the status stayed `pending` forever.

**Fix**: in the preflight,
1. Use `${{ github.event.workflow_run.conclusion }}` directly for the triggering workflow's conclusion — never re-query something we already know.
2. Query only the SIBLING workflow, via the more-reliable `actions/runs?head_sha=` REST endpoint (commit-indexed, no search lag) instead of `gh run list --status completed`.
3. Retry the sibling lookup with backoff (10s → 60s, 6 attempts ≈ 3.5 min) to absorb residual indexer lag.
4. New `sibling_failed=true` output threads into the final-status step so a sibling-failure produces `STATE=failure` instead of stuck-pending placeholder.

## Audit (other workflows)

Cross-checked every workflow in `.github/workflows/`. Only `docker.yml` and `dev-release.yml` had the bug. `ci-preflight.yml` also uses `cancel-in-progress: true` on main pushes but writes an idempotent tracking issue (so cancellation is acceptable). All others either use the canonical `${{ github.event_name == 'pull_request' }}` pattern, run only on PR-keyed groups, or correctly use `false` for queue-serialization (release pipelines, apko-lock, auto-rollover, finalize-release, graduate, pages, test-highlights).

## Backfill (already done out-of-band)

5 stuck commits found in the last 14 days, all with successful tag-pipeline Docker + CLI runs. Backfilled to `success` via `gh api -X POST .../statuses/<sha>` before this PR:

| SHA | Tag | Stuck status |
|---|---|---|
| `5525d25f` | v0.7.5-dev.2 | "Awaiting sibling workflow before publishing v0.7.5-dev.2" |
| `ad52c257` | v0.7.5-dev.3 | "Awaiting sibling workflow before publishing v0.7.5-dev.3" |
| `afbdbcfa` | v0.7.5-dev.4 | "Awaiting sibling workflow before publishing v0.7.5-dev.4" |
| `371e8c1b` | v0.7.5-dev.5 | "Awaiting sibling workflow before publishing v0.7.5-dev.5" |
| `6f2c3214` | v0.7.5-dev.1 | "Awaiting sibling workflow before publishing v0.7.5-dev.1" |

Three leftover draft releases (dev.3, dev.4, dev.5) also published via `gh release edit --draft=false`. dev.1 and dev.2 had already been deleted by the orphan-tag cleanup logic.

## Test plan

CI plumbing changes are hard to unit-test, but the diff is small and the logic changes are localized:

- Bug 1 fixes are mechanical 1-line concurrency edits matching well-established patterns elsewhere in the repo.
- Bug 2 preflight rewrite was guided by direct inspection of run logs (`25014838822`, `25015797807`) showing the search-index lag in action.

The next rapid sequence of dev-tag pushes (next time multiple PRs merge in succession) will exercise both fixes end-to-end. Yellow dots staying yellow is the regression signal to watch for.

## Review coverage

Quick mode (workflow YAML only, no Python/TS/Go code).

Closes #1656
Closes #1657