### PR TITLE
fix: logging hygiene + production-runtime fixes (#1666)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -65,6 +65,7 @@ coverage.xml
 # CI/build utility scripts (not needed in Docker builds)
 scripts/
 !scripts/export_openapi.py
+!scripts/embed_logfire_token.py
 
 # CLI (Go binary, not needed in Docker builds)
 cli/

--- a/.dockerignore
+++ b/.dockerignore
@@ -62,7 +62,12 @@ coverage.xml
 .idea/
 .vscode/
 
-# CI/build utility scripts (not needed in Docker builds)
+# CI/build utility scripts (not needed in Docker builds).
+# Two files are allowlisted because the Dockerfile invokes them at
+# build time:
+#   * export_openapi.py    -- emits the OpenAPI schema baked into the image.
+#   * embed_logfire_token.py -- rewrites the embedded telemetry token
+#     when LOGFIRE_PROJECT_TOKEN is supplied as a --build-arg (#1666 A-3).
 scripts/
 !scripts/export_openapi.py
 !scripts/embed_logfire_token.py

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -507,8 +507,15 @@ jobs:
           base-image-digest: ${{ needs.build-backend-base-publish.outputs.digest }}
           base-image-artifact-name: ${{ needs.build-backend-base.outputs.artifact-name }}
           base-image-tarball-name: ${{ needs.build-backend-base.outputs.tarball-name }}
+          # ``LOGFIRE_PROJECT_TOKEN`` is the GHA repo secret; the
+          # Dockerfile's ``embed_logfire_token.py`` step writes it
+          # into ``_embedded_token.py`` before ``uv sync`` packages
+          # the venv, so published images carry the token while PR
+          # / non-secret-bearing builds (e.g. forks) keep the
+          # sentinel and run telemetry disabled-by-build.
           extra-build-args: |
             DEPLOYMENT_ENV=${{ needs.version.outputs.deployment_env }}
+            LOGFIRE_PROJECT_TOKEN=${{ secrets.LOGFIRE_PROJECT_TOKEN }}
 
       # Smoke-test the just-built backend image. Runs on EVERY event
       # that builds the image (PR, push to main, v* tag pushes,

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -513,9 +513,12 @@ jobs:
           # the venv, so published images carry the token while PR
           # / non-secret-bearing builds (e.g. forks) keep the
           # sentinel and run telemetry disabled-by-build.
+          # Pull-request events deliberately receive an empty token:
+          # unreviewed PR code paths must not have access to the
+          # write-only project secret.
           extra-build-args: |
             DEPLOYMENT_ENV=${{ needs.version.outputs.deployment_env }}
-            LOGFIRE_PROJECT_TOKEN=${{ secrets.LOGFIRE_PROJECT_TOKEN }}
+            LOGFIRE_PROJECT_TOKEN=${{ github.event_name != 'pull_request' && secrets.LOGFIRE_PROJECT_TOKEN || '' }}
 
       # Smoke-test the just-built backend image. Runs on EVERY event
       # that builds the image (PR, push to main, v* tag pushes,

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -84,7 +84,7 @@ No corresponding flag, settable via env var or `config set`:
 | `SYNTHORG_AUTO_UPDATE_CLI` | Auto-accept CLI self-updates |
 | `SYNTHORG_AUTO_PULL` | Auto-accept container image pulls |
 | `SYNTHORG_AUTO_RESTART` | Auto-restart containers after update |
-| `SYNTHORG_TELEMETRY` | Enable anonymous project telemetry (true/false) |
+| `SYNTHORG_TELEMETRY_ENABLED` | Enable anonymous project telemetry (true/false) |
 | `SYNTHORG_FINE_TUNE_IMAGE` | Fine-tune container image ref read by the backend. Set by the CLI in the generated compose.yml to the variant-specific verified image (`synthorg-fine-tune-gpu` or `synthorg-fine-tune-cpu`), chosen via `synthorg init` and persisted as `fine_tuning_variant` in config.json. Not read by the CLI; manual operator overrides bypass CLI signature/provenance verification and are not supported. |
 | `SYNTHORG_REGISTRY_HOST` | Override default container registry hostname (disables verification when set) |
 | `SYNTHORG_IMAGE_REPO_PREFIX` | Override default image repository prefix (disables verification when set) |

--- a/cli/cmd/envvars.go
+++ b/cli/cmd/envvars.go
@@ -21,7 +21,7 @@ const (
 	EnvAutoUpdateCLI = "SYNTHORG_AUTO_UPDATE_CLI"
 	EnvAutoPull      = "SYNTHORG_AUTO_PULL"
 	EnvAutoRestart   = "SYNTHORG_AUTO_RESTART"
-	EnvTelemetry     = "SYNTHORG_TELEMETRY"
+	EnvTelemetry     = "SYNTHORG_TELEMETRY_ENABLED"
 	EnvQuiet         = "SYNTHORG_QUIET"
 	EnvYes           = "SYNTHORG_YES" // suppresses ALL interactive confirmation prompts
 )

--- a/cli/internal/compose/compose.yml.tmpl
+++ b/cli/internal/compose/compose.yml.tmpl
@@ -118,7 +118,7 @@ services:
 {{- end}}
       SYNTHORG_LOG_DIR: "/data/logs"
       MEM0_TELEMETRY: "false"
-      SYNTHORG_TELEMETRY: "{{if .TelemetryOptIn}}true{{else}}false{{end}}"
+      SYNTHORG_TELEMETRY_ENABLED: "{{if .TelemetryOptIn}}true{{else}}false{{end}}"
       SYNTHORG_LOG_LEVEL: {{yamlStr .LogLevel}}
 {{- if .Sandbox}}
       SYNTHORG_SANDBOX_IMAGE: {{yamlStr (sandboxImageRef .ImageTag)}}

--- a/cli/testdata/compose_custom_ports.yml
+++ b/cli/testdata/compose_custom_ports.yml
@@ -41,7 +41,7 @@ services:
       SYNTHORG_BUS_BACKEND: "internal"
       SYNTHORG_LOG_DIR: "/data/logs"
       MEM0_TELEMETRY: "false"
-      SYNTHORG_TELEMETRY: "false"
+      SYNTHORG_TELEMETRY_ENABLED: "false"
       SYNTHORG_LOG_LEVEL: "debug"
       SYNTHORG_JWT_SECRET: "test-secret-value"
       SYNTHORG_SETTINGS_KEY: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="

--- a/cli/testdata/compose_default.yml
+++ b/cli/testdata/compose_default.yml
@@ -41,7 +41,7 @@ services:
       SYNTHORG_BUS_BACKEND: "internal"
       SYNTHORG_LOG_DIR: "/data/logs"
       MEM0_TELEMETRY: "false"
-      SYNTHORG_TELEMETRY: "false"
+      SYNTHORG_TELEMETRY_ENABLED: "false"
       SYNTHORG_LOG_LEVEL: "info"
     # Image sets USER 65532 (docker/backend/Dockerfile); no compose
     # override needed.

--- a/cli/testdata/compose_digest_pins.yml
+++ b/cli/testdata/compose_digest_pins.yml
@@ -41,7 +41,7 @@ services:
       SYNTHORG_BUS_BACKEND: "internal"
       SYNTHORG_LOG_DIR: "/data/logs"
       MEM0_TELEMETRY: "false"
-      SYNTHORG_TELEMETRY: "false"
+      SYNTHORG_TELEMETRY_ENABLED: "false"
       SYNTHORG_LOG_LEVEL: "info"
     # Image sets USER 65532 (docker/backend/Dockerfile); no compose
     # override needed.

--- a/cli/testdata/compose_sandbox.yml
+++ b/cli/testdata/compose_sandbox.yml
@@ -46,7 +46,7 @@ services:
       SYNTHORG_BUS_BACKEND: "internal"
       SYNTHORG_LOG_DIR: "/data/logs"
       MEM0_TELEMETRY: "false"
-      SYNTHORG_TELEMETRY: "false"
+      SYNTHORG_TELEMETRY_ENABLED: "false"
       SYNTHORG_LOG_LEVEL: "info"
       SYNTHORG_SANDBOX_IMAGE: "ghcr.io/aureliolo/synthorg-sandbox:latest"
       SYNTHORG_SIDECAR_IMAGE: "ghcr.io/aureliolo/synthorg-sidecar:latest"

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -118,12 +118,13 @@ FROM ${BASE_IMAGE}
 # synthorg.telemetry.collector._resolve_environment for the full
 # priority chain.
 #
-# The Logfire write token is intentionally **not** a build-arg -- baking
-# it would persist the secret in image layers and registry history
-# (readable via ``docker history`` / registry APIs). Supply it only at
-# runtime via ``SYNTHORG_LOGFIRE_PROJECT_TOKEN`` in compose env or
-# deployment secrets. An empty token downgrades the reporter to noop
-# cleanly.
+# The write-only telemetry-backend token is embedded into source at
+# build time by the builder stage's ``embed_logfire_token.py`` step
+# (gated on the optional ``LOGFIRE_PROJECT_TOKEN`` build-arg). When
+# the build-arg is unset, the sentinel stays in place and the image
+# is telemetry-disabled-by-build. Operators do NOT supply a runtime
+# env var for the token; the only operator-facing knob is
+# ``SYNTHORG_TELEMETRY_ENABLED`` which gates the opt-in itself.
 ARG DEPLOYMENT_ENV="dev"
 
 LABEL org.opencontainers.image.title="synthorg-backend" \

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -41,7 +41,7 @@ USER build
 # image must carry psycopg and nats-py whether or not the user has
 # chosen them yet. `telemetry` ships the logfire SDK so the opt-in
 # project telemetry signal actually reaches Logfire when operators flip
-# `SYNTHORG_TELEMETRY=true` -- shipping the image without it would make
+# `SYNTHORG_TELEMETRY_ENABLED=true` -- shipping the image without it would make
 # the opt-in a silent noop. `fine-tune` lives in the dedicated
 # synthorg-fine-tune-gpu / -cpu images (large, torch inside).
 RUN --mount=type=cache,target=/home/build/.cache/uv,uid=65532,gid=65532 \
@@ -49,6 +49,24 @@ RUN --mount=type=cache,target=/home/build/.cache/uv,uid=65532,gid=65532 \
 
 RUN touch README.md
 COPY --chown=65532:65532 src/ src/
+COPY --chown=65532:65532 scripts/embed_logfire_token.py scripts/embed_logfire_token.py
+
+# Embed the write-only Logfire project token into source. The
+# secret is supplied at build time via ``--build-arg
+# LOGFIRE_PROJECT_TOKEN=...`` (CI sets it from the GHA repo secret;
+# operators building locally leave it unset). When unset the
+# script is skipped and ``_embedded_token.py`` keeps its sentinel
+# value, so the resulting image has telemetry disabled-by-build.
+# The embed runs *before* ``uv sync`` packages the venv so the
+# rewritten module is what gets cached in the wheel cache and
+# copied into the runtime stage.
+ARG LOGFIRE_PROJECT_TOKEN=""
+RUN if [ -n "$LOGFIRE_PROJECT_TOKEN" ]; then \
+        python scripts/embed_logfire_token.py "$LOGFIRE_PROJECT_TOKEN"; \
+    else \
+        echo "LOGFIRE_PROJECT_TOKEN unset; shipping sentinel (telemetry disabled-by-build)"; \
+    fi
+
 RUN --mount=type=cache,target=/home/build/.cache/uv,uid=65532,gid=65532 \
     uv sync --frozen --no-dev --extra postgres --extra distributed --extra telemetry
 

--- a/docs/design/observability.md
+++ b/docs/design/observability.md
@@ -69,12 +69,12 @@ Eleven default sinks, activated at startup via `bootstrap_logging()`:
 | Sink | Type | Level | Format | Routes | Description |
 |------|------|-------|--------|--------|-------------|
 | Console | stderr | INFO | Colored text | All loggers | Human-readable development output |
-| `synthorg.log` | File | INFO | JSON | All loggers | Main application log (catch-all) |
+| `synthorg.log` | File | INFO | JSON | All loggers EXCEPT `api.request.started` / `api.request.completed` | Main application log (catch-all). Request-lifecycle events from `synthorg.api.middleware` are excluded by an event-name filter so the main log is not buried under per-request noise -- those events live in `access.log` only. |
 | `audit.log` | File | INFO | JSON | `synthorg.security.*`, `synthorg.hr.*`, `synthorg.observability.*` | Audit-relevant events (security, HR, observability) |
 | `errors.log` | File | ERROR | JSON | All loggers | Errors and above only |
 | `agent_activity.log` | File | DEBUG | JSON | `synthorg.engine.*`, `synthorg.core.*`, `synthorg.communication.*`, `synthorg.tools.*`, `synthorg.memory.*` | Agent execution, communication, tools, and memory |
 | `cost_usage.log` | File | INFO | JSON | `synthorg.budget.*`, `synthorg.providers.*` | Cost records and provider calls |
-| `debug.log` | File | DEBUG | JSON | All loggers | Full debug trace (catch-all) |
+| `debug.log` | File | DEBUG only (exact match) | JSON | All loggers | Full DEBUG trace. Pinned to `level == DEBUG` exactly so the file stays empty when nothing emits DEBUG instead of accidentally collecting INFO+ as a duplicate of `synthorg.log`. |
 | `access.log` | File | INFO | JSON | `synthorg.api.*` | HTTP request/response access log |
 | `persistence.log` | File | INFO | JSON | `synthorg.persistence.*` | Database operations, migrations, CRUD |
 | `configuration.log` | File | INFO | JSON | `synthorg.settings.*`, `synthorg.config.*` | Settings resolution, config loading |

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -80,8 +80,7 @@ All environment variables are configured in `docker/.env` (copy from `docker/.en
 | `WEB_PORT` | `3000` | Host port for the web dashboard |
 | `MEM0_TELEMETRY` | `false` | Mem0 telemetry (disable to reduce overhead) |
 | `DOCKER_HOST` | *(unset)* | Docker socket for agent code execution sandbox (optional) |
-| `SYNTHORG_TELEMETRY` | `false` | Enable opt-in anonymous product telemetry. Set to `true` / `1` / `yes` to enable; values like `false` / `0` / `no` keep it off. |
-| `SYNTHORG_LOGFIRE_PROJECT_TOKEN` | *(unset)* | Logfire write token for product telemetry delivery. Empty disables delivery (collector falls back to noop). Only consulted when `SYNTHORG_TELEMETRY=true`. **Runtime-only**: supply via compose env or deployment secrets; it is deliberately **not** a Dockerfile build-arg, to keep the secret out of image layers and registry history. |
+| `SYNTHORG_TELEMETRY_ENABLED` | `false` | Enable opt-in anonymous product telemetry. Set to `true` / `1` / `yes` to enable; values like `false` / `0` / `no` keep it off. The Logfire project token is **embedded in the release wheel** at build time -- operators do not configure it. |
 | `SYNTHORG_TELEMETRY_ENV` | *(unset)* | Explicit deployment-environment tag (`dev` / `pre-release` / `prod` / `ci` / `staging-east` / ...). Always wins the resolution chain if set. |
 | `SYNTHORG_TELEMETRY_ENV_BAKED` | set by image | Image-baked fallback tag for the deployment environment. Release-tag CI builds bake `prod`; every pre-release tag form (`-dev.N`, `-rc.*`, `-alpha.*`, `-beta.*`) bakes `pre-release`; everything else bakes `dev`. Consulted only when `SYNTHORG_TELEMETRY_ENV` is unset *and* no CI markers are present; operators normally override via `SYNTHORG_TELEMETRY_ENV`. |
 

--- a/docs/reference/configuration-precedence.md
+++ b/docs/reference/configuration-precedence.md
@@ -75,7 +75,7 @@ from the env var or YAML at first read.
 | `observability.log_directory` | env (`SYNTHORG_LOG_DIR`) > YAML > unset | **Yes** | Read-only-post-init (DB bypassed on reads).  Path-traversal still rejected at boot. |
 | `communication.nats_url` | env (`SYNTHORG_NATS_URL`) > YAML > default | **Yes** | Read-only-post-init (DB bypassed on reads). |
 | `workers.count` | env (`SYNTHORG_WORKERS`) > YAML > default | **Yes** | Read-only-post-init (DB bypassed on reads). |
-| Telemetry opt-in | env (`SYNTHORG_TELEMETRY`) > YAML (`telemetry.enabled`) > default | **Yes** | **No registry entry.**  Read once in `TelemetryCollector.__init__`; runtime mutation has no effect.  Promotion to a registry entry is tracked as follow-up. |
+| `telemetry.enabled` | env (`SYNTHORG_TELEMETRY_ENABLED`) > YAML (`telemetry.enabled`) > default (`false`) | No | Standard mutable.  Registered in `synthorg.settings.definitions.telemetry`; the `/settings` API can introspect and edit it.  The collector reads the env var at boot for the fast-path; runtime DB mutations take effect on the next process restart. |
 | SQLite path | env (`SYNTHORG_DB_PATH`) > YAML | **Yes** | **No registry entry.**  Init-time exception. |
 | Postgres URL | env (`SYNTHORG_DATABASE_URL`) > YAML | **Yes** | **No registry entry.**  Credentials; init-time exception. |
 | JWT secret | env (`SYNTHORG_JWT_SECRET`) | **Yes** | **No registry entry.**  Bootstrap secret. |

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -56,7 +56,7 @@ fall into three categories:
 
 | Variable | Default | Registry key | Purpose |
 |---|---|---|---|
-| `SYNTHORG_TELEMETRY` | unset | `telemetry/enabled` | Master opt-in for product telemetry.  Accepts `true` / `false` / `1` / `0` / `yes` / `no`. |
+| `SYNTHORG_TELEMETRY_ENABLED` | unset | `telemetry/enabled` | Master opt-in for product telemetry.  Accepts `true` / `false` / `1` / `0` / `yes` / `no`. |
 | `SYNTHORG_TELEMETRY_ENV` | unset | n/a | Operator override for the deployment environment tag (`prod` / `dev` / `pre-release` / custom).  Wins over CI auto-detection and the Dockerfile-baked default. |
 | `SYNTHORG_TELEMETRY_ENV_BAKED` | (image-baked) | n/a | Dockerfile-baked deployment environment.  CI sets this in published images; operators normally don't touch it. |
 

--- a/docs/reference/telemetry.md
+++ b/docs/reference/telemetry.md
@@ -4,8 +4,19 @@ On-demand reference for product telemetry. The short rule in `CLAUDE.md` is: tel
 
 ## Enabling
 
-- Off by default. Enable with `SYNTHORG_TELEMETRY=true` or the `telemetry.enabled` setting.
-- Delivery backend is Logfire; missing token or invalid extra config downgrades to the noop reporter silently.
+- Off by default. Enable with `SYNTHORG_TELEMETRY_ENABLED=true` or the `telemetry.enabled` setting (or via the dashboard / DB).
+- Delivery backend is Logfire. The write-only project token is **embedded in the release wheel** at build time (`src/synthorg/telemetry/reporters/_embedded_token.py` is rewritten by `.github/workflows/release.yml` before `uv build`); operators never configure or paste it. Local source installs ship the sentinel and run telemetry-disabled by build.
+
+## Lifecycle log signals
+
+The collector emits **exactly one** lifecycle log line per process boot, depending on which path applies:
+
+| State | Severity | Event | Notes |
+|-------|----------|-------|-------|
+| Disabled (default) | INFO | `telemetry.disabled` | Heartbeat task not started; zero per-cycle warnings. |
+| Enabled, embedded token present | INFO | `telemetry.reporter.initialized` | Heartbeat starts; `deployment.startup` follows. |
+| Enabled, sentinel token (build artifact missing token) | ERROR | `telemetry.token.missing` | Operator-actionable: rebuild with `LOGFIRE_PROJECT_TOKEN` CI secret. Heartbeat NOT started -- no per-cycle spam. |
+| Enabled, `logfire` import or configure failure | WARNING | `telemetry.report.failed` (factory) | `error_type` carries the actual exception class (no longer hardcoded as `ImportError`). Heartbeat NOT started. |
 
 ## Privacy by allowlist
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "packaging==26.2",
     "pydantic==2.13.3",
     "pyjwt[crypto]==2.12.1",
+    "pyngrok==8.1.1",
     "pyyaml==6.0.3",
     "structlog==25.5.0",
     "rfc3161-client==1.0.6",

--- a/scripts/embed_logfire_token.py
+++ b/scripts/embed_logfire_token.py
@@ -43,6 +43,60 @@ def _resolve_target() -> Path:
     return repo_root / _TARGET_RELATIVE
 
 
+def _validate_token(token: str) -> str:
+    """Strip *token* and reject empty / whitespace-only values.
+
+    Raises:
+        ValueError: If *token* is empty after ``strip()``.
+    """
+    cleaned = token.strip()
+    if not cleaned:
+        msg = "token must be a non-empty string"
+        raise ValueError(msg)
+    return cleaned
+
+
+def _find_quoted_sentinel(content: str, target: Path) -> str:
+    """Return the unique ``"sentinel"`` / ``'sentinel'`` literal in *content*.
+
+    Counts occurrences across BOTH quote styles and refuses unless the
+    grand total is exactly one. This closes a subtle hole in a per-
+    style check: a file with the sentinel both single- AND double-
+    quoted (e.g. a future formatter rev plus a stale docstring copy)
+    would otherwise let the script pick whichever style we tried first
+    and silently land ``replace()`` on the wrong line.
+
+    The unquoted-sentinel pre-check stays in the caller so the
+    "already embedded" error message can be tailored.
+
+    Raises:
+        ValueError: If neither quote style appears, or if the combined
+            count across styles is anything other than one.
+    """
+    counts: dict[str, int] = {}
+    for quote in ('"', "'"):
+        candidate = f"{quote}{_TOKEN_SENTINEL}{quote}"
+        n = content.count(candidate)
+        if n:
+            counts[candidate] = n
+    total = sum(counts.values())
+    if total == 0:
+        msg = (
+            f"quoted sentinel for {_TOKEN_SENTINEL!r} not found in {target}; "
+            "refusing to overwrite an already-embedded token"
+        )
+        raise ValueError(msg)
+    if total != 1:
+        msg = (
+            f"expected exactly one quoted occurrence of {_TOKEN_SENTINEL!r} "
+            f"in {target}, found {total} across {sorted(counts)!r}; "
+            "refusing ambiguous replacement"
+        )
+        raise ValueError(msg)
+    [(quoted_sentinel, _)] = counts.items()
+    return quoted_sentinel
+
+
 def embed(token: str, target: Path) -> None:
     """Rewrite the sentinel string literal in *target* to *token* in place.
 
@@ -57,12 +111,10 @@ def embed(token: str, target: Path) -> None:
 
     Raises:
         ValueError: If the quoted sentinel is not found (already
-            embedded or wrong target file).
+            embedded or wrong target file) or appears more than once.
         OSError: If the file cannot be read or written.
     """
-    if not token or not token.strip():
-        msg = "token must be a non-empty string"
-        raise ValueError(msg)
+    cleaned_token = _validate_token(token)
     content = target.read_text(encoding="utf-8")
     if _TOKEN_SENTINEL not in content:
         msg = (
@@ -70,41 +122,8 @@ def embed(token: str, target: Path) -> None:
             "refusing to overwrite an already-embedded token"
         )
         raise ValueError(msg)
-    # Match the sentinel WITH its surrounding quote so we replace the
-    # entire string literal with a freshly-quoted ``repr(token)``.
-    # Ruff format normalises sentinel strings to double quotes today,
-    # but accept either quote style so a manual edit, a different
-    # formatter rev, or a future pre-commit reorg cannot turn this
-    # into a silent exit-3 noop. ``repr(token)`` always emits Python's
-    # canonical quoting on the way out, so the rewritten file remains
-    # syntactically valid regardless of which input quote style we
-    # matched on.
-    quoted_sentinel: str | None = None
-    for quote in ('"', "'"):
-        candidate = f"{quote}{_TOKEN_SENTINEL}{quote}"
-        if candidate in content:
-            quoted_sentinel = candidate
-            break
-    if quoted_sentinel is None:
-        msg = (
-            f"quoted sentinel for {_TOKEN_SENTINEL!r} not found in {target}; "
-            "refusing to overwrite an already-embedded token"
-        )
-        raise ValueError(msg)
-    # The quoted sentinel must appear in exactly one place (the
-    # ``EMBEDDED_TELEMETRY_TOKEN = "..."`` constant). A repeated
-    # occurrence (e.g. someone duplicated the literal into a docstring
-    # or test fixture inside the target file itself) would let
-    # ``replace(..., 1)`` silently land on the wrong line; refuse to
-    # guess and force the operator to disambiguate.
-    occurrences = content.count(quoted_sentinel)
-    if occurrences != 1:
-        msg = (
-            f"expected exactly one {quoted_sentinel!r} occurrence in "
-            f"{target}, found {occurrences}; refusing ambiguous replacement"
-        )
-        raise ValueError(msg)
-    rewritten = content.replace(quoted_sentinel, repr(token), 1)
+    quoted_sentinel = _find_quoted_sentinel(content, target)
+    rewritten = content.replace(quoted_sentinel, repr(cleaned_token), 1)
     target.write_text(rewritten, encoding="utf-8")
 
 

--- a/scripts/embed_logfire_token.py
+++ b/scripts/embed_logfire_token.py
@@ -1,0 +1,84 @@
+"""Embed the Logfire write-only project token into the build artifact.
+
+Run **once** during the build pipeline before ``uv build`` (or
+before the Docker image's ``uv sync`` step packages the source
+tree). Rewrites the sentinel string in
+``src/synthorg/telemetry/reporters/_embedded_token.py`` to the
+real token so the published wheel / built image carries it baked
+into source. Source-tree installs and any build that does NOT run
+this script keep the sentinel and run telemetry-disabled by build.
+
+Usage:
+    python scripts/embed_logfire_token.py <token>
+
+Exit codes:
+    0  Token successfully embedded.
+    2  Usage error (missing or empty token argument).
+    3  Sentinel not found in target file (build artifact already
+       embedded -- safety check, never overwrite an existing token).
+    4  Target file unreadable / unwritable.
+
+Operator-facing token rotation: bump the GitHub Actions repository
+secret ``LOGFIRE_PROJECT_TOKEN`` and re-publish. The next image /
+wheel build picks up the new value automatically.
+"""
+
+import sys
+from pathlib import Path
+
+_TOKEN_SENTINEL = "__SYNTHORG_LOGFIRE_TOKEN_NOT_EMBEDDED__"  # noqa: S105
+_TARGET_RELATIVE = Path("src/synthorg/telemetry/reporters/_embedded_token.py")
+_EXPECTED_ARGV_LEN = 2  # script name + token positional arg
+
+
+def _resolve_target() -> Path:
+    """Return the absolute path to ``_embedded_token.py`` from the repo root."""
+    repo_root = Path(__file__).resolve().parent.parent
+    return repo_root / _TARGET_RELATIVE
+
+
+def embed(token: str, target: Path) -> None:
+    """Rewrite the sentinel in *target* to *token* in place.
+
+    Raises:
+        ValueError: If the sentinel is not found (already embedded
+            or wrong target file).
+        OSError: If the file cannot be read or written.
+    """
+    if not token or not token.strip():
+        msg = "token must be a non-empty string"
+        raise ValueError(msg)
+    content = target.read_text(encoding="utf-8")
+    if _TOKEN_SENTINEL not in content:
+        msg = (
+            f"sentinel {_TOKEN_SENTINEL!r} not found in {target}; "
+            "refusing to overwrite an already-embedded token"
+        )
+        raise ValueError(msg)
+    rewritten = content.replace(_TOKEN_SENTINEL, token, 1)
+    target.write_text(rewritten, encoding="utf-8")
+
+
+def main(argv: list[str]) -> int:
+    """Entry point. Returns a process exit code (see module docstring)."""
+    if len(argv) != _EXPECTED_ARGV_LEN or not argv[1].strip():
+        sys.stderr.write(
+            "usage: python scripts/embed_logfire_token.py <token>\n",
+        )
+        return 2
+    token = argv[1].strip()
+    target = _resolve_target()
+    try:
+        embed(token, target)
+    except ValueError as exc:
+        sys.stderr.write(f"embed_logfire_token: {exc}\n")
+        return 3
+    except OSError as exc:
+        sys.stderr.write(f"embed_logfire_token: {exc}\n")
+        return 4
+    sys.stderr.write(f"Embedded Logfire token into {target}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/embed_logfire_token.py
+++ b/scripts/embed_logfire_token.py
@@ -38,11 +38,20 @@ def _resolve_target() -> Path:
 
 
 def embed(token: str, target: Path) -> None:
-    """Rewrite the sentinel in *target* to *token* in place.
+    """Rewrite the sentinel string literal in *target* to *token* in place.
+
+    The sentinel lives inside a quoted Python string literal. A naive
+    ``str.replace`` would inject the token text directly into the
+    source, which breaks the literal when the token contains a quote,
+    a backslash escape, or a newline. ``repr()`` produces a properly
+    escaped Python string literal that drops in safely regardless of
+    the token's contents -- the surrounding quotes from the existing
+    sentinel literal are also replaced so the result remains
+    syntactically valid.
 
     Raises:
-        ValueError: If the sentinel is not found (already embedded
-            or wrong target file).
+        ValueError: If the quoted sentinel is not found (already
+            embedded or wrong target file).
         OSError: If the file cannot be read or written.
     """
     if not token or not token.strip():
@@ -55,7 +64,18 @@ def embed(token: str, target: Path) -> None:
             "refusing to overwrite an already-embedded token"
         )
         raise ValueError(msg)
-    rewritten = content.replace(_TOKEN_SENTINEL, token, 1)
+    # Match the sentinel WITH its surrounding quote so we replace the
+    # entire string literal with a freshly-quoted ``repr(token)``. The
+    # constants module always quotes the sentinel with double quotes
+    # (preserved by ruff format), so the pattern is exact.
+    quoted_sentinel = f'"{_TOKEN_SENTINEL}"'
+    if quoted_sentinel not in content:
+        msg = (
+            f"quoted sentinel {quoted_sentinel!r} not found in {target}; "
+            "refusing to overwrite an already-embedded token"
+        )
+        raise ValueError(msg)
+    rewritten = content.replace(quoted_sentinel, repr(token), 1)
     target.write_text(rewritten, encoding="utf-8")
 
 

--- a/scripts/embed_logfire_token.py
+++ b/scripts/embed_logfire_token.py
@@ -26,7 +26,7 @@ wheel build picks up the new value automatically.
 import sys
 from pathlib import Path
 
-_TOKEN_SENTINEL = "__SYNTHORG_LOGFIRE_TOKEN_NOT_EMBEDDED__"  # noqa: S105
+_TOKEN_SENTINEL = "__SYNTHORG_TELEMETRY_TOKEN_NOT_EMBEDDED__"  # noqa: S105
 _TARGET_RELATIVE = Path("src/synthorg/telemetry/reporters/_embedded_token.py")
 _EXPECTED_ARGV_LEN = 2  # script name + token positional arg
 

--- a/scripts/embed_logfire_token.py
+++ b/scripts/embed_logfire_token.py
@@ -8,9 +8,11 @@ real token so the published wheel / built image carries it baked
 into source. Source-tree installs and any build that does NOT run
 this script keep the sentinel and run telemetry-disabled by build.
 
-The script filename retains the ``logfire`` token for CI-log
-clarity (it is the build-time secret name), but every operator-
-and developer-facing string in this module is vendor-neutral.
+The script filename is preserved verbatim because it has to
+match the build-time GHA secret name (referenced in the rotation
+note below) for operator clarity in CI logs. Every other prose,
+error message, and stderr line in this module uses vendor-neutral
+phrasing.
 
 Usage:
     python scripts/embed_logfire_token.py <token>
@@ -89,6 +91,19 @@ def embed(token: str, target: Path) -> None:
             "refusing to overwrite an already-embedded token"
         )
         raise ValueError(msg)
+    # The quoted sentinel must appear in exactly one place (the
+    # ``EMBEDDED_TELEMETRY_TOKEN = "..."`` constant). A repeated
+    # occurrence (e.g. someone duplicated the literal into a docstring
+    # or test fixture inside the target file itself) would let
+    # ``replace(..., 1)`` silently land on the wrong line; refuse to
+    # guess and force the operator to disambiguate.
+    occurrences = content.count(quoted_sentinel)
+    if occurrences != 1:
+        msg = (
+            f"expected exactly one {quoted_sentinel!r} occurrence in "
+            f"{target}, found {occurrences}; refusing ambiguous replacement"
+        )
+        raise ValueError(msg)
     rewritten = content.replace(quoted_sentinel, repr(token), 1)
     target.write_text(rewritten, encoding="utf-8")
 
@@ -105,10 +120,10 @@ def main(argv: list[str]) -> int:
     try:
         embed(token, target)
     except ValueError as exc:
-        sys.stderr.write(f"embed_logfire_token: {exc}\n")
+        sys.stderr.write(f"embed_telemetry_token: {exc}\n")
         return 3
     except OSError as exc:
-        sys.stderr.write(f"embed_logfire_token: {exc}\n")
+        sys.stderr.write(f"embed_telemetry_token: {exc}\n")
         return 4
     sys.stderr.write(f"Embedded telemetry token into {target}\n")
     return 0

--- a/scripts/embed_logfire_token.py
+++ b/scripts/embed_logfire_token.py
@@ -1,4 +1,4 @@
-"""Embed the Logfire write-only project token into the build artifact.
+"""Embed the write-only telemetry-backend project token into the build artifact.
 
 Run **once** during the build pipeline before ``uv build`` (or
 before the Docker image's ``uv sync`` step packages the source
@@ -7,6 +7,10 @@ tree). Rewrites the sentinel string in
 real token so the published wheel / built image carries it baked
 into source. Source-tree installs and any build that does NOT run
 this script keep the sentinel and run telemetry-disabled by build.
+
+The script filename retains the ``logfire`` token for CI-log
+clarity (it is the build-time secret name), but every operator-
+and developer-facing string in this module is vendor-neutral.
 
 Usage:
     python scripts/embed_logfire_token.py <token>
@@ -65,13 +69,23 @@ def embed(token: str, target: Path) -> None:
         )
         raise ValueError(msg)
     # Match the sentinel WITH its surrounding quote so we replace the
-    # entire string literal with a freshly-quoted ``repr(token)``. The
-    # constants module always quotes the sentinel with double quotes
-    # (preserved by ruff format), so the pattern is exact.
-    quoted_sentinel = f'"{_TOKEN_SENTINEL}"'
-    if quoted_sentinel not in content:
+    # entire string literal with a freshly-quoted ``repr(token)``.
+    # Ruff format normalises sentinel strings to double quotes today,
+    # but accept either quote style so a manual edit, a different
+    # formatter rev, or a future pre-commit reorg cannot turn this
+    # into a silent exit-3 noop. ``repr(token)`` always emits Python's
+    # canonical quoting on the way out, so the rewritten file remains
+    # syntactically valid regardless of which input quote style we
+    # matched on.
+    quoted_sentinel: str | None = None
+    for quote in ('"', "'"):
+        candidate = f"{quote}{_TOKEN_SENTINEL}{quote}"
+        if candidate in content:
+            quoted_sentinel = candidate
+            break
+    if quoted_sentinel is None:
         msg = (
-            f"quoted sentinel {quoted_sentinel!r} not found in {target}; "
+            f"quoted sentinel for {_TOKEN_SENTINEL!r} not found in {target}; "
             "refusing to overwrite an already-embedded token"
         )
         raise ValueError(msg)
@@ -96,7 +110,7 @@ def main(argv: list[str]) -> int:
     except OSError as exc:
         sys.stderr.write(f"embed_logfire_token: {exc}\n")
         return 4
-    sys.stderr.write(f"Embedded Logfire token into {target}\n")
+    sys.stderr.write(f"Embedded telemetry token into {target}\n")
     return 0
 
 

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -42,7 +42,7 @@ from synthorg.api.bus_bridge import MessageBusBridge
 from synthorg.api.channels import (
     create_channels_plugin,
 )
-from synthorg.api.controllers import BASE_CONTROLLERS
+from synthorg.api.controllers import BASE_CONTROLLERS, OPTIONAL_CONTROLLERS
 from synthorg.api.controllers.ws import ws_handler
 from synthorg.api.cursor import CursorSecret
 from synthorg.api.cursor_config import CursorConfig
@@ -739,12 +739,25 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
                 exc_info=True,
             )
 
+    # Optional controllers gated on their primary collaborator service.
+    # Routes for unconfigured subsystems are not registered at all so
+    # the dashboard receives 404 (route does not exist) instead of the
+    # 503 it used to get for every poll cycle.  /capabilities reports
+    # which subsystems are wired so the dashboard can skip the polling
+    # loops at the source.
+    optional_controllers: tuple[type[Controller], ...] = tuple(
+        controller_cls
+        for controller_cls, predicate_attr in OPTIONAL_CONTROLLERS
+        if getattr(app_state, predicate_attr, False)
+    )
+
     api_router = Router(
         path=api_config.api_prefix,
         route_handlers=[
             *BASE_CONTROLLERS,
             *integration_controllers,
             *a2a_controllers,
+            *optional_controllers,
             ws_handler,
         ],
         guards=[require_password_changed],

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -118,6 +118,7 @@ from synthorg.tools.invocation_tracker import ToolInvocationTracker  # noqa: TC0
 if TYPE_CHECKING:
     from litestar.channels import ChannelsPlugin
 
+    from synthorg.client.simulation_state import ClientSimulationState
     from synthorg.settings.service import SettingsService
 
 logger = get_logger(__name__)
@@ -155,6 +156,7 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
     training_service: TrainingService | None = None,
     event_stream_hub: EventStreamHub | None = None,
     interrupt_store: InterruptStore | None = None,
+    client_simulation_state: ClientSimulationState | None = None,
     _skip_lifecycle_shutdown: bool = False,
 ) -> Litestar:
     """Create and configure the Litestar application.
@@ -192,6 +194,10 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
             if None).
         interrupt_store: Pre-built interrupt store (auto-created
             if None).
+        client_simulation_state: Pre-built client simulation state.
+            Wired before the optional-controller predicate check so
+            the Simulation / Request controllers register correctly
+            on a test app boot (#1666 B-3 regression coverage).
         _skip_lifecycle_shutdown: Test-only flag.  When ``True``, the
             Litestar app is built with an empty ``on_shutdown`` list so
             the lifespan exit is a no-op.  Used by the session-scoped
@@ -739,17 +745,36 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
                 exc_info=True,
             )
 
+    # Wire the optional client-simulation runtime onto AppState BEFORE the
+    # optional-controllers tuple is built so the predicate check below
+    # sees its presence at controller-list-assembly time. Production
+    # callers that need the surface pass it as a kwarg; tests that
+    # exercise the simulation/request endpoints do the same instead of
+    # post-construction ``set_client_simulation_state``.
+    if client_simulation_state is not None:
+        app_state.set_client_simulation_state(client_simulation_state)
+
     # Optional controllers gated on their primary collaborator service.
     # Routes for unconfigured subsystems are not registered at all so
     # the dashboard receives 404 (route does not exist) instead of the
     # 503 it used to get for every poll cycle.  /capabilities reports
     # which subsystems are wired so the dashboard can skip the polling
-    # loops at the source.
-    optional_controllers: tuple[type[Controller], ...] = tuple(
-        controller_cls
-        for controller_cls, predicate_attr in OPTIONAL_CONTROLLERS
-        if getattr(app_state, predicate_attr, False)
-    )
+    # loops at the source. Fail loudly when a registered predicate name
+    # is missing from AppState (typo / rename) -- silently disabling
+    # routes via ``getattr(..., False)`` would turn a wiring bug into
+    # an unnoticed 404 surface regression.
+    _optional: list[type[Controller]] = []
+    for controller_cls, predicate_attr in OPTIONAL_CONTROLLERS:
+        if not hasattr(app_state, predicate_attr):
+            msg = (
+                f"Optional controller predicate {predicate_attr!r} is "
+                f"missing on AppState (controller={controller_cls.__name__})."
+            )
+            logger.error(API_APP_STARTUP, note=msg, controller=controller_cls.__name__)
+            raise RuntimeError(msg)
+        if bool(getattr(app_state, predicate_attr)):
+            _optional.append(controller_cls)
+    optional_controllers: tuple[type[Controller], ...] = tuple(_optional)
 
     api_router = Router(
         path=api_config.api_prefix,

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -807,6 +807,34 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
     startup = [*startup, telemetry_collector.start]
     shutdown = [*shutdown, telemetry_collector.shutdown]
 
+    # Automated report service: wired from the cost tracker + budget config
+    # so the ``POST /api/v1/reports/generate`` endpoint can serve the
+    # documented inputs instead of returning 503 unconfigured. Risk and
+    # performance trackers are optional; the service degrades to empty
+    # per-tracker reports when either is absent (see
+    # ``AutomatedReportService.generate_*_report`` for the None-tolerant
+    # paths). When ``cost_tracker`` is itself absent (degenerate test
+    # configurations) we skip the wire and the controller falls back to
+    # 503 ServiceUnavailableError -- which is the honest status code for
+    # "feature unavailable", not the AttributeError it used to surface.
+    if cost_tracker is not None:
+        from synthorg.budget.automated_reports import (  # noqa: PLC0415
+            AutomatedReportService,
+        )
+        from synthorg.budget.reports import ReportGenerator  # noqa: PLC0415
+
+        report_generator = ReportGenerator(
+            cost_tracker=cost_tracker,
+            budget_config=effective_config.budget,
+        )
+        report_service = AutomatedReportService(
+            report_generator=report_generator,
+            cost_tracker=cost_tracker,
+            risk_tracker=None,
+            performance_tracker=performance_tracker,
+        )
+        app_state.set_report_service(report_service)
+
     # Bring up the notification dispatcher's HTTP-bearing sinks
     # (slack/ntfy ``httpx.AsyncClient``) lazily under their lifecycle
     # locks. Stateless sinks (console/email) implement no-op

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -802,7 +802,7 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
         effective_config=effective_config,
     )
 
-    # Project telemetry: build collector (reads SYNTHORG_TELEMETRY env for
+    # Project telemetry: build collector (reads SYNTHORG_TELEMETRY_ENABLED env for
     # opt-in, defaults to disabled). Attach to app_state so the health
     # endpoint can report the state, and hook start()/shutdown() into the
     # Litestar lifespan. Telemetry is SynthOrg-owned and silent on

--- a/src/synthorg/api/app_builders.py
+++ b/src/synthorg/api/app_builders.py
@@ -223,14 +223,29 @@ def _resolve_telemetry_enabled(parsed: TelemetryConfig) -> TelemetryConfig:
     no longer re-applies this precedence so the audit trail stays
     single-sourced.
 
+    Validates the env value at this system boundary -- a typo such as
+    ``SYNTHORG_TELEMETRY_ENABLED=falsee`` would otherwise silently fall
+    through to the parsed value and mask operator intent.
+
     Returns the (possibly updated) config.
+
+    Raises:
+        ValueError: When the env var is set to a value that is neither
+            a truthy nor falsy token from the recognised vocabulary.
     """
     raw = os.environ.get(_TELEMETRY_ENV_VAR, "").strip().lower()
+    if not raw:
+        return parsed
     if raw in _TELEMETRY_ENV_TRUE:
         return parsed.model_copy(update={"enabled": True})
     if raw in _TELEMETRY_ENV_FALSE:
         return parsed.model_copy(update={"enabled": False})
-    return parsed
+    accepted = sorted(_TELEMETRY_ENV_TRUE | _TELEMETRY_ENV_FALSE)
+    msg = (
+        f"{_TELEMETRY_ENV_VAR} must be one of {accepted!r}; "
+        f"got {raw!r}. Refusing to silently fall back to the parsed value."
+    )
+    raise ValueError(msg)
 
 
 def _build_telemetry_collector(

--- a/src/synthorg/api/app_builders.py
+++ b/src/synthorg/api/app_builders.py
@@ -210,8 +210,11 @@ def _build_telemetry_collector(
 
     Passing ``None`` for ``telemetry_cfg`` falls back to defaults
     (``enabled=False``). :class:`TelemetryCollector` reads
-    ``SYNTHORG_TELEMETRY`` inside its own ``__init__`` and overrides
-    the config's ``enabled`` flag, so the env var still wins.
+    ``SYNTHORG_TELEMETRY_ENABLED`` inside its own ``__init__`` and
+    overrides the config's ``enabled`` flag, so the env var still
+    wins. The same env name is registered as the
+    ``telemetry.enabled`` setting's ``env_var_override`` so the
+    /settings API and the boot path agree on a single source.
     """
     memory_dir = _resolve_memory_dir()
     telemetry_dir = memory_dir.parent / "telemetry"

--- a/src/synthorg/api/app_builders.py
+++ b/src/synthorg/api/app_builders.py
@@ -203,22 +203,53 @@ def _resolve_memory_dir() -> Path:
     return path
 
 
+_TELEMETRY_ENV_VAR = "SYNTHORG_TELEMETRY_ENABLED"
+_TELEMETRY_ENV_TRUE = frozenset({"true", "1", "yes"})
+_TELEMETRY_ENV_FALSE = frozenset({"false", "0", "no"})
+
+
+def _resolve_telemetry_enabled(parsed: TelemetryConfig) -> TelemetryConfig:
+    """Apply env-layer precedence for the registered ``telemetry.enabled`` setting.
+
+    Single source of "env wins over YAML / default" for the boot
+    path. ``SYNTHORG_TELEMETRY_ENABLED`` matches the env name registered
+    on the ``telemetry.enabled`` setting (see
+    ``synthorg.settings.definitions.telemetry``); when the value is
+    set, it overrides the parsed ``TelemetryConfig.enabled`` field.
+    The DB layer is consulted by ``SettingsService`` /
+    ``ConfigResolver`` for runtime ``/settings`` reads and edits;
+    those changes apply on the next process restart per the
+    setting's ``restart_required`` semantics. The collector itself
+    no longer re-applies this precedence so the audit trail stays
+    single-sourced.
+
+    Returns the (possibly updated) config.
+    """
+    raw = os.environ.get(_TELEMETRY_ENV_VAR, "").strip().lower()
+    if raw in _TELEMETRY_ENV_TRUE:
+        return parsed.model_copy(update={"enabled": True})
+    if raw in _TELEMETRY_ENV_FALSE:
+        return parsed.model_copy(update={"enabled": False})
+    return parsed
+
+
 def _build_telemetry_collector(
     telemetry_cfg: TelemetryConfig | None = None,
 ) -> TelemetryCollector:
     """Build the project telemetry collector.
 
     Passing ``None`` for ``telemetry_cfg`` falls back to defaults
-    (``enabled=False``). :class:`TelemetryCollector` reads
-    ``SYNTHORG_TELEMETRY_ENABLED`` inside its own ``__init__`` and
-    overrides the config's ``enabled`` flag, so the env var still
-    wins. The same env name is registered as the
-    ``telemetry.enabled`` setting's ``env_var_override`` so the
+    (``enabled=False``). The env-layer override
+    (``SYNTHORG_TELEMETRY_ENABLED``) is applied here via
+    :func:`_resolve_telemetry_enabled` -- the collector itself takes
+    the resolved boolean as-given. The same env name is registered as
+    the ``telemetry.enabled`` setting's ``env_var_override`` so the
     /settings API and the boot path agree on a single source.
     """
     memory_dir = _resolve_memory_dir()
     telemetry_dir = memory_dir.parent / "telemetry"
-    config = telemetry_cfg if telemetry_cfg is not None else TelemetryConfig()
+    parsed = telemetry_cfg if telemetry_cfg is not None else TelemetryConfig()
+    config = _resolve_telemetry_enabled(parsed)
     return TelemetryCollector(config=config, data_dir=telemetry_dir)
 
 

--- a/src/synthorg/api/controllers/__init__.py
+++ b/src/synthorg/api/controllers/__init__.py
@@ -18,6 +18,7 @@ from synthorg.api.controllers.budget import BudgetController
 from synthorg.api.controllers.budget_config_versions import (
     BudgetConfigVersionController,
 )
+from synthorg.api.controllers.capabilities import CapabilitiesController
 from synthorg.api.controllers.ceremony_policy import (
     CeremonyPolicyController,
 )
@@ -102,6 +103,7 @@ BASE_CONTROLLERS: tuple[type[Controller], ...] = (
     LivenessController,
     ReadinessController,
     MetricsController,
+    CapabilitiesController,
     CompanyController,
     AgentController,
     AgentIdentityVersionController,
@@ -147,14 +149,27 @@ BASE_CONTROLLERS: tuple[type[Controller], ...] = (
     WorkflowExecutionController,
     OntologyController,
     ClientController,
-    RequestController,
-    SimulationController,
     ReviewController,
     ScalingController,
     TrainingController,
     MetaController,
     MetaAnalyticsController,
     CustomRuleController,
+)
+
+# Controllers gated by their collaborator service.  These do NOT live
+# in ``BASE_CONTROLLERS`` -- they are registered only when their
+# dependency is wired so an unconfigured install returns 404 (route
+# does not exist) instead of 503 on every dashboard poll.  The web
+# dashboard reads ``GET /api/v1/capabilities`` once per session and
+# skips polling whichever subsystem reports ``False``.
+#
+# Each tuple is ``(controller_class, predicate_attribute_on_appstate)``;
+# ``app.py`` includes the controller in ``route_handlers`` only when
+# the predicate evaluates truthy at controller-list assembly time.
+OPTIONAL_CONTROLLERS: tuple[tuple[type[Controller], str], ...] = (
+    (SimulationController, "has_client_simulation_state"),
+    (RequestController, "has_client_simulation_state"),
 )
 
 # Integration subsystem controllers. Registered only when
@@ -173,12 +188,14 @@ INTEGRATION_CONTROLLERS: tuple[type[Controller], ...] = (
 ALL_CONTROLLERS: tuple[type[Controller], ...] = (
     *BASE_CONTROLLERS,
     *INTEGRATION_CONTROLLERS,
+    *(controller for controller, _ in OPTIONAL_CONTROLLERS),
 )
 
 __all__ = [
     "ALL_CONTROLLERS",
     "BASE_CONTROLLERS",
     "INTEGRATION_CONTROLLERS",
+    "OPTIONAL_CONTROLLERS",
     "ActivityController",
     "AgentController",
     "AgentIdentityVersionController",

--- a/src/synthorg/api/controllers/capabilities.py
+++ b/src/synthorg/api/controllers/capabilities.py
@@ -16,9 +16,12 @@ from pydantic import BaseModel, ConfigDict
 
 from synthorg.api.dto import ApiResponse
 from synthorg.api.guards import require_read_access
+from synthorg.observability import get_logger
 
 if TYPE_CHECKING:
     from synthorg.api.state import AppState
+
+logger = get_logger(__name__)
 
 
 class CapabilitiesResponse(BaseModel):

--- a/src/synthorg/api/controllers/capabilities.py
+++ b/src/synthorg/api/controllers/capabilities.py
@@ -16,12 +16,9 @@ from pydantic import BaseModel, ConfigDict
 
 from synthorg.api.dto import ApiResponse
 from synthorg.api.guards import require_read_access
-from synthorg.observability import get_logger
 
 if TYPE_CHECKING:
     from synthorg.api.state import AppState
-
-logger = get_logger(__name__)
 
 
 class CapabilitiesResponse(BaseModel):

--- a/src/synthorg/api/controllers/capabilities.py
+++ b/src/synthorg/api/controllers/capabilities.py
@@ -1,0 +1,119 @@
+"""Capabilities controller -- runtime feature discovery for the dashboard.
+
+Returns one boolean per optional subsystem so the web dashboard can
+gate polling on the surfaces that are actually wired in this
+deployment. Without this surface the dashboard polled every endpoint
+unconditionally and recorded a 503 every cycle for any subsystem the
+operator had not configured -- 16+ such errors logged in 57h of
+runtime against a minimally-configured install (issue #1666 B-3).
+"""
+
+from typing import TYPE_CHECKING
+
+from litestar import Controller, get
+from litestar.datastructures import State  # noqa: TC002
+from pydantic import BaseModel, ConfigDict
+
+from synthorg.api.dto import ApiResponse
+from synthorg.api.guards import require_read_access
+from synthorg.observability import get_logger
+
+if TYPE_CHECKING:
+    from synthorg.api.state import AppState
+
+logger = get_logger(__name__)
+
+
+class CapabilitiesResponse(BaseModel):
+    """Boolean flags describing which optional subsystems are wired.
+
+    Every flag here corresponds to either a controller that is only
+    registered when the underlying service is configured (so the
+    route returns 404 when the flag is False) or a controller whose
+    handlers degrade to ``ServiceUnavailableError`` (503) when the
+    matching app-state attribute is absent. The dashboard reads this
+    once per session and skips polling endpoints whose flag is False.
+
+    Attributes:
+        simulations: Client simulation runtime is configured.
+        requests: Request facade (depends on client simulation state)
+            is configured.
+        ontology: Ontology service is configured.
+        tunnel: Tunnel provider is configured (pyngrok + auth token).
+        webhooks: Webhook event bridge is configured.
+        a2a: A2A peer registry / client are configured.
+        telemetry: Anonymous Logfire telemetry is enabled and
+            functional (an enabled-but-degraded reporter still
+            reports False; the dashboard only surfaces telemetry UI
+            when the reporter actually delivers).
+        integrations: The integrations subsystem
+            (``effective_config.integrations.enabled``) is on; when
+            False the connections / oauth / webhooks / mcp catalog
+            surfaces are not registered at all.
+    """
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False, extra="forbid")
+
+    simulations: bool
+    requests: bool
+    ontology: bool
+    tunnel: bool
+    webhooks: bool
+    a2a: bool
+    telemetry: bool
+    integrations: bool
+
+
+class CapabilitiesController(Controller):
+    """Runtime feature-flag introspection for the web dashboard."""
+
+    path = "/capabilities"
+    guards = [require_read_access]  # noqa: RUF012
+
+    @get(
+        "/",
+        summary="Report which optional subsystems are wired",
+        description=(
+            "Returns one boolean per optional subsystem. The dashboard "
+            "uses this to gate polling on the surfaces actually wired "
+            "in this deployment, avoiding 503-spam against optional "
+            "services that are intentionally not configured."
+        ),
+    )
+    async def get_capabilities(
+        self,
+        state: State,
+    ) -> ApiResponse[CapabilitiesResponse]:
+        """Build the capabilities snapshot from the live app state."""
+        app_state: AppState = state.app_state
+        # Reading directly from the live ``has_*`` predicates so the
+        # source of truth is the app state's wiring decisions rather
+        # than a parallel boolean cache that could drift. ``webhooks``
+        # and ``a2a`` use the nullable accessors directly because the
+        # state mixin returns ``None`` (webhook bridge) or raises
+        # 503 (a2a) on absence; ``is not None`` covers both shapes
+        # without a try/except.
+        telemetry_functional = (
+            app_state.has_telemetry_collector
+            and app_state.telemetry_collector.is_functional
+        )
+        webhook_bridge = app_state.webhook_event_bridge
+        a2a_enabled = app_state.config.a2a.enabled
+        return ApiResponse(
+            data=CapabilitiesResponse(
+                simulations=app_state.has_client_simulation_state,
+                requests=app_state.has_client_simulation_state,
+                ontology=app_state.has_ontology_service,
+                tunnel=app_state.has_tunnel_provider,
+                webhooks=webhook_bridge is not None,
+                a2a=a2a_enabled,
+                telemetry=telemetry_functional,
+                integrations=app_state.config.integrations.enabled,
+            ),
+        )
+
+
+__all__ = [
+    "CapabilitiesController",
+    "CapabilitiesResponse",
+]

--- a/src/synthorg/api/controllers/capabilities.py
+++ b/src/synthorg/api/controllers/capabilities.py
@@ -83,19 +83,24 @@ class CapabilitiesController(Controller):
     ) -> ApiResponse[CapabilitiesResponse]:
         """Build the capabilities snapshot from the live app state."""
         app_state: AppState = state.app_state
-        # Reading directly from the live ``has_*`` predicates so the
-        # source of truth is the app state's wiring decisions rather
-        # than a parallel boolean cache that could drift. ``webhooks``
-        # and ``a2a`` use the nullable accessors directly because the
-        # state mixin returns ``None`` (webhook bridge) or raises
-        # 503 (a2a) on absence; ``is not None`` covers both shapes
-        # without a try/except.
+        # Read directly from the live runtime-wiring signals so each
+        # flag reflects what's actually plumbed, not what the config
+        # asked for. ``a2a`` checks the actual peer registry (the
+        # collaborator the gateway routes through) instead of
+        # ``config.a2a.enabled``; if auto-wire silently failed (e.g.
+        # missing ``connection_catalog``), the config flag would still
+        # be ``True`` while the subsystem is unavailable, breaking the
+        # capability-gating contract. ``webhooks`` uses the nullable
+        # accessor directly. ``a2a_peer_registry`` raises 503 when
+        # unset, so we read the private slot via ``getattr`` with a
+        # safe default to avoid the exception inside the response
+        # path.
         telemetry_functional = (
             app_state.has_telemetry_collector
             and app_state.telemetry_collector.is_functional
         )
         webhook_bridge = app_state.webhook_event_bridge
-        a2a_enabled = app_state.config.a2a.enabled
+        a2a_wired = getattr(app_state, "_a2a_peer_registry", None) is not None
         return ApiResponse(
             data=CapabilitiesResponse(
                 simulations=app_state.has_client_simulation_state,
@@ -103,7 +108,7 @@ class CapabilitiesController(Controller):
                 ontology=app_state.has_ontology_service,
                 tunnel=app_state.has_tunnel_provider,
                 webhooks=webhook_bridge is not None,
-                a2a=a2a_enabled,
+                a2a=a2a_wired,
                 telemetry=telemetry_functional,
                 integrations=app_state.config.integrations.enabled,
             ),

--- a/src/synthorg/api/controllers/capabilities.py
+++ b/src/synthorg/api/controllers/capabilities.py
@@ -36,10 +36,14 @@ class CapabilitiesResponse(BaseModel):
         requests: Request facade (depends on client simulation state)
             is configured.
         ontology: Ontology service is configured.
-        tunnel: Tunnel provider is configured (pyngrok + auth token).
-        webhooks: Webhook event bridge is configured.
+        tunnel: External tunnel provider is configured.
+        webhooks: WebhooksController is registered. Mirrors the
+            create_app() readiness predicate
+            (``integrations.enabled`` AND ``connection_catalog`` AND
+            ``message_bus``) so the flag reports the route, not a
+            sibling auto-wired bridge that follows a different gate.
         a2a: A2A peer registry / client are configured.
-        telemetry: Anonymous Logfire telemetry is enabled and
+        telemetry: Anonymous product telemetry is enabled and
             functional (an enabled-but-degraded reporter still
             reports False; the dashboard only surfaces telemetry UI
             when the reporter actually delivers).
@@ -90,16 +94,24 @@ class CapabilitiesController(Controller):
         # ``config.a2a.enabled``; if auto-wire silently failed (e.g.
         # missing ``connection_catalog``), the config flag would still
         # be ``True`` while the subsystem is unavailable, breaking the
-        # capability-gating contract. ``webhooks`` uses the nullable
-        # accessor directly. ``a2a_peer_registry`` raises 503 when
-        # unset, so we read the private slot via ``getattr`` with a
-        # safe default to avoid the exception inside the response
-        # path.
+        # capability-gating contract. ``webhooks`` mirrors the
+        # WebhooksController readiness predicate in ``create_app()``
+        # (``integrations.enabled`` AND ``connection_catalog`` AND
+        # ``message_bus``); reading the bridge accessor instead would
+        # diverge because the bridge requires ``ceremony_scheduler``
+        # while the controller does not. ``a2a_peer_registry`` raises
+        # 503 when unset, so we read the private slot via ``getattr``
+        # with a safe default to avoid the exception inside the
+        # response path.
         telemetry_functional = (
             app_state.has_telemetry_collector
             and app_state.telemetry_collector.is_functional
         )
-        webhook_bridge = app_state.webhook_event_bridge
+        webhooks_wired = (
+            app_state.config.integrations.enabled
+            and app_state.has_connection_catalog
+            and app_state.has_message_bus
+        )
         a2a_wired = getattr(app_state, "_a2a_peer_registry", None) is not None
         return ApiResponse(
             data=CapabilitiesResponse(
@@ -107,7 +119,7 @@ class CapabilitiesController(Controller):
                 requests=app_state.has_client_simulation_state,
                 ontology=app_state.has_ontology_service,
                 tunnel=app_state.has_tunnel_provider,
-                webhooks=webhook_bridge is not None,
+                webhooks=webhooks_wired,
                 a2a=a2a_wired,
                 telemetry=telemetry_functional,
                 integrations=app_state.config.integrations.enabled,

--- a/src/synthorg/api/controllers/mcp_catalog.py
+++ b/src/synthorg/api/controllers/mcp_catalog.py
@@ -66,6 +66,64 @@ class InstallEntryResponse(BaseModel):
     )
 
 
+async def _validate_connection_name_for_install(
+    *,
+    entry_id: str,
+    connection_name: str | None,
+    connection_catalog: object | None,
+) -> None:
+    """Validate ``connection_name`` exists before the install INSERT.
+
+    Pre-validation closes the gap where an unknown ``connection_name``
+    would otherwise reach the FK column on ``mcp_installations`` and
+    raise ``psycopg.errors.ForeignKeyViolation`` outside the service's
+    typed ``ConnectionNotFoundError`` arm (issue #1666 B-1). The
+    service's post-call check still validates the
+    ``required_connection_type`` branch; this gate covers the
+    no-required-type-but-unknown-name path. The IntegrityError
+    backstop in ``api/exception_handlers.py`` covers the racy
+    "connection deleted between validate and INSERT" window.
+
+    Args:
+        entry_id: Catalog entry being installed (used for log context).
+        connection_name: Name supplied by the caller, or ``None`` to
+            skip validation.
+        connection_catalog: Resolved catalog (or ``None`` when the
+            integrations subsystem is unconfigured).
+
+    Raises:
+        ValidationError: When ``connection_name`` is supplied but the
+            catalog is missing or the name does not resolve.
+    """
+    if connection_name is None:
+        return
+    if connection_catalog is None:
+        msg = "Integrations subsystem is not configured; cannot bind connection_name."
+        logger.warning(
+            MCP_SERVER_INSTALL_FAILED,
+            entry_id=entry_id,
+            connection_name=connection_name,
+            reason="connection_catalog_unavailable",
+        )
+        raise ValidationError(msg)
+    # Static-type-friendly: ``connection_catalog`` carries the
+    # ``ConnectionCatalog`` protocol but is typed as ``object`` here
+    # because the controller hands it through unchanged. The runtime
+    # ``get(name) -> Connection | None`` contract is the only thing
+    # we rely on; treating it as object keeps the helper free of an
+    # otherwise-unused import.
+    existing = await connection_catalog.get(connection_name)  # type: ignore[attr-defined]
+    if existing is None:
+        msg = f"unknown connection {connection_name!r}"
+        logger.warning(
+            MCP_SERVER_INSTALL_FAILED,
+            entry_id=entry_id,
+            connection_name=connection_name,
+            reason="connection_not_found_pre_install",
+        )
+        raise ValidationError(msg)
+
+
 class MCPCatalogController(Controller):
     """Browse and install MCP servers from the bundled catalog."""
 
@@ -167,41 +225,11 @@ class MCPCatalogController(Controller):
             app_state.connection_catalog if app_state.has_connection_catalog else None
         )
 
-        # Validate-first: when the caller supplied a ``connection_name``
-        # we look it up in the catalog *before* any INSERT so the
-        # foreign-key column on ``mcp_installations`` cannot trigger a
-        # ``psycopg.errors.ForeignKeyViolation`` and slip out of the
-        # service's typed ``ConnectionNotFoundError`` arm. The service's
-        # post-call check still catches this case on the
-        # ``required_connection_type`` branch -- pre-validation closes
-        # the gap when the entry does not require a connection but the
-        # caller still supplies an unknown ``connection_name``. The
-        # exception handler at api/exception_handlers.py registers a
-        # backstop for ``IntegrityError`` so even the racy "connection
-        # deleted between validate and INSERT" path lands at 400.
-        if connection_name is not None:
-            if connection_catalog is None:
-                msg = (
-                    "Integrations subsystem is not configured; "
-                    "cannot bind connection_name."
-                )
-                logger.warning(
-                    MCP_SERVER_INSTALL_FAILED,
-                    entry_id=entry_id,
-                    connection_name=connection_name,
-                    reason="connection_catalog_unavailable",
-                )
-                raise ValidationError(msg)
-            existing = await connection_catalog.get(connection_name)
-            if existing is None:
-                msg = f"unknown connection {connection_name!r}"
-                logger.warning(
-                    MCP_SERVER_INSTALL_FAILED,
-                    entry_id=entry_id,
-                    connection_name=connection_name,
-                    reason="connection_not_found_pre_install",
-                )
-                raise ValidationError(msg)
+        await _validate_connection_name_for_install(
+            entry_id=entry_id,
+            connection_name=connection_name,
+            connection_catalog=connection_catalog,
+        )
 
         try:
             result = await service.install(

--- a/src/synthorg/api/controllers/mcp_catalog.py
+++ b/src/synthorg/api/controllers/mcp_catalog.py
@@ -167,6 +167,42 @@ class MCPCatalogController(Controller):
             app_state.connection_catalog if app_state.has_connection_catalog else None
         )
 
+        # Validate-first: when the caller supplied a ``connection_name``
+        # we look it up in the catalog *before* any INSERT so the
+        # foreign-key column on ``mcp_installations`` cannot trigger a
+        # ``psycopg.errors.ForeignKeyViolation`` and slip out of the
+        # service's typed ``ConnectionNotFoundError`` arm. The service's
+        # post-call check still catches this case on the
+        # ``required_connection_type`` branch -- pre-validation closes
+        # the gap when the entry does not require a connection but the
+        # caller still supplies an unknown ``connection_name``. The
+        # exception handler at api/exception_handlers.py registers a
+        # backstop for ``IntegrityError`` so even the racy "connection
+        # deleted between validate and INSERT" path lands at 400.
+        if connection_name is not None:
+            if connection_catalog is None:
+                msg = (
+                    "Integrations subsystem is not configured; "
+                    "cannot bind connection_name."
+                )
+                logger.warning(
+                    MCP_SERVER_INSTALL_FAILED,
+                    entry_id=entry_id,
+                    connection_name=connection_name,
+                    reason="connection_catalog_unavailable",
+                )
+                raise ValidationError(msg)
+            existing = await connection_catalog.get(connection_name)
+            if existing is None:
+                msg = f"unknown connection {connection_name!r}"
+                logger.warning(
+                    MCP_SERVER_INSTALL_FAILED,
+                    entry_id=entry_id,
+                    connection_name=connection_name,
+                    reason="connection_not_found_pre_install",
+                )
+                raise ValidationError(msg)
+
         try:
             result = await service.install(
                 entry_id,

--- a/src/synthorg/api/controllers/reports.py
+++ b/src/synthorg/api/controllers/reports.py
@@ -85,12 +85,8 @@ def _get_report_service(
     state: State,
 ) -> AutomatedReportService:
     """Resolve the report service from app state."""
-    app_state: AppState = state._app_state  # noqa: SLF001
-    service: AutomatedReportService | None = getattr(
-        app_state,
-        "report_service",
-        None,
-    )
+    app_state: AppState = state.app_state
+    service = app_state.report_service if app_state.has_report_service else None
     if service is None:
         logger.warning(
             API_SERVICE_UNAVAILABLE,

--- a/src/synthorg/api/controllers/setup_agents.py
+++ b/src/synthorg/api/controllers/setup_agents.py
@@ -13,6 +13,7 @@ from synthorg.observability.events.setup import (
     SETUP_AGENT_SUMMARY_MISSING_FIELDS,
     SETUP_AGENTS_CORRUPTED,
     SETUP_AGENTS_READ_FALLBACK,
+    SETUP_MODEL_FALLBACK_USED,
     SETUP_MODEL_NOT_FOUND,
     SETUP_PRESET_NOT_FOUND,
     SETUP_PROVIDER_NOT_FOUND,
@@ -167,8 +168,16 @@ def match_and_assign_models(
         if idx in match_map:
             result.append({**agent, "model": match_map[idx]})
         else:
-            logger.warning(
-                SETUP_MODEL_NOT_FOUND,
+            # Issue #1666 B-5: downgrade to DEBUG. The matcher's
+            # tier-fallback path is the documented contract; only
+            # the wizard's pre-flight provider gate (added in this
+            # change) escalates "no models at all" to a 422 user
+            # error. This branch fires when the matcher returned no
+            # match for an agent (rare with the gate in place);
+            # leaving a DEBUG breadcrumb still lets operators trace
+            # it without polluting WARNING-level logs.
+            logger.debug(
+                SETUP_MODEL_FALLBACK_USED,
                 agent_index=idx,
                 agent_name=agent.get("name", ""),
                 tier=agent.get("tier", ""),

--- a/src/synthorg/api/controllers/setup_helpers.py
+++ b/src/synthorg/api/controllers/setup_helpers.py
@@ -32,6 +32,7 @@ from synthorg.observability.events.setup import (
     SETUP_NAME_LOCALES_CORRUPTED,
     SETUP_NAME_LOCALES_INVALID,
     SETUP_PROVIDER_RELOAD_FAILED,
+    SETUP_PROVIDER_TIER_COVERAGE_INSUFFICIENT,
     SETUP_STATUS_SETTINGS_DEFAULT_USED,
     SETUP_STATUS_SETTINGS_UNAVAILABLE,
     SETUP_TEMPLATE_INVALID,
@@ -42,6 +43,8 @@ from synthorg.settings.enums import SettingSource
 from synthorg.settings.errors import SettingNotFoundError
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from synthorg.persistence.protocol import PersistenceBackend
     from synthorg.settings.service import SettingsService
     from synthorg.templates.loader import LoadedTemplate
@@ -389,6 +392,41 @@ async def check_setup_not_complete(
         raise ConflictError(msg)
 
 
+def _validate_tier_coverage(providers: Mapping[str, Any]) -> None:
+    """Reject provider sets that cannot satisfy tier classification.
+
+    The model matcher tolerates fewer than three models per provider
+    (``_MIN_TIER_SIZE`` in ``model_matcher.py``: it returns all
+    models for every tier in that case), so the gate's job is just
+    to stop the truly empty case -- zero models across all
+    registered providers, which is what produces the per-agent
+    ``no_models_available`` warnings the issue called out. Setups
+    with a couple of models continue to work; the matcher just
+    assigns the same model to every tier.
+
+    Args:
+        providers: Provider name -> config mapping resolved from
+            ``provider_management.list_providers()``.
+
+    Raises:
+        ValidationError: When NO models are available across the
+            registered providers.
+    """
+    total_models = sum(len(getattr(cfg, "models", ())) for cfg in providers.values())
+    if total_models > 0:
+        return
+    msg = (
+        "Configured providers expose no models. Add at least one "
+        "model to a provider before creating agents."
+    )
+    logger.warning(
+        SETUP_PROVIDER_TIER_COVERAGE_INSUFFICIENT,
+        provider_count=len(providers),
+        total_model_count=0,
+    )
+    raise ValidationError(msg)
+
+
 async def auto_create_template_agents(
     template: CompanyTemplate,
     app_state: AppState,
@@ -415,6 +453,7 @@ async def auto_create_template_agents(
         custom_presets=custom_presets,
     )
     providers = prov_task.result()
+    _validate_tier_coverage(providers)
     agents = match_and_assign_models(agents, providers)
 
     async with AGENT_LOCK:

--- a/src/synthorg/api/exception_handlers.py
+++ b/src/synthorg/api/exception_handlers.py
@@ -817,10 +817,10 @@ def handle_http_exception(
 # UniqueViolation, NotNullViolation, ...) to the validation 400 path.
 _PSYCOPG_INTEGRITY_HANDLER: tuple[type[Exception], object] | None = None
 try:
-    from psycopg.errors import IntegrityError as _PsycopgIntegrityError
+    import psycopg.errors as _psycopg_errors  # lint-allow: persistence-boundary -- HTTP 400 backstop for #1666 B-1  # noqa: E501
 
     _PSYCOPG_INTEGRITY_HANDLER = (
-        _PsycopgIntegrityError,
+        _psycopg_errors.IntegrityError,
         handle_persistence_integrity_error,
     )
 except ImportError:

--- a/src/synthorg/api/exception_handlers.py
+++ b/src/synthorg/api/exception_handlers.py
@@ -48,6 +48,7 @@ from synthorg.core.error_taxonomy import (
     category_type_uri,
 )
 from synthorg.core.persistence_errors import (
+    ConstraintViolationError,
     DuplicateRecordError,
     PersistenceError,
     RecordNotFoundError,
@@ -807,39 +808,23 @@ def handle_http_exception(
     )
 
 
-# Lazy-import psycopg.errors so SQLite-only test runs and dev installs
-# without psycopg are unaffected.  When psycopg is not importable, the
-# IntegrityError handler entry is omitted from the table and any leak
-# of an actual ``psycopg.errors.IntegrityError`` falls through to the
-# generic ``Exception -> handle_unexpected`` (500) path -- which is the
-# same behaviour as before this fix.  When psycopg IS importable, the
-# entry maps every IntegrityError subclass (ForeignKeyViolation,
-# UniqueViolation, NotNullViolation, ...) to the validation 400 path.
-_PSYCOPG_INTEGRITY_HANDLER: tuple[type[Exception], object] | None = None
-try:
-    import psycopg.errors as _psycopg_errors  # lint-allow: persistence-boundary -- HTTP 400 backstop for #1666 B-1  # noqa: E501
-
-    _PSYCOPG_INTEGRITY_HANDLER = (
-        _psycopg_errors.IntegrityError,
-        handle_persistence_integrity_error,
-    )
-except ImportError:
-    _PSYCOPG_INTEGRITY_HANDLER = None
-
-
-# Declarative entry list for ``EXCEPTION_HANDLERS``. The optional
-# psycopg.errors.IntegrityError entry is filtered out of the
-# ``MappingProxyType`` build below when the import failed, so the
-# whole table is one expression: a tuple of (type | None, handler)
-# pairs followed by a single dict-comprehension filter. Litestar
-# resolves handlers by walking the raised exception's MRO and picks
-# the first matching type, so dict insertion order does not affect
-# resolution priority. ``HTTPException`` integer status-code keys
-# are resolved separately by Litestar; this table uses only type
-# keys.
-_HANDLER_ENTRIES: tuple[tuple[type[Exception] | None, object], ...] = (
+# Persistence-layer integrity violations (FK / unique / not-null /
+# generic constraint failures) translate into ``ConstraintViolationError``
+# inside the repository modules; the api layer catches that domain
+# class instead of importing the psycopg driver directly so the HTTP
+# layer stays decoupled from the persistence backend choice. Per the
+# project persistence-boundary rule, ``psycopg`` may only be imported
+# from ``src/synthorg/persistence/``; the previous direct import here
+# was a sanctioned exception kept while the driver-translation path
+# was incomplete -- now that ``ConstraintViolationError`` is the
+# established domain mapping (see
+# ``synthorg.persistence.postgres.approval_repo`` for the canonical
+# translation pattern), the api layer registers the domain class and
+# the driver import is no longer needed.
+_HANDLER_ENTRIES: tuple[tuple[type[Exception], object], ...] = (
     (RecordNotFoundError, handle_record_not_found),
     (DuplicateRecordError, handle_duplicate_record),
+    (ConstraintViolationError, handle_persistence_integrity_error),
     (PersistenceError, handle_persistence_error),
     (NotAuthorizedException, handle_not_authorized),
     (PermissionDeniedException, handle_permission_denied),
@@ -847,13 +832,6 @@ _HANDLER_ENTRIES: tuple[tuple[type[Exception] | None, object], ...] = (
     (InvalidCursorError, handle_invalid_cursor),
     (NotFoundException, handle_not_found),
     (HTTPException, handle_http_exception),
-    # Lazy psycopg import: ``None`` slot when psycopg is unavailable
-    # (SQLite-only test runs); filtered out by the comprehension
-    # below so the entry is simply absent rather than a sentinel.
-    (
-        _PSYCOPG_INTEGRITY_HANDLER[0] if _PSYCOPG_INTEGRITY_HANDLER else None,
-        _PSYCOPG_INTEGRITY_HANDLER[1] if _PSYCOPG_INTEGRITY_HANDLER else None,
-    ),
     # Domain error hierarchies -- MRO dispatch covers every subclass.
     # ``RateLimitError`` is listed explicitly so its narrower 429
     # status takes precedence over the ``ProviderError`` (502) default
@@ -873,6 +851,14 @@ _HANDLER_ENTRIES: tuple[tuple[type[Exception] | None, object], ...] = (
 )
 
 
+# Litestar resolves exception handlers by walking the raised exception's
+# MRO and picks the first matching type, so dict insertion order does
+# not affect resolution priority. ``HTTPException`` integer status-code
+# keys are resolved separately by Litestar; this table uses only type
+# keys. ``ConstraintViolationError`` is registered above
+# ``PersistenceError`` (its parent via ``QueryError``) so the
+# narrower 400 mapping wins for FK / unique violations -- if it were
+# below, MRO would still pick the first match.
 EXCEPTION_HANDLERS: MappingProxyType[type[Exception], object] = MappingProxyType(
     {
         exc_type: handler

--- a/src/synthorg/api/exception_handlers.py
+++ b/src/synthorg/api/exception_handlers.py
@@ -827,45 +827,56 @@ except ImportError:
     _PSYCOPG_INTEGRITY_HANDLER = None
 
 
-def _build_exception_handlers() -> MappingProxyType[type[Exception], object]:
-    """Build the EXCEPTION_HANDLERS table, splicing in psycopg if present."""
-    table: dict[type[Exception], object] = {
-        RecordNotFoundError: handle_record_not_found,
-        DuplicateRecordError: handle_duplicate_record,
-        PersistenceError: handle_persistence_error,
-        NotAuthorizedException: handle_not_authorized,
-        PermissionDeniedException: handle_permission_denied,
-        ValidationException: handle_validation_error,
-        InvalidCursorError: handle_invalid_cursor,
-        NotFoundException: handle_not_found,
-        HTTPException: handle_http_exception,
+# Declarative entry list for ``EXCEPTION_HANDLERS``. The optional
+# psycopg.errors.IntegrityError entry is filtered out of the
+# ``MappingProxyType`` build below when the import failed, so the
+# whole table is one expression: a tuple of (type | None, handler)
+# pairs followed by a single dict-comprehension filter. Litestar
+# resolves handlers by walking the raised exception's MRO and picks
+# the first matching type, so dict insertion order does not affect
+# resolution priority. ``HTTPException`` integer status-code keys
+# are resolved separately by Litestar; this table uses only type
+# keys.
+_HANDLER_ENTRIES: tuple[tuple[type[Exception] | None, object], ...] = (
+    (RecordNotFoundError, handle_record_not_found),
+    (DuplicateRecordError, handle_duplicate_record),
+    (PersistenceError, handle_persistence_error),
+    (NotAuthorizedException, handle_not_authorized),
+    (PermissionDeniedException, handle_permission_denied),
+    (ValidationException, handle_validation_error),
+    (InvalidCursorError, handle_invalid_cursor),
+    (NotFoundException, handle_not_found),
+    (HTTPException, handle_http_exception),
+    # Lazy psycopg import: ``None`` slot when psycopg is unavailable
+    # (SQLite-only test runs); filtered out by the comprehension
+    # below so the entry is simply absent rather than a sentinel.
+    (
+        _PSYCOPG_INTEGRITY_HANDLER[0] if _PSYCOPG_INTEGRITY_HANDLER else None,
+        _PSYCOPG_INTEGRITY_HANDLER[1] if _PSYCOPG_INTEGRITY_HANDLER else None,
+    ),
+    # Domain error hierarchies -- MRO dispatch covers every subclass.
+    # ``RateLimitError`` is listed explicitly so its narrower 429
+    # status takes precedence over the ``ProviderError`` (502) default
+    # when Litestar walks the raised exception's MRO.
+    (RateLimitError, handle_domain_error),
+    (EngineError, handle_domain_error),
+    (BudgetExhaustedError, handle_domain_error),
+    (MixedCurrencyAggregationError, handle_domain_error),
+    (ProviderError, handle_domain_error),
+    (OntologyError, handle_domain_error),
+    (CommunicationError, handle_domain_error),
+    (IntegrationError, handle_domain_error),
+    (ToolError, handle_domain_error),
+    (DomainError, handle_domain_error),
+    (BackupError, handle_backup_error),
+    (Exception, handle_unexpected),
+)
+
+
+EXCEPTION_HANDLERS: MappingProxyType[type[Exception], object] = MappingProxyType(
+    {
+        exc_type: handler
+        for exc_type, handler in _HANDLER_ENTRIES
+        if exc_type is not None
     }
-    if _PSYCOPG_INTEGRITY_HANDLER is not None:
-        table[_PSYCOPG_INTEGRITY_HANDLER[0]] = _PSYCOPG_INTEGRITY_HANDLER[1]
-    table.update(
-        {
-            RateLimitError: handle_domain_error,
-            EngineError: handle_domain_error,
-            BudgetExhaustedError: handle_domain_error,
-            MixedCurrencyAggregationError: handle_domain_error,
-            ProviderError: handle_domain_error,
-            OntologyError: handle_domain_error,
-            CommunicationError: handle_domain_error,
-            IntegrationError: handle_domain_error,
-            ToolError: handle_domain_error,
-            DomainError: handle_domain_error,
-            BackupError: handle_backup_error,
-            Exception: handle_unexpected,
-        }
-    )
-    return MappingProxyType(table)
-
-
-# Litestar resolves exception handlers by walking the raised exception's
-# MRO -- the first matching type found in this dict wins.  Dict insertion
-# order does NOT affect resolution priority.  (For HTTPException subclasses,
-# Litestar also checks integer status-code keys first, but this dict uses
-# only type keys.)
-EXCEPTION_HANDLERS: MappingProxyType[type[Exception], object] = (
-    _build_exception_handlers()
 )

--- a/src/synthorg/api/exception_handlers.py
+++ b/src/synthorg/api/exception_handlers.py
@@ -416,6 +416,34 @@ def handle_persistence_error(
     )
 
 
+def handle_persistence_integrity_error(
+    request: Request[Any, Any, Any],
+    exc: Exception,
+) -> Response[ApiResponse[None]] | Response[ProblemDetail]:
+    """Map ``psycopg.errors.IntegrityError`` (and subclasses) to 400.
+
+    Foreign-key, unique, and not-null violations raised by the
+    underlying driver indicate that the request body referenced a
+    row that does not exist (or violates a uniqueness constraint).
+    These are caller errors, not server errors -- 400 with a
+    structured body is the honest mapping.
+
+    Domain code is expected to validate-first and raise typed
+    domain errors (``ConnectionNotFoundError`` / ``ValidationError``)
+    so this handler is a backstop, not the primary path. Logging
+    via the standard helper keeps any embedded SQL fragments out
+    of the audit trail.
+    """
+    _log_error(request, exc, status=400)
+    return _build_response(
+        request,
+        detail="persistence integrity violation",
+        error_code=ErrorCode.VALIDATION_ERROR,
+        error_category=ErrorCategory.VALIDATION,
+        status_code=400,
+    )
+
+
 def handle_backup_error(
     request: Request[Any, Any, Any],
     exc: BackupError,
@@ -779,13 +807,29 @@ def handle_http_exception(
     )
 
 
-# Litestar resolves exception handlers by walking the raised exception's
-# MRO -- the first matching type found in this dict wins.  Dict insertion
-# order does NOT affect resolution priority.  (For HTTPException subclasses,
-# Litestar also checks integer status-code keys first, but this dict uses
-# only type keys.)
-EXCEPTION_HANDLERS: MappingProxyType[type[Exception], object] = MappingProxyType(
-    {
+# Lazy-import psycopg.errors so SQLite-only test runs and dev installs
+# without psycopg are unaffected.  When psycopg is not importable, the
+# IntegrityError handler entry is omitted from the table and any leak
+# of an actual ``psycopg.errors.IntegrityError`` falls through to the
+# generic ``Exception -> handle_unexpected`` (500) path -- which is the
+# same behaviour as before this fix.  When psycopg IS importable, the
+# entry maps every IntegrityError subclass (ForeignKeyViolation,
+# UniqueViolation, NotNullViolation, ...) to the validation 400 path.
+_PSYCOPG_INTEGRITY_HANDLER: tuple[type[Exception], object] | None = None
+try:
+    from psycopg.errors import IntegrityError as _PsycopgIntegrityError
+
+    _PSYCOPG_INTEGRITY_HANDLER = (
+        _PsycopgIntegrityError,
+        handle_persistence_integrity_error,
+    )
+except ImportError:
+    _PSYCOPG_INTEGRITY_HANDLER = None
+
+
+def _build_exception_handlers() -> MappingProxyType[type[Exception], object]:
+    """Build the EXCEPTION_HANDLERS table, splicing in psycopg if present."""
+    table: dict[type[Exception], object] = {
         RecordNotFoundError: handle_record_not_found,
         DuplicateRecordError: handle_duplicate_record,
         PersistenceError: handle_persistence_error,
@@ -795,24 +839,33 @@ EXCEPTION_HANDLERS: MappingProxyType[type[Exception], object] = MappingProxyType
         InvalidCursorError: handle_invalid_cursor,
         NotFoundException: handle_not_found,
         HTTPException: handle_http_exception,
-        # Domain error hierarchies -- MRO dispatch covers every subclass.
-        # RateLimitError is listed explicitly so its narrower 429 status
-        # takes precedence over the ProviderError (502) default when
-        # Litestar walks the raised exception's MRO.  ``DomainError`` is
-        # the universal RFC-9457 base for what was previously the
-        # ``ApiError`` family plus the generic NotFoundError /
-        # ConflictError / ValidationError relocated to ``core``.
-        RateLimitError: handle_domain_error,
-        EngineError: handle_domain_error,
-        BudgetExhaustedError: handle_domain_error,
-        MixedCurrencyAggregationError: handle_domain_error,
-        ProviderError: handle_domain_error,
-        OntologyError: handle_domain_error,
-        CommunicationError: handle_domain_error,
-        IntegrationError: handle_domain_error,
-        ToolError: handle_domain_error,
-        DomainError: handle_domain_error,
-        BackupError: handle_backup_error,
-        Exception: handle_unexpected,
     }
+    if _PSYCOPG_INTEGRITY_HANDLER is not None:
+        table[_PSYCOPG_INTEGRITY_HANDLER[0]] = _PSYCOPG_INTEGRITY_HANDLER[1]
+    table.update(
+        {
+            RateLimitError: handle_domain_error,
+            EngineError: handle_domain_error,
+            BudgetExhaustedError: handle_domain_error,
+            MixedCurrencyAggregationError: handle_domain_error,
+            ProviderError: handle_domain_error,
+            OntologyError: handle_domain_error,
+            CommunicationError: handle_domain_error,
+            IntegrationError: handle_domain_error,
+            ToolError: handle_domain_error,
+            DomainError: handle_domain_error,
+            BackupError: handle_backup_error,
+            Exception: handle_unexpected,
+        }
+    )
+    return MappingProxyType(table)
+
+
+# Litestar resolves exception handlers by walking the raised exception's
+# MRO -- the first matching type found in this dict wins.  Dict insertion
+# order does NOT affect resolution priority.  (For HTTPException subclasses,
+# Litestar also checks integer status-code keys first, but this dict uses
+# only type keys.)
+EXCEPTION_HANDLERS: MappingProxyType[type[Exception], object] = (
+    _build_exception_handlers()
 )

--- a/src/synthorg/api/state.py
+++ b/src/synthorg/api/state.py
@@ -21,6 +21,9 @@ from synthorg.api.services.org_mutations import OrgMutationService
 from synthorg.api.state_services import AppStateServicesMixin
 from synthorg.approval.protocol import ApprovalStoreProtocol  # noqa: TC001
 from synthorg.backup.service import BackupService  # noqa: TC001
+from synthorg.budget.automated_reports import (
+    AutomatedReportService,  # noqa: TC001
+)
 from synthorg.budget.coordination_store import (
     CoordinationMetricsStore,  # noqa: TC001
 )
@@ -219,6 +222,7 @@ class AppState(AppStateServicesMixin):
         "_provider_registry",
         "_quality_facade_service",
         "_refresh_store",
+        "_report_service",
         "_reports_service",
         "_requests_facade_service",
         "_review_facade_service",
@@ -329,6 +333,7 @@ class AppState(AppStateServicesMixin):
         self._performance_tracker = performance_tracker
         self._trust_service = trust_service
         self._telemetry_collector: TelemetryCollector | None = None
+        self._report_service: AutomatedReportService | None = None
         self._meeting_orchestrator = meeting_orchestrator
         self._meeting_scheduler = meeting_scheduler
         self._ceremony_scheduler = ceremony_scheduler
@@ -874,6 +879,20 @@ class AppState(AppStateServicesMixin):
     def set_telemetry_collector(self, collector: TelemetryCollector) -> None:
         """Attach the project telemetry collector (once-only)."""
         self._set_once("_telemetry_collector", collector, "telemetry collector")
+
+    @property
+    def has_report_service(self) -> bool:
+        """Check whether the automated report service is configured."""
+        return self._report_service is not None
+
+    @property
+    def report_service(self) -> AutomatedReportService:
+        """Return the automated report service or raise 503."""
+        return self._require_service(self._report_service, "report_service")
+
+    def set_report_service(self, service: AutomatedReportService) -> None:
+        """Attach the automated report service (once-only)."""
+        self._set_once("_report_service", service, "report service")
 
     @property
     def coordination_metrics_store(self) -> CoordinationMetricsStore:

--- a/src/synthorg/integrations/tunnel/ngrok_adapter.py
+++ b/src/synthorg/integrations/tunnel/ngrok_adapter.py
@@ -29,8 +29,9 @@ logger = get_logger(__name__)
 class NgrokAdapter:
     """ngrok tunnel provider.
 
-    Exposes the local API port on a public ngrok URL.
-    Requires ``pyngrok`` to be installed (optional dependency).
+    Exposes the local API port on a public ngrok URL. ``pyngrok``
+    is a required runtime dependency; the import is unconditional
+    at module level (#1666 B-4).
 
     All ngrok calls are blocking, so they are offloaded to a
     worker thread via ``asyncio.to_thread`` to keep the event

--- a/src/synthorg/integrations/tunnel/ngrok_adapter.py
+++ b/src/synthorg/integrations/tunnel/ngrok_adapter.py
@@ -1,11 +1,19 @@
 """ngrok tunnel adapter for local webhook development.
 
-Wraps the ``pyngrok`` library (or ngrok binary) to expose the
-local API server on a public URL for receiving webhooks.
+Wraps the ``pyngrok`` library to expose the local API server on a
+public URL for receiving webhooks.
+
+``pyngrok`` is a required runtime dependency (declared in
+``pyproject.toml`` ``[project.dependencies]``); a missing import
+here would be a build / install bug, not a runtime configuration
+issue, so the import is unconditional. Operators who do not need
+the tunnel feature simply do not call the start endpoint.
 """
 
 import asyncio
 import os
+
+from pyngrok import conf, ngrok  # type: ignore[import-not-found]
 
 from synthorg.integrations.errors import TunnelError
 from synthorg.observability import get_logger, safe_error_description
@@ -53,25 +61,11 @@ class NgrokAdapter:
             The public URL.
 
         Raises:
-            TunnelError: If ngrok is not installed or fails to start.
+            TunnelError: If the tunnel fails to start (auth rejected,
+                ngrok service down, etc.). ``pyngrok`` itself is a
+                required runtime dependency so an ImportError here is
+                a build / install bug rather than a runtime concern.
         """
-        try:
-            from pyngrok import (  # type: ignore[import-not-found]  # noqa: PLC0415
-                conf,
-                ngrok,
-            )
-        except ImportError as exc:
-            logger.warning(
-                TUNNEL_ERROR,
-                error="pyngrok not installed",
-                exc_info=True,
-            )
-            msg = (
-                "pyngrok is not installed. Install it with "
-                "'pip install pyngrok' to use the tunnel feature."
-            )
-            raise TunnelError(msg) from exc
-
         auth_token = os.environ.get(self._auth_token_env, "").strip()
         if auth_token:
             conf.get_default().auth_token = auth_token
@@ -113,8 +107,6 @@ class NgrokAdapter:
         if self._tunnel is None:
             return
         try:
-            from pyngrok import ngrok  # noqa: PLC0415
-
             await asyncio.to_thread(ngrok.disconnect, self._public_url)
         except Exception as exc:
             logger.warning(

--- a/src/synthorg/integrations/tunnel/ngrok_adapter.py
+++ b/src/synthorg/integrations/tunnel/ngrok_adapter.py
@@ -13,7 +13,7 @@ the tunnel feature simply do not call the start endpoint.
 import asyncio
 import os
 
-from pyngrok import conf, ngrok  # type: ignore[import-not-found]
+from pyngrok import conf, ngrok  # type: ignore[import-untyped]
 
 from synthorg.integrations.errors import TunnelError
 from synthorg.observability import get_logger, safe_error_description

--- a/src/synthorg/observability/events/setup.py
+++ b/src/synthorg/observability/events/setup.py
@@ -40,6 +40,23 @@ SETUP_PROVIDER_NOT_FOUND: Final[str] = "setup.agent.provider_not_found"
 # Model not found in provider during agent creation
 SETUP_MODEL_NOT_FOUND: Final[str] = "setup.agent.model_not_found"
 
+# Tier matcher could not assign a per-tier model and fell back to the
+# first available model. Logged at DEBUG because fallback IS the
+# documented contract for tier-mismatch and the wizard provider gate
+# now blocks the "no models at all" case where this would actually
+# matter. See issue #1666 B-5.
+SETUP_MODEL_FALLBACK_USED: Final[str] = "setup.agent.model_fallback_used"
+
+# Wizard rejected a provider that could not surface a tier-classifiable
+# model set. The matcher's _MIN_TIER_SIZE = 3 floor requires at least
+# three models with a cost signal so the small/medium/large bucketing
+# is meaningful; below that the operator sees a 422 with this event
+# logged once instead of per-agent matcher warnings during agent
+# creation.
+SETUP_PROVIDER_TIER_COVERAGE_INSUFFICIENT: Final[str] = (
+    "setup.provider.tier_coverage_insufficient"
+)
+
 # No providers configured when attempting to complete setup
 SETUP_NO_PROVIDERS: Final[str] = "setup.flow.no_providers"
 

--- a/src/synthorg/observability/events/telemetry.py
+++ b/src/synthorg/observability/events/telemetry.py
@@ -20,6 +20,12 @@ TELEMETRY_PRIVACY_VIOLATION: Final[str] = "telemetry.privacy.violation"
 TELEMETRY_ENABLED: Final[str] = "telemetry.enabled"
 TELEMETRY_DISABLED: Final[str] = "telemetry.disabled"
 TELEMETRY_REPORTER_INITIALIZED: Final[str] = "telemetry.reporter.initialized"
+# Emitted ONCE at startup when telemetry is enabled but the build artifact
+# ships a sentinel token instead of the embedded write-only project token.
+# This is a build-time misconfiguration, not a runtime issue; surfacing it
+# loudly at boot lets operators escalate to the build pipeline rather than
+# silently degrading to a noop reporter.
+TELEMETRY_TOKEN_MISSING: Final[str] = "telemetry.token.missing"  # noqa: S105
 TELEMETRY_ENVIRONMENT_RESOLVED: Final[str] = "telemetry.environment.resolved"
 # Emitted when an existing deployment ID is read from disk during start().
 TELEMETRY_DEPLOYMENT_ID_LOADED: Final[str] = "telemetry.deployment_id.loaded"

--- a/src/synthorg/observability/events/template.py
+++ b/src/synthorg/observability/events/template.py
@@ -53,6 +53,14 @@ TEMPLATE_WORKFLOW_CONFIG_UNKNOWN_KEY: Final[str] = (
 TEMPLATE_MODEL_MATCH_SUCCESS: Final[str] = "template.model_match.success"
 TEMPLATE_MODEL_MATCH_FAILED: Final[str] = "template.model_match.failed"
 TEMPLATE_MODEL_MATCH_SKIPPED: Final[str] = "template.model_match.skipped"
+# Emitted at DEBUG when the requested tier had no models but the
+# fallback path (first available model with score 0) succeeded.
+# Fallback is the documented contract per the design page; treating
+# it as a WARNING produced ~8 noisy log lines during every clean
+# setup wizard run (issue #1666 B-5). Operators only see WARNING
+# now when the fallback ALSO fails (no models available at all),
+# which after the wizard provider gate should not fire in practice.
+TEMPLATE_MODEL_MATCH_FALLBACK: Final[str] = "template.model_match.fallback"
 
 # Template packs
 TEMPLATE_PACK_LOAD_START: Final[str] = "template.pack.load.start"

--- a/src/synthorg/observability/sinks.py
+++ b/src/synthorg/observability/sinks.py
@@ -22,6 +22,10 @@ from structlog.stdlib import ProcessorFormatter
 
 from synthorg.observability.config import RotationConfig, SinkConfig
 from synthorg.observability.enums import RotationStrategy, SinkType
+from synthorg.observability.events.api import (
+    API_REQUEST_COMPLETED,
+    API_REQUEST_STARTED,
+)
 
 # ── Flushing file handlers ────────────────────────────────────────
 # Standard RotatingFileHandler and WatchedFileHandler buffer writes,
@@ -193,7 +197,7 @@ SINK_ROUTING: MappingProxyType[str, tuple[str, ...]] = MappingProxyType(
 # bury every other event.
 SINK_EVENT_EXCLUDES: MappingProxyType[str, tuple[str, ...]] = MappingProxyType(
     {
-        "synthorg.log": ("api.request.started", "api.request.completed"),
+        "synthorg.log": (API_REQUEST_STARTED, API_REQUEST_COMPLETED),
     }
 )
 

--- a/src/synthorg/observability/sinks.py
+++ b/src/synthorg/observability/sinks.py
@@ -185,6 +185,28 @@ SINK_ROUTING: MappingProxyType[str, tuple[str, ...]] = MappingProxyType(
     }
 )
 
+# Maps sink file_path to structlog event names that must NOT land
+# in that sink even if the logger-name include filter matches.  Used
+# to keep request-lifecycle events out of ``synthorg.log`` (they
+# already have a dedicated home in ``access.log``); without this
+# 96% of main-log volume would be duplicated request records that
+# bury every other event.
+SINK_EVENT_EXCLUDES: MappingProxyType[str, tuple[str, ...]] = MappingProxyType(
+    {
+        "synthorg.log": ("api.request.started", "api.request.completed"),
+    }
+)
+
+# Maps sink file_path to a strict level-equality filter.  ``debug.log``
+# is pinned to ``DEBUG`` exactly so it stays empty when nothing emits
+# DEBUG instead of accidentally collecting INFO+ as a duplicate of the
+# main log.
+SINK_EXACT_LEVELS: MappingProxyType[str, int] = MappingProxyType(
+    {
+        "debug.log": logging.DEBUG,
+    }
+)
+
 
 class _LoggerNameFilter(logging.Filter):
     """Filter log records by logger name prefixes.
@@ -221,6 +243,55 @@ class _LoggerNameFilter(logging.Filter):
         if self._include:
             return any(name.startswith(prefix) for prefix in self._include)
         return True
+
+
+class _EventNameFilter(logging.Filter):
+    """Filter records by structlog event name.
+
+    Records produced through ``structlog.stdlib.ProcessorFormatter.
+    wrap_for_formatter`` carry the processed event_dict as
+    ``record.msg`` (a ``dict`` with an ``event`` key plus all
+    structured kwargs).  Foreign records from third-party loggers
+    carry ``record.msg`` as a plain string -- in that case we
+    compare the string directly so the filter is robust across
+    both record shapes.
+
+    Args:
+        exclude_events: Event names to drop (empty = drop nothing).
+    """
+
+    def __init__(self, *, exclude_events: tuple[str, ...] = ()) -> None:
+        super().__init__()
+        for event in exclude_events:
+            if not event or not event.strip():
+                msg = "Excluded event names must be non-empty strings"
+                raise ValueError(msg)
+        self._exclude = frozenset(exclude_events)
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Return ``True`` if *record* is not in the exclude set."""
+        if not self._exclude:
+            return True
+        msg = record.msg
+        event = msg.get("event", "") if isinstance(msg, dict) else str(msg)
+        return event not in self._exclude
+
+
+class _ExactLevelFilter(logging.Filter):
+    """Accept only records whose level is *exactly* ``levelno``.
+
+    Standard ``handler.setLevel(level)`` accepts ``level`` and above;
+    this filter narrows the gate so a sink can be pinned to one
+    level (``debug.log`` to DEBUG only, for example).
+    """
+
+    def __init__(self, *, levelno: int) -> None:
+        super().__init__()
+        self._levelno = levelno
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Return ``True`` only when ``record.levelno`` matches."""
+        return record.levelno == self._levelno
 
 
 def _ensure_log_dir(file_path: Path, sink_name: str) -> None:
@@ -325,14 +396,35 @@ def _attach_formatter_and_routing(
     foreign_pre_chain: list[Any],
     routing: Mapping[str, tuple[str, ...]],
 ) -> None:
-    """Set formatter and optional routing filter on a handler."""
+    """Set formatter and optional routing filters on a handler.
+
+    Three filter mechanisms are layered, each driven by its own
+    sink-keyed table:
+
+    * ``routing`` (``SINK_ROUTING``): logger-name prefix include.
+    * ``SINK_EVENT_EXCLUDES``: drop specific structlog event names
+      (e.g. request lifecycle out of the catch-all ``synthorg.log``).
+    * ``SINK_EXACT_LEVELS``: pin a sink to one level (``debug.log``
+      to DEBUG only) instead of "this level and above".
+    """
     handler.setLevel(sink.level.value)
     handler.setFormatter(_build_formatter(sink, foreign_pre_chain))
-    if sink.file_path is not None and sink.file_path in routing:
-        name_filter = _LoggerNameFilter(
-            include_prefixes=routing[sink.file_path],
+    if sink.file_path is None:
+        return
+    if sink.file_path in routing:
+        handler.addFilter(
+            _LoggerNameFilter(include_prefixes=routing[sink.file_path]),
         )
-        handler.addFilter(name_filter)
+    if sink.file_path in SINK_EVENT_EXCLUDES:
+        handler.addFilter(
+            _EventNameFilter(
+                exclude_events=SINK_EVENT_EXCLUDES[sink.file_path],
+            ),
+        )
+    if sink.file_path in SINK_EXACT_LEVELS:
+        handler.addFilter(
+            _ExactLevelFilter(levelno=SINK_EXACT_LEVELS[sink.file_path]),
+        )
 
 
 def build_handler(

--- a/src/synthorg/settings/definitions/__init__.py
+++ b/src/synthorg/settings/definitions/__init__.py
@@ -23,6 +23,7 @@ from synthorg.settings.definitions import (
     providers,
     security,
     settings_ns,
+    telemetry,
     tools,
     workers,
 )
@@ -46,6 +47,7 @@ __all__ = [
     "providers",
     "security",
     "settings_ns",
+    "telemetry",
     "tools",
     "workers",
 ]

--- a/src/synthorg/settings/definitions/telemetry.py
+++ b/src/synthorg/settings/definitions/telemetry.py
@@ -1,6 +1,6 @@
 """Telemetry namespace setting definitions.
 
-Anonymous Logfire telemetry is opt-in and off by default. The
+Anonymous product telemetry is opt-in and off by default. The
 write-only project token is **embedded** in the release wheel at
 build time (``synthorg.telemetry.reporters._embedded_token``);
 operators never configure or paste it. They flip
@@ -22,9 +22,9 @@ _r.register(
         type=SettingType.BOOLEAN,
         default="false",
         description=(
-            "Send anonymous usage telemetry to the SynthOrg-owned"
-            " Logfire project. Token is embedded; operators only"
-            " toggle this flag."
+            "Send anonymous product telemetry to the SynthOrg-owned"
+            " telemetry backend. Token is embedded at build time;"
+            " operators only toggle this flag."
         ),
         group="General",
         level=SettingLevel.BASIC,

--- a/src/synthorg/settings/definitions/telemetry.py
+++ b/src/synthorg/settings/definitions/telemetry.py
@@ -1,0 +1,34 @@
+"""Telemetry namespace setting definitions.
+
+Anonymous Logfire telemetry is opt-in and off by default. The
+write-only project token is **embedded** in the release wheel at
+build time (``synthorg.telemetry.reporters._embedded_token``);
+operators never configure or paste it. They flip
+``telemetry.enabled`` (or ``SYNTHORG_TELEMETRY_ENABLED=1``) and
+either get the embedded token (release wheel) or a single-shot
+ERROR at startup explaining the build artifact is missing it.
+"""
+
+from synthorg.settings.enums import SettingLevel, SettingNamespace, SettingType
+from synthorg.settings.models import SettingDefinition
+from synthorg.settings.registry import get_registry
+
+_r = get_registry()
+
+_r.register(
+    SettingDefinition(
+        namespace=SettingNamespace.TELEMETRY,
+        key="enabled",
+        type=SettingType.BOOLEAN,
+        default="false",
+        description=(
+            "Send anonymous usage telemetry to the SynthOrg-owned"
+            " Logfire project. Token is embedded; operators only"
+            " toggle this flag."
+        ),
+        group="General",
+        level=SettingLevel.BASIC,
+        env_var_override="SYNTHORG_TELEMETRY_ENABLED",
+        yaml_path="telemetry.enabled",
+    )
+)

--- a/src/synthorg/settings/definitions/telemetry.py
+++ b/src/synthorg/settings/definitions/telemetry.py
@@ -22,13 +22,19 @@ _r.register(
         type=SettingType.BOOLEAN,
         default="false",
         description=(
-            "Send anonymous product telemetry to the SynthOrg-owned"
-            " telemetry backend. Token is embedded at build time;"
-            " operators only toggle this flag."
+            "Send anonymous product telemetry to the project's telemetry"
+            " backend. Token is embedded at build time; operators only"
+            " toggle this flag."
         ),
         group="General",
         level=SettingLevel.BASIC,
         env_var_override="SYNTHORG_TELEMETRY_ENABLED",
         yaml_path="telemetry.enabled",
+        # The collector is constructed during Phase 1 of app build
+        # (before SettingsService exists), so a DB edit cannot reach
+        # it without a process restart. Mark this explicitly so the
+        # /settings UI surfaces the restart-required affordance and
+        # operators don't expect runtime hot-flips.
+        restart_required=True,
     )
 )

--- a/src/synthorg/settings/enums.py
+++ b/src/synthorg/settings/enums.py
@@ -30,6 +30,7 @@ class SettingNamespace(StrEnum):
     DISPLAY = "display"
     HR = "hr"
     WORKERS = "workers"
+    TELEMETRY = "telemetry"
 
 
 class SettingType(StrEnum):

--- a/src/synthorg/telemetry/__init__.py
+++ b/src/synthorg/telemetry/__init__.py
@@ -16,7 +16,7 @@ Architecture:
 
 Telemetry is **disabled by default**.  Enable via:
 
-- ``SYNTHORG_TELEMETRY=true`` environment variable (containers)
+- ``SYNTHORG_TELEMETRY_ENABLED=true`` environment variable (containers)
 - ``synthorg init`` interactive prompt (CLI)
 - ``telemetry.enabled: true`` in company config
 """

--- a/src/synthorg/telemetry/collector.py
+++ b/src/synthorg/telemetry/collector.py
@@ -405,10 +405,17 @@ class TelemetryCollector:
                 TelemetryBackend,
             )
 
+            if self._token_missing_at_start:
+                # Re-entry after a prior bail-out; the ERROR has
+                # already been logged once. Stay quiet to honour the
+                # "exactly one startup signal" contract and never
+                # start the heartbeat task on this branch.
+                return
             if (
                 self._config.backend == TelemetryBackend.LOGFIRE
                 and not is_token_embedded()
             ):
+                self._token_missing_at_start = True
                 logger.error(
                     TELEMETRY_TOKEN_MISSING,
                     detail=(
@@ -417,7 +424,6 @@ class TelemetryCollector:
                     ),
                     backend=self._config.backend.value,
                 )
-                self._token_missing_at_start = True
                 return
             if self._heartbeat_task is not None and not self._heartbeat_task.done():
                 return

--- a/src/synthorg/telemetry/collector.py
+++ b/src/synthorg/telemetry/collector.py
@@ -283,23 +283,16 @@ class TelemetryCollector:
                 snapshot; used by :meth:`shutdown` to emit the final
                 session summary.
         """
-        # Env var overrides config file (documented priority).
-        # ``SYNTHORG_TELEMETRY_ENABLED`` is the env-layer surface for
-        # the registered ``telemetry.enabled`` setting; the registry
-        # entry's ``env_var_override`` mirrors this name so the
-        # /settings API and the boot path see the same source.
-        env_val = os.environ.get("SYNTHORG_TELEMETRY_ENABLED", "").strip().lower()
-        if env_val in ("true", "1", "yes"):
-            config = config.model_copy(update={"enabled": True})
-        elif env_val in ("false", "0", "no"):
-            config = config.model_copy(update={"enabled": False})
-        elif env_val:
-            logger.warning(
-                TELEMETRY_REPORT_FAILED,
-                detail="invalid_env_value",
-                error_code="SYNTHORG_TELEMETRY_ENABLED_INVALID",
-            )
-
+        # ``config.enabled`` is taken as-given; precedence resolution
+        # for the registered ``telemetry.enabled`` setting (DB > env >
+        # YAML > default) happens upstream in
+        # ``synthorg.api.app_builders._build_telemetry_collector``,
+        # which reads ``SYNTHORG_TELEMETRY_ENABLED`` once and folds the
+        # value into the parsed ``TelemetryConfig`` before
+        # construction. This collector intentionally does not
+        # re-apply precedence here so the audit trail stays single-
+        # sourced and a future routing through ``SettingsService`` /
+        # ``ConfigResolver`` can replace the env read in one place.
         # Resolve the effective deployment-environment tag through
         # the four-level chain (operator override -> CI detection ->
         # Dockerfile-baked default -> parsed config). See
@@ -331,6 +324,12 @@ class TelemetryCollector:
         # safely on a different loop without re-validating that
         # contract end-to-end.
         self._closed: bool = False
+        # Tracks whether ``start()`` deliberately bailed out because the
+        # build artifact ships the sentinel token. Set so ``shutdown()``
+        # can skip the misleading ``TELEMETRY_SHUTDOWN_WITHOUT_START``
+        # warning that would otherwise fire (deployment_id stays None
+        # in this branch by design, not by failure).
+        self._token_missing_at_start: bool = False
 
         if not config.enabled:
             # Operator-visible signal that the collector booted in the
@@ -418,6 +417,7 @@ class TelemetryCollector:
                     ),
                     backend=self._config.backend.value,
                 )
+                self._token_missing_at_start = True
                 return
             if self._heartbeat_task is not None and not self._heartbeat_task.done():
                 return
@@ -506,7 +506,14 @@ class TelemetryCollector:
             # the new lifecycle, so guard explicitly. Log a WARNING
             # in the unloaded-but-enabled branch so operators have a
             # signal that telemetry initialisation failed silently.
-            if self._config.enabled and self._deployment_id is None:
+            # The token-missing branch is excluded: ``start()`` already
+            # logged a single-shot ERROR (TELEMETRY_TOKEN_MISSING) and
+            # deployment_id is None by design, not by failure.
+            if (
+                self._config.enabled
+                and self._deployment_id is None
+                and not self._token_missing_at_start
+            ):
                 logger.warning(
                     TELEMETRY_SHUTDOWN_WITHOUT_START,
                     note="shutdown invoked before deployment ID loaded",

--- a/src/synthorg/telemetry/collector.py
+++ b/src/synthorg/telemetry/collector.py
@@ -259,15 +259,18 @@ class TelemetryCollector:
     ) -> None:
         """Wire the collector to its reporter and resolve runtime env.
 
-        Applies the ``SYNTHORG_TELEMETRY_ENABLED`` opt-in override
-        first, then runs the parsed ``config.environment`` through
-        the four-level resolution chain in
-        :func:`_resolve_environment`. The constructor performs
-        **zero filesystem I/O**; loading or creating the anonymous
-        ``deployment_id`` is deferred to :meth:`start`. The load
-        itself runs outside the event loop's thread via
-        ``asyncio.to_thread`` (#1600). A disabled collector still
-        leaves no on-disk trace.
+        Takes ``config.enabled`` as-given; the
+        ``SYNTHORG_TELEMETRY_ENABLED`` precedence is resolved
+        upstream by the wiring layer (see
+        :func:`synthorg.api.app_builders._build_telemetry_collector`).
+        The constructor only resolves the deployment-environment tag
+        through the four-level chain in :func:`_resolve_environment`
+        (operator override -> CI detection -> Dockerfile-baked default
+        -> parsed config). The constructor performs **zero filesystem
+        I/O**; loading or creating the anonymous ``deployment_id`` is
+        deferred to :meth:`start`. The load itself runs outside the
+        event loop's thread via ``asyncio.to_thread`` (#1600). A
+        disabled collector still leaves no on-disk trace.
 
         Args:
             config: Parsed telemetry configuration from

--- a/src/synthorg/telemetry/collector.py
+++ b/src/synthorg/telemetry/collector.py
@@ -30,12 +30,14 @@ from synthorg.observability.events.telemetry import (
     TELEMETRY_REPORT_FAILED,
     TELEMETRY_SESSION_SUMMARY_SENT,
     TELEMETRY_SHUTDOWN_WITHOUT_START,
+    TELEMETRY_TOKEN_MISSING,
 )
 from synthorg.telemetry.config import DEFAULT_ENVIRONMENT, MAX_STRING_LENGTH
 from synthorg.telemetry.host_info import DockerHostInfo, fetch_docker_info
 from synthorg.telemetry.privacy import PrivacyScrubber, PrivacyViolationError
 from synthorg.telemetry.protocol import TelemetryEvent, TelemetryReporter
 from synthorg.telemetry.reporters import create_reporter
+from synthorg.telemetry.reporters._embedded_token import is_token_embedded
 from synthorg.telemetry.reporters.noop import NoopReporter
 
 _ENV_OVERRIDE_VAR = "SYNTHORG_TELEMETRY_ENV"
@@ -257,14 +259,15 @@ class TelemetryCollector:
     ) -> None:
         """Wire the collector to its reporter and resolve runtime env.
 
-        Applies the ``SYNTHORG_TELEMETRY`` opt-in override first, then
-        runs the parsed ``config.environment`` through the four-level
-        resolution chain in :func:`_resolve_environment`. The
-        constructor performs **zero filesystem I/O**; loading or
-        creating the anonymous ``deployment_id`` is deferred to
-        :meth:`start`. The load itself runs outside the event loop's
-        thread via ``asyncio.to_thread`` (#1600). A disabled collector
-        still leaves no on-disk trace.
+        Applies the ``SYNTHORG_TELEMETRY_ENABLED`` opt-in override
+        first, then runs the parsed ``config.environment`` through
+        the four-level resolution chain in
+        :func:`_resolve_environment`. The constructor performs
+        **zero filesystem I/O**; loading or creating the anonymous
+        ``deployment_id`` is deferred to :meth:`start`. The load
+        itself runs outside the event loop's thread via
+        ``asyncio.to_thread`` (#1600). A disabled collector still
+        leaves no on-disk trace.
 
         Args:
             config: Parsed telemetry configuration from
@@ -281,7 +284,11 @@ class TelemetryCollector:
                 session summary.
         """
         # Env var overrides config file (documented priority).
-        env_val = os.environ.get("SYNTHORG_TELEMETRY", "").strip().lower()
+        # ``SYNTHORG_TELEMETRY_ENABLED`` is the env-layer surface for
+        # the registered ``telemetry.enabled`` setting; the registry
+        # entry's ``env_var_override`` mirrors this name so the
+        # /settings API and the boot path see the same source.
+        env_val = os.environ.get("SYNTHORG_TELEMETRY_ENABLED", "").strip().lower()
         if env_val in ("true", "1", "yes"):
             config = config.model_copy(update={"enabled": True})
         elif env_val in ("false", "0", "no"):
@@ -290,7 +297,7 @@ class TelemetryCollector:
             logger.warning(
                 TELEMETRY_REPORT_FAILED,
                 detail="invalid_env_value",
-                error_code="SYNTHORG_TELEMETRY_INVALID",
+                error_code="SYNTHORG_TELEMETRY_ENABLED_INVALID",
             )
 
         # Resolve the effective deployment-environment tag through
@@ -326,7 +333,13 @@ class TelemetryCollector:
         self._closed: bool = False
 
         if not config.enabled:
-            logger.debug(TELEMETRY_DISABLED)
+            # Operator-visible signal that the collector booted in the
+            # disabled path. INFO (not DEBUG) so a single line lands in
+            # the main log on every boot -- the issue's acceptance
+            # criterion is "exactly one INFO at startup, zero per-cycle
+            # warnings". The heartbeat task is also skipped in start()
+            # so no reporter cycles run while disabled.
+            logger.info(TELEMETRY_DISABLED)
 
     @property
     def deployment_id(self) -> str | None:
@@ -377,6 +390,34 @@ class TelemetryCollector:
                 msg = "TelemetryCollector.start() called after shutdown()"
                 raise RuntimeError(msg)
             if not self._config.enabled:
+                return
+            # Build artifact ships the sentinel token. Operator opted in
+            # to LOGFIRE, but the wheel was published without the
+            # LOGFIRE_PROJECT_TOKEN CI secret -- log ONCE at ERROR
+            # severity so operators can escalate to the build pipeline,
+            # then return without starting the heartbeat loop. This is
+            # the fix for the "every reporter cycle" warning spam: with
+            # no loop, no cycles, no spam. The factory has already
+            # returned a NoopReporter for this state. The check is
+            # scoped to ``TelemetryBackend.LOGFIRE`` so the noop
+            # backend (used by tests and operators who explicitly
+            # opt out of Logfire) is unaffected.
+            from synthorg.telemetry.config import (  # noqa: PLC0415
+                TelemetryBackend,
+            )
+
+            if (
+                self._config.backend == TelemetryBackend.LOGFIRE
+                and not is_token_embedded()
+            ):
+                logger.error(
+                    TELEMETRY_TOKEN_MISSING,
+                    detail=(
+                        "build artifact missing embedded token; rebuild "
+                        "release wheel with LOGFIRE_PROJECT_TOKEN CI secret"
+                    ),
+                    backend=self._config.backend.value,
+                )
                 return
             if self._heartbeat_task is not None and not self._heartbeat_task.done():
                 return

--- a/src/synthorg/telemetry/config.py
+++ b/src/synthorg/telemetry/config.py
@@ -65,7 +65,7 @@ class TelemetryConfig(BaseModel):
 
     Attributes:
         enabled: Master switch (default ``False``). Can be
-            overridden by the ``SYNTHORG_TELEMETRY`` env var.
+            overridden by the ``SYNTHORG_TELEMETRY_ENABLED`` env var.
         backend: Reporter backend to use.
         heartbeat_interval_hours: Hours between periodic heartbeat
             events.

--- a/src/synthorg/telemetry/reporters/__init__.py
+++ b/src/synthorg/telemetry/reporters/__init__.py
@@ -27,11 +27,11 @@ slip past detection.
 
 from typing import TYPE_CHECKING
 
-from synthorg.observability import get_logger
+from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.telemetry import TELEMETRY_REPORT_FAILED
 from synthorg.telemetry.config import TelemetryBackend
 from synthorg.telemetry.reporters._embedded_token import (
-    EMBEDDED_LOGFIRE_TOKEN,
+    EMBEDDED_TELEMETRY_TOKEN,
     is_token_embedded,
 )
 from synthorg.telemetry.reporters.errors import (
@@ -83,7 +83,7 @@ def create_reporter(config: TelemetryConfig) -> TelemetryReporter:
             )
 
             return LogfireReporter(
-                token=EMBEDDED_LOGFIRE_TOKEN,
+                token=EMBEDDED_TELEMETRY_TOKEN,
                 environment=config.environment,
             )
         except ImportError as exc:
@@ -94,11 +94,16 @@ def create_reporter(config: TelemetryConfig) -> TelemetryReporter:
             )
             return NoopReporter()
         except LogfireConfigureError as exc:
+            # ``LogfireConfigureError`` is the sanitised wrapper raised
+            # at the boundary; the underlying SDK chain is intentionally
+            # NOT attached here. Per the project logging-hygiene rule,
+            # degraded paths emit a scrubbed description instead of a
+            # traceback.
             logger.warning(
                 TELEMETRY_REPORT_FAILED,
                 detail="logfire_configure_failed",
                 error_type=type(exc).__name__,
-                exc_info=True,
+                error=safe_error_description(exc),
             )
             return NoopReporter()
 

--- a/src/synthorg/telemetry/reporters/__init__.py
+++ b/src/synthorg/telemetry/reporters/__init__.py
@@ -52,9 +52,12 @@ def create_reporter(config: TelemetryConfig) -> TelemetryReporter:
     """Create a telemetry reporter from configuration.
 
     Returns :class:`NoopReporter` when the backend is set to
-    ``noop`` or when the Logfire reporter cannot be initialised
-    for one of the three sanctioned reasons (logged once with the
-    real ``error_type``).
+    ``noop`` or when the Logfire reporter cannot be initialised.
+    ``ImportError`` and ``LogfireConfigureError`` each emit one
+    WARNING with the real ``error_type``; the missing-embedded-
+    token branch is intentionally silent here so
+    :meth:`TelemetryCollector.start` remains the single emitter
+    of the operator-facing ``TELEMETRY_TOKEN_MISSING`` ERROR.
 
     Args:
         config: Telemetry configuration (already filtered for

--- a/src/synthorg/telemetry/reporters/__init__.py
+++ b/src/synthorg/telemetry/reporters/__init__.py
@@ -7,17 +7,21 @@ working reporter for the configured backend or fail loudly with a
 precise reason -- never to silently fall back to the noop reporter
 on an unknown error class.
 
-Three legitimate failure modes are handled with precise except
+Two legitimate failure modes are handled here with precise except
 arms (each emits one WARNING with the real ``error_type`` and
 returns :class:`NoopReporter`):
 
 * ``ImportError`` -- ``logfire`` package not installable in this
   environment. Should not occur in practice; ``logfire`` is a
   required runtime dep.
-* ``LogfireTokenMissingError`` -- the build artifact ships the
-  sentinel token instead of a real one. Operator-actionable.
 * ``LogfireConfigureError`` -- ``logfire.configure()`` rejected
   the token (network, auth, or SDK-level config issue).
+
+A third condition -- ``is_token_embedded() == False`` -- returns
+:class:`NoopReporter` silently. The operator-facing log for that
+state lives in :meth:`TelemetryCollector.start` so the missing-
+token condition produces exactly one startup signal instead of
+duplicating across factory and collector.
 
 Anything else propagates so silent fallback never hides a
 programming bug -- which is precisely how the previous
@@ -34,10 +38,7 @@ from synthorg.telemetry.reporters._embedded_token import (
     EMBEDDED_TELEMETRY_TOKEN,
     is_token_embedded,
 )
-from synthorg.telemetry.reporters.errors import (
-    LogfireConfigureError,
-    LogfireTokenMissingError,
-)
+from synthorg.telemetry.reporters.errors import LogfireConfigureError
 from synthorg.telemetry.reporters.noop import NoopReporter
 
 if TYPE_CHECKING:
@@ -70,11 +71,11 @@ def create_reporter(config: TelemetryConfig) -> TelemetryReporter:
 
     if config.backend == TelemetryBackend.LOGFIRE:
         if not is_token_embedded():
-            logger.warning(
-                TELEMETRY_REPORT_FAILED,
-                detail="logfire_token_missing",
-                error_type=LogfireTokenMissingError.__name__,
-            )
+            # Stay quiet: ``TelemetryCollector.start()`` owns the
+            # operator-facing ``TELEMETRY_TOKEN_MISSING`` ERROR. Logging
+            # here too would emit two startup records for a single
+            # missing-token condition and break the "exactly one
+            # startup signal" contract this PR is enforcing.
             return NoopReporter()
 
         try:

--- a/src/synthorg/telemetry/reporters/__init__.py
+++ b/src/synthorg/telemetry/reporters/__init__.py
@@ -1,10 +1,43 @@
-"""Reporter factory for telemetry backends."""
+"""Reporter factory for telemetry backends.
+
+Telemetry enable is resolved upstream (the collector reads
+``telemetry.enabled`` via ``ConfigResolver`` before calling this
+factory). When invoked, the factory's job is to materialise a
+working reporter for the configured backend or fail loudly with a
+precise reason -- never to silently fall back to the noop reporter
+on an unknown error class.
+
+Three legitimate failure modes are handled with precise except
+arms (each emits one WARNING with the real ``error_type`` and
+returns :class:`NoopReporter`):
+
+* ``ImportError`` -- ``logfire`` package not installable in this
+  environment. Should not occur in practice; ``logfire`` is a
+  required runtime dep.
+* ``LogfireTokenMissingError`` -- the build artifact ships the
+  sentinel token instead of a real one. Operator-actionable.
+* ``LogfireConfigureError`` -- ``logfire.configure()`` rejected
+  the token (network, auth, or SDK-level config issue).
+
+Anything else propagates so silent fallback never hides a
+programming bug -- which is precisely how the previous
+``except Exception`` arm let two months of broken telemetry
+slip past detection.
+"""
 
 from typing import TYPE_CHECKING
 
 from synthorg.observability import get_logger
 from synthorg.observability.events.telemetry import TELEMETRY_REPORT_FAILED
 from synthorg.telemetry.config import TelemetryBackend
+from synthorg.telemetry.reporters._embedded_token import (
+    EMBEDDED_LOGFIRE_TOKEN,
+    is_token_embedded,
+)
+from synthorg.telemetry.reporters.errors import (
+    LogfireConfigureError,
+    LogfireTokenMissingError,
+)
 from synthorg.telemetry.reporters.noop import NoopReporter
 
 if TYPE_CHECKING:
@@ -17,12 +50,14 @@ logger = get_logger(__name__)
 def create_reporter(config: TelemetryConfig) -> TelemetryReporter:
     """Create a telemetry reporter from configuration.
 
-    Returns a ``NoopReporter`` when telemetry is disabled or the
-    backend is explicitly set to ``noop``.  Falls back to
-    ``NoopReporter`` if the Logfire package is not installed.
+    Returns :class:`NoopReporter` when the backend is set to
+    ``noop`` or when the Logfire reporter cannot be initialised
+    for one of the three sanctioned reasons (logged once with the
+    real ``error_type``).
 
     Args:
-        config: Telemetry configuration.
+        config: Telemetry configuration (already filtered for
+            "is enabled" by the collector).
 
     Returns:
         A concrete ``TelemetryReporter`` implementation.
@@ -34,17 +69,36 @@ def create_reporter(config: TelemetryConfig) -> TelemetryReporter:
         return NoopReporter()
 
     if config.backend == TelemetryBackend.LOGFIRE:
+        if not is_token_embedded():
+            logger.warning(
+                TELEMETRY_REPORT_FAILED,
+                detail="logfire_token_missing",
+                error_type=LogfireTokenMissingError.__name__,
+            )
+            return NoopReporter()
+
         try:
             from synthorg.telemetry.reporters.logfire import (  # noqa: PLC0415
                 LogfireReporter,
             )
 
-            return LogfireReporter(environment=config.environment)
-        except Exception as exc:
+            return LogfireReporter(
+                token=EMBEDDED_LOGFIRE_TOKEN,
+                environment=config.environment,
+            )
+        except ImportError as exc:
             logger.warning(
                 TELEMETRY_REPORT_FAILED,
-                detail="logfire_init_failed",
+                detail="logfire_import_failed",
                 error_type=type(exc).__name__,
+            )
+            return NoopReporter()
+        except LogfireConfigureError as exc:
+            logger.warning(
+                TELEMETRY_REPORT_FAILED,
+                detail="logfire_configure_failed",
+                error_type=type(exc).__name__,
+                exc_info=True,
             )
             return NoopReporter()
 

--- a/src/synthorg/telemetry/reporters/_embedded_token.py
+++ b/src/synthorg/telemetry/reporters/_embedded_token.py
@@ -1,0 +1,37 @@
+"""Embedded Logfire write-only project token.
+
+Sentinel value lives in source. The release workflow rewrites this
+file in-place before ``uv build`` so the published wheel carries
+the real write-only project token; local source installs and
+non-release builds keep the sentinel and fall back to disabled
+(plus a single-shot ERROR if telemetry was explicitly enabled).
+
+Operators do NOT configure this token. They flip
+``SYNTHORG_TELEMETRY_ENABLED=1`` (or the equivalent
+``telemetry.enabled`` setting) and either get the embedded token
+(release wheel) or a startup ERROR explaining the build artifact
+is missing it.
+
+Build pipeline reference: ``scripts/embed_logfire_token.py`` and
+``.github/workflows/release.yml``.
+"""
+
+from typing import Final
+
+# Sentinel string is detectable at runtime via ``is_token_embedded()``.
+# DO NOT change the sentinel without also updating the embedder script
+# AND the comparison in ``is_token_embedded``.
+_TOKEN_SENTINEL: Final[str] = "__SYNTHORG_LOGFIRE_TOKEN_NOT_EMBEDDED__"  # noqa: S105
+
+EMBEDDED_LOGFIRE_TOKEN: Final[str] = _TOKEN_SENTINEL
+
+
+def is_token_embedded() -> bool:
+    """Return True when the build pipeline embedded a real token.
+
+    A bare ``EMBEDDED_LOGFIRE_TOKEN != _TOKEN_SENTINEL`` check would
+    work equally well, but routing through this helper gives the
+    collector and the factory a single import and keeps the
+    sentinel comparison logic in one place.
+    """
+    return EMBEDDED_LOGFIRE_TOKEN != _TOKEN_SENTINEL

--- a/src/synthorg/telemetry/reporters/_embedded_token.py
+++ b/src/synthorg/telemetry/reporters/_embedded_token.py
@@ -21,17 +21,17 @@ from typing import Final
 # Sentinel string is detectable at runtime via ``is_token_embedded()``.
 # DO NOT change the sentinel without also updating the embedder script
 # AND the comparison in ``is_token_embedded``.
-_TOKEN_SENTINEL: Final[str] = "__SYNTHORG_LOGFIRE_TOKEN_NOT_EMBEDDED__"  # noqa: S105
+_TOKEN_SENTINEL: Final[str] = "__SYNTHORG_TELEMETRY_TOKEN_NOT_EMBEDDED__"  # noqa: S105
 
-EMBEDDED_LOGFIRE_TOKEN: Final[str] = _TOKEN_SENTINEL
+EMBEDDED_TELEMETRY_TOKEN: Final[str] = _TOKEN_SENTINEL
 
 
 def is_token_embedded() -> bool:
     """Return True when the build pipeline embedded a real token.
 
-    A bare ``EMBEDDED_LOGFIRE_TOKEN != _TOKEN_SENTINEL`` check would
+    A bare ``EMBEDDED_TELEMETRY_TOKEN != _TOKEN_SENTINEL`` check would
     work equally well, but routing through this helper gives the
     collector and the factory a single import and keeps the
     sentinel comparison logic in one place.
     """
-    return EMBEDDED_LOGFIRE_TOKEN != _TOKEN_SENTINEL
+    return EMBEDDED_TELEMETRY_TOKEN != _TOKEN_SENTINEL

--- a/src/synthorg/telemetry/reporters/_embedded_token.py
+++ b/src/synthorg/telemetry/reporters/_embedded_token.py
@@ -1,4 +1,4 @@
-"""Embedded Logfire write-only project token.
+"""Embedded write-only telemetry-backend project token.
 
 Sentinel value lives in source. The release workflow rewrites this
 file in-place before ``uv build`` so the published wheel carries

--- a/src/synthorg/telemetry/reporters/errors.py
+++ b/src/synthorg/telemetry/reporters/errors.py
@@ -1,0 +1,17 @@
+"""Telemetry reporter exception types.
+
+Precise exception classes let the reporter factory distinguish the
+three legitimate init-failure modes -- logfire not installed, build
+artifact missing the embedded token, SDK configure failure -- and
+log the actual class name instead of swallowing every failure as
+``ImportError``. Anything outside these three classes propagates so
+silent fallback to ``NoopReporter`` never hides a programming bug.
+"""
+
+
+class LogfireTokenMissingError(RuntimeError):
+    """Raised when the build artifact ships the sentinel token."""
+
+
+class LogfireConfigureError(RuntimeError):
+    """Raised when ``logfire.configure()`` fails at init time."""

--- a/src/synthorg/telemetry/reporters/logfire.py
+++ b/src/synthorg/telemetry/reporters/logfire.py
@@ -1,12 +1,18 @@
 """Logfire telemetry reporter.
 
 Sends curated, privacy-validated telemetry events to the
-SynthOrg project on Logfire via the Logfire SDK (OpenTelemetry
-compatible). The ``logfire`` package is an optional dependency.
+SynthOrg-owned project on Logfire via the Logfire SDK
+(OpenTelemetry compatible). The ``logfire`` package is a required
+runtime dependency.
+
+The write-only project token is **embedded** at wheel build time
+via ``synthorg.telemetry.reporters._embedded_token``; operators
+never configure it. Token resolution happens in
+:func:`synthorg.telemetry.reporters.create_reporter` -- this class
+just accepts whatever token its caller passes.
 """
 
 import asyncio
-import os
 from typing import TYPE_CHECKING
 
 from synthorg.observability import get_logger
@@ -15,58 +21,43 @@ from synthorg.observability.events.telemetry import (
     TELEMETRY_REPORTER_INITIALIZED,
 )
 from synthorg.telemetry.config import DEFAULT_ENVIRONMENT
+from synthorg.telemetry.reporters.errors import LogfireConfigureError
 
 if TYPE_CHECKING:
     from synthorg.telemetry.protocol import TelemetryEvent
 
 logger = get_logger(__name__)
 
-_PROJECT_TOKEN_ENV = "SYNTHORG_LOGFIRE_PROJECT_TOKEN"  # noqa: S105
-
 
 class LogfireReporter:
     """Logfire SDK-based telemetry reporter.
 
-    Events are sent as Logfire log records with structured
-    properties. A missing or empty project token disables
-    delivery by raising :class:`ImportError` so the reporter
-    factory falls back to :class:`NoopReporter`.
-
     Args:
+        token: Write-only Logfire project token (resolved by the
+            factory from the embedded build constant).
         environment: Deployment-environment tag (``dev`` /
             ``pre-release`` / ``prod`` / ``ci`` / ...). Passed to
             :func:`logfire.configure` so the OTel
-            ``deployment.environment`` resource attribute is set
-            on every span and also included as a kwarg on every
-            log record -- giving dashboards two ways to filter
-            without joining on a startup event.
+            ``deployment.environment`` resource attribute is set on
+            every span and also included as a kwarg on every log
+            record -- giving dashboards two ways to filter without
+            joining on a startup event.
+
+    Raises:
+        ImportError: If the ``logfire`` package is not importable.
+            Should not happen in practice -- ``logfire`` is a
+            required dependency -- but propagated explicitly so the
+            factory can log the real class name.
+        LogfireConfigureError: If ``logfire.configure()`` fails.
     """
 
-    def __init__(self, environment: str = DEFAULT_ENVIRONMENT) -> None:
-        try:
-            import logfire as _logfire  # type: ignore[import-not-found,unused-ignore]  # noqa: PLC0415
-        except ImportError as exc:
-            msg = (
-                "logfire package not installed. "
-                'Install with: pip install "synthorg[telemetry]"'
-            )
-            logger.warning(
-                TELEMETRY_REPORT_FAILED,
-                detail="logfire_import_failed",
-                error_type="ImportError",
-            )
-            raise ImportError(msg) from exc
-
-        token = os.environ.get(_PROJECT_TOKEN_ENV, "").strip()
-        if not token:
-            logger.warning(
-                TELEMETRY_REPORT_FAILED,
-                detail="logfire_token_missing",
-                error_type="ValueError",
-                env_var=_PROJECT_TOKEN_ENV,
-            )
-            msg = f"{_PROJECT_TOKEN_ENV} is not set; telemetry disabled."
-            raise ImportError(msg)
+    def __init__(
+        self,
+        *,
+        token: str,
+        environment: str = DEFAULT_ENVIRONMENT,
+    ) -> None:
+        import logfire as _logfire  # type: ignore[import-not-found,unused-ignore]  # noqa: PLC0415
 
         self._logfire = _logfire
         self._environment = environment
@@ -74,10 +65,10 @@ class LogfireReporter:
         try:
             # ``inspect_arguments=False`` silences the noisy
             # "Failed to introspect calling code" warning. Logfire
-            # would otherwise try to introspect the source line
-            # for every ``.info(event.event_type, ...)`` call to
-            # treat the first positional as an f-string template.
-            # Our call site passes a variable, not a literal, so
+            # would otherwise try to introspect the source line for
+            # every ``.info(event.event_type, ...)`` call to treat
+            # the first positional as an f-string template. Our
+            # call site passes a variable, not a literal, so
             # introspection fails on every event -- disabling it
             # is the explicit suppression the warning itself
             # suggests. ``environment=`` maps to the OTel
@@ -91,13 +82,8 @@ class LogfireReporter:
                 inspect_arguments=False,
             )
         except Exception as exc:
-            logger.warning(
-                TELEMETRY_REPORT_FAILED,
-                detail="logfire_configure_failed",
-                error_type=type(exc).__name__,
-                exc_info=True,
-            )
-            raise
+            msg = f"logfire.configure() failed: {type(exc).__name__}"
+            raise LogfireConfigureError(msg) from exc
 
         logger.info(
             TELEMETRY_REPORTER_INITIALIZED,

--- a/src/synthorg/telemetry/reporters/logfire.py
+++ b/src/synthorg/telemetry/reporters/logfire.py
@@ -62,6 +62,18 @@ class LogfireReporter:
         self._logfire = _logfire
         self._environment = environment
 
+        # Catch only the SDK's documented configuration-failure type
+        # so genuine bugs (TypeError, AttributeError, ImportError
+        # mid-runtime) propagate and fail loudly. The factory wraps
+        # ``LogfireConfigureError`` to noop; an unknown exception
+        # propagating here surfaces a real defect instead of being
+        # silently degraded -- the previous broad ``except Exception``
+        # is exactly what hid two months of broken telemetry.
+        # ``LogfireConfigError`` is the public, documented class
+        # exposed at the ``logfire`` module's top level (see logfire
+        # SDK 4.32.1+); fall back to ``Exception`` only if a future
+        # SDK rev removes the symbol.
+        configure_error = getattr(self._logfire, "LogfireConfigError", Exception)
         try:
             # ``inspect_arguments=False`` silences the noisy
             # "Failed to introspect calling code" warning. Logfire
@@ -81,7 +93,7 @@ class LogfireReporter:
                 environment=environment,
                 inspect_arguments=False,
             )
-        except Exception as exc:
+        except configure_error as exc:
             msg = f"logfire.configure() failed: {type(exc).__name__}"
             raise LogfireConfigureError(msg) from exc
 

--- a/src/synthorg/telemetry/reporters/logfire.py
+++ b/src/synthorg/telemetry/reporters/logfire.py
@@ -71,9 +71,11 @@ class LogfireReporter:
         # is exactly what hid two months of broken telemetry.
         # ``LogfireConfigError`` is the public, documented class
         # exposed at the ``logfire`` module's top level (see logfire
-        # SDK 4.32.1+); fall back to ``Exception`` only if a future
-        # SDK rev removes the symbol.
-        configure_error = getattr(self._logfire, "LogfireConfigError", Exception)
+        # SDK 4.32.1+ ``logfire/exceptions.py``). Direct attribute
+        # access is intentional: a future SDK rev that removes the
+        # symbol must fail loudly as an unsupported version, not
+        # silently widen the catch back to ``Exception``.
+        configure_error = self._logfire.LogfireConfigError
         try:
             # ``inspect_arguments=False`` silences the noisy
             # "Failed to introspect calling code" warning. Logfire

--- a/src/synthorg/templates/model_matcher.py
+++ b/src/synthorg/templates/model_matcher.py
@@ -15,6 +15,7 @@ from synthorg.core.types import NotBlankStr  # noqa: TC001
 from synthorg.observability import get_logger
 from synthorg.observability.events.template import (
     TEMPLATE_MODEL_MATCH_FAILED,
+    TEMPLATE_MODEL_MATCH_FALLBACK,
     TEMPLATE_MODEL_MATCH_SKIPPED,
     TEMPLATE_MODEL_MATCH_SUCCESS,
 )
@@ -232,9 +233,16 @@ def match_all_agents(
             )
         elif all_models:
             # Fallback: assign first available model with score 0.
+            # This path IS the documented contract for tier-mismatch
+            # (per docs/design/agents.md §"Model matcher"); the
+            # fallback succeeded so logging at WARNING produced
+            # ~8 noisy lines per setup wizard run. Issue #1666 B-5
+            # downgrades this to DEBUG. WARNING stays for the truly
+            # failing path -- the ``no_models_available`` branch
+            # below.
             fb_provider, fb_model = all_models[0]
-            logger.warning(
-                TEMPLATE_MODEL_MATCH_FAILED,
+            logger.debug(
+                TEMPLATE_MODEL_MATCH_FALLBACK,
                 agent_index=idx,
                 tier=tier,
                 fallback_provider=fb_provider,

--- a/tests/e2e/test_client_simulation_e2e.py
+++ b/tests/e2e/test_client_simulation_e2e.py
@@ -19,7 +19,6 @@ import pytest
 from litestar.testing import TestClient
 
 from synthorg.api.app import create_app
-from synthorg.api.state import AppState
 from synthorg.budget.tracker import CostTracker
 from synthorg.client.simulation_state import ClientSimulationState
 from synthorg.config.schema import RootConfig
@@ -83,19 +82,22 @@ def e2e_client(
     config = RootConfig(company_name="e2e-company")
     auth_service = _make_test_auth_service()
     _seed_test_users(fake_persistence, auth_service)
+    state = ClientSimulationState(
+        intake_engine=IntakeEngine(strategy=_AcceptingStrategy()),
+        review_pipeline=ReviewPipeline(stages=(InternalReviewStage(),)),
+    )
+    # Pass ``client_simulation_state`` via kwarg so ``create_app`` wires
+    # it before the OPTIONAL_CONTROLLERS predicate gate -- post-build
+    # ``set_client_simulation_state`` would arrive after route
+    # registration and the simulation/request endpoints would be 404.
     app = create_app(
         config=config,
         persistence=fake_persistence,
         message_bus=fake_message_bus,
         cost_tracker=CostTracker(),
         auth_service=auth_service,
+        client_simulation_state=state,
     )
-    app_state: AppState = app.state.app_state
-    state = ClientSimulationState(
-        intake_engine=IntakeEngine(strategy=_AcceptingStrategy()),
-        review_pipeline=ReviewPipeline(stages=(InternalReviewStage(),)),
-    )
-    app_state.set_client_simulation_state(state)
     with TestClient(app) as client:
         yield client
 

--- a/tests/integration/api/controllers/test_client_simulation.py
+++ b/tests/integration/api/controllers/test_client_simulation.py
@@ -11,7 +11,6 @@ import pytest
 from litestar.testing import TestClient
 
 from synthorg.api.app import create_app
-from synthorg.api.state import AppState
 from synthorg.budget.tracker import CostTracker
 from synthorg.client.adapters import DirectAdapter
 from synthorg.client.pool import RoundRobinStrategy
@@ -68,14 +67,12 @@ async def fake_message_bus() -> AsyncGenerator[FakeMessageBus]:
     await bus.stop()
 
 
-def _install_sim_state(app_state: AppState) -> ClientSimulationState:
-    """Attach a minimal simulation state to the running app."""
-    state = ClientSimulationState(
+def _build_sim_state() -> ClientSimulationState:
+    """Construct a minimal client-simulation state for the test app."""
+    return ClientSimulationState(
         intake_engine=IntakeEngine(strategy=_AcceptingStrategy()),
         review_pipeline=ReviewPipeline(stages=(InternalReviewStage(),)),
     )
-    app_state.set_client_simulation_state(state)
-    return state
 
 
 def _build_client(
@@ -85,15 +82,19 @@ def _build_client(
     config = RootConfig(company_name="test")
     auth_service = _make_test_auth_service()
     _seed_test_users(fake_persistence, auth_service)
+    # Pass ``client_simulation_state`` directly so ``create_app`` wires
+    # it onto AppState before the OPTIONAL_CONTROLLERS predicate check;
+    # post-construction ``set_client_simulation_state`` would land
+    # AFTER the controller list is frozen and the routes would be
+    # absent (issue #1666 B-3 conditional registration).
     app = create_app(
         config=config,
         persistence=fake_persistence,
         message_bus=fake_message_bus,
         cost_tracker=CostTracker(),
         auth_service=auth_service,
+        client_simulation_state=_build_sim_state(),
     )
-    app_state: AppState = app.state.app_state
-    _install_sim_state(app_state)
     return TestClient(app)
 
 

--- a/tests/unit/api/controllers/conftest.py
+++ b/tests/unit/api/controllers/conftest.py
@@ -1,15 +1,15 @@
 """Shared fixtures and helpers for setup controller tests."""
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 from litestar.testing import TestClient
 
 
-def setup_mock_providers(
-    test_client: TestClient[Any],
-) -> tuple[Any, Any]:
-    """Wire up mock providers on the app state. Returns (app_state, original)."""
+def _build_mock_provider_management() -> MagicMock:
+    """Build a stub ``ProviderManagementService`` with one priced model."""
     mock_model = MagicMock()
     mock_model.id = "test-small-001"
     mock_model.alias = None
@@ -24,8 +24,41 @@ def setup_mock_providers(
     mock_mgmt.list_providers = AsyncMock(
         return_value={"test-provider": mock_provider_config},
     )
+    return mock_mgmt
 
+
+@contextmanager
+def mock_providers(test_client: TestClient[Any]) -> Iterator[Any]:
+    """Patch ``app_state._provider_management`` with a stub for the test body.
+
+    The previous helper returned ``(app_state, original)`` and required
+    every caller to wrap the body in their own ``try/finally``. A
+    contextmanager makes restoration unconditional even when an
+    intermediate ``raise`` skips the manual finally block, fixing the
+    fragile state-restoration pattern flagged in the pre-PR review for
+    issue #1666.
+    """
     app_state = test_client.app.state.app_state
     original = app_state._provider_management
-    app_state._provider_management = mock_mgmt
+    app_state._provider_management = _build_mock_provider_management()
+    try:
+        yield app_state
+    finally:
+        app_state._provider_management = original
+
+
+def setup_mock_providers(
+    test_client: TestClient[Any],
+) -> tuple[Any, Any]:
+    """Patch ``app_state._provider_management`` with a stub.
+
+    Legacy entry point kept for tests that have not migrated to the
+    context-manager form. Prefer :func:`mock_providers` -- it
+    guarantees state restoration even when the test body raises.
+    Returns ``(app_state, original)`` so the caller can manually
+    restore in a ``finally`` block.
+    """
+    app_state = test_client.app.state.app_state
+    original = app_state._provider_management
+    app_state._provider_management = _build_mock_provider_management()
     return app_state, original

--- a/tests/unit/api/controllers/test_capabilities.py
+++ b/tests/unit/api/controllers/test_capabilities.py
@@ -40,6 +40,21 @@ class TestCapabilitiesController:
         assert set(data.keys()) == expected_flags
         for key in expected_flags:
             assert isinstance(data[key], bool), key
+        # Exact-value assertions against the test conftest's wiring.
+        # The test fixture does NOT wire the optional subsystems
+        # (client simulation state, ontology service, telemetry
+        # collector, tunnel provider) and ships with
+        # ``integrations.enabled=False``, so each flag has a known
+        # value. A regression where the controller hardcodes a flag
+        # to True (e.g. via a copy-paste mistake) is caught here.
+        assert data["simulations"] is False
+        assert data["requests"] is False
+        assert data["ontology"] is False
+        assert data["tunnel"] is False
+        assert data["webhooks"] is False
+        assert data["a2a"] is False
+        assert data["telemetry"] is False
+        assert data["integrations"] is False
 
     def test_capabilities_reflects_unconfigured_simulations(
         self,

--- a/tests/unit/api/controllers/test_capabilities.py
+++ b/tests/unit/api/controllers/test_capabilities.py
@@ -1,0 +1,88 @@
+"""Tests for ``GET /api/v1/capabilities`` (#1666 B-3)."""
+
+from typing import Any
+
+import pytest
+from litestar.testing import TestClient
+
+from tests.unit.api.conftest import make_auth_headers
+
+_HEADERS = make_auth_headers("ceo")
+
+
+@pytest.mark.unit
+class TestCapabilitiesController:
+    """Capabilities endpoint reports which optional subsystems are wired."""
+
+    def test_capabilities_endpoint_returns_full_flag_matrix(
+        self,
+        test_client: TestClient[Any],
+    ) -> None:
+        resp = test_client.get(
+            "/api/v1/capabilities/",
+            headers=_HEADERS,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["success"] is True
+        data = body["data"]
+        # Every documented flag is present and boolean.
+        expected_flags = {
+            "simulations",
+            "requests",
+            "ontology",
+            "tunnel",
+            "webhooks",
+            "a2a",
+            "telemetry",
+            "integrations",
+        }
+        assert set(data.keys()) == expected_flags
+        for key in expected_flags:
+            assert isinstance(data[key], bool), key
+
+    def test_capabilities_reflects_unconfigured_simulations(
+        self,
+        test_client: TestClient[Any],
+    ) -> None:
+        """Test conftest does not wire client_simulation_state."""
+        resp = test_client.get(
+            "/api/v1/capabilities/",
+            headers=_HEADERS,
+        )
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        # client_simulation_state is not wired in the test fixture so
+        # both the simulations and requests flags must be False -- the
+        # dashboard then knows to skip polling those endpoints.
+        assert data["simulations"] is False
+        assert data["requests"] is False
+
+    def test_simulations_route_returns_404_when_unconfigured(
+        self,
+        test_client: TestClient[Any],
+    ) -> None:
+        """Issue #1666 B-3: unconfigured simulations route does not exist.
+
+        Without ``client_simulation_state`` wired the simulation
+        controller is not registered at all, so the dashboard's
+        polling against ``/api/v1/simulations`` lands at 404 (route
+        not found) instead of 503 (service unavailable). Combined
+        with the frontend reading ``/capabilities`` to gate polling
+        in the first place, the 503-spam from the audit log is gone.
+        """
+        resp = test_client.get(
+            "/api/v1/simulations",
+            headers=_HEADERS,
+        )
+        assert resp.status_code == 404
+
+    def test_requests_route_returns_404_when_unconfigured(
+        self,
+        test_client: TestClient[Any],
+    ) -> None:
+        resp = test_client.get(
+            "/api/v1/requests",
+            headers=_HEADERS,
+        )
+        assert resp.status_code == 404

--- a/tests/unit/api/controllers/test_mcp_catalog_dtos.py
+++ b/tests/unit/api/controllers/test_mcp_catalog_dtos.py
@@ -1,6 +1,7 @@
 """DTO validation tests for the MCP catalog controller."""
 
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydantic import ValidationError
@@ -8,7 +9,9 @@ from pydantic import ValidationError
 from synthorg.api.controllers.mcp_catalog import (
     InstallEntryRequest,
     InstallEntryResponse,
+    MCPCatalogController,
 )
+from synthorg.core.domain_errors import ValidationError as DomainValidationError
 
 
 @pytest.mark.unit
@@ -61,6 +64,76 @@ class TestInstallEntryRequest:
         req = InstallEntryRequest(catalog_entry_id="filesystem-mcp")
         with pytest.raises(ValidationError):
             req.catalog_entry_id = "other"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestInstallEntryValidateFirst:
+    """Issue #1666 B-1: pre-validate ``connection_name`` before INSERT.
+
+    Pre-#1666 an unknown ``connection_name`` reached the persistence
+    layer and surfaced as a 500 from a ``psycopg.errors.ForeignKeyViolation``.
+    The fix is two-pronged: (a) the controller pre-validates against
+    ``connection_catalog.get(...)`` and raises ``ValidationError`` (-> 400)
+    before calling the install service, and (b) ``EXCEPTION_HANDLERS``
+    registers an ``IntegrityError -> 400`` backstop to catch the racy
+    "connection deleted between validate and INSERT" path.
+
+    The DTO test class above exercises the request DTO; this class
+    drives the controller method directly with mocks so we exercise
+    the validate-first branch without spinning up the full app.
+    """
+
+    async def test_unknown_connection_name_raises_validation_error(self) -> None:
+        """Pre-validation rejects unknown ``connection_name`` -> ValidationError."""
+        # The Litestar @post decorator wraps the method as an
+        # HTTPRouteHandler; ``.fn`` is the underlying coroutine that
+        # we can invoke directly with mocks for a unit-level test.
+        install_entry = MCPCatalogController.install_entry.fn
+
+        connection_catalog = MagicMock()
+        connection_catalog.get = AsyncMock(return_value=None)
+
+        app_state = MagicMock()
+        app_state.mcp_catalog_service = MagicMock()
+        app_state.mcp_installations_repo = MagicMock()
+        app_state.has_connection_catalog = True
+        app_state.connection_catalog = connection_catalog
+
+        state = {"app_state": app_state}
+        data = InstallEntryRequest(
+            catalog_entry_id="filesystem-mcp",
+            connection_name="does-not-exist",
+        )
+        with pytest.raises(DomainValidationError, match="unknown connection"):
+            await install_entry(self=None, state=state, data=data)
+        # Ensure we never reached the install service.
+        app_state.mcp_catalog_service.install.assert_not_called()
+        connection_catalog.get.assert_awaited_once_with("does-not-exist")
+
+    async def test_missing_connection_catalog_with_connection_name_raises(
+        self,
+    ) -> None:
+        """Without ``connection_catalog`` wired the pre-validation cannot
+        run -- raise ValidationError instead of letting an unbound name
+        slip through to the persistence layer."""
+        install_entry = MCPCatalogController.install_entry.fn
+
+        app_state = MagicMock()
+        app_state.mcp_catalog_service = MagicMock()
+        app_state.mcp_installations_repo = MagicMock()
+        app_state.has_connection_catalog = False
+
+        state = {"app_state": app_state}
+        data = InstallEntryRequest(
+            catalog_entry_id="filesystem-mcp",
+            connection_name="anything",
+        )
+        with pytest.raises(
+            DomainValidationError,
+            match="Integrations subsystem is not configured",
+        ):
+            await install_entry(self=None, state=state, data=data)
+        app_state.mcp_catalog_service.install.assert_not_called()
 
 
 @pytest.mark.unit

--- a/tests/unit/api/controllers/test_reports.py
+++ b/tests/unit/api/controllers/test_reports.py
@@ -69,3 +69,46 @@ class TestReportsController:
         )
         # Pydantic enum validation fails before the service runs.
         assert resp.status_code == 400
+
+    def test_generate_returns_503_when_service_not_wired(
+        self,
+        test_client: TestClient[Any],
+    ) -> None:
+        """Issue #1666 B-2 regression guard: missing wiring -> 503, not AttributeError.
+
+        Pre-#1666 the controller dereferenced ``state._app_state``
+        (private underscore attr) and surfaced a bare ``AttributeError``
+        as a 500 Internal Server Error to clients. The fix routes
+        through ``app_state.has_report_service`` -- when the service
+        is not wired the controller now raises
+        ``ServiceUnavailableError`` (HTTP 503), the honest status code
+        for "feature unavailable in this deployment". Force the not-
+        wired state by clearing the private slot directly.
+        """
+        app_state = test_client.app.state.app_state
+        original = app_state._report_service
+        app_state._report_service = None
+        try:
+            resp = test_client.post(
+                "/api/v1/reports/generate",
+                headers=_HEADERS,
+                json={"period": "daily"},
+            )
+            # 503 (NOT 500 AttributeError) when service is absent.
+            assert resp.status_code == 503, resp.text
+            body = resp.json()
+            assert body["success"] is False
+            # ``ServiceUnavailableError.error_code`` is the
+            # ``ErrorCode.SERVICE_UNAVAILABLE`` enum value (an int).
+            # Verifying both the HTTP 503 and the structured error code
+            # locks down the contract; see ``core.error_taxonomy``.
+            from synthorg.core.error_taxonomy import (
+                ErrorCode,
+            )
+
+            assert (
+                body.get("error_detail", {}).get("error_code")
+                == ErrorCode.SERVICE_UNAVAILABLE
+            )
+        finally:
+            app_state._report_service = original

--- a/tests/unit/api/controllers/test_reports.py
+++ b/tests/unit/api/controllers/test_reports.py
@@ -1,0 +1,71 @@
+"""Tests for the reports controller (#1666 B-2 regression)."""
+
+from typing import Any
+
+import pytest
+from litestar.testing import TestClient
+
+from tests.unit.api.conftest import make_auth_headers
+
+_HEADERS = make_auth_headers("ceo")
+
+
+@pytest.mark.unit
+class TestReportsController:
+    """Regression coverage for ``POST /api/v1/reports/generate``.
+
+    Pre-#1666 the controller dereferenced ``state._app_state``
+    (private attribute that does not exist on Litestar's ``State``)
+    so the endpoint surfaced a bare ``AttributeError`` to clients.
+    The fix swaps the access to ``state.app_state`` and wires
+    ``AutomatedReportService`` on AppState so the endpoint serves
+    the documented inputs instead of returning 503 unconfigured.
+    """
+
+    def test_generate_daily_report_succeeds(
+        self,
+        test_client: TestClient[Any],
+    ) -> None:
+        resp = test_client.post(
+            "/api/v1/reports/generate",
+            headers=_HEADERS,
+            json={"period": "daily"},
+        )
+        # Litestar defaults POST to 201 Created.
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["success"] is True
+        data = body["data"]
+        assert data["period"] == "daily"
+        assert "start" in data
+        assert "end" in data
+        assert "generated_at" in data
+        # All four sub-report flags are booleans -- the DTO
+        # surfaces "is anything in this slot" rather than
+        # leaking the inner aggregate shape.
+        assert isinstance(data["has_spending"], bool)
+        assert isinstance(data["has_performance"], bool)
+        assert isinstance(data["has_task_completion"], bool)
+        assert isinstance(data["has_risk_trends"], bool)
+
+    def test_list_periods(
+        self,
+        test_client: TestClient[Any],
+    ) -> None:
+        resp = test_client.get("/api/v1/reports/periods", headers=_HEADERS)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert {"daily", "weekly", "monthly"}.issubset(set(body["data"]))
+
+    def test_generate_rejects_unknown_period(
+        self,
+        test_client: TestClient[Any],
+    ) -> None:
+        resp = test_client.post(
+            "/api/v1/reports/generate",
+            headers=_HEADERS,
+            json={"period": "fortnightly"},
+        )
+        # Pydantic enum validation fails before the service runs.
+        assert resp.status_code == 400

--- a/tests/unit/api/controllers/test_setup.py
+++ b/tests/unit/api/controllers/test_setup.py
@@ -251,12 +251,9 @@ class TestSetupCompany:
         # tier-coverage gate added for issue #1666 B-5 passes; the
         # gate rejects setups that would otherwise produce per-agent
         # ``no_models_available`` warnings during template expansion.
-        from tests.unit.api.controllers.conftest import (
-            setup_mock_providers,
-        )
+        from tests.unit.api.controllers.conftest import mock_providers
 
-        app_state, original = setup_mock_providers(test_client)
-        try:
+        with mock_providers(test_client):
             resp = test_client.post(
                 "/api/v1/setup/company",
                 json={
@@ -271,8 +268,6 @@ class TestSetupCompany:
             assert data["company_name"] == "My Startup"
             assert data["template_applied"] == "solo_founder"
             assert data["department_count"] >= 1
-        finally:
-            app_state._provider_management = original
 
     def test_company_with_template_rejects_empty_provider_set(
         self,

--- a/tests/unit/api/controllers/test_setup.py
+++ b/tests/unit/api/controllers/test_setup.py
@@ -247,20 +247,55 @@ class TestSetupCompany:
         self,
         test_client: TestClient[Any],
     ) -> None:
+        # Seed a provider with at least one model so the
+        # tier-coverage gate added for issue #1666 B-5 passes; the
+        # gate rejects setups that would otherwise produce per-agent
+        # ``no_models_available`` warnings during template expansion.
+        from tests.unit.api.controllers.conftest import (
+            setup_mock_providers,
+        )
+
+        app_state, original = setup_mock_providers(test_client)
+        try:
+            resp = test_client.post(
+                "/api/v1/setup/company",
+                json={
+                    "company_name": "My Startup",
+                    "template_name": "solo_founder",
+                },
+            )
+            assert resp.status_code == 201
+            body = resp.json()
+            assert body["success"] is True
+            data = body["data"]
+            assert data["company_name"] == "My Startup"
+            assert data["template_applied"] == "solo_founder"
+            assert data["department_count"] >= 1
+        finally:
+            app_state._provider_management = original
+
+    def test_company_with_template_rejects_empty_provider_set(
+        self,
+        test_client: TestClient[Any],
+    ) -> None:
+        """Issue #1666 B-5: tier-coverage gate at the provider step.
+
+        With no providers configured, the setup wizard refuses the
+        company creation and returns 422 instead of producing per-agent
+        ``template.model_match.failed`` / ``setup.agent.model_not_found``
+        warnings during template expansion.
+        """
         resp = test_client.post(
             "/api/v1/setup/company",
             json={
-                "company_name": "My Startup",
+                "company_name": "No-Providers Startup",
                 "template_name": "solo_founder",
             },
         )
-        assert resp.status_code == 201
+        assert resp.status_code == 422
         body = resp.json()
-        assert body["success"] is True
-        data = body["data"]
-        assert data["company_name"] == "My Startup"
-        assert data["template_applied"] == "solo_founder"
-        assert data["department_count"] >= 1
+        assert body["success"] is False
+        assert "no models" in body["error"].lower()
 
     def test_invalid_template(
         self,

--- a/tests/unit/api/controllers/test_setup.py
+++ b/tests/unit/api/controllers/test_setup.py
@@ -243,55 +243,6 @@ class TestSetupCompany:
         assert stored is not None
         assert stored[0] == ""
 
-    def test_company_with_template(
-        self,
-        test_client: TestClient[Any],
-    ) -> None:
-        # Seed a provider with at least one model so the
-        # tier-coverage gate added for issue #1666 B-5 passes; the
-        # gate rejects setups that would otherwise produce per-agent
-        # ``no_models_available`` warnings during template expansion.
-        from tests.unit.api.controllers.conftest import mock_providers
-
-        with mock_providers(test_client):
-            resp = test_client.post(
-                "/api/v1/setup/company",
-                json={
-                    "company_name": "My Startup",
-                    "template_name": "solo_founder",
-                },
-            )
-            assert resp.status_code == 201
-            body = resp.json()
-            assert body["success"] is True
-            data = body["data"]
-            assert data["company_name"] == "My Startup"
-            assert data["template_applied"] == "solo_founder"
-            assert data["department_count"] >= 1
-
-    def test_company_with_template_rejects_empty_provider_set(
-        self,
-        test_client: TestClient[Any],
-    ) -> None:
-        """Issue #1666 B-5: tier-coverage gate at the provider step.
-
-        With no providers configured, the setup wizard refuses the
-        company creation and returns 422 instead of producing per-agent
-        ``template.model_match.failed`` / ``setup.agent.model_not_found``
-        warnings during template expansion.
-        """
-        resp = test_client.post(
-            "/api/v1/setup/company",
-            json={
-                "company_name": "No-Providers Startup",
-                "template_name": "solo_founder",
-            },
-        )
-        assert resp.status_code == 422
-        body = resp.json()
-        assert body["success"] is False
-        assert "no models" in body["error"].lower()
-
     def test_invalid_template(
         self,
         test_client: TestClient[Any],

--- a/tests/unit/api/controllers/test_setup_company_template_gating.py
+++ b/tests/unit/api/controllers/test_setup_company_template_gating.py
@@ -1,0 +1,67 @@
+"""Tier-coverage gate tests for ``POST /api/v1/setup/company``.
+
+Split out from ``test_setup.py`` to keep that module under the
+800-line cap. Both tests exercise the issue #1666 B-5 contract:
+the wizard refuses to create a company when no providers carry a
+tier-classifiable model, and accepts when at least one model is
+seeded via the shared ``mock_providers`` fixture.
+"""
+
+from typing import Any
+
+import pytest
+from litestar.testing import TestClient
+
+
+@pytest.mark.unit
+class TestSetupCompanyTemplateGating:
+    """Tier-coverage gate -- creation succeeds with seeded providers, fails without."""
+
+    def test_company_with_template(
+        self,
+        test_client: TestClient[Any],
+    ) -> None:
+        # Seed a provider with at least one model so the
+        # tier-coverage gate added for issue #1666 B-5 passes; the
+        # gate rejects setups that would otherwise produce per-agent
+        # ``no_models_available`` warnings during template expansion.
+        from tests.unit.api.controllers.conftest import mock_providers
+
+        with mock_providers(test_client):
+            resp = test_client.post(
+                "/api/v1/setup/company",
+                json={
+                    "company_name": "My Startup",
+                    "template_name": "solo_founder",
+                },
+            )
+            assert resp.status_code == 201
+            body = resp.json()
+            assert body["success"] is True
+            data = body["data"]
+            assert data["company_name"] == "My Startup"
+            assert data["template_applied"] == "solo_founder"
+            assert data["department_count"] >= 1
+
+    def test_company_with_template_rejects_empty_provider_set(
+        self,
+        test_client: TestClient[Any],
+    ) -> None:
+        """Issue #1666 B-5: tier-coverage gate at the provider step.
+
+        With no providers configured, the setup wizard refuses the
+        company creation and returns 422 instead of producing per-agent
+        ``template.model_match.failed`` / ``setup.agent.model_not_found``
+        warnings during template expansion.
+        """
+        resp = test_client.post(
+            "/api/v1/setup/company",
+            json={
+                "company_name": "No-Providers Startup",
+                "template_name": "solo_founder",
+            },
+        )
+        assert resp.status_code == 422
+        body = resp.json()
+        assert body["success"] is False
+        assert "no models" in body["error"].lower()

--- a/tests/unit/api/test_exception_handlers.py
+++ b/tests/unit/api/test_exception_handlers.py
@@ -146,24 +146,24 @@ class TestExceptionHandlers:
                 retryable=False,
             )
 
-    def test_psycopg_integrity_error_maps_to_400(self) -> None:
-        """Issue #1666 B-1 backstop: FK / unique / not-null violations -> 400.
+    def test_constraint_violation_error_maps_to_400(self) -> None:
+        """Issue #1666 B-1 backstop: persistence integrity violations -> 400.
 
-        psycopg's IntegrityError hierarchy lands at 400 with a
-        structured body so callers see "you sent a bad reference"
-        instead of "we exploded internally". Domain code is expected
-        to validate-first, so this handler exists as a defence
-        against race conditions and any path that misses pre-validation.
+        Repository modules translate driver integrity errors (psycopg
+        ForeignKeyViolation / UniqueViolation / NotNullViolation,
+        SQLite IntegrityError) into ``ConstraintViolationError`` at
+        the persistence boundary. The api layer registers the domain
+        class so callers see "you sent a bad reference" instead of
+        "we exploded internally". Domain code is expected to
+        validate-first, so this handler exists as a defence against
+        race conditions and any path that misses pre-validation.
         """
-        psycopg_errors = pytest.importorskip(
-            "psycopg.errors",
-            reason="psycopg not installed in this environment",
-        )
+        from synthorg.core.persistence_errors import ConstraintViolationError
 
         @get("/test")
         async def handler() -> None:
             msg = "fk constraint x violated"
-            raise psycopg_errors.ForeignKeyViolation(msg)
+            raise ConstraintViolationError(msg, constraint="connections_fk")
 
         with TestClient(make_exception_handler_app(handler)) as client:
             resp = client.get("/test")

--- a/tests/unit/api/test_exception_handlers.py
+++ b/tests/unit/api/test_exception_handlers.py
@@ -146,6 +146,38 @@ class TestExceptionHandlers:
                 retryable=False,
             )
 
+    def test_psycopg_integrity_error_maps_to_400(self) -> None:
+        """Issue #1666 B-1 backstop: FK / unique / not-null violations -> 400.
+
+        psycopg's IntegrityError hierarchy lands at 400 with a
+        structured body so callers see "you sent a bad reference"
+        instead of "we exploded internally". Domain code is expected
+        to validate-first, so this handler exists as a defence
+        against race conditions and any path that misses pre-validation.
+        """
+        psycopg_errors = pytest.importorskip(
+            "psycopg.errors",
+            reason="psycopg not installed in this environment",
+        )
+
+        @get("/test")
+        async def handler() -> None:
+            msg = "fk constraint x violated"
+            raise psycopg_errors.ForeignKeyViolation(msg)
+
+        with TestClient(make_exception_handler_app(handler)) as client:
+            resp = client.get("/test")
+            assert resp.status_code == 400
+            body = resp.json()
+            assert body["success"] is False
+            assert body["error"] == "persistence integrity violation"
+            _assert_error_detail(
+                body,
+                error_code=ErrorCode.VALIDATION_ERROR,
+                error_category=ErrorCategory.VALIDATION,
+                retryable=False,
+            )
+
     # The five backup tests below use the explicit form (rather than
     # collapsing into one parametrize) because each exercises a distinct
     # dispatch branch (404 / 409 / 500-with-specific-subtype /

--- a/tests/unit/api/test_telemetry_builder.py
+++ b/tests/unit/api/test_telemetry_builder.py
@@ -2,8 +2,8 @@
 
 ``_build_telemetry_collector`` builds a :class:`TelemetryCollector`
 wired against the memory-dir env var. The collector respects
-``SYNTHORG_TELEMETRY`` internally; this module verifies the path
-derivation, env-var handling, and memory-dir validation around
+``SYNTHORG_TELEMETRY_ENABLED`` internally; this module verifies the
+path derivation, env-var handling, and memory-dir validation around
 construction.
 """
 
@@ -24,7 +24,7 @@ class TestBuildTelemetryCollector:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.delenv("SYNTHORG_MEMORY_DIR", raising=False)
-        monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
+        monkeypatch.delenv("SYNTHORG_TELEMETRY_ENABLED", raising=False)
         collector = _build_telemetry_collector()
         assert isinstance(collector, TelemetryCollector)
         assert collector._data_dir == Path("/data/telemetry")
@@ -37,7 +37,7 @@ class TestBuildTelemetryCollector:
     ) -> None:
         memory_dir = tmp_path / "memory"
         monkeypatch.setenv("SYNTHORG_MEMORY_DIR", str(memory_dir))
-        monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
+        monkeypatch.delenv("SYNTHORG_TELEMETRY_ENABLED", raising=False)
         collector = _build_telemetry_collector()
         assert collector._data_dir == tmp_path / "telemetry"
 
@@ -46,9 +46,21 @@ class TestBuildTelemetryCollector:
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
+        from synthorg.telemetry.config import (
+            TelemetryBackend,
+            TelemetryConfig,
+        )
+
         monkeypatch.setenv("SYNTHORG_MEMORY_DIR", str(tmp_path / "memory"))
-        monkeypatch.setenv("SYNTHORG_TELEMETRY", "true")
-        collector = _build_telemetry_collector()
+        monkeypatch.setenv("SYNTHORG_TELEMETRY_ENABLED", "true")
+        # Use the NOOP backend so this test exercises the
+        # enable-flag plumbing + deployment-id directory creation
+        # without crossing the LOGFIRE token-embedded gate. The
+        # token-missing ERROR path has its own dedicated coverage
+        # in tests/unit/telemetry/test_collector.py.
+        collector = _build_telemetry_collector(
+            TelemetryConfig(backend=TelemetryBackend.NOOP),
+        )
         try:
             assert collector.enabled is True
             # ``start()`` performs the deployment-id load via
@@ -90,7 +102,7 @@ class TestMemoryDirValidation:
         bad_value: str,
     ) -> None:
         monkeypatch.setenv("SYNTHORG_MEMORY_DIR", bad_value)
-        monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
+        monkeypatch.delenv("SYNTHORG_TELEMETRY_ENABLED", raising=False)
         collector = _build_telemetry_collector()
         # Falls back to ``/data/memory`` -> ``/data/telemetry``.
         assert collector._data_dir == Path("/data/telemetry")
@@ -104,7 +116,7 @@ class TestMemoryDirValidation:
             "SYNTHORG_MEMORY_DIR",
             f"  {tmp_path / 'memory'}  ",
         )
-        monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
+        monkeypatch.delenv("SYNTHORG_TELEMETRY_ENABLED", raising=False)
         collector = _build_telemetry_collector()
         # Surrounding whitespace is stripped before the prefix check.
         assert collector._data_dir == tmp_path / "telemetry"
@@ -122,7 +134,7 @@ class TestMemoryDirValidation:
         writes outside the intended surface.
         """
         monkeypatch.setenv("SYNTHORG_MEMORY_DIR", "/etc/synthorg")
-        monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
+        monkeypatch.delenv("SYNTHORG_TELEMETRY_ENABLED", raising=False)
         collector = _build_telemetry_collector()
         assert collector._data_dir == Path("/data/telemetry")
 
@@ -137,7 +149,7 @@ class TestMemoryDirValidation:
         past the allow-list by starting with ``/data``.
         """
         monkeypatch.setenv("SYNTHORG_MEMORY_DIR", "/data/../etc/memory")
-        monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
+        monkeypatch.delenv("SYNTHORG_TELEMETRY_ENABLED", raising=False)
         collector = _build_telemetry_collector()
         assert collector._data_dir == Path("/data/telemetry")
 
@@ -155,6 +167,6 @@ class TestMemoryDirValidation:
         *strict* descendant of a root.
         """
         monkeypatch.setenv("SYNTHORG_MEMORY_DIR", "/data")
-        monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
+        monkeypatch.delenv("SYNTHORG_TELEMETRY_ENABLED", raising=False)
         collector = _build_telemetry_collector()
         assert collector._data_dir == Path("/data/telemetry")

--- a/tests/unit/integrations/test_ngrok_adapter.py
+++ b/tests/unit/integrations/test_ngrok_adapter.py
@@ -1,0 +1,75 @@
+"""Tests for the ngrok tunnel adapter (#1666 B-4 regression guard)."""
+
+import pytest
+
+
+@pytest.mark.unit
+class TestPyngrokIsRequiredDependency:
+    """Issue #1666 B-4: ``pyngrok`` is a required runtime dep, not optional.
+
+    Pre-#1666 the import was guarded by ``try/except ImportError`` so a
+    missing dep silently degraded the tunnel feature to 503 at runtime.
+    Now ``pyngrok`` is declared in ``[project.dependencies]`` and the
+    adapter imports it unconditionally; a missing dep is a build /
+    install bug that surfaces at module load. These tests are smoke-
+    grade regression guards: if ``pyngrok`` is ever removed from
+    ``pyproject.toml`` the tests fail at import time, well before any
+    runtime tunnel request.
+    """
+
+    def test_pyngrok_module_imports_cleanly(self) -> None:
+        """``import pyngrok`` succeeds (i.e., it is installed)."""
+        import importlib
+
+        # Use importlib.import_module so mypy doesn't try to resolve
+        # the (untyped) pyngrok module's attributes at type-check time.
+        pyngrok = importlib.import_module("pyngrok")
+        assert pyngrok is not None
+
+    def test_ngrok_adapter_imports_pyngrok_unconditionally(self) -> None:
+        """The adapter module imports ``pyngrok`` at module load.
+
+        If a future refactor reintroduces the ``try/except ImportError``
+        guard, this assertion still passes (the import would still
+        succeed in this environment), but the companion source-grep
+        regression test below catches that case.
+        """
+        from synthorg.integrations.tunnel import ngrok_adapter
+
+        # The module-level bindings `conf` and `ngrok` must be live --
+        # not None placeholders left by a guarded import. Access via
+        # ``getattr`` so mypy's strict ``--no-implicit-reexport`` does
+        # not flag re-exposed third-party attributes.
+        assert getattr(ngrok_adapter, "conf", None) is not None
+        assert getattr(ngrok_adapter, "ngrok", None) is not None
+
+    def test_no_import_guard_in_adapter_source(self) -> None:
+        """Source-level guard: no ``try/except ImportError`` wraps pyngrok.
+
+        A failing import is a build / install bug per the design
+        contract, not a runtime configuration concern. This grep-level
+        assertion fails loudly if the guard ever creeps back in.
+        """
+        from pathlib import Path
+
+        import synthorg.integrations.tunnel.ngrok_adapter as adapter_module
+
+        source_path = Path(adapter_module.__file__)
+        source = source_path.read_text(encoding="utf-8")
+        # Look for the specific guarded form. A bare ``import pyngrok``
+        # inside an ``except ImportError`` arm in some unrelated test
+        # helper would not be flagged, only the production module's
+        # import.
+        assert "from pyngrok import" in source
+        # Crude but effective: the guard pattern is a single-line
+        # ``try:`` followed by the pyngrok import within ~5 lines.
+        for idx, line in enumerate(source.splitlines()):
+            if "from pyngrok import" not in line:
+                continue
+            # Check the previous handful of lines for a ``try:`` that
+            # could indicate a guarded import.
+            window = source.splitlines()[max(0, idx - 6) : idx]
+            assert not any(line_text.strip() == "try:" for line_text in window), (
+                "pyngrok import appears to be guarded by try/except; "
+                "the dep is required, the import must be unconditional."
+            )

--- a/tests/unit/observability/test_sink_filter_integration.py
+++ b/tests/unit/observability/test_sink_filter_integration.py
@@ -1,0 +1,274 @@
+"""Integration tests for sink-level filtering (#1666 A-1 / A-2).
+
+The unit tests in ``test_sink_routing.py`` cover the filter classes
+in isolation. These tests boot the full handler chain with the new
+``SINK_EVENT_EXCLUDES`` and ``SINK_EXACT_LEVELS`` tables wired in,
+emit real records via :func:`logging.getLogger`, then read the
+on-disk file output to confirm the filters actually drop the
+correct records before they hit the disk sink. A regression where
+``_attach_formatter_and_routing()`` forgets to attach a filter is
+caught here even though the unit tests would still pass.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from synthorg.observability.config import RotationConfig, SinkConfig
+from synthorg.observability.enums import LogLevel, SinkType
+from synthorg.observability.sinks import build_handler
+
+
+def _foreign_pre_chain() -> list[Any]:
+    """Minimal processor chain so the JSON renderer has level + event."""
+    import structlog
+
+    return [
+        structlog.stdlib.add_log_level,
+    ]
+
+
+def _emit_structlog_record(
+    handler: logging.Handler,
+    *,
+    name: str,
+    level: int,
+    event: str,
+    **kwargs: object,
+) -> None:
+    """Build a LogRecord whose ``msg`` is a structlog-style event_dict.
+
+    Production records reach the handler with ``record.msg`` populated
+    by ``structlog.stdlib.ProcessorFormatter.wrap_for_formatter``; this
+    test helper bypasses structlog and constructs the dict-shape
+    record directly so the filter chain is exercised on the same
+    inputs it sees in production.
+    """
+    msg: dict[str, object] = {
+        "event": event,
+        "level": logging.getLevelName(level).lower(),
+    }
+    msg.update(kwargs)
+    record = logging.LogRecord(
+        name=name,
+        level=level,
+        pathname="",
+        lineno=0,
+        msg=msg,
+        args=(),
+        exc_info=None,
+    )
+    handler.handle(record)
+
+
+def _read_lines(path: Path) -> list[str]:
+    """Read raw lines from a log file. Empty file -> ``[]``.
+
+    The integration test bypasses structlog's formatter chain (the
+    handler-builder wires the filters before the formatter ever
+    runs), so the on-disk lines are the str-repr of the event_dict
+    rather than canonical JSON. Lines are still distinct per record;
+    substring matching is enough for the filter-pass / filter-drop
+    contract these tests assert.
+    """
+    if not path.exists():
+        return []
+    raw = path.read_text(encoding="utf-8").strip()
+    if not raw:
+        return []
+    return [line for line in raw.splitlines() if line.strip()]
+
+
+def _count_event(lines: list[str], event: str) -> int:
+    """Count lines whose serialised event_dict carries ``event=<name>``."""
+    return sum(1 for line in lines if f"'event': '{event}'" in line)
+
+
+@pytest.mark.unit
+class TestSynthorgLogExcludesRequestLifecycle:
+    """Issue #1666 A-1: ``synthorg.log`` does not collect request events.
+
+    ``api.request.started`` and ``api.request.completed`` already land
+    in ``access.log`` via the logger-name include filter. Letting them
+    flood the catch-all main log buries 96% of every other event under
+    request-lifecycle noise. ``SINK_EVENT_EXCLUDES`` tells the
+    handler-builder to attach an ``_EventNameFilter`` that drops them
+    before they ever reach disk.
+    """
+
+    def test_main_log_drops_started_and_completed_events(
+        self,
+        tmp_path: Path,
+        handler_cleanup: list[logging.Handler],
+    ) -> None:
+        sink = SinkConfig(
+            sink_type=SinkType.FILE,
+            level=LogLevel.INFO,
+            file_path="synthorg.log",
+            rotation=RotationConfig(),
+            json_format=True,
+        )
+        handler = build_handler(sink, tmp_path, _foreign_pre_chain())
+        handler_cleanup.append(handler)
+
+        # 5 lifecycle records that MUST be dropped + 2 keep-events.
+        for _ in range(3):
+            _emit_structlog_record(
+                handler,
+                name="synthorg.api.middleware",
+                level=logging.INFO,
+                event="api.request.started",
+                method="GET",
+                path="/api/v1/health",
+            )
+        for _ in range(2):
+            _emit_structlog_record(
+                handler,
+                name="synthorg.api.middleware",
+                level=logging.INFO,
+                event="api.request.completed",
+                method="GET",
+                path="/api/v1/health",
+                status_code=200,
+                duration_ms=1.4,
+            )
+        # Same logger but a non-lifecycle event -- this MUST land in
+        # synthorg.log (the filter is event-scoped, not logger-scoped).
+        _emit_structlog_record(
+            handler,
+            name="synthorg.api.middleware",
+            level=logging.WARNING,
+            event="metrics.record.failed",
+            component="api_request_duration",
+        )
+        # Different domain, INFO-level -- must land.
+        _emit_structlog_record(
+            handler,
+            name="synthorg.engine.task",
+            level=logging.INFO,
+            event="task.run.started",
+            task_id="t-1",
+        )
+        handler.flush()
+
+        lines = _read_lines(tmp_path / "synthorg.log")
+        # Lifecycle events dropped.
+        assert _count_event(lines, "api.request.started") == 0
+        assert _count_event(lines, "api.request.completed") == 0
+        # Other events on the same logger pass through.
+        assert _count_event(lines, "metrics.record.failed") == 1
+        assert _count_event(lines, "task.run.started") == 1
+
+    def test_access_log_keeps_lifecycle_events(
+        self,
+        tmp_path: Path,
+        handler_cleanup: list[logging.Handler],
+    ) -> None:
+        """Verify the lifecycle events DO land in ``access.log`` -- the
+        complementary half of the contract."""
+        sink = SinkConfig(
+            sink_type=SinkType.FILE,
+            level=LogLevel.INFO,
+            file_path="access.log",
+            rotation=RotationConfig(),
+            json_format=True,
+        )
+        handler = build_handler(sink, tmp_path, _foreign_pre_chain())
+        handler_cleanup.append(handler)
+
+        for _ in range(2):
+            _emit_structlog_record(
+                handler,
+                name="synthorg.api.middleware",
+                level=logging.INFO,
+                event="api.request.started",
+                method="GET",
+                path="/api/v1/health",
+            )
+        # An off-prefix logger MUST be excluded by the include filter.
+        _emit_structlog_record(
+            handler,
+            name="synthorg.engine.task",
+            level=logging.INFO,
+            event="task.run.started",
+        )
+        handler.flush()
+
+        lines = _read_lines(tmp_path / "access.log")
+        # Lifecycle events kept (this is the access log's whole job).
+        assert _count_event(lines, "api.request.started") == 2
+        # Non-api logger excluded by the access.log include filter.
+        assert _count_event(lines, "task.run.started") == 0
+
+
+@pytest.mark.unit
+class TestDebugLogExactLevel:
+    """Issue #1666 A-2: ``debug.log`` only collects DEBUG-level records.
+
+    Pre-#1666 the sink had ``level=LogLevel.DEBUG`` (meaning "DEBUG and
+    above"), so an INFO-quiet system left ``debug.log`` byte-identical
+    to ``synthorg.log`` with 33,734 lines of INFO. The
+    ``SINK_EXACT_LEVELS`` table now attaches an ``_ExactLevelFilter``
+    that drops every level except DEBUG.
+    """
+
+    def test_debug_log_keeps_only_debug_records(
+        self,
+        tmp_path: Path,
+        handler_cleanup: list[logging.Handler],
+    ) -> None:
+        sink = SinkConfig(
+            sink_type=SinkType.FILE,
+            level=LogLevel.DEBUG,
+            file_path="debug.log",
+            rotation=RotationConfig(),
+            json_format=True,
+        )
+        handler = build_handler(sink, tmp_path, _foreign_pre_chain())
+        handler_cleanup.append(handler)
+
+        for level in (logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR):
+            _emit_structlog_record(
+                handler,
+                name="synthorg.engine.task",
+                level=level,
+                event=f"test.level.{logging.getLevelName(level).lower()}",
+            )
+        handler.flush()
+
+        lines = _read_lines(tmp_path / "debug.log")
+        # Only the DEBUG record landed in debug.log.
+        assert _count_event(lines, "test.level.debug") == 1
+        assert _count_event(lines, "test.level.info") == 0
+        assert _count_event(lines, "test.level.warning") == 0
+        assert _count_event(lines, "test.level.error") == 0
+
+    def test_debug_log_empty_when_no_debug_records(
+        self,
+        tmp_path: Path,
+        handler_cleanup: list[logging.Handler],
+    ) -> None:
+        """With no DEBUG emissions, the file stays empty (no INFO leak)."""
+        sink = SinkConfig(
+            sink_type=SinkType.FILE,
+            level=LogLevel.DEBUG,
+            file_path="debug.log",
+            rotation=RotationConfig(),
+            json_format=True,
+        )
+        handler = build_handler(sink, tmp_path, _foreign_pre_chain())
+        handler_cleanup.append(handler)
+
+        for _ in range(5):
+            _emit_structlog_record(
+                handler,
+                name="synthorg.engine.task",
+                level=logging.INFO,
+                event="task.run.started",
+            )
+        handler.flush()
+
+        lines = _read_lines(tmp_path / "debug.log")
+        assert lines == []

--- a/tests/unit/observability/test_sink_filter_integration.py
+++ b/tests/unit/observability/test_sink_filter_integration.py
@@ -86,7 +86,7 @@ def _count_event(lines: list[str], event: str) -> int:
     return sum(1 for line in lines if f"'event': '{event}'" in line)
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 class TestSynthorgLogExcludesRequestLifecycle:
     """Issue #1666 A-1: ``synthorg.log`` does not collect request events.
 
@@ -187,6 +187,17 @@ class TestSynthorgLogExcludesRequestLifecycle:
                 method="GET",
                 path="/api/v1/health",
             )
+        for _ in range(2):
+            _emit_structlog_record(
+                handler,
+                name="synthorg.api.middleware",
+                level=logging.INFO,
+                event="api.request.completed",
+                method="GET",
+                path="/api/v1/health",
+                status_code=200,
+                duration_ms=1.4,
+            )
         # An off-prefix logger MUST be excluded by the include filter.
         _emit_structlog_record(
             handler,
@@ -197,13 +208,15 @@ class TestSynthorgLogExcludesRequestLifecycle:
         handler.flush()
 
         lines = _read_lines(tmp_path / "access.log")
-        # Lifecycle events kept (this is the access log's whole job).
+        # Both halves of the lifecycle land in access.log; the catch-all
+        # main log is the one excluding them, not this sink.
         assert _count_event(lines, "api.request.started") == 2
+        assert _count_event(lines, "api.request.completed") == 2
         # Non-api logger excluded by the access.log include filter.
         assert _count_event(lines, "task.run.started") == 0
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 class TestDebugLogExactLevel:
     """Issue #1666 A-2: ``debug.log`` only collects DEBUG-level records.
 

--- a/tests/unit/observability/test_sink_routing.py
+++ b/tests/unit/observability/test_sink_routing.py
@@ -47,7 +47,7 @@ def _make_structlog_record(
         level=level,
         pathname="",
         lineno=0,
-        msg=msg,  # type: ignore[arg-type]
+        msg=msg,
         args=(),
         exc_info=None,
     )

--- a/tests/unit/observability/test_sink_routing.py
+++ b/tests/unit/observability/test_sink_routing.py
@@ -1,10 +1,18 @@
-"""Tests for sink routing (logger name filters)."""
+"""Tests for sink routing (logger name + event name + exact level filters)."""
 
 import logging
+from typing import Any
 
 import pytest
 
-from synthorg.observability.sinks import SINK_ROUTING, _LoggerNameFilter
+from synthorg.observability.sinks import (
+    SINK_EVENT_EXCLUDES,
+    SINK_EXACT_LEVELS,
+    SINK_ROUTING,
+    _EventNameFilter,
+    _ExactLevelFilter,
+    _LoggerNameFilter,
+)
 
 
 def _make_record(name: str) -> logging.LogRecord:
@@ -12,6 +20,48 @@ def _make_record(name: str) -> logging.LogRecord:
     return logging.LogRecord(
         name=name,
         level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="test",
+        args=(),
+        exc_info=None,
+    )
+
+
+def _make_structlog_record(
+    event: str,
+    *,
+    name: str = "synthorg.api.middleware",
+    level: int = logging.INFO,
+) -> logging.LogRecord:
+    """Create a LogRecord shaped like structlog's wrap_for_formatter output.
+
+    structlog's stdlib bridge stores the processed event_dict as
+    ``record.msg`` (a dict carrying the ``event`` key plus all
+    structured kwargs).  This helper builds that exact shape so
+    filter tests exercise the production record layout.
+    """
+    msg: dict[str, Any] = {"event": event, "level": logging.getLevelName(level).lower()}
+    return logging.LogRecord(
+        name=name,
+        level=level,
+        pathname="",
+        lineno=0,
+        msg=msg,  # type: ignore[arg-type]
+        args=(),
+        exc_info=None,
+    )
+
+
+def _make_level_record(
+    level: int,
+    *,
+    name: str = "synthorg.core",
+) -> logging.LogRecord:
+    """Create a LogRecord with the given level."""
+    return logging.LogRecord(
+        name=name,
+        level=level,
         pathname="",
         lineno=0,
         msg="test",
@@ -128,3 +178,74 @@ class TestSinkRoutingTable:
     def test_catchall_sinks_not_in_routing(self) -> None:
         for name in ("synthorg.log", "errors.log", "debug.log"):
             assert name not in SINK_ROUTING
+
+
+@pytest.mark.unit
+class TestEventNameFilter:
+    """Tests for the structlog-aware event-name exclusion filter."""
+
+    def test_no_excludes_accepts_all(self) -> None:
+        f = _EventNameFilter(exclude_events=())
+        assert f.filter(_make_structlog_record("api.request.started"))
+        assert f.filter(_make_structlog_record("metrics.record.failed"))
+
+    def test_excludes_match_dropped(self) -> None:
+        f = _EventNameFilter(
+            exclude_events=("api.request.started", "api.request.completed"),
+        )
+        assert not f.filter(_make_structlog_record("api.request.started"))
+        assert not f.filter(_make_structlog_record("api.request.completed"))
+
+    def test_unrelated_events_pass_through(self) -> None:
+        f = _EventNameFilter(
+            exclude_events=("api.request.started", "api.request.completed"),
+        )
+        assert f.filter(_make_structlog_record("metrics.record.failed"))
+        assert f.filter(_make_structlog_record("api.asgi.missing_status"))
+
+    def test_non_dict_msg_falls_back_to_string(self) -> None:
+        """Records from foreign loggers carry record.msg as a string."""
+        f = _EventNameFilter(exclude_events=("api.request.started",))
+        record = _make_record("third.party")
+        record.msg = "api.request.started"
+        assert not f.filter(record)
+        record.msg = "api.request.completed"
+        assert f.filter(record)
+
+    def test_blank_event_string_rejected_in_constructor(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            _EventNameFilter(exclude_events=("", "api.request.started"))
+
+
+@pytest.mark.unit
+class TestExactLevelFilter:
+    """Tests for the strict level-equality filter."""
+
+    def test_only_matching_level_passes(self) -> None:
+        f = _ExactLevelFilter(levelno=logging.DEBUG)
+        assert f.filter(_make_level_record(logging.DEBUG))
+        assert not f.filter(_make_level_record(logging.INFO))
+        assert not f.filter(_make_level_record(logging.WARNING))
+        assert not f.filter(_make_level_record(logging.ERROR))
+
+    def test_info_level_filter(self) -> None:
+        f = _ExactLevelFilter(levelno=logging.INFO)
+        assert f.filter(_make_level_record(logging.INFO))
+        assert not f.filter(_make_level_record(logging.DEBUG))
+        assert not f.filter(_make_level_record(logging.WARNING))
+
+
+@pytest.mark.unit
+class TestSinkEventExcludesTable:
+    def test_synthorg_log_excludes_lifecycle(self) -> None:
+        assert "synthorg.log" in SINK_EVENT_EXCLUDES
+        excludes = SINK_EVENT_EXCLUDES["synthorg.log"]
+        assert "api.request.started" in excludes
+        assert "api.request.completed" in excludes
+
+
+@pytest.mark.unit
+class TestSinkExactLevelsTable:
+    def test_debug_log_pinned_to_debug(self) -> None:
+        assert "debug.log" in SINK_EXACT_LEVELS
+        assert SINK_EXACT_LEVELS["debug.log"] == logging.DEBUG

--- a/tests/unit/scripts/test_embed_logfire_token.py
+++ b/tests/unit/scripts/test_embed_logfire_token.py
@@ -154,4 +154,11 @@ class TestMain:
         """Sanity check: the default target path resolves to the in-repo file."""
         target = embed_module._resolve_target()
         assert target.exists()
-        assert target.name == "_embedded_token.py"
+        # Match the full repo-relative path so a future rename or stray
+        # ``_embedded_token.py`` elsewhere in the tree cannot satisfy
+        # this assertion. The embedder MUST land on this exact file.
+        expected_relative = Path(
+            "src/synthorg/telemetry/reporters/_embedded_token.py",
+        )
+        assert target.is_absolute()
+        assert target.resolve() == (_REPO_ROOT / expected_relative).resolve()

--- a/tests/unit/scripts/test_embed_logfire_token.py
+++ b/tests/unit/scripts/test_embed_logfire_token.py
@@ -1,0 +1,157 @@
+"""Tests for ``scripts/embed_logfire_token.py``."""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "embed_logfire_token.py"
+
+
+def _load_script() -> ModuleType:
+    """Import the embedder script as a module without altering sys.path."""
+    spec = importlib.util.spec_from_file_location(
+        "embed_logfire_token",
+        _SCRIPT_PATH,
+    )
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def embed_module() -> ModuleType:
+    return _load_script()
+
+
+@pytest.fixture
+def fake_target(tmp_path: Path) -> Path:
+    """Create a target file containing the sentinel."""
+    target = tmp_path / "_embedded_token.py"
+    target.write_text(
+        'EMBEDDED_LOGFIRE_TOKEN = "__SYNTHORG_LOGFIRE_TOKEN_NOT_EMBEDDED__"\n',
+        encoding="utf-8",
+    )
+    return target
+
+
+@pytest.mark.unit
+class TestEmbed:
+    """The library entrypoint ``embed(token, target)``."""
+
+    def test_replaces_sentinel(
+        self,
+        embed_module: ModuleType,
+        fake_target: Path,
+    ) -> None:
+        embed_module.embed("pylf_v1_real_secret", fake_target)
+        new = fake_target.read_text(encoding="utf-8")
+        assert "__SYNTHORG_LOGFIRE_TOKEN_NOT_EMBEDDED__" not in new
+        assert "pylf_v1_real_secret" in new
+
+    def test_rejects_empty_token(
+        self,
+        embed_module: ModuleType,
+        fake_target: Path,
+    ) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            embed_module.embed("", fake_target)
+        with pytest.raises(ValueError, match="non-empty"):
+            embed_module.embed("   ", fake_target)
+
+    def test_rejects_already_embedded_target(
+        self,
+        embed_module: ModuleType,
+        tmp_path: Path,
+    ) -> None:
+        """Re-embedding must fail loudly to prevent silently overwriting tokens."""
+        target = tmp_path / "_embedded_token.py"
+        target.write_text(
+            'EMBEDDED_LOGFIRE_TOKEN = "real_token_already_baked"\n',
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="sentinel"):
+            embed_module.embed("another_token", target)
+
+    def test_replaces_only_first_occurrence(
+        self,
+        embed_module: ModuleType,
+        tmp_path: Path,
+    ) -> None:
+        """Defensive: even if a docstring contains the sentinel string,
+        only the constant assignment is rewritten."""
+        target = tmp_path / "_embedded_token.py"
+        sentinel = "__SYNTHORG_LOGFIRE_TOKEN_NOT_EMBEDDED__"
+        target.write_text(
+            (
+                f'"""docstring with sentinel: {sentinel}"""\n'
+                f'EMBEDDED_LOGFIRE_TOKEN = "{sentinel}"\n'
+            ),
+            encoding="utf-8",
+        )
+        embed_module.embed("real_token", target)
+        new = target.read_text(encoding="utf-8")
+        # Exactly one replacement; the docstring still carries the
+        # sentinel literal so future operators can search for the
+        # rotation marker without confusing it for the runtime token.
+        assert new.count("__SYNTHORG_LOGFIRE_TOKEN_NOT_EMBEDDED__") == 1
+        assert "real_token" in new
+
+
+@pytest.mark.unit
+class TestMain:
+    """The CLI entrypoint ``main(argv) -> exit code``."""
+
+    def test_success_returns_zero(
+        self,
+        embed_module: ModuleType,
+        fake_target: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(embed_module, "_resolve_target", lambda: fake_target)
+        rc = embed_module.main(["embed_logfire_token.py", "real_token"])
+        assert rc == 0
+
+    def test_missing_argument_returns_two(
+        self,
+        embed_module: ModuleType,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = embed_module.main(["embed_logfire_token.py"])
+        assert rc == 2
+        assert "usage" in capsys.readouterr().err.lower()
+
+    def test_blank_argument_returns_two(
+        self,
+        embed_module: ModuleType,
+    ) -> None:
+        rc = embed_module.main(["embed_logfire_token.py", "   "])
+        assert rc == 2
+
+    def test_already_embedded_returns_three(
+        self,
+        embed_module: ModuleType,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        target = tmp_path / "_embedded_token.py"
+        target.write_text(
+            'EMBEDDED_LOGFIRE_TOKEN = "already_embedded"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(embed_module, "_resolve_target", lambda: target)
+        rc = embed_module.main(["embed_logfire_token.py", "another_token"])
+        assert rc == 3
+
+    def test_resolve_target_points_at_real_file(
+        self,
+        embed_module: ModuleType,
+    ) -> None:
+        """Sanity check: the default target path resolves to the in-repo file."""
+        target = embed_module._resolve_target()
+        assert target.exists()
+        assert target.name == "_embedded_token.py"

--- a/tests/unit/scripts/test_embed_logfire_token.py
+++ b/tests/unit/scripts/test_embed_logfire_token.py
@@ -33,7 +33,7 @@ def fake_target(tmp_path: Path) -> Path:
     """Create a target file containing the sentinel."""
     target = tmp_path / "_embedded_token.py"
     target.write_text(
-        'EMBEDDED_LOGFIRE_TOKEN = "__SYNTHORG_LOGFIRE_TOKEN_NOT_EMBEDDED__"\n',
+        'EMBEDDED_TELEMETRY_TOKEN = "__SYNTHORG_TELEMETRY_TOKEN_NOT_EMBEDDED__"\n',
         encoding="utf-8",
     )
     return target
@@ -50,7 +50,7 @@ class TestEmbed:
     ) -> None:
         embed_module.embed("pylf_v1_real_secret", fake_target)
         new = fake_target.read_text(encoding="utf-8")
-        assert "__SYNTHORG_LOGFIRE_TOKEN_NOT_EMBEDDED__" not in new
+        assert "__SYNTHORG_TELEMETRY_TOKEN_NOT_EMBEDDED__" not in new
         assert "pylf_v1_real_secret" in new
 
     def test_rejects_empty_token(
@@ -71,7 +71,7 @@ class TestEmbed:
         """Re-embedding must fail loudly to prevent silently overwriting tokens."""
         target = tmp_path / "_embedded_token.py"
         target.write_text(
-            'EMBEDDED_LOGFIRE_TOKEN = "real_token_already_baked"\n',
+            'EMBEDDED_TELEMETRY_TOKEN = "real_token_already_baked"\n',
             encoding="utf-8",
         )
         with pytest.raises(ValueError, match="sentinel"):
@@ -85,11 +85,11 @@ class TestEmbed:
         """Defensive: even if a docstring contains the sentinel string,
         only the constant assignment is rewritten."""
         target = tmp_path / "_embedded_token.py"
-        sentinel = "__SYNTHORG_LOGFIRE_TOKEN_NOT_EMBEDDED__"
+        sentinel = "__SYNTHORG_TELEMETRY_TOKEN_NOT_EMBEDDED__"
         target.write_text(
             (
                 f'"""docstring with sentinel: {sentinel}"""\n'
-                f'EMBEDDED_LOGFIRE_TOKEN = "{sentinel}"\n'
+                f'EMBEDDED_TELEMETRY_TOKEN = "{sentinel}"\n'
             ),
             encoding="utf-8",
         )
@@ -98,7 +98,7 @@ class TestEmbed:
         # Exactly one replacement; the docstring still carries the
         # sentinel literal so future operators can search for the
         # rotation marker without confusing it for the runtime token.
-        assert new.count("__SYNTHORG_LOGFIRE_TOKEN_NOT_EMBEDDED__") == 1
+        assert new.count("__SYNTHORG_TELEMETRY_TOKEN_NOT_EMBEDDED__") == 1
         assert "real_token" in new
 
 
@@ -140,7 +140,7 @@ class TestMain:
     ) -> None:
         target = tmp_path / "_embedded_token.py"
         target.write_text(
-            'EMBEDDED_LOGFIRE_TOKEN = "already_embedded"\n',
+            'EMBEDDED_TELEMETRY_TOKEN = "already_embedded"\n',
             encoding="utf-8",
         )
         monkeypatch.setattr(embed_module, "_resolve_target", lambda: target)

--- a/tests/unit/telemetry/reporters/test_factory.py
+++ b/tests/unit/telemetry/reporters/test_factory.py
@@ -1,9 +1,15 @@
 """Tests for the telemetry reporter factory."""
 
+from unittest.mock import patch
+
 import pytest
+import structlog.testing
 
 from synthorg.telemetry.config import TelemetryBackend, TelemetryConfig
 from synthorg.telemetry.reporters import create_reporter
+from synthorg.telemetry.reporters.errors import (
+    LogfireConfigureError,
+)
 from synthorg.telemetry.reporters.noop import NoopReporter
 
 
@@ -21,38 +27,147 @@ class TestCreateReporter:
         reporter = create_reporter(config)
         assert isinstance(reporter, NoopReporter)
 
+    def test_sentinel_token_falls_back_to_noop_with_log(self) -> None:
+        """Build artifact missing the embedded token -> NoopReporter + WARNING."""
+        config = TelemetryConfig(enabled=True, backend=TelemetryBackend.LOGFIRE)
+        with (
+            patch(
+                "synthorg.telemetry.reporters.is_token_embedded",
+                return_value=False,
+            ),
+            structlog.testing.capture_logs() as logs,
+        ):
+            reporter = create_reporter(config)
+        assert isinstance(reporter, NoopReporter)
+        warnings = [
+            log
+            for log in logs
+            if log.get("event") == "telemetry.report.failed"
+            and log.get("detail") == "logfire_token_missing"
+        ]
+        assert len(warnings) == 1
+        assert warnings[0]["error_type"] == "LogfireTokenMissingError"
+
+    def test_import_failure_falls_back_to_noop_with_real_error_type(self) -> None:
+        """Logfire import failure logs the actual error_type, not a hardcoded string."""
+        config = TelemetryConfig(enabled=True, backend=TelemetryBackend.LOGFIRE)
+
+        def _raise_import_error(**_kwargs: object) -> None:
+            msg = "no logfire here"
+            raise ImportError(msg)
+
+        with (
+            patch(
+                "synthorg.telemetry.reporters.is_token_embedded",
+                return_value=True,
+            ),
+            patch(
+                "synthorg.telemetry.reporters.logfire.LogfireReporter",
+                side_effect=_raise_import_error,
+            ),
+            structlog.testing.capture_logs() as logs,
+        ):
+            reporter = create_reporter(config)
+        assert isinstance(reporter, NoopReporter)
+        warnings = [
+            log
+            for log in logs
+            if log.get("event") == "telemetry.report.failed"
+            and log.get("detail") == "logfire_import_failed"
+        ]
+        assert len(warnings) == 1
+        assert warnings[0]["error_type"] == "ImportError"
+
+    def test_configure_failure_falls_back_to_noop(self) -> None:
+        """LogfireConfigureError -> NoopReporter + WARNING with real error_type."""
+        config = TelemetryConfig(enabled=True, backend=TelemetryBackend.LOGFIRE)
+
+        def _raise_configure_error(**_kwargs: object) -> None:
+            msg = "configure rejected"
+            raise LogfireConfigureError(msg)
+
+        with (
+            patch(
+                "synthorg.telemetry.reporters.is_token_embedded",
+                return_value=True,
+            ),
+            patch(
+                "synthorg.telemetry.reporters.logfire.LogfireReporter",
+                side_effect=_raise_configure_error,
+            ),
+            structlog.testing.capture_logs() as logs,
+        ):
+            reporter = create_reporter(config)
+        assert isinstance(reporter, NoopReporter)
+        warnings = [
+            log
+            for log in logs
+            if log.get("event") == "telemetry.report.failed"
+            and log.get("detail") == "logfire_configure_failed"
+        ]
+        assert len(warnings) == 1
+        assert warnings[0]["error_type"] == "LogfireConfigureError"
+
+    def test_unknown_exception_propagates(self) -> None:
+        """Unknown exception classes must NOT be silently swallowed."""
+        config = TelemetryConfig(enabled=True, backend=TelemetryBackend.LOGFIRE)
+
+        class _CustomError(Exception):
+            pass
+
+        def _raise_custom(**_kwargs: object) -> None:
+            msg = "this is not a sanctioned failure mode"
+            raise _CustomError(msg)
+
+        with (
+            patch(
+                "synthorg.telemetry.reporters.is_token_embedded",
+                return_value=True,
+            ),
+            patch(
+                "synthorg.telemetry.reporters.logfire.LogfireReporter",
+                side_effect=_raise_custom,
+            ),
+            pytest.raises(_CustomError),
+        ):
+            create_reporter(config)
+
     def test_logfire_backend_returns_reporter_or_noop(self) -> None:
-        """Logfire backend returns a reporter or NoopReporter."""
+        """Real init succeeds OR fails through one of the three sanctioned paths."""
         config = TelemetryConfig(enabled=True, backend=TelemetryBackend.LOGFIRE)
         reporter = create_reporter(config)
-        # Factory catches exceptions and falls back to NoopReporter
-        # when logfire is not installed or init fails.
         reporter_name = type(reporter).__name__
         assert reporter_name in {"LogfireReporter", "NoopReporter"}
 
-    def test_config_environment_threaded_into_logfire_reporter(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_config_environment_threaded_into_logfire_reporter(self) -> None:
         """``config.environment`` must reach ``LogfireReporter.__init__``."""
         pytest.importorskip(
             "logfire",
             reason="logfire extra not installed in this environment",
         )
-        from unittest.mock import patch
 
-        monkeypatch.setenv(
-            "SYNTHORG_LOGFIRE_PROJECT_TOKEN",
-            "pylf_v1_test_000000000000000000000000000000000000000000",
-        )
         config = TelemetryConfig(
             enabled=True,
             backend=TelemetryBackend.LOGFIRE,
             environment="staging",
         )
 
-        import synthorg.telemetry.reporters.logfire as logfire_module
-
-        with patch.object(logfire_module, "LogfireReporter") as mock_reporter_cls:
+        with (
+            patch(
+                "synthorg.telemetry.reporters.is_token_embedded",
+                return_value=True,
+            ),
+            patch(
+                "synthorg.telemetry.reporters.EMBEDDED_LOGFIRE_TOKEN",
+                "pylf_v1_test_000000000000000000000000000000000000000000",
+            ),
+            patch(
+                "synthorg.telemetry.reporters.logfire.LogfireReporter",
+            ) as mock_reporter_cls,
+        ):
             create_reporter(config)
 
-        mock_reporter_cls.assert_called_once_with(environment="staging")
+        mock_reporter_cls.assert_called_once_with(
+            token="pylf_v1_test_000000000000000000000000000000000000000000",
+            environment="staging",
+        )

--- a/tests/unit/telemetry/reporters/test_factory.py
+++ b/tests/unit/telemetry/reporters/test_factory.py
@@ -27,8 +27,14 @@ class TestCreateReporter:
         reporter = create_reporter(config)
         assert isinstance(reporter, NoopReporter)
 
-    def test_sentinel_token_falls_back_to_noop_with_log(self) -> None:
-        """Build artifact missing the embedded token -> NoopReporter + WARNING."""
+    def test_sentinel_token_falls_back_to_noop_silently(self) -> None:
+        """Build artifact missing the embedded token -> NoopReporter, no factory log.
+
+        ``TelemetryCollector.start()`` owns the operator-facing
+        ``TELEMETRY_TOKEN_MISSING`` ERROR for this branch; the factory
+        intentionally stays silent so the missing-token condition
+        produces exactly one startup signal instead of two.
+        """
         config = TelemetryConfig(enabled=True, backend=TelemetryBackend.LOGFIRE)
         with (
             patch(
@@ -39,14 +45,9 @@ class TestCreateReporter:
         ):
             reporter = create_reporter(config)
         assert isinstance(reporter, NoopReporter)
-        warnings = [
-            log
-            for log in logs
-            if log.get("event") == "telemetry.report.failed"
-            and log.get("detail") == "logfire_token_missing"
-        ]
-        assert len(warnings) == 1
-        assert warnings[0]["error_type"] == "LogfireTokenMissingError"
+        # The factory must NOT emit telemetry.report.failed for the
+        # missing-token branch; the collector owns that signal.
+        assert all(log.get("event") != "telemetry.report.failed" for log in logs)
 
     def test_import_failure_falls_back_to_noop_with_real_error_type(self) -> None:
         """Logfire import failure logs the actual error_type, not a hardcoded string."""

--- a/tests/unit/telemetry/reporters/test_factory.py
+++ b/tests/unit/telemetry/reporters/test_factory.py
@@ -158,7 +158,7 @@ class TestCreateReporter:
                 return_value=True,
             ),
             patch(
-                "synthorg.telemetry.reporters.EMBEDDED_LOGFIRE_TOKEN",
+                "synthorg.telemetry.reporters.EMBEDDED_TELEMETRY_TOKEN",
                 "pylf_v1_test_000000000000000000000000000000000000000000",
             ),
             patch(

--- a/tests/unit/telemetry/reporters/test_logfire_reporter.py
+++ b/tests/unit/telemetry/reporters/test_logfire_reporter.py
@@ -38,7 +38,7 @@ class TestLogfireReporterReportRaises:
     """``report()`` must propagate backend failures, not swallow them."""
 
     @pytest.fixture
-    def reporter(self, monkeypatch: pytest.MonkeyPatch) -> Any:
+    def reporter(self) -> Any:
         pytest.importorskip(
             "logfire",
             reason="logfire extra not installed in this environment",
@@ -47,20 +47,16 @@ class TestLogfireReporterReportRaises:
 
         from synthorg.telemetry.reporters.logfire import LogfireReporter
 
-        # Reporter refuses to initialise without a token; a dummy
-        # value exercises the construction path without enabling
-        # delivery. ``logfire.configure`` is patched so it does NOT
-        # spawn the background ``check_logfire_token`` thread that
-        # would otherwise hit the real Logfire API with a bogus
-        # token and raise an unhandled 401 in a worker thread;
+        # ``logfire.configure`` is patched so it does NOT spawn the
+        # background ``check_logfire_token`` thread that would
+        # otherwise hit the real Logfire API with a bogus token
+        # and raise an unhandled 401 in a worker thread;
         # pytest-threadexception surfaces those as test errors in
         # the full-suite run the pre-push hook triggers.
-        monkeypatch.setenv(
-            "SYNTHORG_LOGFIRE_PROJECT_TOKEN",
-            "pylf_v1_test_000000000000000000000000000000000000000000",
-        )
         with patch.object(real_logfire, "configure"):
-            return LogfireReporter()
+            return LogfireReporter(
+                token="pylf_v1_test_000000000000000000000000000000000000000000",
+            )
 
     async def test_backend_exception_propagates(
         self,
@@ -103,7 +99,7 @@ class TestLogfireReporterConfigure:
     """``configure()`` call shape: silences introspection + tags environment."""
 
     def test_configure_receives_inspect_arguments_false_and_environment(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
     ) -> None:
         """``configure()`` silences the introspection warning and tags env.
 
@@ -120,13 +116,11 @@ class TestLogfireReporterConfigure:
 
         from synthorg.telemetry.reporters.logfire import LogfireReporter
 
-        monkeypatch.setenv(
-            "SYNTHORG_LOGFIRE_PROJECT_TOKEN",
-            "pylf_v1_test_000000000000000000000000000000000000000000",
-        )
-
         with patch.object(real_logfire, "configure") as mock_configure:
-            LogfireReporter(environment="pre-release")
+            LogfireReporter(
+                token="pylf_v1_test_000000000000000000000000000000000000000000",
+                environment="pre-release",
+            )
 
         mock_configure.assert_called_once()
         kwargs = mock_configure.call_args.kwargs
@@ -146,9 +140,7 @@ class TestLogfireReporterConfigure:
         assert kwargs["service_name"] == "synthorg-telemetry"
         assert kwargs["send_to_logfire"] == "if-token-present"
 
-    async def test_report_includes_environment_kwarg(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_report_includes_environment_kwarg(self) -> None:
         """Per-record ``environment`` kwarg is attached to every ``info()`` call."""
         pytest.importorskip(
             "logfire",
@@ -158,12 +150,11 @@ class TestLogfireReporterConfigure:
 
         from synthorg.telemetry.reporters.logfire import LogfireReporter
 
-        monkeypatch.setenv(
-            "SYNTHORG_LOGFIRE_PROJECT_TOKEN",
-            "pylf_v1_test_000000000000000000000000000000000000000000",
-        )
         with patch.object(real_logfire, "configure"):
-            reporter = LogfireReporter(environment="ci")
+            reporter = LogfireReporter(
+                token="pylf_v1_test_000000000000000000000000000000000000000000",
+                environment="ci",
+            )
 
         event = TelemetryEvent(
             event_type="deployment.heartbeat",
@@ -183,9 +174,7 @@ class TestLogfireReporterConfigure:
         assert kwargs["environment"] == "ci"
         assert kwargs["deployment_id"] == "00000000-0000-0000-0000-000000000002"
 
-    async def test_reserved_kwargs_in_properties_are_filtered(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_reserved_kwargs_in_properties_are_filtered(self) -> None:
         """Reserved kwarg names in ``properties`` are dropped before unpack.
 
         Belt-and-suspenders defense against a future scrubber
@@ -204,12 +193,11 @@ class TestLogfireReporterConfigure:
 
         from synthorg.telemetry.reporters.logfire import LogfireReporter
 
-        monkeypatch.setenv(
-            "SYNTHORG_LOGFIRE_PROJECT_TOKEN",
-            "pylf_v1_test_000000000000000000000000000000000000000000",
-        )
         with patch.object(real_logfire, "configure"):
-            reporter = LogfireReporter(environment="prod")
+            reporter = LogfireReporter(
+                token="pylf_v1_test_000000000000000000000000000000000000000000",
+                environment="prod",
+            )
 
         event = TelemetryEvent(
             event_type="deployment.heartbeat",

--- a/tests/unit/telemetry/reporters/test_logfire_reporter.py
+++ b/tests/unit/telemetry/reporters/test_logfire_reporter.py
@@ -1,14 +1,14 @@
-"""Regression tests for ``LogfireReporter``.
+"""Regression tests for the telemetry-backend reporter.
 
 The collector's ``_send`` helper only flips the "delivered" return
-value to ``False`` when ``report()`` raises. Earlier revisions of
-the Logfire reporter logged and swallowed backend exceptions, so
-failed writes surfaced as successful deliveries (``*_SENT``
-debug events fired regardless). These tests lock in the
-propagate-don't-swallow contract so that regression cannot sneak
-back in. The reporter does **not** log ``TELEMETRY_REPORT_FAILED``
-itself -- :meth:`TelemetryCollector._send` owns that alert and
-duplicate logs would double-count failures.
+value to ``False`` when ``report()`` raises. The reporter must
+propagate backend exceptions instead of logging-and-swallowing
+them: a swallowed exception turns a failed write into a
+successful-looking delivery (``*_SENT`` debug events still fire),
+which is the bug class these tests lock down. The reporter does
+**not** log ``TELEMETRY_REPORT_FAILED`` itself --
+:meth:`TelemetryCollector._send` owns that alert and duplicate
+logs would double-count failures.
 """
 
 from datetime import UTC, datetime

--- a/tests/unit/telemetry/test_collector.py
+++ b/tests/unit/telemetry/test_collector.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
+import structlog.testing
 
 from synthorg.telemetry.collector import (
     TelemetryCollector,
@@ -25,7 +26,7 @@ def clear_synthorg_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
     runs in. Scrub the whole set so each test specifies exactly the
     inputs it exercises.
     """
-    monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
+    monkeypatch.delenv("SYNTHORG_TELEMETRY_ENABLED", raising=False)
     monkeypatch.delenv("SYNTHORG_TELEMETRY_ENV", raising=False)
     monkeypatch.delenv("SYNTHORG_TELEMETRY_ENV_BAKED", raising=False)
     for marker in ("CI", "GITLAB_CI", "BUILDKITE", "JENKINS_URL"):
@@ -45,6 +46,93 @@ class TestTelemetryCollector:
         assert collector.enabled is False
         assert collector.is_functional is False
         assert collector.deployment_id is None
+
+    async def test_disabled_emits_one_info_at_startup_no_heartbeat(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Issue #1666 A-3: disabled state -> one INFO, zero report_failed.
+
+        Nothing should ever fire ``telemetry.report.failed`` on the
+        disabled path -- the heartbeat task isn't scheduled, so no
+        per-cycle warnings can ever land in the main log.
+        """
+        config = TelemetryConfig(enabled=False)
+        with structlog.testing.capture_logs() as logs:
+            collector = TelemetryCollector(config=config, data_dir=tmp_path)
+            try:
+                await collector.start()
+            finally:
+                await collector.shutdown()
+
+        info_lines = [
+            log
+            for log in logs
+            if log.get("event") == "telemetry.disabled"
+            and log.get("log_level") == "info"
+        ]
+        assert len(info_lines) == 1
+        report_failed = [
+            log for log in logs if log.get("event") == "telemetry.report.failed"
+        ]
+        assert report_failed == []
+        # Heartbeat task never scheduled when disabled.
+        assert collector._heartbeat_task is None
+
+    async def test_enabled_logfire_with_sentinel_token_emits_error_no_heartbeat(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Issue #1666 A-3: enabled + sentinel token -> ONE ERROR, no heartbeat.
+
+        With telemetry enabled but the build artifact shipping the
+        sentinel token, the collector must log a single
+        ``telemetry.token.missing`` ERROR at startup and skip the
+        heartbeat scheduling so the per-cycle warning spam is
+        eliminated.
+        """
+        config = TelemetryConfig(enabled=True, backend=TelemetryBackend.LOGFIRE)
+        # Default sentinel is_token_embedded() == False in source-tree
+        # installs (and in this CI environment); no monkeypatch needed.
+        with structlog.testing.capture_logs() as logs:
+            collector = TelemetryCollector(config=config, data_dir=tmp_path)
+            try:
+                await collector.start()
+            finally:
+                await collector.shutdown()
+
+        token_missing = [
+            log
+            for log in logs
+            if log.get("event") == "telemetry.token.missing"
+            and log.get("log_level") == "error"
+        ]
+        assert len(token_missing) == 1
+        # Heartbeat task never scheduled when token is sentinel.
+        assert collector._heartbeat_task is None
+
+    async def test_enabled_noop_backend_skips_token_check(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """NOOP backend bypasses the LOGFIRE-only token-embedded gate.
+
+        Operators who explicitly opt out of Logfire (or tests using
+        the noop reporter) must not see ``telemetry.token.missing``
+        -- the check is scoped to ``TelemetryBackend.LOGFIRE``.
+        """
+        config = TelemetryConfig(enabled=True, backend=TelemetryBackend.NOOP)
+        with structlog.testing.capture_logs() as logs:
+            collector = TelemetryCollector(config=config, data_dir=tmp_path)
+            try:
+                await collector.start()
+            finally:
+                await collector.shutdown()
+
+        token_missing = [
+            log for log in logs if log.get("event") == "telemetry.token.missing"
+        ]
+        assert token_missing == []
 
     def test_is_functional_false_when_reporter_is_noop(
         self,

--- a/tests/unit/telemetry/test_collector.py
+++ b/tests/unit/telemetry/test_collector.py
@@ -82,6 +82,7 @@ class TestTelemetryCollector:
     async def test_enabled_logfire_with_sentinel_token_emits_error_no_heartbeat(
         self,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Issue #1666 A-3: enabled + sentinel token -> ONE ERROR, no heartbeat.
 
@@ -90,10 +91,18 @@ class TestTelemetryCollector:
         ``telemetry.token.missing`` ERROR at startup and skip the
         heartbeat scheduling so the per-cycle warning spam is
         eliminated.
+
+        Pin ``is_token_embedded()`` to ``False`` so the missing-token
+        branch is exercised deterministically. Without the patch, a
+        future build artifact carrying a real token would flip the
+        branch and silently stop testing the regression we're locking
+        down.
         """
         config = TelemetryConfig(enabled=True, backend=TelemetryBackend.LOGFIRE)
-        # Default sentinel is_token_embedded() == False in source-tree
-        # installs (and in this CI environment); no monkeypatch needed.
+        monkeypatch.setattr(
+            "synthorg.telemetry.collector.is_token_embedded",
+            lambda: False,
+        )
         with structlog.testing.capture_logs() as logs:
             collector = TelemetryCollector(config=config, data_dir=tmp_path)
             try:

--- a/tests/unit/telemetry/test_collector_async_init.py
+++ b/tests/unit/telemetry/test_collector_async_init.py
@@ -37,7 +37,7 @@ def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
     :func:`_resolve_environment` cannot leak shell state into the
     async-init contract assertions.
     """
-    monkeypatch.delenv("SYNTHORG_TELEMETRY", raising=False)
+    monkeypatch.delenv("SYNTHORG_TELEMETRY_ENABLED", raising=False)
     monkeypatch.delenv("SYNTHORG_TELEMETRY_ENV", raising=False)
     monkeypatch.delenv("SYNTHORG_TELEMETRY_ENV_BAKED", raising=False)
     for marker in ("CI", "GITLAB_CI", "BUILDKITE", "JENKINS_URL"):

--- a/tests/unit/templates/test_model_matcher.py
+++ b/tests/unit/templates/test_model_matcher.py
@@ -258,6 +258,75 @@ class TestMatchAllAgents:
         assert results[0].provider_name == "test-provider"
         assert results[0].score == 0.0
 
+    def test_fallback_emits_debug_event_not_warning(self) -> None:
+        """Issue #1666 B-5: tier-fallback path logs at DEBUG, not WARNING.
+
+        Per the design contract, falling back to ``all_models[0]`` when
+        the requested tier has no candidate is the documented happy-path
+        and should not pollute WARNING. The dedicated event is
+        ``template.model_match.fallback`` (DEBUG); only the
+        ``no_models_available`` branch keeps WARNING (which the wizard
+        provider gate now prevents from firing in practice).
+        """
+        import structlog.testing
+
+        agents = [
+            {
+                "tier": "large",
+                "personality_preset": "visionary_leader",
+            },
+        ]
+        providers = {
+            "test-provider": _FakeProviderConfig(
+                models=(_make_model("small-ctx", max_context=50_000),),
+            ),
+        }
+        with structlog.testing.capture_logs() as logs:
+            results = match_all_agents(agents, providers)
+        assert len(results) == 1
+        fallback_events = [
+            log for log in logs if log.get("event") == "template.model_match.fallback"
+        ]
+        warning_events = [
+            log
+            for log in logs
+            if log.get("event") == "template.model_match.failed"
+            and log.get("log_level") == "warning"
+        ]
+        # Fallback succeeded -- DEBUG event present, WARNING absent.
+        assert len(fallback_events) == 1
+        assert fallback_events[0]["log_level"] == "debug"
+        assert fallback_events[0]["fallback_provider"] == "test-provider"
+        assert fallback_events[0]["fallback_model"] == "small-ctx"
+        assert warning_events == []
+
+    def test_no_models_available_still_logs_warning(self) -> None:
+        """Issue #1666 B-5: the truly-empty case keeps WARNING severity.
+
+        When ``all_models`` is empty (no providers OR all providers have
+        zero models), the matcher cannot assign anything -- this is the
+        operator-actionable case the wizard's tier-coverage gate now
+        catches before it gets here, but the WARNING should still fire
+        if the gate is bypassed (e.g. in a non-wizard call site).
+        """
+        import structlog.testing
+
+        agents = [{"tier": "large", "personality_preset": None}]
+        providers = {
+            "empty-provider": _FakeProviderConfig(models=()),
+        }
+        with structlog.testing.capture_logs() as logs:
+            results = match_all_agents(agents, providers)
+        assert results == []
+        no_models_events = [
+            log
+            for log in logs
+            if log.get("event") == "template.model_match.failed"
+            and log.get("reason") == "no_models_available"
+        ]
+        assert len(no_models_events) == 1
+        assert no_models_events[0]["log_level"] == "warning"
+
     def test_agent_index_preserved(self) -> None:
         agents = [
             {"tier": "small"},

--- a/uv.lock
+++ b/uv.lock
@@ -2568,6 +2568,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyngrok"
+version = "8.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/3a/648d102f18acf603b64d4895a234213c9a1b1d12c6cc3c1118672a19b039/pyngrok-8.1.1.tar.gz", hash = "sha256:3ea50bfa1153187ffd95fc7c5169d7f1cc62ec80ad79714212123fd3d52077fb", size = 45067, upload-time = "2026-04-27T18:19:57.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/1a/e7941859a204ce7ef2a8b3af2c7ef94fc77eedd6ba15283ade98c84be82d/pyngrok-8.1.1-py3-none-any.whl", hash = "sha256:d2e045dddf21398503d526c517af03bba2a7e17c608cc3e1d2caa9b919438d30", size = 25915, upload-time = "2026-04-27T18:19:56.624Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3258,6 +3270,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pydantic" },
     { name = "pyjwt", extra = ["crypto"] },
+    { name = "pyngrok" },
     { name = "pyyaml" },
     { name = "rfc3161-client" },
     { name = "structlog" },
@@ -3380,6 +3393,7 @@ requires-dist = [
     { name = "psycopg-pool", marker = "extra == 'postgres'", specifier = "==3.3.0" },
     { name = "pydantic", specifier = "==2.13.3" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.12.1" },
+    { name = "pyngrok", specifier = "==8.1.1" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "rfc3161-client", specifier = "==1.0.6" },
     { name = "sentence-transformers", marker = "extra == 'fine-tune-cpu'", specifier = "==5.4.1" },
@@ -3671,14 +3685,14 @@ dependencies = [
     { name = "typing-extensions", marker = "(python_full_version >= '3.15' and extra == 'extra-8-synthorg-fine-tune-cpu') or (python_full_version >= '3.15' and extra == 'group-8-synthorg-fine-tune-cpu') or (python_full_version < '3.15' and extra == 'extra-8-synthorg-fine-tune-cpu' and extra == 'extra-8-synthorg-fine-tune-gpu') or (python_full_version < '3.15' and extra == 'group-8-synthorg-fine-tune-cpu' and extra == 'group-8-synthorg-fine-tune-gpu') or (sys_platform != 'darwin' and extra == 'extra-8-synthorg-fine-tune-cpu') or (sys_platform != 'darwin' and extra == 'group-8-synthorg-fine-tune-cpu')" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-linux_s390x.whl", upload-time = "2026-03-23T14:59:09Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", upload-time = "2026-03-23T14:59:10Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", upload-time = "2026-03-23T14:59:11Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-win_amd64.whl", upload-time = "2026-03-23T14:59:12Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-linux_s390x.whl", upload-time = "2026-03-23T14:59:12Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", upload-time = "2026-03-23T14:59:12Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", upload-time = "2026-03-23T14:59:13Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-win_amd64.whl", upload-time = "2026-03-23T14:59:15Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-linux_s390x.whl", hash = "sha256:c9a14c367f470623b978e273a4e1915995b4ba7a0ae999178b06c273eea3536f", upload-time = "2026-04-28T00:07:54Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:71676f6a9a84bbd385e010198b51fa1c2324fb8f3c512a32d2c81af65f68f4c9", upload-time = "2026-04-28T00:08:02Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:f8481ea9088e4e5b81178a75aabdbb658bde8639bc1a15fd5d8f930abc966735", upload-time = "2026-04-28T00:08:11Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:7575af4c9f7f7500ed62b1dafeb069aa0ba35b368a5f09793b3976b3d50f4fe4", upload-time = "2026-04-28T00:08:20Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-linux_s390x.whl", hash = "sha256:825f1596878280a3a4c861441674888bc2d792e4ab7b045cb35feeab3f4f5dd7", upload-time = "2026-04-28T00:08:27Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c8a0bdfb2fd915b6c2cd27c856f63f729c366a4917772eba6b2b02aa3bce70d5", upload-time = "2026-04-28T00:08:36Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:768f22924a25cad2adeb9c6cbac5159e71067c8d4019b1511960d7435a5ca652", upload-time = "2026-04-28T00:08:47Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:6db45e7b2526d996fbf47c3d08737807a60a4e17996a6d91a97027fe260832c8", upload-time = "2026-04-28T00:08:57Z" },
 ]
 
 [[package]]

--- a/web/public/mockServiceWorker.js
+++ b/web/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.13.4'
+const PACKAGE_VERSION = '2.13.6'
 const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/web/src/api/endpoints/capabilities.ts
+++ b/web/src/api/endpoints/capabilities.ts
@@ -1,0 +1,17 @@
+import { apiClient, unwrap } from '../client'
+import type { Capabilities } from '../types/capabilities'
+import type { ApiResponse } from '../types/http'
+
+/**
+ * Fetch the deployment's capability matrix.
+ *
+ * The matrix is static for the lifetime of the backend process
+ * (changing it requires a restart) so the dashboard caches the
+ * result for the whole session via ``useCapabilities``.
+ */
+export async function getCapabilities(): Promise<Capabilities> {
+  const response = await apiClient.get<ApiResponse<Capabilities>>(
+    '/capabilities/',
+  )
+  return unwrap(response)
+}

--- a/web/src/api/types/capabilities.ts
+++ b/web/src/api/types/capabilities.ts
@@ -1,0 +1,36 @@
+/**
+ * Runtime feature-flag matrix returned by ``GET /api/v1/capabilities``.
+ *
+ * Each boolean reports whether the matching optional subsystem is
+ * wired in this deployment.  The dashboard reads this once per
+ * session and skips polling endpoints whose flag is ``false`` so the
+ * audit log stops collecting 503-spam from unconfigured services
+ * (issue #1666 B-3).
+ */
+export interface Capabilities {
+  /** Client-simulation runtime is configured. */
+  simulations: boolean
+  /** Request facade (depends on simulation state) is configured. */
+  requests: boolean
+  /** Ontology service is configured. */
+  ontology: boolean
+  /** Tunnel provider (pyngrok + auth token) is configured. */
+  tunnel: boolean
+  /** Webhook event bridge is configured. */
+  webhooks: boolean
+  /** A2A peer registry / client are configured. */
+  a2a: boolean
+  /**
+   * Anonymous Logfire telemetry is enabled and the reporter can
+   * actually deliver.  ``true`` only when ``telemetry.enabled`` is
+   * on AND the embedded token is present AND ``logfire.configure``
+   * succeeded.
+   */
+  telemetry: boolean
+  /**
+   * The integrations subsystem is enabled at all -- when ``false``
+   * connections / oauth / webhooks / mcp catalog routes are not
+   * registered.
+   */
+  integrations: boolean
+}

--- a/web/src/api/types/capabilities.ts
+++ b/web/src/api/types/capabilities.ts
@@ -14,7 +14,7 @@ export interface Capabilities {
   requests: boolean
   /** Ontology service is configured. */
   ontology: boolean
-  /** Tunnel provider (pyngrok + auth token) is configured. */
+  /** External tunnel provider with authentication token is configured. */
   tunnel: boolean
   /** Webhook event bridge is configured. */
   webhooks: boolean

--- a/web/src/api/types/capabilities.ts
+++ b/web/src/api/types/capabilities.ts
@@ -21,10 +21,10 @@ export interface Capabilities {
   /** A2A peer registry / client are configured. */
   a2a: boolean
   /**
-   * Anonymous Logfire telemetry is enabled and the reporter can
+   * Anonymous product telemetry is enabled and the reporter can
    * actually deliver.  ``true`` only when ``telemetry.enabled`` is
-   * on AND the embedded token is present AND ``logfire.configure``
-   * succeeded.
+   * on AND the embedded token is present AND the backend SDK
+   * configured successfully.
    */
   telemetry: boolean
   /**

--- a/web/src/components/ui/request-card.stories.tsx
+++ b/web/src/components/ui/request-card.stories.tsx
@@ -4,12 +4,14 @@ import type { ClientRequest, RequestStatus } from '@/api/endpoints/clients'
 
 import { RequestCard } from './request-card'
 
+const SAMPLE_REQUEST_ID = '11111111-2222-3333-4444-555555555555'
+
 function buildRequest(
   status: RequestStatus,
   overrides: Partial<ClientRequest> = {},
 ): ClientRequest {
   return {
-    request_id: '11111111-2222-3333-4444-555555555555',
+    request_id: SAMPLE_REQUEST_ID,
     client_id: 'acme-corp',
     requirement: {
       title: 'Add CSV export to the dashboard',
@@ -90,6 +92,6 @@ export const Cancelled: Story = {
 export const PendingFlightDisablesActions: Story = {
   args: {
     request: buildRequest('triaging'),
-    pending: { '11111111-2222-3333-4444-555555555555': true },
+    pending: { [SAMPLE_REQUEST_ID]: true },
   },
 }

--- a/web/src/components/ui/request-card.stories.tsx
+++ b/web/src/components/ui/request-card.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import type { ClientRequest, RequestStatus } from '@/api/endpoints/clients'
+
+import { RequestCard } from './request-card'
+
+function buildRequest(
+  status: RequestStatus,
+  overrides: Partial<ClientRequest> = {},
+): ClientRequest {
+  return {
+    request_id: '11111111-2222-3333-4444-555555555555',
+    client_id: 'acme-corp',
+    requirement: {
+      title: 'Add CSV export to the dashboard',
+      description:
+        'Operators need a CSV download for the past-30-days task table.',
+      task_type: 'feature',
+      priority: 'medium',
+      estimated_complexity: 'medium',
+    },
+    status,
+    created_at: '2026-04-29T12:00:00Z',
+    metadata: {},
+    ...overrides,
+  }
+}
+
+const meta = {
+  title: 'UI/RequestCard',
+  component: RequestCard,
+  tags: ['autodocs'],
+  argTypes: {
+    onScope: { action: 'onScope' },
+    onApprove: { action: 'onApprove' },
+    onReject: { action: 'onReject' },
+  },
+} satisfies Meta<typeof RequestCard>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Submitted: Story = {
+  args: {
+    request: buildRequest('submitted'),
+    pending: {},
+  },
+}
+
+export const Triaging: Story = {
+  args: {
+    request: buildRequest('triaging'),
+    pending: {},
+  },
+}
+
+export const Scoping: Story = {
+  args: {
+    request: buildRequest('scoping'),
+    pending: {},
+  },
+}
+
+export const Approved: Story = {
+  args: {
+    request: buildRequest('approved'),
+    pending: {},
+  },
+}
+
+export const TaskCreated: Story = {
+  args: {
+    request: buildRequest('task_created'),
+    pending: {},
+  },
+}
+
+export const Cancelled: Story = {
+  args: {
+    request: buildRequest('cancelled'),
+    pending: {},
+  },
+}
+
+export const PendingFlightDisablesActions: Story = {
+  args: {
+    request: buildRequest('triaging'),
+    pending: { '11111111-2222-3333-4444-555555555555': true },
+  },
+}

--- a/web/src/components/ui/request-card.stories.tsx
+++ b/web/src/components/ui/request-card.stories.tsx
@@ -30,6 +30,11 @@ const meta = {
   title: 'UI/RequestCard',
   component: RequestCard,
   tags: ['autodocs'],
+  args: {
+    onScope: () => {},
+    onApprove: () => {},
+    onReject: () => {},
+  },
   argTypes: {
     onScope: { action: 'onScope' },
     onApprove: { action: 'onApprove' },

--- a/web/src/components/ui/request-card.tsx
+++ b/web/src/components/ui/request-card.tsx
@@ -1,0 +1,87 @@
+import type { ClientRequest } from '@/api/endpoints/clients'
+import { Button } from '@/components/ui/button'
+
+/**
+ * Per-request row inside the Request Queue Kanban board.
+ *
+ * Renders the request title + identity line, then a state-conditional
+ * action group ({@link onScope} / {@link onApprove} / {@link onReject})
+ * for requests still in the early stages of the lifecycle. The
+ * caller owns optimistic-action state via the {@link pending} map so
+ * a per-request flight is reflected as a disabled action group
+ * without re-rendering the whole queue.
+ *
+ * Extracted from {@link RequestQueuePage} per the
+ * `web/CLAUDE.md` "no >8-line JSX inside .map()" rule (issue #1666).
+ */
+export interface RequestCardProps {
+  request: ClientRequest
+  /**
+   * Per-request optimistic-flight flag. Disables every action button
+   * for the matching request_id while a Scope / Approve / Reject
+   * call is in flight to prevent double-submission.
+   */
+  pending: Record<string, boolean>
+  onScope: (requestId: string) => void
+  onApprove: (requestId: string) => void
+  onReject: (requestId: string) => void
+}
+
+const _ACTIONABLE_STATUSES = new Set([
+  'submitted',
+  'triaging',
+  'scoping',
+])
+
+const _SCOPE_STATUSES = new Set(['submitted', 'triaging'])
+
+export function RequestCard({
+  request,
+  pending,
+  onScope,
+  onApprove,
+  onReject,
+}: RequestCardProps) {
+  const isPending = !!pending[request.request_id]
+  const showActions = _ACTIONABLE_STATUSES.has(request.status)
+  const showScope = _SCOPE_STATUSES.has(request.status)
+  return (
+    <li className="space-y-2 rounded-md border border-border bg-card-hover p-card text-sm">
+      <div className="font-medium text-foreground">
+        {request.requirement.title}
+      </div>
+      <div className="text-xs text-text-secondary">
+        {request.client_id} · {request.request_id.slice(0, 8)}
+      </div>
+      {showActions && (
+        <div className="flex flex-wrap gap-2 pt-1">
+          {showScope && (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={isPending}
+              onClick={() => onScope(request.request_id)}
+            >
+              Scope
+            </Button>
+          )}
+          <Button
+            size="sm"
+            disabled={isPending}
+            onClick={() => onApprove(request.request_id)}
+          >
+            Approve
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={isPending}
+            onClick={() => onReject(request.request_id)}
+          >
+            Reject
+          </Button>
+        </div>
+      )}
+    </li>
+  )
+}

--- a/web/src/hooks/useCapabilities.ts
+++ b/web/src/hooks/useCapabilities.ts
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react'
+
+import { getCapabilities } from '@/api/endpoints/capabilities'
+import type { Capabilities } from '@/api/types/capabilities'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('useCapabilities')
+
+/**
+ * Module-level cache so multiple consumers share one network call.
+ *
+ * Capabilities are static for the lifetime of the backend process,
+ * so caching across the whole session is correct -- the only way
+ * the matrix changes is a restart, which also reloads the SPA.
+ */
+let _cache: Capabilities | null = null
+let _inflight: Promise<Capabilities> | null = null
+
+const ALL_FALSE: Capabilities = {
+  simulations: false,
+  requests: false,
+  ontology: false,
+  tunnel: false,
+  webhooks: false,
+  a2a: false,
+  telemetry: false,
+  integrations: false,
+}
+
+/**
+ * Read the runtime capability matrix from ``GET /api/v1/capabilities``.
+ *
+ * Returns ``ALL_FALSE`` while the first fetch is in flight so pages
+ * that gate polling on a flag default to "feature unavailable"
+ * during the brief loading window. Pages that need to distinguish
+ * loading from "feature off" should read ``loading`` directly.
+ */
+export function useCapabilities(): {
+  capabilities: Capabilities
+  loading: boolean
+  error: string | null
+} {
+  const [capabilities, setCapabilities] = useState<Capabilities>(
+    () => _cache ?? ALL_FALSE,
+  )
+  const [loading, setLoading] = useState<boolean>(_cache === null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (_cache !== null) {
+      setCapabilities(_cache)
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    if (_inflight === null) {
+      _inflight = getCapabilities()
+    }
+    void _inflight
+      .then((result) => {
+        _cache = result
+        if (!cancelled) {
+          setCapabilities(result)
+          setError(null)
+          setLoading(false)
+        }
+      })
+      .catch((err: unknown) => {
+        log.error('capabilities_fetch_failed', err)
+        if (!cancelled) {
+          setError('Failed to load capability matrix.')
+          setLoading(false)
+        }
+      })
+      .finally(() => {
+        _inflight = null
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return { capabilities, loading, error }
+}
+
+/**
+ * Test-only helper to clear the module-level cache between tests.
+ *
+ * The hook uses a module-scoped ``_cache`` so multiple consumers
+ * share a single network round-trip; that cache leaks across
+ * tests in the same Vitest worker. Tests that need a clean state
+ * call this in a ``beforeEach``.
+ */
+export function _resetCapabilitiesCacheForTesting(): void {
+  _cache = null
+  _inflight = null
+}

--- a/web/src/hooks/useCapabilities.ts
+++ b/web/src/hooks/useCapabilities.ts
@@ -47,9 +47,17 @@ export function useCapabilities(): {
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    // Cache hit -- skip the network call entirely. Async tick keeps
+    // the state setters out of the same synchronous frame as the
+    // effect body so eslint-react's set-state-in-effect rule stays
+    // happy and React does not schedule an extra render-while-render
+    // batch.
     if (_cache !== null) {
-      setCapabilities(_cache)
-      setLoading(false)
+      const cached = _cache
+      queueMicrotask(() => {
+        setCapabilities(cached)
+        setLoading(false)
+      })
       return
     }
     let cancelled = false

--- a/web/src/hooks/useCapabilities.ts
+++ b/web/src/hooks/useCapabilities.ts
@@ -34,6 +34,13 @@ const ALL_FALSE: Capabilities = {
  * that gate polling on a flag default to "feature unavailable"
  * during the brief loading window. Pages that need to distinguish
  * loading from "feature off" should read ``loading`` directly.
+ *
+ * On fetch failure the hook surfaces a non-null ``error`` string and
+ * leaves ``capabilities`` at its prior value. Callers MUST check
+ * ``error`` before treating ``capabilities.<flag> === false`` as
+ * "feature not configured" -- a transient 401/500/network error
+ * would otherwise be indistinguishable from a deliberately-disabled
+ * subsystem and the dashboard would silently hide working features.
  */
 export function useCapabilities(): {
   capabilities: Capabilities
@@ -76,6 +83,9 @@ export function useCapabilities(): {
       .catch((err: unknown) => {
         log.error('capabilities_fetch_failed', err)
         if (!cancelled) {
+          // Deliberately do NOT call setCapabilities here: ``error``
+          // is the distinct signal callers consume to render an error
+          // banner instead of the disabled-capability empty state.
           setError('Failed to load capability matrix.')
           setLoading(false)
         }

--- a/web/src/mocks/handlers/capabilities.ts
+++ b/web/src/mocks/handlers/capabilities.ts
@@ -1,0 +1,29 @@
+import { http, HttpResponse } from 'msw'
+
+import type { getCapabilities } from '@/api/endpoints/capabilities'
+
+import { successFor } from './helpers'
+
+/**
+ * Default capability matrix surfaces every optional subsystem as
+ * ``true`` so existing test cases (which were written against the
+ * pre-#1666 always-registered routes) continue to fire. Per-test
+ * overrides via ``server.use`` can flip individual flags to
+ * exercise the gated UI paths.
+ */
+export const capabilitiesHandlers = [
+  http.get('/api/v1/capabilities/', () =>
+    HttpResponse.json(
+      successFor<typeof getCapabilities>({
+        simulations: true,
+        requests: true,
+        ontology: true,
+        tunnel: true,
+        webhooks: true,
+        a2a: true,
+        telemetry: false,
+        integrations: true,
+      }),
+    ),
+  ),
+]

--- a/web/src/mocks/handlers/index.ts
+++ b/web/src/mocks/handlers/index.ts
@@ -64,6 +64,7 @@ import { artifactsHandlers } from './artifacts'
 import { authHandlers } from './auth'
 import { backupHandlers } from './backup'
 import { budgetHandlers } from './budget'
+import { capabilitiesHandlers } from './capabilities'
 import { ceremonyPolicyHandlers } from './ceremony-policy'
 import { clientsHandlers } from './clients'
 import { collaborationHandlers } from './collaboration'
@@ -110,6 +111,7 @@ export const defaultHandlers = [
   ...authHandlers,
   ...backupHandlers,
   ...budgetHandlers,
+  ...capabilitiesHandlers,
   ...ceremonyPolicyHandlers,
   ...clientsHandlers,
   ...collaborationHandlers,
@@ -153,6 +155,7 @@ export {
   authHandlers,
   backupHandlers,
   budgetHandlers,
+  capabilitiesHandlers,
   ceremonyPolicyHandlers,
   clientsHandlers,
   collaborationHandlers,

--- a/web/src/pages/RequestQueuePage.tsx
+++ b/web/src/pages/RequestQueuePage.tsx
@@ -120,9 +120,15 @@ export default function RequestQueuePage() {
   // requests subsystem is not configured. Backend route is also not
   // registered (returns 404). The early-return path that renders the
   // EmptyState lives below all hooks so React's hook-order rules
-  // stay satisfied across renders.
+  // stay satisfied across renders. While ``capLoading`` is true we
+  // do nothing -- the skeleton branch below covers the in-flight
+  // window so the page never flashes "No requests yet" against an
+  // unconfigured deployment.
   useEffect(() => {
-    if (capLoading || !capabilities.requests) {
+    if (capLoading) {
+      return
+    }
+    if (!capabilities.requests) {
       // Defer the loading flip out of the same synchronous render
       // frame so eslint-react's set-state-in-effect rule stays
       // satisfied and React batches one render instead of two.
@@ -149,7 +155,11 @@ export default function RequestQueuePage() {
     )
   }
 
-  if (loading && requests.length === 0) {
+  // Hold the skeleton until capabilities resolve AND the first refresh
+  // either lands data or sets loading=false. This prevents a one-frame
+  // "No requests yet" flash on an unconfigured-but-not-yet-resolved
+  // deployment.
+  if (capLoading || (loading && requests.length === 0)) {
     return (
       <div className="space-y-section-gap">
         <ListHeader title="Request Queue" />

--- a/web/src/pages/RequestQueuePage.tsx
+++ b/web/src/pages/RequestQueuePage.tsx
@@ -65,31 +65,6 @@ export default function RequestQueuePage() {
     }
   }, [])
 
-  useEffect(() => {
-    if (capLoading || !capabilities.requests) {
-      setLoading(false)
-      return
-    }
-    void refresh()
-  }, [refresh, capLoading, capabilities.requests])
-
-  if (!capLoading && !capabilities.requests) {
-    return (
-      <div className="space-y-section-gap">
-        <ListHeader title="Requests" />
-        <EmptyState
-          icon={Inbox}
-          title="Requests not configured"
-          description={
-            'This deployment did not enable the client request facade. ' +
-            'Configure it in your backend setup to start tracking ' +
-            'incoming requests.'
-          }
-        />
-      </div>
-    )
-  }
-
   const handleScope = useCallback(
     async (requestId: string) => {
       if (pending[requestId]) return
@@ -140,6 +115,39 @@ export default function RequestQueuePage() {
     },
     [refresh, pending],
   )
+
+  // Capability-gated effect: skip the network call entirely when the
+  // requests subsystem is not configured. Backend route is also not
+  // registered (returns 404). The early-return path that renders the
+  // EmptyState lives below all hooks so React's hook-order rules
+  // stay satisfied across renders.
+  useEffect(() => {
+    if (capLoading || !capabilities.requests) {
+      // Defer the loading flip out of the same synchronous render
+      // frame so eslint-react's set-state-in-effect rule stays
+      // satisfied and React batches one render instead of two.
+      queueMicrotask(() => setLoading(false))
+      return
+    }
+    void refresh()
+  }, [refresh, capLoading, capabilities.requests])
+
+  if (!capLoading && !capabilities.requests) {
+    return (
+      <div className="space-y-section-gap">
+        <ListHeader title="Requests" />
+        <EmptyState
+          icon={Inbox}
+          title="Requests not configured"
+          description={
+            'This deployment did not enable the client request facade. ' +
+            'Configure it in your backend setup to start tracking ' +
+            'incoming requests.'
+          }
+        />
+      </div>
+    )
+  }
 
   if (loading && requests.length === 0) {
     return (

--- a/web/src/pages/RequestQueuePage.tsx
+++ b/web/src/pages/RequestQueuePage.tsx
@@ -10,9 +10,9 @@ import {
   type ClientRequest,
   type RequestStatus,
 } from '@/api/endpoints/clients'
-import { Button } from '@/components/ui/button'
 import { EmptyState } from '@/components/ui/empty-state'
 import { ListHeader } from '@/components/ui/list-header'
+import { RequestCard } from '@/components/ui/request-card'
 import { SectionCard } from '@/components/ui/section-card'
 import { SkeletonCard } from '@/components/ui/skeleton'
 import { useCapabilities } from '@/hooks/useCapabilities'
@@ -190,49 +190,14 @@ export default function RequestQueuePage() {
               ) : (
                 <ul className="space-y-2">
                   {entries.map((request) => (
-                    <li
+                    <RequestCard
                       key={request.request_id}
-                      className="space-y-2 rounded-md border border-border bg-card-hover p-card text-sm"
-                    >
-                      <div className="font-medium text-foreground">
-                        {request.requirement.title}
-                      </div>
-                      <div className="text-xs text-text-secondary">
-                        {request.client_id} · {request.request_id.slice(0, 8)}
-                      </div>
-                      {(request.status === 'submitted' ||
-                        request.status === 'triaging' ||
-                        request.status === 'scoping') && (
-                        <div className="flex flex-wrap gap-2 pt-1">
-                          {(request.status === 'submitted' ||
-                            request.status === 'triaging') && (
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              disabled={!!pending[request.request_id]}
-                              onClick={() => void handleScope(request.request_id)}
-                            >
-                              Scope
-                            </Button>
-                          )}
-                          <Button
-                            size="sm"
-                            disabled={!!pending[request.request_id]}
-                            onClick={() => void handleApprove(request.request_id)}
-                          >
-                            Approve
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            disabled={!!pending[request.request_id]}
-                            onClick={() => void handleReject(request.request_id)}
-                          >
-                            Reject
-                          </Button>
-                        </div>
-                      )}
-                    </li>
+                      request={request}
+                      pending={pending}
+                      onScope={(id) => void handleScope(id)}
+                      onApprove={(id) => void handleApprove(id)}
+                      onReject={(id) => void handleReject(id)}
+                    />
                   ))}
                 </ul>
               )}

--- a/web/src/pages/RequestQueuePage.tsx
+++ b/web/src/pages/RequestQueuePage.tsx
@@ -46,7 +46,11 @@ const STATUS_LABELS: Record<RequestStatus, string> = {
  * → TASK_CREATED | CANCELLED) at a glance.
  */
 export default function RequestQueuePage() {
-  const { capabilities, loading: capLoading } = useCapabilities()
+  const {
+    capabilities,
+    loading: capLoading,
+    error: capError,
+  } = useCapabilities()
   const [requests, setRequests] = useState<readonly ClientRequest[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -137,6 +141,19 @@ export default function RequestQueuePage() {
     }
     void refresh()
   }, [refresh, capLoading, capabilities.requests])
+
+  if (!capLoading && capError !== null) {
+    return (
+      <div className="space-y-section-gap">
+        <ListHeader title="Request Queue" />
+        <ErrorBanner
+          severity="error"
+          title="Could not determine available features"
+          description={capError}
+        />
+      </div>
+    )
+  }
 
   if (!capLoading && !capabilities.requests) {
     return (

--- a/web/src/pages/RequestQueuePage.tsx
+++ b/web/src/pages/RequestQueuePage.tsx
@@ -15,6 +15,7 @@ import { EmptyState } from '@/components/ui/empty-state'
 import { ListHeader } from '@/components/ui/list-header'
 import { SectionCard } from '@/components/ui/section-card'
 import { SkeletonCard } from '@/components/ui/skeleton'
+import { useCapabilities } from '@/hooks/useCapabilities'
 import { createLogger } from '@/lib/logger'
 
 const log = createLogger('RequestQueuePage')
@@ -45,6 +46,7 @@ const STATUS_LABELS: Record<RequestStatus, string> = {
  * → TASK_CREATED | CANCELLED) at a glance.
  */
 export default function RequestQueuePage() {
+  const { capabilities, loading: capLoading } = useCapabilities()
   const [requests, setRequests] = useState<readonly ClientRequest[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -64,8 +66,29 @@ export default function RequestQueuePage() {
   }, [])
 
   useEffect(() => {
+    if (capLoading || !capabilities.requests) {
+      setLoading(false)
+      return
+    }
     void refresh()
-  }, [refresh])
+  }, [refresh, capLoading, capabilities.requests])
+
+  if (!capLoading && !capabilities.requests) {
+    return (
+      <div className="space-y-section-gap">
+        <ListHeader title="Requests" />
+        <EmptyState
+          icon={Inbox}
+          title="Requests not configured"
+          description={
+            'This deployment did not enable the client request facade. ' +
+            'Configure it in your backend setup to start tracking ' +
+            'incoming requests.'
+          }
+        />
+      </div>
+    )
+  }
 
   const handleScope = useCallback(
     async (requestId: string) => {

--- a/web/src/pages/SimulationDashboardPage.tsx
+++ b/web/src/pages/SimulationDashboardPage.tsx
@@ -48,36 +48,6 @@ export default function SimulationDashboardPage() {
     }
   }, [])
 
-  useEffect(() => {
-    if (capLoading || !capabilities.simulations) {
-      // Skip the network call entirely when the simulations
-      // subsystem is not configured for this deployment. The
-      // backend route is also not registered (returns 404), so
-      // calling listSimulations() would log a 404 in the audit
-      // trail per the issue #1666 B-3 contract.
-      setLoading(false)
-      return
-    }
-    void refresh()
-  }, [refresh, capLoading, capabilities.simulations])
-
-  if (!capLoading && !capabilities.simulations) {
-    return (
-      <div className="space-y-section-gap">
-        <ListHeader title="Simulations" />
-        <EmptyState
-          icon={Activity}
-          title="Simulations not configured"
-          description={
-            'This deployment did not enable the client simulation ' +
-            'runtime. Configure it in your backend setup to start ' +
-            'tracking simulation runs.'
-          }
-        />
-      </div>
-    )
-  }
-
   const handleCancel = useCallback(
     async (simulationId: string) => {
       try {
@@ -102,6 +72,41 @@ export default function SimulationDashboardPage() {
       setError('Failed to load simulation report.')
     }
   }, [])
+
+  // Capability-gated effect: skip the network call entirely when the
+  // simulations subsystem is not configured for this deployment. The
+  // backend route is also not registered (returns 404), so calling
+  // listSimulations() would log a 404 in the audit trail per the
+  // issue #1666 B-3 contract. The early-return path that renders the
+  // EmptyState is below all hooks so React's hook-order rules stay
+  // satisfied across renders.
+  useEffect(() => {
+    if (capLoading || !capabilities.simulations) {
+      // Defer the loading flip out of the same synchronous render
+      // frame so eslint-react's set-state-in-effect rule stays
+      // satisfied and React batches one render instead of two.
+      queueMicrotask(() => setLoading(false))
+      return
+    }
+    void refresh()
+  }, [refresh, capLoading, capabilities.simulations])
+
+  if (!capLoading && !capabilities.simulations) {
+    return (
+      <div className="space-y-section-gap">
+        <ListHeader title="Simulations" />
+        <EmptyState
+          icon={Activity}
+          title="Simulations not configured"
+          description={
+            'This deployment did not enable the client simulation ' +
+            'runtime. Configure it in your backend setup to start ' +
+            'tracking simulation runs.'
+          }
+        />
+      </div>
+    )
+  }
 
   if (loading && runs.length === 0) {
     return (

--- a/web/src/pages/SimulationDashboardPage.tsx
+++ b/web/src/pages/SimulationDashboardPage.tsx
@@ -15,6 +15,7 @@ import { ListHeader } from '@/components/ui/list-header'
 import { MetricCard } from '@/components/ui/metric-card'
 import { SectionCard } from '@/components/ui/section-card'
 import { SkeletonCard } from '@/components/ui/skeleton'
+import { useCapabilities } from '@/hooks/useCapabilities'
 import { createLogger } from '@/lib/logger'
 
 const log = createLogger('SimulationDashboardPage')
@@ -28,6 +29,7 @@ const log = createLogger('SimulationDashboardPage')
  * per run.
  */
 export default function SimulationDashboardPage() {
+  const { capabilities, loading: capLoading } = useCapabilities()
   const [runs, setRuns] = useState<readonly SimulationStatus[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -47,8 +49,34 @@ export default function SimulationDashboardPage() {
   }, [])
 
   useEffect(() => {
+    if (capLoading || !capabilities.simulations) {
+      // Skip the network call entirely when the simulations
+      // subsystem is not configured for this deployment. The
+      // backend route is also not registered (returns 404), so
+      // calling listSimulations() would log a 404 in the audit
+      // trail per the issue #1666 B-3 contract.
+      setLoading(false)
+      return
+    }
     void refresh()
-  }, [refresh])
+  }, [refresh, capLoading, capabilities.simulations])
+
+  if (!capLoading && !capabilities.simulations) {
+    return (
+      <div className="space-y-section-gap">
+        <ListHeader title="Simulations" />
+        <EmptyState
+          icon={Activity}
+          title="Simulations not configured"
+          description={
+            'This deployment did not enable the client simulation ' +
+            'runtime. Configure it in your backend setup to start ' +
+            'tracking simulation runs.'
+          }
+        />
+      </div>
+    )
+  }
 
   const handleCancel = useCallback(
     async (simulationId: string) => {

--- a/web/src/pages/SimulationDashboardPage.tsx
+++ b/web/src/pages/SimulationDashboardPage.tsx
@@ -29,7 +29,11 @@ const log = createLogger('SimulationDashboardPage')
  * per run.
  */
 export default function SimulationDashboardPage() {
-  const { capabilities, loading: capLoading } = useCapabilities()
+  const {
+    capabilities,
+    loading: capLoading,
+    error: capError,
+  } = useCapabilities()
   const [runs, setRuns] = useState<readonly SimulationStatus[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -96,6 +100,19 @@ export default function SimulationDashboardPage() {
     }
     void refresh()
   }, [refresh, capLoading, capabilities.simulations])
+
+  if (!capLoading && capError !== null) {
+    return (
+      <div className="space-y-section-gap">
+        <ListHeader title="Simulations" />
+        <ErrorBanner
+          severity="error"
+          title="Could not determine available features"
+          description={capError}
+        />
+      </div>
+    )
+  }
 
   if (!capLoading && !capabilities.simulations) {
     return (

--- a/web/src/pages/SimulationDashboardPage.tsx
+++ b/web/src/pages/SimulationDashboardPage.tsx
@@ -79,9 +79,15 @@ export default function SimulationDashboardPage() {
   // listSimulations() would log a 404 in the audit trail per the
   // issue #1666 B-3 contract. The early-return path that renders the
   // EmptyState is below all hooks so React's hook-order rules stay
-  // satisfied across renders.
+  // satisfied across renders. While ``capLoading`` is true the
+  // skeleton branch below covers the in-flight window so the page
+  // never flashes "No simulation runs yet" against an unconfigured
+  // deployment.
   useEffect(() => {
-    if (capLoading || !capabilities.simulations) {
+    if (capLoading) {
+      return
+    }
+    if (!capabilities.simulations) {
       // Defer the loading flip out of the same synchronous render
       // frame so eslint-react's set-state-in-effect rule stays
       // satisfied and React batches one render instead of two.
@@ -108,7 +114,11 @@ export default function SimulationDashboardPage() {
     )
   }
 
-  if (loading && runs.length === 0) {
+  // Hold the skeleton until capabilities resolve AND the first refresh
+  // either lands data or sets loading=false. This prevents a one-frame
+  // "No simulation runs yet" flash on an unconfigured-but-not-yet-
+  // resolved deployment.
+  if (capLoading || (loading && runs.length === 0)) {
     return (
       <div className="space-y-section-gap">
         <ListHeader title="Simulations" />


### PR DESCRIPTION
Closes #1666.

Implements every acceptance criterion in the issue. Pre-reviewed by 13 specialised agents (issue-resolution-verifier, python-reviewer, security-reviewer, logging-audit, resilience-audit, conventions-enforcer, silent-failure-hunter, test-quality-reviewer, frontend-reviewer, infra-reviewer, async-concurrency-reviewer, api-contract-drift, docs-consistency, go-reviewer); 11 findings addressed.

## Summary

### A — Logging pipeline hygiene

- **A-1** `synthorg.log` filter excludes `api.request.started` / `api.request.completed`. New `_EventNameFilter` + `SINK_EVENT_EXCLUDES` table; reclaims 96% of main-log volume that was previously a duplicate of `access.log`.
- **A-2** `debug.log` pinned to `level == DEBUG` exactly via new `_ExactLevelFilter` + `SINK_EXACT_LEVELS` table. Empty file when nothing emits DEBUG; no more accidental INFO-collected duplication.
- **A-3** Logfire telemetry rebuilt:
  - Token embedded at wheel/sdist build time via new `scripts/embed_logfire_token.py` + Dockerfile build-arg + `.github/workflows/docker.yml` secret pass-through.
  - Operators flip `SYNTHORG_TELEMETRY_ENABLED` (renamed from `SYNTHORG_TELEMETRY`); registered as `telemetry.enabled` setting in `src/synthorg/settings/definitions/telemetry.py`.
  - Reporter factory's over-broad `except Exception` replaced with three precise arms (`ImportError`, `LogfireTokenMissingError`, `LogfireConfigureError`); each logs the real exception class name. Unknown exceptions propagate.
  - Collector boot path: single INFO `telemetry.disabled` when off; single ERROR `telemetry.token.missing` when on + sentinel build; heartbeat task never scheduled in either path → no per-cycle warning spam.

### B — Application bugs

- **B-1** `POST /api/v1/integrations/mcp/catalog/install` validate-first against `connection_catalog.get(...)` before INSERT; `psycopg.errors.IntegrityError` family lazy-mapped to 400 in `EXCEPTION_HANDLERS` as a backstop.
- **B-2** `POST /api/v1/reports/generate` AttributeError root cause was `state._app_state` (private underscore); fixed to `state.app_state`. `AutomatedReportService` now wired in `app.py` via new `app_state.set_report_service` / `.has_report_service` / `.report_service` accessors.
- **B-3** New `GET /api/v1/capabilities` endpoint (always registered) reports per-subsystem boolean flags. `SimulationController` + `RequestController` moved out of `BASE_CONTROLLERS` into a new `OPTIONAL_CONTROLLERS` table that registers them only when `app_state.has_client_simulation_state` is truthy → unconfigured installs return 404, not 503. Frontend: new `useCapabilities()` hook caches the matrix; `SimulationDashboardPage` + `RequestQueuePage` short-circuit polling and render `EmptyState` when their flag is false.
- **B-4** `pyngrok==8.1.1` promoted from unbundled-optional to required dep in `pyproject.toml`. `NgrokAdapter` drops the `try/except ImportError` guard. Tunnel start failures (auth rejected, ngrok service down) keep their 503 mapping; pyngrok-not-installed is now a build error.
- **B-5** Tolerant matcher + setup-wizard provider gate. `model_matcher` + `setup_agents` downgrade tier-fallback log from WARNING (`template.model_match.failed`) to DEBUG (`template.model_match.fallback` / `setup.agent.model_fallback_used`); fallback is the documented contract per the design page. New `_validate_tier_coverage()` in `setup_helpers.py` rejects empty-provider setups with HTTP 422 before per-agent matcher warnings ever fire.

## Test plan

- `uv run python -m pytest tests/ -m unit -n auto --ignore=tests/benchmarks/` → 24,759 passed, 16 skipped (logfire-extra and POSIX-only).
- Backend lint + format + mypy: clean.
- Frontend `npm run lint` (zero warnings) + tsc + vitest (2,909 tests): clean.
- Persistence-boundary check: clean (lint-allow marker on the psycopg backstop import).

### New tests added in this PR

- `tests/unit/observability/test_sink_routing.py` — unit tests for `_EventNameFilter`, `_ExactLevelFilter`, `SINK_EVENT_EXCLUDES`, `SINK_EXACT_LEVELS`.
- `tests/unit/observability/test_sink_filter_integration.py` — integration tests booting the actual handler chain to verify A-1 + A-2 contracts on real on-disk file output.
- `tests/unit/telemetry/reporters/test_factory.py` — covers all three precise except arms + unknown-exception propagation.
- `tests/unit/telemetry/test_collector.py` — disabled INFO + sentinel ERROR + NOOP-skip behaviour.
- `tests/unit/api/test_exception_handlers.py` — IntegrityError → 400 backstop.
- `tests/unit/api/controllers/test_reports.py` — happy path + 503-when-not-wired regression guard.
- `tests/unit/api/controllers/test_capabilities.py` — `/capabilities` matrix + 404 on unconfigured routes.
- `tests/unit/api/controllers/test_setup.py` — 200-with-mock-providers + 422 empty-providers gate.
- `tests/unit/api/controllers/test_mcp_catalog_dtos.py` — validate-first 400 paths.
- `tests/unit/templates/test_model_matcher.py` — DEBUG fallback + WARNING `no_models_available` events.
- `tests/unit/integrations/test_ngrok_adapter.py` — pyngrok importability + source-grep regression guard.
- `tests/unit/scripts/test_embed_logfire_token.py` — embed script unit tests.

## Review coverage

- 13 review agents launched in parallel (Phase 4 of `/pre-pr-review`).
- 11 findings addressed in the polish commit (1 Critical extraction, 4 Major, 3 Medium, 3 Minor).
- All issue-resolution-verifier acceptance criteria reported RESOLVED at 95–98% confidence.
- Security review clean (OWASP Top 10 + SEC-1 rules); no CRITICAL/HIGH findings.
- API-contract-drift verified 8 fields exact-match across backend Pydantic / TS interface / MSW handler / hook fallback.
- Resilience, conventions, async-concurrency, silent-failure, and docs-consistency all clean.

## Out of scope (intentionally deferred)

- The AttributeError logging-quality fix (use `safe_error_description`) is tracked by #1638 (SEC-1 baseline drain) per the issue; this PR fixes the underlying B-2 bug, not the logging redaction sweep.
