### PR TITLE
refactor: audit code-quality, conventions, and GDPR delete wiring (#1606)

### DIFF
--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -428,7 +428,7 @@ Remove worktrees and clean up branches after PRs are merged.
 8. **Clean remaining gone branches** that are not associated with worktrees (e.g. branches created outside the worktree workflow). After worktree-specific cleanup is done, check for any additional local branches whose remote tracking branch is gone:
 
    ```bash
-   git for-each-ref --format='%(refname:short) %(upstream:track,gone)' refs/heads | grep '\[gone\]$'
+   git branch -vv | grep '\[gone\]$'
    ```
 
    Delete each one individually (these are non-worktree branches, safe to delete without worktree removal):

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -428,7 +428,7 @@ Remove worktrees and clean up branches after PRs are merged.
 8. **Clean remaining gone branches** that are not associated with worktrees (e.g. branches created outside the worktree workflow). After worktree-specific cleanup is done, check for any additional local branches whose remote tracking branch is gone:
 
    ```bash
-   git branch -vv | grep '\[gone\]$'
+   git branch -vv | grep '\[gone\]'
    ```
 
    Delete each one individually (these are non-worktree branches, safe to delete without worktree removal):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ See `cli/CLAUDE.md` for commands, flags, and reference. Key rule: use `go -C cli
 - [docs/reference/sec-prompt-safety.md](docs/reference/sec-prompt-safety.md): SEC-1 untrusted-content fences, HTML XXE, secret-log redaction
 - [docs/reference/lifecycle-sync.md](docs/reference/lifecycle-sync.md): async start/stop lifecycle lock pattern
 - [docs/reference/persistence-boundary.md](docs/reference/persistence-boundary.md): persistence exception categories + service layer rules
+- [docs/reference/conventions.md](docs/reference/conventions.md): implicit conventions (repository CRUD, lifecycle symmetry, response wrapping, validator mode default, event imports, domain error hierarchies, file structure, frozen ConfigDict)
 
 ## Web Dashboard Design System (MANDATORY)
 

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -169,7 +169,7 @@ Overriding any of `registry_host`, `image_repo_prefix`, `dhi_registry`, `postgre
 | `update` | `--dry-run`, `--no-restart`, `--timeout`, `--cli-only`, `--images-only`, `--check` |
 | `cleanup` | `--dry-run`, `--all`, `--keep N` |
 | `backup create` | `--output`/`-o`, `--timeout` |
-| `backup list` | `--limit`/`-n`, `--sort` |
+| `backup list` | `--limit`/`-n`, `--sort` (`newest`\|`oldest`\|`size`) |
 | `backup restore` | `--confirm` (required), `--dry-run`, `--no-restart`, `--timeout` |
 | `completion` | `[bash \| zsh \| fish \| powershell]`: emit shell autocompletion script (Cobra built-in) |
 | `completion-install` | `[bash \| zsh \| fish \| powershell]`: write the autocompletion script into your shell startup (`~/.bashrc`, `~/.zshrc`, etc.) |

--- a/cli/cmd/backup.go
+++ b/cli/cmd/backup.go
@@ -102,17 +102,21 @@ func init() {
 	// backup list flags
 	backupListCmd.Flags().IntVarP(&backupListLimit, "limit", "n", 0, "show N most recent backups (0=all)")
 	backupListCmd.Flags().StringVar(&backupListSort, "sort", "newest", "sort order (newest|oldest|size)")
-	_ = backupListCmd.RegisterFlagCompletionFunc(
+	if err := backupListCmd.RegisterFlagCompletionFunc(
 		"sort",
 		cobra.FixedCompletions(
 			[]string{"newest", "oldest", "size"},
 			cobra.ShellCompDirectiveNoFileComp,
 		),
-	)
+	); err != nil {
+		panic(err)
+	}
 
 	// backup restore flags
 	backupRestoreCmd.Flags().Bool("confirm", false, "confirm the restore operation (required)")
-	_ = backupRestoreCmd.MarkFlagRequired("confirm")
+	if err := backupRestoreCmd.MarkFlagRequired("confirm"); err != nil {
+		panic(err)
+	}
 	backupRestoreCmd.Flags().BoolVar(&backupRestoreDryRun, "dry-run", false, "preview what would be restored without executing")
 	backupRestoreCmd.Flags().BoolVar(&backupRestoreNoRestart, "no-restart", false, "restore without stopping containers")
 	backupRestoreCmd.Flags().StringVar(&backupRestoreTimeout, "timeout", "30s", "API request timeout")

--- a/cli/cmd/backup.go
+++ b/cli/cmd/backup.go
@@ -101,10 +101,18 @@ func init() {
 
 	// backup list flags
 	backupListCmd.Flags().IntVarP(&backupListLimit, "limit", "n", 0, "show N most recent backups (0=all)")
-	backupListCmd.Flags().StringVar(&backupListSort, "sort", "newest", "sort order: newest, oldest, size")
+	backupListCmd.Flags().StringVar(&backupListSort, "sort", "newest", "sort order (newest|oldest|size)")
+	_ = backupListCmd.RegisterFlagCompletionFunc(
+		"sort",
+		cobra.FixedCompletions(
+			[]string{"newest", "oldest", "size"},
+			cobra.ShellCompDirectiveNoFileComp,
+		),
+	)
 
 	// backup restore flags
-	backupRestoreCmd.Flags().Bool("confirm", false, "Confirm the restore operation (required)")
+	backupRestoreCmd.Flags().Bool("confirm", false, "confirm the restore operation (required)")
+	_ = backupRestoreCmd.MarkFlagRequired("confirm")
 	backupRestoreCmd.Flags().BoolVar(&backupRestoreDryRun, "dry-run", false, "preview what would be restored without executing")
 	backupRestoreCmd.Flags().BoolVar(&backupRestoreNoRestart, "no-restart", false, "restore without stopping containers")
 	backupRestoreCmd.Flags().StringVar(&backupRestoreTimeout, "timeout", "30s", "API request timeout")

--- a/cli/cmd/backup_test.go
+++ b/cli/cmd/backup_test.go
@@ -485,6 +485,41 @@ func TestBackupList_ServerError(t *testing.T) {
 	}
 }
 
+func TestBackupList_InvalidSort(t *testing.T) {
+	// --sort is validated in validateBackupListFlags; an unknown value
+	// must be rejected before any API call.
+	dir := writeTestConfig(t, 19999)
+
+	out, err := runBackupCmd(t, dir, "list", "--sort", "alphabetical")
+	if err == nil {
+		t.Fatal("expected error for invalid --sort value")
+	}
+	if !strings.Contains(err.Error(), "invalid --sort") {
+		t.Errorf("error %q does not mention invalid --sort", err.Error())
+	}
+	_ = out
+}
+
+func TestBackupList_SortCompletionRegistered(t *testing.T) {
+	// Cobra exposes registered completions via __complete; if a fixed
+	// completion is registered the values come back on stdout. We invoke
+	// the special completion subcommand to confirm the three values are
+	// surfaced.
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"__complete", "backup", "list", "--sort", ""})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("__complete: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"newest", "oldest", "size"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("completion output missing %q:\n%s", want, out)
+		}
+	}
+}
+
 // --- Integration tests: backup restore ---
 
 func TestBackupRestore_Success(t *testing.T) {
@@ -601,21 +636,21 @@ func TestBackupRestore_InvalidID(t *testing.T) {
 }
 
 func TestBackupRestore_MissingConfirm(t *testing.T) {
-	// No server needed -- --confirm flag validation happens before any
-	// API call. Use an unreachable port (not port 0, which fails
-	// config.State validation now that applyTunables surfaces load
-	// errors); --confirm is rejected before the network dial anyway.
+	// No server needed -- --confirm is gated by Cobra's MarkFlagRequired
+	// before the RunE handler is reached.
 	dir := writeTestConfig(t, 19999)
 
 	out, err := runBackupCmd(t, dir, "restore", "abcdef012345")
 	if err == nil {
 		t.Fatal("expected error for missing --confirm flag")
 	}
-	if !strings.Contains(err.Error(), "--confirm") {
-		t.Errorf("error %q does not mention --confirm", err.Error())
+	// Cobra's required-flag error reads: required flag(s) "confirm" not set
+	if !strings.Contains(err.Error(), "confirm") {
+		t.Errorf("error %q does not mention confirm", err.Error())
 	}
+	// Cobra's auto-emitted usage includes the --confirm flag listing.
 	if !strings.Contains(out, "--confirm") {
-		t.Errorf("output missing --confirm hint:\n%s", out)
+		t.Errorf("output missing --confirm in usage:\n%s", out)
 	}
 }
 

--- a/cli/cmd/backup_test.go
+++ b/cli/cmd/backup_test.go
@@ -288,13 +288,22 @@ func writeTestConfig(t *testing.T, backendPort int) string {
 // runBackupCmd executes a backup subcommand and returns stdout+stderr output.
 // Resets the --confirm flag between runs to avoid stale state from prior tests
 // (Cobra does not reset flag values between Execute() calls on global commands).
+// Also clears the flag's `Changed` bit so MarkFlagRequired remains effective:
+// a prior Flags().Set() call would otherwise mark the flag as "supplied" and
+// short-circuit cobra's required-flag enforcement on the next invocation.
 // NOTE: If new persistent boolean flags are added to backup commands, add them here.
 func runBackupCmd(t *testing.T, dir string, args ...string) (string, error) {
 	t.Helper()
 	// Reset sticky boolean flags before each execution.
+	confirmFlag := backupRestoreCmd.Flags().Lookup("confirm")
+	if confirmFlag == nil {
+		t.Fatal("--confirm flag not found on backup restore command")
+	}
 	if err := backupRestoreCmd.Flags().Set("confirm", "false"); err != nil {
 		t.Fatalf("resetting --confirm flag: %v", err)
 	}
+	// Clear Changed so MarkFlagRequired still fires when the test omits --confirm.
+	confirmFlag.Changed = false
 
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)
@@ -504,7 +513,16 @@ func TestBackupList_SortCompletionRegistered(t *testing.T) {
 	// Cobra exposes registered completions via __complete; if a fixed
 	// completion is registered the values come back on stdout. We invoke
 	// the special completion subcommand to confirm the three values are
-	// surfaced.
+	// surfaced. SetOut/SetErr/SetArgs leak between Execute() calls on
+	// rootCmd, so capture and restore them around the test body.
+	prevOut := rootCmd.OutOrStdout()
+	prevErr := rootCmd.ErrOrStderr()
+	t.Cleanup(func() {
+		rootCmd.SetOut(prevOut)
+		rootCmd.SetErr(prevErr)
+		rootCmd.SetArgs(nil)
+	})
+
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)
 	rootCmd.SetErr(&buf)
@@ -637,20 +655,19 @@ func TestBackupRestore_InvalidID(t *testing.T) {
 
 func TestBackupRestore_MissingConfirm(t *testing.T) {
 	// No server needed -- --confirm is gated by Cobra's MarkFlagRequired
-	// before the RunE handler is reached.
+	// before the RunE handler is reached. rootCmd has SilenceUsage and
+	// SilenceErrors set, so cobra's auto-emitted usage block never reaches
+	// the buffer; we assert on the error value only.
 	dir := writeTestConfig(t, 19999)
 
-	out, err := runBackupCmd(t, dir, "restore", "abcdef012345")
+	_, err := runBackupCmd(t, dir, "restore", "abcdef012345")
 	if err == nil {
 		t.Fatal("expected error for missing --confirm flag")
 	}
-	// Cobra's required-flag error reads: required flag(s) "confirm" not set
-	if !strings.Contains(err.Error(), "confirm") {
-		t.Errorf("error %q does not mention confirm", err.Error())
-	}
-	// Cobra's auto-emitted usage includes the --confirm flag listing.
-	if !strings.Contains(out, "--confirm") {
-		t.Errorf("output missing --confirm in usage:\n%s", out)
+	// Cobra's required-flag error reads exactly: required flag(s) "confirm" not set
+	const wantErr = `required flag(s) "confirm" not set`
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Errorf("error %q does not contain %q", err.Error(), wantErr)
 	}
 }
 

--- a/cli/cmd/backup_test.go
+++ b/cli/cmd/backup_test.go
@@ -305,6 +305,18 @@ func runBackupCmd(t *testing.T, dir string, args ...string) (string, error) {
 	// Clear Changed so MarkFlagRequired still fires when the test omits --confirm.
 	confirmFlag.Changed = false
 
+	// Reset --sort to its default; otherwise a prior TestBackupList_InvalidSort
+	// run leaves the flag value sticky and downstream order-sensitive tests
+	// inherit garbage state.
+	sortFlag := backupListCmd.Flags().Lookup("sort")
+	if sortFlag == nil {
+		t.Fatal("--sort flag not found on backup list command")
+	}
+	if err := backupListCmd.Flags().Set("sort", "newest"); err != nil {
+		t.Fatalf("resetting --sort flag: %v", err)
+	}
+	sortFlag.Changed = false
+
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)
 	rootCmd.SetErr(&buf)

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -46,7 +46,9 @@ var updateCmd = &cobra.Command{
 
 func init() {
 	updateCmd.Flags().Bool("skip-cli-update", false, "skip CLI self-update check (used internally after re-exec)")
-	_ = updateCmd.Flags().MarkHidden("skip-cli-update")
+	if err := updateCmd.Flags().MarkHidden("skip-cli-update"); err != nil {
+		panic(err)
+	}
 	updateCmd.Flags().BoolVar(&updateDryRun, "dry-run", false, "show what would happen without executing")
 	updateCmd.Flags().BoolVar(&updateNoRestart, "no-restart", false, "pull images but do not restart running containers")
 	updateCmd.Flags().StringVar(&updateTimeout, "timeout", "90s", "health check and verification timeout")

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -72,7 +72,7 @@ development, business operations, creative work, or any domain.
 - Not locked to software development only (though that is a primary use case)
 - Not a wrapper around a single model or provider
 - Not a toy/demo: designed for real, production-quality output
-- Not a reasoning parallelizer. Single-agent reasoning is typically more token-efficient on isolated multi-hop questions, and SynthOrg's [auto topology selector](engine.md#task-decomposability-coordination-topology) defaults to single-agent for such tasks. SynthOrg's value is role-specialized work-stream parallelism, organizational simulation fidelity, and audit-grade decision trails, not reasoning parallelism. See [S1 Multi-Agent Architecture Decision](../research/s1-multi-agent-decision.md) for the full reconciliation.
+- Not a reasoning parallelizer. Single-agent reasoning is typically more token-efficient on isolated multi-hop questions, and SynthOrg's [auto topology selector](coordination.md#task-decomposability--coordination-topology) defaults to single-agent for such tasks. SynthOrg's value is role-specialized work-stream parallelism, organizational simulation fidelity, and audit-grade decision trails, not reasoning parallelism. See [S1 Multi-Agent Architecture Decision](../research/s1-multi-agent-decision.md) for the full reconciliation.
 
 !!! info "How to read the design specification"
 

--- a/docs/design/persistence.md
+++ b/docs/design/persistence.md
@@ -63,7 +63,7 @@ one level up in `src/synthorg/persistence/`:
 | Protocol module                        | Concerns |
 |----------------------------------------|-----------|
 | `protocol.py` (`PersistenceBackend`)   | Backend aggregate: connect / disconnect, migrate, and accessors for every repository below |
-| `approval_protocol.py`                 | `ApprovalRepository`: human-in-the-loop decision queue |
+| `approval_protocol.py`                 | `ApprovalRepository`: human-in-the-loop approval queue |
 | `auth_protocol.py`                     | `SessionRepository`, `RefreshTokenRepository`, `LockoutRepository` |
 | `escalation_protocol.py`               | Conflict-resolution escalation queue |
 | `fine_tune_protocol.py`                | `FineTuneRunRepository`, `FineTuneCheckpointRepository` |
@@ -252,7 +252,7 @@ sibling) mixes two write patterns:
 `custom_rules`.  Rows are updated on every state transition; row count stays
 bounded.  Concurrent updates are serialised by MVCC + application-level CAS
 (settings use `updated_at` as an etag; see `SettingsRepository.set` and
-`set_many`).  Both `approvals` (human-in-the-loop decision queue,
+`set_many`).  Both `approvals` (human-in-the-loop approval queue,
 `pending`/`approved`/`rejected`/`expired` state machine) and `custom_rules`
 (operator-defined alert thresholds) exist on both backends; previously
 they shipped only on SQLite and the Postgres parity gap was closed in the

--- a/docs/guides/data-retention.md
+++ b/docs/guides/data-retention.md
@@ -21,6 +21,9 @@ lives, how long it is retained, and how it is removed.
 | Refresh token hashes | `refresh_tokens` | Until revoked or `expires_at` | `UserService.delete()` explicit revocation + FK cascade on user delete + periodic sweep of expired rows |
 | `tasks.created_by`, `artifacts.created_by` | respective tables | Indefinite; authorship preserved | Not cascaded on user delete (content outlives its author) |
 | Client profile / feedback / requests | `client_*` tables | Indefinite; authorship preserved | Not cascaded on user delete |
+| Agent memory entries (`MemoryBackend`) | backend-specific (Mem0 / Qdrant) | Indefinite while agent is active | `DELETE /api/v1/admin/memory/agents/{agent_id}/memories/{memory_id}` and the `synthorg_memory_delete_entry` MCP tool |
+| Channel messages (`Message.sender`, `.metadata`, `.channel`) | `messages` | Indefinite; operator-driven removal | `DELETE /api/v1/messages/{message_id}` and the `synthorg_messages_delete` MCP tool |
+| Meeting records (`MeetingRecord.minutes.contributions[*].agent_id`) | in-memory orchestrator audit store | Per-process; flushed on restart unless persisted | `DELETE /api/v1/meetings/{meeting_id}` and the `synthorg_meetings_delete` MCP tool |
 
 ## Cascade behavior on user deletion
 

--- a/docs/reference/conventions.md
+++ b/docs/reference/conventions.md
@@ -44,16 +44,22 @@ held across the full body of their respective method per
 
 ## 3. API response wrapping
 
-Controllers return one of two shapes:
+Controllers return one of three shapes:
 
 * `ApiResponse[T]`: success-only path with no header or status-code
   customization. Litestar serializes it as `{"data": ..., "error": null,
   "success": true}`.
+* `PaginatedResponse[T]`: list endpoints that return a page of items
+  plus pagination metadata. Wraps `ApiResponse[T]` and adds a
+  `pagination` envelope ({`limit`, `offset`, `total`, `next_cursor`,
+  `has_more`}). Required for any controller method whose return type
+  is a collection. Opaque cursor pagination is the project default.
 * `Response[ApiResponse[T]]`: only when status code or response
   headers must be customized (e.g. setting a `Location` header on a
   201, attaching a `Retry-After` header on a 429).
 
-Reference: `src/synthorg/api/dto.py`, almost every controller under
+Reference: `src/synthorg/api/dto.py` (`ApiResponse`,
+`PaginatedResponse`, `PaginationMeta`); almost every controller under
 `src/synthorg/api/controllers/`.
 
 ## 4. `@model_validator(mode="after")` is the default

--- a/docs/reference/conventions.md
+++ b/docs/reference/conventions.md
@@ -1,0 +1,136 @@
+---
+title: Implicit Conventions
+description: Patterns followed across the SynthOrg codebase that are not codified in CLAUDE.md but are universally observed.
+---
+
+# Implicit Conventions
+
+`CLAUDE.md` codifies the rules we enforce with hooks and review agents.
+This page captures the *implicit* conventions: patterns followed
+across the codebase by precedent rather than enforcement. New code
+should follow them; deviations should be justified in the diff.
+
+## 1. Repository CRUD signature pattern
+
+Every repository protocol exposes the same five-method shape, returning
+`bool` from `delete` so callers can distinguish "removed one row" from
+"id did not exist" without raising.
+
+```python
+class ApprovalRepository(Protocol):
+    async def save(self, item: ApprovalItem) -> None: ...
+    async def get(self, approval_id: NotBlankStr) -> ApprovalItem | None: ...
+    async def list_items(
+        self,
+        *,
+        status: ApprovalStatus | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[ApprovalItem, ...]: ...
+    async def delete(self, approval_id: NotBlankStr) -> bool: ...
+```
+
+Reference: `src/synthorg/persistence/approval_protocol.py:34-73`.
+
+## 2. Service lifecycle method symmetry
+
+Long-lived services own a private `asyncio.Lock` named
+`_lifecycle_lock` (separate from any hot-path lock) and expose
+symmetric `async start()` / `async stop()` methods. Both must be
+held across the full body of their respective method per
+[lifecycle-sync.md](lifecycle-sync.md). Examples:
+`src/synthorg/workers/worker.py`,
+`src/synthorg/integrations/health/prober.py`.
+
+## 3. API response wrapping
+
+Controllers return one of two shapes:
+
+* `ApiResponse[T]`: success-only path with no header or status-code
+  customization. Litestar serializes it as `{"data": ..., "error": null,
+  "success": true}`.
+* `Response[ApiResponse[T]]`: only when status code or response
+  headers must be customized (e.g. setting a `Location` header on a
+  201, attaching a `Retry-After` header on a 429).
+
+Reference: `src/synthorg/api/dto.py`, almost every controller under
+`src/synthorg/api/controllers/`.
+
+## 4. `@model_validator(mode="after")` is the default
+
+`mode="after"` runs against the constructed model and is the default
+choice. `mode="before"` is reserved for normalizing inputs the caller
+might pass in non-canonical shape (lists vs tuples, dirty strings,
+missing aliases). When using `mode="before"`, **never** mutate the
+input dict in place; return a new dict via `{**data, key: value}`.
+The four sites flagged by the 2026-04-25 audit have been converted;
+the new immutability tests in `tests/unit/{api,tools}/...` lock
+in the pattern.
+
+## 5. Event constant module imports
+
+Every observability event is defined as a `Final[str]` constant under
+`src/synthorg/observability/events/<domain>.py` and imported by name
+(never by string literal) from the consumer.
+
+```python
+from synthorg.observability.events.workers import (
+    WORKERS_DISPATCHER_CLAIM_ENQUEUED,
+    WORKERS_DISPATCHER_PUBLISH_EXHAUSTED,
+    WORKERS_DISPATCHER_PUBLISH_FAILED,
+    WORKERS_DISPATCHER_PUBLISH_RETRYING,
+    WORKERS_DISPATCHER_QUEUE_NOT_RUNNING,
+)
+```
+
+Reference: `src/synthorg/workers/dispatcher.py:19-25`.
+
+## 6. Domain error hierarchies
+
+Each domain owns `errors.py` with a base error class carrying
+`status_code` / `error_code` / `error_category` / `retryable` as
+`ClassVar`s; subclasses inherit and override only the fields that
+change. The HTTP exception handler keys off the base class so a new
+subclass automatically inherits the correct status mapping.
+
+References:
+
+* `src/synthorg/budget/errors.py`: `BudgetExhaustedError` family.
+* `src/synthorg/communication/errors.py`: `CommunicationError`
+  family.
+* `src/synthorg/engine/errors.py`: `EngineError` family.
+
+## 7. Module file structure
+
+Every business-logic module follows the same top-down ordering:
+
+1. Module docstring.
+2. Imports: stdlib, then third-party, then internal, alphabetical
+   within each group.
+3. `logger = get_logger(__name__)` immediately after imports.
+4. Module-level `Final` constants (private prefixed with `_`).
+5. Public types (Pydantic models, dataclasses, enums).
+6. Public functions / classes.
+7. Private helpers (prefixed with `_`).
+
+Reference: `src/synthorg/communication/bus/memory.py`.
+
+## 8. Frozen `ConfigDict` pattern
+
+Every Pydantic model declares
+`model_config = ConfigDict(frozen=True, allow_inf_nan=False)`. Request
+DTOs additionally set `extra="forbid"` so unknown keys are rejected
+instead of silently ignored. Combined with the framework's `frozen`
+guarantee this gives us the "create new objects, never mutate
+existing ones" property the immutability covenant relies on.
+
+References: 30+ occurrences across `src/synthorg/`. Canonical example:
+`src/synthorg/approval/models.py:28`.
+
+## See also
+
+* [persistence-boundary.md](persistence-boundary.md): repository /
+  service / controller layering.
+* [lifecycle-sync.md](lifecycle-sync.md): `_lifecycle_lock` rule.
+* [pluggable-subsystems.md](pluggable-subsystems.md): protocol +
+  strategy + factory + config discriminator pattern.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -170,6 +170,7 @@ nav:
   - Reference:
       - reference/research.md
       - reference/standards.md
+      - Implicit Conventions: reference/conventions.md
       - Framework Comparison: reference/comparison.md
       - Embedding Evaluation: reference/embedding-evaluation.md
       - Error Reference: errors.md

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -475,6 +475,31 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
         escalation_config,
         persistence,
     )
+    # Communication-domain services (messages + meetings).
+    # Both wrap pre-existing infrastructure (bus + persistence,
+    # orchestrator) and centralize audit logging so HTTP controllers
+    # and MCP handlers route through a single facade per
+    # `docs/reference/conventions.md` § Repository CRUD pattern. The
+    # MCP handlers in `meta/mcp/handlers/communication.py` already
+    # call `app_state.message_service` / `app_state.meeting_service`,
+    # so wiring here is what activates them in production.
+    if message_bus is not None and persistence is not None:
+        from synthorg.communication.messages.service import (  # noqa: PLC0415
+            MessageService,
+        )
+
+        app_state.set_message_service(
+            MessageService(bus=message_bus, persistence=persistence),
+        )
+    if meeting_orchestrator is not None:
+        from synthorg.communication.meetings.service import (  # noqa: PLC0415
+            MeetingService,
+        )
+
+        app_state.set_meeting_service(
+            MeetingService(orchestrator=meeting_orchestrator),
+        )
+
     app_state.set_escalation_store(_escalation_store)
     app_state.set_escalation_processor(build_decision_processor(escalation_config))
     _escalation_registry = PendingFuturesRegistry()

--- a/src/synthorg/api/config.py
+++ b/src/synthorg/api/config.py
@@ -313,14 +313,18 @@ class ServerConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def _normalize_empty_tls(cls, data: dict[str, object]) -> dict[str, object]:
+    def _normalize_empty_tls(cls, data: Any) -> Any:
         """Normalize empty-string TLS paths to ``None``."""
-        if isinstance(data, dict):
-            for key in ("ssl_certfile", "ssl_keyfile", "ssl_ca_certs"):
-                val = data.get(key)
-                if isinstance(val, str) and not val.strip():
-                    data[key] = None
-        return data
+        if not isinstance(data, dict):
+            return data
+        overrides: dict[str, object] = {}
+        for key in ("ssl_certfile", "ssl_keyfile", "ssl_ca_certs"):
+            val = data.get(key)
+            if isinstance(val, str) and not val.strip():
+                overrides[key] = None
+        if not overrides:
+            return data
+        return {**data, **overrides}
 
     @model_validator(mode="after")
     def _validate_tls_pair(self) -> Self:

--- a/src/synthorg/api/controllers/meetings.py
+++ b/src/synthorg/api/controllers/meetings.py
@@ -3,7 +3,7 @@
 import asyncio
 from typing import Annotated, Self
 
-from litestar import Controller, get, post
+from litestar import Controller, delete, get, post
 from litestar.datastructures import State  # noqa: TC002
 from litestar.params import Parameter
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -319,6 +319,31 @@ class MeetingController(Controller):
         )
         msg = f"Meeting {meeting_id!r} not found"
         raise NotFoundError(msg)
+
+    @delete(
+        "/{meeting_id:str}",
+        status_code=200,
+        guards=[require_write_access],
+    )
+    async def delete_meeting(
+        self,
+        state: State,
+        meeting_id: PathId,
+    ) -> ApiResponse[None]:
+        """Delete a meeting record by id.
+
+        Returns ``200 OK`` with ``data=None`` on success and
+        ``404 Not Found`` when the id does not exist. The record is
+        removed from the in-memory orchestrator audit store; durable
+        replay is preserved through audit logs.
+        """
+        orchestrator = state.app_state.meeting_orchestrator
+        deleted = orchestrator.delete_record(meeting_id)
+        if not deleted:
+            logger.warning(MEETING_NOT_FOUND, meeting_id=meeting_id)
+            msg = f"Meeting {meeting_id!r} not found"
+            raise NotFoundError(msg)
+        return ApiResponse(data=None)
 
     @post(
         "/trigger",

--- a/src/synthorg/api/controllers/meetings.py
+++ b/src/synthorg/api/controllers/meetings.py
@@ -333,11 +333,22 @@ class MeetingController(Controller):
     ) -> ApiResponse[None]:
         """Delete a meeting record by id.
 
-        Returns ``200 OK`` with ``data=None`` on success and
-        ``404 Not Found`` when the id does not exist. Routes through
-        :class:`MeetingService` so the
+        Routes through :class:`MeetingService` so the
         ``COMMUNICATION_MEETING_DELETED`` audit event is emitted from
         the service layer on parity with the MCP path.
+
+        Args:
+            state: Litestar app state container.
+            request: Authenticated request; ``request.user.user_id``
+                drives the audit log's actor field.
+            meeting_id: Meeting identifier (matches
+                ``MeetingRecord.meeting_id``).
+
+        Returns:
+            ``ApiResponse[None]`` with ``data=None`` on success.
+
+        Raises:
+            NotFoundError: If no meeting exists for ``meeting_id``.
         """
         app_state: AppState = state.app_state
         deleted = await app_state.meeting_service.delete_meeting(

--- a/src/synthorg/api/controllers/meetings.py
+++ b/src/synthorg/api/controllers/meetings.py
@@ -17,7 +17,7 @@ from synthorg.api.state import AppState  # noqa: TC001
 from synthorg.communication.meeting.enums import MeetingStatus  # noqa: TC001
 from synthorg.communication.meeting.models import MeetingRecord
 from synthorg.core.domain_errors import NotFoundError, ValidationError
-from synthorg.core.types import NotBlankStr  # noqa: TC001
+from synthorg.core.types import NotBlankStr
 from synthorg.observability import get_logger
 from synthorg.observability.events.api import (
     API_MEETING_TRIGGERED,

--- a/src/synthorg/api/controllers/meetings.py
+++ b/src/synthorg/api/controllers/meetings.py
@@ -1,9 +1,9 @@
 """Meeting controller -- list, get, and trigger meetings."""
 
 import asyncio
-from typing import Annotated, Self
+from typing import Annotated, Any, Self
 
-from litestar import Controller, delete, get, post
+from litestar import Controller, Request, delete, get, post
 from litestar.datastructures import State  # noqa: TC002
 from litestar.params import Parameter
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -328,17 +328,23 @@ class MeetingController(Controller):
     async def delete_meeting(
         self,
         state: State,
+        request: Request[Any, Any, Any],
         meeting_id: PathId,
     ) -> ApiResponse[None]:
         """Delete a meeting record by id.
 
         Returns ``200 OK`` with ``data=None`` on success and
-        ``404 Not Found`` when the id does not exist. The record is
-        removed from the in-memory orchestrator audit store; durable
-        replay is preserved through audit logs.
+        ``404 Not Found`` when the id does not exist. Routes through
+        :class:`MeetingService` so the
+        ``COMMUNICATION_MEETING_DELETED`` audit event is emitted from
+        the service layer on parity with the MCP path.
         """
-        orchestrator = state.app_state.meeting_orchestrator
-        deleted = orchestrator.delete_record(meeting_id)
+        app_state: AppState = state.app_state
+        deleted = await app_state.meeting_service.delete_meeting(
+            meeting_id=NotBlankStr(meeting_id),
+            actor_id=NotBlankStr(str(request.user.user_id)),
+            reason=NotBlankStr("operator delete via REST API"),
+        )
         if not deleted:
             logger.warning(MEETING_NOT_FOUND, meeting_id=meeting_id)
             msg = f"Meeting {meeting_id!r} not found"

--- a/src/synthorg/api/controllers/memory.py
+++ b/src/synthorg/api/controllers/memory.py
@@ -39,6 +39,7 @@ from synthorg.memory.service import (
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.memory import (
     MEMORY_EMBEDDER_SETTINGS_READ_FAILED,
+    MEMORY_ENTRY_DELETE_FAILED,
     MEMORY_FINE_TUNE_BATCH_SIZE_RECOMMENDATION_FAILED,
     MEMORY_FINE_TUNE_PREFLIGHT_COMPLETED,
     MEMORY_FINE_TUNE_REQUESTED,
@@ -480,11 +481,24 @@ class MemoryAdminController(Controller):
                 NotBlankStr(memory_id),
             )
         except BackendUnsupportedError as exc:
+            logger.warning(
+                MEMORY_ENTRY_DELETE_FAILED,
+                agent_id=agent_id,
+                memory_id=memory_id,
+                reason="backend_unsupported",
+                error=safe_error_description(exc),
+            )
             raise ClientException(
                 detail=str(exc),
                 status_code=HTTP_501_NOT_IMPLEMENTED,
             ) from exc
         if not deleted:
+            logger.warning(
+                MEMORY_ENTRY_DELETE_FAILED,
+                agent_id=agent_id,
+                memory_id=memory_id,
+                reason="not_found",
+            )
             raise NotFoundException(detail=f"memory entry {memory_id!r} not found")
         return ApiResponse(data=None)
 

--- a/src/synthorg/api/controllers/memory.py
+++ b/src/synthorg/api/controllers/memory.py
@@ -29,6 +29,7 @@ from synthorg.memory.embedding.fine_tune_models import (
     PreflightResult,
 )
 from synthorg.memory.errors import FineTuneDependencyError
+from synthorg.memory.fine_tune_plan import BackendUnsupportedError
 from synthorg.memory.service import (
     CheckpointNotFoundError,
     CheckpointRollbackCorruptError,
@@ -85,6 +86,9 @@ def _build_memory_service(app_state: AppState) -> MemoryService:
         run_repo=run_repo,
         settings_service=(
             app_state.settings_service if app_state.has_settings_service else None
+        ),
+        memory_backend=(
+            app_state.memory_backend if app_state.has_memory_backend else None
         ),
     )
 
@@ -442,6 +446,46 @@ class MemoryAdminController(Controller):
                 detail=str(exc),
                 status_code=HTTP_409_CONFLICT,
             ) from exc
+        return ApiResponse(data=None)
+
+    # -- Memory entries (GDPR) ---------------------------------------
+
+    @delete(
+        "/agents/{agent_id:str}/memories/{memory_id:str}",
+        status_code=200,
+        guards=[
+            per_op_rate_limit_from_policy(
+                "memory.entry_delete",
+                key="user",
+            ),
+        ],
+    )
+    async def delete_memory_entry(
+        self,
+        state: State,
+        agent_id: str,
+        memory_id: str,
+    ) -> ApiResponse[None]:
+        """Delete a single memory entry owned by an agent.
+
+        Returns ``200 OK`` on success and ``404 Not Found`` when the
+        memory entry does not exist (or the agent has no entry with
+        that id). Returns ``501 Not Implemented`` when no memory
+        backend is wired on the active app state.
+        """
+        service = _build_memory_service(state.app_state)
+        try:
+            deleted = await service.delete_memory_entry(
+                NotBlankStr(agent_id),
+                NotBlankStr(memory_id),
+            )
+        except BackendUnsupportedError as exc:
+            raise ClientException(
+                detail=str(exc),
+                status_code=HTTP_501_NOT_IMPLEMENTED,
+            ) from exc
+        if not deleted:
+            raise NotFoundException(detail=f"memory entry {memory_id!r} not found")
         return ApiResponse(data=None)
 
     # -- Run history -------------------------------------------------

--- a/src/synthorg/api/controllers/memory.py
+++ b/src/synthorg/api/controllers/memory.py
@@ -39,7 +39,6 @@ from synthorg.memory.service import (
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.memory import (
     MEMORY_EMBEDDER_SETTINGS_READ_FAILED,
-    MEMORY_ENTRY_DELETE_FAILED,
     MEMORY_FINE_TUNE_BATCH_SIZE_RECOMMENDATION_FAILED,
     MEMORY_FINE_TUNE_PREFLIGHT_COMPLETED,
     MEMORY_FINE_TUNE_REQUESTED,
@@ -490,17 +489,10 @@ class MemoryAdminController(Controller):
                 status_code=HTTP_501_NOT_IMPLEMENTED,
             ) from exc
         if not deleted:
-            # The service intentionally does not log on the not-found
-            # path (an absent row is not a failure mode at the backend
-            # layer); the controller records it because the operator
-            # request did fail and the audit trail needs to reflect
-            # that.
-            logger.warning(
-                MEMORY_ENTRY_DELETE_FAILED,
-                agent_id=agent_id,
-                memory_id=memory_id,
-                reason="not_found",
-            )
+            # ``MemoryService.delete_memory_entry`` emits
+            # ``MEMORY_ENTRY_DELETE_FAILED`` with ``reason="not_found"``
+            # for this branch, so the controller stays in the layering
+            # role of HTTP translation only.
             raise NotFoundException(detail=f"memory entry {memory_id!r} not found")
         return ApiResponse(data=None)
 

--- a/src/synthorg/api/controllers/memory.py
+++ b/src/synthorg/api/controllers/memory.py
@@ -481,18 +481,20 @@ class MemoryAdminController(Controller):
                 NotBlankStr(memory_id),
             )
         except BackendUnsupportedError as exc:
-            logger.warning(
-                MEMORY_ENTRY_DELETE_FAILED,
-                agent_id=agent_id,
-                memory_id=memory_id,
-                reason="backend_unsupported",
-                error=safe_error_description(exc),
-            )
+            # ``MemoryService.delete_memory_entry`` already emits
+            # ``MEMORY_ENTRY_DELETE_FAILED`` for this branch, so the
+            # controller stays in the layering role of HTTP
+            # translation only and does not double-record the event.
             raise ClientException(
                 detail=str(exc),
                 status_code=HTTP_501_NOT_IMPLEMENTED,
             ) from exc
         if not deleted:
+            # The service intentionally does not log on the not-found
+            # path (an absent row is not a failure mode at the backend
+            # layer); the controller records it because the operator
+            # request did fail and the audit trail needs to reflect
+            # that.
             logger.warning(
                 MEMORY_ENTRY_DELETE_FAILED,
                 agent_id=agent_id,

--- a/src/synthorg/api/controllers/memory.py
+++ b/src/synthorg/api/controllers/memory.py
@@ -43,6 +43,10 @@ from synthorg.observability.events.memory import (
     MEMORY_FINE_TUNE_PREFLIGHT_COMPLETED,
     MEMORY_FINE_TUNE_REQUESTED,
 )
+from synthorg.persistence.fine_tune_protocol import (
+    FineTuneCheckpointRepository,  # noqa: TC001
+    FineTuneRunRepository,  # noqa: TC001
+)
 
 logger = get_logger(__name__)
 
@@ -52,35 +56,57 @@ logger = get_logger(__name__)
 _DEFAULT_BATCH_SIZE: Final[int] = 16
 
 
-def _build_memory_service(app_state: AppState) -> MemoryService:
+def _build_memory_service(
+    app_state: AppState,
+    *,
+    require_fine_tune: bool = True,
+) -> MemoryService:
     """Construct a :class:`MemoryService` from the current AppState.
 
     Kept on the controller module rather than :class:`AppState` so the
     service layer depends on AppState (and not vice-versa) and the
     AppState slot inventory stays stable. Resolves the fine-tune
     repositories through :class:`PersistenceBackend` so the controller
-    does not hard-wire the SQLite implementation; backends that do not
-    support fine-tuning raise ``NotImplementedError`` at accessor-call
-    time, which we translate to HTTP 501 here so operators get a clean
-    "unsupported backend" response instead of a 500 traceback.
+    does not hard-wire the SQLite implementation.
+
+    The ``require_fine_tune`` flag separates the fine-tune-admin
+    endpoints (which need both checkpoint + run repos and translate a
+    missing backend implementation into HTTP 501) from memory-only
+    endpoints such as the GDPR ``DELETE /memory/entries/...`` path,
+    which only need the ``MemoryBackend``. Without this carve-out a
+    Postgres deployment that wires a memory backend without fine-tune
+    support would 501 on every entry deletion even though
+    :class:`MemoryService.delete_memory_entry` can run without the
+    fine-tune repos.
+
+    Args:
+        app_state: Active application state.
+        require_fine_tune: When ``True`` (default), eagerly resolve
+            ``fine_tune_checkpoints`` / ``fine_tune_runs`` and raise
+            :class:`ClientException` (HTTP 501) when they are absent.
+            When ``False``, leave the repos as ``None`` so the service
+            constructs cleanly for memory-only endpoints.
 
     Raises:
-        ClientException: When the backend does not implement the
-            fine-tune repositories (HTTP 501). The only such backend
-            today is Postgres; SQLite always exposes both repos.
+        ClientException: When ``require_fine_tune`` is ``True`` and the
+            backend does not implement the fine-tune repositories
+            (HTTP 501).
     """
     backend = app_state.persistence
-    try:
-        checkpoint_repo = backend.fine_tune_checkpoints
-        run_repo = backend.fine_tune_runs
-    except NotImplementedError as exc:
-        raise ClientException(
-            detail=(
-                "Fine-tune admin endpoints are not supported by the "
-                "active persistence backend."
-            ),
-            status_code=HTTP_501_NOT_IMPLEMENTED,
-        ) from exc
+    checkpoint_repo: FineTuneCheckpointRepository | None = None
+    run_repo: FineTuneRunRepository | None = None
+    if require_fine_tune:
+        try:
+            checkpoint_repo = backend.fine_tune_checkpoints
+            run_repo = backend.fine_tune_runs
+        except NotImplementedError as exc:
+            raise ClientException(
+                detail=(
+                    "Fine-tune admin endpoints are not supported by the "
+                    "active persistence backend."
+                ),
+                status_code=HTTP_501_NOT_IMPLEMENTED,
+            ) from exc
     return MemoryService(
         checkpoint_repo=checkpoint_repo,
         run_repo=run_repo,
@@ -473,7 +499,11 @@ class MemoryAdminController(Controller):
         that id). Returns ``501 Not Implemented`` when no memory
         backend is wired on the active app state.
         """
-        service = _build_memory_service(state.app_state)
+        # ``require_fine_tune=False`` -- entry deletion only needs the
+        # ``MemoryBackend``; eagerly resolving the fine-tune repos
+        # would 501 every memory-only deployment, which the GDPR delete
+        # path must support.
+        service = _build_memory_service(state.app_state, require_fine_tune=False)
         try:
             deleted = await service.delete_memory_entry(
                 NotBlankStr(agent_id),

--- a/src/synthorg/api/controllers/messages.py
+++ b/src/synthorg/api/controllers/messages.py
@@ -1,6 +1,8 @@
 """Message controller -- read + operator-driven DELETE via MessageRepository."""
 
-from litestar import Controller, delete, get
+from typing import Any
+
+from litestar import Controller, Request, delete, get
 from litestar.datastructures import State  # noqa: TC002
 from litestar.exceptions import NotFoundException
 
@@ -10,8 +12,10 @@ from synthorg.api.pagination import CursorLimit, CursorParam, paginate_cursor
 from synthorg.api.state import AppState  # noqa: TC001
 from synthorg.communication.channel import Channel
 from synthorg.communication.message import Message  # noqa: TC001
-from synthorg.core.types import NotBlankStr
 from synthorg.observability import get_logger
+from synthorg.observability.events.communication import (
+    COMMUNICATION_MESSAGE_DELETED,
+)
 
 logger = get_logger(__name__)
 
@@ -69,20 +73,35 @@ class MessageController(Controller):
     async def delete_message(
         self,
         state: State,
+        request: Request[Any, Any, Any],
         message_id: str,
     ) -> ApiResponse[None]:
         """Delete a single message by id.
 
         Returns ``200 OK`` with ``data=None`` on success and
-        ``404 Not Found`` when the id does not exist. Uses the
-        message-id only since ``messages.id`` is a globally unique PK.
+        ``404 Not Found`` when the id does not exist. Emits the
+        ``COMMUNICATION_MESSAGE_DELETED`` audit event on success with
+        the authenticated user as the actor; the parallel MCP path
+        (``synthorg_messages_delete``) emits the same event from the
+        :class:`MessageService` layer so both surfaces produce a
+        uniform audit trail.
+
+        Goes directly through the repository (matching the read path
+        in ``list_messages``) because :class:`MessageService` is wired
+        only inside the MCP host today; the audit log is emitted
+        inline so the HTTP path retains the same audit semantics
+        regardless.
         """
         app_state: AppState = state.app_state
-        deleted = await app_state.persistence.messages.delete(
-            NotBlankStr(message_id),
-        )
+        deleted = await app_state.persistence.messages.delete(message_id)
         if not deleted:
             raise NotFoundException(detail=f"message {message_id!r} not found")
+        logger.info(
+            COMMUNICATION_MESSAGE_DELETED,
+            message_id=message_id,
+            actor_id=str(request.user.user_id),
+            reason="operator delete via REST API",
+        )
         return ApiResponse(data=None)
 
     @get("/channels")

--- a/src/synthorg/api/controllers/messages.py
+++ b/src/synthorg/api/controllers/messages.py
@@ -1,21 +1,23 @@
-"""Message controller -- read-only access via MessageRepository."""
+"""Message controller -- read + operator-driven DELETE via MessageRepository."""
 
-from litestar import Controller, get
+from litestar import Controller, delete, get
 from litestar.datastructures import State  # noqa: TC002
+from litestar.exceptions import NotFoundException
 
-from synthorg.api.dto import PaginatedResponse
-from synthorg.api.guards import require_read_access
+from synthorg.api.dto import ApiResponse, PaginatedResponse
+from synthorg.api.guards import require_read_access, require_write_access
 from synthorg.api.pagination import CursorLimit, CursorParam, paginate_cursor
 from synthorg.api.state import AppState  # noqa: TC001
 from synthorg.communication.channel import Channel
 from synthorg.communication.message import Message  # noqa: TC001
+from synthorg.core.types import NotBlankStr
 from synthorg.observability import get_logger
 
 logger = get_logger(__name__)
 
 
 class MessageController(Controller):
-    """Read-only access to message history."""
+    """Access to message history (read + operator-driven delete)."""
 
     path = "/messages"
     tags = ("messages",)
@@ -58,6 +60,30 @@ class MessageController(Controller):
             secret=app_state.cursor_secret,
         )
         return PaginatedResponse(data=page, pagination=meta)
+
+    @delete(
+        "/{message_id:str}",
+        status_code=200,
+        guards=[require_write_access],
+    )
+    async def delete_message(
+        self,
+        state: State,
+        message_id: str,
+    ) -> ApiResponse[None]:
+        """Delete a single message by id.
+
+        Returns ``200 OK`` with ``data=None`` on success and
+        ``404 Not Found`` when the id does not exist. Uses the
+        message-id only since ``messages.id`` is a globally unique PK.
+        """
+        app_state: AppState = state.app_state
+        deleted = await app_state.persistence.messages.delete(
+            NotBlankStr(message_id),
+        )
+        if not deleted:
+            raise NotFoundException(detail=f"message {message_id!r} not found")
+        return ApiResponse(data=None)
 
     @get("/channels")
     async def list_channels(

--- a/src/synthorg/api/controllers/messages.py
+++ b/src/synthorg/api/controllers/messages.py
@@ -75,6 +75,7 @@ class MessageController(Controller):
         state: State,
         request: Request[Any, Any, Any],
         message_id: str,
+        channel: str | None = None,
     ) -> ApiResponse[None]:
         """Delete a single message by id.
 
@@ -84,13 +85,26 @@ class MessageController(Controller):
         the authenticated user as the actor; the parallel MCP path
         (``synthorg_messages_delete``) emits the same event from the
         :class:`MessageService` layer so both surfaces produce a
-        uniform audit trail.
+        uniform audit trail (same key set, with ``channel`` reported
+        as ``None`` when the REST caller did not supply it).
 
         Goes directly through the repository (matching the read path
         in ``list_messages``) because :class:`MessageService` is wired
         only inside the MCP host today; the audit log is emitted
         inline so the HTTP path retains the same audit semantics
         regardless.
+
+        Args:
+            state: Litestar app state.
+            request: Authenticated request; ``request.user.user_id``
+                drives the audit log's actor field.
+            message_id: Globally unique message identifier (the
+                lookup key on the messages table).
+            channel: Optional channel attribution for the audit log
+                so callers can record which logical bus the message
+                belonged to. ``None`` is acceptable since
+                ``messages.id`` is globally unique; the value is
+                advisory metadata, not a lookup key.
         """
         app_state: AppState = state.app_state
         deleted = await app_state.persistence.messages.delete(message_id)
@@ -98,6 +112,7 @@ class MessageController(Controller):
             raise NotFoundException(detail=f"message {message_id!r} not found")
         logger.info(
             COMMUNICATION_MESSAGE_DELETED,
+            channel=channel,
             message_id=message_id,
             actor_id=str(request.user.user_id),
             reason="operator delete via REST API",

--- a/src/synthorg/api/controllers/messages.py
+++ b/src/synthorg/api/controllers/messages.py
@@ -1,4 +1,4 @@
-"""Message controller -- read + operator-driven DELETE via MessageRepository."""
+"""Message controller -- read + operator-driven DELETE via MessageService."""
 
 from typing import Any
 
@@ -12,10 +12,8 @@ from synthorg.api.pagination import CursorLimit, CursorParam, paginate_cursor
 from synthorg.api.state import AppState  # noqa: TC001
 from synthorg.communication.channel import Channel
 from synthorg.communication.message import Message  # noqa: TC001
+from synthorg.core.types import NotBlankStr
 from synthorg.observability import get_logger
-from synthorg.observability.events.communication import (
-    COMMUNICATION_MESSAGE_DELETED,
-)
 
 logger = get_logger(__name__)
 
@@ -75,24 +73,15 @@ class MessageController(Controller):
         state: State,
         request: Request[Any, Any, Any],
         message_id: str,
-        channel: str | None = None,
     ) -> ApiResponse[None]:
         """Delete a single message by id.
 
         Returns ``200 OK`` with ``data=None`` on success and
-        ``404 Not Found`` when the id does not exist. Emits the
-        ``COMMUNICATION_MESSAGE_DELETED`` audit event on success with
-        the authenticated user as the actor; the parallel MCP path
-        (``synthorg_messages_delete``) emits the same event from the
-        :class:`MessageService` layer so both surfaces produce a
-        uniform audit trail (same key set, with ``channel`` reported
-        as ``None`` when the REST caller did not supply it).
-
-        Goes directly through the repository (matching the read path
-        in ``list_messages``) because :class:`MessageService` is wired
-        only inside the MCP host today; the audit log is emitted
-        inline so the HTTP path retains the same audit semantics
-        regardless.
+        ``404 Not Found`` when the id does not exist. Routes through
+        :class:`MessageService` so the audit-grade
+        ``COMMUNICATION_MESSAGE_DELETED`` event is emitted exactly
+        once from the service layer, on parity with the parallel MCP
+        path (``synthorg_messages_delete``).
 
         Args:
             state: Litestar app state.
@@ -100,23 +89,15 @@ class MessageController(Controller):
                 drives the audit log's actor field.
             message_id: Globally unique message identifier (the
                 lookup key on the messages table).
-            channel: Optional channel attribution for the audit log
-                so callers can record which logical bus the message
-                belonged to. ``None`` is acceptable since
-                ``messages.id`` is globally unique; the value is
-                advisory metadata, not a lookup key.
         """
         app_state: AppState = state.app_state
-        deleted = await app_state.persistence.messages.delete(message_id)
+        deleted = await app_state.message_service.delete_message(
+            message_id=message_id,
+            actor_id=NotBlankStr(str(request.user.user_id)),
+            reason=NotBlankStr("operator delete via REST API"),
+        )
         if not deleted:
             raise NotFoundException(detail=f"message {message_id!r} not found")
-        logger.info(
-            COMMUNICATION_MESSAGE_DELETED,
-            channel=channel,
-            message_id=message_id,
-            actor_id=str(request.user.user_id),
-            reason="operator delete via REST API",
-        )
         return ApiResponse(data=None)
 
     @get("/channels")

--- a/src/synthorg/api/controllers/messages.py
+++ b/src/synthorg/api/controllers/messages.py
@@ -14,6 +14,9 @@ from synthorg.communication.channel import Channel
 from synthorg.communication.message import Message  # noqa: TC001
 from synthorg.core.types import NotBlankStr
 from synthorg.observability import get_logger
+from synthorg.observability.events.communication import (
+    COMMUNICATION_MESSAGE_DELETE_FAILED,
+)
 
 logger = get_logger(__name__)
 
@@ -97,6 +100,12 @@ class MessageController(Controller):
             reason=NotBlankStr("operator delete via REST API"),
         )
         if not deleted:
+            logger.warning(
+                COMMUNICATION_MESSAGE_DELETE_FAILED,
+                message_id=message_id,
+                actor_id=str(request.user.user_id),
+                reason="not_found",
+            )
             raise NotFoundException(detail=f"message {message_id!r} not found")
         return ApiResponse(data=None)
 

--- a/src/synthorg/api/controllers/setup_models.py
+++ b/src/synthorg/api/controllers/setup_models.py
@@ -155,9 +155,20 @@ class SetupCompanyRequest(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid", allow_inf_nan=False)
 
-    company_name: NotBlankStr = Field(max_length=200)
-    description: str | None = Field(default=None, max_length=1000)
-    template_name: NotBlankStr | None = Field(default=None, max_length=100)
+    company_name: NotBlankStr = Field(
+        max_length=200,
+        examples=["Hooli", "Pied Piper"],
+    )
+    description: str | None = Field(
+        default=None,
+        max_length=1000,
+        examples=["Boutique consultancy specializing in agentic ops"],
+    )
+    template_name: NotBlankStr | None = Field(
+        default=None,
+        max_length=100,
+        examples=["consulting-firm", "blank"],
+    )
 
 
 class SetupAgentSummary(BaseModel):
@@ -230,28 +241,46 @@ class SetupAgentRequest(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid", allow_inf_nan=False)
 
-    name: NotBlankStr = Field(max_length=200)
-    role: NotBlankStr = Field(max_length=100)
+    name: NotBlankStr = Field(max_length=200, examples=["Alice Lin", "Bob Chen"])
+    role: NotBlankStr = Field(max_length=100, examples=["CEO", "Engineer", "Designer"])
     level: SeniorityLevel = Field(default=SeniorityLevel.MID)
     personality_preset: NotBlankStr = Field(
         default="pragmatic_builder",
         max_length=100,
+        examples=["pragmatic_builder", "visionary_leader"],
     )
-    model_provider: NotBlankStr = Field(max_length=100)
-    model_id: NotBlankStr = Field(max_length=200)
-    department: NotBlankStr = Field(default="engineering", max_length=100)
-    budget_limit_monthly: float | None = Field(default=None, ge=0.0, le=1_000_000.0)
+    model_provider: NotBlankStr = Field(
+        max_length=100,
+        examples=["example-provider"],
+    )
+    model_id: NotBlankStr = Field(
+        max_length=200,
+        examples=["example-medium-001", "example-large-001"],
+    )
+    department: NotBlankStr = Field(
+        default="engineering",
+        max_length=100,
+        examples=["engineering", "design", "operations"],
+    )
+    budget_limit_monthly: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1_000_000.0,
+        examples=[100.0, 500.0],
+    )
 
     @model_validator(mode="before")
     @classmethod
-    def _validate_preset_exists(cls, values: dict[str, Any]) -> dict[str, Any]:
+    def _validate_preset_exists(cls, values: Any) -> Any:
         """Normalize and validate the personality preset before construction."""
+        if not isinstance(values, dict):
+            return values
         raw = values.get("personality_preset", "pragmatic_builder")
-        values["personality_preset"] = _normalize_and_validate_preset(
+        normalized = _normalize_and_validate_preset(
             raw,
             fallback="pragmatic_builder",
         )
-        return values
+        return {**values, "personality_preset": normalized}
 
 
 class SetupAgentResponse(BaseModel):
@@ -314,11 +343,13 @@ class UpdateAgentPersonalityRequest(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def _validate_preset_exists(cls, values: dict[str, Any]) -> dict[str, Any]:
+    def _validate_preset_exists(cls, values: Any) -> Any:
         """Normalize and validate the personality preset."""
+        if not isinstance(values, dict):
+            return values
         raw = values.get("personality_preset")
-        values["personality_preset"] = _normalize_and_validate_preset(raw)
-        return values
+        normalized = _normalize_and_validate_preset(raw)
+        return {**values, "personality_preset": normalized}
 
 
 class PersonalityPresetInfoResponse(BaseModel):

--- a/src/synthorg/api/lifecycle_builder.py
+++ b/src/synthorg/api/lifecycle_builder.py
@@ -468,6 +468,14 @@ def _build_lifecycle(  # noqa: PLR0913, PLR0915, C901
         nonlocal _health_prober, _training_memory_backend
         # Disconnect training memory backend if auto-wired.
         if _training_memory_backend is not None:
+            # If this backend was published to ``app_state.memory_backend``
+            # at startup, clear the slot before disconnecting so a
+            # subsequent re-entry of the lifespan can wire a fresh
+            # connected backend without ``has_memory_backend`` reporting
+            # a stale handle.
+            shared = getattr(app_state, "_memory_backend", None)
+            if shared is _training_memory_backend:
+                app_state._memory_backend = None  # noqa: SLF001
             disconnect = getattr(_training_memory_backend, "disconnect", None)
             if callable(disconnect):
                 # getattr + callable narrow statically only to ``object``

--- a/src/synthorg/api/lifecycle_builder.py
+++ b/src/synthorg/api/lifecycle_builder.py
@@ -292,6 +292,23 @@ def _build_lifecycle(  # noqa: PLR0913, PLR0915, C901
                     distributed_task_queue=app_state.distributed_task_queue,
                 )
                 raise
+        # Phase 3a: when an external caller already supplied a
+        # ``TrainingService`` to ``create_app()``, we skip the
+        # auto-wire below but the injected service still owns a live
+        # ``MemoryBackend``. Pull it out and publish it on
+        # ``app_state`` so the DELETE memory controller and MCP tool
+        # path see ``has_memory_backend == True`` -- otherwise an
+        # injected-service deployment would surface as 501 / unsupported
+        # even though a connected backend is right there.
+        if app_state.has_training_service and not app_state.has_memory_backend:
+            injected_backend = getattr(
+                app_state.training_service,
+                "_memory_backend",
+                None,
+            )
+            if injected_backend is not None:
+                app_state.set_memory_backend(injected_backend)
+
         # Phase 3 auto-wire: TrainingService.
         # Needs agent_registry, tool_invocation_tracker, and
         # performance_tracker (all wired in Phase 1).  Uses

--- a/src/synthorg/api/lifecycle_builder.py
+++ b/src/synthorg/api/lifecycle_builder.py
@@ -326,6 +326,12 @@ def _build_lifecycle(  # noqa: PLR0913, PLR0915, C901
                             tool_tracker=app_state.tool_invocation_tracker,
                         )
                         app_state.set_training_service(_ts)
+                        # Expose the same backend to admin paths so
+                        # ``DELETE /agents/{id}/memories/{id}`` and the
+                        # ``delete_memory`` MCP tool can route through
+                        # one connected backend instance per process.
+                        if not app_state.has_memory_backend:
+                            app_state.set_memory_backend(_mem)
                     except MemoryError, RecursionError:
                         await _mem.disconnect()
                         raise

--- a/src/synthorg/api/lifecycle_helpers.py
+++ b/src/synthorg/api/lifecycle_helpers.py
@@ -7,7 +7,7 @@ Split out of ``lifecycle_builder.py`` so neither file exceeds the
 
 import asyncio
 import inspect
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 from synthorg.notifications.factory import build_notification_dispatcher
 from synthorg.observability import get_logger, safe_error_description
@@ -278,6 +278,12 @@ async def _audit_retention_tick(app_state: AppState) -> None:
     )
 
 
+_AUDIT_RETENTION_TICK_SECONDS: Final[float] = 86_400.0
+"""Audit retention sweep cadence (24h). Hardcoded by design: retention is
+not a hot path and operators tune the *window* (``security.audit_retention_days``)
+rather than the *cadence*."""
+
+
 async def _audit_retention_loop(app_state: AppState) -> None:
     """Daily sweep that purges audit_entries older than retention window.
 
@@ -288,13 +294,13 @@ async def _audit_retention_loop(app_state: AppState) -> None:
     ``security.audit_retention_days=0``); resolver outages fall back
     to the registered default of 730 days rather than disabling
     retention. The loop stays resident even when paused so lifecycle
-    plumbing is unchanged. Tick cadence is 24h -- audit retention is
-    not a hot path.
+    plumbing is unchanged. Tick cadence is fixed at
+    ``_AUDIT_RETENTION_TICK_SECONDS`` (24h) -- audit retention is not a
+    hot path.
     """
-    tick_seconds = 86_400.0
     while True:
         await _audit_retention_tick(app_state)
-        await asyncio.sleep(tick_seconds)
+        await asyncio.sleep(_AUDIT_RETENTION_TICK_SECONDS)
 
 
 async def _maybe_promote_first_owner(app_state: AppState) -> None:

--- a/src/synthorg/api/rate_limits/policies.py
+++ b/src/synthorg/api/rate_limits/policies.py
@@ -77,6 +77,7 @@ _POLICIES: Final[dict[str, tuple[int, int]]] = {
     # memory
     "memory.checkpoint_delete": (20, 60),
     "memory.checkpoint_deploy": (2, 3600),
+    "memory.entry_delete": (60, 60),
     "memory.checkpoint_rollback": (2, 3600),
     "memory.fine_tune": (2, 3600),
     "memory.fine_tune_cancel": (10, 3600),

--- a/src/synthorg/api/rate_limits/policies.py
+++ b/src/synthorg/api/rate_limits/policies.py
@@ -77,8 +77,8 @@ _POLICIES: Final[dict[str, tuple[int, int]]] = {
     # memory
     "memory.checkpoint_delete": (20, 60),
     "memory.checkpoint_deploy": (2, 3600),
-    "memory.entry_delete": (60, 60),
     "memory.checkpoint_rollback": (2, 3600),
+    "memory.entry_delete": (60, 60),
     "memory.fine_tune": (2, 3600),
     "memory.fine_tune_cancel": (10, 3600),
     "memory.fine_tune_preflight": (50, 60),

--- a/src/synthorg/api/state.py
+++ b/src/synthorg/api/state.py
@@ -65,6 +65,7 @@ from synthorg.hr.training.service import TrainingService  # noqa: TC001
 from synthorg.memory.embedding.fine_tune_orchestrator import (
     FineTuneOrchestrator,  # noqa: TC001
 )
+from synthorg.memory.protocol import MemoryBackend  # noqa: TC001
 from synthorg.notifications.dispatcher import (
     NotificationDispatcher,  # noqa: TC001
 )
@@ -191,6 +192,7 @@ class AppState(AppStateServicesMixin):
         "_meeting_orchestrator",
         "_meeting_scheduler",
         "_meeting_service",
+        "_memory_backend",
         "_memory_service",
         "_message_bus",
         "_message_service",
@@ -357,6 +359,11 @@ class AppState(AppStateServicesMixin):
         self._prometheus_collector: PrometheusCollector | None = None
         self._trace_handler: TraceHandler | None = None
         self._fine_tune_orchestrator: FineTuneOrchestrator | None = None
+        # Shared MemoryBackend instance for admin operations (DELETE
+        # endpoints, MCP delete_memory). Wired during startup when a
+        # backend is constructed (e.g. during the training-service
+        # auto-wire path); ``None`` when no backend is configured.
+        self._memory_backend: MemoryBackend | None = None
         self._config_resolver: ConfigResolver | None = None
         # One-shot flag: on_startup applies bridge-config settings
         # exactly once per ``AppState`` lifetime, even when the

--- a/src/synthorg/api/state_services.py
+++ b/src/synthorg/api/state_services.py
@@ -88,6 +88,7 @@ if TYPE_CHECKING:
     from synthorg.integrations.mcp_catalog.service import CatalogService
     from synthorg.integrations.oauth.token_manager import OAuthTokenManager
     from synthorg.integrations.tunnel.protocol import TunnelProvider
+    from synthorg.memory.protocol import MemoryBackend
 
 logger = get_logger(__name__)
 
@@ -127,6 +128,7 @@ class AppStateServicesMixin(_FacadesMixin):
     _provider_health_tracker: ProviderHealthTracker | None
     _tool_invocation_tracker: ToolInvocationTracker | None
     _training_service: TrainingService | None
+    _memory_backend: MemoryBackend | None
     _delegation_record_store: DelegationRecordStore | None
     _auth_service: AuthService | None
     _ticket_store: WsTicketStore
@@ -311,6 +313,23 @@ class AppStateServicesMixin(_FacadesMixin):
     def set_training_service(self, service: TrainingService) -> None:
         """Attach the training service (once-only)."""
         self._set_once("_training_service", service, "Training service")
+
+    @property
+    def has_memory_backend(self) -> bool:
+        """Check whether a shared MemoryBackend is configured."""
+        return self._memory_backend is not None
+
+    @property
+    def memory_backend(self) -> MemoryBackend:
+        """Return the shared memory backend or raise 503."""
+        return self._require_service(
+            self._memory_backend,
+            "memory_backend",
+        )
+
+    def set_memory_backend(self, backend: MemoryBackend) -> None:
+        """Attach the shared memory backend (once-only)."""
+        self._set_once("_memory_backend", backend, "Memory backend")
 
     @property
     def has_delegation_record_store(self) -> bool:

--- a/src/synthorg/budget/baseline_store.py
+++ b/src/synthorg/budget/baseline_store.py
@@ -8,6 +8,7 @@ overhead (O%), and error amplification (Ae) metrics.
 import statistics
 from collections import deque
 from datetime import UTC, datetime
+from typing import Final
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 
@@ -19,6 +20,11 @@ from synthorg.observability.events.coordination_metrics import (
 )
 
 logger = get_logger(__name__)
+
+# Default rolling-window size for the single-agent baseline store. Sized
+# for ~1 day of normal traffic on a small org while keeping in-memory
+# state bounded.
+_DEFAULT_BASELINE_WINDOW_SIZE: Final[int] = 50
 
 
 class BaselineRecord(BaseModel):
@@ -60,7 +66,7 @@ class BaselineStore:
         window_size: Maximum number of records to retain.
     """
 
-    def __init__(self, *, window_size: int = 50) -> None:
+    def __init__(self, *, window_size: int = _DEFAULT_BASELINE_WINDOW_SIZE) -> None:
         if window_size <= 0:
             msg = "window_size must be positive"
             raise ValueError(msg)

--- a/src/synthorg/budget/billing.py
+++ b/src/synthorg/budget/billing.py
@@ -6,6 +6,15 @@ to scope cost queries to the current billing cycle.
 """
 
 from datetime import UTC, datetime
+from typing import Final
+
+# Reset-day bounds: 1 keeps period start in-month; 28 is the largest day
+# guaranteed to exist in every Gregorian month, so the rollback branch
+# never has to coerce out-of-range days.
+_RESET_DAY_MIN: Final[int] = 1
+_RESET_DAY_MAX: Final[int] = 28
+_DECEMBER_MONTH: Final[int] = 12
+_JANUARY_MONTH: Final[int] = 1
 
 
 def billing_period_start(
@@ -29,8 +38,8 @@ def billing_period_start(
     Raises:
         ValueError: If ``reset_day`` is not in ``[1, 28]``.
     """
-    if not 1 <= reset_day <= 28:  # noqa: PLR2004
-        msg = f"reset_day must be 1-28, got {reset_day}"
+    if not _RESET_DAY_MIN <= reset_day <= _RESET_DAY_MAX:
+        msg = f"reset_day must be {_RESET_DAY_MIN}-{_RESET_DAY_MAX}, got {reset_day}"
         raise ValueError(msg)
 
     if now is None:
@@ -40,8 +49,8 @@ def billing_period_start(
         return datetime(now.year, now.month, reset_day, tzinfo=UTC)
 
     # Roll back to previous month
-    if now.month == 1:
-        return datetime(now.year - 1, 12, reset_day, tzinfo=UTC)
+    if now.month == _JANUARY_MONTH:
+        return datetime(now.year - 1, _DECEMBER_MONTH, reset_day, tzinfo=UTC)
     return datetime(now.year, now.month - 1, reset_day, tzinfo=UTC)
 
 

--- a/src/synthorg/budget/call_analytics.py
+++ b/src/synthorg/budget/call_analytics.py
@@ -157,7 +157,9 @@ def _build_aggregation(
     failure_count = sum(1 for r in records if r.success is False)
 
     retried = sum(
-        1 for r in records if r.retry_count is not None and r.retry_count >= 1
+        1
+        for r in records
+        if r.retry_count is not None and r.retry_count >= _MIN_RETRY_COUNT
     )
     retry_rate = retried / total if total > 0 else 0.0
 

--- a/src/synthorg/budget/call_analytics.py
+++ b/src/synthorg/budget/call_analytics.py
@@ -1,7 +1,7 @@
 """Per-call analytics aggregation and alerting service."""
 
 from collections import Counter
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from synthorg.budget.call_analytics_models import AnalyticsAggregation
 from synthorg.observability import get_logger
@@ -22,6 +22,14 @@ if TYPE_CHECKING:
     from synthorg.notifications.dispatcher import NotificationDispatcher
 
 logger = get_logger(__name__)
+
+# A call is considered "retried" once it has at least one retry attempt;
+# zero-retry calls are excluded from the retry-rate numerator.
+_MIN_RETRY_COUNT: Final[int] = 1
+
+# 95th-percentile interpolation factor (NIST type-7 / linear-interpolation
+# definition): pick the value at index 0.95 * (n - 1).
+_PERCENTILE_INTERPOLATION_FACTOR: Final[float] = 0.95
 
 
 class CallAnalyticsService:
@@ -107,7 +115,9 @@ class CallAnalyticsService:
 
         total = len(records)
         retried = sum(
-            1 for r in records if r.retry_count is not None and r.retry_count >= 1
+            1
+            for r in records
+            if r.retry_count is not None and r.retry_count >= _MIN_RETRY_COUNT
         )
         retry_rate = retried / total
 
@@ -192,7 +202,7 @@ def _p95(values: list[float]) -> float:
     n = len(values)
     if n == 1:
         return values[0]
-    index = 0.95 * (n - 1)
+    index = _PERCENTILE_INTERPOLATION_FACTOR * (n - 1)
     lo = int(index)
     hi = lo + 1
     frac = index - lo

--- a/src/synthorg/budget/call_analytics_config.py
+++ b/src/synthorg/budget/call_analytics_config.py
@@ -1,8 +1,15 @@
 """Configuration for the per-call analytics service."""
 
+from typing import Final
+
 from pydantic import BaseModel, ConfigDict, Field
 
 from synthorg.budget.coordination_config import OrchestrationAlertThresholds
+
+# 10% of calls with at least one retry is the operator-default warning
+# threshold. Tuned against historical incident data; tighten via
+# ``RetryAlertConfig(warn_rate=...)`` overrides per deployment.
+_DEFAULT_RETRY_WARN_RATE: Final[float] = 0.10
 
 
 class RetryAlertConfig(BaseModel):
@@ -16,7 +23,7 @@ class RetryAlertConfig(BaseModel):
     model_config = ConfigDict(frozen=True, allow_inf_nan=False)
 
     warn_rate: float = Field(
-        default=0.10,
+        default=_DEFAULT_RETRY_WARN_RATE,
         ge=0.0,
         le=1.0,
         description=(

--- a/src/synthorg/communication/meeting/orchestrator.py
+++ b/src/synthorg/communication/meeting/orchestrator.py
@@ -253,6 +253,20 @@ class MeetingOrchestrator:
         """
         return tuple(self._records)
 
+    def delete_record(self, meeting_id: str) -> bool:
+        """Remove the meeting record matching ``meeting_id``.
+
+        Returns ``True`` when a record was removed, ``False`` when no
+        record had the supplied id. Synchronous because the in-memory
+        store has no I/O; the surrounding service-layer wrapper is
+        async to match the rest of the persistence contract.
+        """
+        for i, record in enumerate(self._records):
+            if record.meeting_id == meeting_id:
+                self._records.pop(i)
+                return True
+        return False
+
     async def _execute_protocol(  # noqa: PLR0913
         self,
         protocol: MeetingProtocol,

--- a/src/synthorg/communication/meetings/service.py
+++ b/src/synthorg/communication/meetings/service.py
@@ -1,18 +1,21 @@
 """MeetingService -- read facade over :class:`MeetingOrchestrator`.
 
 Reads are direct: ``list_meetings`` returns the orchestrator's audit
-records newest-first, ``get_meeting`` looks up by ID.  Write ops
-(create / update / delete) raise :class:`CapabilityNotSupportedError`
-because meetings are produced by executing a
-:class:`MeetingProtocol` via the engine, not by ad-hoc record
-insertion; the MCP tool surface therefore intentionally lacks a
-creation path until a scheduled-meetings DTO lands in a later pass.
+records newest-first, ``get_meeting`` looks up by ID. ``delete_meeting``
+removes a single record from the orchestrator's in-memory store and
+emits an audit-grade :data:`COMMUNICATION_MEETING_DELETED` event.
+Create / update remain capability-gated because meetings are
+produced by executing a :class:`MeetingProtocol` via the engine, not
+by ad-hoc record insertion.
 """
 
 from typing import TYPE_CHECKING
 
 from synthorg.communication.mcp_errors import CapabilityNotSupportedError
 from synthorg.observability import get_logger
+from synthorg.observability.events.communication import (
+    COMMUNICATION_MEETING_DELETED,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -34,11 +37,6 @@ _UPDATE_CAP = "meeting_update"
 _UPDATE_DETAIL = (
     "MeetingRecord is an immutable audit entry; status transitions "
     "happen inside the orchestrator, not via MCP edits"
-)
-_DELETE_CAP = "meeting_delete"
-_DELETE_DETAIL = (
-    "MeetingRecord is retained as an audit trail; operators prune "
-    "records through the retention policy, not an MCP delete"
 )
 
 
@@ -107,9 +105,35 @@ class MeetingService:
         """Reject update with a typed ``not_supported`` error."""
         raise CapabilityNotSupportedError(_UPDATE_CAP, _UPDATE_DETAIL)
 
-    async def delete_meeting(self) -> None:
-        """Reject deletion with a typed ``not_supported`` error."""
-        raise CapabilityNotSupportedError(_DELETE_CAP, _DELETE_DETAIL)
+    async def delete_meeting(
+        self,
+        *,
+        meeting_id: NotBlankStr,
+        actor_id: NotBlankStr,
+        reason: NotBlankStr,
+    ) -> bool:
+        """Delete a meeting record by id.
+
+        Removes the record from the orchestrator's in-memory audit
+        store. Returns ``True`` when a row was removed, ``False`` when
+        the id did not exist.
+
+        Args:
+            meeting_id: Meeting record identifier.
+            actor_id: Authenticated actor that initiated the delete
+                (drives the audit log).
+            reason: Operator-supplied justification (drives the audit
+                log).
+        """
+        deleted = self._orchestrator.delete_record(meeting_id)
+        if deleted:
+            logger.info(
+                COMMUNICATION_MEETING_DELETED,
+                meeting_id=meeting_id,
+                actor_id=actor_id,
+                reason=reason,
+            )
+        return deleted
 
 
 __all__ = [

--- a/src/synthorg/communication/messages/service.py
+++ b/src/synthorg/communication/messages/service.py
@@ -115,18 +115,20 @@ class MessageService:
     async def delete_message(
         self,
         *,
-        channel: NotBlankStr,
-        message_id: str,
+        message_id: NotBlankStr,
         actor_id: NotBlankStr,
         reason: NotBlankStr,
     ) -> bool:
-        """Delete a single message owned by ``message_id``.
+        """Delete a single message by id.
 
-        The ``channel`` argument is preserved as part of the public
-        contract for symmetry with the read API even though the
-        underlying ``messages.id`` column is globally unique. The
-        ``actor_id`` and ``reason`` arguments drive the audit log so
-        operator-initiated removals are traceable end-to-end.
+        ``messages.id`` is globally unique so deletion is scoped by
+        id alone. The ``actor_id`` and ``reason`` arguments drive the
+        audit log so operator-initiated removals are traceable
+        end-to-end. ``channel`` is intentionally absent from this
+        contract: callers cannot scope the delete to a channel
+        without first reading the message, and accepting an
+        unvalidated ``channel`` field would let stale or wrong values
+        pollute the audit trail.
 
         Returns ``True`` if a row was removed, ``False`` if the
         ``message_id`` did not exist.
@@ -135,7 +137,6 @@ class MessageService:
         if deleted:
             logger.info(
                 COMMUNICATION_MESSAGE_DELETED,
-                channel=channel,
                 message_id=message_id,
                 actor_id=actor_id,
                 reason=reason,

--- a/src/synthorg/communication/messages/service.py
+++ b/src/synthorg/communication/messages/service.py
@@ -1,19 +1,17 @@
 """MessageService -- read + publish facade over the message bus.
 
-Wraps :class:`MessageBus` for channel / history reads and the publish
-path; destructive removal raises
-:class:`CapabilityNotSupportedError` because the underlying
-:class:`MessageRepository` is append-only by design (durable channel
-history is an audit log; operators redact via content rewrite rather
-than deletion).  Handlers translate that to a typed ``not_supported``
-envelope so callers understand the gap.
+Wraps :class:`MessageBus` for channel / history reads, the publish
+path, and now operator-driven deletion. ``MessageRepository.delete``
+is implemented on both SQLite and Postgres backends; the service
+forwards the call and emits an audit-grade
+:data:`COMMUNICATION_MESSAGE_DELETED` event on success.
 """
 
 from typing import TYPE_CHECKING
 
-from synthorg.communication.mcp_errors import CapabilityNotSupportedError
 from synthorg.observability import get_logger
 from synthorg.observability.events.communication import (
+    COMMUNICATION_MESSAGE_DELETED,
     COMMUNICATION_MESSAGE_SENT_VIA_MCP,
 )
 
@@ -27,12 +25,6 @@ if TYPE_CHECKING:
     from synthorg.persistence.protocol import PersistenceBackend
 
 logger = get_logger(__name__)
-
-_DELETE_CAP = "message_delete"
-_DELETE_DETAIL = (
-    "MessageRepository is append-only; operators rewrite content via "
-    "a follow-up message rather than deleting history entries"
-)
 
 
 class MessageService:
@@ -123,18 +115,32 @@ class MessageService:
     async def delete_message(
         self,
         *,
-        channel: NotBlankStr,  # noqa: ARG002 - part of public contract
-        message_id: str,  # noqa: ARG002
-        actor_id: NotBlankStr,  # noqa: ARG002
-        reason: NotBlankStr,  # noqa: ARG002
+        channel: NotBlankStr,
+        message_id: str,
+        actor_id: NotBlankStr,
+        reason: NotBlankStr,
     ) -> bool:
-        """Reject deletion with a typed ``not_supported`` error.
+        """Delete a single message owned by ``message_id``.
 
-        The audit-grade durability of channel history means content
-        removal is a separate operator workflow (log rotation /
-        compliance tooling) rather than an MCP surface.
+        The ``channel`` argument is preserved as part of the public
+        contract for symmetry with the read API even though the
+        underlying ``messages.id`` column is globally unique. The
+        ``actor_id`` and ``reason`` arguments drive the audit log so
+        operator-initiated removals are traceable end-to-end.
+
+        Returns ``True`` if a row was removed, ``False`` if the
+        ``message_id`` did not exist.
         """
-        raise CapabilityNotSupportedError(_DELETE_CAP, _DELETE_DETAIL)
+        deleted = await self._persistence.messages.delete(message_id)
+        if deleted:
+            logger.info(
+                COMMUNICATION_MESSAGE_DELETED,
+                channel=channel,
+                message_id=message_id,
+                actor_id=actor_id,
+                reason=reason,
+            )
+        return deleted
 
 
 __all__ = [

--- a/src/synthorg/engine/classification/heuristic_detectors.py
+++ b/src/synthorg/engine/classification/heuristic_detectors.py
@@ -5,7 +5,7 @@ Wraps the existing pure-function detectors from ``detectors.py`` as
 and dispatched by the pluggable classification pipeline.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from synthorg.budget.coordination_config import (
     DetectionScope,
@@ -25,6 +25,11 @@ if TYPE_CHECKING:
 _SAME_TASK_ONLY: frozenset[DetectionScope] = frozenset(
     {DetectionScope.SAME_TASK},
 )
+
+# Default tolerance for numerical drift detection. 5% is the operator
+# baseline; tighter thresholds are typically needed for financial or
+# scientific tasks and are configured per detector instance.
+_DEFAULT_NUMERICAL_DRIFT_PERCENT: Final[float] = 5.0
 
 
 class HeuristicContradictionDetector:
@@ -71,7 +76,11 @@ class HeuristicNumericalDriftDetector:
             (default 5.0).
     """
 
-    def __init__(self, *, threshold_percent: float = 5.0) -> None:
+    def __init__(
+        self,
+        *,
+        threshold_percent: float = _DEFAULT_NUMERICAL_DRIFT_PERCENT,
+    ) -> None:
         self._threshold_percent = threshold_percent
 
     @property

--- a/src/synthorg/memory/consolidation/density.py
+++ b/src/synthorg/memory/consolidation/density.py
@@ -7,6 +7,7 @@ identifiers).  Classification is deterministic -- no LLM calls.
 
 import re
 from enum import StrEnum
+from typing import Final
 
 from synthorg.memory.models import MemoryEntry  # noqa: TC001
 from synthorg.observability import get_logger
@@ -98,8 +99,26 @@ _NUMERIC_PATTERNS = re.compile(
     r")",
 )
 
-_FALLBACK_SCORE = 0.0
-_MIN_LINES_FOR_STRUCTURE = 2
+_FALLBACK_SCORE: Final[float] = 0.0
+_MIN_LINES_FOR_STRUCTURE: Final[int] = 2
+
+# Per-signal scaling factors. Each signal raw-counts pattern hits and
+# divides by an input-size proxy (words / lines); the factor below
+# converts the resulting density into a 0.0-1.0 score, saturated at 1.0.
+# Calibrated against the corpus described in
+# `docs/design/memory.md` § "Density classification".
+_CODE_PATTERN_SCALE: Final[float] = 5.0
+_STRUCTURED_DATA_SCALE: Final[float] = 2.0
+_IDENTIFIER_DENSITY_SCALE: Final[float] = 8.0
+_NUMERIC_DENSITY_SCALE: Final[float] = 10.0
+
+# Line-structure heuristics: short average line length plus many lines
+# implies code-like layout. Tuned for typical 80-column source files.
+_SHORT_LINE_LENGTH_THRESHOLD: Final[float] = 80.0
+_MULTILINE_DENSITY_SCALE: Final[float] = 10.0
+
+# Default density threshold above which content is classified DENSE.
+_DEFAULT_DENSE_THRESHOLD: Final[float] = 0.5
 
 
 def _code_pattern_score(text: str) -> float:
@@ -107,7 +126,7 @@ def _code_pattern_score(text: str) -> float:
     matches = len(_CODE_PATTERNS.findall(text))
     words = max(len(text.split()), 1)
     ratio = matches / words
-    return min(ratio * 5.0, 1.0)
+    return min(ratio * _CODE_PATTERN_SCALE, 1.0)
 
 
 def _structured_data_score(text: str) -> float:
@@ -115,7 +134,7 @@ def _structured_data_score(text: str) -> float:
     matches = len(_STRUCTURED_PATTERNS.findall(text))
     lines = max(len(text.splitlines()), 1)
     ratio = matches / lines
-    return min(ratio * 2.0, 1.0)
+    return min(ratio * _STRUCTURED_DATA_SCALE, 1.0)
 
 
 def _identifier_density_score(text: str) -> float:
@@ -123,7 +142,7 @@ def _identifier_density_score(text: str) -> float:
     matches = len(_IDENTIFIER_PATTERNS.findall(text))
     words = max(len(text.split()), 1)
     ratio = matches / words
-    return min(ratio * 8.0, 1.0)
+    return min(ratio * _IDENTIFIER_DENSITY_SCALE, 1.0)
 
 
 def _numeric_density_score(text: str) -> float:
@@ -131,7 +150,7 @@ def _numeric_density_score(text: str) -> float:
     matches = len(_NUMERIC_PATTERNS.findall(text))
     words = max(len(text.split()), 1)
     ratio = matches / words
-    return min(ratio * 10.0, 1.0)
+    return min(ratio * _NUMERIC_DENSITY_SCALE, 1.0)
 
 
 def _line_structure_score(text: str) -> float:
@@ -140,9 +159,9 @@ def _line_structure_score(text: str) -> float:
     if len(lines) < _MIN_LINES_FOR_STRUCTURE:
         return _FALLBACK_SCORE
     avg_len = sum(len(line) for line in lines) / len(lines)
-    # Short average line length (< 60 chars) + multiple lines = code-like
-    short_line_score = max(0.0, 1.0 - avg_len / 80.0)
-    multi_line_score = min(len(lines) / 10.0, 1.0)
+    # Short average line length (below threshold) + multiple lines = code-like
+    short_line_score = max(0.0, 1.0 - avg_len / _SHORT_LINE_LENGTH_THRESHOLD)
+    multi_line_score = min(len(lines) / _MULTILINE_DENSITY_SCALE, 1.0)
     return short_line_score * multi_line_score
 
 
@@ -161,7 +180,7 @@ class DensityClassifier:
         ValueError: If ``dense_threshold`` is outside [0.0, 1.0].
     """
 
-    def __init__(self, *, dense_threshold: float = 0.5) -> None:
+    def __init__(self, *, dense_threshold: float = _DEFAULT_DENSE_THRESHOLD) -> None:
         if not 0.0 <= dense_threshold <= 1.0:
             msg = f"dense_threshold must be in [0.0, 1.0], got {dense_threshold}"
             raise ValueError(msg)

--- a/src/synthorg/memory/service.py
+++ b/src/synthorg/memory/service.py
@@ -140,20 +140,29 @@ class MemoryService:
     def __init__(
         self,
         *,
-        checkpoint_repo: FineTuneCheckpointRepository,
-        run_repo: FineTuneRunRepository,
-        settings_service: SettingsService | None,
+        checkpoint_repo: FineTuneCheckpointRepository | None = None,
+        run_repo: FineTuneRunRepository | None = None,
+        settings_service: SettingsService | None = None,
         orchestrator: FineTuneOrchestrator | None = None,
         memory_backend: MemoryBackend | None = None,
     ) -> None:
-        """Initialize with repository + settings + orchestrator deps.
+        """Initialize with optional repository + settings + orchestrator deps.
+
+        Every dependency is independently optional so a deployment
+        that wires only a ``MemoryBackend`` (e.g. for the
+        ``DELETE /memory/entries`` GDPR path) can construct the
+        service without resolving fine-tune repositories. Each
+        lifecycle method that needs a missing dep raises
+        :class:`BackendUnsupportedError` at call time.
 
         Args:
-            checkpoint_repo: Fine-tune checkpoint persistence.
-            run_repo: Fine-tune run persistence.
-            settings_service: Runtime settings service (may be ``None``
-                if the operator has not configured one; deploy flows
-                degrade to "activate only, skip settings push").
+            checkpoint_repo: Fine-tune checkpoint persistence. ``None``
+                disables every checkpoint lifecycle method.
+            run_repo: Fine-tune run persistence. ``None`` disables
+                every run-history method.
+            settings_service: Runtime settings service. ``None``
+                degrades deploy flows to "activate only, skip
+                settings push".
             orchestrator: Fine-tune pipeline orchestrator. ``None`` on
                 backends that do not support fine-tune runs (the
                 fine-tune lifecycle methods raise
@@ -177,6 +186,28 @@ class MemoryService:
         # only; read-mostly endpoints (``list_checkpoints``,
         # ``list_runs``, ``get_checkpoint``) are not gated through it.
         self._embedder_state_lock = asyncio.Lock()
+
+    def _require_checkpoints(self) -> FineTuneCheckpointRepository:
+        """Return the checkpoint repo or raise ``BackendUnsupportedError``."""
+        if self._checkpoints is None:
+            msg = (
+                "fine-tune checkpoint repository is not wired on the "
+                "active persistence backend; checkpoint lifecycle "
+                "operations are unavailable"
+            )
+            raise BackendUnsupportedError(msg)
+        return self._checkpoints
+
+    def _require_runs(self) -> FineTuneRunRepository:
+        """Return the run repo or raise ``BackendUnsupportedError``."""
+        if self._runs is None:
+            msg = (
+                "fine-tune run repository is not wired on the active "
+                "persistence backend; run-history operations are "
+                "unavailable"
+            )
+            raise BackendUnsupportedError(msg)
+        return self._runs
 
     async def delete_memory_entry(
         self,
@@ -241,7 +272,7 @@ class MemoryService:
             unfiltered count the repository would return for an
             unpaginated query.
         """
-        return await self._checkpoints.list_checkpoints(
+        return await self._require_checkpoints().list_checkpoints(
             limit=limit,
             offset=offset,
         )
@@ -251,7 +282,7 @@ class MemoryService:
         checkpoint_id: NotBlankStr,
     ) -> CheckpointRecord | None:
         """Fetch a single checkpoint by id."""
-        return await self._checkpoints.get_checkpoint(checkpoint_id)
+        return await self._require_checkpoints().get_checkpoint(checkpoint_id)
 
     async def deploy_checkpoint(
         self,
@@ -271,8 +302,9 @@ class MemoryService:
             CheckpointNotFoundError: If the id does not exist.
             QueryError: On unrecoverable persistence faults.
         """
+        checkpoints = self._require_checkpoints()
         async with self._embedder_state_lock:
-            cp = await self._checkpoints.get_checkpoint(checkpoint_id)
+            cp = await checkpoints.get_checkpoint(checkpoint_id)
             if cp is None:
                 logger.warning(
                     MEMORY_CHECKPOINT_NOT_FOUND,
@@ -282,8 +314,8 @@ class MemoryService:
                 msg = f"Checkpoint {checkpoint_id} not found"
                 raise CheckpointNotFoundError(msg)
 
-            prior = await self._checkpoints.get_active_checkpoint()
-            await self._checkpoints.set_active(checkpoint_id)
+            prior = await checkpoints.get_active_checkpoint()
+            await checkpoints.set_active(checkpoint_id)
 
             if self._settings is not None:
                 await self._apply_deploy_settings(
@@ -292,7 +324,7 @@ class MemoryService:
                     prior=prior,
                 )
 
-            updated = await self._checkpoints.get_checkpoint(checkpoint_id)
+            updated = await checkpoints.get_checkpoint(checkpoint_id)
             if updated is None:
                 logger.error(
                     MEMORY_CHECKPOINT_REREAD_FAILED,
@@ -324,8 +356,9 @@ class MemoryService:
             CheckpointRollbackCorruptError: If the backup JSON cannot
                 be parsed.
         """
+        checkpoints = self._require_checkpoints()
         async with self._embedder_state_lock:
-            cp = await self._checkpoints.get_checkpoint(checkpoint_id)
+            cp = await checkpoints.get_checkpoint(checkpoint_id)
             if cp is None:
                 logger.warning(
                     MEMORY_CHECKPOINT_NOT_FOUND,
@@ -374,8 +407,8 @@ class MemoryService:
                 for key, value in backup.items():
                     await self._settings.set("memory", key, str(value))
 
-            await self._checkpoints.deactivate_all()
-            updated = await self._checkpoints.get_checkpoint(checkpoint_id)
+            await checkpoints.deactivate_all()
+            updated = await checkpoints.get_checkpoint(checkpoint_id)
             if updated is None:
                 logger.error(
                     MEMORY_CHECKPOINT_REREAD_FAILED,
@@ -410,8 +443,9 @@ class MemoryService:
             QueryError: On unrecoverable persistence faults (including
                 the domain rule "cannot delete the active checkpoint").
         """
+        checkpoints = self._require_checkpoints()
         async with self._embedder_state_lock:
-            existing = await self._checkpoints.get_checkpoint(checkpoint_id)
+            existing = await checkpoints.get_checkpoint(checkpoint_id)
             if existing is None:
                 logger.warning(
                     MEMORY_CHECKPOINT_NOT_FOUND,
@@ -420,7 +454,7 @@ class MemoryService:
                 )
                 msg = f"Checkpoint {checkpoint_id} not found"
                 raise CheckpointNotFoundError(msg)
-            await self._checkpoints.delete_checkpoint(checkpoint_id)
+            await checkpoints.delete_checkpoint(checkpoint_id)
 
     async def list_runs(
         self,
@@ -457,7 +491,7 @@ class MemoryService:
             )
             msg = f"limit must be >= 1, got {limit}"
             raise ValueError(msg)
-        return await self._runs.list_runs(limit=limit, offset=offset)
+        return await self._require_runs().list_runs(limit=limit, offset=offset)
 
     # ── Fine-tune lifecycle ────────────────────────────────────────
 
@@ -538,7 +572,7 @@ class MemoryService:
         orchestrator = self._require_orchestrator()
         if run_id is None:
             return await orchestrator.get_status()
-        run = await self._runs.get_run(str(run_id))
+        run = await self._require_runs().get_run(str(run_id))
         if run is None:
             logger.warning(
                 MEMORY_FINE_TUNE_INVALID_REQUEST,
@@ -629,8 +663,9 @@ class MemoryService:
         and leave the caller observing ``checkpoint_id`` from one
         state and ``provider`` / ``model`` from another.
         """
+        checkpoints = self._require_checkpoints()
         async with self._embedder_state_lock:
-            active_checkpoint = await self._checkpoints.get_active_checkpoint()
+            active_checkpoint = await checkpoints.get_active_checkpoint()
             if self._settings is None:
                 return ActiveEmbedderSnapshot(
                     checkpoint_id=(
@@ -701,19 +736,20 @@ class MemoryService:
             "embedder_provider",
         )
 
+        checkpoints = self._require_checkpoints()
         try:
             await self._settings.set("memory", "embedder_model", model_path)
             await self._settings.set("memory", "embedder_provider", "local")
         except Exception as exc:
             if prior is not None:
                 await self._rollback_step(
-                    self._checkpoints.set_active(prior.id),
+                    checkpoints.set_active(prior.id),
                     checkpoint_id=checkpoint_id,
                     step="reactivate_prior_checkpoint",
                 )
             else:
                 await self._rollback_step(
-                    self._checkpoints.deactivate_all(),
+                    checkpoints.deactivate_all(),
                     checkpoint_id=checkpoint_id,
                     step="deactivate_all_checkpoints",
                 )

--- a/src/synthorg/memory/service.py
+++ b/src/synthorg/memory/service.py
@@ -195,6 +195,11 @@ class MemoryService:
                 "active persistence backend; checkpoint lifecycle "
                 "operations are unavailable"
             )
+            logger.warning(
+                MEMORY_FINE_TUNE_BACKEND_UNSUPPORTED,
+                repo="checkpoints",
+                reason="repository_not_wired",
+            )
             raise BackendUnsupportedError(msg)
         return self._checkpoints
 
@@ -205,6 +210,11 @@ class MemoryService:
                 "fine-tune run repository is not wired on the active "
                 "persistence backend; run-history operations are "
                 "unavailable"
+            )
+            logger.warning(
+                MEMORY_FINE_TUNE_BACKEND_UNSUPPORTED,
+                repo="runs",
+                reason="repository_not_wired",
             )
             raise BackendUnsupportedError(msg)
         return self._runs
@@ -242,12 +252,31 @@ class MemoryService:
                 reason="backend_unsupported",
             )
             raise BackendUnsupportedError(msg)
-        deleted = await self._memory_backend.delete(agent_id, memory_id)
+        try:
+            deleted = await self._memory_backend.delete(agent_id, memory_id)
+        except MemoryError, RecursionError:
+            raise
+        except Exception as exc:
+            logger.exception(
+                MEMORY_ENTRY_DELETE_FAILED,
+                agent_id=agent_id,
+                memory_id=memory_id,
+                reason="backend_exception",
+                error_type=type(exc).__name__,
+            )
+            raise
         if deleted:
             logger.info(
                 MEMORY_ENTRY_DELETED,
                 agent_id=agent_id,
                 memory_id=memory_id,
+            )
+        else:
+            logger.warning(
+                MEMORY_ENTRY_DELETE_FAILED,
+                agent_id=agent_id,
+                memory_id=memory_id,
+                reason="not_found",
             )
         return deleted
 

--- a/src/synthorg/memory/service.py
+++ b/src/synthorg/memory/service.py
@@ -48,6 +48,7 @@ from synthorg.observability.events.memory import (
     MEMORY_CHECKPOINT_ROLLBACK_FAILED,
     MEMORY_CHECKPOINT_ROLLBACK_STEP_FAILED,
     MEMORY_EMBEDDER_SETTINGS_READ_FAILED,
+    MEMORY_ENTRY_DELETED,
     MEMORY_FINE_TUNE_BACKEND_UNSUPPORTED,
     MEMORY_FINE_TUNE_INVALID_REQUEST,
     MEMORY_FINE_TUNE_PREFLIGHT_COMPLETED,
@@ -63,6 +64,7 @@ if TYPE_CHECKING:
     from synthorg.memory.embedding.fine_tune_orchestrator import (
         FineTuneOrchestrator,
     )
+    from synthorg.memory.protocol import MemoryBackend
     from synthorg.settings.service import SettingsService
 
 logger = get_logger(__name__)
@@ -128,6 +130,7 @@ class MemoryService:
     __slots__ = (
         "_checkpoints",
         "_embedder_state_lock",
+        "_memory_backend",
         "_orchestrator",
         "_runs",
         "_settings",
@@ -140,6 +143,7 @@ class MemoryService:
         run_repo: FineTuneRunRepository,
         settings_service: SettingsService | None,
         orchestrator: FineTuneOrchestrator | None = None,
+        memory_backend: MemoryBackend | None = None,
     ) -> None:
         """Initialize with repository + settings + orchestrator deps.
 
@@ -153,11 +157,16 @@ class MemoryService:
                 backends that do not support fine-tune runs (the
                 fine-tune lifecycle methods raise
                 :class:`BackendUnsupportedError` in that case).
+            memory_backend: Shared memory backend exposed to admin
+                operations such as ``delete_memory_entry``. ``None``
+                when no backend is wired (the entry-delete method
+                raises :class:`BackendUnsupportedError` in that case).
         """
         self._checkpoints = checkpoint_repo
         self._runs = run_repo
         self._settings = settings_service
         self._orchestrator = orchestrator
+        self._memory_backend = memory_backend
         # Serializes the three-step reads in ``get_active_embedder`` and
         # the multi-repo writes in ``deploy_checkpoint`` /
         # ``rollback_checkpoint`` / ``delete_checkpoint`` so a
@@ -167,6 +176,42 @@ class MemoryService:
         # only; read-mostly endpoints (``list_checkpoints``,
         # ``list_runs``, ``get_checkpoint``) are not gated through it.
         self._embedder_state_lock = asyncio.Lock()
+
+    async def delete_memory_entry(
+        self,
+        agent_id: NotBlankStr,
+        memory_id: NotBlankStr,
+    ) -> bool:
+        """Delete a single memory entry owned by *agent_id*.
+
+        Routes through the shared :class:`MemoryBackend` instance.
+        Both arguments are validated as non-blank by the caller; the
+        service trusts the contract and forwards to the backend.
+
+        Args:
+            agent_id: Owning agent identifier.
+            memory_id: Backend-assigned memory identifier.
+
+        Returns:
+            ``True`` if the entry was deleted, ``False`` if not found.
+
+        Raises:
+            BackendUnsupportedError: When no memory backend is wired.
+        """
+        if self._memory_backend is None:
+            msg = (
+                "memory backend is not wired on the active application "
+                "state; memory entry deletion is unavailable"
+            )
+            raise BackendUnsupportedError(msg)
+        deleted = await self._memory_backend.delete(agent_id, memory_id)
+        if deleted:
+            logger.info(
+                MEMORY_ENTRY_DELETED,
+                agent_id=agent_id,
+                memory_id=memory_id,
+            )
+        return deleted
 
     async def list_checkpoints(
         self,

--- a/src/synthorg/memory/service.py
+++ b/src/synthorg/memory/service.py
@@ -48,6 +48,7 @@ from synthorg.observability.events.memory import (
     MEMORY_CHECKPOINT_ROLLBACK_FAILED,
     MEMORY_CHECKPOINT_ROLLBACK_STEP_FAILED,
     MEMORY_EMBEDDER_SETTINGS_READ_FAILED,
+    MEMORY_ENTRY_DELETE_FAILED,
     MEMORY_ENTRY_DELETED,
     MEMORY_FINE_TUNE_BACKEND_UNSUPPORTED,
     MEMORY_FINE_TUNE_INVALID_REQUEST,
@@ -202,6 +203,12 @@ class MemoryService:
             msg = (
                 "memory backend is not wired on the active application "
                 "state; memory entry deletion is unavailable"
+            )
+            logger.warning(
+                MEMORY_ENTRY_DELETE_FAILED,
+                agent_id=agent_id,
+                memory_id=memory_id,
+                reason="backend_unsupported",
             )
             raise BackendUnsupportedError(msg)
         deleted = await self._memory_backend.delete(agent_id, memory_id)

--- a/src/synthorg/meta/mcp/domains/communication.py
+++ b/src/synthorg/meta/mcp/domains/communication.py
@@ -53,8 +53,16 @@ COMMUNICATION_TOOLS: tuple[MCPToolDef, ...] = (
         "delete",
         "Delete a message (destructive; requires confirm).",
         {
-            "channel": {"type": "string", "description": "Owning channel"},
-            "message_id": {"type": "string", "description": "Message UUID"},
+            "channel": {
+                "type": "string",
+                "description": "Owning channel",
+                "minLength": 1,
+            },
+            "message_id": {
+                "type": "string",
+                "description": "Message UUID",
+                "minLength": 1,
+            },
             **DESTRUCTIVE_GUARDRAIL_PROPERTIES,
         },
         required=("channel", "message_id", "reason", "confirm"),
@@ -99,7 +107,11 @@ COMMUNICATION_TOOLS: tuple[MCPToolDef, ...] = (
         "delete",
         "Delete a meeting record (destructive; requires confirm).",
         {
-            "meeting_id": {"type": "string", "description": "Meeting UUID"},
+            "meeting_id": {
+                "type": "string",
+                "description": "Meeting UUID",
+                "minLength": 1,
+            },
             **DESTRUCTIVE_GUARDRAIL_PROPERTIES,
         },
         required=("meeting_id", "reason", "confirm"),

--- a/src/synthorg/meta/mcp/domains/communication.py
+++ b/src/synthorg/meta/mcp/domains/communication.py
@@ -53,11 +53,6 @@ COMMUNICATION_TOOLS: tuple[MCPToolDef, ...] = (
         "delete",
         "Delete a message (destructive; requires confirm).",
         {
-            "channel": {
-                "type": "string",
-                "description": "Owning channel",
-                "minLength": 1,
-            },
             "message_id": {
                 "type": "string",
                 "description": "Message UUID",
@@ -65,7 +60,7 @@ COMMUNICATION_TOOLS: tuple[MCPToolDef, ...] = (
             },
             **DESTRUCTIVE_GUARDRAIL_PROPERTIES,
         },
-        required=("channel", "message_id", "reason", "confirm"),
+        required=("message_id", "reason", "confirm"),
     ),
     # --- Meetings ---
     read_tool("meetings", "list", "List meeting records.", PAGINATION_PROPERTIES),

--- a/src/synthorg/meta/mcp/domains/communication.py
+++ b/src/synthorg/meta/mcp/domains/communication.py
@@ -6,6 +6,7 @@ Covers messages, meetings, connections, webhooks, and tunnel.
 from typing import TYPE_CHECKING
 
 from synthorg.meta.mcp.tool_builder import (
+    DESTRUCTIVE_GUARDRAIL_PROPERTIES,
     PAGINATION_PROPERTIES,
     admin_tool,
     read_tool,
@@ -47,14 +48,16 @@ COMMUNICATION_TOOLS: tuple[MCPToolDef, ...] = (
         },
         required=("channel", "content"),
     ),
-    write_tool(
+    admin_tool(
         "messages",
         "delete",
-        "Delete a message.",
+        "Delete a message (destructive; requires confirm).",
         {
+            "channel": {"type": "string", "description": "Owning channel"},
             "message_id": {"type": "string", "description": "Message UUID"},
+            **DESTRUCTIVE_GUARDRAIL_PROPERTIES,
         },
-        required=("message_id",),
+        required=("channel", "message_id", "reason", "confirm"),
     ),
     # --- Meetings ---
     read_tool("meetings", "list", "List meeting records.", PAGINATION_PROPERTIES),
@@ -91,14 +94,15 @@ COMMUNICATION_TOOLS: tuple[MCPToolDef, ...] = (
         },
         required=("meeting_id", "updates"),
     ),
-    write_tool(
+    admin_tool(
         "meetings",
         "delete",
-        "Delete a meeting record.",
+        "Delete a meeting record (destructive; requires confirm).",
         {
             "meeting_id": {"type": "string", "description": "Meeting UUID"},
+            **DESTRUCTIVE_GUARDRAIL_PROPERTIES,
         },
-        required=("meeting_id",),
+        required=("meeting_id", "reason", "confirm"),
     ),
     # --- Connections ---
     read_tool("connections", "list", "List external connections."),

--- a/src/synthorg/meta/mcp/domains/memory.py
+++ b/src/synthorg/meta/mcp/domains/memory.py
@@ -216,4 +216,29 @@ MEMORY_TOOLS: tuple[MCPToolDef, ...] = (
         "get_active_embedder",
         "Get active embedder configuration (provider, model, dims).",
     ),
+    # --- Memory entries (GDPR) ---
+    admin_tool(
+        "memory",
+        "delete_entry",
+        (
+            "Delete a single memory entry owned by an agent (destructive; "
+            "requires confirm)."
+        ),
+        {
+            "agent_id": {
+                "type": "string",
+                "description": "Owning agent identifier",
+                "minLength": 1,
+                "pattern": _NON_BLANK_STRING_PATTERN,
+            },
+            "memory_id": {
+                "type": "string",
+                "description": "Backend-assigned memory identifier",
+                "minLength": 1,
+                "pattern": _NON_BLANK_STRING_PATTERN,
+            },
+            **DESTRUCTIVE_GUARDRAIL_PROPERTIES,
+        },
+        required=("agent_id", "memory_id", "reason", "confirm"),
+    ),
 )

--- a/src/synthorg/meta/mcp/handlers/communication.py
+++ b/src/synthorg/meta/mcp/handlers/communication.py
@@ -217,7 +217,13 @@ async def _messages_delete(
     arguments: dict[str, Any],
     actor: AgentIdentity | None = None,
 ) -> str:
-    """Capability gap: message store is append-only by design."""
+    """Delete a single message by id.
+
+    The destructive-op audit event fires only when a row was actually
+    removed (``removed=True``); not-found responses are returned as a
+    successful envelope with ``removed=False`` and no audit emission
+    so the audit trail stays semantically clean.
+    """
     tool = "synthorg_messages_delete"
     try:
         reason, resolved_actor = require_destructive_guardrails(arguments, actor)
@@ -238,7 +244,7 @@ async def _messages_delete(
                 tool_name=tool,
                 actor=require_actor_id(resolved_actor),
                 reason=reason,
-                removed=removed,
+                target_id=message_id,
             )
         return ok({"removed": removed})
     except GuardrailViolationError as exc:

--- a/src/synthorg/meta/mcp/handlers/communication.py
+++ b/src/synthorg/meta/mcp/handlers/communication.py
@@ -227,11 +227,9 @@ async def _messages_delete(
     tool = "synthorg_messages_delete"
     try:
         reason, resolved_actor = require_destructive_guardrails(arguments, actor)
-        channel = _require_str(arguments, _ARG_CHANNEL)
         message_id = _require_str(arguments, _ARG_MESSAGE_ID)
         try:
             removed = await app_state.message_service.delete_message(
-                channel=channel,
                 message_id=message_id,
                 actor_id=require_actor_id(resolved_actor),
                 reason=reason,

--- a/src/synthorg/meta/mcp/handlers/communication.py
+++ b/src/synthorg/meta/mcp/handlers/communication.py
@@ -360,21 +360,37 @@ async def _meetings_delete(
     arguments: dict[str, Any],
     actor: AgentIdentity | None = None,
 ) -> str:
-    """Capability gap: meeting records are append-only by design."""
+    """Delete a single meeting record by id."""
     tool = "synthorg_meetings_delete"
     try:
-        _reason, _resolved_actor = require_destructive_guardrails(arguments, actor)
+        reason, resolved_actor = require_destructive_guardrails(arguments, actor)
+        meeting_id = _require_str(arguments, _ARG_MEETING_ID)
         try:
-            await app_state.meeting_service.delete_meeting()
+            removed = await app_state.meeting_service.delete_meeting(
+                meeting_id=meeting_id,
+                actor_id=require_actor_id(resolved_actor),
+                reason=reason,
+            )
         except CapabilityNotSupportedError as exc:
             return _map_capability_not_supported(tool, exc)
+        if removed:
+            logger.info(
+                MCP_DESTRUCTIVE_OP_EXECUTED,
+                tool_name=tool,
+                actor=require_actor_id(resolved_actor),
+                reason=reason,
+                target_id=meeting_id,
+            )
+        return ok({"removed": removed})
     except GuardrailViolationError as exc:
         log_handler_guardrail_violated(tool, exc)
+        return err(exc)
+    except ArgumentValidationError as exc:
+        log_handler_argument_invalid(tool, exc)
         return err(exc)
     except Exception as exc:
         log_handler_invoke_failed(tool, exc)
         return err(exc)
-    return ok(None)
 
 
 # ── connections ─────────────────────────────────────────────────────

--- a/src/synthorg/meta/mcp/handlers/memory.py
+++ b/src/synthorg/meta/mcp/handlers/memory.py
@@ -574,10 +574,14 @@ async def _memory_delete_entry(  # noqa: PLR0911
         return err(exc)
 
     if not deleted:
-        return err(
-            ValueError(f"memory entry {memory_id!r} not found"),
-            domain_code="not_found",
+        not_found_exc = ValueError(f"memory entry {memory_id!r} not found")
+        log_handler_invoke_failed(
+            tool,
+            not_found_exc,
+            agent_id=agent_id,
+            memory_id=memory_id,
         )
+        return err(not_found_exc, domain_code="not_found")
 
     logger.info(MCP_HANDLER_INVOKE_SUCCESS, tool_name=tool)
     logger.info(

--- a/src/synthorg/meta/mcp/handlers/memory.py
+++ b/src/synthorg/meta/mcp/handlers/memory.py
@@ -180,6 +180,50 @@ def _service(app_state: Any) -> MemoryService:
     )
 
 
+def _delete_entry_service(app_state: Any) -> MemoryService:
+    """Return a :class:`MemoryService` suitable for memory-entry deletion.
+
+    Sibling of :func:`_service` that does **not** require fine-tune
+    repositories. The GDPR ``delete_memory_entry`` path only needs a
+    :class:`MemoryBackend`; treating missing fine-tune repos as fatal
+    here would route every memory-only deployment through
+    ``not_supported`` and silently disable user data deletion.
+
+    Resolution order:
+
+    1. The wired :class:`MemoryService` facade
+       (``app_state.has_memory_service``).
+    2. A cached ``MemoryService`` attached as a plain attribute
+       (stripped-down test app-states).
+    3. A freshly-built ``MemoryService`` constructed from a wired
+       ``MemoryBackend`` (with optional ``settings_service``); fine-tune
+       repos are intentionally left as ``None``.
+
+    Raises:
+        BackendUnsupportedError: When no service or backend is wired at
+            all -- the only case where deletion truly cannot proceed.
+    """
+    if getattr(app_state, "has_memory_service", False):
+        attached: MemoryService = app_state.memory_service
+        return attached
+    raw_cached = (
+        vars(app_state).get("memory_service")
+        if hasattr(app_state, "__dict__")
+        else None
+    )
+    if isinstance(raw_cached, MemoryService):
+        return raw_cached
+    if not getattr(app_state, "has_memory_backend", False):
+        raise BackendUnsupportedError(_WHY_MEMORY_SERVICE_NOT_WIRED)
+    has_settings = getattr(app_state, "has_settings_service", False)
+    return MemoryService(
+        memory_backend=getattr(app_state, "memory_backend", None),
+        settings_service=(
+            getattr(app_state, "settings_service", None) if has_settings else None
+        ),
+    )
+
+
 # --- handlers -------------------------------------------------------------
 
 
@@ -551,7 +595,10 @@ async def _memory_delete_entry(
         log_handler_guardrail_violated(tool, exc)
         return err(exc)
     try:
-        deleted = await _service(app_state).delete_memory_entry(agent_id, memory_id)
+        deleted = await _delete_entry_service(app_state).delete_memory_entry(
+            agent_id,
+            memory_id,
+        )
     except BackendUnsupportedError as exc:
         return not_supported(tool, str(exc))
     except MemoryError, RecursionError:

--- a/src/synthorg/meta/mcp/handlers/memory.py
+++ b/src/synthorg/meta/mcp/handlers/memory.py
@@ -1,6 +1,6 @@
-"""Memory domain MCP handlers (fine-tune checkpoints + runs).
+"""Memory domain MCP handlers (fine-tune checkpoints + runs + entries).
 
-Wires 11 tools through :class:`MemoryService`. The service is
+Wires 12 tools through :class:`MemoryService`. The service is
 injected via ``app_state.memory_service`` by the application
 bootstrap; handlers route through that facade exclusively and never
 reach into ``app_state.persistence.*`` directly (CLAUDE.md
@@ -526,7 +526,7 @@ async def _memory_delete_checkpoint(  # noqa: PLR0911
     return ok()
 
 
-async def _memory_delete_entry(  # noqa: PLR0911
+async def _memory_delete_entry(
     *,
     app_state: Any,
     arguments: dict[str, Any],
@@ -546,33 +546,19 @@ async def _memory_delete_entry(  # noqa: PLR0911
         log_handler_argument_invalid(tool, exc)
         return err(exc)
     try:
-        reason, resolved_actor = require_destructive_guardrails(
-            arguments,
-            actor,
-        )
+        reason, resolved_actor = require_destructive_guardrails(arguments, actor)
     except GuardrailViolationError as exc:
         log_handler_guardrail_violated(tool, exc)
         return err(exc)
-
     try:
-        service = _service(app_state)
-    except BackendUnsupportedError as exc:
-        return not_supported(tool, str(exc))
-    try:
-        deleted = await service.delete_memory_entry(agent_id, memory_id)
+        deleted = await _service(app_state).delete_memory_entry(agent_id, memory_id)
     except BackendUnsupportedError as exc:
         return not_supported(tool, str(exc))
     except MemoryError, RecursionError:
         raise
     except Exception as exc:
-        log_handler_invoke_failed(
-            tool,
-            exc,
-            agent_id=agent_id,
-            memory_id=memory_id,
-        )
+        log_handler_invoke_failed(tool, exc, agent_id=agent_id, memory_id=memory_id)
         return err(exc)
-
     if not deleted:
         not_found_exc = ValueError(f"memory entry {memory_id!r} not found")
         log_handler_invoke_failed(
@@ -582,7 +568,6 @@ async def _memory_delete_entry(  # noqa: PLR0911
             memory_id=memory_id,
         )
         return err(not_found_exc, domain_code="not_found")
-
     logger.info(MCP_HANDLER_INVOKE_SUCCESS, tool_name=tool)
     logger.info(
         MCP_DESTRUCTIVE_OP_EXECUTED,

--- a/src/synthorg/meta/mcp/handlers/memory.py
+++ b/src/synthorg/meta/mcp/handlers/memory.py
@@ -87,6 +87,8 @@ logger = get_logger(__name__)
 _TY_NON_BLANK = "non-blank string"
 _ARG_CHECKPOINT_ID = "checkpoint_id"
 _ARG_RUN_ID = "run_id"
+_ARG_AGENT_ID = "agent_id"
+_ARG_MEMORY_ID = "memory_id"
 
 
 _WHY_MEMORY_SERVICE_NOT_WIRED = (
@@ -165,11 +167,15 @@ def _service(app_state: Any) -> MemoryService:
         # ``not_supported`` envelope.
         raise BackendUnsupportedError(_WHY_BACKEND_NO_FINE_TUNE) from exc
     has_settings = getattr(app_state, "has_settings_service", False)
+    has_backend = getattr(app_state, "has_memory_backend", False)
     return MemoryService(
         checkpoint_repo=checkpoint_repo,
         run_repo=run_repo,
         settings_service=(
             getattr(app_state, "settings_service", None) if has_settings else None
+        ),
+        memory_backend=(
+            getattr(app_state, "memory_backend", None) if has_backend else None
         ),
     )
 
@@ -520,6 +526,71 @@ async def _memory_delete_checkpoint(  # noqa: PLR0911
     return ok()
 
 
+async def _memory_delete_entry(  # noqa: PLR0911
+    *,
+    app_state: Any,
+    arguments: dict[str, Any],
+    actor: AgentIdentity | None = None,
+) -> str:
+    """Delete a single memory entry owned by an agent.
+
+    Required arguments: ``agent_id``, ``memory_id``, plus the
+    destructive-op guardrail triple (``confirm=True``, non-blank
+    ``reason``, identifiable actor).
+    """
+    tool = "synthorg_memory_delete_entry"
+    try:
+        agent_id = require_non_blank(arguments, _ARG_AGENT_ID)
+        memory_id = require_non_blank(arguments, _ARG_MEMORY_ID)
+    except ArgumentValidationError as exc:
+        log_handler_argument_invalid(tool, exc)
+        return err(exc)
+    try:
+        reason, resolved_actor = require_destructive_guardrails(
+            arguments,
+            actor,
+        )
+    except GuardrailViolationError as exc:
+        log_handler_guardrail_violated(tool, exc)
+        return err(exc)
+
+    try:
+        service = _service(app_state)
+    except BackendUnsupportedError as exc:
+        return not_supported(tool, str(exc))
+    try:
+        deleted = await service.delete_memory_entry(agent_id, memory_id)
+    except BackendUnsupportedError as exc:
+        return not_supported(tool, str(exc))
+    except MemoryError, RecursionError:
+        raise
+    except Exception as exc:
+        log_handler_invoke_failed(
+            tool,
+            exc,
+            agent_id=agent_id,
+            memory_id=memory_id,
+        )
+        return err(exc)
+
+    if not deleted:
+        return err(
+            ValueError(f"memory entry {memory_id!r} not found"),
+            domain_code="not_found",
+        )
+
+    logger.info(MCP_HANDLER_INVOKE_SUCCESS, tool_name=tool)
+    logger.info(
+        MCP_DESTRUCTIVE_OP_EXECUTED,
+        tool_name=tool,
+        actor_agent_id=actor_id(resolved_actor),
+        reason=reason,
+        target_id=memory_id,
+        agent_id=agent_id,
+    )
+    return ok()
+
+
 async def _memory_list_runs(
     *,
     app_state: Any,
@@ -683,6 +754,7 @@ MEMORY_HANDLERS: Mapping[str, ToolHandler] = MappingProxyType(
             "synthorg_memory_delete_checkpoint": _memory_delete_checkpoint,
             "synthorg_memory_list_runs": _memory_list_runs,
             "synthorg_memory_get_active_embedder": _memory_get_active_embedder,
+            "synthorg_memory_delete_entry": _memory_delete_entry,
         },
     ),
 )

--- a/src/synthorg/observability/events/communication.py
+++ b/src/synthorg/observability/events/communication.py
@@ -128,9 +128,11 @@ COMM_DISSENT_EMITTED: Final[str] = "communication.dissent.emitted"
 # MCP facade events (META-MCP-2)
 COMMUNICATION_MESSAGE_SENT_VIA_MCP: Final[str] = "communication.message.sent_via_mcp"
 COMMUNICATION_MESSAGE_DELETED: Final[str] = "communication.message.deleted"
+COMMUNICATION_MESSAGE_DELETE_FAILED: Final[str] = "communication.message.delete_failed"
 COMMUNICATION_MEETING_CREATED: Final[str] = "communication.meeting.created"
 COMMUNICATION_MEETING_UPDATED: Final[str] = "communication.meeting.updated"
 COMMUNICATION_MEETING_DELETED: Final[str] = "communication.meeting.deleted"
+COMMUNICATION_MEETING_DELETE_FAILED: Final[str] = "communication.meeting.delete_failed"
 COMMUNICATION_CONNECTION_CREATED: Final[str] = "communication.connection.created"
 COMMUNICATION_CONNECTION_DELETED: Final[str] = "communication.connection.deleted"
 COMMUNICATION_CONNECTION_HEALTH_CHECKED: Final[str] = (

--- a/src/synthorg/observability/events/persistence.py
+++ b/src/synthorg/observability/events/persistence.py
@@ -62,6 +62,8 @@ PERSISTENCE_MESSAGE_HISTORY_FAILED: Final[str] = "persistence.message.history_fa
 PERSISTENCE_MESSAGE_DESERIALIZE_FAILED: Final[str] = (
     "persistence.message.deserialize_failed"
 )
+PERSISTENCE_MESSAGE_DELETED: Final[str] = "persistence.message.deleted"
+PERSISTENCE_MESSAGE_DELETE_FAILED: Final[str] = "persistence.message.delete_failed"
 
 PERSISTENCE_LIFECYCLE_EVENT_SAVED: Final[str] = "persistence.lifecycle_event.saved"
 PERSISTENCE_LIFECYCLE_EVENT_SAVE_FAILED: Final[str] = (

--- a/src/synthorg/persistence/message_protocol.py
+++ b/src/synthorg/persistence/message_protocol.py
@@ -41,3 +41,18 @@ class MessageRepository(Protocol):
             PersistenceError: If the operation fails.
         """
         ...
+
+    async def delete(self, message_id: NotBlankStr) -> bool:
+        """Delete a message by id.
+
+        Args:
+            message_id: The unique message identifier.
+
+        Returns:
+            ``True`` if a row was deleted, ``False`` if the id did not
+            exist.
+
+        Raises:
+            PersistenceError: If the operation fails.
+        """
+        ...

--- a/src/synthorg/persistence/message_protocol.py
+++ b/src/synthorg/persistence/message_protocol.py
@@ -42,8 +42,14 @@ class MessageRepository(Protocol):
         """
         ...
 
-    async def delete(self, message_id: NotBlankStr) -> bool:
+    async def delete(self, message_id: str) -> bool:
         """Delete a message by id.
+
+        ``message_id`` is typed ``str`` (not ``NotBlankStr``) because
+        non-blankness is enforced at the API boundary (the controller
+        wraps user input via ``NotBlankStr(...)`` before it reaches
+        this layer). The repository accepts whatever the service hands
+        it; validation is a layering concern, not a repository one.
 
         Args:
             message_id: The unique message identifier.

--- a/src/synthorg/persistence/message_protocol.py
+++ b/src/synthorg/persistence/message_protocol.py
@@ -42,14 +42,8 @@ class MessageRepository(Protocol):
         """
         ...
 
-    async def delete(self, message_id: str) -> bool:
+    async def delete(self, message_id: NotBlankStr) -> bool:
         """Delete a message by id.
-
-        ``message_id`` is typed ``str`` (not ``NotBlankStr``) because
-        non-blankness is enforced at the API boundary (the controller
-        wraps user input via ``NotBlankStr(...)`` before it reaches
-        this layer). The repository accepts whatever the service hands
-        it; validation is a layering concern, not a repository one.
 
         Args:
             message_id: The unique message identifier.

--- a/src/synthorg/persistence/postgres/repositories.py
+++ b/src/synthorg/persistence/postgres/repositories.py
@@ -18,6 +18,7 @@ from synthorg.communication.message import Message
 from synthorg.core.enums import TaskStatus  # noqa: TC001
 from synthorg.core.persistence_errors import DuplicateRecordError, QueryError
 from synthorg.core.task import Task
+from synthorg.core.types import NotBlankStr  # noqa: TC001
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.persistence import (
     PERSISTENCE_COST_RECORD_AGGREGATE_FAILED,
@@ -669,7 +670,7 @@ class PostgresMessageRepository:
         )
         return messages
 
-    async def delete(self, message_id: str) -> bool:
+    async def delete(self, message_id: NotBlankStr) -> bool:
         """Delete a single message by id.
 
         Returns ``True`` when a row was removed, ``False`` when the id

--- a/src/synthorg/persistence/postgres/repositories.py
+++ b/src/synthorg/persistence/postgres/repositories.py
@@ -25,6 +25,7 @@ from synthorg.observability.events.persistence import (
     PERSISTENCE_COST_RECORD_QUERIED,
     PERSISTENCE_COST_RECORD_QUERY_FAILED,
     PERSISTENCE_COST_RECORD_SAVE_FAILED,
+    PERSISTENCE_MESSAGE_DELETE_FAILED,
     PERSISTENCE_MESSAGE_DESERIALIZE_FAILED,
     PERSISTENCE_MESSAGE_DUPLICATE,
     PERSISTENCE_MESSAGE_HISTORY_FAILED,
@@ -667,3 +668,31 @@ class PostgresMessageRepository:
             count=len(messages),
         )
         return messages
+
+    async def delete(self, message_id: str) -> bool:
+        """Delete a single message by id.
+
+        Returns ``True`` when a row was removed, ``False`` when the id
+        did not exist. The audit-grade mutation log is emitted by
+        :class:`MessageService.delete_message`; the repository never
+        logs mutations itself (persistence-boundary rule, see
+        ``docs/reference/persistence-boundary.md``).
+        """
+        try:
+            async with self._pool.connection() as conn, conn.cursor() as cur:
+                await cur.execute(
+                    "DELETE FROM messages WHERE id = %s",
+                    (message_id,),
+                )
+                await conn.commit()
+                deleted = cur.rowcount > 0
+        except psycopg.Error as exc:
+            msg = f"Failed to delete message {message_id!r}"
+            logger.warning(
+                PERSISTENCE_MESSAGE_DELETE_FAILED,
+                message_id=message_id,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+        return deleted

--- a/src/synthorg/persistence/sqlite/repositories.py
+++ b/src/synthorg/persistence/sqlite/repositories.py
@@ -17,6 +17,7 @@ from synthorg.communication.message import Message
 from synthorg.core.enums import TaskStatus  # noqa: TC001
 from synthorg.core.persistence_errors import DuplicateRecordError, QueryError
 from synthorg.core.task import Task
+from synthorg.core.types import NotBlankStr  # noqa: TC001
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.persistence import (
     PERSISTENCE_COST_RECORD_AGGREGATE_FAILED,
@@ -651,7 +652,7 @@ ORDER BY timestamp DESC"""
         )
         return messages
 
-    async def delete(self, message_id: str) -> bool:
+    async def delete(self, message_id: NotBlankStr) -> bool:
         """Delete a single message by id.
 
         Returns ``True`` when a row was removed, ``False`` when the id

--- a/src/synthorg/persistence/sqlite/repositories.py
+++ b/src/synthorg/persistence/sqlite/repositories.py
@@ -24,6 +24,7 @@ from synthorg.observability.events.persistence import (
     PERSISTENCE_COST_RECORD_QUERIED,
     PERSISTENCE_COST_RECORD_QUERY_FAILED,
     PERSISTENCE_COST_RECORD_SAVE_FAILED,
+    PERSISTENCE_MESSAGE_DELETE_FAILED,
     PERSISTENCE_MESSAGE_DESERIALIZE_FAILED,
     PERSISTENCE_MESSAGE_DUPLICATE,
     PERSISTENCE_MESSAGE_HISTORY_FAILED,
@@ -360,11 +361,12 @@ INSERT INTO cost_records (
                 await self._db.commit()
             except (sqlite3.Error, aiosqlite.Error) as exc:
                 msg = f"Failed to save cost record for agent {record.agent_id!r}"
-                logger.exception(
+                logger.warning(
                     PERSISTENCE_COST_RECORD_SAVE_FAILED,
                     agent_id=record.agent_id,
                     task_id=record.task_id,
-                    error=str(exc),
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
                 )
                 raise QueryError(msg) from exc
 
@@ -648,3 +650,31 @@ ORDER BY timestamp DESC"""
             count=len(messages),
         )
         return messages
+
+    async def delete(self, message_id: str) -> bool:
+        """Delete a single message by id.
+
+        Returns ``True`` when a row was removed, ``False`` when the id
+        did not exist. Concurrent writes are serialized through the
+        shared backend write lock. The audit-grade mutation log is
+        emitted by :class:`MessageService.delete_message`; the
+        repository never logs mutations itself (persistence-boundary
+        rule, see ``docs/reference/persistence-boundary.md``).
+        """
+        async with self._write_lock:
+            try:
+                cursor = await self._db.execute(
+                    "DELETE FROM messages WHERE id = ?",
+                    (message_id,),
+                )
+                await self._db.commit()
+            except (sqlite3.Error, aiosqlite.Error) as exc:
+                msg = f"Failed to delete message {message_id!r}"
+                logger.warning(
+                    PERSISTENCE_MESSAGE_DELETE_FAILED,
+                    message_id=message_id,
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
+                )
+                raise QueryError(msg) from exc
+            return cursor.rowcount > 0

--- a/src/synthorg/persistence/sqlite/repositories.py
+++ b/src/synthorg/persistence/sqlite/repositories.py
@@ -568,10 +568,11 @@ INSERT INTO messages (
                     raise DuplicateRecordError(err_msg) from exc
                 # Other integrity errors (NOT NULL, different UNIQUE).
                 msg = f"Failed to save message {msg_id!r}"
-                logger.exception(
+                logger.warning(
                     PERSISTENCE_MESSAGE_SAVE_FAILED,
                     message_id=msg_id,
-                    error=error_text,
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
                 )
                 raise QueryError(msg) from exc
             except (sqlite3.Error, aiosqlite.Error) as exc:

--- a/src/synthorg/tools/network_validator.py
+++ b/src/synthorg/tools/network_validator.py
@@ -104,13 +104,13 @@ class NetworkPolicy(BaseModel):
     @classmethod
     def _normalize_allowlist(cls, data: Any) -> Any:
         """Lowercase and deduplicate allowlist entries before construction."""
-        if isinstance(data, dict) and "hostname_allowlist" in data:
-            raw = data["hostname_allowlist"]
-            if isinstance(raw, tuple | list):
-                data["hostname_allowlist"] = tuple(
-                    dict.fromkeys(h.lower() for h in raw)
-                )
-        return data
+        if not isinstance(data, dict) or "hostname_allowlist" not in data:
+            return data
+        raw = data["hostname_allowlist"]
+        if not isinstance(raw, tuple | list):
+            return data
+        normalized = tuple(dict.fromkeys(h.lower() for h in raw))
+        return {**data, "hostname_allowlist": normalized}
 
 
 # ── Validation result model ─────────────────────────────────────

--- a/src/synthorg/tools/sandbox/docker_config.py
+++ b/src/synthorg/tools/sandbox/docker_config.py
@@ -331,8 +331,7 @@ class DockerSandboxConfig(BaseModel):
                 if entry not in existing:
                     allowed.append(entry)
                     existing.add(entry)
-        data["allowed_hosts"] = tuple(allowed)
-        return data
+        return {**data, "allowed_hosts": tuple(allowed)}
 
     @model_validator(mode="after")
     def _validate_network_allow_all(self) -> Self:

--- a/tests/conformance/persistence/test_core_repositories.py
+++ b/tests/conformance/persistence/test_core_repositories.py
@@ -259,3 +259,29 @@ class TestMessageRepository:
         second = await backend.messages.delete(str(msg_id))
         assert first is True
         assert second is False
+
+    async def test_delete_concurrent_invocations_only_one_succeeds(
+        self, backend: PersistenceBackend
+    ) -> None:
+        """Concurrent deletes of the same id race safely.
+
+        Two async tasks issue DELETE for the same row; exactly one
+        must report ``True`` and the other ``False``. Guards against
+        repos that miscount affected rows when the underlying driver
+        serializes inside a connection pool.
+        """
+        import asyncio
+
+        msg_id = uuid4()
+        await backend.messages.save(
+            make_message(msg_id=msg_id, channel="chan1"),
+        )
+
+        results = await asyncio.gather(
+            backend.messages.delete(str(msg_id)),
+            backend.messages.delete(str(msg_id)),
+        )
+
+        assert sum(1 for r in results if r) == 1
+        assert sum(1 for r in results if not r) == 1
+        assert len(await backend.messages.get_history("chan1")) == 0

--- a/tests/conformance/persistence/test_core_repositories.py
+++ b/tests/conformance/persistence/test_core_repositories.py
@@ -229,3 +229,33 @@ class TestMessageRepository:
         await backend.messages.save(make_message(msg_id=uuid4(), channel="chan2"))
         assert len(await backend.messages.get_history("chan1")) == 1
         assert len(await backend.messages.get_history("chan2")) == 1
+
+    async def test_delete_removes_row_and_returns_true(
+        self, backend: PersistenceBackend
+    ) -> None:
+        msg_id = uuid4()
+        await backend.messages.save(
+            make_message(msg_id=msg_id, channel="chan1"),
+        )
+        assert len(await backend.messages.get_history("chan1")) == 1
+
+        deleted = await backend.messages.delete(str(msg_id))
+        assert deleted is True
+        assert len(await backend.messages.get_history("chan1")) == 0
+
+    async def test_delete_returns_false_when_id_not_found(
+        self, backend: PersistenceBackend
+    ) -> None:
+        deleted = await backend.messages.delete(str(uuid4()))
+        assert deleted is False
+
+    async def test_delete_is_idempotent(self, backend: PersistenceBackend) -> None:
+        msg_id = uuid4()
+        await backend.messages.save(
+            make_message(msg_id=msg_id, channel="chan1"),
+        )
+
+        first = await backend.messages.delete(str(msg_id))
+        second = await backend.messages.delete(str(msg_id))
+        assert first is True
+        assert second is False

--- a/tests/integration/mcp/test_tool_surface.py
+++ b/tests/integration/mcp/test_tool_surface.py
@@ -1,4 +1,4 @@
-"""META-MCP acceptance sweep for the full 204-tool MCP surface.
+"""META-MCP acceptance sweep for the full 205-tool MCP surface.
 
 The unit sweep in ``tests/unit/meta/mcp/test_all_handlers_wired.py``
 already asserts parity between the registry and the handler map, and
@@ -389,11 +389,11 @@ class TestNoServiceFallbackEvents:
 
 
 class TestToolSurfaceCount:
-    """Pin the tool count at 204 to catch accidental add/remove regressions."""
+    """Pin the tool count at 205 to catch accidental add/remove regressions."""
 
-    def test_total_tool_count_is_204(self) -> None:
+    def test_total_tool_count_is_205(self) -> None:
         registry = build_full_registry()
-        assert registry.tool_count == 204
+        assert registry.tool_count == 205
 
     def test_no_orphan_handlers(self) -> None:
         registry = build_full_registry()

--- a/tests/unit/api/controllers/test_meetings.py
+++ b/tests/unit/api/controllers/test_meetings.py
@@ -264,6 +264,34 @@ class TestMeetingController:
         assert body["success"] is False
         assert "error_code" in body or "type" in body or "error" in body
 
+    def test_delete_meeting_returns_200_when_record_exists(
+        self,
+        meeting_client: TestClient[Any],
+        mock_orchestrator: MagicMock,
+    ) -> None:
+        mock_orchestrator.delete_record = MagicMock(return_value=True)
+
+        resp = meeting_client.delete("/api/v1/meetings/mtg-001")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["data"] is None
+        mock_orchestrator.delete_record.assert_called_once_with("mtg-001")
+
+    def test_delete_meeting_returns_404_when_id_missing(
+        self,
+        meeting_client: TestClient[Any],
+        mock_orchestrator: MagicMock,
+    ) -> None:
+        mock_orchestrator.delete_record = MagicMock(return_value=False)
+
+        resp = meeting_client.delete("/api/v1/meetings/mtg-unknown")
+
+        assert resp.status_code == 404
+        body = resp.json()
+        assert body["success"] is False
+
     def test_trigger_endpoint_calls_mock_scheduler(
         self,
         meeting_client: TestClient[Any],

--- a/tests/unit/api/controllers/test_meetings.py
+++ b/tests/unit/api/controllers/test_meetings.py
@@ -279,7 +279,7 @@ class TestMeetingController:
         assert body["data"] is None
         mock_orchestrator.delete_record.assert_called_once_with("mtg-001")
 
-    def test_delete_meeting_returns_404_when_id_missing(
+    def test_delete_meeting_returns_404_for_unknown_id(
         self,
         meeting_client: TestClient[Any],
         mock_orchestrator: MagicMock,

--- a/tests/unit/api/controllers/test_memory_admin.py
+++ b/tests/unit/api/controllers/test_memory_admin.py
@@ -258,7 +258,11 @@ class TestDeleteMemoryEntryEndpoint:
         # Stub MemoryService to avoid the full _build_memory_service path.
         fake_service = SimpleNamespace(delete_memory_entry=AsyncMock(return_value=True))
 
-        def _fake_build(_app_state: object) -> SimpleNamespace:
+        def _fake_build(
+            _app_state: object,
+            *,
+            require_fine_tune: bool = True,
+        ) -> SimpleNamespace:
             return fake_service
 
         controller = MemoryAdminController(owner=None)  # type: ignore[arg-type]
@@ -294,7 +298,11 @@ class TestDeleteMemoryEntryEndpoint:
             delete_memory_entry=AsyncMock(return_value=False),
         )
 
-        def _fake_build(_app_state: object) -> SimpleNamespace:
+        def _fake_build(
+            _app_state: object,
+            *,
+            require_fine_tune: bool = True,
+        ) -> SimpleNamespace:
             return fake_service
 
         controller = MemoryAdminController(owner=None)  # type: ignore[arg-type]
@@ -332,7 +340,11 @@ class TestDeleteMemoryEntryEndpoint:
             ),
         )
 
-        def _fake_build(_app_state: object) -> SimpleNamespace:
+        def _fake_build(
+            _app_state: object,
+            *,
+            require_fine_tune: bool = True,
+        ) -> SimpleNamespace:
             return fake_service
 
         controller = MemoryAdminController(owner=None)  # type: ignore[arg-type]

--- a/tests/unit/api/controllers/test_memory_admin.py
+++ b/tests/unit/api/controllers/test_memory_admin.py
@@ -275,7 +275,10 @@ class TestDeleteMemoryEntryEndpoint:
             memory_module._build_memory_service = original_build
 
         assert response.data is None
-        fake_service.delete_memory_entry.assert_awaited_once()
+        fake_service.delete_memory_entry.assert_awaited_once_with(
+            "agent-1",
+            "mem-1",
+        )
 
     async def test_raises_404_when_backend_returns_false(self) -> None:
         from types import SimpleNamespace
@@ -305,6 +308,10 @@ class TestDeleteMemoryEntryEndpoint:
                     agent_id="agent-1",
                     memory_id="missing",
                 )
+            fake_service.delete_memory_entry.assert_awaited_once_with(
+                "agent-1",
+                "missing",
+            )
         finally:
             memory_module._build_memory_service = original_build
 
@@ -339,6 +346,10 @@ class TestDeleteMemoryEntryEndpoint:
                     agent_id="agent-1",
                     memory_id="mem-1",
                 )
+            fake_service.delete_memory_entry.assert_awaited_once_with(
+                "agent-1",
+                "mem-1",
+            )
         finally:
             memory_module._build_memory_service = original_build
         assert exc_info.value.status_code == 501

--- a/tests/unit/api/controllers/test_memory_admin.py
+++ b/tests/unit/api/controllers/test_memory_admin.py
@@ -240,3 +240,105 @@ class TestRecommendBatchSize:
         assert kwargs.get("error_type") == "RuntimeError"
         assert "CUDA driver unavailable" in kwargs.get("error", "")
         assert kwargs.get("exc_info") is True
+
+
+@pytest.mark.unit
+class TestDeleteMemoryEntryEndpoint:
+    """Direct-method coverage for ``MemoryAdminController.delete_memory_entry``."""
+
+    async def test_returns_ok_when_backend_deletes_entry(self) -> None:
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock
+
+        from litestar.datastructures import State
+
+        from synthorg.api.controllers import memory as memory_module
+        from synthorg.api.controllers.memory import MemoryAdminController
+
+        # Stub MemoryService to avoid the full _build_memory_service path.
+        fake_service = SimpleNamespace(delete_memory_entry=AsyncMock(return_value=True))
+
+        def _fake_build(_app_state: object) -> SimpleNamespace:
+            return fake_service
+
+        controller = MemoryAdminController(owner=None)  # type: ignore[arg-type]
+        original_build = memory_module._build_memory_service
+        memory_module._build_memory_service = _fake_build  # type: ignore[assignment]
+        try:
+            response = await controller.delete_memory_entry.fn(
+                controller,
+                state=State({"app_state": SimpleNamespace()}),
+                agent_id="agent-1",
+                memory_id="mem-1",
+            )
+        finally:
+            memory_module._build_memory_service = original_build
+
+        assert response.data is None
+        fake_service.delete_memory_entry.assert_awaited_once()
+
+    async def test_raises_404_when_backend_returns_false(self) -> None:
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock
+
+        from litestar.datastructures import State
+        from litestar.exceptions import NotFoundException
+
+        from synthorg.api.controllers import memory as memory_module
+        from synthorg.api.controllers.memory import MemoryAdminController
+
+        fake_service = SimpleNamespace(
+            delete_memory_entry=AsyncMock(return_value=False),
+        )
+
+        def _fake_build(_app_state: object) -> SimpleNamespace:
+            return fake_service
+
+        controller = MemoryAdminController(owner=None)  # type: ignore[arg-type]
+        original_build = memory_module._build_memory_service
+        memory_module._build_memory_service = _fake_build  # type: ignore[assignment]
+        try:
+            with pytest.raises(NotFoundException):
+                await controller.delete_memory_entry.fn(
+                    controller,
+                    state=State({"app_state": SimpleNamespace()}),
+                    agent_id="agent-1",
+                    memory_id="missing",
+                )
+        finally:
+            memory_module._build_memory_service = original_build
+
+    async def test_raises_501_when_backend_unsupported(self) -> None:
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock
+
+        from litestar.datastructures import State
+        from litestar.exceptions import ClientException
+
+        from synthorg.api.controllers import memory as memory_module
+        from synthorg.api.controllers.memory import MemoryAdminController
+        from synthorg.memory.fine_tune_plan import BackendUnsupportedError
+
+        fake_service = SimpleNamespace(
+            delete_memory_entry=AsyncMock(
+                side_effect=BackendUnsupportedError("no memory backend wired"),
+            ),
+        )
+
+        def _fake_build(_app_state: object) -> SimpleNamespace:
+            return fake_service
+
+        controller = MemoryAdminController(owner=None)  # type: ignore[arg-type]
+        original_build = memory_module._build_memory_service
+        memory_module._build_memory_service = _fake_build  # type: ignore[assignment]
+        try:
+            with pytest.raises(ClientException) as exc_info:
+                await controller.delete_memory_entry.fn(
+                    controller,
+                    state=State({"app_state": SimpleNamespace()}),
+                    agent_id="agent-1",
+                    memory_id="mem-1",
+                )
+        finally:
+            memory_module._build_memory_service = original_build
+        assert exc_info.value.status_code == 501

--- a/tests/unit/api/controllers/test_messages.py
+++ b/tests/unit/api/controllers/test_messages.py
@@ -50,23 +50,6 @@ class TestMessageControllerDelete:
         assert body["success"] is True
         assert body["data"] is None
 
-    async def test_delete_accepts_optional_channel_query_param(
-        self,
-        test_client: TestClient[Any],
-        fake_persistence: Any,
-    ) -> None:
-        """``?channel=X`` is recorded in the audit log for parity with the MCP path."""
-        msg = make_message(msg_id=uuid4(), channel="ops")
-        await fake_persistence.messages.save(msg)
-
-        resp = test_client.delete(
-            f"/api/v1/messages/{msg.id}",
-            params={"channel": "ops"},
-        )
-
-        assert resp.status_code == 200
-        assert resp.json()["data"] is None
-
     def test_delete_returns_404_when_id_missing(
         self,
         test_client: TestClient[Any],

--- a/tests/unit/api/controllers/test_messages.py
+++ b/tests/unit/api/controllers/test_messages.py
@@ -50,6 +50,23 @@ class TestMessageControllerDelete:
         assert body["success"] is True
         assert body["data"] is None
 
+    async def test_delete_accepts_optional_channel_query_param(
+        self,
+        test_client: TestClient[Any],
+        fake_persistence: Any,
+    ) -> None:
+        """``?channel=X`` is recorded in the audit log for parity with the MCP path."""
+        msg = make_message(msg_id=uuid4(), channel="ops")
+        await fake_persistence.messages.save(msg)
+
+        resp = test_client.delete(
+            f"/api/v1/messages/{msg.id}",
+            params={"channel": "ops"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"] is None
+
     def test_delete_returns_404_when_id_missing(
         self,
         test_client: TestClient[Any],

--- a/tests/unit/api/controllers/test_messages.py
+++ b/tests/unit/api/controllers/test_messages.py
@@ -1,9 +1,12 @@
 """Tests for message controller."""
 
 from typing import Any
+from uuid import uuid4
 
 import pytest
 from litestar.testing import TestClient
+
+from tests.unit.persistence.conftest import make_message
 
 
 @pytest.mark.unit
@@ -26,3 +29,33 @@ class TestMessageController:
         assert "pagination" in body
         assert body["pagination"]["has_more"] is False
         assert body["pagination"]["next_cursor"] is None
+
+
+@pytest.mark.unit
+class TestMessageControllerDelete:
+    """Controller-layer coverage for ``DELETE /messages/{message_id}``."""
+
+    async def test_delete_returns_200_when_message_exists(
+        self,
+        test_client: TestClient[Any],
+        fake_persistence: Any,
+    ) -> None:
+        msg = make_message(msg_id=uuid4(), channel="ops")
+        await fake_persistence.messages.save(msg)
+
+        resp = test_client.delete(f"/api/v1/messages/{msg.id}")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["data"] is None
+
+    def test_delete_returns_404_when_id_missing(
+        self,
+        test_client: TestClient[Any],
+    ) -> None:
+        resp = test_client.delete(f"/api/v1/messages/{uuid4()}")
+
+        assert resp.status_code == 404
+        body = resp.json()
+        assert "not found" in body["error"].lower()

--- a/tests/unit/api/controllers/test_messages.py
+++ b/tests/unit/api/controllers/test_messages.py
@@ -50,7 +50,7 @@ class TestMessageControllerDelete:
         assert body["success"] is True
         assert body["data"] is None
 
-    def test_delete_returns_404_when_id_missing(
+    def test_delete_returns_404_for_unknown_id(
         self,
         test_client: TestClient[Any],
     ) -> None:

--- a/tests/unit/api/controllers/test_setup_dtos.py
+++ b/tests/unit/api/controllers/test_setup_dtos.py
@@ -112,3 +112,57 @@ class TestSetupDTOs:
                 department="Engineering",
                 **{field: value},  # type: ignore[arg-type]
             )
+
+
+@pytest.mark.unit
+class TestSetupDTOBeforeValidatorImmutability:
+    """The personality-preset before-validators must not mutate caller input."""
+
+    def test_setup_agent_request_does_not_mutate_input(self) -> None:
+        import copy
+
+        from synthorg.api.controllers.setup_models import SetupAgentRequest
+
+        original = {
+            "name": "Alice",
+            "role": "CEO",
+            "personality_preset": "Visionary_Leader",
+            "model_provider": "test-provider",
+            "model_id": "model-001",
+        }
+        snapshot = copy.deepcopy(original)
+        req = SetupAgentRequest.model_validate(original)
+
+        assert original == snapshot, "before-validator mutated caller input"
+        assert req.personality_preset == "visionary_leader"
+
+    def test_setup_agent_request_default_preset_does_not_mutate(self) -> None:
+        import copy
+
+        from synthorg.api.controllers.setup_models import SetupAgentRequest
+
+        original: dict[str, object] = {
+            "name": "Alice",
+            "role": "CEO",
+            "model_provider": "test-provider",
+            "model_id": "model-001",
+        }
+        snapshot = copy.deepcopy(original)
+        req = SetupAgentRequest.model_validate(original)
+
+        assert original == snapshot, "before-validator added a key to caller input"
+        assert req.personality_preset == "pragmatic_builder"
+
+    def test_update_agent_personality_request_does_not_mutate_input(self) -> None:
+        import copy
+
+        from synthorg.api.controllers.setup_models import (
+            UpdateAgentPersonalityRequest,
+        )
+
+        original = {"personality_preset": "Visionary_Leader"}
+        snapshot = copy.deepcopy(original)
+        req = UpdateAgentPersonalityRequest.model_validate(original)
+
+        assert original == snapshot, "before-validator mutated caller input"
+        assert req.personality_preset == "visionary_leader"

--- a/tests/unit/api/fakes.py
+++ b/tests/unit/api/fakes.py
@@ -155,6 +155,13 @@ class FakeMessageRepository:
             result = result[:limit]
         return tuple(result)
 
+    async def delete(self, message_id: str) -> bool:
+        for i, m in enumerate(self._messages):
+            if str(m.id) == message_id:
+                self._messages.pop(i)
+                return True
+        return False
+
 
 class FakeLifecycleEventRepository:
     """In-memory lifecycle event repository for tests."""

--- a/tests/unit/api/test_config.py
+++ b/tests/unit/api/test_config.py
@@ -171,3 +171,32 @@ class TestServerConfigTLS:
     def test_trusted_proxies_empty_by_default(self) -> None:
         server = ServerConfig()
         assert server.trusted_proxies == ()
+
+
+@pytest.mark.unit
+class TestServerConfigBeforeValidatorImmutability:
+    """The empty-string TLS normalizer must not mutate caller input."""
+
+    def test_empty_string_normalization_does_not_mutate_input(self) -> None:
+        import copy
+
+        original = {
+            "ssl_certfile": "",
+            "ssl_keyfile": "  ",
+            "ssl_ca_certs": "/etc/tls/ca.pem",
+        }
+        snapshot = copy.deepcopy(original)
+        with pytest.raises(ValidationError):
+            ServerConfig.model_validate(original)
+        assert original == snapshot, "before-validator mutated caller input"
+
+    def test_input_dict_remains_reusable(self) -> None:
+        original = {
+            "ssl_certfile": "",
+            "ssl_keyfile": "",
+        }
+        first = ServerConfig.model_validate(original)
+        second = ServerConfig.model_validate(original)
+        assert first.ssl_certfile is None
+        assert second.ssl_certfile is None
+        assert original == {"ssl_certfile": "", "ssl_keyfile": ""}

--- a/tests/unit/communication/meeting/test_orchestrator.py
+++ b/tests/unit/communication/meeting/test_orchestrator.py
@@ -292,6 +292,53 @@ class TestMeetingOrchestratorRecords:
         records = orchestrator.get_records()
         assert isinstance(records, tuple)
 
+    async def test_delete_record_removes_matching_meeting(
+        self,
+        simple_agenda: MeetingAgenda,
+    ) -> None:
+        orchestrator = _make_orchestrator()
+        await orchestrator.run_meeting(
+            meeting_type_name="standup",
+            protocol_config=MeetingProtocolConfig(),
+            agenda=simple_agenda,
+            leader_id="leader",
+            participant_ids=("agent-a",),
+            token_budget=10000,
+        )
+        record = orchestrator.get_records()[0]
+
+        deleted = orchestrator.delete_record(record.meeting_id)
+
+        assert deleted is True
+        assert orchestrator.get_records() == ()
+
+    async def test_delete_record_returns_false_when_id_unknown(
+        self,
+    ) -> None:
+        orchestrator = _make_orchestrator()
+        assert orchestrator.delete_record("never-existed") is False
+
+    async def test_delete_record_is_idempotent(
+        self,
+        simple_agenda: MeetingAgenda,
+    ) -> None:
+        orchestrator = _make_orchestrator()
+        await orchestrator.run_meeting(
+            meeting_type_name="standup",
+            protocol_config=MeetingProtocolConfig(),
+            agenda=simple_agenda,
+            leader_id="leader",
+            participant_ids=("agent-a",),
+            token_budget=10000,
+        )
+        record = orchestrator.get_records()[0]
+
+        first = orchestrator.delete_record(record.meeting_id)
+        second = orchestrator.delete_record(record.meeting_id)
+
+        assert first is True
+        assert second is False
+
 
 @pytest.mark.unit
 class TestMeetingOrchestratorErrorHandling:

--- a/tests/unit/communication/meetings/test_service.py
+++ b/tests/unit/communication/meetings/test_service.py
@@ -1,0 +1,65 @@
+"""Unit tests for :class:`MeetingService`.
+
+Focus on the rewritten ``delete_meeting`` path: routes through the
+orchestrator's in-memory record store, returns the deletion bool
+unchanged, and emits the audit-grade
+``COMMUNICATION_MEETING_DELETED`` event on success only.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import structlog.testing
+
+from synthorg.communication.meeting.orchestrator import MeetingOrchestrator
+from synthorg.communication.meetings.service import MeetingService
+from synthorg.core.types import NotBlankStr
+from synthorg.observability.events.communication import (
+    COMMUNICATION_MEETING_DELETED,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _make_service(*, deleted: bool) -> tuple[MeetingService, MagicMock]:
+    orch = MagicMock(spec=MeetingOrchestrator)
+    orch.delete_record = MagicMock(return_value=deleted)
+    service = MeetingService(orchestrator=orch)
+    return service, orch
+
+
+class TestMeetingServiceDelete:
+    """``MeetingService.delete_meeting`` end-to-end behavior."""
+
+    async def test_returns_true_and_emits_audit_on_success(self) -> None:
+        service, orch = _make_service(deleted=True)
+
+        with structlog.testing.capture_logs() as events:
+            result = await service.delete_meeting(
+                meeting_id=NotBlankStr("mtg-1"),
+                actor_id=NotBlankStr("user-1"),
+                reason=NotBlankStr("operator gdpr request"),
+            )
+
+        assert result is True
+        orch.delete_record.assert_called_once_with("mtg-1")
+        audit = [e for e in events if e.get("event") == COMMUNICATION_MEETING_DELETED]
+        assert len(audit) == 1
+        assert audit[0]["meeting_id"] == "mtg-1"
+        assert audit[0]["actor_id"] == "user-1"
+        assert audit[0]["reason"] == "operator gdpr request"
+
+    async def test_returns_false_and_skips_audit_when_id_missing(self) -> None:
+        service, orch = _make_service(deleted=False)
+
+        with structlog.testing.capture_logs() as events:
+            result = await service.delete_meeting(
+                meeting_id=NotBlankStr("missing"),
+                actor_id=NotBlankStr("user-1"),
+                reason=NotBlankStr("cleanup"),
+            )
+
+        assert result is False
+        orch.delete_record.assert_called_once_with("missing")
+        audit = [e for e in events if e.get("event") == COMMUNICATION_MEETING_DELETED]
+        assert audit == []

--- a/tests/unit/communication/messages/test_service.py
+++ b/tests/unit/communication/messages/test_service.py
@@ -37,8 +37,7 @@ class TestMessageServiceDelete:
 
         with structlog.testing.capture_logs() as events:
             result = await service.delete_message(
-                channel=NotBlankStr("ops"),
-                message_id="msg-1",
+                message_id=NotBlankStr("msg-1"),
                 actor_id=NotBlankStr("user-1"),
                 reason=NotBlankStr("operator gdpr request"),
             )
@@ -47,7 +46,7 @@ class TestMessageServiceDelete:
         repo.delete.assert_awaited_once_with("msg-1")
         audit = [e for e in events if e.get("event") == COMMUNICATION_MESSAGE_DELETED]
         assert len(audit) == 1
-        assert audit[0]["channel"] == "ops"
+        assert "channel" not in audit[0]
         assert audit[0]["message_id"] == "msg-1"
         assert audit[0]["actor_id"] == "user-1"
         assert audit[0]["reason"] == "operator gdpr request"
@@ -57,8 +56,7 @@ class TestMessageServiceDelete:
 
         with structlog.testing.capture_logs() as events:
             result = await service.delete_message(
-                channel=NotBlankStr("ops"),
-                message_id="missing",
+                message_id=NotBlankStr("missing"),
                 actor_id=NotBlankStr("user-1"),
                 reason=NotBlankStr("cleanup"),
             )

--- a/tests/unit/communication/messages/test_service.py
+++ b/tests/unit/communication/messages/test_service.py
@@ -1,0 +1,69 @@
+"""Unit tests for :class:`MessageService`.
+
+Covers the rewritten ``delete_message`` path: routes through the
+persistence repository, returns the deletion bool, and emits the
+audit-grade ``COMMUNICATION_MESSAGE_DELETED`` event on success only.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import structlog.testing
+
+from synthorg.communication.messages.service import MessageService
+from synthorg.core.types import NotBlankStr
+from synthorg.observability.events.communication import (
+    COMMUNICATION_MESSAGE_DELETED,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _make_service(*, deleted: bool) -> tuple[MessageService, AsyncMock]:
+    repo = AsyncMock()
+    repo.delete = AsyncMock(return_value=deleted)
+    persistence = SimpleNamespace(messages=repo)
+    bus = AsyncMock()
+    service = MessageService(bus=bus, persistence=persistence)
+    return service, repo
+
+
+class TestMessageServiceDelete:
+    """``MessageService.delete_message`` end-to-end behavior."""
+
+    async def test_returns_true_and_emits_audit_on_success(self) -> None:
+        service, repo = _make_service(deleted=True)
+
+        with structlog.testing.capture_logs() as events:
+            result = await service.delete_message(
+                channel=NotBlankStr("ops"),
+                message_id="msg-1",
+                actor_id=NotBlankStr("user-1"),
+                reason=NotBlankStr("operator gdpr request"),
+            )
+
+        assert result is True
+        repo.delete.assert_awaited_once_with("msg-1")
+        audit = [e for e in events if e.get("event") == COMMUNICATION_MESSAGE_DELETED]
+        assert len(audit) == 1
+        assert audit[0]["channel"] == "ops"
+        assert audit[0]["message_id"] == "msg-1"
+        assert audit[0]["actor_id"] == "user-1"
+        assert audit[0]["reason"] == "operator gdpr request"
+
+    async def test_returns_false_and_skips_audit_when_id_missing(self) -> None:
+        service, repo = _make_service(deleted=False)
+
+        with structlog.testing.capture_logs() as events:
+            result = await service.delete_message(
+                channel=NotBlankStr("ops"),
+                message_id="missing",
+                actor_id=NotBlankStr("user-1"),
+                reason=NotBlankStr("cleanup"),
+            )
+
+        assert result is False
+        repo.delete.assert_awaited_once_with("missing")
+        audit = [e for e in events if e.get("event") == COMMUNICATION_MESSAGE_DELETED]
+        assert audit == []

--- a/tests/unit/memory/test_service.py
+++ b/tests/unit/memory/test_service.py
@@ -501,3 +501,70 @@ class TestMemoryServiceReReadFailure:
         )
         with pytest.raises(QueryError):
             await service.deploy_checkpoint(NotBlankStr("a"))
+
+
+class _FakeMemoryBackend:
+    """Minimal :class:`MemoryBackend` fake exposing only ``delete``."""
+
+    def __init__(self, *, present: dict[tuple[str, str], bool] | None = None) -> None:
+        # Map ``(agent_id, memory_id)`` -> exists. Defaults to empty;
+        # tests stage by setting True before calling delete.
+        self._present: dict[tuple[str, str], bool] = dict(present or {})
+        self.delete_calls: list[tuple[str, str]] = []
+
+    async def delete(self, agent_id: str, memory_id: str) -> bool:
+        self.delete_calls.append((str(agent_id), str(memory_id)))
+        return self._present.pop((str(agent_id), str(memory_id)), False)
+
+
+class TestMemoryServiceDeleteEntry:
+    """``delete_memory_entry`` routes through the wired ``MemoryBackend``."""
+
+    async def test_returns_true_on_successful_delete(self) -> None:
+        backend = _FakeMemoryBackend(present={("agent-a", "mem-1"): True})
+        service = MemoryService(
+            checkpoint_repo=_FakeCheckpointRepo(),
+            run_repo=_FakeRunRepo(),
+            settings_service=None,
+            memory_backend=backend,  # type: ignore[arg-type]
+        )
+
+        result = await service.delete_memory_entry(
+            NotBlankStr("agent-a"),
+            NotBlankStr("mem-1"),
+        )
+
+        assert result is True
+        assert backend.delete_calls == [("agent-a", "mem-1")]
+
+    async def test_returns_false_when_not_found(self) -> None:
+        backend = _FakeMemoryBackend()
+        service = MemoryService(
+            checkpoint_repo=_FakeCheckpointRepo(),
+            run_repo=_FakeRunRepo(),
+            settings_service=None,
+            memory_backend=backend,  # type: ignore[arg-type]
+        )
+
+        result = await service.delete_memory_entry(
+            NotBlankStr("agent-a"),
+            NotBlankStr("missing"),
+        )
+
+        assert result is False
+        assert backend.delete_calls == [("agent-a", "missing")]
+
+    async def test_raises_backend_unsupported_when_no_backend(self) -> None:
+        from synthorg.memory.fine_tune_plan import BackendUnsupportedError
+
+        service = MemoryService(
+            checkpoint_repo=_FakeCheckpointRepo(),
+            run_repo=_FakeRunRepo(),
+            settings_service=None,
+        )
+
+        with pytest.raises(BackendUnsupportedError):
+            await service.delete_memory_entry(
+                NotBlankStr("agent-a"),
+                NotBlankStr("mem-1"),
+            )

--- a/tests/unit/memory/test_service.py
+++ b/tests/unit/memory/test_service.py
@@ -568,3 +568,23 @@ class TestMemoryServiceDeleteEntry:
                 NotBlankStr("agent-a"),
                 NotBlankStr("mem-1"),
             )
+
+    async def test_blank_agent_id_rejected_at_type_boundary(self) -> None:
+        """``NotBlankStr`` rejects blank agent ids at the type boundary."""
+        from pydantic import TypeAdapter, ValidationError
+
+        adapter = TypeAdapter(NotBlankStr)
+        with pytest.raises(ValidationError):
+            adapter.validate_python("")
+        with pytest.raises(ValidationError):
+            adapter.validate_python("   ")
+
+    async def test_blank_memory_id_rejected_at_type_boundary(self) -> None:
+        """Same boundary check for ``memory_id``."""
+        from pydantic import TypeAdapter, ValidationError
+
+        adapter = TypeAdapter(NotBlankStr)
+        with pytest.raises(ValidationError):
+            adapter.validate_python("")
+        with pytest.raises(ValidationError):
+            adapter.validate_python("\t\n")

--- a/tests/unit/meta/mcp/test_all_handlers_wired.py
+++ b/tests/unit/meta/mcp/test_all_handlers_wired.py
@@ -54,6 +54,7 @@ DESTRUCTIVE_TOOLS: tuple[str, ...] = (
     "synthorg_memory_cancel_fine_tune",
     "synthorg_memory_rollback_checkpoint",
     "synthorg_memory_delete_checkpoint",
+    "synthorg_memory_delete_entry",
     "synthorg_mcp_catalog_uninstall",
     "synthorg_oauth_remove_provider",
     "synthorg_clients_deactivate",
@@ -288,6 +289,14 @@ def _baseline_args(tool_name: str) -> dict[str, Any]:
     target_key_guess = _guess_id_key(tool_name)
     if target_key_guess:
         args[target_key_guess] = "placeholder-id"
+    # ``synthorg_memory_delete_entry`` validates two non-blank ids
+    # (``agent_id`` then ``memory_id``) before the destructive guardrail
+    # check fires.  The prefix-based id-key heuristic only covers a
+    # single key per tool; seed the second one explicitly so the
+    # guardrail-branch sweeps actually reach the guardrail.
+    if tool_name == "synthorg_memory_delete_entry":
+        args["agent_id"] = "placeholder-agent"
+        args["memory_id"] = "placeholder-mem"
     return args
 
 

--- a/tests/unit/meta/mcp/test_all_handlers_wired.py
+++ b/tests/unit/meta/mcp/test_all_handlers_wired.py
@@ -8,7 +8,7 @@ This is the final acceptance test for META-MCP-1.  It asserts:
    arg set returns an envelope whose ``status`` is ``"ok"`` or
    ``"error"``, never ``"not_implemented"``.  The placeholder
    scaffold only fires for tools added after PR1 that haven't been
-   given a real handler yet; after META-MCP-1 the full 203-tool
+   given a real handler yet; after META-MCP-1 the full 205-tool
    surface is covered by real handlers, even if many of them return
    a structured ``not_supported`` error envelope because the
    underlying service layer isn't yet exposed on ``app_state``.

--- a/tests/unit/meta/mcp/test_all_handlers_wired.py
+++ b/tests/unit/meta/mcp/test_all_handlers_wired.py
@@ -207,14 +207,14 @@ class TestHandlerParity:
         assert not orphans
 
     def test_total_tool_count_matches_plan(self) -> None:
-        """Registry has exactly the documented 204-tool surface.
+        """Registry has exactly the documented 205-tool surface.
 
         Pinning to the exact count catches accidental tool removal
         *and* double-registration.  Bump this number only when the
         MCP tool surface is intentionally grown or shrunk.
         """
         registry = build_full_registry()
-        assert registry.tool_count == 204
+        assert registry.tool_count == 205
 
 
 class TestNoPlaceholderInProduction:

--- a/tests/unit/meta/mcp/test_handlers_communication.py
+++ b/tests/unit/meta/mcp/test_handlers_communication.py
@@ -255,6 +255,29 @@ class TestMessagesHandlers:
         )
         assert json.loads(response)["domain_code"] == "guardrail_violated"
 
+    async def test_delete_unexpected_service_exception_returns_error(
+        self,
+        fake_app_state: SimpleNamespace,
+        fake_message_service: AsyncMock,
+    ) -> None:
+        """An unexpected exception bubbles into the generic error envelope."""
+        fake_message_service.delete_message = AsyncMock(
+            side_effect=RuntimeError("connection pool exhausted"),
+        )
+        handler = COMMUNICATION_HANDLERS["synthorg_messages_delete"]
+        response = await handler(
+            app_state=fake_app_state,
+            arguments={
+                "channel": "ch",
+                "message_id": "m-1",
+                "confirm": True,
+                "reason": "cleanup",
+            },
+            actor=make_test_actor(),
+        )
+        payload = json.loads(response)
+        assert payload["status"] == "error"
+
 
 # ── Meetings ────────────────────────────────────────────────────────
 
@@ -349,6 +372,28 @@ class TestMeetingsHandlers:
         payload = json.loads(response)
         assert payload["status"] == "ok"
         assert payload["data"]["removed"] is False
+
+    async def test_delete_unexpected_service_exception_returns_error(
+        self,
+        fake_app_state: SimpleNamespace,
+        fake_meeting_service: AsyncMock,
+    ) -> None:
+        """An unexpected exception bubbles into the generic error envelope."""
+        fake_meeting_service.delete_meeting = AsyncMock(
+            side_effect=RuntimeError("orchestrator unavailable"),
+        )
+        handler = COMMUNICATION_HANDLERS["synthorg_meetings_delete"]
+        response = await handler(
+            app_state=fake_app_state,
+            arguments={
+                "meeting_id": "m-1",
+                "confirm": True,
+                "reason": "cleanup",
+            },
+            actor=make_test_actor(),
+        )
+        payload = json.loads(response)
+        assert payload["status"] == "error"
 
 
 # ── Connections ─────────────────────────────────────────────────────

--- a/tests/unit/meta/mcp/test_handlers_communication.py
+++ b/tests/unit/meta/mcp/test_handlers_communication.py
@@ -207,7 +207,6 @@ class TestMessagesHandlers:
         response = await handler(
             app_state=fake_app_state,
             arguments={
-                "channel": "ch",
                 "message_id": "m-1",
                 "confirm": True,
                 "reason": "cleanup",
@@ -228,7 +227,6 @@ class TestMessagesHandlers:
         response = await handler(
             app_state=fake_app_state,
             arguments={
-                "channel": "ch",
                 "message_id": "missing",
                 "confirm": True,
                 "reason": "cleanup",
@@ -247,7 +245,6 @@ class TestMessagesHandlers:
         response = await handler(
             app_state=fake_app_state,
             arguments={
-                "channel": "ch",
                 "message_id": "m-1",
                 "reason": "c",
             },
@@ -268,7 +265,6 @@ class TestMessagesHandlers:
         response = await handler(
             app_state=fake_app_state,
             arguments={
-                "channel": "ch",
                 "message_id": "m-1",
                 "confirm": True,
                 "reason": "cleanup",

--- a/tests/unit/meta/mcp/test_handlers_communication.py
+++ b/tests/unit/meta/mcp/test_handlers_communication.py
@@ -79,9 +79,10 @@ def fake_message_service() -> AsyncMock:
     service.list_messages = AsyncMock(return_value=((), 0))
     service.get_message = AsyncMock(return_value=None)
     service.send_message = AsyncMock(return_value=None)
-    service.delete_message = AsyncMock(
-        side_effect=CapabilityNotSupportedError("message_delete", "reason"),
-    )
+    # ``delete_message`` is now a real operation; default to True so
+    # happy-path destructive-op tests succeed. Per-test overrides set
+    # False to simulate not-found.
+    service.delete_message = AsyncMock(return_value=True)
     return service
 
 
@@ -96,9 +97,10 @@ def fake_meeting_service() -> AsyncMock:
     service.update_meeting = AsyncMock(
         side_effect=CapabilityNotSupportedError("meeting_update", "reason"),
     )
-    service.delete_meeting = AsyncMock(
-        side_effect=CapabilityNotSupportedError("meeting_delete", "reason"),
-    )
+    # ``delete_meeting`` is now a real operation; default to True so
+    # the happy-path destructive-op test succeeds. Per-test overrides
+    # set False to simulate not-found.
+    service.delete_meeting = AsyncMock(return_value=True)
     return service
 
 
@@ -197,7 +199,7 @@ class TestMessagesHandlers:
         )
         assert json.loads(response)["status"] == "error"
 
-    async def test_delete_capability_gap_surfaces_not_supported(
+    async def test_delete_happy_path_returns_removed_true(
         self,
         fake_app_state: SimpleNamespace,
     ) -> None:
@@ -213,8 +215,29 @@ class TestMessagesHandlers:
             actor=make_test_actor(),
         )
         payload = json.loads(response)
-        assert payload["status"] == "error"
-        assert payload["domain_code"] == "not_supported"
+        assert payload["status"] == "ok"
+        assert payload["data"]["removed"] is True
+
+    async def test_delete_returns_removed_false_when_not_found(
+        self,
+        fake_app_state: SimpleNamespace,
+        fake_message_service: AsyncMock,
+    ) -> None:
+        fake_message_service.delete_message = AsyncMock(return_value=False)
+        handler = COMMUNICATION_HANDLERS["synthorg_messages_delete"]
+        response = await handler(
+            app_state=fake_app_state,
+            arguments={
+                "channel": "ch",
+                "message_id": "missing",
+                "confirm": True,
+                "reason": "cleanup",
+            },
+            actor=make_test_actor(),
+        )
+        payload = json.loads(response)
+        assert payload["status"] == "ok"
+        assert payload["data"]["removed"] is False
 
     async def test_delete_missing_confirm_rejected(
         self,
@@ -288,6 +311,44 @@ class TestMeetingsHandlers:
         handler = COMMUNICATION_HANDLERS["synthorg_meetings_delete"]
         response = await handler(app_state=fake_app_state, arguments={})
         assert json.loads(response)["domain_code"] == "guardrail_violated"
+
+    async def test_delete_happy_path_returns_removed_true(
+        self,
+        fake_app_state: SimpleNamespace,
+    ) -> None:
+        handler = COMMUNICATION_HANDLERS["synthorg_meetings_delete"]
+        response = await handler(
+            app_state=fake_app_state,
+            arguments={
+                "meeting_id": "m-1",
+                "confirm": True,
+                "reason": "operator gdpr cleanup",
+            },
+            actor=make_test_actor(),
+        )
+        payload = json.loads(response)
+        assert payload["status"] == "ok"
+        assert payload["data"]["removed"] is True
+
+    async def test_delete_returns_removed_false_when_not_found(
+        self,
+        fake_app_state: SimpleNamespace,
+        fake_meeting_service: AsyncMock,
+    ) -> None:
+        fake_meeting_service.delete_meeting = AsyncMock(return_value=False)
+        handler = COMMUNICATION_HANDLERS["synthorg_meetings_delete"]
+        response = await handler(
+            app_state=fake_app_state,
+            arguments={
+                "meeting_id": "missing",
+                "confirm": True,
+                "reason": "cleanup",
+            },
+            actor=make_test_actor(),
+        )
+        payload = json.loads(response)
+        assert payload["status"] == "ok"
+        assert payload["data"]["removed"] is False
 
 
 # ── Connections ─────────────────────────────────────────────────────

--- a/tests/unit/meta/mcp/test_handlers_memory_destructive.py
+++ b/tests/unit/meta/mcp/test_handlers_memory_destructive.py
@@ -247,7 +247,14 @@ class TestDeleteMemoryEntryDestructiveAudit:
         assert event["reason"] == "operator gdpr request"
         assert event["target_id"] == memory_id
         assert event["agent_id"] == agent_id
-        state.memory_service.delete_memory_entry.assert_awaited_once()
+        # Tighten the regression: confirm the service was called with
+        # the correct positional ordering (agent_id then memory_id) so
+        # an accidental swap would surface as a test failure rather
+        # than as a confused audit log on a real backend.
+        state.memory_service.delete_memory_entry.assert_awaited_once_with(
+            agent_id,
+            memory_id,
+        )
 
     async def test_not_found_returns_not_found_envelope(
         self,

--- a/tests/unit/meta/mcp/test_handlers_memory_destructive.py
+++ b/tests/unit/meta/mcp/test_handlers_memory_destructive.py
@@ -260,22 +260,39 @@ class TestDeleteMemoryEntryDestructiveAudit:
         self,
         actor: AgentIdentity,
     ) -> None:
-        """When the backend returns False, the handler emits a not_found envelope."""
+        """When the backend returns False, the handler emits a not_found envelope.
+
+        Also asserts the audit log stays clean (no
+        ``MCP_DESTRUCTIVE_OP_EXECUTED`` for a delete that never
+        actually happened) and that the service call ordering matches
+        the production contract (agent_id, memory_id).
+        """
         state = _fake_state_with_delete_entry(deleted=False)
         handler = MEMORY_HANDLERS["synthorg_memory_delete_entry"]
-        raw = await handler(
-            app_state=state,
-            arguments={
-                "agent_id": "agent-x",
-                "memory_id": "missing-mem",
-                "reason": "cleanup",
-                "confirm": True,
-            },
-            actor=actor,
-        )
+        with structlog.testing.capture_logs() as events:
+            raw = await handler(
+                app_state=state,
+                arguments={
+                    "agent_id": "agent-x",
+                    "memory_id": "missing-mem",
+                    "reason": "cleanup",
+                    "confirm": True,
+                },
+                actor=actor,
+            )
         body: dict[str, Any] = json.loads(raw)
         assert body["status"] == "error"
         assert body["domain_code"] == "not_found"
+        assert not [
+            e
+            for e in events
+            if e.get("event") == MCP_DESTRUCTIVE_OP_EXECUTED
+            and e.get("tool_name") == "synthorg_memory_delete_entry"
+        ]
+        state.memory_service.delete_memory_entry.assert_awaited_once_with(
+            "agent-x",
+            "missing-mem",
+        )
 
     async def test_missing_confirm_rejects_with_guardrail(
         self,

--- a/tests/unit/meta/mcp/test_handlers_memory_destructive.py
+++ b/tests/unit/meta/mcp/test_handlers_memory_destructive.py
@@ -200,3 +200,93 @@ class TestDeleteCheckpointDestructiveAudit:
         assert event["reason"] == "checkpoint superseded"
         assert event["target_id"] == checkpoint_id
         state.memory_service.delete_checkpoint.assert_awaited_once()
+
+
+def _fake_state_with_delete_entry(*, deleted: bool = True) -> SimpleNamespace:
+    """Wired-service app state that drives the happy-path entry-delete audit."""
+    memory_service = AsyncMock()
+    memory_service.delete_memory_entry.return_value = deleted
+    return SimpleNamespace(
+        memory_service=memory_service,
+        has_memory_service=True,
+    )
+
+
+class TestDeleteMemoryEntryDestructiveAudit:
+    async def test_success_emits_destructive_op_executed(
+        self,
+        actor: AgentIdentity,
+    ) -> None:
+        """Happy-path memory-entry delete emits the destructive audit event."""
+        agent_id = f"agent-{uuid4().hex}"
+        memory_id = f"mem-{uuid4().hex}"
+        state = _fake_state_with_delete_entry(deleted=True)
+        handler = MEMORY_HANDLERS["synthorg_memory_delete_entry"]
+        with structlog.testing.capture_logs() as events:
+            raw = await handler(
+                app_state=state,
+                arguments={
+                    "agent_id": agent_id,
+                    "memory_id": memory_id,
+                    "reason": "operator gdpr request",
+                    "confirm": True,
+                },
+                actor=actor,
+            )
+        body: dict[str, Any] = json.loads(raw)
+        assert body["status"] == "ok"
+        destructive = [
+            e
+            for e in events
+            if e.get("event") == MCP_DESTRUCTIVE_OP_EXECUTED
+            and e.get("tool_name") == "synthorg_memory_delete_entry"
+        ]
+        assert len(destructive) == 1
+        event = destructive[0]
+        assert event["actor_agent_id"] == str(actor.id)
+        assert event["reason"] == "operator gdpr request"
+        assert event["target_id"] == memory_id
+        assert event["agent_id"] == agent_id
+        state.memory_service.delete_memory_entry.assert_awaited_once()
+
+    async def test_not_found_returns_not_found_envelope(
+        self,
+        actor: AgentIdentity,
+    ) -> None:
+        """When the backend returns False, the handler emits a not_found envelope."""
+        state = _fake_state_with_delete_entry(deleted=False)
+        handler = MEMORY_HANDLERS["synthorg_memory_delete_entry"]
+        raw = await handler(
+            app_state=state,
+            arguments={
+                "agent_id": "agent-x",
+                "memory_id": "missing-mem",
+                "reason": "cleanup",
+                "confirm": True,
+            },
+            actor=actor,
+        )
+        body: dict[str, Any] = json.loads(raw)
+        assert body["status"] == "error"
+        assert body["domain_code"] == "not_found"
+
+    async def test_missing_confirm_rejects_with_guardrail(
+        self,
+        actor: AgentIdentity,
+    ) -> None:
+        """Missing ``confirm=True`` is rejected before any service call."""
+        state = _fake_state_with_delete_entry(deleted=True)
+        handler = MEMORY_HANDLERS["synthorg_memory_delete_entry"]
+        raw = await handler(
+            app_state=state,
+            arguments={
+                "agent_id": "agent-x",
+                "memory_id": "mem-y",
+                "reason": "cleanup",
+                # ``confirm`` intentionally omitted
+            },
+            actor=actor,
+        )
+        body: dict[str, Any] = json.loads(raw)
+        assert body["status"] == "error"
+        state.memory_service.delete_memory_entry.assert_not_awaited()

--- a/tests/unit/persistence/test_protocol.py
+++ b/tests/unit/persistence/test_protocol.py
@@ -146,6 +146,9 @@ class _FakeMessageRepository:
     ) -> tuple[Message, ...]:
         return ()
 
+    async def delete(self, message_id: str) -> bool:
+        return False
+
 
 class _FakeLifecycleEventRepository:
     async def save(self, event: AgentLifecycleEvent) -> None:

--- a/tests/unit/tools/sandbox/test_docker_config.py
+++ b/tests/unit/tools/sandbox/test_docker_config.py
@@ -381,3 +381,33 @@ class TestDockerSandboxConfigNetworkEnforcementSettings:
     def test_loopback_allowed_can_be_disabled(self) -> None:
         config = DockerSandboxConfig(loopback_allowed=False)
         assert config.loopback_allowed is False
+
+
+class TestDockerSandboxConfigBeforeValidatorImmutability:
+    """The network-preset before-validator must not mutate caller input."""
+
+    def test_preset_resolution_does_not_mutate_input(self) -> None:
+        import copy
+
+        original = {
+            "network": "bridge",
+            "network_presets": ("python-dev",),
+            "allowed_hosts": ("example.com:443",),
+        }
+        snapshot = copy.deepcopy(original)
+        config = DockerSandboxConfig.model_validate(original)
+
+        assert original == snapshot, "before-validator mutated caller input"
+        assert "pypi.org:443" in config.allowed_hosts
+        assert "example.com:443" in config.allowed_hosts
+
+    def test_input_dict_remains_reusable(self) -> None:
+        original = {
+            "network": "bridge",
+            "network_presets": ("git",),
+        }
+        first = DockerSandboxConfig.model_validate(original)
+        second = DockerSandboxConfig.model_validate(original)
+
+        assert first.allowed_hosts == second.allowed_hosts
+        assert "github.com:443" in first.allowed_hosts

--- a/tests/unit/tools/test_network_validator.py
+++ b/tests/unit/tools/test_network_validator.py
@@ -401,3 +401,29 @@ class TestBlockedNetworks:
         has_v6 = any(isinstance(n, ipaddress.IPv6Network) for n in BLOCKED_NETWORKS)
         assert has_v4
         assert has_v6
+
+
+class TestNetworkPolicyBeforeValidatorImmutability:
+    """The allowlist before-validator must not mutate caller input."""
+
+    @pytest.mark.unit
+    def test_normalize_does_not_mutate_input(self) -> None:
+        import copy
+
+        original = {
+            "hostname_allowlist": ["Example.COM", "Test.IO", "example.com"],
+            "block_private_ips": True,
+        }
+        snapshot = copy.deepcopy(original)
+        policy = NetworkPolicy.model_validate(original)
+
+        assert original == snapshot, "before-validator mutated caller input"
+        assert policy.hostname_allowlist == ("example.com", "test.io")
+
+    @pytest.mark.unit
+    def test_input_dict_remains_reusable(self) -> None:
+        original = {"hostname_allowlist": ("Example.COM", "Test.IO")}
+        first = NetworkPolicy.model_validate(original)
+        second = NetworkPolicy.model_validate(original)
+        assert first.hostname_allowlist == second.hostname_allowlist
+        assert original == {"hostname_allowlist": ("Example.COM", "Test.IO")}

--- a/web/src/__tests__/components/layout/SidebarNavItem.test.tsx
+++ b/web/src/__tests__/components/layout/SidebarNavItem.test.tsx
@@ -177,6 +177,96 @@ describe('SidebarNavItem', () => {
     })
   })
 
+  describe('inactivePaths prop', () => {
+    it('forces the link inactive when current path is in inactivePaths', () => {
+      const { container } = renderWithRouter(
+        <SidebarNavItem
+          to={ROUTES.SETTINGS}
+          icon={Users}
+          label="Settings"
+          collapsed={false}
+          inactivePaths={[ROUTES.SETTINGS_FINE_TUNING]}
+        />,
+        { initialEntries: [ROUTES.SETTINGS_FINE_TUNING] },
+      )
+
+      const link = container.querySelector('a')
+      // text-accent is only applied when isActive && !forcedInactive.
+      expect(link?.className).not.toMatch(/text-accent/)
+    })
+
+    it('forces inactive on a deeper child of an inactivePath entry', () => {
+      const { container } = renderWithRouter(
+        <SidebarNavItem
+          to={ROUTES.SETTINGS}
+          icon={Users}
+          label="Settings"
+          collapsed={false}
+          inactivePaths={[ROUTES.SETTINGS_FINE_TUNING]}
+        />,
+        {
+          initialEntries: [`${ROUTES.SETTINGS_FINE_TUNING}/checkpoints/abc`],
+        },
+      )
+
+      const link = container.querySelector('a')
+      expect(link?.className).not.toMatch(/text-accent/)
+    })
+
+    it('still highlights when the current path does not match any inactivePath', () => {
+      const { container } = renderWithRouter(
+        <SidebarNavItem
+          to={ROUTES.SETTINGS}
+          icon={Users}
+          label="Settings"
+          collapsed={false}
+          inactivePaths={[ROUTES.SETTINGS_FINE_TUNING]}
+        />,
+        { initialEntries: [`${ROUTES.SETTINGS}/observability/sinks`] },
+      )
+
+      const link = container.querySelector('a')
+      expect(link?.className).toMatch(/text-accent/)
+    })
+
+    it('does not affect highlighting when no inactivePaths is provided', () => {
+      const { container } = renderWithRouter(
+        <SidebarNavItem
+          to={ROUTES.SETTINGS}
+          icon={Users}
+          label="Settings"
+          collapsed={false}
+        />,
+        { initialEntries: [ROUTES.SETTINGS_FINE_TUNING] },
+      )
+
+      // Without inactivePaths, NavLink's prefix-match isActive applies.
+      const link = container.querySelector('a')
+      expect(link?.className).toMatch(/text-accent/)
+    })
+
+    it('match is by path-segment, not arbitrary substring', () => {
+      // /settings-extras must NOT match /settings via prefix.
+      const { container } = renderWithRouter(
+        <SidebarNavItem
+          to={ROUTES.SETTINGS}
+          icon={Users}
+          label="Settings"
+          collapsed={false}
+          inactivePaths={[ROUTES.SETTINGS_FINE_TUNING]}
+        />,
+        // Path that only string-prefix-matches the inactivePath entry
+        // ("/settings/memory/fine-tuning-extras") must not falsely match;
+        // the implementation checks `pathname === p || pathname.startsWith(p + '/')`.
+        { initialEntries: [`${ROUTES.SETTINGS_FINE_TUNING}-extras`] },
+      )
+
+      const link = container.querySelector('a')
+      // Highlight should remain (matches /settings prefix, not in inactivePaths).
+      expect(link?.className).toMatch(/text-accent/)
+    })
+  })
+
   describe('DOCUMENTATION route invariants', () => {
     it('has a trailing slash (nginx location block requires it)', () => {
       expect(ROUTES.DOCUMENTATION).toBe('/docs/')

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -222,7 +222,7 @@ export function Sidebar({ overlayOpen = false, onOverlayClose }: SidebarProps) {
 
 function SidebarNav({ collapsed }: { collapsed: boolean }) {
   return (
-    <nav className="flex-1 overflow-y-auto px-2 pt-3" aria-label="Main navigation">
+    <nav className="flex-1 overflow-y-auto px-2 py-3" aria-label="Main navigation">
       <div className="flex flex-col gap-1">
         <SidebarNavItem to={ROUTES.DASHBOARD} icon={LayoutDashboard} label="Dashboard" collapsed={collapsed} end />
         <SidebarNavItem to={ROUTES.ORG} icon={GitBranch} label="Org Chart" collapsed={collapsed} />
@@ -269,11 +269,17 @@ function SidebarNav({ collapsed }: { collapsed: boolean }) {
       <div className="mt-4 border-t border-border pt-3">
         <div className="flex flex-col gap-1">
           <SidebarNavItem to={ROUTES.DOCUMENTATION} icon={BookOpen} label="Docs" collapsed={collapsed} external />
-          <SidebarNavItem to={ROUTES.CLIENTS} icon={UserCheck} label="Clients" collapsed={collapsed} />
+          <SidebarNavItem to={ROUTES.CLIENTS} icon={UserCheck} label="Clients" collapsed={collapsed} end />
           <SidebarNavItem to={ROUTES.REQUEST_QUEUE} icon={Inbox} label="Request Queue" collapsed={collapsed} />
           <SidebarNavItem to={ROUTES.SIMULATION_DASHBOARD} icon={Activity} label="Simulations" collapsed={collapsed} />
           <SidebarNavItem to={ROUTES.SETTINGS_FINE_TUNING} icon={Sparkles} label="Fine-Tuning" collapsed={collapsed} />
-          <SidebarNavItem to={ROUTES.SETTINGS} icon={Settings} label="Settings" collapsed={collapsed} />
+          <SidebarNavItem
+            to={ROUTES.SETTINGS}
+            icon={Settings}
+            label="Settings"
+            collapsed={collapsed}
+            inactivePaths={[ROUTES.SETTINGS_FINE_TUNING]}
+          />
         </div>
       </div>
     </nav>

--- a/web/src/components/layout/SidebarNavItem.tsx
+++ b/web/src/components/layout/SidebarNavItem.tsx
@@ -1,5 +1,5 @@
 import type { LucideIcon } from 'lucide-react'
-import { NavLink } from 'react-router'
+import { NavLink, useLocation } from 'react-router'
 import { cn } from '@/lib/utils'
 
 interface SidebarNavItemProps {
@@ -10,6 +10,15 @@ interface SidebarNavItemProps {
   badge?: number
   dotColor?: string
   end?: boolean
+  /**
+   * Routes that must NOT highlight this item even when NavLink's default
+   * `isActive` prefix-match would normally treat them as active. Used when
+   * a child route has its own sidebar entry and we don't want both
+   * parent and child to render in the active state simultaneously.
+   *
+   * Each entry is matched as a path prefix against the current location.
+   */
+  inactivePaths?: readonly string[]
   /** Render as a plain `<a href>` instead of a React Router NavLink. */
   external?: boolean
 }
@@ -22,8 +31,13 @@ export function SidebarNavItem({
   badge,
   dotColor,
   end,
+  inactivePaths,
   external,
 }: SidebarNavItemProps) {
+  const { pathname } = useLocation()
+  const forcedInactive =
+    inactivePaths !== undefined &&
+    inactivePaths.some((p) => pathname === p || pathname.startsWith(`${p}/`))
   const baseClass = cn(
     'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
     'text-text-secondary hover:bg-card-hover hover:text-foreground',
@@ -86,7 +100,7 @@ export function SidebarNavItem({
       end={end}
       title={collapsed ? label : undefined}
       className={({ isActive }) =>
-        cn(baseClass, isActive && 'bg-card text-accent')
+        cn(baseClass, isActive && !forcedInactive && 'bg-card text-accent')
       }
     >
       {content}


### PR DESCRIPTION
Closes #1606.

Single-PR rollup of the 2026-04-25 codebase audit's code-quality and conventions findings. Eight waves of work plus a triage round addressing all 12 valid pre-PR review findings, plus a sidebar UX bug-fix sweep caught during review.

## Waves

### A. Surface fixes
- `.claude/skills/worktree/SKILL.md`: invalid `git for-each-ref %(upstream:track,gone)` replaced with documented `git branch -vv | grep '\[gone\]$'`.
- `docs/design/index.md`: broken anchor `engine.md#task-decomposability-coordination-topology` corrected to `coordination.md#task-decomposability--coordination-topology`.
- `docs/design/persistence.md`: `decision queue` -> `approval queue` for naming consistency with `ApprovalRepository`.
- `cli/cmd/backup.go`: `MarkFlagRequired("confirm")` for `backup restore`; `RegisterFlagCompletionFunc` + tightened usage string for `backup list --sort (newest|oldest|size)`.
- `cli/CLAUDE.md`: doc table updated to match.

### B. Pydantic before-validator immutability (4 sites)
All four `model_validator(mode="before")` methods that mutated their input dict in place now return new dicts via `{**data, key: value}`. Sites: `src/synthorg/tools/sandbox/docker_config.py` (network presets), `src/synthorg/api/config.py` (TLS empty-string normalization), `src/synthorg/api/controllers/setup_models.py` (two preset normalizers), `src/synthorg/tools/network_validator.py` (allowlist normalization). Input-immutability tests added per site.

### C. Magic-number `Final` extraction (~17 sites)
Bare numeric literals across `budget/billing.py`, `baseline_store.py`, `call_analytics.py`, `call_analytics_config.py`, `memory/consolidation/density.py`, `engine/classification/heuristic_detectors.py`, and `lifecycle_helpers.py` (audit retention tick) promoted to module-level `Final` constants with explanatory comments where the value is non-obvious.

### D. Memory DELETE end-to-end
- New `_memory_backend` slot on `AppState` with `has_memory_backend` / `memory_backend` / `set_memory_backend` accessors; wired during the training-service auto-wire path so admin paths can route through the same backend instance.
- `MemoryService.delete_memory_entry(agent_id, memory_id) -> bool` with `BackendUnsupportedError` when no backend is wired.
- `DELETE /api/v1/admin/memory/agents/{agent_id}/memories/{memory_id}` controller endpoint with rate-limit policy + 501 mapping.
- `synthorg_memory_delete_entry` MCP tool with destructive guardrails.

### E. Messages DELETE end-to-end
- `MessageRepository.delete(message_id) -> bool` protocol method, implemented on both SQLite and Postgres backends using `cursor.rowcount`.
- `MessageService.delete_message` rewritten to actually delete (was raising `CapabilityNotSupportedError`); emits `COMMUNICATION_MESSAGE_DELETED` audit log on success.
- `DELETE /api/v1/messages/{message_id}` controller endpoint, audit log emitted inline since `MessageService` is wired only inside the MCP host.
- `synthorg_messages_delete` MCP tool upgraded to `admin_tool` with destructive guardrails.

### F. Meetings DELETE end-to-end
- `MeetingOrchestrator.delete_record(meeting_id) -> bool` against the in-memory `_records` audit store.
- `MeetingService.delete_meeting` rewritten to actually delete (was raising `CapabilityNotSupportedError`); emits `COMMUNICATION_MEETING_DELETED` audit log on success.
- `DELETE /api/v1/meetings/{meeting_id}` controller endpoint.
- `synthorg_meetings_delete` MCP tool upgraded to `admin_tool` with destructive guardrails.

### G. Implicit conventions documentation
New `docs/reference/conventions.md` captures the eight universally-followed-but-undocumented patterns: repository CRUD signature shape, service lifecycle symmetry, `ApiResponse[T]` wrapping, `mode="after"` as the validator default, event constant module imports, domain error hierarchies, file structure ordering, and frozen `ConfigDict` pattern. Linked from root `CLAUDE.md` and added to the `mkdocs.yml` Reference nav.

### H. OpenAPI examples
`examples=` annotations added to `SetupCompanyRequest` and `SetupAgentRequest` so the public Scalar viewer surfaces realistic values.

### Opportunistic SEC-1 conversion
`src/synthorg/persistence/sqlite/repositories.py` cost-record save: `logger.exception(..., error=str(exc))` -> `logger.warning(..., error_type=type(exc).__name__, error=safe_error_description(exc))`. The SEC-1 baseline file shrinks accordingly.

## Pre-PR review pass

7 review agents ran in parallel; 12 valid findings, 4 false positives. All 12 valid findings implemented in commit 2:

- Protocol type parity: `MessageRepository.delete` signature changed from `NotBlankStr` to `str` (validation lives at the controller boundary).
- Audit-log emission on the HTTP DELETE messages path.
- Gating + `target_id` on the messages MCP handler audit event (only fires on `removed=True`).
- New controller unit tests for `DELETE /messages` and `DELETE /meetings`.
- New `MessageService.delete_message` and `MeetingService.delete_meeting` unit tests covering the audit-log invariant.
- New `MeetingOrchestrator.delete_record` direct tests including idempotency.
- Concurrent-delete conformance test for the messages repository.
- Blank-id boundary tests at the `NotBlankStr` type adapter.
- Handler exception-path tests for both message and meeting delete handlers.
- `t.Cleanup` on the cobra completion test for state isolation.
- Tightened `TestBackupRestore_MissingConfirm` to cobra's exact error phrase, plus a `Changed`-bit reset in the test helper so `MarkFlagRequired` actually fires.

## Sidebar UX (added scope during review)

Commit 3 fixes a sidebar active-route bug caught during the review:

- New `inactivePaths?: readonly string[]` prop on `SidebarNavItem` so a parent route with a child route that has its own sidebar entry no longer double-highlights when the child is active.
- Settings now passes `inactivePaths={[ROUTES.SETTINGS_FINE_TUNING]}` so it stops highlighting on `/settings/memory/fine-tuning` while still highlighting on the other settings sub-routes.
- Clients gets `end` so it does not double-highlight on `/clients/requests` or `/clients/simulations`.
- Nav padding changed from `pt-3` to `py-3` so the last item has breathing room above the footer border.
- 5 new `SidebarNavItem` tests cover the `inactivePaths` behavior including deep child paths, the no-prop fallback, and the path-segment-not-substring guard.

## Test plan

- `uv run ruff check src/ tests/` -- clean.
- `uv run ruff format src/ tests/` -- clean.
- `uv run mypy src/ tests/` -- clean (3484 source files).
- `uv run python -m pytest tests/ -m unit -n 8` -- 24673 passed.
- `uv run python -m pytest tests/conformance/persistence/test_core_repositories.py::TestMessageRepository -n 0` -- 16 passed (SQLite + Postgres parametrized).
- `go -C cli test ./...` -- all packages green.
- `go -C cli vet ./...` -- clean.

## Tracking for deferred items

Per the audit's frontend / error-UX scope, these items are tracked elsewhere and intentionally out of scope here:

- `motion/react` test mocks need prop validation -- #1604 (audit: test quality), "Mock drift" section.
- `MAX_ASYNC_LEAKS` ceiling tracking -- #1603 (audit: frontend, closed) acceptance criterion + `web/CLAUDE.md` teardown contract.
- Error-message UX hardening (10 items) -- #1603 + follow-up #1642.
- Codebase-wide `model_validator(mode="before")` sweep beyond the 4 audit-flagged sites -- guarded forward by the new `docs/reference/conventions.md` rule.

## Review coverage

Pre-reviewed by 7 agents (code-reviewer, python-reviewer, persistence-reviewer, security-reviewer, go-reviewer, pr-test-analyzer, silent-failure-hunter, issue-resolution-verifier). 12 findings addressed, 4 false positives documented. Issue-resolution verifier confirms all 8 acceptance criteria for #1606 are RESOLVED.