### PR TITLE
fix(ci): anchor auto-rollover + dev-release skip-conditions on subject prefix

### DIFF
--- a/.github/workflows/auto-rollover.yml
+++ b/.github/workflows/auto-rollover.yml
@@ -19,13 +19,20 @@ concurrency:
 jobs:
   rollover:
     name: Check Rollover
-    # Skip on Release Please release commits and on commits that already
-    # carry a Release-As trailer (including our own rollover commits).
+    # Skip Release Please release-PR merges and our own auto-rollover
+    # PR merges. The subject-prefix matches are anchored to avoid the
+    # false-positive where any unrelated PR's body that mentions
+    # `Release-As:` in prose / code blocks would silently disable
+    # rollover for that push. Manual `Release-As:` trailers on feature
+    # PRs are still detected by the in-step grep below
+    # ("Release-As trailer already queued in unreleased commits") which
+    # matches the real anchored trailer (`^Release-As:`) rather than
+    # any substring.
     # Skip in forks -- needs the upstream-only release-bot App token.
     if: >-
       !github.event.repository.fork
       && !startsWith(github.event.head_commit.message, 'chore(main): release')
-      && !contains(github.event.head_commit.message, 'Release-As:')
+      && !startsWith(github.event.head_commit.message, 'chore: auto-rollover')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: release

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -23,15 +23,24 @@ concurrency:
 jobs:
   dev-release:
     name: Create Dev Pre-Release
-    # Skip Release Please version-bump merges and tag pushes (handled by
-    # the stable release pipeline). Also skip if a v* tag already points
-    # at this commit (the stable release just landed). Skip in forks;
-    # the release-bot App token isn't available off the upstream release
-    # environment.
+    # Skip Release Please version-bump merges and our own auto-rollover
+    # PR merges (those carry the trailer that produces the next release;
+    # they are rapidly superseded by the actual `chore(main): release`
+    # commit). Skip if a v* tag already points at this commit (the
+    # stable release just landed). Skip in forks; the release-bot App
+    # token isn't available off the upstream release environment. The
+    # subject-prefix matches are anchored to avoid the false-positive
+    # where any unrelated PR's body that mentions `Release-As:` in
+    # prose / code blocks would silently leave a gap in the per-commit
+    # dev-tag sequence. Feature PRs that carry an explicit
+    # `Release-As:` trailer in the body still mint a dev tag for their
+    # commit -- the cosmetic cost (one extra dev tag) is preferable to
+    # the prior false-positive that swallowed every dev-tag for any PR
+    # mentioning the trailer in prose.
     if: >-
       !github.event.repository.fork
       && !startsWith(github.event.head_commit.message, 'chore(main): release')
-      && !contains(github.event.head_commit.message, 'Release-As:')
+      && !startsWith(github.event.head_commit.message, 'chore: auto-rollover')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: release


### PR DESCRIPTION
## Summary

PR #1763 surfaced a pre-existing footgun in two release workflows. Both `auto-rollover.yml` and `dev-release.yml` used:

```yaml
!contains(github.event.head_commit.message, 'Release-As:')
```

This was meant to skip rollover commits, but with squash-merge it false-positive matches any PR whose body mentions `Release-As:` in prose or code blocks. #1763's merge commit body had two such prose mentions, so both workflows silently skipped on `850eaf249`:

- `auto-rollover` skipped its rollover-needed check (no harm; it would have skipped via the in-step grep anyway)
- `dev-release` skipped, leaving a gap in the per-commit dev-tag sequence (no `v0.7.10-dev.13` for that commit)

This also defers the v0.7.9 to v0.8.0 rollover trigger by one push.

## Fix

Replace `contains(message, 'Release-As:')` with anchored `startsWith(message, 'chore: auto-rollover')`. That subject prefix is the stable identity of an auto-rollover squash commit (the PR title becomes the squash subject).

Manual `Release-As:` trailers on feature PRs are still detected by:
- `auto-rollover.yml`: the in-step grep `^Release-As:` in the rollover-needed check (line ~113), which uses anchored line-start matching.
- `dev-release.yml`: no longer skipped. One extra dev tag for trailer-bearing commits is preferable to the prior false-positive that swallowed every dev tag for any PR mentioning the trailer in prose.

## Test plan

- YAML lint passes (`uv run pre-commit run check-yaml`).
- The next push to main exercises the fix:
  - If the next merge commit subject does not start with `chore(main): release` or `chore: auto-rollover`, both workflows run.
  - Auto-rollover sees `last stable = v0.7.9`, `patch == ROLLOVER_AT (9)`, and opens `chore/auto-rollover-v0.8.0` PR.
  - Dev-release mints `v0.7.10-dev.13` for that commit.
- This very PR's merge commit subject (`fix(ci): anchor auto-rollover...`) does not start with either skipped prefix, so when this lands, both workflows run on the merge commit. That is the integration test.

## Followups

If the auto-rollover PR opens but cannot auto-merge due to branch-protection's required-status-checks vs empty-diff PRs, the `report-failure` job from #1763 will surface that condition. We will deal with it in a follow-up.