### PR TITLE
chore(ci): unify apko-version under workflow env so Renovate manages it everywhere

### DIFF
--- a/.github/actions/build-apko-base/action.yml
+++ b/.github/actions/build-apko-base/action.yml
@@ -14,10 +14,10 @@ inputs:
     description: "Path to apko.yaml relative to repo root"
     required: true
   apko-version:
-    description: "apko version to install (caller MUST pass; no default to keep the version pin under Renovate's eye in the calling workflow)"
+    description: "apko version to install, including the leading `v` (e.g. `v1.2.9`). Used verbatim in the GitHub releases download URL."
     required: true
   trivy-version:
-    description: "Trivy version"
+    description: "Trivy version, WITHOUT a leading `v` (e.g. `0.70.0`). The release download URL adds the `v` prefix; the tarball filename does not."
     required: true
 
 outputs:

--- a/.github/actions/build-apko-base/action.yml
+++ b/.github/actions/build-apko-base/action.yml
@@ -14,9 +14,8 @@ inputs:
     description: "Path to apko.yaml relative to repo root"
     required: true
   apko-version:
-    description: "apko version to install"
+    description: "apko version to install (caller MUST pass; no default to keep the version pin under Renovate's eye in the calling workflow)"
     required: true
-    default: "v1.2.3"
   trivy-version:
     description: "Trivy version"
     required: true

--- a/.github/workflows/apko-lock.yml
+++ b/.github/workflows/apko-lock.yml
@@ -19,6 +19,10 @@ concurrency:
   group: apko-lock-update
   cancel-in-progress: false
 
+env:
+  # renovate: datasource=github-releases depName=chainguard-dev/apko
+  APKO_VERSION: "v1.2.9"
+
 jobs:
   update-lockfiles:
     name: apko lock
@@ -69,8 +73,7 @@ jobs:
       - name: Set up apko
         uses: ./.github/actions/setup-apko
         with:
-          # renovate: datasource=github-releases depName=chainguard-dev/apko
-          version: v1.2.9
+          version: ${{ env.APKO_VERSION }}
 
       - name: Update lockfiles
         run: |

--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -12,7 +12,8 @@ concurrency:
   cancel-in-progress: false  # Serialize: only one DAST scan at a time
 
 env:
-  TRIVY_VERSION: 0.70.0
+  # renovate: datasource=github-releases depName=aquasecurity/trivy
+  TRIVY_VERSION: "0.70.0"
   # renovate: datasource=github-releases depName=chainguard-dev/apko
   APKO_VERSION: "v1.2.9"
   # COMPOSE_FILE makes every `docker compose` invocation in this job pick

--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -13,6 +13,8 @@ concurrency:
 
 env:
   TRIVY_VERSION: 0.70.0
+  # renovate: datasource=github-releases depName=chainguard-dev/apko
+  APKO_VERSION: "v1.2.9"
   # COMPOSE_FILE makes every `docker compose` invocation in this job pick
   # up both the base + DAST overlay automatically (colon separator on
   # Linux runners), so we don't repeat `-f docker/compose.yml -f
@@ -90,6 +92,7 @@ jobs:
         with:
           image-name: backend
           apko-yaml: docker/backend/apko.yaml
+          apko-version: ${{ env.APKO_VERSION }}
           trivy-version: ${{ env.TRIVY_VERSION }}
 
       # Build the backend application image. Compose passes the

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,8 @@ concurrency:
 env:
   # renovate: datasource=github-releases depName=aquasecurity/trivy
   TRIVY_VERSION: "0.70.0"
+  # renovate: datasource=github-releases depName=chainguard-dev/apko
+  APKO_VERSION: "v1.2.9"
 
 jobs:
   # Detect which domains changed so docs-only PRs skip backend/sandbox builds
@@ -271,6 +273,7 @@ jobs:
         with:
           image-name: backend
           apko-yaml: docker/backend/apko.yaml
+          apko-version: ${{ env.APKO_VERSION }}
           trivy-version: ${{ env.TRIVY_VERSION }}
 
   build-backend-base-publish:
@@ -334,6 +337,7 @@ jobs:
         with:
           image-name: sandbox
           apko-yaml: docker/sandbox/apko.yaml
+          apko-version: ${{ env.APKO_VERSION }}
           trivy-version: ${{ env.TRIVY_VERSION }}
 
   build-sandbox-base-publish:
@@ -392,6 +396,7 @@ jobs:
         with:
           image-name: sidecar
           apko-yaml: docker/sidecar/apko.yaml
+          apko-version: ${{ env.APKO_VERSION }}
           trivy-version: ${{ env.TRIVY_VERSION }}
 
   build-sidecar-base-publish:
@@ -450,6 +455,7 @@ jobs:
         with:
           image-name: fine-tune
           apko-yaml: docker/fine-tune/apko.yaml
+          apko-version: ${{ env.APKO_VERSION }}
           trivy-version: ${{ env.TRIVY_VERSION }}
 
   build-fine-tune-base-publish:
@@ -736,8 +742,7 @@ jobs:
       - name: Set up apko
         uses: ./.github/actions/setup-apko
         with:
-          # renovate: datasource=github-releases depName=chainguard-dev/apko
-          version: v1.2.9
+          version: ${{ env.APKO_VERSION }}
 
       - name: Build web image
         run: |


### PR DESCRIPTION
## Summary

Closes a follow-up flagged in the approval message of #1698. The `build-apko-base` composite action carried a hidden `default: "v1.2.3"` for its `apko-version` input with no `# renovate: ...` marker. All 5 callers (4 in `docker.yml`, 1 in `dast.yml`) inherited that silently because none passed the input explicitly. While `docker.yml`'s web base build and `apko-lock.yml` were on `v1.2.9` (latest), the 4 backend / sandbox / sidecar / fine-tune apko bases plus the DAST scan were running on `v1.2.3` — six patches behind. The hash-against-`.PKGINFO` verification (apko #2206 in v1.2.9) and the release-process / SDK chore work in v1.2.4-v1.2.9 never reached those images.

## What changed

**Commit 1: `chore(ci): unify apko-version under workflow env so Renovate manages it everywhere`**

- Lift the version into a workflow-scoped `env: APKO_VERSION` in **all three** workflows that touch apko (`docker.yml`, `dast.yml`, `apko-lock.yml`), each with the canonical `# renovate: datasource=github-releases depName=chainguard-dev/apko` marker. Renovate's existing `chainguard-dev/apko` packageRule routes the bump through "Container dependencies" and keeps all three sites in lockstep.
- Pass `apko-version: ${{ env.APKO_VERSION }}` from each of the 5 `build-apko-base` callers, mirroring the existing `trivy-version: ${{ env.TRIVY_VERSION }}` pattern in the same files.
- Drop the `default: "v1.2.3"` line from `.github/actions/build-apko-base/action.yml` so a future caller that forgets to pass `apko-version` fails workflow validation immediately instead of silently building on a stale binary.
- Collapse the inline `# renovate: ... \n version: v1.2.9` annotations on `docker.yml`'s web base build (line 736) and `apko-lock.yml`'s setup-apko step into the same env reference; one source of truth per workflow.

**Commit 2: `chore(ci): annotate dast.yml TRIVY_VERSION for Renovate`**

- Drive-by: `dast.yml` carried `TRIVY_VERSION: 0.70.0` without the canonical `# renovate: datasource=github-releases depName=aquasecurity/trivy` marker, so the DAST scan silently fell behind every Container-deps grouped Trivy bump landing in `docker.yml` (which has the marker). Add the marker and quote the value to match.

## Net effect

| Before | After |
|---|---|
| `v1.2.9` on web base + apko-lock | `v1.2.9` everywhere |
| `v1.2.3` on backend / sandbox / sidecar / fine-tune base + DAST (silent) | covered |
| 2 Renovate-tracked apko sites (docker.yml inline, apko-lock.yml inline) + 1 stale hidden default | 3 Renovate-tracked apko sites (docker.yml env, dast.yml env, apko-lock.yml env), no hidden defaults |
| `dast.yml` TRIVY_VERSION un-tracked by Renovate | tracked alongside `docker.yml`'s TRIVY_VERSION |

## Test plan

YAML-only change. Pre-commit hooks pass (trailing-whitespace, EOF, em-dash, secret scan, commitizen, ESLint web). The composite-action input is now strictly `required: true` with no default; the 5 caller sites all pass it explicitly, so workflow validation will catch any regression where a future caller forgets to pass it. Confirmed by `grep` that no other workflow uses `build-apko-base`.

## Review coverage

`/pre-pr-review quick` — CI-only YAML change, no code agents required. Pre-commit gate passed.