### PR TITLE
chore: consolidate DHI image-pin custom regex managers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -201,19 +201,10 @@
     },
     {
       "customType": "regex",
-      "description": "DHI pinned index digests in Go verify code",
-      "managerFilePatterns": ["/cli/internal/verify/dhi\\.go$/"],
+      "description": "DHI image pins across CLI Go files: the pinned-digest map in cli/internal/verify/dhi.go and the default-tag constants in cli/internal/config/state.go (single source of truth referenced by verify/dhi.go vars, start.go third-party list, and dhi_test.go). Both file shapes share one manager so Renovate makes a single docker-datasource lookup per (depName, currentValue) pair, avoiding the upgrade-collision warning that surfaced when two managers raced on the same dep.",
+      "managerFilePatterns": ["/cli/internal/verify/dhi\\.go$/", "/cli/internal/config/state\\.go$/"],
       "matchStrings": [
-        "// renovate: datasource=docker depName=(?<depName>[^\\s]+)\\n\\s+\"[^:]+:(?<currentValue>[^\"]+)\":\\s+\"(?<currentDigest>sha256:[a-f0-9]+)\""
-      ],
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "docker"
-    },
-    {
-      "customType": "regex",
-      "description": "DHI image tag default constants in CLI config (single source of truth referenced by verify/dhi.go vars, start.go third-party list, and dhi_test.go)",
-      "managerFilePatterns": ["/cli/internal/config/state\\.go$/"],
-      "matchStrings": [
+        "// renovate: datasource=docker depName=(?<depName>[^\\s]+)\\n\\s+\"[^:]+:(?<currentValue>[^\"]+)\":\\s+\"(?<currentDigest>sha256:[a-f0-9]+)\"",
         "// renovate: datasource=docker depName=(?<depName>[^\\s]+)\\n\\s+Default[A-Za-z]+ImageTag\\s*=\\s*\"(?<currentValue>[^\"]+)\""
       ],
       "datasourceTemplate": "docker",


### PR DESCRIPTION
## Summary

Collapse the two `custom.regex` managers in `renovate.json` that pin `dhi.io` images across CLI Go files into a single manager covering both file shapes.

Before:
- One manager extracted `(depName, currentValue, currentDigest)` from the pinned-digest map in `cli/internal/verify/dhi.go`.
- A second manager extracted `(depName, currentValue)` from the `Default<X>ImageTag` constants in `cli/internal/config/state.go`.

Both used `datasourceTemplate=docker` + `versioningTemplate=docker` for the same `depName=dhi.io/<image>`, but Renovate ran two independent extraction passes per (depName, currentValue) tuple, which can race on the registry response.

After: one manager with both `managerFilePatterns` and both `matchStrings`. Same emitted deps (`depName`, `currentValue`, optional `currentDigest`), same `packageRules` apply, same downstream behaviour.

## Why now

The May 3 Renovate run for `renovate/container` logged:

```
INFO: Ignoring upgrade collision (branch="renovate/container")
  packageFile: cli/internal/verify/dhi.go
  depName:           dhi.io/nats
  currentValue:      2.12-debian13
  previousNewValue:  2.14-debian13
  thisNewValue:      2.12-debian13

WARN: Error updating branch: update failure (branch="renovate/container")
```

Two extracts for the same dep within one run resolved to different `newValue`s, Renovate aborted the branch update, and no `renovate/container` PR was opened that cycle. Consolidating the managers removes the structural cause; if the next run still warns, the cause is upstream (registry transient) and not config.

## Verification

- `python -m json.tool renovate.json` parses cleanly.
- `pre-commit run --files renovate.json` passes (json check, em-dash gate, etc.).
- No code change; pure config refactor. The set of (depName, currentValue, currentDigest) tuples Renovate extracts is unchanged, so `packageRules` (`Container dependencies` group via `matchManagers: ["custom.regex"]` + `matchDepNames` for `dhi.io/.*`, `nats`, `postgres`, ...) still match identically.

## Risk

Low. Renovate evaluates each `matchStrings` regex against each file matched by `managerFilePatterns`; non-matching combinations are silently skipped, so combining the two patterns under one manager doesn't cross-contaminate file shapes.

Follow-up: if the collision recurs on the next scheduled cycle (Saturday 00:00-06:59 UTC per the `schedule` array), revisit with a `lookupNameTemplate` or `extractVersionTemplate` to force a single shared lookup key.
