### PR TITLE
fix(ci): retry transient GHCR errors in docker publish + retag

### DIFF
--- a/.github/actions/publish-apko-base/action.yml
+++ b/.github/actions/publish-apko-base/action.yml
@@ -76,6 +76,7 @@ runs:
         set -euo pipefail
         REPO="ghcr.io/aureliolo/synthorg-${IMAGE_NAME}-base"
         IFS=',' read -ra ARCHS <<< "${ARCHITECTURES}"
+        RETRY="${GITHUB_WORKSPACE}/.github/scripts/docker_push_with_retry.sh"
 
         # Push each per-arch image, capturing its manifest digest
         # directly from `docker push` stdout (`<tag>: digest:
@@ -86,12 +87,15 @@ runs:
         # the tag via `docker buildx imagetools inspect`) closes the
         # TOCTOU window where a parallel run could overwrite the tag
         # between push and inspect.
-        # Wrap each `docker push` so `set -e` doesn't abort the step
-        # before we can dump the captured stderr to the build log on
-        # failure. See publish-image-loaded for the same pattern.
+        #
+        # Wrap each push in docker_push_with_retry.sh so transient GHCR
+        # 5xx responses ("page is taking too long", "unknown blob", TLS
+        # reset, etc.) are retried with exponential backoff. The push is
+        # idempotent: re-pushing the same content yields the same digest,
+        # so a retry never alters the published image.
         MANIFEST_ARGS=()
         for arch in "${ARCHS[@]}"; do
-          if ! PUSH_OUTPUT="$(docker push "${REPO}:${TAG}-${arch}" 2>&1)"; then
+          if ! PUSH_OUTPUT="$(bash "$RETRY" "docker push ${REPO}:${TAG}-${arch}" docker push "${REPO}:${TAG}-${arch}")"; then
             printf '%s\n' "${PUSH_OUTPUT}"
             echo "::error::docker push failed for ${REPO}:${TAG}-${arch}"
             exit 1
@@ -108,7 +112,7 @@ runs:
         # prior run leaves the manifest list present, and a plain `create` would
         # fail with "manifest already exists" before the idempotent push below.
         docker manifest create --amend "${REPO}:${TAG}" "${MANIFEST_ARGS[@]}"
-        docker manifest push "${REPO}:${TAG}"
+        bash "$RETRY" "docker manifest push ${REPO}:${TAG}" docker manifest push "${REPO}:${TAG}"
         # Read the canonical manifest list digest back from the
         # registry. Stable across re-runs because the create above pins
         # source members by digest.

--- a/.github/actions/publish-image-loaded/action.yml
+++ b/.github/actions/publish-image-loaded/action.yml
@@ -112,13 +112,17 @@ runs:
         set -euo pipefail
         REPO="ghcr.io/aureliolo/synthorg-${IMAGE_NAME}"
         SHORT_SHA="${GITHUB_SHA::7}"
+        RETRY="${GITHUB_WORKSPACE}/.github/scripts/docker_push_with_retry.sh"
 
-        # Wrap each `docker push` so `set -e` doesn't abort the step
-        # before we can dump the captured stderr to the build log on
-        # failure. Without this, a real GHCR/auth error is swallowed
-        # because the variable assignment exits before the next line
-        # runs.
-        if ! AMD64_PUSH_OUTPUT="$(docker push "${REPO}:sha-${SHORT_SHA}-amd64" 2>&1)"; then
+        # Wrap each push in docker_push_with_retry.sh so transient GHCR
+        # 5xx responses ("page is taking too long", "unknown blob", TLS
+        # reset, etc.) are retried with exponential backoff. The push is
+        # idempotent: re-pushing the same content yields the same digest,
+        # so a retry never alters the published image. The retry helper
+        # also captures combined stdout+stderr so a real GHCR/auth error
+        # surfaces in the build log instead of being swallowed by the
+        # variable assignment.
+        if ! AMD64_PUSH_OUTPUT="$(bash "$RETRY" "docker push ${REPO}:sha-${SHORT_SHA}-amd64" docker push "${REPO}:sha-${SHORT_SHA}-amd64")"; then
           printf '%s\n' "${AMD64_PUSH_OUTPUT}"
           echo "::error::docker push failed for ${REPO}:sha-${SHORT_SHA}-amd64"
           exit 1
@@ -132,7 +136,7 @@ runs:
 
         ARM64_DIGEST=""
         if [ "$ENABLE_ARM64" = "true" ]; then
-          if ! ARM64_PUSH_OUTPUT="$(docker push "${REPO}:sha-${SHORT_SHA}-arm64" 2>&1)"; then
+          if ! ARM64_PUSH_OUTPUT="$(bash "$RETRY" "docker push ${REPO}:sha-${SHORT_SHA}-arm64" docker push "${REPO}:sha-${SHORT_SHA}-arm64")"; then
             printf '%s\n' "${ARM64_PUSH_OUTPUT}"
             echo "::error::docker push failed for ${REPO}:sha-${SHORT_SHA}-arm64"
             exit 1
@@ -164,7 +168,7 @@ runs:
             docker manifest create --amend "${REPO}:${t}" \
               "${REPO}@${AMD64_DIGEST}"
           fi
-          docker manifest push "${REPO}:${t}"
+          bash "$RETRY" "docker manifest push ${REPO}:${t}" docker manifest push "${REPO}:${t}"
           PUSHED_TAGS+=("${t}")
 
           # Read the canonical manifest list digest back from the

--- a/.github/actions/publish-image-retag/action.yml
+++ b/.github/actions/publish-image-retag/action.yml
@@ -88,6 +88,7 @@ runs:
         set -euo pipefail
         REPO="ghcr.io/aureliolo/synthorg-${IMAGE_NAME}"
         SHORT_SHA="${GITHUB_SHA::7}"
+        RETRY="${GITHUB_WORKSPACE}/.github/scripts/docker_push_with_retry.sh"
 
         # Inspect stdout carries the digest, so we cannot merge stderr
         # (Docker emits deprecation warnings on stderr that would
@@ -96,19 +97,18 @@ runs:
         # Transient GHCR 5xx -> retry with backoff; a true 404 (image
         # not published by main-run) fails immediately.
         #
-        # Regex intentionally diverges from docker_push_with_retry.sh:
-        #   - `manifest unknown` is EXCLUDED. It is the legitimate 404
-        #     signal we must surface as the "main-push did not publish
-        #     this image" branch below; retrying it would silently mask
-        #     the real failure.
-        #   - `blob upload invalid` is EXCLUDED -- write-side error that
+        # Source the canonical TRANSIENT_RE from docker_push_with_retry.sh
+        # and strip the patterns the inspect path cannot benefit from:
+        #   - `manifest unknown`: legitimate 404 we MUST fail-fast on
+        #     (the "main-push did not publish this image" signal below).
+        #   - `blob upload invalid`: write-side error that
         #     `imagetools inspect` cannot produce.
-        #   - `unknown blob` / `blob unknown` are INCLUDED. They are
-        #     unlikely from a read, but the rare cross-arch race the
-        #     helper covers can also surface here, and re-reading is
-        #     idempotent.
-        TRANSIENT_RE='page is taking too long|unknown blob|blob unknown|received unexpected HTTP status: 5[0-9]{2}|HTTP/[0-9.]+ 5[0-9]{2}|HTTP 5[0-9]{2}|status: 5[0-9]{2}|429 Too Many Requests|temporarily unavailable|server is currently unable|service unavailable|bad gateway|gateway time-?out|i/o timeout|tls handshake|tls: |connection reset|connection refused|EOF|unexpected EOF|read: connection|net/http: TLS handshake'
-        ERR_FILE="$(mktemp)"
+        # `unknown blob` / `blob unknown` stay in: unlikely from a read,
+        # but the rare cross-arch race the helper covers can also surface
+        # here, and re-reading is idempotent.
+        TRANSIENT_RE="$(bash "$RETRY" --print-transient-re \
+          | sed -E 's/\|manifest unknown//; s/\|blob upload invalid//')"
+        ERR_FILE="$(mktemp /tmp/docker-inspect-err.XXXXXX)"
         trap 'rm -f "$ERR_FILE"' EXIT
         ATTEMPTS=4
         BACKOFF=15

--- a/.github/actions/publish-image-retag/action.yml
+++ b/.github/actions/publish-image-retag/action.yml
@@ -114,11 +114,17 @@ runs:
         BACKOFF=15
         DIGEST=""
         for ((i = 1; i <= ATTEMPTS; i++)); do
-          if DIGEST="$(docker buildx imagetools inspect "${REPO}:sha-${SHORT_SHA}" --format '{{.Manifest.Digest}}' 2>"$ERR_FILE")"; then
+          rc=0
+          # Use `cmd || rc=$?` so set -e does not abort and so rc reflects the
+          # wrapped command's actual exit code. The `if cmd; then ... fi; rc=$?`
+          # idiom would always capture 0 here -- a failed `if cmd` clears $?
+          # to 0 once the if-statement completes (same trap the helper has to
+          # avoid in docker_push_with_retry.sh).
+          DIGEST="$(docker buildx imagetools inspect "${REPO}:sha-${SHORT_SHA}" --format '{{.Manifest.Digest}}' 2>"$ERR_FILE")" || rc=$?
+          if [ "$rc" -eq 0 ]; then
             cat "$ERR_FILE" >&2
             break
           fi
-          rc=$?
           ERR="$(cat "$ERR_FILE")"
           if [ "$i" -lt "$ATTEMPTS" ] && printf '%s' "$ERR" | grep -qiE "$TRANSIENT_RE"; then
             printf '%s\n' "$ERR" >&2
@@ -127,9 +133,13 @@ runs:
             BACKOFF=$((BACKOFF * 2))
             continue
           fi
+          # Non-transient or attempts exhausted. Surface the captured stderr
+          # and rc; the message names the most-common cause as a hint but
+          # does not assume it -- auth failures, registry config errors, and
+          # TLS verification failures land here too.
           printf '%s\n' "$ERR" >&2
-          echo "::error::Could not resolve ${REPO}:sha-${SHORT_SHA} -- the main-push run of docker.yml for SHA ${SHORT_SHA} did not publish this image. Re-run the main-push first; this tag-push retag job will then succeed on re-run."
-          exit 1
+          echo "::error::imagetools inspect ${REPO}:sha-${SHORT_SHA} failed (exit ${rc}) with non-transient error. Most common cause: the main-push run of docker.yml for SHA ${SHORT_SHA} did not publish this image (look for 'manifest unknown' / 404 in the stderr above; re-run main-push, then re-run this retag job). For other causes (auth, registry config, TLS verification, ...) inspect the stderr above."
+          exit "$rc"
         done
 
         if [[ ! "${DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then

--- a/.github/actions/publish-image-retag/action.yml
+++ b/.github/actions/publish-image-retag/action.yml
@@ -94,10 +94,20 @@ runs:
         # corrupt the regex check below). Capture stderr to a tmpfile
         # and inspect it ONLY on failure to decide retry vs fail-fast.
         # Transient GHCR 5xx -> retry with backoff; a true 404 (image
-        # not published by main-run) fails immediately. Same transient
-        # signatures as docker_push_with_retry.sh, intentionally
-        # mirrored so the two paths agree on what counts as transient.
-        TRANSIENT_RE='page is taking too long|received unexpected HTTP status: 5[0-9]{2}|HTTP/[0-9.]+ 5[0-9]{2}|HTTP 5[0-9]{2}|status: 5[0-9]{2}|429 Too Many Requests|temporarily unavailable|server is currently unable|service unavailable|bad gateway|gateway time-?out|i/o timeout|tls handshake|tls: |connection reset|connection refused|EOF|unexpected EOF|read: connection|net/http: TLS handshake'
+        # not published by main-run) fails immediately.
+        #
+        # Regex intentionally diverges from docker_push_with_retry.sh:
+        #   - `manifest unknown` is EXCLUDED. It is the legitimate 404
+        #     signal we must surface as the "main-push did not publish
+        #     this image" branch below; retrying it would silently mask
+        #     the real failure.
+        #   - `blob upload invalid` is EXCLUDED -- write-side error that
+        #     `imagetools inspect` cannot produce.
+        #   - `unknown blob` / `blob unknown` are INCLUDED. They are
+        #     unlikely from a read, but the rare cross-arch race the
+        #     helper covers can also surface here, and re-reading is
+        #     idempotent.
+        TRANSIENT_RE='page is taking too long|unknown blob|blob unknown|received unexpected HTTP status: 5[0-9]{2}|HTTP/[0-9.]+ 5[0-9]{2}|HTTP 5[0-9]{2}|status: 5[0-9]{2}|429 Too Many Requests|temporarily unavailable|server is currently unable|service unavailable|bad gateway|gateway time-?out|i/o timeout|tls handshake|tls: |connection reset|connection refused|EOF|unexpected EOF|read: connection|net/http: TLS handshake'
         ERR_FILE="$(mktemp)"
         trap 'rm -f "$ERR_FILE"' EXIT
         ATTEMPTS=4

--- a/.github/actions/publish-image-retag/action.yml
+++ b/.github/actions/publish-image-retag/action.yml
@@ -126,19 +126,35 @@ runs:
             break
           fi
           ERR="$(cat "$ERR_FILE")"
-          if [ "$i" -lt "$ATTEMPTS" ] && printf '%s' "$ERR" | grep -qiE "$TRANSIENT_RE"; then
+          IS_TRANSIENT=false
+          if printf '%s' "$ERR" | grep -qiE "$TRANSIENT_RE"; then
+            IS_TRANSIENT=true
+          fi
+
+          # Mid-loop transient: sleep and retry.
+          if [ "$IS_TRANSIENT" = "true" ] && [ "$i" -lt "$ATTEMPTS" ]; then
             printf '%s\n' "$ERR" >&2
             echo "::warning::imagetools inspect ${REPO}:sha-${SHORT_SHA} hit transient registry error (attempt ${i}/${ATTEMPTS}, rc=${rc}); sleeping ${BACKOFF}s before retry" >&2
             sleep "$BACKOFF"
             BACKOFF=$((BACKOFF * 2))
             continue
           fi
-          # Non-transient or attempts exhausted. Surface the captured stderr
-          # and rc; the message names the most-common cause as a hint but
-          # does not assume it -- auth failures, registry config errors, and
-          # TLS verification failures land here too.
+
+          # Otherwise we're done. Surface stderr first; then the annotation
+          # differentiates transient-retries-exhausted from a genuine
+          # non-transient failure so the operator knows which recovery path
+          # to take.
           printf '%s\n' "$ERR" >&2
-          echo "::error::imagetools inspect ${REPO}:sha-${SHORT_SHA} failed (exit ${rc}) with non-transient error. Most common cause: the main-push run of docker.yml for SHA ${SHORT_SHA} did not publish this image (look for 'manifest unknown' / 404 in the stderr above; re-run main-push, then re-run this retag job). For other causes (auth, registry config, TLS verification, ...) inspect the stderr above."
+          if [ "$IS_TRANSIENT" = "true" ]; then
+            # i == ATTEMPTS and ERR matched TRANSIENT_RE -- the error pattern
+            # was transient but persisted through the full backoff window
+            # (15s + 30s + 60s = ~1m45s). GHCR is likely in a longer outage;
+            # waiting and re-running the job is the correct response.
+            echo "::error::imagetools inspect ${REPO}:sha-${SHORT_SHA} failed (exit ${rc}) -- transient retries exhausted after ${ATTEMPTS} attempts. The error pattern matched TRANSIENT_RE but persisted through the full backoff window; GHCR may be in a longer outage. Check https://www.githubstatus.com/ and re-run this retag job once recovered."
+          else
+            # Genuine non-transient: no amount of retries would have helped.
+            echo "::error::imagetools inspect ${REPO}:sha-${SHORT_SHA} failed (exit ${rc}) with non-transient error. Most common cause: the main-push run of docker.yml for SHA ${SHORT_SHA} did not publish this image (look for 'manifest unknown' / 404 in the stderr above; re-run main-push, then re-run this retag job). For other causes (auth, registry config, TLS verification, ...) inspect the stderr above."
+          fi
           exit "$rc"
         done
 

--- a/.github/actions/publish-image-retag/action.yml
+++ b/.github/actions/publish-image-retag/action.yml
@@ -88,15 +88,40 @@ runs:
         set -euo pipefail
         REPO="ghcr.io/aureliolo/synthorg-${IMAGE_NAME}"
         SHORT_SHA="${GITHUB_SHA::7}"
-        # Capture only stdout so the digest variable can never be
-        # corrupted by stderr (Docker emits experimental-feature /
-        # deprecation warnings on stderr; merging via `2>&1` would
-        # break the regex check below). On failure stderr still
-        # reaches the GHA log via the inherited file descriptor.
-        if ! DIGEST="$(docker buildx imagetools inspect "${REPO}:sha-${SHORT_SHA}" --format '{{.Manifest.Digest}}')"; then
+
+        # Inspect stdout carries the digest, so we cannot merge stderr
+        # (Docker emits deprecation warnings on stderr that would
+        # corrupt the regex check below). Capture stderr to a tmpfile
+        # and inspect it ONLY on failure to decide retry vs fail-fast.
+        # Transient GHCR 5xx -> retry with backoff; a true 404 (image
+        # not published by main-run) fails immediately. Same transient
+        # signatures as docker_push_with_retry.sh, intentionally
+        # mirrored so the two paths agree on what counts as transient.
+        TRANSIENT_RE='page is taking too long|received unexpected HTTP status: 5[0-9]{2}|HTTP/[0-9.]+ 5[0-9]{2}|HTTP 5[0-9]{2}|status: 5[0-9]{2}|429 Too Many Requests|temporarily unavailable|server is currently unable|service unavailable|bad gateway|gateway time-?out|i/o timeout|tls handshake|tls: |connection reset|connection refused|EOF|unexpected EOF|read: connection|net/http: TLS handshake'
+        ERR_FILE="$(mktemp)"
+        trap 'rm -f "$ERR_FILE"' EXIT
+        ATTEMPTS=4
+        BACKOFF=15
+        DIGEST=""
+        for ((i = 1; i <= ATTEMPTS; i++)); do
+          if DIGEST="$(docker buildx imagetools inspect "${REPO}:sha-${SHORT_SHA}" --format '{{.Manifest.Digest}}' 2>"$ERR_FILE")"; then
+            cat "$ERR_FILE" >&2
+            break
+          fi
+          rc=$?
+          ERR="$(cat "$ERR_FILE")"
+          if [ "$i" -lt "$ATTEMPTS" ] && printf '%s' "$ERR" | grep -qiE "$TRANSIENT_RE"; then
+            printf '%s\n' "$ERR" >&2
+            echo "::warning::imagetools inspect ${REPO}:sha-${SHORT_SHA} hit transient registry error (attempt ${i}/${ATTEMPTS}, rc=${rc}); sleeping ${BACKOFF}s before retry" >&2
+            sleep "$BACKOFF"
+            BACKOFF=$((BACKOFF * 2))
+            continue
+          fi
+          printf '%s\n' "$ERR" >&2
           echo "::error::Could not resolve ${REPO}:sha-${SHORT_SHA} -- the main-push run of docker.yml for SHA ${SHORT_SHA} did not publish this image. Re-run the main-push first; this tag-push retag job will then succeed on re-run."
           exit 1
-        fi
+        done
+
         if [[ ! "${DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
           echo "::error::imagetools inspect returned an unexpected digest: ${DIGEST}"
           exit 1
@@ -121,6 +146,7 @@ runs:
       run: |
         set -euo pipefail
         REPO="ghcr.io/aureliolo/synthorg-${IMAGE_NAME}"
+        RETRY="${GITHUB_WORKSPACE}/.github/scripts/docker_push_with_retry.sh"
         PUSHED_TAGS=()
         CREATE_ARGS=()
         while IFS= read -r full_tag; do
@@ -137,7 +163,10 @@ runs:
           exit 1
         fi
 
-        docker buildx imagetools create "${CREATE_ARGS[@]}" "${REPO}@${SIGNED_DIGEST}"
+        # Retry transient GHCR 5xx during the manifest-list write. Source
+        # is digest-pinned so re-runs produce byte-identical results.
+        bash "$RETRY" "docker buildx imagetools create ${REPO} (${#PUSHED_TAGS[@]} tags)" \
+          docker buildx imagetools create "${CREATE_ARGS[@]}" "${REPO}@${SIGNED_DIGEST}"
         for t in "${PUSHED_TAGS[@]}"; do
           echo "✓ ${REPO}:${t} -> ${SIGNED_DIGEST}"
         done

--- a/.github/scripts/docker_push_with_retry.sh
+++ b/.github/scripts/docker_push_with_retry.sh
@@ -13,6 +13,8 @@
 # Usage:
 #   docker_push_with_retry.sh "label for log" docker push <ref>
 #   docker_push_with_retry.sh "label for log" docker manifest push <ref>
+#   docker_push_with_retry.sh --print-transient-re   # canonical regex, for callers
+#                                                    # that need to share the list
 #
 # Behaviour:
 #   - Captures combined stdout+stderr of the wrapped command.
@@ -23,6 +25,25 @@
 #     output to stdout (so callers that capture it can dump it) and exits
 #     with the wrapped command's exit code.
 set -euo pipefail
+
+# Patterns that indicate the registry (or the network path to it) is the
+# problem, not the image. Case-insensitive. Anchored loosely so format
+# changes upstream do not silently disable the retry.
+#
+# `tls handshake` and `net/http: TLS handshake` are kept (transient handshake
+# failures); a bare `tls: ` is intentionally NOT included because it would
+# also match non-transient configuration errors like
+# `tls: failed to verify certificate` or `tls: bad certificate`.
+TRANSIENT_RE='page is taking too long|unknown blob|blob unknown|blob upload invalid|manifest unknown|received unexpected HTTP status: 5[0-9]{2}|HTTP/[0-9.]+ 5[0-9]{2}|HTTP 5[0-9]{2}|status: 5[0-9]{2}|429 Too Many Requests|temporarily unavailable|server is currently unable|service unavailable|bad gateway|gateway time-?out|i/o timeout|tls handshake|connection reset|connection refused|EOF|unexpected EOF|read: connection|net/http: TLS handshake'
+
+# Discovery flag: callers that need to share the same regex (for example the
+# inline retag-inspect retry loop, which must drop a couple of patterns the
+# inspect path cannot benefit from) source it from here so a new pattern added
+# here automatically propagates.
+if [ "${1:-}" = "--print-transient-re" ]; then
+  printf '%s\n' "$TRANSIENT_RE"
+  exit 0
+fi
 
 LABEL="${1:?missing label}"
 shift
@@ -36,11 +57,6 @@ fi
 # unicorn windows; short enough to fail loudly on a real outage.
 ATTEMPTS=4
 BACKOFF=15
-
-# Patterns that indicate the registry (or the network path to it) is the
-# problem, not the image. Case-insensitive. Anchored loosely so format
-# changes upstream do not silently disable the retry.
-TRANSIENT_RE='page is taking too long|unknown blob|blob unknown|blob upload invalid|manifest unknown|received unexpected HTTP status: 5[0-9]{2}|HTTP/[0-9.]+ 5[0-9]{2}|HTTP 5[0-9]{2}|status: 5[0-9]{2}|429 Too Many Requests|temporarily unavailable|server is currently unable|service unavailable|bad gateway|gateway time-?out|i/o timeout|tls handshake|tls: |connection reset|connection refused|EOF|unexpected EOF|read: connection|net/http: TLS handshake'
 
 for ((i = 1; i <= ATTEMPTS; i++)); do
   out=""

--- a/.github/scripts/docker_push_with_retry.sh
+++ b/.github/scripts/docker_push_with_retry.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Retry transient GHCR push failures.
+#
+# Both `docker push <repo>:<tag>` and `docker manifest push <repo>:<tag>` are
+# idempotent for content we control: identical bytes -> identical digest, so
+# re-pushing on a transient registry error never publishes anything different
+# from the first successful attempt.
+#
+# Real failures (auth denied, permission, repository not found, malformed
+# image) are NOT retried -- their output never matches the transient
+# patterns below, so this wrapper exits 1 on the first attempt for them.
+#
+# Usage:
+#   docker_push_with_retry.sh "label for log" docker push <ref>
+#   docker_push_with_retry.sh "label for log" docker manifest push <ref>
+#
+# Behaviour:
+#   - Captures combined stdout+stderr of the wrapped command.
+#   - On success: prints captured output to stdout, exits 0.
+#   - On a transient signature with attempts remaining: prints output and a
+#     warning to stderr, sleeps with exponential backoff, retries.
+#   - On a non-transient error or exhausted attempts: prints captured
+#     output to stdout (so callers that capture it can dump it) and exits
+#     with the wrapped command's exit code.
+set -euo pipefail
+
+LABEL="${1:?missing label}"
+shift
+if [ "$#" -eq 0 ]; then
+  echo "::error::docker_push_with_retry.sh: no command supplied" >&2
+  exit 2
+fi
+
+# 4 attempts, backoff 15s -> 30s -> 60s = ~1m45s of wait in the worst case
+# before the final attempt. Long enough to ride through GHCR's typical 30-90s
+# unicorn windows; short enough to fail loudly on a real outage.
+ATTEMPTS=4
+BACKOFF=15
+
+# Patterns that indicate the registry (or the network path to it) is the
+# problem, not the image. Case-insensitive. Anchored loosely so format
+# changes upstream do not silently disable the retry.
+TRANSIENT_RE='page is taking too long|unknown blob|blob unknown|blob upload invalid|manifest unknown|received unexpected HTTP status: 5[0-9]{2}|HTTP/[0-9.]+ 5[0-9]{2}|HTTP 5[0-9]{2}|status: 5[0-9]{2}|429 Too Many Requests|temporarily unavailable|server is currently unable|service unavailable|bad gateway|gateway time-?out|i/o timeout|tls handshake|tls: |connection reset|connection refused|EOF|unexpected EOF|read: connection|net/http: TLS handshake'
+
+for ((i = 1; i <= ATTEMPTS; i++)); do
+  out=""
+  rc=0
+  # Capture combined stdout+stderr; on failure, save the wrapped exit
+  # code via `|| rc=$?` so set -e does not abort and the `if cmd; then`
+  # idiom does not silently overwrite it (a failed `if cmd` clears $?
+  # to 0 once the if-statement completes, which is why this uses an
+  # explicit `||` instead of `if ! ... ; then`).
+  out="$("$@" 2>&1)" || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    printf '%s\n' "$out"
+    exit 0
+  fi
+
+  # Final attempt: surface output to caller and bubble up the failure.
+  if [ "$i" -eq "$ATTEMPTS" ]; then
+    printf '%s\n' "$out"
+    echo "::error::${LABEL} failed after ${ATTEMPTS} attempts (last exit ${rc})" >&2
+    exit "$rc"
+  fi
+
+  # Mid-loop: only retry if the error looks transient. Echo the captured
+  # output to stderr so the build log shows what happened on each attempt
+  # without contaminating the caller's captured stdout.
+  if printf '%s' "$out" | grep -qiE "$TRANSIENT_RE"; then
+    printf '%s\n' "$out" >&2
+    echo "::warning::${LABEL} hit transient registry error (attempt ${i}/${ATTEMPTS}, rc=${rc}); sleeping ${BACKOFF}s before retry" >&2
+    sleep "$BACKOFF"
+    BACKOFF=$((BACKOFF * 2))
+    continue
+  fi
+
+  # Non-transient: do not retry. Surface output and bubble up.
+  printf '%s\n' "$out"
+  echo "::error::${LABEL} failed with non-transient error (exit ${rc}); not retrying" >&2
+  exit "$rc"
+done


### PR DESCRIPTION
## Summary

When GHCR has a brief upstream wobble during apko publish or manifest assembly, the docker workflow currently fails outright and `finalize-release.yml` refuses to publish the draft (it correctly gates on both CLI and Docker succeeding). That left two real release drafts (`v0.7.8` and `v0.7.9-dev.1`) stuck in Draft state earlier today: `Publish Sandbox Base (apko)` and `Publish Web (apko)` both got `"This page is taking too long to load"` HTML 5xx pages from GHCR mid-push.

This PR makes the publish/retag pipeline ride through those windows.

## Changes

- **New shared helper** `.github/scripts/docker_push_with_retry.sh`: wraps a command in up to 4 attempts with exponential backoff (15s → 30s → 60s, ~1m45s worst-case wait before the final attempt). Retries **only** on signatures that indicate the registry or network path is the problem (`page is taking too long`, `unknown blob`, `blob unknown`, `blob upload invalid`, `manifest unknown`, 5xx status, 429, gateway timeout, TLS reset, EOF, connection reset/refused). Real auth/permission/repository-not-found errors never match the regex and still fail fast on attempt 1.

- **`publish-apko-base/action.yml`**: per-arch `docker push` and the manifest-list `docker manifest push` now go through the helper.

- **`publish-image-loaded/action.yml`**: per-arch (`amd64` + `arm64`) `docker push` and the manifest-list `docker manifest push` now go through the helper.

- **`publish-image-retag/action.yml`**:
  - `docker buildx imagetools inspect` (the "resolve main-run signed digest" step) gets an inline retry loop with stderr captured separately so the digest on stdout stays clean.
  - `docker buildx imagetools create` (the "apply version tags to signed digest" step) goes through the helper.

## Why retries are safe

- `docker push` and `docker manifest push` are content-addressed: re-pushing the same layers / manifest list yields the same digest, so a retry never publishes anything different from a successful first attempt.
- `docker buildx imagetools create` is also idempotent for digest-pinned manifest lists — same input, same output, byte-identical bytes.
- The helper's transient regex is intentionally narrow: real auth / permission / repository-not-found errors don't match, so they fail fast on attempt 1 instead of waiting 1m45s through retries.
- The retag inspect path **deliberately diverges** from the helper's regex: `manifest unknown` is excluded so the legitimate "main-push did not publish this image" 404 keeps failing immediately (the existing `::error::Could not resolve...` branch). The comment block at the call site spells out exactly which patterns are dropped and why.

## What this does not change

- No new permissions, no new secrets, no new dependencies.
- Cosign signing, SLSA L3 attestation, SBOM emission, and Trivy/CIS scanning paths are untouched.
- `finalize-release.yml`'s gating logic is untouched.

## Test plan

- Unit-tested the helper locally with simulated transient + non-transient + recoverable cases (success path, fail-fast on non-transient, retry-then-recover, retry-exhausted with correct rc propagation).
- Bash syntax check (`bash -n`) on the new helper.
- Pre-commit hooks pass (gitleaks, no-em-dashes, etc.).
- The two stuck releases (`v0.7.8` final, `v0.7.9-dev.1`) were unblocked manually before this PR landed: `gh run rerun --failed` on the original Docker runs (which still ran the pre-fix code) succeeded once GHCR settled, `finalize-release.yml` published v0.7.8 stable at 18:26:41 UTC, and the post-stable cleanup wiped all dev tags as designed. The fix in this PR prevents recurrence.

## Review coverage

Pre-reviewed by 3 agents via `/pre-pr-review`: `docs-consistency`, `comment-quality-rot`, `infra-reviewer`. 1 finding addressed (regex-comment drift in the retag inspect loop, which now spells out the intentional divergence from the helper). 0 findings from the other two agents.