### PR TITLE
chore: add 5 FP-prevention rules to /codebase-audit agent prompts

### DIFF
--- a/.claude/skills/codebase-audit/SKILL.md
+++ b/.claude/skills/codebase-audit/SKILL.md
@@ -178,6 +178,98 @@ Rules:
   The Write tool exists ONLY to write your finding file. The audit Bash tool is
   for read-only inspection (`git`, `gh`, `find`, `wc`); never for `python -c`,
   `cat >`, `tee`, redirects, or heredocs.
+
+## Five FP-prevention rules (LOAD-BEARING)
+
+These rules are mandatory for every audit agent. The 2026-05-03 run produced
+12 distinct FP categories that traced back to one of these five gaps. Apply
+all five before emitting a finding.
+
+### R-A: Verify the proposed fix isn't already in place
+
+Before writing a finding, verify the proposed fix is not ALREADY in place:
+- For "missing X" findings: grep for X in the surrounding 50 lines, in the
+  file's `__init__` / setup function, and in the test-setup module if
+  applicable. If X exists, do NOT flag.
+- For "no implementation" findings: grep for concrete subclasses overriding
+  the method. Inspect MRO. If a subclass implements it, do NOT flag.
+- For "settings-not-wired" findings: trace the setting through the consuming
+  object's STARTUP wiring, not just import-graph references. A setting
+  consumed by code that never runs at startup (because the parent service is
+  never instantiated in `lifecycle_helpers.py` / `app.py`) is dead-on-arrival
+  AND structurally hidden -- flag with `severity: high, kind: dead-on-arrival`
+  rather than as a generic dead setting. The 2026-05-03 run had 11/13
+  settings flagged as dead that were actually consumed by living machinery
+  whose owning service was simply never started at boot. The audit's
+  import-graph trace missed this entirely.
+
+### R-B: Read existing helper docstrings for design carve-outs
+
+Before recommending consolidation into an existing helper (e.g.
+`GeneralRetryHandler`, `core.utils`, `core.normalization`), READ the helper's
+module docstring and class docstring. If the docstring contains opt-out
+language (`carve out`, `do not use for X`, `intentionally excluded`,
+`deliberate non-goal`, `out of scope`), DO NOT flag the inline call site as
+needing centralization. Document the carve-out as a known exception, not a
+finding. The 2026-05-03 run had agent 138 flag 5 inline retry loops as
+"should use GeneralRetryHandler" -- but the handler's module docstring
+explicitly carved out 4 of the 5 patterns (semantic self-correction loops,
+contention loops, sync logging-handler thread). Reading the docstring would
+have caught this.
+
+### R-C: Scope estimate alongside cited cases
+
+When the audit covers a project-wide convention (e.g. "all exceptions must
+inherit DomainError", "no hardcoded values", "every model must be frozen"),
+the agent MUST emit a scope estimate alongside the cited cases:
+- Sample 3-5 random files from candidate domains.
+- Estimate total population (e.g. "12 cited; sample suggests ~80-120 across
+  19 error modules").
+- Distinguish "cited cases" from "tip of the iceberg" so the user can decide
+  between surgical fix and convention rollout.
+
+The 2026-05-03 run had agent 34 cite 12 plain-Exception classes; the actual
+project-wide population was ~80-120 across 19 modules. The user's surgical
+vs convention-rollout decision depends on knowing the gap.
+
+### R-D: Semantic equivalence before flagging duplicates
+
+When flagging duplicate / redundant code:
+- Diff the loop body / inner predicate / inner expression -- not just the
+  outer iteration shape. Two functions with identical structure but different
+  inner logic are NOT duplicates.
+- Distinguish *intentional* multi-instance patterns (different domains using
+  the same shape, multiple bootstrap surfaces by design) from *accidental*
+  duplication (same code copy-pasted by accident). Look for in-code comments,
+  design-doc references, stable naming differences (`ConfigA` vs `ConfigB` =
+  intentional vs `_helper` vs `_helper_v2` = accidental).
+
+The 2026-05-03 run had agent 110 flag a pairwise-compare cluster as duplicate
+when one used field-equality and the other used text-similarity -- identical
+iteration shape, divergent inner predicate. Consolidating would have lost
+domain semantics. Agent 146 flagged 8 multi-surface settings as "soup" but 4
+of them were intentional bootstrap patterns (env-only init-time secrets,
+operator-facing legacy env-var overrides).
+
+### R-E: Caller-context distribution for API duplication findings
+
+For findings of the shape "API has multiple variants" (mixed sync/async,
+dual surfaces, multiple methods for one operation):
+- Enumerate ALL callers in `src/synthorg/` AND `tests/`.
+- Classify each caller by context (async route / sync helper / test fixture
+  / CLI command).
+- Emit the distribution in the finding (e.g. "100% of production callers are
+  async; only test fixtures use sync").
+- Severity calibration: only "high" if the duplication causes real ambiguity
+  at production call sites; "low/info" if usage is segregated by call-site
+  type. Mock-drift findings should sample actual mock-method usage in the
+  test file and downgrade severity if the missing methods aren't called by
+  any test.
+
+The 2026-05-03 run had agent flag AuthService's mixed sync/async API as
+high-severity duplication; the actual distribution was 100% production-async
++ test-fixture-sync, which made the choice obvious (drop sync, keep async).
+Without the distribution, the finding looked like a hard choice.
 ```
 
 ### Streaming Pool Execution


### PR DESCRIPTION
## Summary

Adds Rules **R-A through R-E** to the `/codebase-audit` agent-prompt template. Each is grounded in a specific FP category observed in the 2026-05-03 audit run (12 categories tracked during the post-run walk-through). Skill-only change; no source code touched.

## Why

After PR #1732 (round-1 fixes), four agents still produced FPs at significant rates because their prompts shared the same underlying gaps:

- Agents flag patterns without verifying the surrounding state (existing fixes, docstring carve-outs, caller distribution, semantic equivalence).
- Convention-scope findings cite N cases without estimating total population, so the user can't choose between surgical fix and convention rollout.
- Mock-drift / API-duplication findings calibrate severity without sampling actual usage.

These five rules are mandatory for every audit agent.

## The 5 rules

### R-A: Verify the proposed fix isn't already in place

Catches:
- Memory-leak findings whose cleanup hook IS already registered (agent 97 Site 2 was a FP because `cancelPendingPersist` is in `test-setup.tsx:272`).
- NotImplementedError-in-mixin findings overridden in concrete subclass (agent 18 had 2/3 sample FP rate).
- **Ghost-wired settings (most severe class)**: agent 09 flagged 13 settings dead; 11 of 13 were consumed by living machinery whose owning service was simply never instantiated at boot. Import-graph trace missed this entirely. The new rule requires tracing through `lifecycle_helpers.py` / `app.py` startup wiring.

### R-B: Read existing helper docstrings for design carve-outs

Catches: agent 138 flagged 5 inline retry loops as needing centralisation, but `GeneralRetryHandler`'s module docstring explicitly carved out 4 of the 5 (semantic self-correction, contention, sync-thread). Reading the docstring catches design intent.

### R-C: Scope estimate alongside cited cases

Catches: agent 34 cited 12 plain-Exception classes; actual project-wide population is ~80-120 across 19 modules. User's surgical-vs-convention-rollout decision depends on knowing the gap. New rule: agents emit "12 cited; sample suggests ~80-120 across N modules".

### R-D: Semantic equivalence before flagging duplicates

Catches: agent 110 flagged a pairwise-compare cluster as duplicate when one used field-equality and the other used text-similarity (identical iteration, divergent inner predicate). Agent 146 conflated intentional bootstrap multi-surface settings with accidental duplication (4 of 8 flagged settings were intentional).

### R-E: Caller-context distribution for API duplication findings

Catches: AuthService mixed sync/async API was high-severity in raw findings; actual distribution was 100% production-async + test-fixture-sync, which made the choice obvious. New rule: agents emit caller distribution before recommending the fix shape.

## Test plan

Skill is docs-only. Validated by:
- Reading the 5 new rules end-to-end for clarity + grounding.
- Each rule cites the concrete 2026-05-03 example so future agents can recognise the pattern.

## Out of scope

A separate master tracking issue (filed alongside this PR) captures the remaining session learnings: 5 follow-up issues for larger workstreams (config layering, error-handling convention rollout, no-hardcoded-values rule, bootstrap-wiring lint, scoring research), Group 1+2+3 decisions with research-backed rationale, and the meta-process plan (scaffolding templates, pre-PR mini-audit, worktree do-not-introduce, convention-must-ship-its-gate).

## Closes

No linked issue (skill self-improvement).
