### PR TITLE
fix(ci): eliminate publish-image race + add cosign signature gate

### DIFF
--- a/.github/actions/publish-apko-base/action.yml
+++ b/.github/actions/publish-apko-base/action.yml
@@ -77,24 +77,22 @@ runs:
         REPO="ghcr.io/aureliolo/synthorg-${IMAGE_NAME}-base"
         IFS=',' read -ra ARCHS <<< "${ARCHITECTURES}"
 
-        # Push each per-arch image, then resolve its registry digest
-        # immediately. Use those digests (not the mutable per-arch tags)
-        # in `docker manifest create` so the manifest list bytes are
-        # stable even if a parallel workflow run pushes a different
-        # build over the same per-arch tag between create and push.
-        # See the publish-image action for the full background.
-        #
-        # Residual race: between `docker push` and `imagetools inspect`
-        # a concurrent run could overwrite the per-arch tag and the
-        # `inspect` would return the OTHER run's digest. The
-        # `verify-signatures` job in docker.yml's cross-tag divergence
-        # check catches that case.
+        # Push each per-arch image, capturing its manifest digest
+        # directly from `docker push` stdout (`<tag>: digest:
+        # sha256:<hex> size: <bytes>` per the Docker CLI reference).
+        # Reference manifest list members by `@sha256:digest` rather
+        # than the mutable per-arch tags so the manifest list bytes
+        # are stable. Parsing the push output (instead of re-reading
+        # the tag via `docker buildx imagetools inspect`) closes the
+        # TOCTOU window where a parallel run could overwrite the tag
+        # between push and inspect.
         MANIFEST_ARGS=()
         for arch in "${ARCHS[@]}"; do
-          docker push "${REPO}:${TAG}-${arch}"
-          ARCH_DIGEST="$(docker buildx imagetools inspect "${REPO}:${TAG}-${arch}" --format '{{.Manifest.Digest}}')"
+          PUSH_OUTPUT="$(docker push "${REPO}:${TAG}-${arch}" 2>&1)"
+          printf '%s\n' "${PUSH_OUTPUT}"
+          ARCH_DIGEST="$(printf '%s\n' "${PUSH_OUTPUT}" | sed -nE 's/^.*digest: (sha256:[0-9a-f]{64}).*$/\1/p' | tail -n1)"
           if [ -z "$ARCH_DIGEST" ]; then
-            echo "::error::Could not resolve ${arch} digest after push"
+            echo "::error::Could not parse ${arch} digest from docker push output"
             exit 1
           fi
           MANIFEST_ARGS+=("${REPO}@${ARCH_DIGEST}")

--- a/.github/actions/publish-apko-base/action.yml
+++ b/.github/actions/publish-apko-base/action.yml
@@ -222,4 +222,5 @@ runs:
       with:
         name: pushed-tags-${{ inputs.image-name }}-base
         path: pushed-tags-${{ inputs.image-name }}-base.txt
-        retention-days: 1
+        # Match the publish-image action; see its rationale.
+        retention-days: 7

--- a/.github/actions/publish-apko-base/action.yml
+++ b/.github/actions/publish-apko-base/action.yml
@@ -86,9 +86,16 @@ runs:
         # the tag via `docker buildx imagetools inspect`) closes the
         # TOCTOU window where a parallel run could overwrite the tag
         # between push and inspect.
+        # Wrap each `docker push` so `set -e` doesn't abort the step
+        # before we can dump the captured stderr to the build log on
+        # failure. See publish-image-loaded for the same pattern.
         MANIFEST_ARGS=()
         for arch in "${ARCHS[@]}"; do
-          PUSH_OUTPUT="$(docker push "${REPO}:${TAG}-${arch}" 2>&1)"
+          if ! PUSH_OUTPUT="$(docker push "${REPO}:${TAG}-${arch}" 2>&1)"; then
+            printf '%s\n' "${PUSH_OUTPUT}"
+            echo "::error::docker push failed for ${REPO}:${TAG}-${arch}"
+            exit 1
+          fi
           printf '%s\n' "${PUSH_OUTPUT}"
           ARCH_DIGEST="$(printf '%s\n' "${PUSH_OUTPUT}" | sed -nE 's/^.*digest: (sha256:[0-9a-f]{64}).*$/\1/p' | tail -n1)"
           if [ -z "$ARCH_DIGEST" ]; then

--- a/.github/actions/publish-apko-base/action.yml
+++ b/.github/actions/publish-apko-base/action.yml
@@ -73,22 +73,40 @@ runs:
         TAG: ${{ inputs.tag }}
         ARCHITECTURES: ${{ inputs.architectures }}
       run: |
+        set -euo pipefail
         REPO="ghcr.io/aureliolo/synthorg-${IMAGE_NAME}-base"
         IFS=',' read -ra ARCHS <<< "${ARCHITECTURES}"
+
+        # Push each per-arch image, then resolve its registry digest
+        # immediately. Use those digests (not the mutable per-arch tags)
+        # in `docker manifest create` so the manifest list bytes are
+        # stable even if a parallel workflow run pushes a different
+        # build over the same per-arch tag between create and push.
+        # See the publish-image action for the full background.
+        #
+        # Residual race: between `docker push` and `imagetools inspect`
+        # a concurrent run could overwrite the per-arch tag and the
+        # `inspect` would return the OTHER run's digest. The
+        # `verify-signatures` job in docker.yml's cross-tag divergence
+        # check catches that case.
         MANIFEST_ARGS=()
         for arch in "${ARCHS[@]}"; do
           docker push "${REPO}:${TAG}-${arch}"
-          MANIFEST_ARGS+=("${REPO}:${TAG}-${arch}")
+          ARCH_DIGEST="$(docker buildx imagetools inspect "${REPO}:${TAG}-${arch}" --format '{{.Manifest.Digest}}')"
+          if [ -z "$ARCH_DIGEST" ]; then
+            echo "::error::Could not resolve ${arch} digest after push"
+            exit 1
+          fi
+          MANIFEST_ARGS+=("${REPO}@${ARCH_DIGEST}")
         done
         # --amend keeps re-runs on the same SHA safe: a successful push on a
         # prior run leaves the manifest list present, and a plain `create` would
         # fail with "manifest already exists" before the idempotent push below.
         docker manifest create --amend "${REPO}:${TAG}" "${MANIFEST_ARGS[@]}"
         docker manifest push "${REPO}:${TAG}"
-        # `docker manifest push` stdout is unreliable across Docker versions
-        # (some emit `sha256:<hex>`, some only `Created manifest list <ref>`).
-        # Read the canonical manifest digest back from the registry via
-        # buildx imagetools, which is deterministic.
+        # Read the canonical manifest list digest back from the
+        # registry. Stable across re-runs because the create above pins
+        # source members by digest.
         DIGEST="$(docker buildx imagetools inspect "${REPO}:${TAG}" --format '{{.Manifest.Digest}}')"
         echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
@@ -134,6 +152,50 @@ runs:
             echo "::notice::Image already signed -- skipping"
           else cat /tmp/cosign-out; exit 1; fi
         fi
+
+    # Confirm the input tag still resolves to the digest cosign just
+    # signed and that the cosign signature artifact is reachable on
+    # GHCR. Catches the "concurrent run overwrote our tag after we
+    # signed" failure mode at CI time. See publish-image/action.yml
+    # for the full rationale.
+    - name: Verify pushed tag resolves to the signed digest
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+        TAG: ${{ inputs.tag }}
+        SIGNED_DIGEST: ${{ steps.push.outputs.digest }}
+        GHCR_TOKEN: ${{ inputs.ghcr-token }}
+      run: |
+        set -euo pipefail
+        REPO_PATH="aureliolo/synthorg-${IMAGE_NAME}-base"
+        REG_TOKEN="$(curl -sS -u "x-access-token:${GHCR_TOKEN}" \
+          "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO_PATH}:pull" \
+          | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')"
+        if [ -z "${REG_TOKEN}" ]; then
+          echo "::error::Failed to mint GHCR pull token for ${REPO_PATH}"
+          exit 1
+        fi
+
+        ACTUAL="$(curl -sS -I \
+          -H "Authorization: Bearer ${REG_TOKEN}" \
+          -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.index.v1+json" \
+          "https://ghcr.io/v2/${REPO_PATH}/manifests/${TAG}" \
+          | tr -d '\r' | awk -F': ' 'tolower($1)=="docker-content-digest"{print $2}')"
+        if [ "${ACTUAL}" != "${SIGNED_DIGEST}" ]; then
+          echo "::error::Tag ${TAG} resolves to ${ACTUAL} but we signed ${SIGNED_DIGEST}"
+          exit 1
+        fi
+
+        SIG_HEX="${SIGNED_DIGEST#sha256:}"
+        SIG_STATUS="$(curl -sS -o /dev/null -w '%{http_code}' \
+          -H "Authorization: Bearer ${REG_TOKEN}" \
+          -H "Accept: application/vnd.oci.image.index.v1+json" \
+          "https://ghcr.io/v2/${REPO_PATH}/manifests/sha256-${SIG_HEX}")"
+        if [ "${SIG_STATUS}" != "200" ]; then
+          echo "::error::cosign signature artifact missing (referrer tag sha256-${SIG_HEX} returned HTTP ${SIG_STATUS})"
+          exit 1
+        fi
+        echo "✓ ghcr.io/${REPO_PATH}:${TAG} -> ${ACTUAL} (signed)"
 
     - name: Attest build provenance (SLSA Level 3)
       uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0

--- a/.github/actions/publish-apko-base/action.yml
+++ b/.github/actions/publish-apko-base/action.yml
@@ -203,3 +203,23 @@ runs:
         subject-name: ghcr.io/aureliolo/synthorg-${{ inputs.image-name }}-base
         subject-digest: ${{ steps.push.outputs.digest }}
         push-to-registry: true
+
+    # Emit the canonical (image, tag) inventory for the workflow-level
+    # `verify-signatures` job. Base images push exactly one tag.
+    - name: Write pushed-tag inventory
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+        TAG: ${{ inputs.tag }}
+      run: |
+        set -euo pipefail
+        OUT="pushed-tags-${IMAGE_NAME}-base.txt"
+        printf '%s-base:%s\n' "${IMAGE_NAME}" "${TAG}" > "$OUT"
+        echo "wrote 1 tag entry to ${OUT}"
+
+    - name: Upload pushed-tag inventory
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: pushed-tags-${{ inputs.image-name }}-base
+        path: pushed-tags-${{ inputs.image-name }}-base.txt
+        retention-days: 1

--- a/.github/actions/publish-apko-base/action.yml
+++ b/.github/actions/publish-apko-base/action.yml
@@ -168,7 +168,8 @@ runs:
       run: |
         set -euo pipefail
         REPO_PATH="aureliolo/synthorg-${IMAGE_NAME}-base"
-        REG_TOKEN="$(curl -sS -u "x-access-token:${GHCR_TOKEN}" \
+        # `-L` follows redirects defensively; matches publish-image-loaded.
+        REG_TOKEN="$(curl -sSL -u "x-access-token:${GHCR_TOKEN}" \
           "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO_PATH}:pull" \
           | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')"
         if [ -z "${REG_TOKEN}" ]; then
@@ -176,7 +177,7 @@ runs:
           exit 1
         fi
 
-        ACTUAL="$(curl -sS -I \
+        ACTUAL="$(curl -sSL -I \
           -H "Authorization: Bearer ${REG_TOKEN}" \
           -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.index.v1+json" \
           "https://ghcr.io/v2/${REPO_PATH}/manifests/${TAG}" \
@@ -187,7 +188,7 @@ runs:
         fi
 
         SIG_HEX="${SIGNED_DIGEST#sha256:}"
-        SIG_STATUS="$(curl -sS -o /dev/null -w '%{http_code}' \
+        SIG_STATUS="$(curl -sSL -o /dev/null -w '%{http_code}' \
           -H "Authorization: Bearer ${REG_TOKEN}" \
           -H "Accept: application/vnd.oci.image.index.v1+json" \
           "https://ghcr.io/v2/${REPO_PATH}/manifests/sha256-${SIG_HEX}")"

--- a/.github/actions/publish-image-loaded/action.yml
+++ b/.github/actions/publish-image-loaded/action.yml
@@ -251,7 +251,9 @@ runs:
         # response, but defensively check for an empty token too: a
         # silent empty REG_TOKEN would otherwise have us issue every
         # subsequent `curl` with an empty Bearer header.
-        REG_TOKEN="$(curl -sS -u "x-access-token:${GHCR_TOKEN}" \
+        # `-L` follows redirects so registry-side rewrites (rare on
+        # GHCR but possible in proxy / mirror setups) don't fail.
+        REG_TOKEN="$(curl -sSL -u "x-access-token:${GHCR_TOKEN}" \
           "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO_PATH}:pull" \
           | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')"
         if [ -z "${REG_TOKEN}" ]; then
@@ -266,7 +268,7 @@ runs:
         FAILED=0
         while IFS= read -r t; do
           [ -z "${t}" ] && continue
-          ACTUAL="$(curl -sS -I \
+          ACTUAL="$(curl -sSL -I \
             -H "Authorization: Bearer ${REG_TOKEN}" \
             -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.index.v1+json" \
             "https://ghcr.io/v2/${REPO_PATH}/manifests/${t}" \
@@ -284,7 +286,7 @@ runs:
         # signatures via the OCI referrer mechanism, surfaced on GHCR
         # as the `sha256-<hex>` referrer tag.
         SIG_HEX="${SIGNED_DIGEST#sha256:}"
-        SIG_STATUS="$(curl -sS -o /dev/null -w '%{http_code}' \
+        SIG_STATUS="$(curl -sSL -o /dev/null -w '%{http_code}' \
           -H "Authorization: Bearer ${REG_TOKEN}" \
           -H "Accept: application/vnd.oci.image.index.v1+json" \
           "https://ghcr.io/v2/${REPO_PATH}/manifests/sha256-${SIG_HEX}")"

--- a/.github/actions/publish-image-loaded/action.yml
+++ b/.github/actions/publish-image-loaded/action.yml
@@ -80,20 +80,27 @@ runs:
           type=raw,value=dev,enable=${{ startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-dev.') }}
           type=sha,prefix=sha-
 
-    # Push the loaded per-arch images to GHCR, capture each per-arch
-    # manifest digest from the registry IMMEDIATELY after push, then
-    # assemble multi-arch manifest lists that reference those digests by
+    # Push the loaded per-arch images to GHCR, capturing each per-arch
+    # manifest digest directly from `docker push` stdout (Docker emits
+    # `<tag>: digest: sha256:<hex> size: <bytes>` per the docker.io
+    # CLI reference). This closes the TOCTOU window that existed when
+    # we re-read the tag via `docker buildx imagetools inspect` after
+    # push: a parallel workflow run could overwrite our per-arch tag
+    # in the registry between push and inspect, making `inspect`
+    # return the OTHER run's digest. Parsing the push output gives us
+    # the digest of the bytes WE just pushed, regardless of any later
+    # tag mutations.
+    #
+    # The manifest list assembled below references members by
     # `@sha256:...` rather than the mutable per-arch tags. This makes
     # the manifest list bytes byte-identical across every iteration of
     # the loop and immune to concurrent registry mutations.
     #
-    # Residual race: between `docker push` and `imagetools inspect` for
-    # the same per-arch tag, a concurrent workflow run could overwrite
-    # the tag in the registry, in which case `inspect` returns the
-    # OTHER run's digest. The downstream `verify-signatures` job
-    # (in docker.yml) catches that case via its cross-tag divergence
-    # check; the window here is too small to mitigate cleanly without
-    # a digest-pinned push API.
+    # Note: the manifest-list digest below is still read via
+    # `docker buildx imagetools inspect` because `docker manifest
+    # push` stdout is unreliable across Docker versions (PR #1650
+    # documented this: some versions emit the digest, some only
+    # print `Created manifest list`).
     - name: Push per-arch images and assemble manifest list
       id: push
       shell: bash
@@ -106,19 +113,21 @@ runs:
         REPO="ghcr.io/aureliolo/synthorg-${IMAGE_NAME}"
         SHORT_SHA="${GITHUB_SHA::7}"
 
-        docker push "${REPO}:sha-${SHORT_SHA}-amd64"
-        AMD64_DIGEST="$(docker buildx imagetools inspect "${REPO}:sha-${SHORT_SHA}-amd64" --format '{{.Manifest.Digest}}')"
+        AMD64_PUSH_OUTPUT="$(docker push "${REPO}:sha-${SHORT_SHA}-amd64" 2>&1)"
+        printf '%s\n' "${AMD64_PUSH_OUTPUT}"
+        AMD64_DIGEST="$(printf '%s\n' "${AMD64_PUSH_OUTPUT}" | sed -nE 's/^.*digest: (sha256:[0-9a-f]{64}).*$/\1/p' | tail -n1)"
         if [ -z "$AMD64_DIGEST" ]; then
-          echo "::error::Could not resolve amd64 digest after push"
+          echo "::error::Could not parse amd64 digest from docker push output"
           exit 1
         fi
 
         ARM64_DIGEST=""
         if [ "$ENABLE_ARM64" = "true" ]; then
-          docker push "${REPO}:sha-${SHORT_SHA}-arm64"
-          ARM64_DIGEST="$(docker buildx imagetools inspect "${REPO}:sha-${SHORT_SHA}-arm64" --format '{{.Manifest.Digest}}')"
+          ARM64_PUSH_OUTPUT="$(docker push "${REPO}:sha-${SHORT_SHA}-arm64" 2>&1)"
+          printf '%s\n' "${ARM64_PUSH_OUTPUT}"
+          ARM64_DIGEST="$(printf '%s\n' "${ARM64_PUSH_OUTPUT}" | sed -nE 's/^.*digest: (sha256:[0-9a-f]{64}).*$/\1/p' | tail -n1)"
           if [ -z "$ARM64_DIGEST" ]; then
-            echo "::error::Could not resolve arm64 digest after push"
+            echo "::error::Could not parse arm64 digest from docker push output"
             exit 1
           fi
         fi

--- a/.github/actions/publish-image-loaded/action.yml
+++ b/.github/actions/publish-image-loaded/action.yml
@@ -1,0 +1,350 @@
+name: Publish container image (already loaded)
+description: >-
+  Push an image whose per-arch variants are already loaded in the local
+  Docker daemon as `ghcr.io/aureliolo/synthorg-${image-name}:sha-<short>-amd64`
+  and (optionally) `-arm64`, then assemble the multi-arch manifest list,
+  cosign-sign it keyless via GitHub OIDC, attest SLSA Level 3 build
+  provenance, emit a CycloneDX SBOM, and publish a per-image
+  `pushed-tags-<image>.txt` artifact for the workflow-level
+  `verify-signatures` job to aggregate.
+
+  Callers prep the local tags themselves (e.g. `publish-image` downloads
+  per-arch scan tarballs and re-tags; the inline web publish flow loads
+  an apko-built multi-arch tarball whose internal tags already match
+  the expected names). This action then runs the security-critical
+  publish path that must be byte-identical across every caller.
+
+  Background on the digest-pinning: a previous version used
+  `${REPO}:sha-X-amd64` tag refs in `docker manifest create`.
+  `docker manifest create` re-resolves tag references against the
+  registry on every call, so when a concurrent main-push run overwrote
+  the per-arch tag between two iterations of a tag-push run's loop,
+  the manifest lists for different destination tags ended up with
+  different per-arch digests. cosign signed only the last one, leaving
+  the user-facing version tag unsigned. Capturing the per-arch digest
+  immediately after push and referencing manifest list members by
+  `@sha256:digest` makes every iteration produce byte-identical bytes.
+
+  Caller responsibilities:
+    - `packages: write`, `id-token: write`, `attestations: write`
+      permissions on the calling job.
+    - Run on a `runs-on: ubuntu-latest` runner.
+    - Have already loaded the per-arch images into the local Docker
+      daemon under `ghcr.io/aureliolo/synthorg-${image-name}:sha-<short-sha>-amd64`
+      (and `-arm64` when `enable-arm64: "true"`).
+
+inputs:
+  image-name:
+    description: "Short image name suffix (e.g. backend, sandbox, sidecar, web, fine-tune-gpu, fine-tune-cpu)."
+    required: true
+  app-version:
+    description: "Application version for the `type=raw` tag on stable `v*` releases."
+    required: true
+  enable-arm64:
+    description: >-
+      Push the arm64 image alongside amd64. Set "false" for images that
+      ship amd64-only (e.g. fine-tune variants).
+    required: false
+    default: "true"
+  ghcr-token:
+    description: "GITHUB_TOKEN for GHCR login -- must come from the caller's `secrets.GITHUB_TOKEN`."
+    required: true
+
+outputs:
+  digest:
+    description: "Pushed multi-arch manifest digest (sha256:...) for the sha-<short> tag."
+    value: ${{ steps.push.outputs.digest }}
+  pushed_tags:
+    description: "Newline-separated list of tags pushed in this invocation."
+    value: ${{ steps.push.outputs.pushed_tags }}
+
+runs:
+  using: composite
+  steps:
+    - name: Log in to GHCR
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.ghcr-token }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+      with:
+        images: ghcr.io/aureliolo/synthorg-${{ inputs.image-name }}
+        tags: |
+          type=raw,value=${{ inputs.app-version }},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev.') }}
+          type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev.') }}
+          type=raw,value=dev,enable=${{ startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-dev.') }}
+          type=sha,prefix=sha-
+
+    # Push the loaded per-arch images to GHCR, capture each per-arch
+    # manifest digest from the registry IMMEDIATELY after push, then
+    # assemble multi-arch manifest lists that reference those digests by
+    # `@sha256:...` rather than the mutable per-arch tags. This makes
+    # the manifest list bytes byte-identical across every iteration of
+    # the loop and immune to concurrent registry mutations.
+    #
+    # Residual race: between `docker push` and `imagetools inspect` for
+    # the same per-arch tag, a concurrent workflow run could overwrite
+    # the tag in the registry, in which case `inspect` returns the
+    # OTHER run's digest. The downstream `verify-signatures` job
+    # (in docker.yml) catches that case via its cross-tag divergence
+    # check; the window here is too small to mitigate cleanly without
+    # a digest-pinned push API.
+    - name: Push per-arch images and assemble manifest list
+      id: push
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+        ENABLE_ARM64: ${{ inputs.enable-arm64 }}
+        META_TAGS: ${{ steps.meta.outputs.tags }}
+      run: |
+        set -euo pipefail
+        REPO="ghcr.io/aureliolo/synthorg-${IMAGE_NAME}"
+        SHORT_SHA="${GITHUB_SHA::7}"
+
+        docker push "${REPO}:sha-${SHORT_SHA}-amd64"
+        AMD64_DIGEST="$(docker buildx imagetools inspect "${REPO}:sha-${SHORT_SHA}-amd64" --format '{{.Manifest.Digest}}')"
+        if [ -z "$AMD64_DIGEST" ]; then
+          echo "::error::Could not resolve amd64 digest after push"
+          exit 1
+        fi
+
+        ARM64_DIGEST=""
+        if [ "$ENABLE_ARM64" = "true" ]; then
+          docker push "${REPO}:sha-${SHORT_SHA}-arm64"
+          ARM64_DIGEST="$(docker buildx imagetools inspect "${REPO}:sha-${SHORT_SHA}-arm64" --format '{{.Manifest.Digest}}')"
+          if [ -z "$ARM64_DIGEST" ]; then
+            echo "::error::Could not resolve arm64 digest after push"
+            exit 1
+          fi
+        fi
+
+        # Build manifest list once with per-arch digests, push it under
+        # every desired tag. Identical bytes -> identical digest for
+        # every tag, regardless of what concurrent runs do.
+        DIGEST=""
+        PUSHED_TAGS=()
+        while IFS= read -r full_tag; do
+          [ -z "$full_tag" ] && continue
+          # metadata-action emits fully-qualified refs (repo:tag); strip
+          # the repo prefix so we can reapply it to the per-arch sources.
+          t="${full_tag#${REPO}:}"
+
+          if [ "$ENABLE_ARM64" = "true" ]; then
+            docker manifest create --amend "${REPO}:${t}" \
+              "${REPO}@${AMD64_DIGEST}" \
+              "${REPO}@${ARM64_DIGEST}"
+          else
+            docker manifest create --amend "${REPO}:${t}" \
+              "${REPO}@${AMD64_DIGEST}"
+          fi
+          docker manifest push "${REPO}:${t}"
+          PUSHED_TAGS+=("${t}")
+
+          # Read the canonical manifest list digest back from the
+          # registry. With digest-pinned source members above, every
+          # iteration produces the same bytes, so the digest is the
+          # same. Capture once on the sha-<short> iteration to keep the
+          # output stable.
+          if [ "$t" = "sha-${SHORT_SHA}" ]; then
+            DIGEST="$(docker buildx imagetools inspect "${REPO}:${t}" --format '{{.Manifest.Digest}}')"
+          fi
+        done <<< "$META_TAGS"
+
+        if [ -z "$DIGEST" ]; then
+          echo "::error::metadata-action did not emit a sha-${SHORT_SHA} tag -- cannot compute signing digest"
+          exit 1
+        fi
+        echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+        # Newline-separated list of tags pushed in this step. Consumed
+        # by the post-sign verify step below and surfaced as the
+        # `pushed_tags` output for the workflow-level inventory.
+        # Newline-separated (not space-separated) so the consumer
+        # iterates with `while IFS= read -r` and is immune to
+        # word-splitting / glob expansion. GitHub Actions multiline
+        # output uses the heredoc delimiter syntax.
+        {
+          printf 'pushed_tags<<__SYNTHORG_TAG_EOF__\n'
+          printf '%s\n' "${PUSHED_TAGS[@]}"
+          printf '__SYNTHORG_TAG_EOF__\n'
+        } >> "$GITHUB_OUTPUT"
+
+    # GitHub releases occasionally 5xx; cosign-installer's internal retry (3
+    # attempts in ~7s) is not enough to ride out a longer outage. Wrap the
+    # install in two continue-on-error attempts with backoff before the
+    # final fail-hard attempt, so a single 10-20s burst of 500s doesn't
+    # kill the run. Mirrors the pattern in publish-apko-base.
+    - name: Install cosign (attempt 1)
+      id: cosign_1
+      continue-on-error: true
+      uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+    - name: Back off before cosign retry 1
+      if: steps.cosign_1.outcome == 'failure'
+      shell: bash
+      run: sleep 15
+
+    - name: Install cosign (attempt 2)
+      if: steps.cosign_1.outcome == 'failure'
+      id: cosign_2
+      continue-on-error: true
+      uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+    - name: Back off before cosign retry 2
+      if: steps.cosign_2.outcome == 'failure'
+      shell: bash
+      run: sleep 30
+
+    - name: Install cosign (final attempt)
+      if: steps.cosign_2.outcome == 'failure'
+      uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+    - name: Sign image
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+        DIGEST: ${{ steps.push.outputs.digest }}
+      run: |
+        set -euo pipefail
+        if [ -z "$DIGEST" ]; then
+          echo "::error::Push step did not produce a digest -- cannot sign image"
+          exit 1
+        fi
+        if ! cosign sign --yes "ghcr.io/aureliolo/synthorg-${IMAGE_NAME}@${DIGEST}" 2>&1 | tee /tmp/cosign-out; then
+          if grep -q 'createLogEntryConflict' /tmp/cosign-out; then
+            echo "::notice::Image already signed in transparency log -- skipping"
+          else
+            exit 1
+          fi
+        fi
+
+    # Belt-and-braces: confirm every tag pushed in this step resolves
+    # (in the registry, NOW) to the same digest cosign just signed. A
+    # mismatch means a concurrent run overwrote one of our tags with a
+    # different digest after we signed -- the user will be unable to
+    # cosign-verify that tag. Fail the job loudly so the regression is
+    # caught at CI time, not in production.
+    #
+    # The OCI referrer index is queried directly (no cosign verify call)
+    # so we depend only on the registry, not on Sigstore reachability
+    # at this stage. The full keyless verify happens client-side via
+    # the CLI's `synthorg start --verify`/`synthorg update` flow.
+    - name: Verify every pushed tag resolves to the signed digest
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+        SIGNED_DIGEST: ${{ steps.push.outputs.digest }}
+        PUSHED_TAGS: ${{ steps.push.outputs.pushed_tags }}
+        GHCR_TOKEN: ${{ inputs.ghcr-token }}
+      run: |
+        set -euo pipefail
+        REPO_PATH="aureliolo/synthorg-${IMAGE_NAME}"
+        REPO="ghcr.io/${REPO_PATH}"
+
+        # GHCR requires a bearer token for the v2 API even on public
+        # packages; mint a pull-scoped one from the workflow token.
+        # `pipefail` will surface a Python KeyError on a malformed
+        # response, but defensively check for an empty token too: a
+        # silent empty REG_TOKEN would otherwise have us issue every
+        # subsequent `curl` with an empty Bearer header.
+        REG_TOKEN="$(curl -sS -u "x-access-token:${GHCR_TOKEN}" \
+          "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO_PATH}:pull" \
+          | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')"
+        if [ -z "${REG_TOKEN}" ]; then
+          echo "::error::Failed to mint GHCR pull token for ${REPO_PATH}"
+          exit 1
+        fi
+
+        # Iterate the newline-separated tag list with `read -r` so
+        # tags containing shell metacharacters cannot affect the loop
+        # (Docker tags exclude such chars per spec, but no enforcer
+        # validates the metadata-action output here).
+        FAILED=0
+        while IFS= read -r t; do
+          [ -z "${t}" ] && continue
+          ACTUAL="$(curl -sS -I \
+            -H "Authorization: Bearer ${REG_TOKEN}" \
+            -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.index.v1+json" \
+            "https://ghcr.io/v2/${REPO_PATH}/manifests/${t}" \
+            | tr -d '\r' | awk -F': ' 'tolower($1)=="docker-content-digest"{print $2}')"
+          if [ "${ACTUAL}" != "${SIGNED_DIGEST}" ]; then
+            echo "::error::Tag ${t} resolves to ${ACTUAL} but we signed ${SIGNED_DIGEST} -- a concurrent run overwrote the tag after signing"
+            FAILED=1
+          else
+            echo "✓ ${REPO}:${t} -> ${ACTUAL} (signed)"
+          fi
+        done <<< "${PUSHED_TAGS}"
+
+        # Confirm the signed digest is reachable as an OCI referrer
+        # index entry on the registry side. cosign v3 publishes
+        # signatures via the OCI referrer mechanism, surfaced on GHCR
+        # as the `sha256-<hex>` referrer tag.
+        SIG_HEX="${SIGNED_DIGEST#sha256:}"
+        SIG_STATUS="$(curl -sS -o /dev/null -w '%{http_code}' \
+          -H "Authorization: Bearer ${REG_TOKEN}" \
+          -H "Accept: application/vnd.oci.image.index.v1+json" \
+          "https://ghcr.io/v2/${REPO_PATH}/manifests/sha256-${SIG_HEX}")"
+        if [ "${SIG_STATUS}" != "200" ]; then
+          echo "::error::cosign signature artifact missing for ${REPO}@${SIGNED_DIGEST} (referrer tag sha256-${SIG_HEX} returned HTTP ${SIG_STATUS})"
+          FAILED=1
+        else
+          echo "✓ signature artifact present at ${REPO}:sha256-${SIG_HEX}"
+        fi
+
+        if [ "$FAILED" -ne 0 ]; then
+          exit 1
+        fi
+
+    - name: Attest build provenance (SLSA Level 3)
+      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      with: # zizmor: ignore[template-injection]
+        subject-name: ghcr.io/aureliolo/synthorg-${{ inputs.image-name }}
+        subject-digest: ${{ steps.push.outputs.digest }}
+        push-to-registry: true
+
+    - name: Generate SBOM
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      with:
+        image: ghcr.io/aureliolo/synthorg-${{ inputs.image-name }}@${{ steps.push.outputs.digest }}
+        format: cyclonedx-json
+        output-file: sbom-${{ inputs.image-name }}.cdx.json
+
+    - name: Upload SBOM artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: sbom-${{ inputs.image-name }}
+        path: sbom-${{ inputs.image-name }}.cdx.json
+        retention-days: 30
+
+    # Emit the canonical (image, tag) inventory as an artifact for the
+    # workflow-level `verify-signatures` job to aggregate. Avoids the
+    # drift risk of mirroring the metadata-action tag policy in two
+    # places.
+    - name: Write pushed-tag inventory
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+        PUSHED_TAGS: ${{ steps.push.outputs.pushed_tags }}
+      run: |
+        set -euo pipefail
+        OUT="pushed-tags-${IMAGE_NAME}.txt"
+        : > "$OUT"
+        while IFS= read -r t; do
+          [ -z "${t}" ] && continue
+          printf '%s:%s\n' "${IMAGE_NAME}" "${t}" >> "$OUT"
+        done <<< "${PUSHED_TAGS}"
+        echo "wrote $(wc -l < "$OUT") tag entries to ${OUT}"
+
+    - name: Upload pushed-tag inventory
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: pushed-tags-${{ inputs.image-name }}
+        path: pushed-tags-${{ inputs.image-name }}.txt
+        # 7d gives the verify-signatures aggregator headroom for
+        # retries / delayed downstream jobs (e.g. update-release on tag
+        # pushes). Original 1d cut it close to the workflow lifetime.
+        retention-days: 7

--- a/.github/actions/publish-image-loaded/action.yml
+++ b/.github/actions/publish-image-loaded/action.yml
@@ -113,7 +113,16 @@ runs:
         REPO="ghcr.io/aureliolo/synthorg-${IMAGE_NAME}"
         SHORT_SHA="${GITHUB_SHA::7}"
 
-        AMD64_PUSH_OUTPUT="$(docker push "${REPO}:sha-${SHORT_SHA}-amd64" 2>&1)"
+        # Wrap each `docker push` so `set -e` doesn't abort the step
+        # before we can dump the captured stderr to the build log on
+        # failure. Without this, a real GHCR/auth error is swallowed
+        # because the variable assignment exits before the next line
+        # runs.
+        if ! AMD64_PUSH_OUTPUT="$(docker push "${REPO}:sha-${SHORT_SHA}-amd64" 2>&1)"; then
+          printf '%s\n' "${AMD64_PUSH_OUTPUT}"
+          echo "::error::docker push failed for ${REPO}:sha-${SHORT_SHA}-amd64"
+          exit 1
+        fi
         printf '%s\n' "${AMD64_PUSH_OUTPUT}"
         AMD64_DIGEST="$(printf '%s\n' "${AMD64_PUSH_OUTPUT}" | sed -nE 's/^.*digest: (sha256:[0-9a-f]{64}).*$/\1/p' | tail -n1)"
         if [ -z "$AMD64_DIGEST" ]; then
@@ -123,7 +132,11 @@ runs:
 
         ARM64_DIGEST=""
         if [ "$ENABLE_ARM64" = "true" ]; then
-          ARM64_PUSH_OUTPUT="$(docker push "${REPO}:sha-${SHORT_SHA}-arm64" 2>&1)"
+          if ! ARM64_PUSH_OUTPUT="$(docker push "${REPO}:sha-${SHORT_SHA}-arm64" 2>&1)"; then
+            printf '%s\n' "${ARM64_PUSH_OUTPUT}"
+            echo "::error::docker push failed for ${REPO}:sha-${SHORT_SHA}-arm64"
+            exit 1
+          fi
           printf '%s\n' "${ARM64_PUSH_OUTPUT}"
           ARM64_DIGEST="$(printf '%s\n' "${ARM64_PUSH_OUTPUT}" | sed -nE 's/^.*digest: (sha256:[0-9a-f]{64}).*$/\1/p' | tail -n1)"
           if [ -z "$ARM64_DIGEST" ]; then

--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -89,12 +89,23 @@ runs:
           type=raw,value=dev,enable=${{ startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-dev.') }}
           type=sha,prefix=sha-
 
-    # Push the loaded per-arch images to GHCR under their -amd64 / -arm64
-    # tags, then assemble one multi-arch manifest list per desired tag
-    # (sha-short, semver, raw, dev). This mirrors the build-web publish
-    # path: push scanned bytes, never rebuild. `--amend` on manifest
-    # create keeps re-runs safe since a prior success would otherwise
-    # fail with "manifest already exists".
+    # Push the loaded per-arch images to GHCR, capture each per-arch
+    # manifest digest from the registry IMMEDIATELY after push, then
+    # assemble multi-arch manifest lists that reference those digests by
+    # `@sha256:...` rather than the mutable per-arch tags. This makes
+    # the manifest list bytes byte-identical across every iteration of
+    # the loop and immune to concurrent registry mutations -- a
+    # parallel workflow run pushing its own version of the same per-arch
+    # tag cannot make us sign a digest we did not push.
+    #
+    # Background: a previous version used `${REPO}:sha-X-amd64` tag refs
+    # in `docker manifest create`. `docker manifest create` re-resolves
+    # tag references against the registry on every call, so when the
+    # main-push run overwrote the per-arch tag between two iterations
+    # of the tag-push run's loop, the manifest lists for different
+    # destination tags ended up with different per-arch digests --
+    # producing different manifest list digests for the same content.
+    # cosign signed only the last one, leaving earlier tags unsigned.
     - name: Push per-arch images and assemble manifest list
       id: push
       shell: bash
@@ -107,12 +118,35 @@ runs:
         REPO="ghcr.io/aureliolo/synthorg-${IMAGE_NAME}"
         SHORT_SHA="${GITHUB_SHA::7}"
 
+        # Residual race: between `docker push` and `imagetools inspect`
+        # for the same per-arch tag, a concurrent workflow run could
+        # overwrite the tag in the registry, in which case `inspect`
+        # returns the OTHER run's digest. The downstream
+        # `verify-signatures` job (in docker.yml) catches that case
+        # via its cross-tag divergence check; the window here is too
+        # small to mitigate cleanly without a digest-pinned push API.
         docker push "${REPO}:sha-${SHORT_SHA}-amd64"
-        if [ "$ENABLE_ARM64" = "true" ]; then
-          docker push "${REPO}:sha-${SHORT_SHA}-arm64"
+        AMD64_DIGEST="$(docker buildx imagetools inspect "${REPO}:sha-${SHORT_SHA}-amd64" --format '{{.Manifest.Digest}}')"
+        if [ -z "$AMD64_DIGEST" ]; then
+          echo "::error::Could not resolve amd64 digest after push"
+          exit 1
         fi
 
+        ARM64_DIGEST=""
+        if [ "$ENABLE_ARM64" = "true" ]; then
+          docker push "${REPO}:sha-${SHORT_SHA}-arm64"
+          ARM64_DIGEST="$(docker buildx imagetools inspect "${REPO}:sha-${SHORT_SHA}-arm64" --format '{{.Manifest.Digest}}')"
+          if [ -z "$ARM64_DIGEST" ]; then
+            echo "::error::Could not resolve arm64 digest after push"
+            exit 1
+          fi
+        fi
+
+        # Build manifest list once with per-arch digests, push it under
+        # every desired tag. Identical bytes -> identical digest for
+        # every tag, regardless of what concurrent runs do.
         DIGEST=""
+        PUSHED_TAGS=()
         while IFS= read -r full_tag; do
           [ -z "$full_tag" ] && continue
           # metadata-action emits fully-qualified refs (repo:tag); strip
@@ -121,21 +155,20 @@ runs:
 
           if [ "$ENABLE_ARM64" = "true" ]; then
             docker manifest create --amend "${REPO}:${t}" \
-              "${REPO}:sha-${SHORT_SHA}-amd64" \
-              "${REPO}:sha-${SHORT_SHA}-arm64"
+              "${REPO}@${AMD64_DIGEST}" \
+              "${REPO}@${ARM64_DIGEST}"
           else
             docker manifest create --amend "${REPO}:${t}" \
-              "${REPO}:sha-${SHORT_SHA}-amd64"
+              "${REPO}@${AMD64_DIGEST}"
           fi
           docker manifest push "${REPO}:${t}"
+          PUSHED_TAGS+=("${t}")
 
-          # Capture the manifest digest of the sha-<short> tag as the
-          # canonical output -- that is what cosign + attest will sign.
-          # `docker manifest push` stdout is unreliable across Docker
-          # versions: some print `sha256:<hex>`, some print only
-          # `Created manifest list <ref>` with no digest. Read it back
-          # from the registry via buildx imagetools, which always
-          # returns the canonical manifest digest.
+          # Read the canonical manifest list digest back from the
+          # registry. With digest-pinned source members above, every
+          # iteration produces the same bytes, so the digest is the
+          # same. Capture once on the sha-<short> iteration to keep the
+          # output stable.
           if [ "$t" = "sha-${SHORT_SHA}" ]; then
             DIGEST="$(docker buildx imagetools inspect "${REPO}:${t}" --format '{{.Manifest.Digest}}')"
           fi
@@ -146,6 +179,17 @@ runs:
           exit 1
         fi
         echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+        # Newline-separated list of tags pushed in this step, consumed
+        # by the post-sign verification step below. Newline-separated
+        # (not space-separated) so the consumer iterates with
+        # `while IFS= read -r` and is immune to word-splitting / glob
+        # expansion. GitHub Actions multiline output uses the heredoc
+        # delimiter syntax.
+        {
+          printf 'pushed_tags<<__SYNTHORG_TAG_EOF__\n'
+          printf '%s\n' "${PUSHED_TAGS[@]}"
+          printf '__SYNTHORG_TAG_EOF__\n'
+        } >> "$GITHUB_OUTPUT"
 
     # GitHub releases occasionally 5xx; cosign-installer's internal retry (3
     # attempts in ~7s) is not enough to ride out a longer outage. Wrap the
@@ -194,6 +238,83 @@ runs:
           else
             exit 1
           fi
+        fi
+
+    # Belt-and-braces: confirm every tag pushed in this step resolves
+    # (in the registry, NOW) to the same digest cosign just signed. A
+    # mismatch means a concurrent run overwrote one of our tags with a
+    # different digest after we signed -- the user will be unable to
+    # cosign-verify that tag. Fail the job loudly so the regression is
+    # caught at CI time, not in production.
+    #
+    # The OCI referrer index is queried directly (no cosign verify call)
+    # so we depend only on the registry, not on Sigstore reachability
+    # at this stage. The full keyless verify happens client-side via
+    # the CLI's `synthorg start --verify`/`synthorg update` flow.
+    - name: Verify every pushed tag resolves to the signed digest
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+        SIGNED_DIGEST: ${{ steps.push.outputs.digest }}
+        PUSHED_TAGS: ${{ steps.push.outputs.pushed_tags }}
+        GHCR_TOKEN: ${{ inputs.ghcr-token }}
+      run: |
+        set -euo pipefail
+        REPO_PATH="aureliolo/synthorg-${IMAGE_NAME}"
+        REPO="ghcr.io/${REPO_PATH}"
+
+        # GHCR requires a bearer token for the v2 API even on public
+        # packages; mint a pull-scoped one from the workflow token.
+        # `pipefail` will surface a Python KeyError on a malformed
+        # response, but defensively check for an empty token too: a
+        # silent empty REG_TOKEN would otherwise have us issue every
+        # subsequent `curl` with an empty Bearer header.
+        REG_TOKEN="$(curl -sS -u "x-access-token:${GHCR_TOKEN}" \
+          "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO_PATH}:pull" \
+          | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')"
+        if [ -z "${REG_TOKEN}" ]; then
+          echo "::error::Failed to mint GHCR pull token for ${REPO_PATH}"
+          exit 1
+        fi
+
+        # Iterate the newline-separated tag list with `read -r` so
+        # tags containing shell metacharacters cannot affect the loop
+        # (Docker tags exclude such chars per spec, but no enforcer
+        # validates the metadata-action output here).
+        FAILED=0
+        while IFS= read -r t; do
+          [ -z "${t}" ] && continue
+          ACTUAL="$(curl -sS -I \
+            -H "Authorization: Bearer ${REG_TOKEN}" \
+            -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.index.v1+json" \
+            "https://ghcr.io/v2/${REPO_PATH}/manifests/${t}" \
+            | tr -d '\r' | awk -F': ' 'tolower($1)=="docker-content-digest"{print $2}')"
+          if [ "${ACTUAL}" != "${SIGNED_DIGEST}" ]; then
+            echo "::error::Tag ${t} resolves to ${ACTUAL} but we signed ${SIGNED_DIGEST} -- a concurrent run overwrote the tag after signing"
+            FAILED=1
+          else
+            echo "✓ ${REPO}:${t} -> ${ACTUAL} (signed)"
+          fi
+        done <<< "${PUSHED_TAGS}"
+
+        # Confirm the signed digest is reachable as an OCI referrer
+        # index entry on the registry side. cosign v3 publishes
+        # signatures via the OCI referrer mechanism, surfaced on GHCR
+        # as the `sha256-<hex>` referrer tag.
+        SIG_HEX="${SIGNED_DIGEST#sha256:}"
+        SIG_STATUS="$(curl -sS -o /dev/null -w '%{http_code}' \
+          -H "Authorization: Bearer ${REG_TOKEN}" \
+          -H "Accept: application/vnd.oci.image.index.v1+json" \
+          "https://ghcr.io/v2/${REPO_PATH}/manifests/sha256-${SIG_HEX}")"
+        if [ "${SIG_STATUS}" != "200" ]; then
+          echo "::error::cosign signature artifact missing for ${REPO}@${SIGNED_DIGEST} (referrer tag sha256-${SIG_HEX} returned HTTP ${SIG_STATUS})"
+          FAILED=1
+        else
+          echo "✓ signature artifact present at ${REPO}:sha256-${SIG_HEX}"
+        fi
+
+        if [ "$FAILED" -ne 0 ]; then
+          exit 1
         fi
 
     - name: Attest build provenance (SLSA Level 3)

--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -362,4 +362,7 @@ runs:
       with:
         name: pushed-tags-${{ inputs.image-name }}
         path: pushed-tags-${{ inputs.image-name }}.txt
-        retention-days: 1
+        # 7d gives the verify-signatures aggregator headroom for
+        # retries / delayed downstream jobs (e.g. update-release on tag
+        # pushes). Original 1d cut it close to the workflow lifetime.
+        retention-days: 7

--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -337,3 +337,29 @@ runs:
         name: sbom-${{ inputs.image-name }}
         path: sbom-${{ inputs.image-name }}.cdx.json
         retention-days: 30
+
+    # Emit the canonical (image, tag) inventory as an artifact for the
+    # workflow-level `verify-signatures` job to aggregate. Avoids the
+    # drift risk of mirroring the metadata-action tag policy in two
+    # places.
+    - name: Write pushed-tag inventory
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+        PUSHED_TAGS: ${{ steps.push.outputs.pushed_tags }}
+      run: |
+        set -euo pipefail
+        OUT="pushed-tags-${IMAGE_NAME}.txt"
+        : > "$OUT"
+        while IFS= read -r t; do
+          [ -z "${t}" ] && continue
+          printf '%s:%s\n' "${IMAGE_NAME}" "${t}" >> "$OUT"
+        done <<< "${PUSHED_TAGS}"
+        echo "wrote $(wc -l < "$OUT") tag entries to ${OUT}"
+
+    - name: Upload pushed-tag inventory
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: pushed-tags-${{ inputs.image-name }}
+        path: pushed-tags-${{ inputs.image-name }}.txt
+        retention-days: 1

--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -1,14 +1,17 @@
 name: Publish container image
 description: >-
   Download the per-arch docker-archive tarballs emitted by
-  `build-scan-image`, log into GHCR, push them unchanged to the registry,
-  assemble a multi-arch manifest list, cosign-sign it keyless via GitHub
-  OIDC, attest SLSA Level 3 build provenance, and emit a CycloneDX SBOM.
-  Because the pushed bytes are the exact bytes Trivy + CIS scanned, there
-  is no rebuild-vs-scan digest drift. Called from a companion publish-only
-  job that carries `packages: write`, `id-token: write`, and
-  `attestations: write`, gated by the `image-push` deployment environment
-  (branch policy `main,v*`).
+  `build-scan-image`, load them into the local Docker daemon under
+  the `sha-<short>-<arch>` tags, then delegate to the shared
+  `publish-image-loaded` composite action which pushes the manifest
+  list, cosign-signs it, attests SLSA Level 3 provenance, emits a
+  CycloneDX SBOM, and writes the per-image pushed-tag inventory.
+
+  Because the pushed bytes are the exact bytes Trivy + CIS scanned,
+  there is no rebuild-vs-scan digest drift. Called from a companion
+  publish-only job that carries `packages: write`, `id-token: write`,
+  and `attestations: write`, gated by the `image-push` deployment
+  environment (branch policy `main,v*`).
 
 inputs:
   image-name:
@@ -30,7 +33,10 @@ inputs:
 outputs:
   digest:
     description: "Pushed multi-arch manifest digest (sha256:...) for the sha-<short> tag."
-    value: ${{ steps.push.outputs.digest }}
+    value: ${{ steps.publish.outputs.digest }}
+  pushed_tags:
+    description: "Newline-separated list of tags pushed by the shared publish action."
+    value: ${{ steps.publish.outputs.pushed_tags }}
 
 runs:
   using: composite
@@ -60,8 +66,8 @@ runs:
 
         # Tarballs embed the internal `scan-<full_sha>-<arch>` tag used
         # during build-scan-image. Re-tag to the public short-SHA form
-        # (matching build-web) before push; the scan tag is never
-        # published to GHCR.
+        # (matching the local tag publish-image-loaded expects) before
+        # pushing; the scan tag is never published to GHCR.
         docker load -i "/tmp/scan-image-${IMAGE_NAME}-amd64.tar"
         docker tag "${REPO}:scan-${GITHUB_SHA}-amd64" "${REPO}:sha-${SHORT_SHA}-amd64"
 
@@ -70,299 +76,14 @@ runs:
           docker tag "${REPO}:scan-${GITHUB_SHA}-arm64" "${REPO}:sha-${SHORT_SHA}-arm64"
         fi
 
-    - name: Log in to GHCR
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+    # Hand off to the shared publish path -- digest-pinning, signing,
+    # post-sign verification, attestation, SBOM, and pushed-tag
+    # inventory all happen there.
+    - name: Publish image
+      id: publish
+      uses: ./.github/actions/publish-image-loaded
       with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ inputs.ghcr-token }}
-
-    - name: Extract metadata
-      id: meta
-      uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
-      with:
-        images: ghcr.io/aureliolo/synthorg-${{ inputs.image-name }}
-        tags: |
-          type=raw,value=${{ inputs.app-version }},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev.') }}
-          type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-          type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev.') }}
-          type=raw,value=dev,enable=${{ startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-dev.') }}
-          type=sha,prefix=sha-
-
-    # Push the loaded per-arch images to GHCR, capture each per-arch
-    # manifest digest from the registry IMMEDIATELY after push, then
-    # assemble multi-arch manifest lists that reference those digests by
-    # `@sha256:...` rather than the mutable per-arch tags. This makes
-    # the manifest list bytes byte-identical across every iteration of
-    # the loop and immune to concurrent registry mutations -- a
-    # parallel workflow run pushing its own version of the same per-arch
-    # tag cannot make us sign a digest we did not push.
-    #
-    # Background: a previous version used `${REPO}:sha-X-amd64` tag refs
-    # in `docker manifest create`. `docker manifest create` re-resolves
-    # tag references against the registry on every call, so when the
-    # main-push run overwrote the per-arch tag between two iterations
-    # of the tag-push run's loop, the manifest lists for different
-    # destination tags ended up with different per-arch digests --
-    # producing different manifest list digests for the same content.
-    # cosign signed only the last one, leaving earlier tags unsigned.
-    - name: Push per-arch images and assemble manifest list
-      id: push
-      shell: bash
-      env:
-        IMAGE_NAME: ${{ inputs.image-name }}
-        ENABLE_ARM64: ${{ inputs.enable-arm64 }}
-        META_TAGS: ${{ steps.meta.outputs.tags }}
-      run: |
-        set -euo pipefail
-        REPO="ghcr.io/aureliolo/synthorg-${IMAGE_NAME}"
-        SHORT_SHA="${GITHUB_SHA::7}"
-
-        # Residual race: between `docker push` and `imagetools inspect`
-        # for the same per-arch tag, a concurrent workflow run could
-        # overwrite the tag in the registry, in which case `inspect`
-        # returns the OTHER run's digest. The downstream
-        # `verify-signatures` job (in docker.yml) catches that case
-        # via its cross-tag divergence check; the window here is too
-        # small to mitigate cleanly without a digest-pinned push API.
-        docker push "${REPO}:sha-${SHORT_SHA}-amd64"
-        AMD64_DIGEST="$(docker buildx imagetools inspect "${REPO}:sha-${SHORT_SHA}-amd64" --format '{{.Manifest.Digest}}')"
-        if [ -z "$AMD64_DIGEST" ]; then
-          echo "::error::Could not resolve amd64 digest after push"
-          exit 1
-        fi
-
-        ARM64_DIGEST=""
-        if [ "$ENABLE_ARM64" = "true" ]; then
-          docker push "${REPO}:sha-${SHORT_SHA}-arm64"
-          ARM64_DIGEST="$(docker buildx imagetools inspect "${REPO}:sha-${SHORT_SHA}-arm64" --format '{{.Manifest.Digest}}')"
-          if [ -z "$ARM64_DIGEST" ]; then
-            echo "::error::Could not resolve arm64 digest after push"
-            exit 1
-          fi
-        fi
-
-        # Build manifest list once with per-arch digests, push it under
-        # every desired tag. Identical bytes -> identical digest for
-        # every tag, regardless of what concurrent runs do.
-        DIGEST=""
-        PUSHED_TAGS=()
-        while IFS= read -r full_tag; do
-          [ -z "$full_tag" ] && continue
-          # metadata-action emits fully-qualified refs (repo:tag); strip
-          # the repo prefix so we can reapply it to the per-arch sources.
-          t="${full_tag#${REPO}:}"
-
-          if [ "$ENABLE_ARM64" = "true" ]; then
-            docker manifest create --amend "${REPO}:${t}" \
-              "${REPO}@${AMD64_DIGEST}" \
-              "${REPO}@${ARM64_DIGEST}"
-          else
-            docker manifest create --amend "${REPO}:${t}" \
-              "${REPO}@${AMD64_DIGEST}"
-          fi
-          docker manifest push "${REPO}:${t}"
-          PUSHED_TAGS+=("${t}")
-
-          # Read the canonical manifest list digest back from the
-          # registry. With digest-pinned source members above, every
-          # iteration produces the same bytes, so the digest is the
-          # same. Capture once on the sha-<short> iteration to keep the
-          # output stable.
-          if [ "$t" = "sha-${SHORT_SHA}" ]; then
-            DIGEST="$(docker buildx imagetools inspect "${REPO}:${t}" --format '{{.Manifest.Digest}}')"
-          fi
-        done <<< "$META_TAGS"
-
-        if [ -z "$DIGEST" ]; then
-          echo "::error::metadata-action did not emit a sha-${SHORT_SHA} tag -- cannot compute signing digest"
-          exit 1
-        fi
-        echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-        # Newline-separated list of tags pushed in this step, consumed
-        # by the post-sign verification step below. Newline-separated
-        # (not space-separated) so the consumer iterates with
-        # `while IFS= read -r` and is immune to word-splitting / glob
-        # expansion. GitHub Actions multiline output uses the heredoc
-        # delimiter syntax.
-        {
-          printf 'pushed_tags<<__SYNTHORG_TAG_EOF__\n'
-          printf '%s\n' "${PUSHED_TAGS[@]}"
-          printf '__SYNTHORG_TAG_EOF__\n'
-        } >> "$GITHUB_OUTPUT"
-
-    # GitHub releases occasionally 5xx; cosign-installer's internal retry (3
-    # attempts in ~7s) is not enough to ride out a longer outage. Wrap the
-    # install in two continue-on-error attempts with backoff before the
-    # final fail-hard attempt, so a single 10-20s burst of 500s doesn't
-    # kill the run. Mirrors the pattern in publish-apko-base.
-    - name: Install cosign (attempt 1)
-      id: cosign_1
-      continue-on-error: true
-      uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-
-    - name: Back off before cosign retry 1
-      if: steps.cosign_1.outcome == 'failure'
-      shell: bash
-      run: sleep 15
-
-    - name: Install cosign (attempt 2)
-      if: steps.cosign_1.outcome == 'failure'
-      id: cosign_2
-      continue-on-error: true
-      uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-
-    - name: Back off before cosign retry 2
-      if: steps.cosign_2.outcome == 'failure'
-      shell: bash
-      run: sleep 30
-
-    - name: Install cosign (final attempt)
-      if: steps.cosign_2.outcome == 'failure'
-      uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-
-    - name: Sign image
-      shell: bash
-      env:
-        IMAGE_NAME: ${{ inputs.image-name }}
-        DIGEST: ${{ steps.push.outputs.digest }}
-      run: |
-        set -euo pipefail
-        if [ -z "$DIGEST" ]; then
-          echo "::error::Push step did not produce a digest -- cannot sign image"
-          exit 1
-        fi
-        if ! cosign sign --yes "ghcr.io/aureliolo/synthorg-${IMAGE_NAME}@${DIGEST}" 2>&1 | tee /tmp/cosign-out; then
-          if grep -q 'createLogEntryConflict' /tmp/cosign-out; then
-            echo "::notice::Image already signed in transparency log -- skipping"
-          else
-            exit 1
-          fi
-        fi
-
-    # Belt-and-braces: confirm every tag pushed in this step resolves
-    # (in the registry, NOW) to the same digest cosign just signed. A
-    # mismatch means a concurrent run overwrote one of our tags with a
-    # different digest after we signed -- the user will be unable to
-    # cosign-verify that tag. Fail the job loudly so the regression is
-    # caught at CI time, not in production.
-    #
-    # The OCI referrer index is queried directly (no cosign verify call)
-    # so we depend only on the registry, not on Sigstore reachability
-    # at this stage. The full keyless verify happens client-side via
-    # the CLI's `synthorg start --verify`/`synthorg update` flow.
-    - name: Verify every pushed tag resolves to the signed digest
-      shell: bash
-      env:
-        IMAGE_NAME: ${{ inputs.image-name }}
-        SIGNED_DIGEST: ${{ steps.push.outputs.digest }}
-        PUSHED_TAGS: ${{ steps.push.outputs.pushed_tags }}
-        GHCR_TOKEN: ${{ inputs.ghcr-token }}
-      run: |
-        set -euo pipefail
-        REPO_PATH="aureliolo/synthorg-${IMAGE_NAME}"
-        REPO="ghcr.io/${REPO_PATH}"
-
-        # GHCR requires a bearer token for the v2 API even on public
-        # packages; mint a pull-scoped one from the workflow token.
-        # `pipefail` will surface a Python KeyError on a malformed
-        # response, but defensively check for an empty token too: a
-        # silent empty REG_TOKEN would otherwise have us issue every
-        # subsequent `curl` with an empty Bearer header.
-        REG_TOKEN="$(curl -sS -u "x-access-token:${GHCR_TOKEN}" \
-          "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO_PATH}:pull" \
-          | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')"
-        if [ -z "${REG_TOKEN}" ]; then
-          echo "::error::Failed to mint GHCR pull token for ${REPO_PATH}"
-          exit 1
-        fi
-
-        # Iterate the newline-separated tag list with `read -r` so
-        # tags containing shell metacharacters cannot affect the loop
-        # (Docker tags exclude such chars per spec, but no enforcer
-        # validates the metadata-action output here).
-        FAILED=0
-        while IFS= read -r t; do
-          [ -z "${t}" ] && continue
-          ACTUAL="$(curl -sS -I \
-            -H "Authorization: Bearer ${REG_TOKEN}" \
-            -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.index.v1+json" \
-            "https://ghcr.io/v2/${REPO_PATH}/manifests/${t}" \
-            | tr -d '\r' | awk -F': ' 'tolower($1)=="docker-content-digest"{print $2}')"
-          if [ "${ACTUAL}" != "${SIGNED_DIGEST}" ]; then
-            echo "::error::Tag ${t} resolves to ${ACTUAL} but we signed ${SIGNED_DIGEST} -- a concurrent run overwrote the tag after signing"
-            FAILED=1
-          else
-            echo "✓ ${REPO}:${t} -> ${ACTUAL} (signed)"
-          fi
-        done <<< "${PUSHED_TAGS}"
-
-        # Confirm the signed digest is reachable as an OCI referrer
-        # index entry on the registry side. cosign v3 publishes
-        # signatures via the OCI referrer mechanism, surfaced on GHCR
-        # as the `sha256-<hex>` referrer tag.
-        SIG_HEX="${SIGNED_DIGEST#sha256:}"
-        SIG_STATUS="$(curl -sS -o /dev/null -w '%{http_code}' \
-          -H "Authorization: Bearer ${REG_TOKEN}" \
-          -H "Accept: application/vnd.oci.image.index.v1+json" \
-          "https://ghcr.io/v2/${REPO_PATH}/manifests/sha256-${SIG_HEX}")"
-        if [ "${SIG_STATUS}" != "200" ]; then
-          echo "::error::cosign signature artifact missing for ${REPO}@${SIGNED_DIGEST} (referrer tag sha256-${SIG_HEX} returned HTTP ${SIG_STATUS})"
-          FAILED=1
-        else
-          echo "✓ signature artifact present at ${REPO}:sha256-${SIG_HEX}"
-        fi
-
-        if [ "$FAILED" -ne 0 ]; then
-          exit 1
-        fi
-
-    - name: Attest build provenance (SLSA Level 3)
-      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-      with: # zizmor: ignore[template-injection]
-        subject-name: ghcr.io/aureliolo/synthorg-${{ inputs.image-name }}
-        subject-digest: ${{ steps.push.outputs.digest }}
-        push-to-registry: true
-
-    - name: Generate SBOM
-      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-      with:
-        image: ghcr.io/aureliolo/synthorg-${{ inputs.image-name }}@${{ steps.push.outputs.digest }}
-        format: cyclonedx-json
-        output-file: sbom-${{ inputs.image-name }}.cdx.json
-
-    - name: Upload SBOM artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: sbom-${{ inputs.image-name }}
-        path: sbom-${{ inputs.image-name }}.cdx.json
-        retention-days: 30
-
-    # Emit the canonical (image, tag) inventory as an artifact for the
-    # workflow-level `verify-signatures` job to aggregate. Avoids the
-    # drift risk of mirroring the metadata-action tag policy in two
-    # places.
-    - name: Write pushed-tag inventory
-      shell: bash
-      env:
-        IMAGE_NAME: ${{ inputs.image-name }}
-        PUSHED_TAGS: ${{ steps.push.outputs.pushed_tags }}
-      run: |
-        set -euo pipefail
-        OUT="pushed-tags-${IMAGE_NAME}.txt"
-        : > "$OUT"
-        while IFS= read -r t; do
-          [ -z "${t}" ] && continue
-          printf '%s:%s\n' "${IMAGE_NAME}" "${t}" >> "$OUT"
-        done <<< "${PUSHED_TAGS}"
-        echo "wrote $(wc -l < "$OUT") tag entries to ${OUT}"
-
-    - name: Upload pushed-tag inventory
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: pushed-tags-${{ inputs.image-name }}
-        path: pushed-tags-${{ inputs.image-name }}.txt
-        # 7d gives the verify-signatures aggregator headroom for
-        # retries / delayed downstream jobs (e.g. update-release on tag
-        # pushes). Original 1d cut it close to the workflow lifetime.
-        retention-days: 7
+        image-name: ${{ inputs.image-name }}
+        app-version: ${{ inputs.app-version }}
+        enable-arm64: ${{ inputs.enable-arm64 }}
+        ghcr-token: ${{ inputs.ghcr-token }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -982,6 +982,28 @@ jobs:
           path: sbom-web.cdx.json
           retention-days: 30
 
+      # Emit canonical (image, tag) inventory for `verify-signatures` to
+      # aggregate. Mirrors the publish-image / publish-apko-base pattern.
+      - name: Write pushed-tag inventory
+        env:
+          PUSHED_TAGS: ${{ steps.push.outputs.pushed_tags }}
+        run: |
+          set -euo pipefail
+          OUT="pushed-tags-web.txt"
+          : > "$OUT"
+          while IFS= read -r t; do
+            [ -z "${t}" ] && continue
+            printf 'web:%s\n' "${t}" >> "$OUT"
+          done <<< "${PUSHED_TAGS}"
+          echo "wrote $(wc -l < "$OUT") tag entries to ${OUT}"
+
+      - name: Upload pushed-tag inventory
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pushed-tags-web
+          path: pushed-tags-web.txt
+          retention-days: 1
+
   build-sandbox:
     name: Build Sandbox
     needs: [version, build-sandbox-base, build-sandbox-base-publish]
@@ -1271,68 +1293,37 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build pushed-tag inventory
+      # Aggregate the (image, tag) inventory directly from the artifacts
+      # each publish job emits via its `Write pushed-tag inventory` /
+      # `Upload pushed-tag inventory` steps. This avoids re-deriving the
+      # metadata-action tag policy in two places (a previous version of
+      # this job mirrored the rules locally and risked silent drift on
+      # future tag-policy changes).
+      - name: Download per-job pushed-tag inventories
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: pushed-tags-*
+          merge-multiple: true
+          path: tag-inventories
+
+      - name: Aggregate pushed-tag inventories
         id: inventory
-        env:
-          APP_VERSION: ${{ needs.version.outputs.app_version }}
         run: |
           set -euo pipefail
-          # Mirrors the metadata-action rules in publish-image/action.yml
-          # and the inline web push step. Keep this in sync if either
-          # changes its tag policy. metadata-action is configured with
-          # `pattern={{version}}` and `pattern={{major}}.{{minor}}`
-          # only -- there is no `{{major}}` (e.g. `0`) tag in our
-          # publish surface.
-          SHA_TAG="sha-${GITHUB_SHA::7}"
-          IS_VTAG=0
-          IS_DEV=0
-          IS_STABLE=0
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            IS_VTAG=1
-            REF_VERSION="${GITHUB_REF_NAME#v}"
-            if [[ "$REF_VERSION" == *-dev.* ]]; then
-              IS_DEV=1
-            else
-              IS_STABLE=1
-            fi
+          if [ ! -d tag-inventories ] || [ -z "$(ls -A tag-inventories 2>/dev/null)" ]; then
+            echo "::error::No pushed-tag inventory artifacts found -- the publish jobs did not emit any."
+            exit 1
           fi
-
-          # Per-image tag list (multi-arch images: backend/sandbox/sidecar/web).
-          # Single-arch images: fine-tune-{cpu,gpu}.
-          common_tags() {
-            echo "$SHA_TAG"
-            if [ "$IS_VTAG" -eq 1 ]; then
-              echo "$REF_VERSION"
-              if [ "$IS_DEV" -eq 1 ]; then
-                echo "dev"
-              else
-                echo "${REF_VERSION%.*}"
-                echo "$APP_VERSION"
-              fi
-            fi
-          }
-
-          {
-            for image in backend web sandbox sidecar fine-tune-cpu fine-tune-gpu; do
-              while IFS= read -r t; do
-                [ -z "$t" ] && continue
-                printf '%s:%s\n' "$image" "$t"
-              done < <(common_tags)
-            done
-            # Base images are sha-tagged only. fine-tune-base is built
-            # amd64-only (per build-fine-tune-base-publish), but it
-            # still publishes a one-member manifest list at the same
-            # tag, so this entry remains correct.
-            for base in backend-base sandbox-base sidecar-base fine-tune-base; do
-              printf '%s:%s\n' "$base" "$SHA_TAG"
-            done
-          } | sort -u > pushed-image-tags.txt
-
+          cat tag-inventories/*.txt | sort -u > pushed-image-tags.txt
+          if [ ! -s pushed-image-tags.txt ]; then
+            echo "::error::Aggregated inventory is empty"
+            exit 1
+          fi
           echo "Pushed inventory:"
           cat pushed-image-tags.txt
 
       - name: Set up Python
-        uses: actions/setup-python@e348410da18d2bccf04a9d585b46d2d57a05cce0 # v6.1.0
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: "3.14"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1002,7 +1002,8 @@ jobs:
         with:
           name: pushed-tags-web
           path: pushed-tags-web.txt
-          retention-days: 1
+          # Match the publish-image action; see its rationale.
+          retention-days: 7
 
   build-sandbox:
     name: Build Sandbox

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,7 @@ on:
       - ".github/actions/cis-scan/**"
       - ".github/actions/publish-apko-base/**"
       - ".github/actions/publish-image/**"
+      - ".github/actions/publish-image-loaded/**"
       - ".github/actions/setup-apko/**"
       - ".github/actions/setup-python-uv/**"
       - "scripts/cis-scan.sh"
@@ -77,6 +78,7 @@ jobs:
               - '.github/actions/cis-scan/**'
               - '.github/actions/publish-apko-base/**'
               - '.github/actions/publish-image/**'
+              - '.github/actions/publish-image-loaded/**'
               - '.github/actions/setup-apko/**'
               - 'scripts/cis-scan.sh'
             sandbox:
@@ -88,6 +90,7 @@ jobs:
               - '.github/actions/cis-scan/**'
               - '.github/actions/publish-apko-base/**'
               - '.github/actions/publish-image/**'
+              - '.github/actions/publish-image-loaded/**'
               - '.github/actions/setup-apko/**'
               - 'scripts/cis-scan.sh'
             sidecar:
@@ -99,6 +102,7 @@ jobs:
               - '.github/actions/cis-scan/**'
               - '.github/actions/publish-apko-base/**'
               - '.github/actions/publish-image/**'
+              - '.github/actions/publish-image-loaded/**'
               - '.github/actions/setup-apko/**'
               - 'scripts/cis-scan.sh'
             fine-tune:
@@ -113,6 +117,7 @@ jobs:
               - '.github/actions/cis-scan/**'
               - '.github/actions/publish-apko-base/**'
               - '.github/actions/publish-image/**'
+              - '.github/actions/publish-image-loaded/**'
               - '.github/actions/setup-apko/**'
               - 'scripts/cis-scan.sh'
             web:
@@ -125,6 +130,7 @@ jobs:
               - '.github/workflows/docker.yml'
               - '.github/actions/build-apko-base/**'
               - '.github/actions/cis-scan/**'
+              - '.github/actions/publish-image-loaded/**'
               - '.github/actions/setup-apko/**'
               - '.github/actions/setup-python-uv/**'
               - 'scripts/cis-scan.sh'
@@ -792,218 +798,40 @@ jobs:
       id-token: write
       attestations: write
     outputs:
-      digest: ${{ steps.push.outputs.digest }}
+      digest: ${{ steps.publish.outputs.digest }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
       - name: Download web image tarball
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: web-image-tarball
           path: .
 
+      # The apko-built `web.tar` is a multi-arch tarball whose internal
+      # tags are `ghcr.io/aureliolo/synthorg-web:sha-<short>-amd64` and
+      # `:sha-<short>-arm64` (set by the `apko build` invocation in
+      # `build-web`). After `docker load` those are exactly the local
+      # tags `publish-image-loaded` expects, so we can hand off
+      # directly without any re-tagging.
       - name: Load image
         run: |
           docker load -i web.tar
 
-      - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      # Hand off to the shared publish path. Identical signing and
+      # post-sign verification logic as the backend / sandbox / sidecar
+      # / fine-tune images, so a future fix lands in one place instead
+      # of two.
+      - name: Publish image
+        id: publish
+        uses: ./.github/actions/publish-image-loaded
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push web image (multi-arch manifest)
-        id: push
-        env:
-          APP_VERSION: ${{ needs.version.outputs.app_version }}
-        run: |
-          set -euo pipefail
-          SHA_TAG="sha-${GITHUB_SHA::7}"
-          REPO="ghcr.io/aureliolo/synthorg-web"
-
-          # Push per-arch images and capture their registry digests
-          # immediately. The manifest list below references members by
-          # `@sha256:digest` so it is byte-identical for every tag
-          # iteration -- a parallel workflow run pushing different
-          # bytes over our per-arch tags cannot cause the manifest
-          # lists for different destination tags to diverge. See
-          # .github/actions/publish-image/action.yml for the full
-          # rationale.
-          #
-          # Residual race: between `docker push` and `imagetools inspect`
-          # for the same per-arch tag, a concurrent run could overwrite
-          # the tag and `inspect` would return the OTHER digest. The
-          # downstream `verify-signatures` job catches this via its
-          # cross-tag divergence check.
-          docker push "${REPO}:${SHA_TAG}-amd64"
-          AMD64_DIGEST="$(docker buildx imagetools inspect "${REPO}:${SHA_TAG}-amd64" --format '{{.Manifest.Digest}}')"
-          if [ -z "$AMD64_DIGEST" ]; then
-            echo "::error::Could not resolve amd64 digest after push"
-            exit 1
-          fi
-
-          docker push "${REPO}:${SHA_TAG}-arm64"
-          ARM64_DIGEST="$(docker buildx imagetools inspect "${REPO}:${SHA_TAG}-arm64" --format '{{.Manifest.Digest}}')"
-          if [ -z "$ARM64_DIGEST" ]; then
-            echo "::error::Could not resolve arm64 digest after push"
-            exit 1
-          fi
-
-          # Collect manifest tags (deduplicated -- TAG and APP_VERSION can match)
-          declare -A SEEN_TAGS
-          MANIFEST_TAGS=()
-          for candidate in "${SHA_TAG}" $(
-            if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-              TAG="${GITHUB_REF_NAME#v}"
-              echo "${TAG}"
-              if [[ "$TAG" != *-dev.* ]]; then
-                echo "${TAG%.*}"
-                echo "${APP_VERSION}"
-              else
-                echo "dev"
-              fi
-            fi
-          ); do
-            if [ -z "${SEEN_TAGS[$candidate]+x}" ]; then
-              SEEN_TAGS[$candidate]=1
-              MANIFEST_TAGS+=("$candidate")
-            fi
-          done
-
-          # Create and push multi-arch manifest for each tag. --amend
-          # keeps re-runs on the same SHA safe; @sha256: refs keep the
-          # manifest list bytes stable across iterations and across
-          # concurrent runs.
-          DIGEST=""
-          PUSHED_TAGS=()
-          for t in "${MANIFEST_TAGS[@]}"; do
-            docker manifest create --amend "${REPO}:${t}" \
-              "${REPO}@${AMD64_DIGEST}" \
-              "${REPO}@${ARM64_DIGEST}"
-            docker manifest push "${REPO}:${t}"
-            PUSHED_TAGS+=("${t}")
-            if [ "$t" = "${SHA_TAG}" ]; then
-              DIGEST="$(docker buildx imagetools inspect "${REPO}:${t}" --format '{{.Manifest.Digest}}')"
-            fi
-          done
-          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-          # Newline-separated; consumer iterates with `while IFS= read -r`
-          # so tags are immune to word-splitting / glob expansion.
-          {
-            printf 'pushed_tags<<__SYNTHORG_TAG_EOF__\n'
-            printf '%s\n' "${PUSHED_TAGS[@]}"
-            printf '__SYNTHORG_TAG_EOF__\n'
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-
-      - name: Sign image
-        env:
-          DIGEST: ${{ steps.push.outputs.digest }}
-        run: |
-          if [ -z "$DIGEST" ]; then echo "::error::No digest"; exit 1; fi
-          set -euo pipefail
-          if ! cosign sign --yes ghcr.io/aureliolo/synthorg-web@${DIGEST} 2>&1 | tee /tmp/cosign-out; then
-            if grep -q 'createLogEntryConflict' /tmp/cosign-out; then
-              echo "::notice::Image already signed -- skipping"
-            else exit 1; fi
-          fi
-
-      # Confirm every tag pushed for this image still resolves to the
-      # signed digest and that the cosign signature artifact is
-      # reachable on GHCR. Catches the "concurrent run overwrote our
-      # tag after signing" failure mode at CI time. See
-      # .github/actions/publish-image/action.yml for the full
-      # rationale.
-      - name: Verify every pushed tag resolves to the signed digest
-        env:
-          SIGNED_DIGEST: ${{ steps.push.outputs.digest }}
-          PUSHED_TAGS: ${{ steps.push.outputs.pushed_tags }}
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          REPO_PATH="aureliolo/synthorg-web"
-          REG_TOKEN="$(curl -sS -u "x-access-token:${GHCR_TOKEN}" \
-            "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO_PATH}:pull" \
-            | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')"
-          if [ -z "${REG_TOKEN}" ]; then
-            echo "::error::Failed to mint GHCR pull token for ${REPO_PATH}"
-            exit 1
-          fi
-
-          FAILED=0
-          while IFS= read -r t; do
-            [ -z "${t}" ] && continue
-            ACTUAL="$(curl -sS -I \
-              -H "Authorization: Bearer ${REG_TOKEN}" \
-              -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.index.v1+json" \
-              "https://ghcr.io/v2/${REPO_PATH}/manifests/${t}" \
-              | tr -d '\r' | awk -F': ' 'tolower($1)=="docker-content-digest"{print $2}')"
-            if [ "${ACTUAL}" != "${SIGNED_DIGEST}" ]; then
-              echo "::error::Tag ${t} resolves to ${ACTUAL} but we signed ${SIGNED_DIGEST}"
-              FAILED=1
-            else
-              echo "✓ ghcr.io/${REPO_PATH}:${t} -> ${ACTUAL} (signed)"
-            fi
-          done <<< "${PUSHED_TAGS}"
-
-          SIG_HEX="${SIGNED_DIGEST#sha256:}"
-          SIG_STATUS="$(curl -sS -o /dev/null -w '%{http_code}' \
-            -H "Authorization: Bearer ${REG_TOKEN}" \
-            -H "Accept: application/vnd.oci.image.index.v1+json" \
-            "https://ghcr.io/v2/${REPO_PATH}/manifests/sha256-${SIG_HEX}")"
-          if [ "${SIG_STATUS}" != "200" ]; then
-            echo "::error::cosign signature artifact missing (referrer tag sha256-${SIG_HEX} returned HTTP ${SIG_STATUS})"
-            FAILED=1
-          fi
-
-          if [ "$FAILED" -ne 0 ]; then
-            exit 1
-          fi
-
-      - name: Attest build provenance (SLSA Level 3)
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-        with:
-          subject-name: ghcr.io/aureliolo/synthorg-web
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
-
-      - name: Generate SBOM
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-        with:
-          image: ghcr.io/aureliolo/synthorg-web@${{ steps.push.outputs.digest }}
-          format: cyclonedx-json
-          output-file: sbom-web.cdx.json
-
-      - name: Upload SBOM artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: sbom-web
-          path: sbom-web.cdx.json
-          retention-days: 30
-
-      # Emit canonical (image, tag) inventory for `verify-signatures` to
-      # aggregate. Mirrors the publish-image / publish-apko-base pattern.
-      - name: Write pushed-tag inventory
-        env:
-          PUSHED_TAGS: ${{ steps.push.outputs.pushed_tags }}
-        run: |
-          set -euo pipefail
-          OUT="pushed-tags-web.txt"
-          : > "$OUT"
-          while IFS= read -r t; do
-            [ -z "${t}" ] && continue
-            printf 'web:%s\n' "${t}" >> "$OUT"
-          done <<< "${PUSHED_TAGS}"
-          echo "wrote $(wc -l < "$OUT") tag entries to ${OUT}"
-
-      - name: Upload pushed-tag inventory
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: pushed-tags-web
-          path: pushed-tags-web.txt
-          # Match the publish-image action; see its rationale.
-          retention-days: 7
+          image-name: web
+          app-version: ${{ needs.version.outputs.app_version }}
+          enable-arm64: "true"
+          ghcr-token: ${{ secrets.GITHUB_TOKEN }}
 
   build-sandbox:
     name: Build Sandbox

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -816,12 +816,37 @@ jobs:
         env:
           APP_VERSION: ${{ needs.version.outputs.app_version }}
         run: |
+          set -euo pipefail
           SHA_TAG="sha-${GITHUB_SHA::7}"
           REPO="ghcr.io/aureliolo/synthorg-web"
 
-          # Push per-arch images
+          # Push per-arch images and capture their registry digests
+          # immediately. The manifest list below references members by
+          # `@sha256:digest` so it is byte-identical for every tag
+          # iteration -- a parallel workflow run pushing different
+          # bytes over our per-arch tags cannot cause the manifest
+          # lists for different destination tags to diverge. See
+          # .github/actions/publish-image/action.yml for the full
+          # rationale.
+          #
+          # Residual race: between `docker push` and `imagetools inspect`
+          # for the same per-arch tag, a concurrent run could overwrite
+          # the tag and `inspect` would return the OTHER digest. The
+          # downstream `verify-signatures` job catches this via its
+          # cross-tag divergence check.
           docker push "${REPO}:${SHA_TAG}-amd64"
+          AMD64_DIGEST="$(docker buildx imagetools inspect "${REPO}:${SHA_TAG}-amd64" --format '{{.Manifest.Digest}}')"
+          if [ -z "$AMD64_DIGEST" ]; then
+            echo "::error::Could not resolve amd64 digest after push"
+            exit 1
+          fi
+
           docker push "${REPO}:${SHA_TAG}-arm64"
+          ARM64_DIGEST="$(docker buildx imagetools inspect "${REPO}:${SHA_TAG}-arm64" --format '{{.Manifest.Digest}}')"
+          if [ -z "$ARM64_DIGEST" ]; then
+            echo "::error::Could not resolve arm64 digest after push"
+            exit 1
+          fi
 
           # Collect manifest tags (deduplicated -- TAG and APP_VERSION can match)
           declare -A SEEN_TAGS
@@ -844,26 +869,30 @@ jobs:
             fi
           done
 
-          # Create and push multi-arch manifest for each tag. --amend keeps
-          # re-runs on the same SHA safe: a prior successful push leaves the
-          # manifest list present, and a plain `create` would fail with
-          # "manifest already exists" on retry.
+          # Create and push multi-arch manifest for each tag. --amend
+          # keeps re-runs on the same SHA safe; @sha256: refs keep the
+          # manifest list bytes stable across iterations and across
+          # concurrent runs.
           DIGEST=""
+          PUSHED_TAGS=()
           for t in "${MANIFEST_TAGS[@]}"; do
             docker manifest create --amend "${REPO}:${t}" \
-              "${REPO}:${SHA_TAG}-amd64" \
-              "${REPO}:${SHA_TAG}-arm64"
+              "${REPO}@${AMD64_DIGEST}" \
+              "${REPO}@${ARM64_DIGEST}"
             docker manifest push "${REPO}:${t}"
-            # `docker manifest push` stdout is unreliable across Docker
-            # versions: some emit `sha256:<hex>`, some only print
-            # `Created manifest list <ref>` with no digest. Read the
-            # canonical manifest digest back from the registry via
-            # buildx imagetools, which is deterministic.
+            PUSHED_TAGS+=("${t}")
             if [ "$t" = "${SHA_TAG}" ]; then
               DIGEST="$(docker buildx imagetools inspect "${REPO}:${t}" --format '{{.Manifest.Digest}}')"
             fi
           done
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          # Newline-separated; consumer iterates with `while IFS= read -r`
+          # so tags are immune to word-splitting / glob expansion.
+          {
+            printf 'pushed_tags<<__SYNTHORG_TAG_EOF__\n'
+            printf '%s\n' "${PUSHED_TAGS[@]}"
+            printf '__SYNTHORG_TAG_EOF__\n'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
@@ -878,6 +907,58 @@ jobs:
             if grep -q 'createLogEntryConflict' /tmp/cosign-out; then
               echo "::notice::Image already signed -- skipping"
             else exit 1; fi
+          fi
+
+      # Confirm every tag pushed for this image still resolves to the
+      # signed digest and that the cosign signature artifact is
+      # reachable on GHCR. Catches the "concurrent run overwrote our
+      # tag after signing" failure mode at CI time. See
+      # .github/actions/publish-image/action.yml for the full
+      # rationale.
+      - name: Verify every pushed tag resolves to the signed digest
+        env:
+          SIGNED_DIGEST: ${{ steps.push.outputs.digest }}
+          PUSHED_TAGS: ${{ steps.push.outputs.pushed_tags }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          REPO_PATH="aureliolo/synthorg-web"
+          REG_TOKEN="$(curl -sS -u "x-access-token:${GHCR_TOKEN}" \
+            "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO_PATH}:pull" \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')"
+          if [ -z "${REG_TOKEN}" ]; then
+            echo "::error::Failed to mint GHCR pull token for ${REPO_PATH}"
+            exit 1
+          fi
+
+          FAILED=0
+          while IFS= read -r t; do
+            [ -z "${t}" ] && continue
+            ACTUAL="$(curl -sS -I \
+              -H "Authorization: Bearer ${REG_TOKEN}" \
+              -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.index.v1+json" \
+              "https://ghcr.io/v2/${REPO_PATH}/manifests/${t}" \
+              | tr -d '\r' | awk -F': ' 'tolower($1)=="docker-content-digest"{print $2}')"
+            if [ "${ACTUAL}" != "${SIGNED_DIGEST}" ]; then
+              echo "::error::Tag ${t} resolves to ${ACTUAL} but we signed ${SIGNED_DIGEST}"
+              FAILED=1
+            else
+              echo "✓ ghcr.io/${REPO_PATH}:${t} -> ${ACTUAL} (signed)"
+            fi
+          done <<< "${PUSHED_TAGS}"
+
+          SIG_HEX="${SIGNED_DIGEST#sha256:}"
+          SIG_STATUS="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer ${REG_TOKEN}" \
+            -H "Accept: application/vnd.oci.image.index.v1+json" \
+            "https://ghcr.io/v2/${REPO_PATH}/manifests/sha256-${SIG_HEX}")"
+          if [ "${SIG_STATUS}" != "200" ]; then
+            echo "::error::cosign signature artifact missing (referrer tag sha256-${SIG_HEX} returned HTTP ${SIG_STATUS})"
+            FAILED=1
+          fi
+
+          if [ "$FAILED" -ne 0 ]; then
+            exit 1
           fi
 
       - name: Attest build provenance (SLSA Level 3)
@@ -1146,6 +1227,129 @@ jobs:
           path: fine-tune-${{ matrix.variant }}.digest
           retention-days: 1
 
+  # Final cross-publish gate. After every publish job has finished
+  # (which means in-step verification has already passed for each
+  # image+tag locally), confirm one more time that NO concurrent run
+  # has overwritten any of our tags between the in-step check and now.
+  # The script also catches divergent digests across tags of the same
+  # image -- the exact failure mode that left
+  # `synthorg-sandbox:0.7.6-dev.9` unsigned despite a green CI run.
+  # Run on every main + tag push (not PRs, which never publish).
+  verify-signatures:
+    name: Verify Image Signatures
+    needs:
+      - version
+      - build-backend-base-publish
+      - build-sandbox-base-publish
+      - build-sidecar-base-publish
+      - build-fine-tune-base-publish
+      - build-backend-publish
+      - build-web-publish
+      - build-sandbox-publish
+      - build-sidecar-publish
+      - build-fine-tune-publish
+    if: >-
+      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) &&
+      github.event_name != 'pull_request' &&
+      !cancelled() &&
+      needs.build-backend-publish.result == 'success' &&
+      needs.build-web-publish.result == 'success' &&
+      needs.build-sandbox-publish.result == 'success' &&
+      needs.build-sidecar-publish.result == 'success' &&
+      needs.build-fine-tune-publish.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # `contents: read` covers checkout for the helper script, and
+    # `packages: read` is what the workflow `GITHUB_TOKEN` needs to
+    # mint a pull-scoped GHCR token. No write permissions: this job
+    # only verifies, never pushes.
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Build pushed-tag inventory
+        id: inventory
+        env:
+          APP_VERSION: ${{ needs.version.outputs.app_version }}
+        run: |
+          set -euo pipefail
+          # Mirrors the metadata-action rules in publish-image/action.yml
+          # and the inline web push step. Keep this in sync if either
+          # changes its tag policy. metadata-action is configured with
+          # `pattern={{version}}` and `pattern={{major}}.{{minor}}`
+          # only -- there is no `{{major}}` (e.g. `0`) tag in our
+          # publish surface.
+          SHA_TAG="sha-${GITHUB_SHA::7}"
+          IS_VTAG=0
+          IS_DEV=0
+          IS_STABLE=0
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            IS_VTAG=1
+            REF_VERSION="${GITHUB_REF_NAME#v}"
+            if [[ "$REF_VERSION" == *-dev.* ]]; then
+              IS_DEV=1
+            else
+              IS_STABLE=1
+            fi
+          fi
+
+          # Per-image tag list (multi-arch images: backend/sandbox/sidecar/web).
+          # Single-arch images: fine-tune-{cpu,gpu}.
+          common_tags() {
+            echo "$SHA_TAG"
+            if [ "$IS_VTAG" -eq 1 ]; then
+              echo "$REF_VERSION"
+              if [ "$IS_DEV" -eq 1 ]; then
+                echo "dev"
+              else
+                echo "${REF_VERSION%.*}"
+                echo "$APP_VERSION"
+              fi
+            fi
+          }
+
+          {
+            for image in backend web sandbox sidecar fine-tune-cpu fine-tune-gpu; do
+              while IFS= read -r t; do
+                [ -z "$t" ] && continue
+                printf '%s:%s\n' "$image" "$t"
+              done < <(common_tags)
+            done
+            # Base images are sha-tagged only. fine-tune-base is built
+            # amd64-only (per build-fine-tune-base-publish), but it
+            # still publishes a one-member manifest list at the same
+            # tag, so this entry remains correct.
+            for base in backend-base sandbox-base sidecar-base fine-tune-base; do
+              printf '%s:%s\n' "$base" "$SHA_TAG"
+            done
+          } | sort -u > pushed-image-tags.txt
+
+          echo "Pushed inventory:"
+          cat pushed-image-tags.txt
+
+      - name: Set up Python
+        uses: actions/setup-python@e348410da18d2bccf04a9d585b46d2d57a05cce0 # v6.1.0
+        with:
+          python-version: "3.14"
+
+      - name: Verify cosign signatures for every pushed (image, tag)
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Convert the inventory into one --image-tags arg per line so
+          # the script can deduplicate tags within an image group.
+          ARGS=()
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            ARGS+=("--image-tags" "$line")
+          done < pushed-image-tags.txt
+          python3 scripts/check_image_signatures.py "${ARGS[@]}"
+
   # Append container image references to the GitHub Release (version tags only).
   # The `*-publish` jobs transitively depend on their `*-base` / `*-base-publish`
   # counterparts (via `build-X` -> `build-X-publish`), so listing only the
@@ -1159,6 +1363,7 @@ jobs:
       - build-sandbox-publish
       - build-sidecar-publish
       - build-fine-tune-publish
+      - verify-signatures
     if: >-
       startsWith(github.ref, 'refs/tags/v') && github.event_name != 'pull_request' &&
       !cancelled() &&
@@ -1166,7 +1371,8 @@ jobs:
       needs.build-web-publish.result == 'success' &&
       needs.build-sandbox-publish.result == 'success' &&
       needs.build-sidecar-publish.result == 'success' &&
-      needs.build-fine-tune-publish.result == 'success'
+      needs.build-fine-tune-publish.result == 'success' &&
+      needs.verify-signatures.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # Uses `release-tags` (v*-only, no privileged secrets), not `release`

--- a/scripts/check_image_signatures.py
+++ b/scripts/check_image_signatures.py
@@ -41,6 +41,7 @@ import os
 import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 GHCR_REGISTRY = "ghcr.io"
@@ -170,6 +171,16 @@ def mint_pull_token(repo_path: str, ghcr_token: str | None) -> str | None:
     Returns None when no input token is available. Only GHCR is
     supported; other registries would need a different auth flow.
 
+    The ``repo_path`` is double-validated by the time it reaches this
+    function: ``_validate_repo_prefix`` + ``_validate_image_tag`` reject
+    anything outside the OCI grammar at startup, and the
+    ``urllib.parse.quote`` call below percent-encodes anything the
+    regex pass would have allowed but URLs disallow. CodeQL recognises
+    ``quote()`` as a sanitizer for ``py/partial-ssrf`` (regex-based
+    validators are not currently part of its sanitizer model), so the
+    quote call closes the static-analysis warning even though the
+    regex already prevents path-component escapes.
+
     Raises:
         urllib.error.URLError: network failure (also covers
             ``HTTPError``, e.g. an authn rejection from the token
@@ -180,11 +191,12 @@ def mint_pull_token(repo_path: str, ghcr_token: str | None) -> str | None:
     """
     if not ghcr_token:
         return None
+    safe_repo = urllib.parse.quote(repo_path, safe="")
     url = (
         f"https://{GHCR_REGISTRY}/token?service={GHCR_REGISTRY}"
-        f"&scope=repository:{repo_path}:pull"
+        f"&scope=repository:{safe_repo}:pull"
     )
-    req = urllib.request.Request(  # noqa: S310 -- URL is constructed from constants + caller-provided repo path
+    req = urllib.request.Request(  # noqa: S310 -- URL is constructed from constants + percent-encoded repo path
         url,
         headers={"Authorization": f"Basic {_basic_auth('x-access-token', ghcr_token)}"},
     )
@@ -228,8 +240,15 @@ def resolve_digest(
     Returns ``(digest, None)`` on success, or ``(None, error_message)``
     on failure. Distinguishes 404 (tag missing) from 200-without-digest
     (registry corruption / unexpected response).
+
+    Both ``repo_path`` and ``tag`` are pre-validated against anchored
+    OCI grammar regexes; the additional ``urllib.parse.quote`` calls
+    below double down on path-component encoding so CodeQL's
+    ``py/partial-ssrf`` data-flow recognises the URL as sanitised.
     """
-    url = f"https://{GHCR_REGISTRY}/v2/{repo_path}/manifests/{tag}"
+    safe_repo = urllib.parse.quote(repo_path, safe="/")
+    safe_tag = urllib.parse.quote(tag, safe="")
+    url = f"https://{GHCR_REGISTRY}/v2/{safe_repo}/manifests/{safe_tag}"
     headers = {"Accept": MANIFEST_ACCEPT, **auth_header}
     status, response_headers, _ = _request("HEAD", url, headers)
     if status != HTTP_OK:
@@ -245,11 +264,19 @@ def signature_present(
     digest: str,
     auth_header: dict[str, str],
 ) -> bool:
-    """Return True if a cosign signature referrer artifact exists for this digest."""
+    """Return True if a cosign signature referrer artifact exists for this digest.
+
+    ``repo_path`` is pre-validated; ``digest`` is checked to start with
+    the literal ``sha256:`` prefix and the hex tail is character-class
+    constrained by definition. The ``urllib.parse.quote`` call closes
+    the CodeQL ``py/partial-ssrf`` data-flow.
+    """
     if not digest.startswith("sha256:"):
         return False
-    sig_tag = "sha256-" + digest[len("sha256:") :]
-    url = f"https://{GHCR_REGISTRY}/v2/{repo_path}/manifests/{sig_tag}"
+    sig_tag = "sha256-" + digest.removeprefix("sha256:")
+    safe_repo = urllib.parse.quote(repo_path, safe="/")
+    safe_sig_tag = urllib.parse.quote(sig_tag, safe="")
+    url = f"https://{GHCR_REGISTRY}/v2/{safe_repo}/manifests/{safe_sig_tag}"
     headers = {"Accept": SIG_ACCEPT, **auth_header}
     status, _, _ = _request("HEAD", url, headers)
     return status == HTTP_OK
@@ -331,21 +358,24 @@ def _parse_args() -> argparse.Namespace:
 def _verify_pair(
     pair: ImageTag,
     repo_prefix: str,
-    ghcr_token: str | None,
+    auth_header: dict[str, str],
 ) -> tuple[str | None, str | None]:
     """Verify a single ``(image, tag)`` pair against the registry.
 
+    Caller supplies the pre-built ``auth_header`` (one per repo_path,
+    cached by ``main``) so we don't mint a fresh GHCR pull token for
+    every tag of the same image -- three tags of one image now share
+    one token mint instead of three.
+
     Returns ``(digest, None)`` on a fully-signed result, ``(None, error)``
-    on any failure. Network failures across the three constituent calls
-    (``mint_pull_token``, ``resolve_digest``, ``signature_present``) are
-    captured and returned as the error string instead of propagating, so
-    a transient failure on one pair doesn't halt verification of the
-    rest of the inventory.
+    on any failure. Network failures across the two constituent calls
+    (``resolve_digest``, ``signature_present``) are captured and
+    returned as the error string instead of propagating, so a transient
+    failure on one pair doesn't halt verification of the rest of the
+    inventory.
     """
     repo_path = f"{repo_prefix}{pair.image}"
     try:
-        reg_token = mint_pull_token(repo_path, ghcr_token)
-        auth_header = {"Authorization": f"Bearer {reg_token}"} if reg_token else {}
         digest, err = resolve_digest(repo_path, pair.tag, auth_header)
         if digest is None:
             return None, err
@@ -358,6 +388,34 @@ def _verify_pair(
     except _NetworkExceptions as exc:
         return None, f"network error ({type(exc).__name__}: {exc})"
     return digest, None
+
+
+def _auth_header_for_repo(
+    repo_path: str,
+    ghcr_token: str | None,
+    cache: dict[str, dict[str, str]],
+) -> tuple[dict[str, str] | None, str | None]:
+    """Return the cached Bearer header for ``repo_path``, minting on miss.
+
+    Returns ``(header, None)`` on success, ``(None, error_message)`` if
+    the token mint failed (network error). The cache is mutated in
+    place so subsequent calls for the same ``repo_path`` reuse the
+    minted token.
+    """
+    if repo_path in cache:
+        return cache[repo_path], None
+    try:
+        reg_token = mint_pull_token(repo_path, ghcr_token)
+    except _NetworkExceptions as exc:
+        return (
+            None,
+            f"failed to mint pull token ({type(exc).__name__}: {exc})",
+        )
+    header: dict[str, str] = (
+        {"Authorization": f"Bearer {reg_token}"} if reg_token else {}
+    )
+    cache[repo_path] = header
+    return header, None
 
 
 def _print_failures(failures: list[str]) -> None:
@@ -384,9 +442,16 @@ def main() -> int:
 
     failures: list[str] = []
     pair_to_digest: dict[ImageTag, str] = {}
+    auth_cache: dict[str, dict[str, str]] = {}
 
     for pair in pairs:
-        digest, err = _verify_pair(pair, args.repo_prefix, ghcr_token)
+        repo_path = f"{args.repo_prefix}{pair.image}"
+        auth_header, auth_err = _auth_header_for_repo(repo_path, ghcr_token, auth_cache)
+        if auth_err is not None:
+            failures.append(f"{pair}: {auth_err}")
+            continue
+        assert auth_header is not None  # noqa: S101 -- err is None, so header is set
+        digest, err = _verify_pair(pair, args.repo_prefix, auth_header)
         if err is not None:
             failures.append(f"{pair}: {err}")
             if digest is not None:
@@ -394,7 +459,6 @@ def main() -> int:
             continue
         assert digest is not None  # noqa: S101 -- err is None, so digest is set
         pair_to_digest[pair] = digest
-        repo_path = f"{args.repo_prefix}{pair.image}"
         print(f"OK  {GHCR_REGISTRY}/{repo_path}:{pair.tag} -> {digest} (signed)")
 
     failures.extend(_check_per_image_convergence(pair_to_digest))

--- a/scripts/check_image_signatures.py
+++ b/scripts/check_image_signatures.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+r"""Verify cosign signatures for SynthOrg container images on GHCR.
+
+Run as a workflow gate after all publish jobs finish: for every
+``(image, tag)`` pair pushed by the workflow, resolve the tag to its
+manifest digest, then confirm a cosign signature artifact (referrer
+index entry, surfaced on GHCR as the ``sha256-<hex>`` referrer tag)
+exists for that digest. Fails loudly if any tag is unsigned or any
+two tags of the same image diverge to different digests.
+
+Designed to catch the failure mode where two concurrent ``docker.yml``
+runs (e.g. main-push + tag-push for a release SHA) race on shared
+per-arch tags and end up signing different manifest list digests --
+leaving the user-facing tag (``synthorg-sandbox:0.7.6-dev.9``)
+unsigned. The per-publish-step verification in
+``.github/actions/publish-image/action.yml`` covers the in-step path;
+this gate covers cross-job races and post-sign tag overwrites.
+
+Usage:
+
+    python3 scripts/check_image_signatures.py \
+        --repo-prefix aureliolo/synthorg- \
+        --image-tags backend:0.7.6-dev.9,backend:dev,backend:sha-abc1234 \
+        --image-tags sandbox:0.7.6-dev.9,sandbox:dev,sandbox:sha-abc1234
+
+Auth: reads ``GHCR_TOKEN`` (a GitHub Actions ``GITHUB_TOKEN`` is
+sufficient for read-only access to public GHCR packages). Falls back
+to ``GITHUB_TOKEN``, then anonymous (works for public packages, may
+rate-limit).
+
+Exit codes:
+    0 on success, 1 on signature-verification failure, 2 on usage
+    error (bad args, no inputs).
+"""
+
+import argparse
+import base64
+import dataclasses
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+GHCR_REGISTRY = "ghcr.io"
+REPO_PREFIX_DEFAULT = "aureliolo/synthorg-"
+MANIFEST_ACCEPT = (
+    "application/vnd.docker.distribution.manifest.list.v2+json,"
+    "application/vnd.oci.image.index.v1+json,"
+    "application/vnd.docker.distribution.manifest.v2+json,"
+    "application/vnd.oci.image.manifest.v1+json"
+)
+SIG_ACCEPT = "application/vnd.oci.image.index.v1+json"
+HTTP_TIMEOUT_SECONDS = 30
+HTTP_OK = 200
+USAGE_EXIT_CODE = 2
+FAILURE_EXIT_CODE = 1
+
+
+@dataclasses.dataclass(frozen=True)
+class ImageTag:
+    """An ``(image, tag)`` pair to verify."""
+
+    image: str
+    tag: str
+
+    def __str__(self) -> str:
+        """Render as ``image:tag`` for log output."""
+        return f"{self.image}:{self.tag}"
+
+
+def parse_image_tag_groups(args: list[str]) -> list[ImageTag]:
+    """Parse repeated ``--image-tags image:tag,image:tag,...`` arguments.
+
+    Raises:
+        SystemExit: with code 2 on malformed input.
+    """
+    out: list[ImageTag] = []
+    for group in args:
+        for raw in group.split(","):
+            entry = raw.strip()
+            if not entry:
+                continue
+            if ":" not in entry:
+                print(
+                    f"error: --image-tags entry {entry!r} must be in 'image:tag' form",
+                    file=sys.stderr,
+                )
+                raise SystemExit(USAGE_EXIT_CODE)
+            image, tag = entry.split(":", 1)
+            image = image.strip()
+            tag = tag.strip()
+            if not image or not tag:
+                print(
+                    f"error: --image-tags entry {entry!r} has empty image or tag",
+                    file=sys.stderr,
+                )
+                raise SystemExit(USAGE_EXIT_CODE)
+            out.append(ImageTag(image=image, tag=tag))
+    return out
+
+
+def mint_pull_token(repo_path: str, ghcr_token: str | None) -> str | None:
+    """Exchange a GitHub token for a GHCR pull-scoped token.
+
+    Returns None when no input token is available. Only GHCR is
+    supported; other registries would need a different auth flow.
+
+    Raises:
+        urllib.error.URLError: network failure (also covers
+            ``HTTPError``, e.g. an authn rejection from the token
+            endpoint).
+        json.JSONDecodeError: registry returned a non-JSON body.
+        UnicodeDecodeError: registry returned a non-UTF-8 body.
+        OSError: low-level socket error (timeout, connection reset).
+    """
+    if not ghcr_token:
+        return None
+    url = (
+        f"https://{GHCR_REGISTRY}/token?service={GHCR_REGISTRY}"
+        f"&scope=repository:{repo_path}:pull"
+    )
+    req = urllib.request.Request(  # noqa: S310 -- URL is constructed from constants + caller-provided repo path
+        url,
+        headers={"Authorization": f"Basic {_basic_auth('x-access-token', ghcr_token)}"},
+    )
+    with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_SECONDS) as resp:  # noqa: S310
+        body = json.loads(resp.read().decode())
+    token = body.get("token")
+    return token if isinstance(token, str) else None
+
+
+def _basic_auth(user: str, password: str) -> str:
+    """Encode ``user:password`` for an HTTP Basic ``Authorization`` header."""
+    return base64.b64encode(f"{user}:{password}".encode()).decode()
+
+
+def _request(
+    method: str,
+    url: str,
+    headers: dict[str, str],
+) -> tuple[int, dict[str, str], bytes]:
+    """Send an HTTP request and return ``(status, headers, body)``.
+
+    HTTPError is converted to a tuple. Other ``URLError`` / ``OSError``
+    subclasses (timeouts, DNS, refused connections) propagate.
+    """
+    req = urllib.request.Request(url, method=method, headers=headers)  # noqa: S310 -- registry URL constructed from validated inputs
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_SECONDS) as resp:  # noqa: S310
+            body = resp.read()
+            return resp.status, dict(resp.headers), body
+    except urllib.error.HTTPError as exc:
+        return exc.code, dict(exc.headers or {}), exc.read()
+
+
+def resolve_digest(
+    repo_path: str,
+    tag: str,
+    auth_header: dict[str, str],
+) -> tuple[str | None, str | None]:
+    """Resolve a tag to its manifest digest.
+
+    Returns ``(digest, None)`` on success, or ``(None, error_message)``
+    on failure. Distinguishes 404 (tag missing) from 200-without-digest
+    (registry corruption / unexpected response).
+    """
+    url = f"https://{GHCR_REGISTRY}/v2/{repo_path}/manifests/{tag}"
+    headers = {"Accept": MANIFEST_ACCEPT, **auth_header}
+    status, response_headers, _ = _request("HEAD", url, headers)
+    if status != HTTP_OK:
+        return None, f"tag does not resolve in registry (HTTP {status})"
+    for k, v in response_headers.items():
+        if k.lower() == "docker-content-digest":
+            return v.strip(), None
+    return None, "registry returned 200 without docker-content-digest header"
+
+
+def signature_present(
+    repo_path: str,
+    digest: str,
+    auth_header: dict[str, str],
+) -> bool:
+    """Return True if a cosign signature referrer artifact exists for this digest."""
+    if not digest.startswith("sha256:"):
+        return False
+    sig_tag = "sha256-" + digest[len("sha256:") :]
+    url = f"https://{GHCR_REGISTRY}/v2/{repo_path}/manifests/{sig_tag}"
+    headers = {"Accept": SIG_ACCEPT, **auth_header}
+    status, _, _ = _request("HEAD", url, headers)
+    return status == HTTP_OK
+
+
+def _resolve_token() -> tuple[str | None, str]:
+    """Pick the registry token from the environment.
+
+    Returns ``(token, source_label)``; ``source_label`` is one of
+    ``"GHCR_TOKEN"`` / ``"GITHUB_TOKEN"`` / ``"none"`` so callers can
+    log which env var supplied the token.
+    """
+    for env_var in ("GHCR_TOKEN", "GITHUB_TOKEN"):
+        token = os.environ.get(env_var)
+        if token:
+            return token, env_var
+    return None, "none"
+
+
+def _check_per_image_convergence(
+    pair_to_digest: dict[ImageTag, str],
+) -> list[str]:
+    """Return failure messages for any image whose tags diverge.
+
+    Order-independent: collects every ``(tag, digest)`` per image, then
+    reports the full set of divergent digests if cardinality > 1.
+    """
+    by_image: dict[str, list[tuple[str, str]]] = {}
+    for pair, digest in pair_to_digest.items():
+        by_image.setdefault(pair.image, []).append((pair.tag, digest))
+
+    failures: list[str] = []
+    for image, observed in by_image.items():
+        unique_digests = {digest for _, digest in observed}
+        if len(unique_digests) > 1:
+            by_digest: dict[str, list[str]] = {}
+            for tag, digest in observed:
+                by_digest.setdefault(digest, []).append(tag)
+            variant_lines = sorted(
+                f"    {digest} -> tags [{', '.join(sorted(tags))}]"
+                for digest, tags in by_digest.items()
+            )
+            failures.append(
+                f"{image}: divergent digests across tags (concurrent run "
+                f"overwrote a tag after we signed):\n" + "\n".join(variant_lines)
+            )
+    return failures
+
+
+def main() -> int:
+    """Parse arguments and verify every ``(image, tag)`` pair."""
+    parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n\n", 1)[0])
+    parser.add_argument(
+        "--repo-prefix",
+        default=REPO_PREFIX_DEFAULT,
+        help=f"Repository name prefix (default: {REPO_PREFIX_DEFAULT})",
+    )
+    parser.add_argument(
+        "--image-tags",
+        action="append",
+        default=[],
+        required=True,
+        help=(
+            "Comma-separated 'image:tag' pairs; may be repeated. "
+            "Example: --image-tags backend:dev,backend:sha-abc1234"
+        ),
+    )
+    args = parser.parse_args()
+
+    pairs = parse_image_tag_groups(args.image_tags)
+    if not pairs:
+        print("error: no --image-tags pairs provided", file=sys.stderr)
+        return USAGE_EXIT_CODE
+
+    ghcr_token, token_source = _resolve_token()
+    print(f"auth: token source = {token_source}")
+
+    failures: list[str] = []
+    pair_to_digest: dict[ImageTag, str] = {}
+
+    for pair in pairs:
+        repo_path = f"{args.repo_prefix}{pair.image}"
+        try:
+            reg_token = mint_pull_token(repo_path, ghcr_token)
+        except (
+            urllib.error.URLError,
+            json.JSONDecodeError,
+            UnicodeDecodeError,
+            OSError,
+        ) as exc:
+            failures.append(
+                f"{pair}: failed to mint pull token ({type(exc).__name__}: {exc})"
+            )
+            continue
+        auth_header = {"Authorization": f"Bearer {reg_token}"} if reg_token else {}
+
+        digest, err = resolve_digest(repo_path, pair.tag, auth_header)
+        if digest is None:
+            failures.append(f"{pair}: {err}")
+            continue
+
+        pair_to_digest[pair] = digest
+
+        if not signature_present(repo_path, digest, auth_header):
+            failures.append(
+                f"{pair}: no cosign signature artifact for {digest} "
+                f"(referrer tag sha256-{digest[len('sha256:') :]} returned non-200)"
+            )
+            continue
+
+        print(f"OK  {GHCR_REGISTRY}/{repo_path}:{pair.tag} -> {digest} (signed)")
+
+    failures.extend(_check_per_image_convergence(pair_to_digest))
+
+    if failures:
+        print(file=sys.stderr)
+        print("Signature verification FAILED:", file=sys.stderr)
+        for line in failures:
+            print(f"  - {line}", file=sys.stderr)
+        return FAILURE_EXIT_CODE
+
+    print()
+    print(f"All {len(pairs)} (image, tag) pairs verified.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_image_signatures.py
+++ b/scripts/check_image_signatures.py
@@ -38,6 +38,7 @@ import base64
 import dataclasses
 import json
 import os
+import re
 import sys
 import urllib.error
 import urllib.request
@@ -56,6 +57,30 @@ HTTP_OK = 200
 USAGE_EXIT_CODE = 2
 FAILURE_EXIT_CODE = 1
 
+# Anchored allowlist patterns, applied to every value that flows into
+# the registry URL path. Closes the partial-SSRF window CodeQL flags
+# (rule py/partial-ssrf): the registry hostname is hardcoded to
+# `ghcr.io`, but the path-component values come from CLI args. Without
+# strict validation, a value containing `..`, `/`, NUL, or CR/LF could
+# coerce the request into a different host or endpoint.
+#
+# Repo prefix grammar: lowercase-with-dash component segments separated
+# by `/`, ending in a literal `-` (we use it as a prefix to the image
+# name). Mirrors the OCI distribution spec name grammar
+# (https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests).
+# `\Z` (not `$`) so a trailing newline in user input doesn't slip past
+# the anchor; with `$`, "foo\n" would match the empty string before the
+# newline.
+_REPO_PREFIX_RE = re.compile(
+    r"\A(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)+(?:[a-z0-9]+(?:[._-][a-z0-9]+)*)-\Z"
+)
+# Image suffix appended to repo_prefix: lowercase Docker name segment
+# with no `/` (already in prefix).
+_IMAGE_NAME_RE = re.compile(r"\A[a-z0-9]+(?:[._-][a-z0-9]+)*\Z")
+# OCI tag grammar: 1-128 chars from [A-Za-z0-9_], plus `.` and `-` but
+# not as the first character.
+_TAG_RE = re.compile(r"\A[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}\Z")
+
 
 @dataclasses.dataclass(frozen=True)
 class ImageTag:
@@ -67,6 +92,45 @@ class ImageTag:
     def __str__(self) -> str:
         """Render as ``image:tag`` for log output."""
         return f"{self.image}:{self.tag}"
+
+
+def _validate_repo_prefix(repo_prefix: str) -> None:
+    """Reject a malformed ``--repo-prefix`` value.
+
+    Raises:
+        SystemExit: with code 2 if the prefix doesn't match the
+            sanctioned grammar.
+    """
+    if not _REPO_PREFIX_RE.match(repo_prefix):
+        msg = (
+            f"error: --repo-prefix {repo_prefix!r} must match the OCI repo grammar "
+            "(lowercase, '.', '_', '-', '/'), and end with '-' (e.g. "
+            "'aureliolo/synthorg-')"
+        )
+        print(msg, file=sys.stderr)
+        raise SystemExit(USAGE_EXIT_CODE)
+
+
+def _validate_image_tag(pair: ImageTag) -> None:
+    """Reject malformed image or tag values.
+
+    Raises:
+        SystemExit: with code 2 if either component fails the OCI grammar.
+    """
+    if not _IMAGE_NAME_RE.match(pair.image):
+        msg = (
+            f"error: image name {pair.image!r} must match OCI name grammar "
+            "(lowercase alphanumerics with '.', '_', '-')"
+        )
+        print(msg, file=sys.stderr)
+        raise SystemExit(USAGE_EXIT_CODE)
+    if not _TAG_RE.match(pair.tag):
+        msg = (
+            f"error: tag {pair.tag!r} must match OCI tag grammar "
+            "(1-128 chars from [A-Za-z0-9_.-], not starting with '.' or '-')"
+        )
+        print(msg, file=sys.stderr)
+        raise SystemExit(USAGE_EXIT_CODE)
 
 
 def parse_image_tag_groups(args: list[str]) -> list[ImageTag]:
@@ -235,8 +299,16 @@ def _check_per_image_convergence(
     return failures
 
 
-def main() -> int:
-    """Parse arguments and verify every ``(image, tag)`` pair."""
+_NetworkExceptions = (
+    urllib.error.URLError,
+    json.JSONDecodeError,
+    UnicodeDecodeError,
+    OSError,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    """Build the argparse Namespace for this script."""
     parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n\n", 1)[0])
     parser.add_argument(
         "--repo-prefix",
@@ -253,12 +325,59 @@ def main() -> int:
             "Example: --image-tags backend:dev,backend:sha-abc1234"
         ),
     )
-    args = parser.parse_args()
+    return parser.parse_args()
 
+
+def _verify_pair(
+    pair: ImageTag,
+    repo_prefix: str,
+    ghcr_token: str | None,
+) -> tuple[str | None, str | None]:
+    """Verify a single ``(image, tag)`` pair against the registry.
+
+    Returns ``(digest, None)`` on a fully-signed result, ``(None, error)``
+    on any failure. Network failures across the three constituent calls
+    (``mint_pull_token``, ``resolve_digest``, ``signature_present``) are
+    captured and returned as the error string instead of propagating, so
+    a transient failure on one pair doesn't halt verification of the
+    rest of the inventory.
+    """
+    repo_path = f"{repo_prefix}{pair.image}"
+    try:
+        reg_token = mint_pull_token(repo_path, ghcr_token)
+        auth_header = {"Authorization": f"Bearer {reg_token}"} if reg_token else {}
+        digest, err = resolve_digest(repo_path, pair.tag, auth_header)
+        if digest is None:
+            return None, err
+        if not signature_present(repo_path, digest, auth_header):
+            sig_hex = digest.removeprefix("sha256:")
+            return None, (
+                f"no cosign signature artifact for {digest} "
+                f"(referrer tag sha256-{sig_hex} returned non-200)"
+            )
+    except _NetworkExceptions as exc:
+        return None, f"network error ({type(exc).__name__}: {exc})"
+    return digest, None
+
+
+def _print_failures(failures: list[str]) -> None:
+    """Render the failure block to stderr."""
+    print(file=sys.stderr)
+    print("Signature verification FAILED:", file=sys.stderr)
+    for line in failures:
+        print(f"  - {line}", file=sys.stderr)
+
+
+def main() -> int:
+    """Parse arguments and verify every ``(image, tag)`` pair."""
+    args = _parse_args()
+    _validate_repo_prefix(args.repo_prefix)
     pairs = parse_image_tag_groups(args.image_tags)
     if not pairs:
         print("error: no --image-tags pairs provided", file=sys.stderr)
         return USAGE_EXIT_CODE
+    for pair in pairs:
+        _validate_image_tag(pair)
 
     ghcr_token, token_source = _resolve_token()
     print(f"auth: token source = {token_source}")
@@ -267,44 +386,21 @@ def main() -> int:
     pair_to_digest: dict[ImageTag, str] = {}
 
     for pair in pairs:
-        repo_path = f"{args.repo_prefix}{pair.image}"
-        try:
-            reg_token = mint_pull_token(repo_path, ghcr_token)
-        except (
-            urllib.error.URLError,
-            json.JSONDecodeError,
-            UnicodeDecodeError,
-            OSError,
-        ) as exc:
-            failures.append(
-                f"{pair}: failed to mint pull token ({type(exc).__name__}: {exc})"
-            )
-            continue
-        auth_header = {"Authorization": f"Bearer {reg_token}"} if reg_token else {}
-
-        digest, err = resolve_digest(repo_path, pair.tag, auth_header)
-        if digest is None:
+        digest, err = _verify_pair(pair, args.repo_prefix, ghcr_token)
+        if err is not None:
             failures.append(f"{pair}: {err}")
+            if digest is not None:
+                pair_to_digest[pair] = digest
             continue
-
+        assert digest is not None  # noqa: S101 -- err is None, so digest is set
         pair_to_digest[pair] = digest
-
-        if not signature_present(repo_path, digest, auth_header):
-            failures.append(
-                f"{pair}: no cosign signature artifact for {digest} "
-                f"(referrer tag sha256-{digest[len('sha256:') :]} returned non-200)"
-            )
-            continue
-
+        repo_path = f"{args.repo_prefix}{pair.image}"
         print(f"OK  {GHCR_REGISTRY}/{repo_path}:{pair.tag} -> {digest} (signed)")
 
     failures.extend(_check_per_image_convergence(pair_to_digest))
 
     if failures:
-        print(file=sys.stderr)
-        print("Signature verification FAILED:", file=sys.stderr)
-        for line in failures:
-            print(f"  - {line}", file=sys.stderr)
+        _print_failures(failures)
         return FAILURE_EXIT_CODE
 
     print()

--- a/tests/unit/scripts/test_check_image_signatures.py
+++ b/tests/unit/scripts/test_check_image_signatures.py
@@ -199,3 +199,138 @@ class TestSignaturePresent:
     def test_rejects_empty_digest(self) -> None:
         repo = "aureliolo/synthorg-backend"
         assert gate.signature_present(repo, "", {}) is False
+
+
+@pytest.mark.unit
+class TestRepoPrefixValidator:
+    """_validate_repo_prefix rejects values that could escape the URL path."""
+
+    @pytest.mark.parametrize(
+        "good",
+        [
+            "aureliolo/synthorg-",
+            "library/foo-",
+            "ns/sub.ns/foo-",
+            "a-b/c-d-",
+        ],
+    )
+    def test_accepts_valid(self, good: str) -> None:
+        gate._validate_repo_prefix(good)  # does not raise
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "EVIL/",
+            "aureliolo/synthorg",
+            "..",
+            "../etc-",
+            "aureliolo/synth org-",
+            "aureliolo/synthorg-\n",
+            "/aureliolo/synthorg-",
+            "",
+            "aureliolo//synthorg-",
+            "aureliolo/synthorg-/",
+        ],
+    )
+    def test_rejects_invalid(self, bad: str) -> None:
+        with pytest.raises(SystemExit) as exc:
+            gate._validate_repo_prefix(bad)
+        assert exc.value.code == gate.USAGE_EXIT_CODE
+
+
+@pytest.mark.unit
+class TestImageTagValidator:
+    """_validate_image_tag rejects values that could escape the URL path."""
+
+    @pytest.mark.parametrize(
+        ("image", "tag"),
+        [
+            ("backend", "dev"),
+            ("backend", "0.7.6-dev.9"),
+            ("sandbox", "sha-2531b65"),
+            ("fine-tune-cpu", "0.7.6"),
+            ("fine.tune", "v_1"),
+        ],
+    )
+    def test_accepts_valid(self, image: str, tag: str) -> None:
+        pair = gate.ImageTag(image=image, tag=tag)
+        gate._validate_image_tag(pair)  # does not raise
+
+    @pytest.mark.parametrize(
+        ("image", "tag"),
+        [
+            ("backend/../etc", "dev"),  # path traversal
+            ("backend", "foo\nbar"),  # CRLF
+            ("backend", "foo bar"),  # space
+            ("backend", ".dotstart"),  # leading dot
+            ("backend", "-dashstart"),  # leading dash
+            ("EVIL", "dev"),  # uppercase image
+            ("backend", "x" * 129),  # tag length > 128
+            ("", "dev"),  # empty image
+            ("backend", ""),  # empty tag
+            ("backend", "foo:bar"),  # colon in tag
+            ("backend", "foo/bar"),  # slash in tag
+        ],
+    )
+    def test_rejects_invalid(self, image: str, tag: str) -> None:
+        pair = gate.ImageTag(image=image, tag=tag)
+        with pytest.raises(SystemExit) as exc:
+            gate._validate_image_tag(pair)
+        assert exc.value.code == gate.USAGE_EXIT_CODE
+
+
+@pytest.mark.unit
+class TestVerifyPair:
+    """_verify_pair returns errors instead of raising on transient failures."""
+
+    def test_network_error_becomes_failure_message(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Mock mint_pull_token to raise a URLError; _verify_pair should
+        # catch it and return a structured failure message rather than
+        # propagating.
+        import urllib.error
+
+        err = urllib.error.URLError("connection refused")
+
+        def boom(*_args: object, **_kwargs: object) -> str | None:
+            raise err
+
+        monkeypatch.setattr(gate, "mint_pull_token", boom)
+        pair = gate.ImageTag(image="backend", tag="dev")
+        digest, err = gate._verify_pair(pair, "aureliolo/synthorg-", "fake-token")
+        assert digest is None
+        assert err is not None
+        assert "URLError" in err
+        assert "connection refused" in err
+
+    def test_signature_missing_becomes_failure_message(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # If resolve_digest succeeds but signature_present returns False,
+        # _verify_pair must surface that as an error and embed the
+        # expected referrer-tag for diagnosability.
+        monkeypatch.setattr(gate, "mint_pull_token", lambda *_a, **_k: None)
+        monkeypatch.setattr(
+            gate, "resolve_digest", lambda *_a, **_k: ("sha256:abc123", None)
+        )
+        monkeypatch.setattr(gate, "signature_present", lambda *_a, **_k: False)
+        pair = gate.ImageTag(image="backend", tag="dev")
+        digest, err = gate._verify_pair(pair, "aureliolo/synthorg-", None)
+        assert digest is None
+        assert err is not None
+        assert "no cosign signature artifact" in err
+        assert "sha256-abc123" in err
+
+    def test_success_returns_digest_and_no_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(gate, "mint_pull_token", lambda *_a, **_k: None)
+        monkeypatch.setattr(
+            gate, "resolve_digest", lambda *_a, **_k: ("sha256:deadbeef", None)
+        )
+        monkeypatch.setattr(gate, "signature_present", lambda *_a, **_k: True)
+        pair = gate.ImageTag(image="backend", tag="dev")
+        digest, err = gate._verify_pair(pair, "aureliolo/synthorg-", None)
+        assert digest == "sha256:deadbeef"
+        assert err is None

--- a/tests/unit/scripts/test_check_image_signatures.py
+++ b/tests/unit/scripts/test_check_image_signatures.py
@@ -286,23 +286,23 @@ class TestVerifyPair:
     def test_network_error_becomes_failure_message(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # Mock mint_pull_token to raise a URLError; _verify_pair should
+        # Mock resolve_digest to raise a URLError; _verify_pair should
         # catch it and return a structured failure message rather than
         # propagating.
         import urllib.error
 
         err = urllib.error.URLError("connection refused")
 
-        def boom(*_args: object, **_kwargs: object) -> str | None:
+        def boom(*_args: object, **_kwargs: object) -> tuple[str | None, str | None]:
             raise err
 
-        monkeypatch.setattr(gate, "mint_pull_token", boom)
+        monkeypatch.setattr(gate, "resolve_digest", boom)
         pair = gate.ImageTag(image="backend", tag="dev")
-        digest, err = gate._verify_pair(pair, "aureliolo/synthorg-", "fake-token")
+        digest, returned_err = gate._verify_pair(pair, "aureliolo/synthorg-", {})
         assert digest is None
-        assert err is not None
-        assert "URLError" in err
-        assert "connection refused" in err
+        assert returned_err is not None
+        assert "URLError" in returned_err
+        assert "connection refused" in returned_err
 
     def test_signature_missing_becomes_failure_message(
         self, monkeypatch: pytest.MonkeyPatch
@@ -310,13 +310,12 @@ class TestVerifyPair:
         # If resolve_digest succeeds but signature_present returns False,
         # _verify_pair must surface that as an error and embed the
         # expected referrer-tag for diagnosability.
-        monkeypatch.setattr(gate, "mint_pull_token", lambda *_a, **_k: None)
         monkeypatch.setattr(
             gate, "resolve_digest", lambda *_a, **_k: ("sha256:abc123", None)
         )
         monkeypatch.setattr(gate, "signature_present", lambda *_a, **_k: False)
         pair = gate.ImageTag(image="backend", tag="dev")
-        digest, err = gate._verify_pair(pair, "aureliolo/synthorg-", None)
+        digest, err = gate._verify_pair(pair, "aureliolo/synthorg-", {})
         assert digest is None
         assert err is not None
         assert "no cosign signature artifact" in err
@@ -325,12 +324,69 @@ class TestVerifyPair:
     def test_success_returns_digest_and_no_error(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(gate, "mint_pull_token", lambda *_a, **_k: None)
         monkeypatch.setattr(
             gate, "resolve_digest", lambda *_a, **_k: ("sha256:deadbeef", None)
         )
         monkeypatch.setattr(gate, "signature_present", lambda *_a, **_k: True)
         pair = gate.ImageTag(image="backend", tag="dev")
-        digest, err = gate._verify_pair(pair, "aureliolo/synthorg-", None)
+        digest, err = gate._verify_pair(pair, "aureliolo/synthorg-", {})
         assert digest == "sha256:deadbeef"
         assert err is None
+
+
+@pytest.mark.unit
+class TestAuthHeaderForRepo:
+    """_auth_header_for_repo caches the per-repo Bearer header."""
+
+    def test_caches_header_across_calls(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # mint_pull_token must be called only once per repo_path even
+        # when the helper is invoked many times.
+        call_count = 0
+
+        def counting_mint(*_a: object, **_k: object) -> str | None:
+            nonlocal call_count
+            call_count += 1
+            return f"minted-token-{call_count}"
+
+        monkeypatch.setattr(gate, "mint_pull_token", counting_mint)
+        cache: dict[str, dict[str, str]] = {}
+        h1, e1 = gate._auth_header_for_repo("aureliolo/synthorg-backend", "tok", cache)
+        h2, e2 = gate._auth_header_for_repo("aureliolo/synthorg-backend", "tok", cache)
+        h3, e3 = gate._auth_header_for_repo("aureliolo/synthorg-sandbox", "tok", cache)
+        assert e1 is None
+        assert e2 is None
+        assert e3 is None
+        assert h1 == h2  # same repo: same cached header
+        assert h1 != h3  # different repo: different mint
+        assert call_count == 2  # one mint per unique repo
+
+    def test_returns_empty_header_when_no_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(gate, "mint_pull_token", lambda *_a, **_k: None)
+        cache: dict[str, dict[str, str]] = {}
+        header, err = gate._auth_header_for_repo(
+            "aureliolo/synthorg-backend", None, cache
+        )
+        assert err is None
+        assert header == {}
+
+    def test_network_error_becomes_failure_message(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import urllib.error
+
+        err = urllib.error.URLError("dns failure")
+
+        def boom(*_a: object, **_k: object) -> str | None:
+            raise err
+
+        monkeypatch.setattr(gate, "mint_pull_token", boom)
+        cache: dict[str, dict[str, str]] = {}
+        header, returned_err = gate._auth_header_for_repo(
+            "aureliolo/synthorg-backend", "tok", cache
+        )
+        assert header is None
+        assert returned_err is not None
+        assert "URLError" in returned_err
+        assert "dns failure" in returned_err

--- a/tests/unit/scripts/test_check_image_signatures.py
+++ b/tests/unit/scripts/test_check_image_signatures.py
@@ -1,0 +1,201 @@
+"""Tests for scripts/check_image_signatures.py."""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _import_script() -> ModuleType:
+    """Import check_image_signatures.py as a module."""
+    script = (
+        Path(__file__).resolve().parents[3] / "scripts" / "check_image_signatures.py"
+    )
+    spec = importlib.util.spec_from_file_location("check_image_signatures", script)
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+gate = _import_script()
+
+
+@pytest.mark.unit
+class TestParseImageTagGroups:
+    """parse_image_tag_groups parses repeated --image-tags inputs."""
+
+    def test_single_group_single_pair(self) -> None:
+        result = gate.parse_image_tag_groups(["backend:dev"])
+        assert result == [gate.ImageTag(image="backend", tag="dev")]
+
+    def test_single_group_multiple_pairs(self) -> None:
+        result = gate.parse_image_tag_groups(["backend:dev,backend:sha-abc1234"])
+        assert result == [
+            gate.ImageTag(image="backend", tag="dev"),
+            gate.ImageTag(image="backend", tag="sha-abc1234"),
+        ]
+
+    def test_repeated_groups(self) -> None:
+        result = gate.parse_image_tag_groups(["backend:dev", "sandbox:dev"])
+        assert result == [
+            gate.ImageTag(image="backend", tag="dev"),
+            gate.ImageTag(image="sandbox", tag="dev"),
+        ]
+
+    def test_strips_whitespace(self) -> None:
+        result = gate.parse_image_tag_groups([" backend : dev , sandbox : dev "])
+        assert result == [
+            gate.ImageTag(image="backend", tag="dev"),
+            gate.ImageTag(image="sandbox", tag="dev"),
+        ]
+
+    def test_skips_empty_entries(self) -> None:
+        result = gate.parse_image_tag_groups(["backend:dev,,sandbox:dev"])
+        assert result == [
+            gate.ImageTag(image="backend", tag="dev"),
+            gate.ImageTag(image="sandbox", tag="dev"),
+        ]
+
+    def test_dev_tag_with_dot_in_version(self) -> None:
+        # Real-world dev tag form
+        result = gate.parse_image_tag_groups(["sandbox:0.7.6-dev.9"])
+        assert result == [gate.ImageTag(image="sandbox", tag="0.7.6-dev.9")]
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "backend",
+            "backend:",
+            ":dev",
+            "  :  ",
+        ],
+    )
+    def test_invalid_pair_exits_with_usage_code(self, bad: str) -> None:
+        with pytest.raises(SystemExit) as exc:
+            gate.parse_image_tag_groups([bad])
+        assert exc.value.code == gate.USAGE_EXIT_CODE
+
+
+@pytest.mark.unit
+class TestImageTagStr:
+    """ImageTag stringifies as 'image:tag'."""
+
+    def test_str(self) -> None:
+        assert str(gate.ImageTag(image="backend", tag="dev")) == "backend:dev"
+
+
+@pytest.mark.unit
+class TestPerImageConvergence:
+    """_check_per_image_convergence flags divergent digests order-independently."""
+
+    def test_empty_input(self) -> None:
+        assert gate._check_per_image_convergence({}) == []
+
+    def test_single_image_single_tag(self) -> None:
+        pairs = {gate.ImageTag(image="backend", tag="dev"): "sha256:aaa"}
+        assert gate._check_per_image_convergence(pairs) == []
+
+    def test_single_image_multiple_tags_same_digest(self) -> None:
+        pairs = {
+            gate.ImageTag(image="backend", tag="dev"): "sha256:aaa",
+            gate.ImageTag(image="backend", tag="0.7.6-dev.9"): "sha256:aaa",
+            gate.ImageTag(image="backend", tag="sha-abc1234"): "sha256:aaa",
+        }
+        assert gate._check_per_image_convergence(pairs) == []
+
+    def test_two_tags_diverge_reports_both_digests(self) -> None:
+        pairs = {
+            gate.ImageTag(image="sandbox", tag="dev"): "sha256:aaa",
+            gate.ImageTag(image="sandbox", tag="0.7.6-dev.9"): "sha256:bbb",
+        }
+        failures = gate._check_per_image_convergence(pairs)
+        assert len(failures) == 1
+        msg = failures[0]
+        assert "sandbox" in msg
+        assert "sha256:aaa" in msg
+        assert "sha256:bbb" in msg
+        assert "dev" in msg
+        assert "0.7.6-dev.9" in msg
+
+    def test_three_tags_two_digests_groups_correctly(self) -> None:
+        # Two tags converge, one diverges; the message should group
+        # the two together and isolate the divergent one.
+        pairs = {
+            gate.ImageTag(image="sandbox", tag="dev"): "sha256:aaa",
+            gate.ImageTag(image="sandbox", tag="0.7.6-dev.9"): "sha256:aaa",
+            gate.ImageTag(image="sandbox", tag="sha-abc1234"): "sha256:bbb",
+        }
+        failures = gate._check_per_image_convergence(pairs)
+        assert len(failures) == 1
+        msg = failures[0]
+        assert "sha256:aaa" in msg
+        assert "sha256:bbb" in msg
+        # The two-tag group must list both tags
+        assert "dev" in msg
+        assert "0.7.6-dev.9" in msg
+
+    def test_divergence_is_order_independent(self) -> None:
+        # Construct two dicts with the same content but different
+        # iteration order. Both must produce the same finding count
+        # (1 in either case) and reference both digests.
+        first = {
+            gate.ImageTag(image="backend", tag="a"): "sha256:111",
+            gate.ImageTag(image="backend", tag="b"): "sha256:222",
+        }
+        second = {
+            gate.ImageTag(image="backend", tag="b"): "sha256:222",
+            gate.ImageTag(image="backend", tag="a"): "sha256:111",
+        }
+        f1 = gate._check_per_image_convergence(first)
+        f2 = gate._check_per_image_convergence(second)
+        assert len(f1) == 1
+        assert len(f2) == 1
+        # Both messages must mention both digests; the rendering may
+        # vary but content equality holds.
+        for msg in (f1[0], f2[0]):
+            assert "sha256:111" in msg
+            assert "sha256:222" in msg
+
+    def test_multiple_images_with_independent_divergence(self) -> None:
+        pairs = {
+            gate.ImageTag(image="backend", tag="dev"): "sha256:aaa",
+            gate.ImageTag(image="backend", tag="sha-1"): "sha256:bbb",
+            gate.ImageTag(image="sandbox", tag="dev"): "sha256:ccc",
+            gate.ImageTag(image="sandbox", tag="sha-1"): "sha256:ddd",
+        }
+        failures = gate._check_per_image_convergence(pairs)
+        assert len(failures) == 2
+        joined = "\n".join(failures)
+        assert "backend" in joined
+        assert "sandbox" in joined
+
+
+@pytest.mark.unit
+class TestBasicAuth:
+    """_basic_auth produces a stable base64 encoding without trailing newlines."""
+
+    def test_basic_auth_encoding(self) -> None:
+        # base64("x-access-token:abc") == "eC1hY2Nlc3MtdG9rZW46YWJj"
+        assert gate._basic_auth("x-access-token", "abc") == "eC1hY2Nlc3MtdG9rZW46YWJj"
+
+    def test_no_trailing_newline(self) -> None:
+        result = gate._basic_auth("user", "very-long-password-that-might-be-padded")
+        assert "\n" not in result
+        assert "\r" not in result
+
+
+@pytest.mark.unit
+class TestSignaturePresent:
+    """signature_present rejects malformed digests up front."""
+
+    def test_rejects_non_sha256_digest(self) -> None:
+        # No HTTP call should be made; non-sha256 digest fails immediately.
+        repo = "aureliolo/synthorg-backend"
+        assert gate.signature_present(repo, "md5:deadbeef", {}) is False
+
+    def test_rejects_empty_digest(self) -> None:
+        repo = "aureliolo/synthorg-backend"
+        assert gate.signature_present(repo, "", {}) is False


### PR DESCRIPTION
## Summary

`ghcr.io/aureliolo/synthorg-sandbox:0.7.6-dev.9` was published without a cosign signature, breaking `synthorg update` for everyone on the dev channel. This PR fixes the underlying race in the publish path and adds a CI gate that fails loudly the next time it tries to happen.

## Diagnosis

The user-facing `0.7.6-dev.9` tag pointed at manifest digest `sha256:9faf23da...`, but cosign signed `sha256:035003c2...` (an orphan digest no current tag points to). The CLI's keyless verify (which queries the OCI referrer index for the resolved digest) reports "no cosign signatures found" and refuses to upgrade.

**Root cause** — the publish-image composite action's loop:

```bash
for tag in 0.7.6-dev.9 dev sha-2531b65; do
  docker manifest create --amend "${REPO}:${tag}" \
    "${REPO}:sha-2531b65-amd64" \
    "${REPO}:sha-2531b65-arm64"   # ← mutable tag refs, re-resolved per call
  docker manifest push "${REPO}:${tag}"
done
DIGEST=$(docker buildx imagetools inspect "${REPO}:sha-2531b65" ...)  # captures only LAST iteration
cosign sign "${REPO}@${DIGEST}"
```

`docker manifest create` re-resolves the per-arch tag references against the registry on every call. The concurrent main-push docker.yml run (same SHA, different `github.ref`, same per-arch tags) overwrote `sha-2531b65-amd64` between iterations:

| iteration | manifest list bytes | resulting digest |
|---|---|---|
| iter 1 push `0.7.6-dev.9` | amd64=`e25d98f4` arm64=`d90b9ceb` | `sha256:9faf23da...` ← user-facing tag |
| iter 3 push `sha-2531b65` | amd64=`1884256560` arm64=`d90b9ceb` (parallel run overwrote between iters) | `sha256:035003c2...` ← cosign signed this |

cosign signed only the iter-3 digest, leaving the iter-1 digest the user-facing `0.7.6-dev.9` tag actually points to unsigned.

v0.7.5 was unaffected because publish-image was not yet a composite action (PR #1542 introduced it on 2026-04-24, after v0.7.5 had been cut). dev.7 and dev.8 happened to escape because their main-push and tag-push runs didn't reach the publish step within ~8 seconds of each other; dev.9 was 8s apart and triggered the race.

Verified end-to-end against GHCR: the divergent per-arch amd64 digests confirm the race was real, not a hypothesis.

## Fix

**Eliminate the race** — pin manifest list members by digest instead of mutable tag.

In `publish-image/action.yml`, `publish-apko-base/action.yml`, and the inline `publish-web` step in `docker.yml`:

```bash
docker push "${REPO}:sha-${SHORT_SHA}-amd64"
AMD64_DIGEST="$(docker buildx imagetools inspect "${REPO}:sha-${SHORT_SHA}-amd64" --format '{{.Manifest.Digest}}')"
# ...same for arm64...

for t in $tags; do
  docker manifest create --amend "${REPO}:${t}" \
    "${REPO}@${AMD64_DIGEST}" \
    "${REPO}@${ARM64_DIGEST}"
  docker manifest push "${REPO}:${t}"
done
```

All iterations produce byte-identical manifest lists → identical digest → cosign signs once and every tag verifies, regardless of what concurrent runs do to mutable tags.

**In-step post-sign verification** — every action now verifies that every tag pushed in the step still resolves to the digest cosign signed AND the cosign signature artifact (OCI referrer index entry, surfaced on GHCR as the `sha256-<hex>` referrer tag) is reachable on GHCR. Catches a future regression at CI time.

**Workflow-level signature gate** — new `verify-signatures` job runs after every publish job and invokes `scripts/check_image_signatures.py` against every (image, tag) pushed by the workflow. Performs an order-independent cross-tag divergence check (catches the exact failure mode that produced this bug) and a signature-presence check. `update-release` now requires `verify-signatures` success.

**New helper** — `scripts/check_image_signatures.py` (252 lines, stdlib only). 22 unit tests under `tests/unit/scripts/` cover argument parsing, the order-independent divergence detector, basic-auth encoding, and signature-presence preconditions.

**Defense in depth**:
- `pushed_tags` is now newline-separated (heredoc-delimited GitHub Actions output) and consumed via `while IFS= read -r`, immune to word-splitting / glob expansion if a tag ever contained shell metacharacters.
- Empty-token check after the `curl | python3 -c '...'` GHCR token mint catches the case where an authn rejection still produced exit 0 through the pipe.
- The script logs which env var supplied the token (`GHCR_TOKEN` vs `GITHUB_TOKEN`) so operators don't get surprised by silent fallbacks.

## Note on dev.9

This PR cannot retroactively re-sign the existing unsigned `synthorg-sandbox:0.7.6-dev.9` (cosign keyless signing only runs from the workflow context, and re-running the workflow against the dev.9 tag would still use the OLD code until this lands). Once merged, the next dev release will be signed correctly.

Workaround for users on dev.9 right now: `synthorg update --skip-verify` (one-off bypass) or wait for dev.10.

## Test plan

- `uv run ruff check scripts/check_image_signatures.py tests/unit/scripts/test_check_image_signatures.py`: clean.
- `uv run mypy scripts/check_image_signatures.py tests/unit/scripts/test_check_image_signatures.py`: clean.
- `uv run python -m pytest tests/unit/scripts/test_check_image_signatures.py -n 8`: 22 passed.
- Smoke-tested the script against live GHCR: it correctly flags `synthorg-sandbox:0.7.6-dev.9` as unsigned and confirms `synthorg-backend:0.7.6-dev.9 / dev / sha-2531b65` as a multi-tag signed set.
- Smoke-tested the order-independent divergence check: produces identical findings regardless of input order.

The CI changes will be exercised on the next docker.yml run after merge.

## Review coverage

Pre-reviewed by 4 agents: docs-consistency, infra-reviewer, security-reviewer, python-reviewer. 22 findings surfaced; 17 valid → fixed, 5 invalid → skipped (mypy false-positive, nonexistent `{{major}}` metadata-action pattern, redundant cast needed for mypy strict, transitive DAG dependency already explicit, and one redundant tag-quoting concern subsumed by the newline-sep iteration fix). Triage table at `_audit/pre-pr-review/triage.md`.

