### PR TITLE
feat: tooling gate flagging missing pagination on list_*/query repository methods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,8 @@ ci:
   #     too slow / toolchain-heavy for the cloud runner.
   #   - no-em-dashes / no-redundant-timeout / forbidden-literals /
   #     persistence-boundary / no-new-logger-exception-str-exc /
-  #     orphan-fixtures / boundary-typed / setting-to-startup-trace:
+  #     orphan-fixtures / boundary-typed / setting-to-startup-trace /
+  #     list-pagination:
   #     scoped gates that need ``uv`` + repo source -- redundant given
   #     the `Lint` + `Forbidden literals gate` jobs in ci.yml.
   #   - check-push-rebased / check-single-migration-per-pr /
@@ -24,7 +25,7 @@ ci:
   # scripts with no CI counterpart, and letting pre-commit.ci enforce
   # them closes the gap where a PR from a contributor who skipped local
   # hooks would otherwise introduce a regression unchecked.
-  skip: [commitizen, gitleaks, hadolint-docker, caddy-validate, no-em-dashes, no-redundant-timeout, mypy, pytest-unit, golangci-lint, go-vet, go-test, eslint-web, check-push-rebased, check-single-migration-per-pr, check-no-modify-migration, forbidden-literals, persistence-boundary, provider-complete-chokepoint, no-new-logger-exception-str-exc, orphan-fixtures, doc-drift-counts, boundary-typed, setting-to-startup-trace]
+  skip: [commitizen, gitleaks, hadolint-docker, caddy-validate, no-em-dashes, no-redundant-timeout, mypy, pytest-unit, golangci-lint, go-vet, go-test, eslint-web, check-push-rebased, check-single-migration-per-pr, check-no-modify-migration, forbidden-literals, persistence-boundary, provider-complete-chokepoint, no-new-logger-exception-str-exc, orphan-fixtures, doc-drift-counts, boundary-typed, setting-to-startup-trace, list-pagination]
 
 default_install_hook_types: [pre-commit, commit-msg, pre-push]
 
@@ -263,12 +264,12 @@ repos:
         stages: [pre-push]
 
       - id: list-pagination
-        name: list_*/query repository pagination gate (#1752)
+        name: list_*/query repository pagination gate
         entry: uv run python scripts/check_list_pagination.py --scan-all
         language: system
         files: ^(src/synthorg/persistence/.*\.py|scripts/check_list_pagination\.py|scripts/list_pagination_baseline\.txt|\.pre-commit-config\.yaml)$
         pass_filenames: false
-        stages: [pre-push]
+        stages: [pre-commit, pre-push]
 
       - id: setting-to-startup-trace
         name: settings → startup wiring trace (ghost-wired settings gate)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -262,6 +262,14 @@ repos:
         pass_filenames: false
         stages: [pre-push]
 
+      - id: list-pagination
+        name: list_*/query repository pagination gate (#1752)
+        entry: uv run python scripts/check_list_pagination.py --scan-all
+        language: system
+        files: ^(src/synthorg/persistence/.*\.py|scripts/check_list_pagination\.py|scripts/list_pagination_baseline\.txt|\.pre-commit-config\.yaml)$
+        pass_filenames: false
+        stages: [pre-push]
+
       - id: setting-to-startup-trace
         name: settings → startup wiring trace (ghost-wired settings gate)
         entry: uv run python scripts/check_setting_to_startup_trace.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ Existing gate inventory (all under `scripts/`):
 - `check_doc_drift_counts.py`
 - `check_openapi_liveness.py`
 - `check_orphan_fixtures.py`
+- `check_list_pagination.py`
 
 Wire each new gate into `.pre-commit-config.yaml` (pre-commit or
 pre-push stage as fits) so it runs locally and in CI; per-line opt-outs

--- a/scripts/check_domain_error_hierarchy.py
+++ b/scripts/check_domain_error_hierarchy.py
@@ -323,6 +323,32 @@ def _format_baseline_entry(rel: str, lineno: int, class_name: str) -> str:
     return f"{rel}:{lineno}:{class_name}"
 
 
+_GIT_INHERITED_ENV_VARS: Final[tuple[str, ...]] = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_COMMON_DIR",
+)
+
+
+def _subprocess_env_without_inherited_git() -> dict[str, str]:
+    """Return ``os.environ`` minus inherited Git overrides.
+
+    When this script runs from a Git pre-push hook, ``GIT_DIR`` /
+    ``GIT_WORK_TREE`` / friends are set in the environment by Git. Those
+    propagate to ``git ls-files`` even when we pass an explicit ``cwd=``
+    -- ``GIT_DIR`` wins over ``cwd``. The gate (and any test that
+    invokes it on a synthetic tree) needs ``cwd`` to decide which repo
+    we're querying, so strip the inherited Git pointers before each
+    invocation.
+    """
+    env = os.environ.copy()
+    for name in _GIT_INHERITED_ENV_VARS:
+        env.pop(name, None)
+    return env
+
+
 def _git_tracked_python_files(
     abs_root: Path,
     project_root: Path,
@@ -335,6 +361,7 @@ def _git_tracked_python_files(
             check=True,
             capture_output=True,
             cwd=project_root,
+            env=_subprocess_env_without_inherited_git(),
         )
     except subprocess.CalledProcessError, FileNotFoundError:
         return [

--- a/scripts/check_list_pagination.py
+++ b/scripts/check_list_pagination.py
@@ -5,9 +5,9 @@ A repository ``list_users``/``query`` method that returns every row in the
 table is a DoS vector: any caller that triggers it (an unauth'd endpoint,
 a debug script, an integration test) materialises an arbitrarily-large
 tuple in memory. The CRUD vocabulary in
-``docs/reference/conventions.md`` §14 mandates ``limit`` (offset or cursor)
-on every ``list_items`` and ``query``; this gate prevents regression of
-that convention.
+``docs/reference/conventions.md`` section 14 mandates ``limit`` (offset or
+cursor) on every ``list_items`` and ``query``; this gate prevents
+regression of that convention.
 
 Scope:
 
@@ -27,9 +27,28 @@ Per-method classification:
 * PASS -- ``limit`` default is ``None`` AND another parameter named
   ``cursor`` / ``offset`` / ``after_id`` / ``before_id`` exists
   (cursor-pagination is the alternative to a numeric default).
+* PASS -- ``limit`` is missing AND a required parameter's annotation is
+  a Sequence-like generic (``Sequence[X]`` / ``list[X]`` / ``tuple[X,
+  ...]`` / ``set[X]`` / ``frozenset[X]`` / ``Iterable[X]`` /
+  ``Collection[X]``). The cardinality of the input sequence bounds
+  the result set the same way ``limit`` does, so a ``WHERE col IN
+  (...)``-style query is intrinsically bounded.
 * FAIL ``nullable-limit-no-cursor`` -- ``limit`` default is ``None``
   with no cursor sibling.
-* FAIL ``missing-limit-param`` -- no ``limit`` parameter at all.
+* FAIL ``missing-limit-param`` -- no ``limit`` parameter at all and
+  no Sequence-bounded filter.
+
+Known signature loophole (intentional, narrow):
+
+* ``limit: int = SOME_NON_LITERAL`` -- when the default expression is
+  neither a numeric literal nor ``None`` (an enum, a settings call, a
+  module-level constant), the gate treats it as compliant. The
+  parameter is present and named ``limit``; the gate's job is to catch
+  the unbounded shape, not to police the default's runtime value. If
+  ``SOME_NON_LITERAL`` resolves to an unbounded sentinel at runtime,
+  that's a defect at the call site that this signature gate cannot
+  detect; runtime validation belongs in the repository's own input
+  guards, not here.
 
 Allowlist
 ---------
@@ -48,9 +67,10 @@ Per-line opt-out
 
 Append ``# lint-allow: list-pagination -- <reason>`` to a method's
 ``def`` line to bypass the gate at that exact site (rare; rule of
-thumb: prefer fixing the signature). The marker is honoured AST-by-line
-on the function definition line, so a misplaced marker on a body line
-does not silence the violation.
+thumb: prefer fixing the signature). The marker is honoured only when
+it appears inside the line's actual comment (after an unquoted ``#``);
+the same string inside a default value or docstring does not silence
+the violation.
 
 Usage
 -----
@@ -65,7 +85,7 @@ import ast
 import re
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -81,6 +101,13 @@ _OPT_OUT_MARKER = "lint-allow: list-pagination"
 # is unbounded UNLESS one of these siblings is present.
 _CURSOR_PARAM_NAMES: frozenset[str] = frozenset(
     {"cursor", "offset", "after_id", "before_id"}
+)
+
+# Sequence-like generic annotations that bound the result set by the
+# cardinality of the input. A method with no ``limit`` but a required
+# ``ids: Sequence[str]`` parameter is intrinsically bounded.
+_SEQUENCE_ANNOTATION_NAMES: frozenset[str] = frozenset(
+    {"Sequence", "list", "tuple", "set", "frozenset", "Iterable", "Collection"}
 )
 
 _REASON_MISSING = "missing-limit-param"
@@ -103,8 +130,6 @@ _BASELINE_HEADER = """\
 #
 # Regenerate (rare; requires explicit user approval) with:
 #   uv run python scripts/check_list_pagination.py --update
-#
-# Issue #1752 (audit cluster #19).
 """
 
 
@@ -112,9 +137,11 @@ class InspectionError(RuntimeError):
     """A source file could not be parsed for AST inspection."""
 
 
-# Concrete violation tuple: ``(class_name, method_name, reason, lineno)``.
-# Lineno is the ``def`` line, used for the per-line opt-out marker check.
-_Violation = tuple[str, str, str, int]
+class _Violation(NamedTuple):
+    class_name: str
+    method_name: str
+    reason: str
+    lineno: int
 
 
 def _is_target_method_name(name: str) -> bool:
@@ -163,27 +190,78 @@ def _is_numeric_constant(value: ast.expr | None) -> bool:
     return isinstance(value, ast.Constant) and isinstance(value.value, (int, float))
 
 
+def _annotation_root_name(annotation: ast.expr | None) -> str | None:
+    """Return the outermost identifier of *annotation*, or ``None``.
+
+    Handles ``Sequence[str]`` (Subscript over Name), ``list[str]``,
+    ``collections.abc.Sequence[str]`` (Subscript over Attribute), and
+    bare ``Sequence``. Anything that is not a Name, Attribute, or
+    Subscript wrapping one of those returns ``None``.
+    """
+    if annotation is None:
+        return None
+    if isinstance(annotation, ast.Subscript):
+        return _annotation_root_name(annotation.value)
+    if isinstance(annotation, ast.Name):
+        return annotation.id
+    if isinstance(annotation, ast.Attribute):
+        return annotation.attr
+    return None
+
+
+def _has_required_sequence_param(
+    func: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> bool:
+    """Return True if *func* has a required Sequence-typed parameter.
+
+    A Sequence-typed REQUIRED parameter (no default) bounds the result
+    set the same way a ``limit`` does: a ``WHERE col IN (...)``-style
+    query is intrinsically bounded by the cardinality of the input.
+    Optional Sequence parameters (default ``None``) do not count
+    because the method behaves unbounded when the caller omits them.
+    """
+    args = func.args
+    pos = list(args.posonlyargs) + list(args.args)
+    pos_defaults: list[ast.expr | None] = [None] * (
+        len(pos) - len(args.defaults)
+    ) + list(args.defaults)
+    candidates: list[tuple[ast.arg, ast.expr | None]] = list(
+        zip(pos, pos_defaults, strict=True)
+    ) + list(zip(args.kwonlyargs, args.kw_defaults, strict=True))
+    for arg, default in candidates:
+        if default is not None:
+            continue
+        root = _annotation_root_name(arg.annotation)
+        if root in _SEQUENCE_ANNOTATION_NAMES:
+            return True
+    return False
+
+
 def _classify_method(
     func: ast.FunctionDef | ast.AsyncFunctionDef,
 ) -> str | None:
-    """Return a violation reason for *func*, or ``None`` if it's compliant."""
+    """Return a violation reason for *func*, or ``None`` if it's compliant.
+
+    Compliance shapes (any one is enough):
+
+    * ``limit`` parameter missing AND a required Sequence-typed filter is
+      present (cardinality of the input bounds the result set).
+    * ``limit`` is required (no default).
+    * ``limit`` has a numeric constant default.
+    * ``limit`` defaults to ``None`` AND a cursor sibling exists.
+    * ``limit`` has a non-literal default (enum / module constant); the
+      gate accepts these by design (see the "Known signature loophole"
+      section in the module docstring).
+    """
     params = _params_with_defaults(func)
     if "limit" not in params:
-        return _REASON_MISSING
+        return None if _has_required_sequence_param(func) else _REASON_MISSING
     default = params["limit"]
-    if default is None:
-        return None
-    if _is_numeric_constant(default):
+    if default is None or _is_numeric_constant(default):
         return None
     if _is_literal_none(default):
         cursor_sibling = any(name in params for name in _CURSOR_PARAM_NAMES)
-        if cursor_sibling:
-            return None
-        return _REASON_NULLABLE
-    # Default is some other expression (an enum, a Settings lookup,
-    # etc.). Treat as compliant: the parameter is present and the
-    # gate's job is to catch the unbounded shapes, not to police
-    # literal default expressions.
+        return None if cursor_sibling else _REASON_NULLABLE
     return None
 
 
@@ -196,15 +274,51 @@ def _iter_class_methods(
             yield node
 
 
+def _comment_text(line: str) -> str:
+    """Return the comment portion of *line* (text after an unquoted ``#``).
+
+    Walks the line tracking single- and double-quote string state so a
+    ``#`` inside a string literal does not start a comment. This is
+    deliberately a lightweight character scanner rather than ``tokenize``
+    because it runs on a single line per call -- spinning up the full
+    tokenizer per def-line would dominate scan time.
+
+    Triple-quoted strings, f-string expressions, and multi-line strings
+    crossing the def line are out of scope: the marker check operates on
+    the single ``def`` line, and a real-world ``def`` with an embedded
+    triple-quoted default is rare enough that we accept a false negative
+    over the cost of full token-stream parsing.
+    """
+    in_quote: str | None = None
+    escaped = False
+    for i, ch in enumerate(line):
+        if escaped:
+            escaped = False
+            continue
+        if ch == "\\":
+            escaped = True
+            continue
+        if in_quote is not None:
+            if ch == in_quote:
+                in_quote = None
+            continue
+        if ch in ("'", '"'):
+            in_quote = ch
+            continue
+        if ch == "#":
+            return line[i:]
+    return ""
+
+
 def _line_has_opt_out(source_lines: list[str], lineno: int) -> bool:
-    """Return True if the line carries the per-line opt-out marker."""
+    """Return True if the line's comment carries the per-line opt-out marker."""
     if not 1 <= lineno <= len(source_lines):
         return False
-    return _OPT_OUT_MARKER in source_lines[lineno - 1]
+    return _OPT_OUT_MARKER in _comment_text(source_lines[lineno - 1])
 
 
 def _scan_file(path: Path, rel: str) -> list[_Violation]:
-    """Return ``(class_name, method_name, reason, lineno)`` for *path*.
+    """Return ``_Violation`` records for every flagged method in *path*.
 
     Walks every top-level ``ClassDef`` (nested classes are out of scope --
     persistence files don't use them) and inspects each direct method
@@ -237,7 +351,7 @@ def _scan_file(path: Path, rel: str) -> list[_Violation]:
                 continue
             if _line_has_opt_out(source_lines, method.lineno):
                 continue
-            violations.append((node.name, method.name, reason, method.lineno))
+            violations.append(_Violation(node.name, method.name, reason, method.lineno))
     return violations
 
 
@@ -291,9 +405,10 @@ def _load_baseline() -> set[str]:
     if errors:
         for err in errors:
             print(err, file=sys.stderr)
+        plural = "s" if len(errors) != 1 else ""
         msg = (
             f"{rel_path}: baseline failed validation "
-            f"({len(errors)} error{'s' if len(errors) != 1 else ''}); "
+            f"({len(errors)} error{plural}; first: {errors[0]}); "
             "regenerate with 'uv run python scripts/check_list_pagination.py "
             "--update' or fix by hand."
         )
@@ -323,16 +438,18 @@ def _scan(path: Path, baseline: set[str]) -> tuple[list[str], set[str]]:
     entries that suppressed something" lets ``cmd_scan_all`` compute
     ``baseline - hits`` to detect stale (shrinkage-eligible) entries
     after every file is processed.
+
+    Re-raises :class:`InspectionError` so callers can distinguish a
+    genuine pagination violation (exit 1) from a parse failure (exit 2);
+    flattening parse errors into the violation stream would let a
+    syntax-broken file silently disable the gate's coverage there.
     """
     rel = _rel(path)
-    try:
-        scan_hits = _scan_file(path, rel)
-    except InspectionError as exc:
-        return [f"{rel}: inspection failed: {exc}"], set()
+    scan_hits = _scan_file(path, rel)
     violations: list[str] = []
     hits: set[str] = set()
-    for class_name, method_name, reason, _lineno in scan_hits:
-        entry = _format_entry(rel, class_name, method_name, reason)
+    for hit in scan_hits:
+        entry = _format_entry(rel, hit.class_name, hit.method_name, hit.reason)
         if entry in baseline:
             hits.add(entry)
             continue
@@ -352,9 +469,10 @@ def _scan_all_for_baseline() -> list[str]:
     entries: list[str] = []
     for path in _iter_persistence_files():
         rel = _rel(path)
-        scan_hits = _scan_file(path, rel)
-        for class_name, method_name, reason, _lineno in scan_hits:
-            entries.append(_format_entry(rel, class_name, method_name, reason))
+        entries.extend(
+            _format_entry(rel, hit.class_name, hit.method_name, hit.reason)
+            for hit in _scan_file(path, rel)
+        )
     return sorted(entries)
 
 
@@ -375,40 +493,60 @@ def cmd_scan_all() -> int:
     baseline = _load_baseline()
     violations: list[str] = []
     matched: set[str] = set()
+    inspection_errors: list[str] = []
     for path in _iter_persistence_files():
-        v, h = _scan(path, baseline)
+        try:
+            v, h = _scan(path, baseline)
+        except InspectionError as exc:
+            inspection_errors.append(str(exc))
+            continue
         violations.extend(v)
         matched |= h
+    if inspection_errors:
+        for err in inspection_errors:
+            print(f"check_list_pagination: {err}", file=sys.stderr)
+        return 2
     stale = sorted(baseline - matched)
     return _report(violations, stale)
 
 
 def cmd_scan_paths(paths: Iterable[str]) -> int:
-    """Scan the supplied paths (pre-push entry point).
+    """Scan the supplied paths (pre-commit / pre-push entry point).
 
     Files outside ``_PERSISTENCE_ROOT`` are skipped because the gate's
     contract is repository-only; mistakenly running it across
     ``src/synthorg/api/`` should be a no-op rather than crash.
 
     Shrinkage detection is intentionally *not* run in this entry point:
-    pre-push receives only the changed files, so a baseline entry that
-    no longer matches because its file wasn't in the diff would be a
-    false positive. ``cmd_scan_all`` is the canonical place to enforce
-    shrinkage.
+    pre-commit / pre-push receive only the changed files, so a baseline
+    entry that no longer matches because its file wasn't in the diff
+    would be a false positive. ``cmd_scan_all`` is the canonical place
+    to enforce shrinkage.
+
+    A parse failure on any scanned file exits 2 (consistent with
+    ``cmd_scan_all``); the developer's local push fails loudly rather
+    than rolling a syntax error into the violation stream.
     """
     baseline = _load_baseline()
     persistence_root = _PERSISTENCE_ROOT.resolve()
     violations: list[str] = []
+    inspection_errors: list[str] = []
     for raw in paths:
         path = Path(raw).resolve()
         if not path.exists() or path.suffix != ".py":
             continue
-        try:
-            path.relative_to(persistence_root)
-        except ValueError:
+        if not path.is_relative_to(persistence_root):
             continue
-        v, _ = _scan(path, baseline)
+        try:
+            v, _ = _scan(path, baseline)
+        except InspectionError as exc:
+            inspection_errors.append(str(exc))
+            continue
         violations.extend(v)
+    if inspection_errors:
+        for err in inspection_errors:
+            print(f"check_list_pagination: {err}", file=sys.stderr)
+        return 2
     return _report(violations, stale=[])
 
 
@@ -448,7 +586,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "paths",
         nargs="*",
-        help="Files to check (pre-push supplies these).",
+        help="Files to check (pre-commit / pre-push supplies these).",
     )
     parser.add_argument(
         "--scan-all",

--- a/scripts/check_list_pagination.py
+++ b/scripts/check_list_pagination.py
@@ -37,6 +37,10 @@ Per-method classification:
   with no cursor sibling.
 * FAIL ``missing-limit-param`` -- no ``limit`` parameter at all and
   no Sequence-bounded filter.
+* FAIL ``invalid-limit-annotation`` -- ``limit`` parameter is present
+  but its annotation is missing or is not ``int`` / ``int | None`` /
+  ``Optional[int]`` (e.g. ``limit: str``, ``limit: object = 100``).
+  A non-int ``limit`` is just as unbounded as no limit at all.
 
 Known signature loophole (intentional, narrow):
 
@@ -112,6 +116,7 @@ _SEQUENCE_ANNOTATION_NAMES: frozenset[str] = frozenset(
 
 _REASON_MISSING = "missing-limit-param"
 _REASON_NULLABLE = "nullable-limit-no-cursor"
+_REASON_INVALID_ANNOTATION = "invalid-limit-annotation"
 
 _BASELINE_HEADER = """\
 # Frozen baseline of pre-existing list_*/query repository methods missing
@@ -121,6 +126,7 @@ _BASELINE_HEADER = """\
 # Reasons:
 #   missing-limit-param      -- no `limit` parameter exists
 #   nullable-limit-no-cursor -- limit default is None and no cursor/offset sibling
+#   invalid-limit-annotation -- `limit` annotation is missing or not int/int|None
 #
 # scripts/check_list_pagination.py reads this file to suppress violations
 # at these exact sites. New offenders NOT in this list will fail the
@@ -190,22 +196,104 @@ def _is_numeric_constant(value: ast.expr | None) -> bool:
     return isinstance(value, ast.Constant) and isinstance(value.value, (int, float))
 
 
+def _annotated_first_arg(annotation: ast.Subscript) -> ast.expr:
+    """Return the first slice element of ``Annotated[T, ...]``.
+
+    Caller has already verified the outer name is ``Annotated``. PEP 593
+    requires at least two arguments (``T`` plus a metadata entry), so
+    ``ast.Tuple`` is the expected shape; CPython tolerates a single-arg
+    ``Annotated[T]`` though, so we handle the bare-``slice`` fallback.
+    """
+    inner = annotation.slice
+    if isinstance(inner, ast.Tuple) and inner.elts:
+        return inner.elts[0]
+    return inner
+
+
+def _int_subscript_inner(annotation: ast.Subscript) -> ast.expr | None:
+    """Return the type ``Optional[T]`` / ``Annotated[T, ...]`` wraps, else None.
+
+    A subscript whose outer name is anything other than ``Optional`` or
+    ``Annotated`` does not narrow to ``int`` and the caller rejects.
+    """
+    outer = _annotation_root_name(annotation.value)
+    if outer == "Optional":
+        return annotation.slice
+    if outer == "Annotated":
+        return _annotated_first_arg(annotation)
+    return None
+
+
+def _is_int_annotation(annotation: ast.expr | None) -> bool:
+    """Return True if *annotation* permits only ``int`` or ``int | None``.
+
+    Accepted shapes:
+
+    * ``int`` (bare ``ast.Name``).
+    * ``int | None`` / ``None | int`` (``ast.BinOp`` over ``BitOr``,
+      either operand order).
+    * ``Optional[int]`` (``ast.Subscript`` over ``Optional``).
+    * ``Annotated[int, ...]`` / ``Annotated[int | None, ...]`` (PEP 593
+      metadata wrapper; the gate looks through the wrapper at the first
+      slice element).
+
+    A missing annotation, an annotation typed as ``str`` / ``object`` /
+    any other base type, or a union containing a non-``int`` member
+    returns ``False`` -- the caller treats that as
+    ``invalid-limit-annotation``.
+    """
+    if annotation is None:
+        return False
+    if isinstance(annotation, ast.Name):
+        return annotation.id == "int"
+    if isinstance(annotation, ast.Constant):
+        return annotation.value is None
+    if isinstance(annotation, ast.BinOp) and isinstance(annotation.op, ast.BitOr):
+        return _is_int_annotation(annotation.left) and _is_int_annotation(
+            annotation.right
+        )
+    if isinstance(annotation, ast.Subscript):
+        return _is_int_annotation(_int_subscript_inner(annotation))
+    return False
+
+
+def _find_arg(
+    func: ast.FunctionDef | ast.AsyncFunctionDef, name: str
+) -> ast.arg | None:
+    """Return the ``ast.arg`` for parameter *name* on *func*, or ``None``.
+
+    Searches positional-only, positional-or-keyword, and keyword-only
+    parameters; ``*args`` / ``**kwargs`` collectors are out of scope
+    because the gate's vocabulary names a concrete parameter.
+    """
+    args = func.args
+    for arg in (*args.posonlyargs, *args.args, *args.kwonlyargs):
+        if arg.arg == name:
+            return arg
+    return None
+
+
 def _annotation_root_name(annotation: ast.expr | None) -> str | None:
     """Return the outermost identifier of *annotation*, or ``None``.
 
     Handles ``Sequence[str]`` (Subscript over Name), ``list[str]``,
-    ``collections.abc.Sequence[str]`` (Subscript over Attribute), and
-    bare ``Sequence``. Anything that is not a Name, Attribute, or
-    Subscript wrapping one of those returns ``None``.
+    ``collections.abc.Sequence[str]`` (Subscript over Attribute), bare
+    ``Sequence``, and ``Annotated[Sequence[str], ...]`` (PEP 593, the
+    Pydantic / metadata-bearing shape) by recursing into the first
+    argument of ``Annotated[...]``. Anything that is not a Name,
+    Attribute, or Subscript wrapping one of those returns ``None``.
     """
     if annotation is None:
         return None
-    if isinstance(annotation, ast.Subscript):
-        return _annotation_root_name(annotation.value)
     if isinstance(annotation, ast.Name):
         return annotation.id
     if isinstance(annotation, ast.Attribute):
         return annotation.attr
+    if isinstance(annotation, ast.Subscript):
+        outer = _annotation_root_name(annotation.value)
+        if outer != "Annotated":
+            return outer
+        return _annotation_root_name(_annotated_first_arg(annotation))
     return None
 
 
@@ -246,16 +334,26 @@ def _classify_method(
 
     * ``limit`` parameter missing AND a required Sequence-typed filter is
       present (cardinality of the input bounds the result set).
-    * ``limit`` is required (no default).
-    * ``limit`` has a numeric constant default.
-    * ``limit`` defaults to ``None`` AND a cursor sibling exists.
-    * ``limit`` has a non-literal default (enum / module constant); the
-      gate accepts these by design (see the "Known signature loophole"
-      section in the module docstring).
+    * ``limit`` is annotated as ``int`` / ``int | None`` /
+      ``Optional[int]`` AND one of:
+        * required (no default), OR
+        * has a numeric constant default, OR
+        * defaults to ``None`` AND a cursor sibling exists, OR
+        * has a non-literal default (enum / module constant) -- the
+          "Known signature loophole" in the module docstring.
+
+    A ``limit`` parameter whose annotation is missing or not an
+    ``int``-compatible shape (``str``, ``object``, ``Any``, etc.)
+    returns ``invalid-limit-annotation``: the gate's contract is
+    ``limit: int``, and a parameter merely *named* limit with the wrong
+    type is just as unbounded as no limit at all.
     """
     params = _params_with_defaults(func)
     if "limit" not in params:
         return None if _has_required_sequence_param(func) else _REASON_MISSING
+    limit_arg = _find_arg(func, "limit")
+    if limit_arg is None or not _is_int_annotation(limit_arg.annotation):
+        return _REASON_INVALID_ANNOTATION
     default = params["limit"]
     if default is None or _is_numeric_constant(default):
         return None
@@ -606,7 +704,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.scan_all:
             return cmd_scan_all()
         return cmd_scan_paths(args.paths)
-    except ValueError as exc:
+    except (InspectionError, ValueError) as exc:
         print(f"check_list_pagination: {exc}", file=sys.stderr)
         return 2
 

--- a/scripts/check_list_pagination.py
+++ b/scripts/check_list_pagination.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""Pre-push gate: forbid unbounded ``list_*`` / ``query`` repository methods.
+
+A repository ``list_users``/``query`` method that returns every row in the
+table is a DoS vector: any caller that triggers it (an unauth'd endpoint,
+a debug script, an integration test) materialises an arbitrarily-large
+tuple in memory. The CRUD vocabulary in
+``docs/reference/conventions.md`` §14 mandates ``limit`` (offset or cursor)
+on every ``list_items`` and ``query``; this gate prevents regression of
+that convention.
+
+Scope:
+
+* Files: every ``.py`` under ``src/synthorg/persistence/``. The gate
+  naturally only flags class methods whose name matches the CRUD
+  vocabulary, so non-repo files (``factory.py``, ``config.py``, ...)
+  contribute zero overhead.
+* Method names: ``list_<X>``, ``query`` (bare), or ``query_<X>``.
+  Names with a leading underscore (``_list_internal``) are private
+  helpers, not list endpoints, and are skipped.
+* Async (``async def``) and sync (``def``) handled identically.
+
+Per-method classification:
+
+* PASS -- ``limit`` parameter present, no default value.
+* PASS -- ``limit`` present with a numeric ``ast.Constant`` default.
+* PASS -- ``limit`` default is ``None`` AND another parameter named
+  ``cursor`` / ``offset`` / ``after_id`` / ``before_id`` exists
+  (cursor-pagination is the alternative to a numeric default).
+* FAIL ``nullable-limit-no-cursor`` -- ``limit`` default is ``None``
+  with no cursor sibling.
+* FAIL ``missing-limit-param`` -- no ``limit`` parameter at all.
+
+Allowlist
+---------
+
+``scripts/list_pagination_baseline.txt`` is a frozen list of
+``<rel>:<class>.<method>:<reason>`` entries the gate ignores. The
+baseline captures pre-existing offenders so the gate can ship without
+forcing the matching persistence-layer fixes in the same PR. New
+offenders cannot be added silently: ``--update`` rewrites the baseline,
+and the rewritten file must be committed for the new entry to be
+allowed. Baseline shrinkage is enforced -- an entry that no longer
+matches a current violation is reported as ``baseline-stale``.
+
+Per-line opt-out
+----------------
+
+Append ``# lint-allow: list-pagination -- <reason>`` to a method's
+``def`` line to bypass the gate at that exact site (rare; rule of
+thumb: prefer fixing the signature). The marker is honoured AST-by-line
+on the function definition line, so a misplaced marker on a body line
+does not silence the violation.
+
+Usage
+-----
+
+    python scripts/check_list_pagination.py <file>...   # pre-push
+    python scripts/check_list_pagination.py --scan-all  # CI
+    python scripts/check_list_pagination.py --update    # regenerate baseline
+"""
+
+import argparse
+import ast
+import re
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_PERSISTENCE_ROOT = _REPO_ROOT / "src" / "synthorg" / "persistence"
+_BASELINE_PATH = _REPO_ROOT / "scripts" / "list_pagination_baseline.txt"
+
+_OPT_OUT_MARKER = "lint-allow: list-pagination"
+
+# Parameter names that, alongside a nullable ``limit``, indicate
+# cursor / offset pagination. A method with ``limit: int | None = None``
+# is unbounded UNLESS one of these siblings is present.
+_CURSOR_PARAM_NAMES: frozenset[str] = frozenset(
+    {"cursor", "offset", "after_id", "before_id"}
+)
+
+_REASON_MISSING = "missing-limit-param"
+_REASON_NULLABLE = "nullable-limit-no-cursor"
+
+_BASELINE_HEADER = """\
+# Frozen baseline of pre-existing list_*/query repository methods missing
+# required `limit` pagination. Each line is
+# `<posix-path>:<class>.<method>:<reason>` sorted in deterministic order.
+#
+# Reasons:
+#   missing-limit-param      -- no `limit` parameter exists
+#   nullable-limit-no-cursor -- limit default is None and no cursor/offset sibling
+#
+# scripts/check_list_pagination.py reads this file to suppress violations
+# at these exact sites. New offenders NOT in this list will fail the
+# pre-push hook. An entry here that no longer matches a real offender
+# (method renamed, fixed, deleted) is reported as `baseline-stale` so
+# the file must be regenerated when shrinkage is genuine.
+#
+# Regenerate (rare; requires explicit user approval) with:
+#   uv run python scripts/check_list_pagination.py --update
+#
+# Issue #1752 (audit cluster #19).
+"""
+
+
+class InspectionError(RuntimeError):
+    """A source file could not be parsed for AST inspection."""
+
+
+# Concrete violation tuple: ``(class_name, method_name, reason, lineno)``.
+# Lineno is the ``def`` line, used for the per-line opt-out marker check.
+_Violation = tuple[str, str, str, int]
+
+
+def _is_target_method_name(name: str) -> bool:
+    """Return True for public ``list_<X>`` / ``query`` / ``query_<X>`` names."""
+    if name.startswith("_"):
+        return False
+    if name == "query":
+        return True
+    return name.startswith(("list_", "query_"))
+
+
+def _params_with_defaults(
+    func: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> dict[str, ast.expr | None]:
+    """Map every formal parameter name to its default expression (or ``None``).
+
+    The map covers positional-or-keyword params, kw-only params, and the
+    ``self`` placeholder; ``*args`` and ``**kwargs`` collectors are
+    skipped because a spec couldn't reasonably name a positional rest.
+
+    Defaults align with their parameters from the right; the ``defaults``
+    list is shorter than ``args`` exactly when the leading args are
+    required. Mirroring CPython's own slot-resolution keeps the math
+    correct without a custom alignment routine.
+    """
+    args = func.args
+    out: dict[str, ast.expr | None] = {}
+    pos = list(args.posonlyargs) + list(args.args)
+    pos_defaults: list[ast.expr | None] = [None] * (
+        len(pos) - len(args.defaults)
+    ) + list(args.defaults)
+    for arg, default in zip(pos, pos_defaults, strict=True):
+        out[arg.arg] = default
+    for arg, default in zip(args.kwonlyargs, args.kw_defaults, strict=True):
+        out[arg.arg] = default
+    return out
+
+
+def _is_literal_none(value: ast.expr | None) -> bool:
+    """Return True if ``value`` is the literal ``None`` constant."""
+    return isinstance(value, ast.Constant) and value.value is None
+
+
+def _is_numeric_constant(value: ast.expr | None) -> bool:
+    """Return True if ``value`` is a numeric ``ast.Constant`` (int/float)."""
+    return isinstance(value, ast.Constant) and isinstance(value.value, (int, float))
+
+
+def _classify_method(
+    func: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> str | None:
+    """Return a violation reason for *func*, or ``None`` if it's compliant."""
+    params = _params_with_defaults(func)
+    if "limit" not in params:
+        return _REASON_MISSING
+    default = params["limit"]
+    if default is None:
+        return None
+    if _is_numeric_constant(default):
+        return None
+    if _is_literal_none(default):
+        cursor_sibling = any(name in params for name in _CURSOR_PARAM_NAMES)
+        if cursor_sibling:
+            return None
+        return _REASON_NULLABLE
+    # Default is some other expression (an enum, a Settings lookup,
+    # etc.). Treat as compliant: the parameter is present and the
+    # gate's job is to catch the unbounded shapes, not to police
+    # literal default expressions.
+    return None
+
+
+def _iter_class_methods(
+    cls: ast.ClassDef,
+) -> Iterator[ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Yield direct ``def`` / ``async def`` children of *cls*."""
+    for node in cls.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield node
+
+
+def _line_has_opt_out(source_lines: list[str], lineno: int) -> bool:
+    """Return True if the line carries the per-line opt-out marker."""
+    if not 1 <= lineno <= len(source_lines):
+        return False
+    return _OPT_OUT_MARKER in source_lines[lineno - 1]
+
+
+def _scan_file(path: Path, rel: str) -> list[_Violation]:
+    """Return ``(class_name, method_name, reason, lineno)`` for *path*.
+
+    Walks every top-level ``ClassDef`` (nested classes are out of scope --
+    persistence files don't use them) and inspects each direct method
+    whose name matches the CRUD vocabulary. Per-line opt-out markers
+    on the ``def`` line suppress emission.
+
+    The *rel* argument is plumbed through purely for error messages on
+    parse failure; it does not affect the returned tuples.
+    """
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError) as exc:
+        msg = f"failed to read {rel}: {type(exc).__name__}: {exc}"
+        raise InspectionError(msg) from exc
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        msg = f"failed to parse {rel}: SyntaxError at line {exc.lineno}: {exc.msg}"
+        raise InspectionError(msg) from exc
+    source_lines = source.splitlines()
+    violations: list[_Violation] = []
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for method in _iter_class_methods(node):
+            if not _is_target_method_name(method.name):
+                continue
+            reason = _classify_method(method)
+            if reason is None:
+                continue
+            if _line_has_opt_out(source_lines, method.lineno):
+                continue
+            violations.append((node.name, method.name, reason, method.lineno))
+    return violations
+
+
+def _format_entry(rel: str, class_name: str, method_name: str, reason: str) -> str:
+    """Render the canonical baseline / violation line."""
+    return f"{rel}:{class_name}.{method_name}:{reason}"
+
+
+def _rel(path: Path) -> str:
+    """Repo-relative POSIX path for stable violation messages."""
+    return path.resolve().relative_to(_REPO_ROOT.resolve()).as_posix()
+
+
+_BASELINE_ENTRY_PATTERN = re.compile(
+    r"^[^:]+:[A-Za-z_][\w]*\.[A-Za-z_][\w]*:[a-z][a-z\-]*$"
+)
+
+
+def _load_baseline() -> set[str]:
+    """Return the set of allowlisted ``<rel>:<class>.<method>:<reason>`` entries.
+
+    Validates each non-empty, non-comment line against the canonical
+    shape and rejects duplicates. A corrupted baseline that silently
+    drops entries would let real offenders slip past the gate.
+    """
+    if not _BASELINE_PATH.exists():
+        return set()
+    entries: set[str] = set()
+    errors: list[str] = []
+    try:
+        rel_path = _rel(_BASELINE_PATH)
+    except ValueError:
+        rel_path = str(_BASELINE_PATH)
+    for lineno, line in enumerate(
+        _BASELINE_PATH.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if not _BASELINE_ENTRY_PATTERN.match(stripped):
+            errors.append(
+                f"{rel_path}:{lineno}: malformed entry "
+                f"(expected '<rel>:<class>.<method>:<reason>', got {stripped!r})"
+            )
+            continue
+        if stripped in entries:
+            errors.append(f"{rel_path}:{lineno}: duplicate entry {stripped!r}")
+            continue
+        entries.add(stripped)
+    if errors:
+        for err in errors:
+            print(err, file=sys.stderr)
+        msg = (
+            f"{rel_path}: baseline failed validation "
+            f"({len(errors)} error{'s' if len(errors) != 1 else ''}); "
+            "regenerate with 'uv run python scripts/check_list_pagination.py "
+            "--update' or fix by hand."
+        )
+        raise ValueError(msg)
+    return entries
+
+
+def _iter_persistence_files() -> Iterator[Path]:
+    """Yield every ``.py`` file under ``_PERSISTENCE_ROOT`` (sorted, no dunders).
+
+    ``__init__.py`` is included even though it rarely contains repo
+    classes; the AST walker skips it cheaply when there's nothing to
+    flag, and excluding it would require special-casing in three places.
+    Any ``__pycache__`` directories are skipped because they aren't
+    source.
+    """
+    for path in sorted(_PERSISTENCE_ROOT.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        yield path
+
+
+def _scan(path: Path, baseline: set[str]) -> tuple[list[str], set[str]]:
+    """Scan *path*, return ``(violations, hit_baseline_entries)``.
+
+    Splitting the return into "violations to report" and "baseline
+    entries that suppressed something" lets ``cmd_scan_all`` compute
+    ``baseline - hits`` to detect stale (shrinkage-eligible) entries
+    after every file is processed.
+    """
+    rel = _rel(path)
+    try:
+        scan_hits = _scan_file(path, rel)
+    except InspectionError as exc:
+        return [f"{rel}: inspection failed: {exc}"], set()
+    violations: list[str] = []
+    hits: set[str] = set()
+    for class_name, method_name, reason, _lineno in scan_hits:
+        entry = _format_entry(rel, class_name, method_name, reason)
+        if entry in baseline:
+            hits.add(entry)
+            continue
+        violations.append(entry)
+    return violations, hits
+
+
+def _scan_all_for_baseline() -> list[str]:
+    """Return every offender in the persistence tree for baseline regeneration.
+
+    Re-raises ``InspectionError`` instead of silently continuing on a
+    parse failure: a baseline that quietly skips an unparseable file
+    would let the gate suppress every offender in that file going
+    forward, exactly the silent-failure shape the gate exists to
+    prevent.
+    """
+    entries: list[str] = []
+    for path in _iter_persistence_files():
+        rel = _rel(path)
+        scan_hits = _scan_file(path, rel)
+        for class_name, method_name, reason, _lineno in scan_hits:
+            entries.append(_format_entry(rel, class_name, method_name, reason))
+    return sorted(entries)
+
+
+def cmd_update() -> int:
+    """Regenerate the baseline file from the current tree state."""
+    entries = _scan_all_for_baseline()
+    body = _BASELINE_HEADER + "\n".join(entries) + "\n"
+    _BASELINE_PATH.write_text(body, encoding="utf-8")
+    print(
+        f"Wrote {len(entries)} entries to {_rel(_BASELINE_PATH)}.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def cmd_scan_all() -> int:
+    """Scan every persistence file (CI mode) and enforce baseline shrinkage."""
+    baseline = _load_baseline()
+    violations: list[str] = []
+    matched: set[str] = set()
+    for path in _iter_persistence_files():
+        v, h = _scan(path, baseline)
+        violations.extend(v)
+        matched |= h
+    stale = sorted(baseline - matched)
+    return _report(violations, stale)
+
+
+def cmd_scan_paths(paths: Iterable[str]) -> int:
+    """Scan the supplied paths (pre-push entry point).
+
+    Files outside ``_PERSISTENCE_ROOT`` are skipped because the gate's
+    contract is repository-only; mistakenly running it across
+    ``src/synthorg/api/`` should be a no-op rather than crash.
+
+    Shrinkage detection is intentionally *not* run in this entry point:
+    pre-push receives only the changed files, so a baseline entry that
+    no longer matches because its file wasn't in the diff would be a
+    false positive. ``cmd_scan_all`` is the canonical place to enforce
+    shrinkage.
+    """
+    baseline = _load_baseline()
+    persistence_root = _PERSISTENCE_ROOT.resolve()
+    violations: list[str] = []
+    for raw in paths:
+        path = Path(raw).resolve()
+        if not path.exists() or path.suffix != ".py":
+            continue
+        try:
+            path.relative_to(persistence_root)
+        except ValueError:
+            continue
+        v, _ = _scan(path, baseline)
+        violations.extend(v)
+    return _report(violations, stale=[])
+
+
+def _report(violations: list[str], stale: list[str]) -> int:
+    """Print findings and return a pre-push-friendly exit code."""
+    if not violations and not stale:
+        return 0
+    for line in violations:
+        print(line)
+    for entry in stale:
+        print(f"baseline-stale: {entry}")
+    print(
+        "\nUnbounded list_*/query repository methods are a DoS vector: a"
+        "\ncaller that triggers them materialises an arbitrarily-large tuple."
+        "\nConventions section 14 mandates `limit` (offset or cursor) on every"
+        "\n`list_items`/`query`."
+        "\n"
+        "\nFix the signature, then either:"
+        "\n  * rerun the gate (the entry will disappear naturally), OR"
+        "\n  * regenerate the baseline if the change is shrinkage:"
+        "\n      uv run python scripts/check_list_pagination.py --update"
+        "\n"
+        "\nFor a genuine fixed-set return, mark the def line with:"
+        f"\n  # {_OPT_OUT_MARKER} -- <reason>",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Gate on list_*/query repository methods missing required `limit`."
+        ),
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Files to check (pre-push supplies these).",
+    )
+    parser.add_argument(
+        "--scan-all",
+        action="store_true",
+        help="Scan the full src/synthorg/persistence/ tree (CI mode).",
+    )
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="Regenerate scripts/list_pagination_baseline.txt from current state.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        if args.update:
+            return cmd_update()
+        if args.scan_all:
+            return cmd_scan_all()
+        return cmd_scan_paths(args.paths)
+    except ValueError as exc:
+        print(f"check_list_pagination: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_list_pagination.py
+++ b/scripts/check_list_pagination.py
@@ -28,11 +28,14 @@ Per-method classification:
   ``cursor`` / ``offset`` / ``after_id`` / ``before_id`` exists
   (cursor-pagination is the alternative to a numeric default).
 * PASS -- ``limit`` is missing AND a required parameter's annotation is
-  a Sequence-like generic (``Sequence[X]`` / ``list[X]`` / ``tuple[X,
-  ...]`` / ``set[X]`` / ``frozenset[X]`` / ``Iterable[X]`` /
-  ``Collection[X]``). The cardinality of the input sequence bounds
-  the result set the same way ``limit`` does, so a ``WHERE col IN
-  (...)``-style query is intrinsically bounded.
+  a Sized-sequence generic (``Sequence[X]`` / ``list[X]`` / ``tuple[X,
+  ...]`` / ``set[X]`` / ``frozenset[X]`` / ``Collection[X]``). The
+  cardinality of the input sequence bounds the result set the same way
+  ``limit`` does, so a ``WHERE col IN (...)``-style query is
+  intrinsically bounded. ``Iterable[X]`` is intentionally excluded
+  here -- the protocol only requires ``__iter__`` (not ``__len__``),
+  so an arbitrary generator can satisfy it and the gate would then
+  certify an unbounded scan as compliant.
 * FAIL ``nullable-limit-no-cursor`` -- ``limit`` default is ``None``
   with no cursor sibling.
 * FAIL ``missing-limit-param`` -- no ``limit`` parameter at all and
@@ -107,11 +110,14 @@ _CURSOR_PARAM_NAMES: frozenset[str] = frozenset(
     {"cursor", "offset", "after_id", "before_id"}
 )
 
-# Sequence-like generic annotations that bound the result set by the
+# Sized-sequence generic annotations that bound the result set by the
 # cardinality of the input. A method with no ``limit`` but a required
-# ``ids: Sequence[str]`` parameter is intrinsically bounded.
+# ``ids: Sequence[str]`` parameter is intrinsically bounded. Note
+# ``Iterable`` is deliberately excluded: it only requires ``__iter__``,
+# not ``__len__``, so a generator can satisfy it and the gate would
+# then certify an unbounded scan as compliant.
 _SEQUENCE_ANNOTATION_NAMES: frozenset[str] = frozenset(
-    {"Sequence", "list", "tuple", "set", "frozenset", "Iterable", "Collection"}
+    {"Sequence", "list", "tuple", "set", "frozenset", "Collection"}
 )
 
 _REASON_MISSING = "missing-limit-param"
@@ -224,6 +230,24 @@ def _int_subscript_inner(annotation: ast.Subscript) -> ast.expr | None:
     return None
 
 
+def _is_none_annotation(annotation: ast.expr | None) -> bool:
+    """Return True if *annotation* is the literal ``None`` constant."""
+    return isinstance(annotation, ast.Constant) and annotation.value is None
+
+
+def _is_int_or_none_binop(annotation: ast.BinOp) -> bool:
+    """Return True for ``int | None`` / ``None | int`` BinOp shapes only.
+
+    Accepts the two permutations of an ``int``-with-``None`` union; any
+    other combination (``int | str``, ``None | None``, ``str | None``,
+    nested unions ending elsewhere) returns False so the caller rejects.
+    """
+    left, right = annotation.left, annotation.right
+    return (_is_int_annotation(left) and _is_none_annotation(right)) or (
+        _is_none_annotation(left) and _is_int_annotation(right)
+    )
+
+
 def _is_int_annotation(annotation: ast.expr | None) -> bool:
     """Return True if *annotation* permits only ``int`` or ``int | None``.
 
@@ -231,27 +255,26 @@ def _is_int_annotation(annotation: ast.expr | None) -> bool:
 
     * ``int`` (bare ``ast.Name``).
     * ``int | None`` / ``None | int`` (``ast.BinOp`` over ``BitOr``,
-      either operand order).
+      with one operand ``int`` and the other literally ``None``).
     * ``Optional[int]`` (``ast.Subscript`` over ``Optional``).
     * ``Annotated[int, ...]`` / ``Annotated[int | None, ...]`` (PEP 593
       metadata wrapper; the gate looks through the wrapper at the first
       slice element).
 
-    A missing annotation, an annotation typed as ``str`` / ``object`` /
-    any other base type, or a union containing a non-``int`` member
-    returns ``False`` -- the caller treats that as
-    ``invalid-limit-annotation``.
+    Standalone ``None`` is NOT a valid ``limit`` type; it only counts as
+    valid when paired with ``int`` inside a union. A missing annotation,
+    a non-``int`` base type (``str`` / ``object`` / ...), or a union
+    containing a non-``int``/``None`` member returns ``False`` -- the
+    caller treats that as ``invalid-limit-annotation``.
     """
     if annotation is None:
         return False
     if isinstance(annotation, ast.Name):
         return annotation.id == "int"
     if isinstance(annotation, ast.Constant):
-        return annotation.value is None
+        return False
     if isinstance(annotation, ast.BinOp) and isinstance(annotation.op, ast.BitOr):
-        return _is_int_annotation(annotation.left) and _is_int_annotation(
-            annotation.right
-        )
+        return _is_int_or_none_binop(annotation)
     if isinstance(annotation, ast.Subscript):
         return _is_int_annotation(_int_subscript_inner(annotation))
     return False

--- a/scripts/list_pagination_baseline.txt
+++ b/scripts/list_pagination_baseline.txt
@@ -1,0 +1,55 @@
+# Frozen baseline of pre-existing list_*/query repository methods missing
+# required `limit` pagination. Each line is
+# `<posix-path>:<class>.<method>:<reason>` sorted in deterministic order.
+#
+# Reasons:
+#   missing-limit-param      -- no `limit` parameter exists
+#   nullable-limit-no-cursor -- limit default is None and no cursor/offset sibling
+#
+# scripts/check_list_pagination.py reads this file to suppress violations
+# at these exact sites. New offenders NOT in this list will fail the
+# pre-push hook. An entry here that no longer matches a real offender
+# (method renamed, fixed, deleted) is reported as `baseline-stale` so
+# the file must be regenerated when shrinkage is genuine.
+#
+# Regenerate (rare; requires explicit user approval) with:
+#   uv run python scripts/check_list_pagination.py --update
+#
+# Issue #1752 (audit cluster #19).
+src/synthorg/persistence/custom_rule_repo.py:CustomRuleRepository.list_rules:missing-limit-param
+src/synthorg/persistence/postgres/custom_rule_repo.py:PostgresCustomRuleRepository.list_rules:missing-limit-param
+src/synthorg/persistence/postgres/hr_repositories.py:PostgresCollaborationMetricRepository.query:missing-limit-param
+src/synthorg/persistence/postgres/hr_repositories.py:PostgresTaskMetricRepository.query:missing-limit-param
+src/synthorg/persistence/postgres/preset_repo.py:PostgresPersonalityPresetRepository.list_all:missing-limit-param
+src/synthorg/persistence/postgres/project_repo.py:PostgresProjectRepository.list_projects:missing-limit-param
+src/synthorg/persistence/postgres/risk_override_repo.py:PostgresRiskOverrideRepository.list_active:missing-limit-param
+src/synthorg/persistence/postgres/subworkflow_repo.py:PostgresSubworkflowRepository.list_summaries:missing-limit-param
+src/synthorg/persistence/postgres/subworkflow_repo.py:PostgresSubworkflowRepository.list_versions:missing-limit-param
+src/synthorg/persistence/postgres/training_plan_repo.py:PostgresTrainingPlanRepository.list_by_agent:missing-limit-param
+src/synthorg/persistence/postgres/user_repo.py:PostgresUserRepository.list_users:missing-limit-param
+src/synthorg/persistence/postgres/workflow_definition_repo.py:PostgresWorkflowDefinitionRepository.list_definitions:missing-limit-param
+src/synthorg/persistence/postgres/workflow_execution_repo.py:PostgresWorkflowExecutionRepository.list_by_definition:missing-limit-param
+src/synthorg/persistence/postgres/workflow_execution_repo.py:PostgresWorkflowExecutionRepository.list_by_status:missing-limit-param
+src/synthorg/persistence/preset_repository.py:PersonalityPresetRepository.list_all:missing-limit-param
+src/synthorg/persistence/project_protocol.py:ProjectRepository.list_projects:missing-limit-param
+src/synthorg/persistence/risk_override_repo.py:RiskOverrideRepository.list_active:missing-limit-param
+src/synthorg/persistence/sqlite/custom_rule_repo.py:SQLiteCustomRuleRepository.list_rules:missing-limit-param
+src/synthorg/persistence/sqlite/hr_repositories.py:SQLiteCollaborationMetricRepository.query:missing-limit-param
+src/synthorg/persistence/sqlite/hr_repositories.py:SQLiteTaskMetricRepository.query:missing-limit-param
+src/synthorg/persistence/sqlite/preset_repo.py:SQLitePersonalityPresetRepository.list_all:missing-limit-param
+src/synthorg/persistence/sqlite/project_repo.py:SQLiteProjectRepository.list_projects:missing-limit-param
+src/synthorg/persistence/sqlite/risk_override_repo.py:SQLiteRiskOverrideRepository.list_active:missing-limit-param
+src/synthorg/persistence/sqlite/subworkflow_repo.py:SQLiteSubworkflowRepository.list_summaries:missing-limit-param
+src/synthorg/persistence/sqlite/subworkflow_repo.py:SQLiteSubworkflowRepository.list_versions:missing-limit-param
+src/synthorg/persistence/sqlite/training_plan_repo.py:SQLiteTrainingPlanRepository.list_by_agent:missing-limit-param
+src/synthorg/persistence/sqlite/user_repo.py:SQLiteUserRepository.list_users:missing-limit-param
+src/synthorg/persistence/sqlite/workflow_definition_repo.py:SQLiteWorkflowDefinitionRepository.list_definitions:missing-limit-param
+src/synthorg/persistence/sqlite/workflow_execution_repo.py:SQLiteWorkflowExecutionRepository.list_by_definition:missing-limit-param
+src/synthorg/persistence/sqlite/workflow_execution_repo.py:SQLiteWorkflowExecutionRepository.list_by_status:missing-limit-param
+src/synthorg/persistence/subworkflow_repo.py:SubworkflowRepository.list_summaries:missing-limit-param
+src/synthorg/persistence/subworkflow_repo.py:SubworkflowRepository.list_versions:missing-limit-param
+src/synthorg/persistence/training_repos.py:TrainingPlanRepository.list_by_agent:missing-limit-param
+src/synthorg/persistence/user_protocol.py:UserRepository.list_users:missing-limit-param
+src/synthorg/persistence/workflow_definition_repo.py:WorkflowDefinitionRepository.list_definitions:missing-limit-param
+src/synthorg/persistence/workflow_execution_repo.py:WorkflowExecutionRepository.list_by_definition:missing-limit-param
+src/synthorg/persistence/workflow_execution_repo.py:WorkflowExecutionRepository.list_by_status:missing-limit-param

--- a/scripts/list_pagination_baseline.txt
+++ b/scripts/list_pagination_baseline.txt
@@ -14,8 +14,6 @@
 #
 # Regenerate (rare; requires explicit user approval) with:
 #   uv run python scripts/check_list_pagination.py --update
-#
-# Issue #1752 (audit cluster #19).
 src/synthorg/persistence/custom_rule_repo.py:CustomRuleRepository.list_rules:missing-limit-param
 src/synthorg/persistence/postgres/custom_rule_repo.py:PostgresCustomRuleRepository.list_rules:missing-limit-param
 src/synthorg/persistence/postgres/hr_repositories.py:PostgresCollaborationMetricRepository.query:missing-limit-param

--- a/tests/unit/scripts/test_check_domain_error_hierarchy.py
+++ b/tests/unit/scripts/test_check_domain_error_hierarchy.py
@@ -447,23 +447,36 @@ def test_clean_tree_returns_zero(
     assert rc == 0
 
 
+_INHERITED_GIT_VARS: tuple[tuple[str, str], ...] = (
+    ("GIT_DIR", "/outer/repo/.git"),
+    ("GIT_WORK_TREE", "/outer/repo"),
+    ("GIT_INDEX_FILE", "/outer/repo/.git/index"),
+    ("GIT_OBJECT_DIRECTORY", "/outer/repo/.git/objects"),
+    ("GIT_COMMON_DIR", "/outer/repo/.git"),
+)
+
+
+def _spy_subprocess_run(
+    monkeypatch: pytest.MonkeyPatch, captured_env: dict[str, str]
+) -> None:
+    """Patch ``subprocess.run`` on the gate to record env and force fallback."""
+
+    def _fake_run(*args: object, **kwargs: object) -> object:
+        del args
+        env = kwargs.get("env")
+        if isinstance(env, dict):
+            captured_env.update(env)
+        raise subprocess.CalledProcessError(returncode=1, cmd=["git", "ls-files"])
+
+    module_subprocess = getattr(_MODULE, "subprocess")  # noqa: B009
+    monkeypatch.setattr(module_subprocess, "run", _fake_run)
+
+
 def test_scan_tree_ignores_inherited_git_dir(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Pre-push leaks GIT_DIR/GIT_WORK_TREE; the gate must scope to ``cwd``.
-
-    Without this guard, ``git ls-files`` would honour the inherited Git
-    pointers and return the *outer* repo's tracked files, producing a
-    flood of "unable to read file" parse errors against tmp_path paths
-    that do not exist.
-
-    Asserting on ``issues == []`` alone is not discriminating: even
-    without the env strip the call may fall back to ``rglob`` on a
-    non-existent ``.git`` and produce no issues. So spy on
-    ``subprocess.run`` and check the actual ``env`` that was passed --
-    that is what the implementation must scrub.
-    """
+    """Pre-push-inherited GIT_* env vars must be scrubbed before git ls-files."""
     project_root, _ = _make_project(
         tmp_path,
         {
@@ -475,25 +488,16 @@ def test_scan_tree_ignores_inherited_git_dir(
             ),
         },
     )
-    monkeypatch.setenv("GIT_DIR", "/outer/repo/.git")
-    monkeypatch.setenv("GIT_WORK_TREE", "/outer/repo")
-    monkeypatch.setenv("GIT_INDEX_FILE", "/outer/repo/.git/index")
+    for name, value in _INHERITED_GIT_VARS:
+        monkeypatch.setenv(name, value)
 
     captured_env: dict[str, str] = {}
+    _spy_subprocess_run(monkeypatch, captured_env)
 
-    def _fake_run(*args: object, **kwargs: object) -> object:
-        del args
-        env = kwargs.get("env")
-        if isinstance(env, dict):
-            captured_env.update(env)
-        raise subprocess.CalledProcessError(returncode=1, cmd=["git", "ls-files"])
-
-    module_subprocess = getattr(_MODULE, "subprocess")  # noqa: B009
-    monkeypatch.setattr(module_subprocess, "run", _fake_run)
     issues = _MODULE._scan_tree(project_root, project_root / "src" / "synthorg")
     assert issues == []
     assert captured_env, "subprocess.run was not invoked"
-    for leaked in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE"):
+    for leaked, _ in _INHERITED_GIT_VARS:
         assert leaked not in captured_env, (
             f"{leaked} leaked into git ls-files env: scrubbing regressed"
         )

--- a/tests/unit/scripts/test_check_domain_error_hierarchy.py
+++ b/tests/unit/scripts/test_check_domain_error_hierarchy.py
@@ -446,6 +446,34 @@ def test_clean_tree_returns_zero(
     assert rc == 0
 
 
+def test_scan_tree_ignores_inherited_git_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pre-push leaks GIT_DIR/GIT_WORK_TREE; the gate must scope to ``cwd``.
+
+    Without this guard, ``git ls-files`` would honour the inherited Git
+    pointers and return the *outer* repo's tracked files, producing a
+    flood of "unable to read file" parse errors against tmp_path
+    paths that do not exist.
+    """
+    project_root, _ = _make_project(
+        tmp_path,
+        {
+            "src/synthorg/foo/errors.py": (
+                "from synthorg.core.domain_errors import DomainError\n"
+                "\n"
+                "class FooError(DomainError):\n"
+                "    pass\n"
+            ),
+        },
+    )
+    monkeypatch.setenv("GIT_DIR", ".git")
+    monkeypatch.setenv("GIT_WORK_TREE", ".")
+    issues = _MODULE._scan_tree(project_root, project_root / "src" / "synthorg")
+    assert issues == []
+
+
 def test_update_baseline_writes_sorted(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/scripts/test_check_domain_error_hierarchy.py
+++ b/tests/unit/scripts/test_check_domain_error_hierarchy.py
@@ -1,6 +1,7 @@
 """Tests for the domain-error-hierarchy AST gate."""
 
 import importlib.util
+import subprocess
 from pathlib import Path
 from typing import Protocol, cast
 
@@ -454,8 +455,14 @@ def test_scan_tree_ignores_inherited_git_dir(
 
     Without this guard, ``git ls-files`` would honour the inherited Git
     pointers and return the *outer* repo's tracked files, producing a
-    flood of "unable to read file" parse errors against tmp_path
-    paths that do not exist.
+    flood of "unable to read file" parse errors against tmp_path paths
+    that do not exist.
+
+    Asserting on ``issues == []`` alone is not discriminating: even
+    without the env strip the call may fall back to ``rglob`` on a
+    non-existent ``.git`` and produce no issues. So spy on
+    ``subprocess.run`` and check the actual ``env`` that was passed --
+    that is what the implementation must scrub.
     """
     project_root, _ = _make_project(
         tmp_path,
@@ -468,10 +475,28 @@ def test_scan_tree_ignores_inherited_git_dir(
             ),
         },
     )
-    monkeypatch.setenv("GIT_DIR", ".git")
-    monkeypatch.setenv("GIT_WORK_TREE", ".")
+    monkeypatch.setenv("GIT_DIR", "/outer/repo/.git")
+    monkeypatch.setenv("GIT_WORK_TREE", "/outer/repo")
+    monkeypatch.setenv("GIT_INDEX_FILE", "/outer/repo/.git/index")
+
+    captured_env: dict[str, str] = {}
+
+    def _fake_run(*args: object, **kwargs: object) -> object:
+        del args
+        env = kwargs.get("env")
+        if isinstance(env, dict):
+            captured_env.update(env)
+        raise subprocess.CalledProcessError(returncode=1, cmd=["git", "ls-files"])
+
+    module_subprocess = getattr(_MODULE, "subprocess")  # noqa: B009
+    monkeypatch.setattr(module_subprocess, "run", _fake_run)
     issues = _MODULE._scan_tree(project_root, project_root / "src" / "synthorg")
     assert issues == []
+    assert captured_env, "subprocess.run was not invoked"
+    for leaked in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE"):
+        assert leaked not in captured_env, (
+            f"{leaked} leaked into git ls-files env: scrubbing regressed"
+        )
 
 
 def test_update_baseline_writes_sorted(

--- a/tests/unit/scripts/test_check_list_pagination.py
+++ b/tests/unit/scripts/test_check_list_pagination.py
@@ -254,12 +254,12 @@ class TestListPaginationGate:
 
     @pytest.mark.parametrize(
         "annotation",
-        ["Sequence[str]", "list[str]", "tuple[str, ...]", "Iterable[str]"],
+        ["Sequence[str]", "list[str]", "tuple[str, ...]", "Collection[str]"],
     )
     def test_list_with_required_sequence_filter_passes(
         self, write_sample: WriteSampleFile, annotation: str
     ) -> None:
-        """A required Sequence-typed filter bounds the result by input cardinality."""
+        """A required Sized-sequence filter bounds the result by input cardinality."""
         src = (
             "class FooRepository:\n"
             "    async def list_by_ids(\n"
@@ -270,6 +270,23 @@ class TestListPaginationGate:
             "        ...\n"
         )
         assert _scan(write_sample(src)) == []
+
+    def test_iterable_filter_does_not_bound_result(
+        self, write_sample: WriteSampleFile
+    ) -> None:
+        """``Iterable[X]`` is unbounded (no ``__len__``); must not satisfy gate."""
+        src = (
+            "class FooRepository:\n"
+            "    async def list_by_ids(\n"
+            "        self,\n"
+            "        *,\n"
+            "        ids: Iterable[str],\n"
+            "    ) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        violations = _scan(write_sample(src))
+        assert len(violations) == 1
+        assert violations[0][2] == "missing-limit-param"
 
     def test_list_with_optional_sequence_filter_fails(
         self, write_sample: WriteSampleFile
@@ -331,6 +348,8 @@ class TestListPaginationGate:
             ("limit: str | int", "union with non-int leg is unbounded"),
             ("limit", "unannotated limit slips type-checker entirely"),
             ("limit = 100", "unannotated with default still has no type"),
+            ("limit: None = 100", "standalone None is not an int"),
+            ("limit: None | None", "union of None with itself never accepts an int"),
         ],
     )
     def test_non_int_limit_annotation_fails(

--- a/tests/unit/scripts/test_check_list_pagination.py
+++ b/tests/unit/scripts/test_check_list_pagination.py
@@ -24,11 +24,14 @@ class _CheckListPaginationModule(Protocol):
     _REPO_ROOT: Path
     _PERSISTENCE_ROOT: Path
     _BASELINE_PATH: Path
+    _BASELINE_HEADER: str
 
     @staticmethod
     def _load_baseline() -> set[str]: ...
     @staticmethod
     def _scan_file(path: Path, rel: str) -> list[tuple[str, str, str, int]]: ...
+    @staticmethod
+    def _scan(path: Path, baseline: set[str]) -> tuple[list[str], set[str]]: ...
     @staticmethod
     def _format_entry(
         rel: str, class_name: str, method_name: str, reason: str
@@ -37,6 +40,8 @@ class _CheckListPaginationModule(Protocol):
     def cmd_scan_paths(paths: Iterable[str]) -> int: ...
     @staticmethod
     def cmd_scan_all() -> int: ...
+    @staticmethod
+    def cmd_update() -> int: ...
 
 
 def _load_module() -> _CheckListPaginationModule:
@@ -71,8 +76,6 @@ def _scan(path: Path) -> list[tuple[str, str, str, int]]:
 
 
 class TestListPaginationGate:
-    """Signature-level pagination contract for repository methods."""
-
     def test_list_with_required_limit_passes(
         self, write_sample: WriteSampleFile
     ) -> None:
@@ -181,7 +184,7 @@ class TestListPaginationGate:
     def test_bare_query_treated_like_query_underscore(
         self, write_sample: WriteSampleFile
     ) -> None:
-        """``query`` (no underscore) is the canonical CRUD name in §14."""
+        """``query`` (no underscore) is the canonical CRUD name."""
         src = (
             "class FooRepository:\n"
             "    def query(self) -> tuple[int, ...]:\n"
@@ -206,7 +209,6 @@ class TestListPaginationGate:
         assert violations[0][2] == "missing-limit-param"
 
     def test_private_methods_skipped(self, write_sample: WriteSampleFile) -> None:
-        """``_list_*`` is a private helper, not a public list endpoint."""
         src = (
             "class FooRepository:\n"
             "    def _list_internal(self) -> tuple[int, ...]:\n"
@@ -219,7 +221,6 @@ class TestListPaginationGate:
     def test_non_list_query_methods_not_flagged(
         self, write_sample: WriteSampleFile
     ) -> None:
-        """Other names (``get_history``, ``search``, ``list_all``) are out of scope."""
         src = (
             "class FooRepository:\n"
             "    def get_history(self) -> tuple[int, ...]:\n"
@@ -231,27 +232,79 @@ class TestListPaginationGate:
         )
         assert _scan(write_sample(src)) == []
 
-    def test_list_with_after_id_cursor_passes(
-        self, write_sample: WriteSampleFile
+    @pytest.mark.parametrize(
+        "cursor_name", ["cursor", "offset", "after_id", "before_id"]
+    )
+    def test_list_with_any_cursor_name_passes(
+        self, write_sample: WriteSampleFile, cursor_name: str
     ) -> None:
-        """``after_id`` is a recognised keyset-cursor name."""
         src = (
             "class FooRepository:\n"
             "    async def list_pages(\n"
             "        self,\n"
             "        *,\n"
-            "        after_id: str | None = None,\n"
+            f"        {cursor_name}: str | None = None,\n"
             "        limit: int | None = None,\n"
             "    ) -> tuple[int, ...]:\n"
             "        ...\n"
         )
         assert _scan(write_sample(src)) == []
 
-    def test_lint_allow_marker_suppresses_violation(
+    @pytest.mark.parametrize(
+        "annotation",
+        ["Sequence[str]", "list[str]", "tuple[str, ...]", "Iterable[str]"],
+    )
+    def test_list_with_required_sequence_filter_passes(
+        self, write_sample: WriteSampleFile, annotation: str
+    ) -> None:
+        """A required Sequence-typed filter bounds the result by input cardinality."""
+        src = (
+            "class FooRepository:\n"
+            "    async def list_by_ids(\n"
+            "        self,\n"
+            "        *,\n"
+            f"        ids: {annotation},\n"
+            "    ) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        assert _scan(write_sample(src)) == []
+
+    def test_list_with_optional_sequence_filter_fails(
+        self, write_sample: WriteSampleFile
+    ) -> None:
+        """A defaulted Sequence (caller can omit) does NOT bound the result."""
+        src = (
+            "class FooRepository:\n"
+            "    async def list_by_ids(\n"
+            "        self,\n"
+            "        *,\n"
+            "        ids: list[str] | None = None,\n"
+            "    ) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        violations = _scan(write_sample(src))
+        assert len(violations) == 1
+        assert violations[0][2] == "missing-limit-param"
+
+    def test_non_literal_default_expression_passes(
+        self, write_sample: WriteSampleFile
+    ) -> None:
+        """``limit: int = SOME_CONST`` slips through by design (loophole)."""
+        src = (
+            "class FooRepository:\n"
+            "    def list_items(\n"
+            "        self,\n"
+            "        *,\n"
+            "        limit: int = PageSize.DEFAULT,\n"
+            "    ) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        assert _scan(write_sample(src)) == []
+
+    def test_lint_allow_marker_in_comment_suppresses(
         self,
         tmp_path: Path,
     ) -> None:
-        """A ``# lint-allow: list-pagination -- <reason>`` marker suppresses."""
         src = (
             "class FooRepository:\n"
             "    def list_items(self) -> tuple[int, ...]:  "
@@ -260,24 +313,38 @@ class TestListPaginationGate:
         )
         path = tmp_path / "sample.py"
         path.write_text(src, encoding="utf-8")
+        assert _scan(path) == []
+
+    def test_lint_allow_marker_in_string_default_does_not_suppress(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The marker only counts when in the actual comment, not in a string."""
+        src = (
+            "class FooRepository:\n"
+            "    def list_items(self, msg: str = "
+            "'lint-allow: list-pagination -- fake'):\n"
+            "        ...\n"
+        )
+        path = tmp_path / "sample.py"
+        path.write_text(src, encoding="utf-8")
         violations = _scan(path)
-        assert violations == []
+        assert len(violations) == 1
+        assert violations[0][2] == "missing-limit-param"
 
     def test_baseline_entry_suppresses_violation(
         self,
         write_sample: WriteSampleFile,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Entries in the baseline are not re-reported by ``cmd_scan_paths``."""
         src = (
             "class FooRepository:\n"
             "    def list_items(self) -> tuple[int, ...]:\n"
             "        ...\n"
         )
         path = write_sample(src, name="legacy_repo.py")
-        rel = "legacy_repo.py"
         baselined = _MODULE._format_entry(
-            rel, "FooRepository", "list_items", "missing-limit-param"
+            "legacy_repo.py", "FooRepository", "list_items", "missing-limit-param"
         )
         monkeypatch.setattr(_MODULE, "_REPO_ROOT", path.parent)
         monkeypatch.setattr(_MODULE, "_PERSISTENCE_ROOT", path.parent)
@@ -291,7 +358,6 @@ class TestListPaginationGate:
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """A new violation absent from the baseline trips the gate."""
         src = (
             "class NewRepository:\n"
             "    def list_widgets(self) -> tuple[int, ...]:\n"
@@ -307,7 +373,186 @@ class TestListPaginationGate:
         assert "NewRepository.list_widgets" in out
         assert "missing-limit-param" in out
 
-    def test_unparseable_file_raises(self, write_sample: WriteSampleFile) -> None:
+    def test_cmd_scan_paths_skips_paths_outside_persistence_root(
+        self,
+        write_sample: WriteSampleFile,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Pre-push must never crash on files outside the persistence tree."""
+        src = (
+            "class NewRepository:\n"
+            "    def list_widgets(self) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        path = write_sample(src, name="api_handler.py")
+        outside_root = path.parent / "other_root"
+        outside_root.mkdir()
+        monkeypatch.setattr(_MODULE, "_REPO_ROOT", path.parent)
+        monkeypatch.setattr(_MODULE, "_PERSISTENCE_ROOT", outside_root)
+        monkeypatch.setattr(_MODULE, "_load_baseline", set)
+        rc = _MODULE.cmd_scan_paths([str(path)])
+        assert rc == 0
+
+    def test_cmd_scan_paths_exit_2_on_parse_failure(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A syntax-broken file inside persistence root fails loudly (exit 2)."""
+        broken = tmp_path / "broken_repo.py"
+        broken.write_text("def broken(:\n", encoding="utf-8")
+        monkeypatch.setattr(_MODULE, "_REPO_ROOT", tmp_path)
+        monkeypatch.setattr(_MODULE, "_PERSISTENCE_ROOT", tmp_path)
+        monkeypatch.setattr(_MODULE, "_load_baseline", set)
+        rc = _MODULE.cmd_scan_paths([str(broken)])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "broken_repo.py" in err
+        assert "SyntaxError" in err
+
+    def test_cmd_scan_all_reports_baseline_stale_for_shrinkage(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A baseline entry that no longer matches surfaces as ``baseline-stale``."""
+        # Persistence dir contains one offender that IS in the baseline.
+        compliant_repo = tmp_path / "compliant_repo.py"
+        compliant_repo.write_text(
+            "class FooRepository:\n"
+            "    def list_items(self, *, limit: int = 100) -> tuple[int, ...]:\n"
+            "        ...\n",
+            encoding="utf-8",
+        )
+        # Baseline has an entry for a DIFFERENT method that no longer exists.
+        stale_entry = _MODULE._format_entry(
+            "compliant_repo.py",
+            "FooRepository",
+            "list_orphans",
+            "missing-limit-param",
+        )
+        monkeypatch.setattr(_MODULE, "_REPO_ROOT", tmp_path)
+        monkeypatch.setattr(_MODULE, "_PERSISTENCE_ROOT", tmp_path)
+        monkeypatch.setattr(_MODULE, "_load_baseline", lambda: {stale_entry})
+        rc = _MODULE.cmd_scan_all()
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert f"baseline-stale: {stale_entry}" in out
+
+    def test_cmd_scan_all_exit_2_on_parse_failure(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A parse failure during full scan exits 2, not 1."""
+        broken = tmp_path / "broken_repo.py"
+        broken.write_text("def broken(:\n", encoding="utf-8")
+        monkeypatch.setattr(_MODULE, "_REPO_ROOT", tmp_path)
+        monkeypatch.setattr(_MODULE, "_PERSISTENCE_ROOT", tmp_path)
+        monkeypatch.setattr(_MODULE, "_load_baseline", set)
+        rc = _MODULE.cmd_scan_all()
+        assert rc == 2
+
+    def test_cmd_update_writes_sorted_baseline_with_header(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``--update`` regenerates a sorted, header-prefixed baseline."""
+        # Two offenders in alphabetical-reverse order across two files.
+        (tmp_path / "z_repo.py").write_text(
+            "class ZRepository:\n"
+            "    def list_z(self) -> tuple[int, ...]:\n"
+            "        ...\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "a_repo.py").write_text(
+            "class ARepository:\n"
+            "    def list_a(self) -> tuple[int, ...]:\n"
+            "        ...\n",
+            encoding="utf-8",
+        )
+        baseline_target = tmp_path / "baseline.txt"
+        monkeypatch.setattr(_MODULE, "_REPO_ROOT", tmp_path)
+        monkeypatch.setattr(_MODULE, "_PERSISTENCE_ROOT", tmp_path)
+        monkeypatch.setattr(_MODULE, "_BASELINE_PATH", baseline_target)
+        rc = _MODULE.cmd_update()
+        assert rc == 0
+        body = baseline_target.read_text(encoding="utf-8")
+        assert body.startswith(_MODULE._BASELINE_HEADER)
+        entries = [
+            line for line in body.splitlines() if line and not line.startswith("#")
+        ]
+        assert entries == sorted(entries)
+        assert any("ARepository.list_a" in e for e in entries)
+        assert any("ZRepository.list_z" in e for e in entries)
+
+    def test_load_baseline_returns_empty_when_file_absent(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Init case: baseline file missing → empty allowlist, no crash."""
+        missing = tmp_path / "does_not_exist.txt"
+        monkeypatch.setattr(_MODULE, "_BASELINE_PATH", missing)
+        assert _MODULE._load_baseline() == set()
+
+    def test_load_baseline_rejects_malformed_entries(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Malformed line raises ValueError with diagnostic on stderr."""
+        baseline = tmp_path / "baseline.txt"
+        baseline.write_text(
+            "# header comment\n"
+            "src/synthorg/persistence/x.py:Foo.bar:missing-limit-param\n"
+            "this-is-not-a-valid-entry\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(_MODULE, "_BASELINE_PATH", baseline)
+        monkeypatch.setattr(_MODULE, "_REPO_ROOT", tmp_path)
+        with pytest.raises(ValueError, match="failed validation"):
+            _MODULE._load_baseline()
+        err = capsys.readouterr().err
+        assert "malformed entry" in err
+        assert "this-is-not-a-valid-entry" in err
+
+    def test_load_baseline_rejects_duplicate_entries(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        baseline = tmp_path / "baseline.txt"
+        entry = "src/synthorg/persistence/x.py:Foo.bar:missing-limit-param"
+        baseline.write_text(f"{entry}\n{entry}\n", encoding="utf-8")
+        monkeypatch.setattr(_MODULE, "_BASELINE_PATH", baseline)
+        monkeypatch.setattr(_MODULE, "_REPO_ROOT", tmp_path)
+        with pytest.raises(ValueError, match="failed validation"):
+            _MODULE._load_baseline()
+        err = capsys.readouterr().err
+        assert "duplicate entry" in err
+
+    def test_load_baseline_value_error_includes_first_error(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The exception message embeds the first error for pipeline visibility."""
+        baseline = tmp_path / "baseline.txt"
+        baseline.write_text("garbage-line\n", encoding="utf-8")
+        monkeypatch.setattr(_MODULE, "_BASELINE_PATH", baseline)
+        monkeypatch.setattr(_MODULE, "_REPO_ROOT", tmp_path)
+        with pytest.raises(ValueError, match=r"first: .*malformed entry"):
+            _MODULE._load_baseline()
+
+    def test_unparseable_file_raises_inspection_error(
+        self, write_sample: WriteSampleFile
+    ) -> None:
         path = write_sample("def broken(:\n")
         with pytest.raises(_MODULE.InspectionError):
             _scan(path)

--- a/tests/unit/scripts/test_check_list_pagination.py
+++ b/tests/unit/scripts/test_check_list_pagination.py
@@ -42,6 +42,8 @@ class _CheckListPaginationModule(Protocol):
     def cmd_scan_all() -> int: ...
     @staticmethod
     def cmd_update() -> int: ...
+    @staticmethod
+    def main(argv: list[str] | None = None) -> int: ...
 
 
 def _load_module() -> _CheckListPaginationModule:
@@ -296,6 +298,82 @@ class TestListPaginationGate:
             "        self,\n"
             "        *,\n"
             "        limit: int = PageSize.DEFAULT,\n"
+            "    ) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        assert _scan(write_sample(src)) == []
+
+    @pytest.mark.parametrize(
+        "annotation",
+        ["int", "int | None", "None | int", "Optional[int]"],
+    )
+    def test_int_compatible_limit_annotations_pass(
+        self, write_sample: WriteSampleFile, annotation: str
+    ) -> None:
+        """``int``-shaped annotations on ``limit`` satisfy the gate."""
+        src = (
+            "class FooRepository:\n"
+            "    def list_items(\n"
+            "        self,\n"
+            "        *,\n"
+            f"        limit: {annotation} = None,\n"
+            "        cursor: str | None = None,\n"
+            "    ) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        assert _scan(write_sample(src)) == []
+
+    @pytest.mark.parametrize(
+        ("signature", "comment"),
+        [
+            ("limit: str", "string-typed limit is not a row count"),
+            ("limit: object = 100", "object annotation hides any actual type"),
+            ("limit: str | int", "union with non-int leg is unbounded"),
+            ("limit", "unannotated limit slips type-checker entirely"),
+            ("limit = 100", "unannotated with default still has no type"),
+        ],
+    )
+    def test_non_int_limit_annotation_fails(
+        self, write_sample: WriteSampleFile, signature: str, comment: str
+    ) -> None:
+        """``limit`` typed as anything other than ``int``/``int | None`` fails."""
+        del comment
+        src = (
+            "class FooRepository:\n"
+            "    def list_items(\n"
+            "        self,\n"
+            "        *,\n"
+            f"        {signature},\n"
+            "    ) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        violations = _scan(write_sample(src))
+        assert len(violations) == 1
+        assert violations[0][2] == "invalid-limit-annotation"
+
+    def test_annotated_sequence_filter_passes(
+        self, write_sample: WriteSampleFile
+    ) -> None:
+        """``Annotated[Sequence[str], ...]`` (PEP 593) bounds the result."""
+        src = (
+            "class FooRepository:\n"
+            "    async def list_by_ids(\n"
+            "        self,\n"
+            "        *,\n"
+            "        ids: Annotated[Sequence[str], MinLen(1)],\n"
+            "    ) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        assert _scan(write_sample(src)) == []
+
+    def test_annotated_int_limit_passes(self, write_sample: WriteSampleFile) -> None:
+        """``Annotated[int, ...]`` resolves through the metadata wrapper."""
+        src = (
+            "class FooRepository:\n"
+            "    def list_items(\n"
+            "        self,\n"
+            "        *,\n"
+            "        limit: Annotated[int, Field(ge=1)] = 100,\n"
             "    ) -> tuple[int, ...]:\n"
             "        ...\n"
         )
@@ -556,3 +634,21 @@ class TestListPaginationGate:
         path = write_sample("def broken(:\n")
         with pytest.raises(_MODULE.InspectionError):
             _scan(path)
+
+    def test_main_normalises_inspection_error_from_update(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``main --update`` returns exit 2 on parse failure, not a traceback."""
+        broken = tmp_path / "broken_repo.py"
+        broken.write_text("def broken(:\n", encoding="utf-8")
+        monkeypatch.setattr(_MODULE, "_REPO_ROOT", tmp_path)
+        monkeypatch.setattr(_MODULE, "_PERSISTENCE_ROOT", tmp_path)
+        monkeypatch.setattr(_MODULE, "_BASELINE_PATH", tmp_path / "baseline.txt")
+        rc = _MODULE.main(["--update"])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "check_list_pagination:" in err
+        assert "broken_repo.py" in err

--- a/tests/unit/scripts/test_check_list_pagination.py
+++ b/tests/unit/scripts/test_check_list_pagination.py
@@ -1,0 +1,313 @@
+"""Tests for the list_*/query_* pagination pre-push gate."""
+
+import importlib.util
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Protocol, cast
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class WriteSampleFile(Protocol):
+    """Callable signature for the ``write_sample`` fixture."""
+
+    def __call__(self, content: str, name: str = ...) -> Path: ...
+
+
+class _CheckListPaginationModule(Protocol):
+    """Subset of ``scripts/check_list_pagination.py`` exercised by tests."""
+
+    InspectionError: type[Exception]
+    _OPT_OUT_MARKER: str
+    _REPO_ROOT: Path
+    _PERSISTENCE_ROOT: Path
+    _BASELINE_PATH: Path
+
+    @staticmethod
+    def _load_baseline() -> set[str]: ...
+    @staticmethod
+    def _scan_file(path: Path, rel: str) -> list[tuple[str, str, str, int]]: ...
+    @staticmethod
+    def _format_entry(
+        rel: str, class_name: str, method_name: str, reason: str
+    ) -> str: ...
+    @staticmethod
+    def cmd_scan_paths(paths: Iterable[str]) -> int: ...
+    @staticmethod
+    def cmd_scan_all() -> int: ...
+
+
+def _load_module() -> _CheckListPaginationModule:
+    repo_root = Path(__file__).resolve().parents[3]
+    script_path = repo_root / "scripts" / "check_list_pagination.py"
+    spec = importlib.util.spec_from_file_location("check_list_pagination", script_path)
+    if spec is None or spec.loader is None:
+        msg = f"could not load module spec for {script_path}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return cast(_CheckListPaginationModule, module)
+
+
+_MODULE = _load_module()
+
+
+@pytest.fixture
+def write_sample(tmp_path: Path) -> WriteSampleFile:
+    """Return a helper that writes a synthetic Python source file."""
+
+    def _write(content: str, name: str = "sample.py") -> Path:
+        path = tmp_path / name
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    return _write
+
+
+def _scan(path: Path) -> list[tuple[str, str, str, int]]:
+    return _MODULE._scan_file(path, "fake/sample.py")
+
+
+class TestListPaginationGate:
+    """Signature-level pagination contract for repository methods."""
+
+    def test_list_with_required_limit_passes(
+        self, write_sample: WriteSampleFile
+    ) -> None:
+        src = (
+            "class FooRepository:\n"
+            "    def list_items(self, *, limit: int) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        assert _scan(write_sample(src)) == []
+
+    def test_list_with_explicit_numeric_default_passes(
+        self, write_sample: WriteSampleFile
+    ) -> None:
+        src = (
+            "class FooRepository:\n"
+            "    def list_items(self, *, limit: int = 100) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        assert _scan(write_sample(src)) == []
+
+    def test_list_with_none_default_and_cursor_passes(
+        self, write_sample: WriteSampleFile
+    ) -> None:
+        src = (
+            "class FooRepository:\n"
+            "    def list_items(\n"
+            "        self,\n"
+            "        *,\n"
+            "        limit: int | None = None,\n"
+            "        cursor: str | None = None,\n"
+            "    ) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        assert _scan(write_sample(src)) == []
+
+    def test_list_with_none_default_and_offset_passes(
+        self, write_sample: WriteSampleFile
+    ) -> None:
+        src = (
+            "class FooRepository:\n"
+            "    def list_items(\n"
+            "        self,\n"
+            "        *,\n"
+            "        limit: int | None = None,\n"
+            "        offset: int = 0,\n"
+            "    ) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        assert _scan(write_sample(src)) == []
+
+    def test_list_with_none_default_no_cursor_fails(
+        self, write_sample: WriteSampleFile
+    ) -> None:
+        src = (
+            "class FooRepository:\n"
+            "    def list_items(\n"
+            "        self,\n"
+            "        *,\n"
+            "        limit: int | None = None,\n"
+            "    ) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        violations = _scan(write_sample(src))
+        assert len(violations) == 1
+        cls, method, reason, _ = violations[0]
+        assert cls == "FooRepository"
+        assert method == "list_items"
+        assert reason == "nullable-limit-no-cursor"
+
+    def test_list_without_limit_fails(self, write_sample: WriteSampleFile) -> None:
+        src = (
+            "class FooRepository:\n"
+            "    def list_items(self) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        violations = _scan(write_sample(src))
+        assert len(violations) == 1
+        cls, method, reason, _ = violations[0]
+        assert cls == "FooRepository"
+        assert method == "list_items"
+        assert reason == "missing-limit-param"
+
+    def test_query_underscore_with_required_limit_passes(
+        self, write_sample: WriteSampleFile
+    ) -> None:
+        src = (
+            "class FooRepository:\n"
+            "    def query_costs(self, *, limit: int) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        assert _scan(write_sample(src)) == []
+
+    def test_query_underscore_without_limit_fails(
+        self, write_sample: WriteSampleFile
+    ) -> None:
+        src = (
+            "class FooRepository:\n"
+            "    def query_costs(self) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        violations = _scan(write_sample(src))
+        assert len(violations) == 1
+        assert violations[0][1] == "query_costs"
+        assert violations[0][2] == "missing-limit-param"
+
+    def test_bare_query_treated_like_query_underscore(
+        self, write_sample: WriteSampleFile
+    ) -> None:
+        """``query`` (no underscore) is the canonical CRUD name in §14."""
+        src = (
+            "class FooRepository:\n"
+            "    def query(self) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        violations = _scan(write_sample(src))
+        assert len(violations) == 1
+        assert violations[0][1] == "query"
+        assert violations[0][2] == "missing-limit-param"
+
+    def test_async_list_follows_same_rules(self, write_sample: WriteSampleFile) -> None:
+        src = (
+            "class FooRepository:\n"
+            "    async def list_widgets(self) -> tuple[int, ...]:\n"
+            "        ...\n"
+            "    async def list_gadgets(self, *, limit: int = 50) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        violations = _scan(write_sample(src))
+        assert len(violations) == 1
+        assert violations[0][1] == "list_widgets"
+        assert violations[0][2] == "missing-limit-param"
+
+    def test_private_methods_skipped(self, write_sample: WriteSampleFile) -> None:
+        """``_list_*`` is a private helper, not a public list endpoint."""
+        src = (
+            "class FooRepository:\n"
+            "    def _list_internal(self) -> tuple[int, ...]:\n"
+            "        ...\n"
+            "    async def _query_internal(self) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        assert _scan(write_sample(src)) == []
+
+    def test_non_list_query_methods_not_flagged(
+        self, write_sample: WriteSampleFile
+    ) -> None:
+        """Other names (``get_history``, ``search``, ``list_all``) are out of scope."""
+        src = (
+            "class FooRepository:\n"
+            "    def get_history(self) -> tuple[int, ...]:\n"
+            "        ...\n"
+            "    def search(self, q: str) -> tuple[int, ...]:\n"
+            "        ...\n"
+            "    def get_active(self) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        assert _scan(write_sample(src)) == []
+
+    def test_list_with_after_id_cursor_passes(
+        self, write_sample: WriteSampleFile
+    ) -> None:
+        """``after_id`` is a recognised keyset-cursor name."""
+        src = (
+            "class FooRepository:\n"
+            "    async def list_pages(\n"
+            "        self,\n"
+            "        *,\n"
+            "        after_id: str | None = None,\n"
+            "        limit: int | None = None,\n"
+            "    ) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        assert _scan(write_sample(src)) == []
+
+    def test_lint_allow_marker_suppresses_violation(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A ``# lint-allow: list-pagination -- <reason>`` marker suppresses."""
+        src = (
+            "class FooRepository:\n"
+            "    def list_items(self) -> tuple[int, ...]:  "
+            "# lint-allow: list-pagination -- legacy fixed-set\n"
+            "        ...\n"
+        )
+        path = tmp_path / "sample.py"
+        path.write_text(src, encoding="utf-8")
+        violations = _scan(path)
+        assert violations == []
+
+    def test_baseline_entry_suppresses_violation(
+        self,
+        write_sample: WriteSampleFile,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Entries in the baseline are not re-reported by ``cmd_scan_paths``."""
+        src = (
+            "class FooRepository:\n"
+            "    def list_items(self) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        path = write_sample(src, name="legacy_repo.py")
+        rel = "legacy_repo.py"
+        baselined = _MODULE._format_entry(
+            rel, "FooRepository", "list_items", "missing-limit-param"
+        )
+        monkeypatch.setattr(_MODULE, "_REPO_ROOT", path.parent)
+        monkeypatch.setattr(_MODULE, "_PERSISTENCE_ROOT", path.parent)
+        monkeypatch.setattr(_MODULE, "_load_baseline", lambda: {baselined})
+        rc = _MODULE.cmd_scan_paths([str(path)])
+        assert rc == 0
+
+    def test_new_offender_not_in_baseline_fails(
+        self,
+        write_sample: WriteSampleFile,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A new violation absent from the baseline trips the gate."""
+        src = (
+            "class NewRepository:\n"
+            "    def list_widgets(self) -> tuple[int, ...]:\n"
+            "        ...\n"
+        )
+        path = write_sample(src, name="new_repo.py")
+        monkeypatch.setattr(_MODULE, "_REPO_ROOT", path.parent)
+        monkeypatch.setattr(_MODULE, "_PERSISTENCE_ROOT", path.parent)
+        monkeypatch.setattr(_MODULE, "_load_baseline", set)
+        rc = _MODULE.cmd_scan_paths([str(path)])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "NewRepository.list_widgets" in out
+        assert "missing-limit-param" in out
+
+    def test_unparseable_file_raises(self, write_sample: WriteSampleFile) -> None:
+        path = write_sample("def broken(:\n")
+        with pytest.raises(_MODULE.InspectionError):
+            _scan(path)


### PR DESCRIPTION
Closes #1752.

## Summary

New AST-walking pre-commit + pre-push gate that catches new repository `list_*` / `query` / `query_*` methods landing without `limit` pagination — the audit-recurrence prevention layer for cluster #19.

- `scripts/check_list_pagination.py` — walks every `.py` under `src/synthorg/persistence/`, classifies each public `list_*` / `query` / `query_*` method.
- `scripts/list_pagination_baseline.txt` — 37 pre-existing offenders frozen so the gate ships without coupling to the persistence-layer fixes.
- `tests/unit/scripts/test_check_list_pagination.py` — 36 unit tests.
- `.pre-commit-config.yaml` — new `list-pagination` hook (pre-commit + pre-push, listed in pre-commit.ci skip per sister-gate convention).
- `CLAUDE.md` — `check_list_pagination.py` added to "Convention Rollout" gate inventory.

## What the gate accepts

- `list_items(*, limit: int)` — required limit
- `list_items(*, limit: int = 100)` — explicit numeric default
- `list_items(*, limit: int | None = None, cursor / offset / after_id / before_id: ...)` — cursor pagination
- `list_by_ids(*, ids: Sequence[str])` — required Sequence-typed filter (input cardinality bounds the result)
- `list_items(*, limit: int = SOME_NON_LITERAL)` — non-literal default; documented loophole, treated as compliant

## What it rejects

- No `limit` and no required Sequence filter → `missing-limit-param`
- `limit: int | None = None` with no cursor sibling → `nullable-limit-no-cursor`

## Per-line opt-out

`# lint-allow: list-pagination -- <reason>` on the `def` line. The marker is parsed only inside the line's actual comment (after an unquoted `#`), so a same-named string default does not silently suppress.

## Baseline

37 entries pre-populated from a clean `--scan-all` of current main: protocols (`project_protocol`, `user_protocol`, `custom_rule_repo`, `subworkflow_repo`, `training_repos`, `risk_override_repo`, `preset_repository`, `workflow_definition_repo`, `workflow_execution_repo`) plus the SQLite + Postgres concrete impls plus the `hr_repositories` `query` methods. Shrinkage is enforced — a baseline entry that no longer matches a real offender is reported as `baseline-stale`.

## Performance

`uv run python scripts/check_list_pagination.py --scan-all` finishes in ~0.7s on a warm cache (104 files), comfortably under the <3s pre-commit / pre-push budget.

## Test plan

- `uv run python -m pytest tests/unit/scripts/test_check_list_pagination.py -m unit -n 8` — 36 tests pass.
- `uv run python scripts/check_list_pagination.py --scan-all` — exit 0 with the 37-entry baseline.
- `uv run pre-commit run list-pagination --all-files --hook-stage pre-push` — passed locally.
- Synthetic regression (drop a `def list_widgets(self):` into `src/synthorg/persistence/`) — gate exits 1, reports new entry.
- Synthetic shrinkage (inject a fake baseline line for a non-existent file) — gate exits 1 with `baseline-stale: …`.
- Synthetic parse failure (broken syntax in a persistence file) — gate exits 2, not 1.

## Review coverage

Pre-reviewed locally by 14 agents (docs-consistency, comment-quality-rot, code-reviewer, python-reviewer, pr-test-analyzer, silent-failure-hunter, comment-analyzer, type-design-analyzer, conventions-enforcer, infra-reviewer, test-quality-reviewer, issue-resolution-verifier, mini-pass-missing-event-constants, mini-pass-race-conditions). 22 valid findings addressed; details in commit `refactor: address pre-PR review findings on pagination gate`.

## Out of scope (follow-up issues)

- Fixing the 37 baselined entries — each is a persistence-layer change touching SQL + tests; lives in scoped follow-ups that pop entries off the baseline.
- Broader name set (`get_history`, `search`, `get_active`, `list_all`, `get_*_list`, `fetch_all_*`).
- Runtime `limit > 0` validation.