### PR TITLE
test(engine): make TestDrainTimeout deterministic + preserve subclass type in @ontology_entity

### DIFF
--- a/src/synthorg/ontology/decorator.py
+++ b/src/synthorg/ontology/decorator.py
@@ -22,6 +22,8 @@ from synthorg.ontology.errors import OntologyDuplicateError
 logger = get_logger(__name__)
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pydantic import BaseModel
 
     from synthorg.ontology.models import (
@@ -127,17 +129,26 @@ def _annotation_to_str(annotation: Any) -> str:
     return str(annotation)
 
 
+# Parameterise over the decorated class so callers see the concrete
+# subclass type rather than ``type[BaseModel]``. Without inline type
+# parameters, every ``@ontology_entity``-decorated class loses its
+# identity in static type-checkers (Pyright surfaces this; mypy is
+# more lenient with decorators that return ``Any``) and attribute
+# access on instances returned by typed APIs (e.g. the result of
+# ``await eng.create_task(...)`` which is annotated to return
+# ``Task``) resolves against the bare ``BaseModel``, producing
+# false-positive "no attribute" diagnostics.
 @overload
-def ontology_entity(cls: type[BaseModel], /) -> type[BaseModel]: ...
+def ontology_entity[T: BaseModel](cls: type[T], /) -> type[T]: ...
 
 
 @overload
-def ontology_entity(
+def ontology_entity[T: BaseModel](
     *,
     entity_name: str | None = None,
     tier: EntityTier | None = None,
     source: EntitySource | None = None,
-) -> Any: ...
+) -> Callable[[type[T]], type[T]]: ...
 
 
 def ontology_entity(

--- a/tests/unit/engine/test_task_engine_integration.py
+++ b/tests/unit/engine/test_task_engine_integration.py
@@ -317,8 +317,23 @@ class TestDrainTimeout:
         await entered_save.wait()
         eng._queue.put_nowait(envelope)
 
-        # Stop with a very short timeout -- loop is blocked, so timeout fires
-        await eng.stop(timeout=0.05)
+        # The processing loop is genuinely stuck on ``block.wait()``, so
+        # ``_drain_processing`` will reliably hit its inner ``wait_for``
+        # timeout, cancel the processing task, and fail queued futures
+        # before returning. ``stop()`` then returns cleanly.
+        #
+        # Budget choice: ``stop(timeout=T)`` adds an outer hard-deadline
+        # at ``2 * T`` (see ``TaskEngine.stop``). If cleanup overruns
+        # that hard deadline, ``TimeoutError`` propagates to the caller
+        # and the engine is marked unrestartable. The original 50 ms
+        # budget left only ~50 ms for cancellation + future-cleanup,
+        # which intermittently raced under xdist load on CI runners
+        # and surfaced as ``TimeoutError`` escaping ``stop()``. 500 ms
+        # gives a 500 ms cleanup margin -- comfortably above the few
+        # milliseconds the cleanup actually needs even under heavy
+        # contention -- without lengthening the test meaningfully (the
+        # inner drain still fires after 500 ms, not 1 s).
+        await eng.stop(timeout=0.5)
 
         # The queued envelope (not yet processed) must be failed
         assert envelope.future.done()


### PR DESCRIPTION
## Summary

Fix the timing-sensitive `TestDrainTimeout::test_drain_timeout_resolves_pending_futures` flake hit by PR #1727's `Test (Python 3.14)` job, plus a foundational fix to the `@ontology_entity` decorator that surfaced as Pyright false-positives in the same file.

## Root cause (test flake)

PR #1545 (commit `13f3db679`, "TOCTOU races + resource leaks") changed `TaskEngine.stop()` to install an outer hard-deadline at `2 × timeout` and re-raise `TimeoutError` when cleanup exceeds it. The pre-existing test called `await eng.stop(timeout=0.05)` and expected `stop()` to return cleanly, leaving only ~50 ms for cancellation + future-cleanup. Under xdist load on slow Ubuntu CI runners, cleanup intermittently overruns 50 ms, the outer hard-deadline fires, and `TimeoutError` escapes to the test as `1 failed, 27881 passed`.

## Changes

**`tests/unit/engine/test_task_engine_integration.py`**
- Bump `stop(timeout=…)` from `0.05` to `0.5`. Same contract is exercised (inner drain still fires, queued futures still resolve to shutdown failure) without race sensitivity. Cleanup margin grows from 50 ms to 500 ms — comfortably above the few milliseconds the cleanup actually needs.
- Inline comment ties the budget to the `2 × timeout` hard-deadline ratio so the next reader doesn't lower it back.

**`src/synthorg/ontology/decorator.py`**
- The decorator's positional overload returned `type[BaseModel]`, erasing concrete subclass identity. Pyright reported false-positive "no attribute" diagnostics on every `@ontology_entity`-decorated class (Task, Artifact, Agent, Project, Role, MeetingRecord, OrgFact, etc.). Mypy was lenient because the alternative overload returned `Any`.
- Switched to PEP 695 inline type parameters (`def ontology_entity[T: BaseModel](cls: type[T], /) -> type[T]: ...`), bound to `BaseModel`. Static analysers now resolve `Task` as `type[Task]` instead of `type[BaseModel]`.

## Test plan

- Targeted test 5 consecutive runs, including one slow run (31 s) that mirrors the CI-runner pressure that flaked the original — 5/5 PASSED.
- Full file `tests/unit/engine/test_task_engine_integration.py` — 11/11 PASSED in 12 s.
- Full strict mypy: `Success: no issues found in 3626 source files`.
- Ruff lint + format clean.
- Pre-push gates green: mypy (affected modules), pytest unit (affected modules), forbidden-literal gate, persistence-boundary gate, typed-boundary contract, cost-recording chokepoint.

## Review coverage

This PR was opened directly via the GitHub MCP tool because a parallel `/pre-pr-review` is running in another terminal on a different branch. The full pre-PR review pipeline (specialist agents, triage gate) was not invoked. The changes are narrow and verified by the gates listed above.

Run `/aurelio-review-pr` after external reviewers (CodeRabbit, etc.) provide feedback.