### PR TITLE
fix(ci): replace unsupported package-lock-json extraFile with json jsonpath entries

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -41,8 +41,14 @@
           "jsonpath": "$.version"
         },
         {
-          "type": "package-lock-json",
-          "path": "web/package-lock.json"
+          "type": "json",
+          "path": "web/package-lock.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "web/package-lock.json",
+          "jsonpath": "$.packages[''].version"
         }
       ]
     }


### PR DESCRIPTION
## Summary

#1672 added `{"type": "package-lock-json", "path": "web/package-lock.json"}` to `.github/release-please-config.json` as part of the conventional-commit-type expansion. `googleapis/release-please-action@17.6.0` does not recognize that extra-file type, so the Release workflow run for the merge of #1672 (run [25094741194](https://github.com/Aureliolo/synthorg/actions/runs/25094741194)) failed with:

```
release-please failed: unsupported extraFile type: package-lock-json
```

The failure prevented the release-please PR (#1670) from being refreshed, leaving #1672 itself out of the changelog and stalling the new section configuration it introduced.

This PR replaces the broken entry with two `json` extra-files using `jsonpath`, one for each version field present in lockfileVersion 3:

- `$.version` (top-level, mirrors `package.json`)
- `$.packages[''].version` (nested entry for the root package; required to keep the lockfile self-consistent on each bump)

Untouched and continuing to bump exactly as today:
- `pyproject.toml` (`generic` updater + `# x-release-please-version` annotation at line 324)
- `src/synthorg/__init__.py` (`generic` updater + `# x-release-please-version` annotation at line 3)
- `web/package.json` (`json` updater on `$.version`)

## Why two entries instead of one

Release Please's bundled `node` release-type knows how to handle `package-lock.json` natively (it updates both version fields), but switching the package's `release-type` from `python` to `node` would change every other thing the Python strategy does. Adding two scoped `json` entries is the minimal fix that keeps the Python release-type and still updates both version fields atomically per bump.

## Follow-ups (out of scope for this PR)

- The same workflow log shows commit `9e5b33d5` (#1569 chore: Update Web dependencies) failing the conventional-commit parser with `unexpected token '(' at 269:17`. That looks like a malformed bracket in the body of #1569 itself; it is independent of the extraFile failure and is best addressed by inspecting the commit body. The current PR does nothing to address it; once this PR's fix lands, the next release-please run will surface it again as a parser warning rather than as a fatal failure.

## Test plan

- `jq .` round-trip on `.github/release-please-config.json`: file remains valid JSON.
- Visual diff: only the `extra-files` array is touched; all other fields, including `release-type: python`, `versioning: always-bump-patch`, `changelog-sections`, `extra-files` for `pyproject.toml`, `src/synthorg/__init__.py`, and `web/package.json`, are untouched.
- After merge, the Release workflow will run on `main` and either (a) succeed and refresh PR #1670 with #1672 included, or (b) surface a different release-please error which we triage separately.

## Review coverage

`/pre-pr-review quick` mode: this is a single-file CI config change with no Python, web, or Go code touched, so the agent roster and the automated `ruff`/`mypy`/`pytest`/`npm`/`go` checks do not apply. The skill's quick path is the appropriate gate for this change.
