### PR TITLE
feat: add convention-gate inventory meta-gate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,8 @@ ci:
   #     persistence-boundary / no-new-logger-exception-str-exc /
   #     orphan-fixtures / boundary-typed / setting-to-startup-trace /
   #     domain-error-hierarchy / list-pagination / dead-api-endpoints /
-  #     dual-backend-test-parity / schema-drift / no-magic-numbers:
+  #     dual-backend-test-parity / schema-drift / no-magic-numbers /
+  #     convention-gate-inventory:
   #     scoped gates that need ``uv`` + repo source -- redundant given
   #     the `Lint` + `Forbidden literals gate` jobs in ci.yml.
   #   - check-push-rebased / check-single-migration-per-pr /
@@ -26,7 +27,7 @@ ci:
   # scripts with no CI counterpart, and letting pre-commit.ci enforce
   # them closes the gap where a PR from a contributor who skipped local
   # hooks would otherwise introduce a regression unchecked.
-  skip: [commitizen, gitleaks, hadolint-docker, caddy-validate, no-em-dashes, no-redundant-timeout, mypy, pytest-unit, golangci-lint, go-vet, go-test, eslint-web, check-push-rebased, check-single-migration-per-pr, check-no-modify-migration, forbidden-literals, persistence-boundary, provider-complete-chokepoint, no-new-logger-exception-str-exc, orphan-fixtures, doc-drift-counts, boundary-typed, setting-to-startup-trace, list-pagination, domain-error-hierarchy, dead-api-endpoints, dual-backend-test-parity, schema-drift, no-magic-numbers]
+  skip: [commitizen, gitleaks, hadolint-docker, caddy-validate, no-em-dashes, no-redundant-timeout, mypy, pytest-unit, golangci-lint, go-vet, go-test, eslint-web, check-push-rebased, check-single-migration-per-pr, check-no-modify-migration, forbidden-literals, persistence-boundary, provider-complete-chokepoint, no-new-logger-exception-str-exc, orphan-fixtures, doc-drift-counts, boundary-typed, setting-to-startup-trace, list-pagination, domain-error-hierarchy, dead-api-endpoints, dual-backend-test-parity, schema-drift, no-magic-numbers, convention-gate-inventory]
 
 default_install_hook_types: [pre-commit, commit-msg, pre-push]
 
@@ -386,5 +387,17 @@ repos:
         # the baseline, or this config so a PR that weakens the gate
         # cannot bypass the check by not touching schema.sql.
         files: ^(src/synthorg/persistence/(sqlite|postgres)/(schema\.sql|revisions/.*\.sql)|scripts/check_schema_drift\.py|scripts/_schema_drift_.*\.py|scripts/schema_drift_baseline\.txt|\.pre-commit-config\.yaml)$
+        pass_filenames: false
+        stages: [pre-push]
+
+      - id: convention-gate-inventory
+        name: convention-gate inventory (MANDATORY <-> gate parity)
+        entry: uv run python scripts/check_convention_gate_inventory.py
+        language: system
+        # Trigger on any canonical doc file, the inventory YAML, the
+        # gate script itself, or this config so a PR that adds a
+        # MANDATORY paragraph or weakens the inventory cannot bypass
+        # the check.
+        files: ^(CLAUDE\.md|web/CLAUDE\.md|cli/CLAUDE\.md|docs/reference/.*\.md|docs/design/.*\.md|scripts/check_convention_gate_inventory\.py|scripts/convention_gate_map\.yaml|\.pre-commit-config\.yaml)$
         pass_filenames: false
         stages: [pre-push]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,14 @@ Wire each new gate into `.pre-commit-config.yaml` (pre-commit or
 pre-push stage as fits) so it runs locally and in CI; per-line opt-outs
 use a stable `# lint-allow: <gate-name> -- <reason>` comment.
 
+The machine-readable inventory of every MANDATORY paragraph in the
+canonical doc set lives in `scripts/convention_gate_map.yaml`. The
+meta-gate `scripts/check_convention_gate_inventory.py` enforces that
+every MANDATORY paragraph has either a registered gate or an explicit
+`exempt: { reason }` entry; adding a new MANDATORY without updating the
+YAML fails pre-push. See [conventions.md §17](docs/reference/conventions.md)
+for the registration procedure.
+
 ## Configuration Precedence (MANDATORY)
 
 For every mutable setting: **DB > env (`SYNTHORG_<NS>_<KEY>`) > YAML > code default**, resolved through `SettingsService` / `ConfigResolver`. First cold read emits one INFO `settings.value.resolved`; subsequent reads stay DEBUG. Sanctioned exceptions: init-time only (env-only, no registry entry) and read-only post-init (`read_only_post_init=True`; `set()` raises `SettingReadOnlyError`). Direct `os.environ.get(...)` outside startup is forbidden. Register new settings in `src/synthorg/settings/definitions/<namespace>.py`. Ghost-wired settings (consuming service never instantiated at boot) are flagged by `scripts/check_setting_to_startup_trace.py`; per-setting opt-out via `# lint-allow: bootstrap-wiring -- <reason>`. See [docs/reference/configuration-precedence.md](docs/reference/configuration-precedence.md).

--- a/docs/reference/conventions.md
+++ b/docs/reference/conventions.md
@@ -429,6 +429,66 @@ file, not 200+ handler methods.
 * The naming consistency lets `glob`-based test discovery and
   contributor onboarding find the right files without grepping.
 
+## 17. Registering a new MANDATORY rule
+
+Every paragraph marked `(MANDATORY)` in the canonical doc set
+(`CLAUDE.md`, `web/CLAUDE.md`, `cli/CLAUDE.md`, `docs/reference/*.md`,
+`docs/design/*.md`) must be registered in
+`scripts/convention_gate_map.yaml` in the same PR that introduces it.
+The meta-gate `scripts/check_convention_gate_inventory.py` runs at
+pre-push and fails the build if a paragraph is unregistered, an entry
+is stale, or a referenced gate path is missing on disk.
+
+Each registration takes one of two shapes:
+
+* **Gate-backed** (the default; the goal for every new rule):
+
+  ```yaml
+  - id: <file-slug>::<header-slug>
+    file: <repo-relative path>
+    header: <exact header text without the "(MANDATORY)" suffix>
+    gate: scripts/check_<your-rule>.py
+  ```
+
+  The gate path can point at any file whose presence and correctness
+  enforce the rule (a `scripts/check_*.py` AST gate, an ESLint config,
+  a CI ceiling file). The path is verified to exist on disk; broken
+  references fail the gate.
+
+* **Exempt** (reserved for rules that are genuinely not script-
+  enforceable -- process rules requiring user approval, workflow rules
+  enforced by hookify or skills):
+
+  ```yaml
+  - id: <file-slug>::<header-slug>
+    file: <repo-relative path>
+    header: <exact header text>
+    exempt:
+      reason: |
+        <one or more sentences explaining why no script can enforce
+        this rule and what does (peer review, /pre-pr-review skill,
+        runtime test guard, etc.)>
+  ```
+
+  Exempt entries are technical debt. The convention-rollout policy
+  aims to drive the exempt list toward zero by promoting each
+  exemption into a real gate as enforcement options become tractable.
+
+### Generating the rule id
+
+The id is `<file-slug>::<header-slug>`, both halves lowercase ASCII
+slugs (alphanumeric runs separated by `-`, with the file path's `/`
+treated as whitespace). Examples:
+
+| File              | Header                      | id                                          |
+| ----------------- | --------------------------- | ------------------------------------------- |
+| `CLAUDE.md`       | `Persistence Boundary`      | `claude-md::persistence-boundary`           |
+| `web/CLAUDE.md`   | `MSW handlers`              | `web-claude-md::msw-handlers`               |
+| `docs/reference/foo.md` | `Async-Leak Ceiling`  | `docs-reference-foo-md::async-leak-ceiling` |
+
+If you rename a header, update both `header:` and `id:` in the same
+edit. The gate's stale-entry check surfaces orphans automatically.
+
 ## See also
 
 * [persistence-boundary.md](persistence-boundary.md): repository /

--- a/scripts/check_convention_gate_inventory.py
+++ b/scripts/check_convention_gate_inventory.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+"""Meta-gate: every MANDATORY paragraph maps to a registered gate or exemption.
+
+Globs the canonical doc set (CLAUDE.md, web/CLAUDE.md, cli/CLAUDE.md,
+docs/reference/*.md, docs/design/*.md), extracts every ``(MANDATORY)``
+section header and inline-bold subsection, and verifies each one has a
+matching entry in ``scripts/convention_gate_map.yaml``. Each YAML entry
+declares one of:
+
+* ``gate: <relative path to scripts/check_*.py or other enforcement>``
+* ``exempt: { reason: "<non-empty justification>" }``
+
+Exit codes:
+
+* 0: every MANDATORY entry is registered and every referenced gate exists
+* 1: missing entries, stale YAML entries, or missing gate scripts
+* 2: YAML schema error (treated as setup failure, not regression)
+
+Catches the SECOND occurrence of an ungated convention. Audits catch the
+first. See CLAUDE.md "Convention Rollout (MANDATORY)" for the policy.
+"""
+
+import argparse
+import dataclasses
+import re
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+_REPO_ROOT_DEFAULT = Path(__file__).resolve().parent.parent
+_INVENTORY_RELATIVE = Path("scripts") / "convention_gate_map.yaml"
+
+_CANONICAL_DOC_FILES: tuple[str, ...] = (
+    "CLAUDE.md",
+    "web/CLAUDE.md",
+    "cli/CLAUDE.md",
+)
+_CANONICAL_DOC_GLOBS: tuple[str, ...] = (
+    "docs/reference/*.md",
+    "docs/design/*.md",
+)
+
+_HEADER_RE = re.compile(r"^(?P<hashes>#{1,6})\s+(?P<text>.+?)\s*\(MANDATORY[^)]*\)\s*$")
+_INLINE_BOLD_RE = re.compile(r"\*\*(?P<text>[^*\n]+?)\s*\(MANDATORY[^)]*\)\*\*")
+
+_SLUG_NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
+
+
+class InventorySchemaError(Exception):
+    """Raised when ``scripts/convention_gate_map.yaml`` violates its schema.
+
+    Schema errors are setup failures (exit code 2), distinct from
+    regression failures (exit code 1). Surfacing them as a typed
+    exception lets ``main`` map cleanly to the right exit code.
+    """
+
+
+@dataclasses.dataclass(frozen=True)
+class MandatoryEntry:
+    """One MANDATORY paragraph extracted from a markdown file."""
+
+    file: str
+    line: int
+    header: str
+    kind: str  # "header" or "inline"
+
+    @property
+    def rule_id(self) -> str:
+        """Stable id derived from ``(file, header)``; survives line drift."""
+        return make_id(self.file, self.header)
+
+
+@dataclasses.dataclass(frozen=True)
+class InventoryEntry:
+    """One registered rule from ``scripts/convention_gate_map.yaml``.
+
+    Exactly one of ``gate`` / ``exempt_reason`` is set. The schema
+    loader enforces that invariant before constructing the dataclass.
+    """
+
+    rule_id: str
+    file: str
+    header: str
+    gate: str | None
+    exempt_reason: str | None
+
+
+@dataclasses.dataclass(frozen=True)
+class Violation:
+    """A single failure surfaced by the gate."""
+
+    location: str
+    message: str
+
+    def render(self) -> str:
+        """Format for stdout: ``<location>: <message>``."""
+        return f"{self.location}: {self.message}"
+
+
+def slugify(text: str) -> str:
+    """Lowercase, ASCII-only, hyphen-separated slug.
+
+    Args:
+        text: Free-form header text or file path component.
+
+    Returns:
+        Slug suitable for use as the right half of a rule id. Empty
+        input maps to the empty string; callers should reject that.
+    """
+    lowered = text.strip().lower()
+    return _SLUG_NON_ALNUM_RE.sub("-", lowered).strip("-")
+
+
+def make_id(file: str, header: str) -> str:
+    """Build the stable ``<file-slug>::<header-slug>`` rule id."""
+    file_slug = slugify(file.replace("/", " "))
+    header_slug = slugify(header)
+    return f"{file_slug}::{header_slug}"
+
+
+def extract_mandatory_entries(text: str, file: str) -> list[MandatoryEntry]:
+    """Extract every MANDATORY header / inline-bold subsection from ``text``.
+
+    Args:
+        text: Full file contents.
+        file: Repo-relative POSIX path used to label each entry.
+
+    Returns:
+        Entries in source-order. Header matches use ``kind="header"``;
+        inline ``**...(MANDATORY)**`` matches use ``kind="inline"``.
+        The header text has the trailing ``(MANDATORY...)`` stripped
+        and surrounding whitespace normalised; case is preserved.
+    """
+    entries: list[MandatoryEntry] = []
+    for line_index, line in enumerate(text.splitlines(), start=1):
+        header_match = _HEADER_RE.match(line)
+        if header_match is not None:
+            entries.append(
+                MandatoryEntry(
+                    file=file,
+                    line=line_index,
+                    header=header_match.group("text").strip(),
+                    kind="header",
+                )
+            )
+            continue
+        entries.extend(
+            MandatoryEntry(
+                file=file,
+                line=line_index,
+                header=inline_match.group("text").strip(),
+                kind="inline",
+            )
+            for inline_match in _INLINE_BOLD_RE.finditer(line)
+        )
+    return entries
+
+
+def collect_doc_files(repo_root: Path) -> list[Path]:
+    """Return every canonical doc file that exists, sorted deterministically."""
+    found: list[Path] = []
+    for fixed in _CANONICAL_DOC_FILES:
+        candidate = repo_root / fixed
+        if candidate.is_file():
+            found.append(candidate)
+    for pattern in _CANONICAL_DOC_GLOBS:
+        found.extend(path for path in sorted(repo_root.glob(pattern)) if path.is_file())
+    return found
+
+
+def _relative_posix(path: Path, repo_root: Path) -> str:
+    return path.resolve().relative_to(repo_root.resolve()).as_posix()
+
+
+def scan_repo(repo_root: Path) -> list[MandatoryEntry]:
+    """Walk the canonical doc set and extract every MANDATORY entry."""
+    entries: list[MandatoryEntry] = []
+    for path in collect_doc_files(repo_root):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            msg = f"Could not read {path}: {type(exc).__name__}: {exc.strerror or exc}"
+            raise InventorySchemaError(msg) from exc
+        rel = _relative_posix(path, repo_root)
+        entries.extend(extract_mandatory_entries(text, rel))
+    return entries
+
+
+def load_inventory(yaml_path: Path) -> tuple[InventoryEntry, ...]:
+    """Parse and validate ``scripts/convention_gate_map.yaml``.
+
+    Raises:
+        InventorySchemaError: If the file is missing, malformed, the top
+            level is not a list under ``mandatory_rules``, an entry is
+            missing required fields, neither or both of ``gate`` /
+            ``exempt`` are set, ``exempt.reason`` is empty, or the same
+            ``id`` appears twice.
+    """
+    if not yaml_path.is_file():
+        msg = f"Inventory file missing: {yaml_path}"
+        raise InventorySchemaError(msg)
+    try:
+        raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        msg = f"Inventory YAML parse error: {type(exc).__name__}"
+        raise InventorySchemaError(msg) from exc
+    if not isinstance(raw, dict) or "mandatory_rules" not in raw:
+        msg = "Inventory missing top-level 'mandatory_rules' list"
+        raise InventorySchemaError(msg)
+    rules = raw["mandatory_rules"]
+    if not isinstance(rules, list):
+        msg = "'mandatory_rules' must be a list"
+        raise InventorySchemaError(msg)
+    entries: list[InventoryEntry] = []
+    seen_ids: set[str] = set()
+    for index, item in enumerate(rules):
+        entry = _validate_inventory_item(item, index)
+        if entry.rule_id in seen_ids:
+            msg = f"Duplicate rule id in inventory: {entry.rule_id!r}"
+            raise InventorySchemaError(msg)
+        seen_ids.add(entry.rule_id)
+        entries.append(entry)
+    return tuple(entries)
+
+
+def _require_non_empty_str(value: object, label: str) -> str:
+    """Return ``value`` if it's a non-empty string, otherwise raise."""
+    if not isinstance(value, str) or not value.strip():
+        msg = f"{label} must be a non-empty string"
+        raise InventorySchemaError(msg)
+    return value
+
+
+def _validate_gate_or_exempt(
+    item: dict[object, object], index: int, rule_id: str
+) -> tuple[str | None, str | None]:
+    """Return ``(gate, exempt_reason)`` from one inventory item.
+
+    Exactly one of ``gate`` or ``exempt`` must be present; the other
+    return slot is ``None``. Splitting this branch out of
+    ``_validate_inventory_item`` keeps each function under the
+    cyclomatic-complexity ceiling (C901, max 10).
+    """
+    has_gate = "gate" in item
+    has_exempt = "exempt" in item
+    if has_gate == has_exempt:
+        msg = (
+            f"mandatory_rules[{index}] ({rule_id!r}) must have exactly one of"
+            " 'gate' or 'exempt'"
+        )
+        raise InventorySchemaError(msg)
+    if has_gate:
+        gate_value = _require_non_empty_str(
+            item["gate"], f"mandatory_rules[{index}] ({rule_id!r}).gate"
+        )
+        return gate_value, None
+    exempt_raw = item["exempt"]
+    if not isinstance(exempt_raw, dict) or "reason" not in exempt_raw:
+        msg = (
+            f"mandatory_rules[{index}] ({rule_id!r}).exempt must be a mapping"
+            " with a 'reason' field"
+        )
+        raise InventorySchemaError(msg)
+    reason = _require_non_empty_str(
+        exempt_raw["reason"],
+        f"mandatory_rules[{index}] ({rule_id!r}).exempt.reason",
+    )
+    return None, reason
+
+
+def _validate_inventory_item(item: object, index: int) -> InventoryEntry:
+    if not isinstance(item, dict):
+        msg = f"mandatory_rules[{index}] must be a mapping"
+        raise InventorySchemaError(msg)
+    for required in ("id", "file", "header"):
+        if required not in item:
+            msg = f"mandatory_rules[{index}] missing required field: {required!r}"
+            raise InventorySchemaError(msg)
+    rule_id = _require_non_empty_str(item["id"], f"mandatory_rules[{index}].id")
+    file_value = _require_non_empty_str(item["file"], f"mandatory_rules[{index}].file")
+    header = _require_non_empty_str(item["header"], f"mandatory_rules[{index}].header")
+    gate_value, exempt_reason = _validate_gate_or_exempt(item, index, rule_id)
+    return InventoryEntry(
+        rule_id=rule_id,
+        file=file_value,
+        header=header,
+        gate=gate_value,
+        exempt_reason=exempt_reason,
+    )
+
+
+def reconcile(
+    extracted: Iterable[MandatoryEntry],
+    inventory: Iterable[InventoryEntry],
+    repo_root: Path,
+) -> list[Violation]:
+    """Produce one Violation per mismatch between docs and inventory.
+
+    Three checks:
+
+    1. Every extracted MANDATORY entry must be registered in the
+       inventory under a matching ``rule_id``.
+    2. For inventory entries with ``gate:``, the path must exist.
+    3. Every inventory entry must match at least one extracted entry
+       (no stale rules).
+    """
+    inventory_by_id: dict[str, InventoryEntry] = {
+        entry.rule_id: entry for entry in inventory
+    }
+    extracted_ids: set[str] = set()
+    violations: list[Violation] = []
+    for entry in extracted:
+        extracted_ids.add(entry.rule_id)
+        registered = inventory_by_id.get(entry.rule_id)
+        if registered is None:
+            violations.append(
+                Violation(
+                    location=f"{entry.file}:{entry.line}",
+                    message=(
+                        "MANDATORY rule not registered in"
+                        f" {_INVENTORY_RELATIVE.as_posix()}: id={entry.rule_id!r}"
+                        f" header={entry.header!r}"
+                    ),
+                )
+            )
+            continue
+        if registered.gate is not None:
+            gate_path = repo_root / registered.gate
+            if not gate_path.is_file():
+                violations.append(
+                    Violation(
+                        location=f"{entry.file}:{entry.line}",
+                        message=(
+                            f"gate script missing on disk: {registered.gate}"
+                            f" (rule id={entry.rule_id!r})"
+                        ),
+                    )
+                )
+    violations.extend(
+        Violation(
+            location=_INVENTORY_RELATIVE.as_posix(),
+            message=(
+                f"stale entry: id={inventory_entry.rule_id!r} has no matching"
+                " MANDATORY paragraph in the canonical doc set"
+            ),
+        )
+        for inventory_entry in inventory_by_id.values()
+        if inventory_entry.rule_id not in extracted_ids
+    )
+    return violations
+
+
+def check(repo_root: Path) -> list[Violation]:
+    """Run the full gate against ``repo_root`` and return all violations.
+
+    Schema errors propagate as ``InventorySchemaError`` and should be
+    handled by ``main`` (exit code 2). Reconciliation violations
+    return as a list (exit code 1 if non-empty).
+    """
+    extracted = scan_repo(repo_root)
+    inventory = load_inventory(repo_root / _INVENTORY_RELATIVE)
+    return reconcile(extracted, inventory, repo_root)
+
+
+def _resolve_repo_root(arg: Path | None) -> Path:
+    if arg is None:
+        return _REPO_ROOT_DEFAULT
+    return arg.resolve(strict=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Returns:
+        ``0`` if every MANDATORY entry is registered and every gate
+        path exists; ``1`` if reconciliation surfaces violations;
+        ``2`` if the inventory YAML fails schema validation or the
+        repo root cannot be resolved.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Override the repo root (default: scripts/.. relative to this file)",
+    )
+    args = parser.parse_args(argv)
+    try:
+        repo_root = _resolve_repo_root(args.repo_root)
+    except (FileNotFoundError, OSError) as exc:
+        print(
+            f"Error: --repo-root does not exist: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        violations = check(repo_root)
+    except InventorySchemaError as exc:
+        print(f"Inventory schema error: {exc}", file=sys.stderr)
+        return 2
+    if not violations:
+        return 0
+    for violation in violations:
+        print(violation.render())
+    inventory_path = _INVENTORY_RELATIVE.as_posix()
+    epilogue = (
+        "\nConvention-rollout gate failed. Edit "
+        + inventory_path
+        + " so every MANDATORY paragraph in the canonical doc set has either"
+        " a registered gate or an explicit exemption. See"
+        " docs/reference/conventions.md '17. Registering a new MANDATORY"
+        " rule' for the procedure."
+    )
+    print(epilogue, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_convention_gate_inventory.py
+++ b/scripts/check_convention_gate_inventory.py
@@ -257,7 +257,14 @@ def load_inventory(yaml_path: Path) -> tuple[InventoryEntry, ...]:
         msg = f"Inventory file missing: {yaml_path}"
         raise InventorySchemaError(msg)
     try:
-        raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+        raw_text = yaml_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        msg = (
+            f"Could not read inventory file {yaml_path}: {type(exc).__name__}: {exc!s}"
+        )
+        raise InventorySchemaError(msg) from exc
+    try:
+        raw = yaml.safe_load(raw_text)
     except yaml.YAMLError as exc:
         msg = f"Inventory YAML parse error: {_yaml_error_summary(exc)}"
         raise InventorySchemaError(msg) from exc
@@ -363,6 +370,22 @@ def _validate_inventory_item(item: object, index: int) -> InventoryEntry:
     )
 
 
+def _gate_resolves_inside_repo(gate: str, repo_root: Path) -> bool:
+    """Return True iff ``gate`` resolves to a regular file inside ``repo_root``.
+
+    Resolution is strict (missing files return False) and the resolved
+    path must remain under ``repo_root.resolve()`` so a symlink that
+    escapes the repo cannot satisfy the gate-existence check.
+    """
+    candidate = repo_root / gate
+    try:
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(repo_root.resolve())
+    except FileNotFoundError, OSError, ValueError:
+        return False
+    return resolved.is_file()
+
+
 def _check_extracted_against_inventory(
     extracted: Iterable[MandatoryEntry],
     inventory_by_id: dict[str, InventoryEntry],
@@ -390,7 +413,9 @@ def _check_extracted_against_inventory(
                 )
             )
             continue
-        if registered.gate is not None and not (repo_root / registered.gate).is_file():
+        if registered.gate is not None and not _gate_resolves_inside_repo(
+            registered.gate, repo_root
+        ):
             violations.append(
                 Violation(
                     location=f"{entry.file}:{entry.line}",

--- a/scripts/check_convention_gate_inventory.py
+++ b/scripts/check_convention_gate_inventory.py
@@ -485,7 +485,9 @@ def check(repo_root: Path, *, verbose: bool = False) -> list[Violation]:
             from a correctly-empty repo.
     """
     extracted = scan_repo(repo_root)
-    inventory = load_inventory(repo_root / _INVENTORY_RELATIVE)
+    inventory_path = repo_root / _INVENTORY_RELATIVE
+    _relative_posix(inventory_path, repo_root)
+    inventory = load_inventory(inventory_path)
     if verbose:
         print(
             f"convention-gate: extracted {len(extracted)} MANDATORY entries,"
@@ -498,7 +500,11 @@ def check(repo_root: Path, *, verbose: bool = False) -> list[Violation]:
 def _resolve_repo_root(arg: Path | None) -> Path:
     if arg is None:
         return _REPO_ROOT_DEFAULT
-    return arg.resolve(strict=True)
+    resolved = arg.resolve(strict=True)
+    if not resolved.is_dir():
+        msg = f"--repo-root must be a directory: {resolved}"
+        raise NotADirectoryError(msg)
+    return resolved
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
@@ -523,6 +529,9 @@ def _resolve_repo_root_or_exit(arg: Path | None) -> Path | int:
         return _resolve_repo_root(arg)
     except FileNotFoundError as exc:
         print(f"Error: --repo-root does not exist: {exc}", file=sys.stderr)
+        return 2
+    except NotADirectoryError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
         return 2
     except OSError as exc:
         print(

--- a/scripts/check_convention_gate_inventory.py
+++ b/scripts/check_convention_gate_inventory.py
@@ -25,7 +25,7 @@ import dataclasses
 import re
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import yaml
 
@@ -67,7 +67,7 @@ class MandatoryEntry:
     file: str
     line: int
     header: str
-    kind: str  # "header" or "inline"
+    kind: Literal["header", "inline"]
 
     @property
     def rule_id(self) -> str:
@@ -79,8 +79,11 @@ class MandatoryEntry:
 class InventoryEntry:
     """One registered rule from ``scripts/convention_gate_map.yaml``.
 
-    Exactly one of ``gate`` / ``exempt_reason`` is set. The schema
-    loader enforces that invariant before constructing the dataclass.
+    Exactly one of ``gate`` / ``exempt_reason`` is set. The XOR
+    invariant is enforced both at YAML load time (via
+    ``_validate_gate_or_exempt``) and at construction (via
+    ``__post_init__``) so direct instantiation outside the loader
+    cannot produce an invalid instance.
     """
 
     rule_id: str
@@ -88,6 +91,15 @@ class InventoryEntry:
     header: str
     gate: str | None
     exempt_reason: str | None
+
+    def __post_init__(self) -> None:
+        """Enforce the XOR invariant: exactly one of gate or exempt_reason."""
+        if (self.gate is None) == (self.exempt_reason is None):
+            msg = (
+                f"InventoryEntry {self.rule_id!r} must have exactly one of"
+                " gate or exempt_reason"
+            )
+            raise InventorySchemaError(msg)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -117,9 +129,19 @@ def slugify(text: str) -> str:
 
 
 def make_id(file: str, header: str) -> str:
-    """Build the stable ``<file-slug>::<header-slug>`` rule id."""
+    """Build the stable ``<file-slug>::<header-slug>`` rule id.
+
+    Raises:
+        InventorySchemaError: If either ``file`` or ``header`` slugifies
+            to the empty string. A degenerate id like ``"::"`` would
+            silently mismatch every inventory entry; failing loud lets
+            callers surface the underlying input bug instead.
+    """
     file_slug = slugify(file.replace("/", " "))
     header_slug = slugify(header)
+    if not file_slug or not header_slug:
+        msg = f"Cannot build rule id from empty slug: file={file!r} header={header!r}"
+        raise InventorySchemaError(msg)
     return f"{file_slug}::{header_slug}"
 
 
@@ -174,7 +196,19 @@ def collect_doc_files(repo_root: Path) -> list[Path]:
 
 
 def _relative_posix(path: Path, repo_root: Path) -> str:
-    return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    """Return ``path`` relative to ``repo_root`` as a POSIX string.
+
+    Raises:
+        InventorySchemaError: If ``path`` resolves outside ``repo_root``
+            (e.g. via a symlink that escapes the repo). Surfacing this
+            as the typed schema error lets ``main`` exit cleanly with
+            code 2 instead of crashing on an uncaught ``ValueError``.
+    """
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError as exc:
+        msg = f"Doc file path escapes repo root: {path}"
+        raise InventorySchemaError(msg) from exc
 
 
 def scan_repo(repo_root: Path) -> list[MandatoryEntry]:
@@ -184,11 +218,29 @@ def scan_repo(repo_root: Path) -> list[MandatoryEntry]:
         try:
             text = path.read_text(encoding="utf-8")
         except OSError as exc:
-            msg = f"Could not read {path}: {type(exc).__name__}: {exc.strerror or exc}"
+            msg = f"Could not read {path}: {type(exc).__name__}: {exc!s}"
             raise InventorySchemaError(msg) from exc
         rel = _relative_posix(path, repo_root)
         entries.extend(extract_mandatory_entries(text, rel))
     return entries
+
+
+def _yaml_error_summary(exc: yaml.YAMLError) -> str:
+    """Build a one-line summary of a YAML parse error with position info.
+
+    PyYAML's ``MarkedYAMLError`` subclasses (Scanner / Parser / Constructor
+    errors) carry ``problem``, ``problem_mark``, and ``context`` attributes
+    that point at the syntax error's location. The default ``str(exc)``
+    is multi-line and ugly; this helper produces a single line suitable
+    for the gate's stderr output.
+    """
+    problem = getattr(exc, "problem", None)
+    mark = getattr(exc, "problem_mark", None)
+    if problem and mark is not None:
+        line = mark.line + 1
+        column = mark.column + 1
+        return f"{type(exc).__name__} at line {line}, column {column}: {problem}"
+    return f"{type(exc).__name__}: {exc!s}"
 
 
 def load_inventory(yaml_path: Path) -> tuple[InventoryEntry, ...]:
@@ -207,7 +259,7 @@ def load_inventory(yaml_path: Path) -> tuple[InventoryEntry, ...]:
     try:
         raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
     except yaml.YAMLError as exc:
-        msg = f"Inventory YAML parse error: {type(exc).__name__}"
+        msg = f"Inventory YAML parse error: {_yaml_error_summary(exc)}"
         raise InventorySchemaError(msg) from exc
     if not isinstance(raw, dict) or "mandatory_rules" not in raw:
         msg = "Inventory missing top-level 'mandatory_rules' list"
@@ -231,7 +283,23 @@ def load_inventory(yaml_path: Path) -> tuple[InventoryEntry, ...]:
 def _require_non_empty_str(value: object, label: str) -> str:
     """Return ``value`` if it's a non-empty string, otherwise raise."""
     if not isinstance(value, str) or not value.strip():
-        msg = f"{label} must be a non-empty string"
+        msg = f"{label} must be a non-empty string (got {type(value).__name__})"
+        raise InventorySchemaError(msg)
+    return value
+
+
+def _require_safe_relative_path(value: str, label: str) -> str:
+    """Reject absolute paths and parent-directory escapes in YAML gate refs.
+
+    Defence-in-depth for committed YAML: a ``gate`` entry pointing at an
+    absolute path or one containing ``..`` segments could match a file
+    outside the repo root and silently satisfy the existence check.
+    """
+    if Path(value).is_absolute():
+        msg = f"{label} must be a relative path (got absolute: {value!r})"
+        raise InventorySchemaError(msg)
+    if any(part == ".." for part in Path(value).parts):
+        msg = f"{label} must not contain '..' segments (got: {value!r})"
         raise InventorySchemaError(msg)
     return value
 
@@ -246,29 +314,23 @@ def _validate_gate_or_exempt(
     ``_validate_inventory_item`` keeps each function under the
     cyclomatic-complexity ceiling (C901, max 10).
     """
+    entry_label = f"mandatory_rules[{index}] ({rule_id!r})"
     has_gate = "gate" in item
     has_exempt = "exempt" in item
     if has_gate == has_exempt:
-        msg = (
-            f"mandatory_rules[{index}] ({rule_id!r}) must have exactly one of"
-            " 'gate' or 'exempt'"
-        )
+        msg = f"{entry_label} must have exactly one of 'gate' or 'exempt'"
         raise InventorySchemaError(msg)
     if has_gate:
-        gate_value = _require_non_empty_str(
-            item["gate"], f"mandatory_rules[{index}] ({rule_id!r}).gate"
-        )
+        gate_label = f"{entry_label}.gate"
+        gate_value = _require_non_empty_str(item["gate"], gate_label)
+        gate_value = _require_safe_relative_path(gate_value, gate_label)
         return gate_value, None
     exempt_raw = item["exempt"]
     if not isinstance(exempt_raw, dict) or "reason" not in exempt_raw:
-        msg = (
-            f"mandatory_rules[{index}] ({rule_id!r}).exempt must be a mapping"
-            " with a 'reason' field"
-        )
+        msg = f"{entry_label}.exempt must be a mapping with a 'reason' field"
         raise InventorySchemaError(msg)
     reason = _require_non_empty_str(
-        exempt_raw["reason"],
-        f"mandatory_rules[{index}] ({rule_id!r}).exempt.reason",
+        exempt_raw["reason"], f"{entry_label}.exempt.reason"
     )
     return None, reason
 
@@ -294,6 +356,64 @@ def _validate_inventory_item(item: object, index: int) -> InventoryEntry:
     )
 
 
+def _check_extracted_against_inventory(
+    extracted: Iterable[MandatoryEntry],
+    inventory_by_id: dict[str, InventoryEntry],
+    repo_root: Path,
+) -> tuple[list[Violation], set[str]]:
+    """Per-entry check: registration coverage + gate-path liveness.
+
+    Returns the violations list and the set of extracted rule ids
+    (used by the caller to detect stale inventory entries).
+    """
+    violations: list[Violation] = []
+    extracted_ids: set[str] = set()
+    for entry in extracted:
+        extracted_ids.add(entry.rule_id)
+        registered = inventory_by_id.get(entry.rule_id)
+        if registered is None:
+            violations.append(
+                Violation(
+                    location=f"{entry.file}:{entry.line}",
+                    message=(
+                        "MANDATORY rule not registered in"
+                        f" {_INVENTORY_RELATIVE.as_posix()}: id={entry.rule_id!r}"
+                        f" header={entry.header!r}"
+                    ),
+                )
+            )
+            continue
+        if registered.gate is not None and not (repo_root / registered.gate).is_file():
+            violations.append(
+                Violation(
+                    location=f"{entry.file}:{entry.line}",
+                    message=(
+                        f"gate script missing on disk: {registered.gate}"
+                        f" (rule id={entry.rule_id!r})"
+                    ),
+                )
+            )
+    return violations, extracted_ids
+
+
+def _check_stale_inventory(
+    inventory_by_id: dict[str, InventoryEntry],
+    extracted_ids: set[str],
+) -> list[Violation]:
+    """Per-inventory check: every YAML rule must match an extracted entry."""
+    return [
+        Violation(
+            location=_INVENTORY_RELATIVE.as_posix(),
+            message=(
+                f"stale entry: id={inventory_entry.rule_id!r} has no matching"
+                " MANDATORY paragraph in the canonical doc set"
+            ),
+        )
+        for inventory_entry in inventory_by_id.values()
+        if inventory_entry.rule_id not in extracted_ids
+    ]
+
+
 def reconcile(
     extracted: Iterable[MandatoryEntry],
     inventory: Iterable[InventoryEntry],
@@ -312,58 +432,34 @@ def reconcile(
     inventory_by_id: dict[str, InventoryEntry] = {
         entry.rule_id: entry for entry in inventory
     }
-    extracted_ids: set[str] = set()
-    violations: list[Violation] = []
-    for entry in extracted:
-        extracted_ids.add(entry.rule_id)
-        registered = inventory_by_id.get(entry.rule_id)
-        if registered is None:
-            violations.append(
-                Violation(
-                    location=f"{entry.file}:{entry.line}",
-                    message=(
-                        "MANDATORY rule not registered in"
-                        f" {_INVENTORY_RELATIVE.as_posix()}: id={entry.rule_id!r}"
-                        f" header={entry.header!r}"
-                    ),
-                )
-            )
-            continue
-        if registered.gate is not None:
-            gate_path = repo_root / registered.gate
-            if not gate_path.is_file():
-                violations.append(
-                    Violation(
-                        location=f"{entry.file}:{entry.line}",
-                        message=(
-                            f"gate script missing on disk: {registered.gate}"
-                            f" (rule id={entry.rule_id!r})"
-                        ),
-                    )
-                )
-    violations.extend(
-        Violation(
-            location=_INVENTORY_RELATIVE.as_posix(),
-            message=(
-                f"stale entry: id={inventory_entry.rule_id!r} has no matching"
-                " MANDATORY paragraph in the canonical doc set"
-            ),
-        )
-        for inventory_entry in inventory_by_id.values()
-        if inventory_entry.rule_id not in extracted_ids
+    violations, extracted_ids = _check_extracted_against_inventory(
+        extracted, inventory_by_id, repo_root
     )
+    violations.extend(_check_stale_inventory(inventory_by_id, extracted_ids))
     return violations
 
 
-def check(repo_root: Path) -> list[Violation]:
+def check(repo_root: Path, *, verbose: bool = False) -> list[Violation]:
     """Run the full gate against ``repo_root`` and return all violations.
 
     Schema errors propagate as ``InventorySchemaError`` and should be
     handled by ``main`` (exit code 2). Reconciliation violations
     return as a list (exit code 1 if non-empty).
+
+    Args:
+        repo_root: Resolved path to the repo root.
+        verbose: If True, print extracted/inventory counts to stderr so a
+            "passes silently due to broken glob" failure is distinguishable
+            from a correctly-empty repo.
     """
     extracted = scan_repo(repo_root)
     inventory = load_inventory(repo_root / _INVENTORY_RELATIVE)
+    if verbose:
+        print(
+            f"convention-gate: extracted {len(extracted)} MANDATORY entries,"
+            f" inventory has {len(inventory)} registered rules",
+            file=sys.stderr,
+        )
     return reconcile(extracted, inventory, repo_root)
 
 
@@ -389,17 +485,25 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Override the repo root (default: scripts/.. relative to this file)",
     )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print extracted/inventory counts to stderr (debugging aid)",
+    )
     args = parser.parse_args(argv)
     try:
         repo_root = _resolve_repo_root(args.repo_root)
-    except (FileNotFoundError, OSError) as exc:
+    except FileNotFoundError as exc:
+        print(f"Error: --repo-root does not exist: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:
         print(
-            f"Error: --repo-root does not exist: {exc}",
+            f"Error: cannot access --repo-root: {type(exc).__name__}: {exc}",
             file=sys.stderr,
         )
         return 2
     try:
-        violations = check(repo_root)
+        violations = check(repo_root, verbose=args.verbose)
     except InventorySchemaError as exc:
         print(f"Inventory schema error: {exc}", file=sys.stderr)
         return 2

--- a/scripts/check_convention_gate_inventory.py
+++ b/scripts/check_convention_gate_inventory.py
@@ -346,6 +346,13 @@ def _validate_inventory_item(item: object, index: int) -> InventoryEntry:
     rule_id = _require_non_empty_str(item["id"], f"mandatory_rules[{index}].id")
     file_value = _require_non_empty_str(item["file"], f"mandatory_rules[{index}].file")
     header = _require_non_empty_str(item["header"], f"mandatory_rules[{index}].header")
+    expected_id = make_id(file_value, header)
+    if rule_id != expected_id:
+        msg = (
+            f"mandatory_rules[{index}] id mismatch: expected {expected_id!r}"
+            f" (derived from file/header), got {rule_id!r}"
+        )
+        raise InventorySchemaError(msg)
     gate_value, exempt_reason = _validate_gate_or_exempt(item, index, rule_id)
     return InventoryEntry(
         rule_id=rule_id,
@@ -469,15 +476,7 @@ def _resolve_repo_root(arg: Path | None) -> Path:
     return arg.resolve(strict=True)
 
 
-def main(argv: list[str] | None = None) -> int:
-    """CLI entry point.
-
-    Returns:
-        ``0`` if every MANDATORY entry is registered and every gate
-        path exists; ``1`` if reconciliation surfaces violations;
-        ``2`` if the inventory YAML fails schema validation or the
-        repo root cannot be resolved.
-    """
+def _build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--repo-root",
@@ -490,9 +489,13 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Print extracted/inventory counts to stderr (debugging aid)",
     )
-    args = parser.parse_args(argv)
+    return parser
+
+
+def _resolve_repo_root_or_exit(arg: Path | None) -> Path | int:
+    """Resolve ``--repo-root`` or return the exit code to surface to ``main``."""
     try:
-        repo_root = _resolve_repo_root(args.repo_root)
+        return _resolve_repo_root(arg)
     except FileNotFoundError as exc:
         print(f"Error: --repo-root does not exist: {exc}", file=sys.stderr)
         return 2
@@ -502,15 +505,9 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 2
-    try:
-        violations = check(repo_root, verbose=args.verbose)
-    except InventorySchemaError as exc:
-        print(f"Inventory schema error: {exc}", file=sys.stderr)
-        return 2
-    if not violations:
-        return 0
-    for violation in violations:
-        print(violation.render())
+
+
+def _print_failure_epilogue() -> None:
     inventory_path = _INVENTORY_RELATIVE.as_posix()
     epilogue = (
         "\nConvention-rollout gate failed. Edit "
@@ -521,6 +518,31 @@ def main(argv: list[str] | None = None) -> int:
         " rule' for the procedure."
     )
     print(epilogue, file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Returns:
+        ``0`` if every MANDATORY entry is registered and every gate
+        path exists; ``1`` if reconciliation surfaces violations;
+        ``2`` if the inventory YAML fails schema validation or the
+        repo root cannot be resolved.
+    """
+    args = _build_arg_parser().parse_args(argv)
+    resolved = _resolve_repo_root_or_exit(args.repo_root)
+    if isinstance(resolved, int):
+        return resolved
+    try:
+        violations = check(resolved, verbose=args.verbose)
+    except InventorySchemaError as exc:
+        print(f"Inventory schema error: {exc}", file=sys.stderr)
+        return 2
+    if not violations:
+        return 0
+    for violation in violations:
+        print(violation.render())
+    _print_failure_epilogue()
     return 1
 
 

--- a/scripts/check_convention_gate_inventory.py
+++ b/scripts/check_convention_gate_inventory.py
@@ -215,12 +215,12 @@ def scan_repo(repo_root: Path) -> list[MandatoryEntry]:
     """Walk the canonical doc set and extract every MANDATORY entry."""
     entries: list[MandatoryEntry] = []
     for path in collect_doc_files(repo_root):
+        rel = _relative_posix(path, repo_root)
         try:
             text = path.read_text(encoding="utf-8")
-        except OSError as exc:
+        except (OSError, UnicodeDecodeError) as exc:
             msg = f"Could not read {path}: {type(exc).__name__}: {exc!s}"
             raise InventorySchemaError(msg) from exc
-        rel = _relative_posix(path, repo_root)
         entries.extend(extract_mandatory_entries(text, rel))
     return entries
 
@@ -258,7 +258,7 @@ def load_inventory(yaml_path: Path) -> tuple[InventoryEntry, ...]:
         raise InventorySchemaError(msg)
     try:
         raw_text = yaml_path.read_text(encoding="utf-8")
-    except OSError as exc:
+    except (OSError, UnicodeDecodeError) as exc:
         msg = (
             f"Could not read inventory file {yaml_path}: {type(exc).__name__}: {exc!s}"
         )

--- a/scripts/check_convention_gate_inventory.py
+++ b/scripts/check_convention_gate_inventory.py
@@ -381,7 +381,7 @@ def _gate_resolves_inside_repo(gate: str, repo_root: Path) -> bool:
     try:
         resolved = candidate.resolve(strict=True)
         resolved.relative_to(repo_root.resolve())
-    except FileNotFoundError, OSError, ValueError:
+    except OSError, ValueError:
         return False
     return resolved.is_file()
 

--- a/scripts/convention_gate_map.yaml
+++ b/scripts/convention_gate_map.yaml
@@ -1,0 +1,215 @@
+# Inventory of every MANDATORY paragraph in the canonical doc set.
+#
+# Canonical files: CLAUDE.md, web/CLAUDE.md, cli/CLAUDE.md,
+# docs/reference/*.md, docs/design/*.md.
+#
+# Per rule: ONE of `gate` (relative path to enforcement file) or
+# `exempt: { reason }` (non-empty justification). Exempt entries are
+# technical debt; the convention-rollout policy aims to drive the
+# exempt list toward zero by promoting each into a real script.
+#
+# Enforced by scripts/check_convention_gate_inventory.py (pre-push +
+# CI). See docs/reference/conventions.md '17. Registering a new
+# MANDATORY rule' for the procedure.
+
+mandatory_rules:
+  # ---------------------------------------------------------------
+  # CLAUDE.md (root)
+  # ---------------------------------------------------------------
+  - id: claude-md::design-spec
+    file: CLAUDE.md
+    header: Design Spec
+    exempt:
+      reason: |
+        Process rule: requires user approval before deviating from
+        docs/design/. Not script-enforceable. Enforced by
+        /pre-pr-review skill phases and code review.
+
+  - id: claude-md::planning
+    file: CLAUDE.md
+    header: Planning
+    exempt:
+      reason: |
+        Process rule: every implementation plan needs user accept/deny
+        before coding. Not script-enforceable. Enforced by
+        /pre-pr-review skill phases.
+
+  - id: claude-md::web-dashboard-design-system
+    file: CLAUDE.md
+    header: Web Dashboard Design System
+    gate: scripts/check_web_design_system.py
+
+  - id: claude-md::regional-defaults
+    file: CLAUDE.md
+    header: Regional Defaults
+    gate: scripts/check_backend_regional_defaults.py
+
+  - id: claude-md::persistence-boundary
+    file: CLAUDE.md
+    header: Persistence Boundary
+    gate: scripts/check_persistence_boundary.py
+
+  - id: claude-md::convention-rollout
+    file: CLAUDE.md
+    header: Convention Rollout
+    gate: scripts/check_convention_gate_inventory.py
+
+  - id: claude-md::configuration-precedence
+    file: CLAUDE.md
+    header: Configuration Precedence
+    gate: scripts/check_setting_to_startup_trace.py
+
+  - id: claude-md::no-hardcoded-values
+    file: CLAUDE.md
+    header: No Hardcoded Values
+    gate: scripts/check_no_magic_numbers.py
+
+  - id: claude-md::test-regression
+    file: CLAUDE.md
+    header: Test Regression
+    gate: scripts/check_no_edit_baseline.sh
+
+  - id: claude-md::post-implementation-pre-pr-review
+    file: CLAUDE.md
+    header: Post-Implementation + Pre-PR Review
+    exempt:
+      reason: |
+        Workflow rule enforced by hookify (block-pr-create) and the
+        /pre-pr-review + /aurelio-review-pr skills. The dev-time
+        prevention lives in .claude/hookify.block-pr-create.md
+        rather than scripts/.
+
+  # ---------------------------------------------------------------
+  # web/CLAUDE.md
+  # ---------------------------------------------------------------
+  - id: web-claude-md::zustand-store-error-handling
+    file: web/CLAUDE.md
+    header: Zustand Store Error Handling
+    exempt:
+      reason: |
+        Code-pattern contract enforced by peer review. Stores wrap
+        try/catch internally; callers must not. No AST/lint signal
+        catches "caller wraps store mutation in try/catch" without
+        a custom ESLint rule, which is not yet written.
+
+  - id: web-claude-md::cursor-pagination
+    file: web/CLAUDE.md
+    header: Cursor pagination
+    exempt:
+      reason: |
+        API-contract rule: list endpoints expose PaginationMeta;
+        stores read nextCursor + hasMore. Enforced by the typed
+        envelope in src/synthorg/api (no `total` field) and by the
+        store-shape types. No standalone gate script.
+
+  - id: web-claude-md::health-readiness-endpoints
+    file: web/CLAUDE.md
+    header: Health / readiness endpoints
+    exempt:
+      reason: |
+        Two-state contract (200 ok / 503 unavailable) enforced at
+        type level by the endpoint return signatures and at runtime
+        by the API tests. No standalone gate script.
+
+  - id: web-claude-md::msw-handlers
+    file: web/CLAUDE.md
+    header: MSW handlers
+    gate: web/src/test-setup.tsx
+
+  - id: web-claude-md::test-teardown
+    file: web/CLAUDE.md
+    header: Test teardown
+    gate: web/src/test-setup.tsx
+
+  - id: web-claude-md::async-leak-ceiling
+    file: web/CLAUDE.md
+    header: Async-leak ceiling
+    gate: .github/ci/web-async-leaks.max
+
+  - id: web-claude-md::ws-wire-protocol
+    file: web/CLAUDE.md
+    header: WS wire protocol
+    exempt:
+      reason: |
+        Cross-side contract: web/src/utils/constants.ts must stay in
+        lockstep with src/synthorg/api/ws_models.py. Enforced by
+        integration tests and code review; no AST gate cross-checks
+        the two files yet.
+
+  - id: web-claude-md::design-system
+    file: web/CLAUDE.md
+    header: Design System
+    gate: scripts/check_web_design_system.py
+
+  - id: web-claude-md::eslint
+    file: web/CLAUDE.md
+    header: ESLint
+    gate: web/eslint.config.js
+
+  # ---------------------------------------------------------------
+  # docs/reference/web-zustand-stores.md
+  #
+  # Each MANDATORY here is a detailed expansion of the parent rule
+  # in web/CLAUDE.md. The parent rule's gate / exemption applies;
+  # this file is documentation, not an independent enforcement
+  # surface.
+  # ---------------------------------------------------------------
+  - id: docs-reference-web-zustand-stores-md::mutation-action-pattern
+    file: docs/reference/web-zustand-stores.md
+    header: Mutation Action Pattern
+    exempt:
+      reason: |
+        Detailed expansion of web/CLAUDE.md "Zustand Store Error
+        Handling (MANDATORY)". Same enforcement chain (peer review).
+
+  - id: docs-reference-web-zustand-stores-md::cursor-pagination
+    file: docs/reference/web-zustand-stores.md
+    header: Cursor Pagination
+    exempt:
+      reason: |
+        Detailed expansion of web/CLAUDE.md "Cursor pagination
+        (MANDATORY)". Same enforcement chain (typed envelope).
+
+  - id: docs-reference-web-zustand-stores-md::health-readiness-endpoints
+    file: docs/reference/web-zustand-stores.md
+    header: Health / Readiness Endpoints
+    exempt:
+      reason: |
+        Detailed expansion of web/CLAUDE.md "Health / readiness
+        endpoints (MANDATORY)". Same enforcement chain (type
+        system + API tests).
+
+  - id: docs-reference-web-zustand-stores-md::msw-handlers
+    file: docs/reference/web-zustand-stores.md
+    header: MSW Handlers
+    exempt:
+      reason: |
+        Detailed expansion of web/CLAUDE.md "MSW handlers
+        (MANDATORY)". Same enforcement (web/src/test-setup.tsx
+        runtime guard).
+
+  - id: docs-reference-web-zustand-stores-md::test-teardown
+    file: docs/reference/web-zustand-stores.md
+    header: Test Teardown
+    exempt:
+      reason: |
+        Detailed expansion of web/CLAUDE.md "Test teardown
+        (MANDATORY)". Same enforcement (web/src/test-setup.tsx
+        global afterEach).
+
+  - id: docs-reference-web-zustand-stores-md::async-leak-ceiling
+    file: docs/reference/web-zustand-stores.md
+    header: Async-Leak Ceiling
+    exempt:
+      reason: |
+        Detailed expansion of web/CLAUDE.md "Async-leak ceiling
+        (MANDATORY)". Same enforcement (.github/ci/web-async-leaks.max
+        + vitest --detect-async-leaks).
+
+  - id: docs-reference-web-zustand-stores-md::ws-wire-protocol
+    file: docs/reference/web-zustand-stores.md
+    header: WS Wire Protocol
+    exempt:
+      reason: |
+        Detailed expansion of web/CLAUDE.md "WS wire protocol
+        (MANDATORY)". Same enforcement chain.

--- a/scripts/convention_gate_map.yaml
+++ b/scripts/convention_gate_map.yaml
@@ -3,8 +3,9 @@
 # Canonical files: CLAUDE.md, web/CLAUDE.md, cli/CLAUDE.md,
 # docs/reference/*.md, docs/design/*.md.
 #
-# Per rule: ONE of `gate` (relative path to enforcement file) or
-# `exempt: { reason }` (non-empty justification). Exempt entries are
+# Per rule: ONE of `gate` (relative path to enforcement file -- must
+# stay inside the repo, no '..' segments, no absolute paths) or
+# `exempt: { reason: <non-empty justification> }`. Exempt entries are
 # technical debt; the convention-rollout policy aims to drive the
 # exempt list toward zero by promoting each into a real script.
 #

--- a/tests/unit/scripts/test_check_convention_gate_inventory.py
+++ b/tests/unit/scripts/test_check_convention_gate_inventory.py
@@ -457,6 +457,22 @@ def test_scan_repo_raises_schema_error_on_unreadable_file(
         _MODULE.scan_repo(fake_repo)
 
 
+def test_scan_repo_raises_schema_error_on_invalid_utf8_doc(fake_repo: Path) -> None:
+    """Invalid UTF-8 in a doc file maps to InventorySchemaError (exit 2)."""
+    bad_doc = fake_repo / "CLAUDE.md"
+    bad_doc.write_bytes(b"## Foo (MANDATORY)\n\xff\xfe broken bytes\n")
+    with pytest.raises(_MODULE.InventorySchemaError):
+        _MODULE.scan_repo(fake_repo)
+
+
+def test_load_inventory_raises_schema_error_on_invalid_utf8(fake_repo: Path) -> None:
+    """Invalid UTF-8 in the inventory yaml maps to InventorySchemaError (exit 2)."""
+    inventory = fake_repo / "scripts" / "convention_gate_map.yaml"
+    inventory.write_bytes(b"mandatory_rules: []\n\xff\xfe\n")
+    with pytest.raises(_MODULE.InventorySchemaError):
+        _MODULE.load_inventory(inventory)
+
+
 def test_extract_two_inline_bold_on_same_line() -> None:
     """A line with two ``**Foo (MANDATORY)**`` matches must yield both entries."""
     text = "**Foo (MANDATORY)** and also **Bar (MANDATORY)** in one sentence."

--- a/tests/unit/scripts/test_check_convention_gate_inventory.py
+++ b/tests/unit/scripts/test_check_convention_gate_inventory.py
@@ -473,6 +473,41 @@ def test_load_inventory_raises_schema_error_on_invalid_utf8(fake_repo: Path) -> 
         _MODULE.load_inventory(inventory)
 
 
+def test_inventory_yaml_symlink_escape_rejected(
+    fake_repo: Path, tmp_path_factory: pytest.TempPathFactory
+) -> None:
+    """A symlinked inventory yaml resolving outside repo_root is rejected.
+
+    ``check()`` validates containment of the inventory path before loading,
+    same containment guarantee already applied to canonical doc files and
+    gate-script targets.
+    """
+    outside_dir = tmp_path_factory.mktemp("outside_inventory")
+    outside_yaml = outside_dir / "evil.yaml"
+    outside_yaml.write_text("mandatory_rules: []\n", encoding="utf-8")
+
+    inventory_link = fake_repo / "scripts" / "convention_gate_map.yaml"
+    try:
+        inventory_link.symlink_to(outside_yaml)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink creation unsupported on this platform: {exc}")
+
+    _write(fake_repo / "CLAUDE.md", "# Title\n\nNo MANDATORY paragraphs here.\n")
+    with pytest.raises(_MODULE.InventorySchemaError):
+        _MODULE.check(fake_repo)
+
+
+def test_main_exit_two_on_repo_root_pointing_at_file(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``--repo-root`` pointing at a regular file exits 2 with a clear message."""
+    not_a_dir = tmp_path / "regular_file"
+    not_a_dir.write_text("not a directory\n", encoding="utf-8")
+    assert _MODULE.main(["--repo-root", str(not_a_dir)]) == 2
+    err = capsys.readouterr().err
+    assert "must be a directory" in err
+
+
 def test_extract_two_inline_bold_on_same_line() -> None:
     """A line with two ``**Foo (MANDATORY)**`` matches must yield both entries."""
     text = "**Foo (MANDATORY)** and also **Bar (MANDATORY)** in one sentence."

--- a/tests/unit/scripts/test_check_convention_gate_inventory.py
+++ b/tests/unit/scripts/test_check_convention_gate_inventory.py
@@ -1,0 +1,417 @@
+"""Tests for the convention-rollout meta-gate.
+
+The gate's contract: catch the SECOND occurrence of an ungated
+convention. Audits catch the first. These tests encode that intent
+explicitly: a single new MANDATORY paragraph absent from the YAML is
+already a regression (test_first_occurrence_is_strict), and a tree
+with ONE registered + ONE unregistered MANDATORY surfaces only the
+unregistered one (test_second_occurrence_isolated).
+"""
+
+import importlib.util
+import textwrap
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Protocol, cast
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class _CheckConventionGateModule(Protocol):
+    """Subset of ``scripts/check_convention_gate_inventory.py`` the tests use.
+
+    Captures the dynamically-loaded module surface so mypy strict mode
+    can type-check call sites without ``# type: ignore`` markers.
+    """
+
+    InventorySchemaError: type[Exception]
+
+    @staticmethod
+    def slugify(text: str) -> str: ...
+    @staticmethod
+    def make_id(file: str, header: str) -> str: ...
+    @staticmethod
+    def extract_mandatory_entries(text: str, file: str) -> list[object]: ...
+    @staticmethod
+    def collect_doc_files(repo_root: Path) -> list[Path]: ...
+    @staticmethod
+    def scan_repo(repo_root: Path) -> list[object]: ...
+    @staticmethod
+    def load_inventory(yaml_path: Path) -> tuple[object, ...]: ...
+    @staticmethod
+    def reconcile(
+        extracted: Iterable[object],
+        inventory: Iterable[object],
+        repo_root: Path,
+    ) -> list[object]: ...
+    @staticmethod
+    def check(repo_root: Path) -> list[object]: ...
+    @staticmethod
+    def main(argv: list[str] | None = None) -> int: ...
+
+
+def _load_module() -> _CheckConventionGateModule:
+    repo_root = Path(__file__).resolve().parents[3]
+    script_path = repo_root / "scripts" / "check_convention_gate_inventory.py"
+    spec = importlib.util.spec_from_file_location(
+        "check_convention_gate_inventory", script_path
+    )
+    if spec is None or spec.loader is None:
+        msg = f"could not load module spec for {script_path}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return cast(_CheckConventionGateModule, module)
+
+
+_MODULE = _load_module()
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path) -> Path:
+    """Build a minimal fake repo with the doc-set tree pre-created."""
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "docs" / "reference").mkdir(parents=True)
+    (tmp_path / "docs" / "design").mkdir(parents=True)
+    (tmp_path / "web").mkdir()
+    (tmp_path / "cli").mkdir()
+    return tmp_path
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+
+
+def test_slug_round_trip() -> None:
+    assert _MODULE.slugify("Persistence Boundary") == "persistence-boundary"
+    assert _MODULE.slugify("MSW handlers") == "msw-handlers"
+    assert _MODULE.slugify("  Trim Me  ") == "trim-me"
+    assert _MODULE.slugify("Foo / Bar (v2)") == "foo-bar-v2"
+
+
+def test_make_id_combines_file_and_header() -> None:
+    assert _MODULE.make_id("CLAUDE.md", "Persistence Boundary") == (
+        "claude-md::persistence-boundary"
+    )
+    assert _MODULE.make_id("web/CLAUDE.md", "MSW handlers") == (
+        "web-claude-md::msw-handlers"
+    )
+
+
+def test_extract_header_only_matches_mandatory_lines() -> None:
+    text = textwrap.dedent(
+        """
+        # Title
+
+        ## Persistence Boundary (MANDATORY)
+
+        Body text.
+
+        ## Other Section
+
+        ### Sub (MANDATORY)
+        """
+    ).strip()
+    entries = _MODULE.extract_mandatory_entries(text, "CLAUDE.md")
+    assert len(entries) == 2
+    assert entries[0].header == "Persistence Boundary"  # type: ignore[attr-defined]
+    assert entries[0].kind == "header"  # type: ignore[attr-defined]
+    assert entries[1].header == "Sub"  # type: ignore[attr-defined]
+
+
+def test_extract_inline_bold_subsections() -> None:
+    text = "**MSW handlers (MANDATORY)** must mirror the production routes."
+    entries = _MODULE.extract_mandatory_entries(text, "web/CLAUDE.md")
+    assert len(entries) == 1
+    assert entries[0].header == "MSW handlers"  # type: ignore[attr-defined]
+    assert entries[0].kind == "inline"  # type: ignore[attr-defined]
+
+
+def test_extract_mandatory_variant_phrase() -> None:
+    text = "**Foo (MANDATORY for every store)** sentence body."
+    entries = _MODULE.extract_mandatory_entries(text, "docs/reference/x.md")
+    assert len(entries) == 1
+    assert entries[0].header == "Foo"  # type: ignore[attr-defined]
+
+
+def test_load_inventory_happy_path(fake_repo: Path) -> None:
+    inventory = fake_repo / "scripts" / "convention_gate_map.yaml"
+    _write(
+        inventory,
+        """
+        mandatory_rules:
+          - id: claude-md::persistence-boundary
+            file: CLAUDE.md
+            header: Persistence Boundary
+            gate: scripts/check_persistence_boundary.py
+          - id: claude-md::planning
+            file: CLAUDE.md
+            header: Planning
+            exempt:
+              reason: Process rule, user approval before coding.
+        """,
+    )
+    entries = _MODULE.load_inventory(inventory)
+    assert len(entries) == 2
+    assert entries[0].gate == "scripts/check_persistence_boundary.py"  # type: ignore[attr-defined]
+    assert entries[1].exempt_reason  # type: ignore[attr-defined]
+
+
+def test_load_inventory_rejects_empty_reason(fake_repo: Path) -> None:
+    inventory = fake_repo / "scripts" / "convention_gate_map.yaml"
+    _write(
+        inventory,
+        """
+        mandatory_rules:
+          - id: claude-md::planning
+            file: CLAUDE.md
+            header: Planning
+            exempt:
+              reason: ""
+        """,
+    )
+    with pytest.raises(_MODULE.InventorySchemaError):
+        _MODULE.load_inventory(inventory)
+
+
+def test_load_inventory_rejects_duplicate_ids(fake_repo: Path) -> None:
+    inventory = fake_repo / "scripts" / "convention_gate_map.yaml"
+    _write(
+        inventory,
+        """
+        mandatory_rules:
+          - id: claude-md::persistence-boundary
+            file: CLAUDE.md
+            header: Persistence Boundary
+            gate: scripts/check_persistence_boundary.py
+          - id: claude-md::persistence-boundary
+            file: CLAUDE.md
+            header: Persistence Boundary
+            exempt:
+              reason: oops second copy
+        """,
+    )
+    with pytest.raises(_MODULE.InventorySchemaError):
+        _MODULE.load_inventory(inventory)
+
+
+def test_load_inventory_rejects_both_gate_and_exempt(fake_repo: Path) -> None:
+    inventory = fake_repo / "scripts" / "convention_gate_map.yaml"
+    _write(
+        inventory,
+        """
+        mandatory_rules:
+          - id: claude-md::foo
+            file: CLAUDE.md
+            header: Foo
+            gate: scripts/check_foo.py
+            exempt:
+              reason: cannot have both
+        """,
+    )
+    with pytest.raises(_MODULE.InventorySchemaError):
+        _MODULE.load_inventory(inventory)
+
+
+def test_load_inventory_rejects_neither_gate_nor_exempt(fake_repo: Path) -> None:
+    inventory = fake_repo / "scripts" / "convention_gate_map.yaml"
+    _write(
+        inventory,
+        """
+        mandatory_rules:
+          - id: claude-md::foo
+            file: CLAUDE.md
+            header: Foo
+        """,
+    )
+    with pytest.raises(_MODULE.InventorySchemaError):
+        _MODULE.load_inventory(inventory)
+
+
+def _seed_one_rule(repo: Path, *, registered: bool) -> None:
+    """Write CLAUDE.md with one MANDATORY paragraph; YAML matches iff ``registered``."""
+    _write(
+        repo / "CLAUDE.md",
+        """
+        # Title
+
+        ## Persistence Boundary (MANDATORY)
+
+        Body text.
+        """,
+    )
+    if registered:
+        # The gate script the YAML names must exist in the fake repo too.
+        _write(repo / "scripts" / "check_persistence_boundary.py", "# stub\n")
+        _write(
+            repo / "scripts" / "convention_gate_map.yaml",
+            """
+            mandatory_rules:
+              - id: claude-md::persistence-boundary
+                file: CLAUDE.md
+                header: Persistence Boundary
+                gate: scripts/check_persistence_boundary.py
+            """,
+        )
+    else:
+        _write(
+            repo / "scripts" / "convention_gate_map.yaml",
+            "mandatory_rules: []\n",
+        )
+
+
+def test_happy_path_zero_violations(fake_repo: Path) -> None:
+    _seed_one_rule(fake_repo, registered=True)
+    assert _MODULE.check(fake_repo) == []
+
+
+def test_first_occurrence_is_strict(fake_repo: Path) -> None:
+    _seed_one_rule(fake_repo, registered=False)
+    violations = _MODULE.check(fake_repo)
+    assert len(violations) == 1
+    rendered = violations[0].render()  # type: ignore[attr-defined]
+    assert "claude-md::persistence-boundary" in rendered
+    assert "not registered" in rendered
+
+
+def test_second_occurrence_isolated(fake_repo: Path) -> None:
+    _write(
+        fake_repo / "CLAUDE.md",
+        """
+        ## Persistence Boundary (MANDATORY)
+
+        First rule.
+
+        ## New Untracked Convention (MANDATORY)
+
+        Second rule, missing from YAML.
+        """,
+    )
+    _write(fake_repo / "scripts" / "check_persistence_boundary.py", "# stub\n")
+    _write(
+        fake_repo / "scripts" / "convention_gate_map.yaml",
+        """
+        mandatory_rules:
+          - id: claude-md::persistence-boundary
+            file: CLAUDE.md
+            header: Persistence Boundary
+            gate: scripts/check_persistence_boundary.py
+        """,
+    )
+    violations = _MODULE.check(fake_repo)
+    assert len(violations) == 1
+    rendered = violations[0].render()  # type: ignore[attr-defined]
+    assert "claude-md::new-untracked-convention" in rendered
+
+
+def test_exempt_entry_passes(fake_repo: Path) -> None:
+    _write(
+        fake_repo / "CLAUDE.md",
+        """
+        ## Planning (MANDATORY)
+
+        Process rule.
+        """,
+    )
+    _write(
+        fake_repo / "scripts" / "convention_gate_map.yaml",
+        """
+        mandatory_rules:
+          - id: claude-md::planning
+            file: CLAUDE.md
+            header: Planning
+            exempt:
+              reason: Process rule, user approval before coding.
+        """,
+    )
+    assert _MODULE.check(fake_repo) == []
+
+
+def test_gate_script_missing_on_disk(fake_repo: Path) -> None:
+    _seed_one_rule(fake_repo, registered=True)
+    (fake_repo / "scripts" / "check_persistence_boundary.py").unlink()
+    violations = _MODULE.check(fake_repo)
+    assert len(violations) == 1
+    rendered = violations[0].render()  # type: ignore[attr-defined]
+    assert "gate script missing" in rendered
+    assert "scripts/check_persistence_boundary.py" in rendered
+
+
+def test_inline_bold_unregistered_triggers_violation(fake_repo: Path) -> None:
+    _write(
+        fake_repo / "web" / "CLAUDE.md",
+        "**MSW handlers (MANDATORY)** must mirror production routes.\n",
+    )
+    _write(
+        fake_repo / "scripts" / "convention_gate_map.yaml",
+        "mandatory_rules: []\n",
+    )
+    violations = _MODULE.check(fake_repo)
+    assert len(violations) == 1
+    rendered = violations[0].render()  # type: ignore[attr-defined]
+    assert "web-claude-md::msw-handlers" in rendered
+
+
+def test_stale_yaml_entry(fake_repo: Path) -> None:
+    _write(fake_repo / "CLAUDE.md", "# Title\n\nNo MANDATORY paragraphs here.\n")
+    _write(fake_repo / "scripts" / "check_phantom.py", "# stub\n")
+    _write(
+        fake_repo / "scripts" / "convention_gate_map.yaml",
+        """
+        mandatory_rules:
+          - id: claude-md::phantom
+            file: CLAUDE.md
+            header: Phantom
+            gate: scripts/check_phantom.py
+        """,
+    )
+    violations = _MODULE.check(fake_repo)
+    assert len(violations) == 1
+    rendered = violations[0].render()  # type: ignore[attr-defined]
+    assert "stale entry" in rendered
+    assert "claude-md::phantom" in rendered
+
+
+def test_main_exit_zero_on_clean_tree(fake_repo: Path) -> None:
+    _seed_one_rule(fake_repo, registered=True)
+    assert _MODULE.main(["--repo-root", str(fake_repo)]) == 0
+
+
+def test_main_exit_one_on_regression(
+    fake_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _seed_one_rule(fake_repo, registered=False)
+    assert _MODULE.main(["--repo-root", str(fake_repo)]) == 1
+    out = capsys.readouterr()
+    assert "not registered" in out.out
+    assert "Convention-rollout gate failed" in out.err
+
+
+def test_main_exit_two_on_schema_error(
+    fake_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write(fake_repo / "CLAUDE.md", "# nothing\n")
+    _write(
+        fake_repo / "scripts" / "convention_gate_map.yaml",
+        "mandatory_rules: not-a-list\n",
+    )
+    assert _MODULE.main(["--repo-root", str(fake_repo)]) == 2
+    err = capsys.readouterr().err
+    assert "Inventory schema error" in err
+
+
+def test_real_repo_passes() -> None:
+    """End-to-end seal: the seeded YAML is consistent with the actual repo.
+
+    This is the only test that runs the gate against the real working
+    tree. It catches drift between the inventory and reality at PR
+    time -- if anyone adds a MANDATORY paragraph and forgets to update
+    the YAML, this fails.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    violations = _MODULE.check(repo_root)
+    rendered = "\n".join(v.render() for v in violations)  # type: ignore[attr-defined]
+    assert violations == [], f"Real-tree violations:\n{rendered}"

--- a/tests/unit/scripts/test_check_convention_gate_inventory.py
+++ b/tests/unit/scripts/test_check_convention_gate_inventory.py
@@ -220,6 +220,16 @@ _SCHEMA_REJECTION_CASES: tuple[tuple[str, str], ...] = (
         "mandatory-rules-null",
         "mandatory_rules: null\n",
     ),
+    (
+        "id-mismatch",
+        """
+        mandatory_rules:
+          - id: claude-md::wrong-slug
+            file: CLAUDE.md
+            header: Persistence Boundary
+            gate: scripts/check_persistence_boundary.py
+        """,
+    ),
 )
 
 

--- a/tests/unit/scripts/test_check_convention_gate_inventory.py
+++ b/tests/unit/scripts/test_check_convention_gate_inventory.py
@@ -509,3 +509,68 @@ def test_extract_handles_crlf_line_endings() -> None:
     assert len(entries) == 1
     # Header text must not carry a trailing \r left over from the split.
     assert entries[0].header == "Persistence Boundary"  # type: ignore[attr-defined]
+
+
+def test_load_inventory_raises_schema_error_on_unreadable_yaml(
+    fake_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """OSError on the inventory read surfaces as InventorySchemaError (exit 2)."""
+    inventory = fake_repo / "scripts" / "convention_gate_map.yaml"
+    _write(inventory, "mandatory_rules: []\n")
+
+    real_read_text = Path.read_text
+
+    def _broken_read(self: Path, *args: object, **kwargs: object) -> str:
+        del args, kwargs
+        if self.name == "convention_gate_map.yaml":
+            msg = "synthetic permission error"
+            raise PermissionError(msg)
+        return real_read_text(self, encoding="utf-8")
+
+    monkeypatch.setattr(Path, "read_text", _broken_read)
+    with pytest.raises(_MODULE.InventorySchemaError):
+        _MODULE.load_inventory(inventory)
+
+
+def test_gate_path_symlink_escape_treated_as_missing(
+    fake_repo: Path, tmp_path: Path
+) -> None:
+    """A gate path that is a symlink resolving outside repo_root is rejected.
+
+    Without containment, a malicious or mistaken symlink inside the repo
+    could point at any file on disk and silently satisfy the gate-existence
+    check, defeating the safe-relative-path guarantee that the YAML loader
+    enforces statically.
+    """
+    outside_target = tmp_path / "outside_target.py"
+    outside_target.write_text("# outside repo\n", encoding="utf-8")
+
+    gate_link = fake_repo / "scripts" / "check_escape.py"
+    try:
+        gate_link.symlink_to(outside_target)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink creation unsupported on this platform: {exc}")
+
+    _write(
+        fake_repo / "CLAUDE.md",
+        """
+        ## Persistence Boundary (MANDATORY)
+
+        Body.
+        """,
+    )
+    _write(
+        fake_repo / "scripts" / "convention_gate_map.yaml",
+        """
+        mandatory_rules:
+          - id: claude-md::persistence-boundary
+            file: CLAUDE.md
+            header: Persistence Boundary
+            gate: scripts/check_escape.py
+        """,
+    )
+    violations = _MODULE.check(fake_repo)
+    assert len(violations) == 1
+    rendered = violations[0].render()  # type: ignore[attr-defined]
+    assert "gate script missing" in rendered
+    assert "scripts/check_escape.py" in rendered

--- a/tests/unit/scripts/test_check_convention_gate_inventory.py
+++ b/tests/unit/scripts/test_check_convention_gate_inventory.py
@@ -53,6 +53,14 @@ class _CheckConventionGateModule(Protocol):
 
 
 def _load_module() -> _CheckConventionGateModule:
+    """Load the gate script as a Python module via importlib.
+
+    Direct module import (rather than subprocess invocation) lets the
+    tests drive private helpers and synthesise repos in ``tmp_path``
+    without touching the real working tree. The ``cast`` to the local
+    Protocol gives mypy strict the surface it needs without a sea of
+    ``# type: ignore`` markers at every call site.
+    """
     repo_root = Path(__file__).resolve().parents[3]
     script_path = repo_root / "scripts" / "check_convention_gate_inventory.py"
     spec = importlib.util.spec_from_file_location(
@@ -160,10 +168,9 @@ def test_load_inventory_happy_path(fake_repo: Path) -> None:
     assert entries[1].exempt_reason  # type: ignore[attr-defined]
 
 
-def test_load_inventory_rejects_empty_reason(fake_repo: Path) -> None:
-    inventory = fake_repo / "scripts" / "convention_gate_map.yaml"
-    _write(
-        inventory,
+_SCHEMA_REJECTION_CASES: tuple[tuple[str, str], ...] = (
+    (
+        "empty-reason",
         """
         mandatory_rules:
           - id: claude-md::planning
@@ -172,15 +179,9 @@ def test_load_inventory_rejects_empty_reason(fake_repo: Path) -> None:
             exempt:
               reason: ""
         """,
-    )
-    with pytest.raises(_MODULE.InventorySchemaError):
-        _MODULE.load_inventory(inventory)
-
-
-def test_load_inventory_rejects_duplicate_ids(fake_repo: Path) -> None:
-    inventory = fake_repo / "scripts" / "convention_gate_map.yaml"
-    _write(
-        inventory,
+    ),
+    (
+        "duplicate-ids",
         """
         mandatory_rules:
           - id: claude-md::persistence-boundary
@@ -193,15 +194,9 @@ def test_load_inventory_rejects_duplicate_ids(fake_repo: Path) -> None:
             exempt:
               reason: oops second copy
         """,
-    )
-    with pytest.raises(_MODULE.InventorySchemaError):
-        _MODULE.load_inventory(inventory)
-
-
-def test_load_inventory_rejects_both_gate_and_exempt(fake_repo: Path) -> None:
-    inventory = fake_repo / "scripts" / "convention_gate_map.yaml"
-    _write(
-        inventory,
+    ),
+    (
+        "both-gate-and-exempt",
         """
         mandatory_rules:
           - id: claude-md::foo
@@ -211,28 +206,43 @@ def test_load_inventory_rejects_both_gate_and_exempt(fake_repo: Path) -> None:
             exempt:
               reason: cannot have both
         """,
-    )
-    with pytest.raises(_MODULE.InventorySchemaError):
-        _MODULE.load_inventory(inventory)
-
-
-def test_load_inventory_rejects_neither_gate_nor_exempt(fake_repo: Path) -> None:
-    inventory = fake_repo / "scripts" / "convention_gate_map.yaml"
-    _write(
-        inventory,
+    ),
+    (
+        "neither-gate-nor-exempt",
         """
         mandatory_rules:
           - id: claude-md::foo
             file: CLAUDE.md
             header: Foo
         """,
-    )
+    ),
+    (
+        "mandatory-rules-null",
+        "mandatory_rules: null\n",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "yaml_body",
+    [case[1] for case in _SCHEMA_REJECTION_CASES],
+    ids=[case[0] for case in _SCHEMA_REJECTION_CASES],
+)
+def test_load_inventory_rejects_invalid_schema(fake_repo: Path, yaml_body: str) -> None:
+    inventory = fake_repo / "scripts" / "convention_gate_map.yaml"
+    _write(inventory, yaml_body)
     with pytest.raises(_MODULE.InventorySchemaError):
         _MODULE.load_inventory(inventory)
 
 
 def _seed_one_rule(repo: Path, *, registered: bool) -> None:
-    """Write CLAUDE.md with one MANDATORY paragraph; YAML matches iff ``registered``."""
+    """Seed a fake repo with one MANDATORY paragraph and matching YAML.
+
+    When ``registered=True``, also creates the gate script's path on
+    disk so the gate's existence check passes; the schema validator
+    requires every ``gate:`` entry to resolve to a real file. The
+    rule id is always ``claude-md::persistence-boundary``.
+    """
     _write(
         repo / "CLAUDE.md",
         """
@@ -415,3 +425,77 @@ def test_real_repo_passes() -> None:
     violations = _MODULE.check(repo_root)
     rendered = "\n".join(v.render() for v in violations)  # type: ignore[attr-defined]
     assert violations == [], f"Real-tree violations:\n{rendered}"
+
+
+def test_scan_repo_raises_schema_error_on_unreadable_file(
+    fake_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """OSError on a doc file read surfaces as InventorySchemaError, not a crash."""
+    _write(fake_repo / "CLAUDE.md", "## Foo (MANDATORY)\nbody\n")
+
+    real_read_text = Path.read_text
+
+    def _broken_read(self: Path, *args: object, **kwargs: object) -> str:
+        del args, kwargs
+        if self.name == "CLAUDE.md":
+            msg = "synthetic permission error"
+            raise PermissionError(msg)
+        return real_read_text(self, encoding="utf-8")
+
+    monkeypatch.setattr(Path, "read_text", _broken_read)
+    with pytest.raises(_MODULE.InventorySchemaError):
+        _MODULE.scan_repo(fake_repo)
+
+
+def test_extract_two_inline_bold_on_same_line() -> None:
+    """A line with two ``**Foo (MANDATORY)**`` matches must yield both entries."""
+    text = "**Foo (MANDATORY)** and also **Bar (MANDATORY)** in one sentence."
+    entries = _MODULE.extract_mandatory_entries(text, "web/CLAUDE.md")
+    assert len(entries) == 2
+    headers = sorted(e.header for e in entries)  # type: ignore[attr-defined]
+    assert headers == ["Bar", "Foo"]
+
+
+def test_extract_header_at_line_one() -> None:
+    """A MANDATORY header on line 1 (no leading newline) extracts at line=1."""
+    text = "## Persistence Boundary (MANDATORY)\nBody.\n"
+    entries = _MODULE.extract_mandatory_entries(text, "CLAUDE.md")
+    assert len(entries) == 1
+    assert entries[0].line == 1  # type: ignore[attr-defined]
+
+
+def test_check_with_empty_doc_set_only_surfaces_stale(fake_repo: Path) -> None:
+    """If no canonical doc files exist but YAML lists rules, every rule is stale."""
+    _write(fake_repo / "scripts" / "check_phantom.py", "# stub\n")
+    _write(
+        fake_repo / "scripts" / "convention_gate_map.yaml",
+        """
+        mandatory_rules:
+          - id: claude-md::phantom
+            file: CLAUDE.md
+            header: Phantom
+            gate: scripts/check_phantom.py
+        """,
+    )
+    violations = _MODULE.check(fake_repo)
+    assert len(violations) == 1
+    assert "stale entry" in violations[0].render()  # type: ignore[attr-defined]
+
+
+def test_main_exit_two_on_bad_repo_root(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Passing --repo-root to a path that does not exist exits 2 with a clear msg."""
+    missing = tmp_path / "nonexistent-subdir"
+    assert _MODULE.main(["--repo-root", str(missing)]) == 2
+    err = capsys.readouterr().err
+    assert "does not exist" in err
+
+
+def test_extract_handles_crlf_line_endings() -> None:
+    """Markdown files with CRLF line endings (Windows default) extract cleanly."""
+    text = "## Persistence Boundary (MANDATORY)\r\nBody.\r\n"
+    entries = _MODULE.extract_mandatory_entries(text, "CLAUDE.md")
+    assert len(entries) == 1
+    # Header text must not carry a trailing \r left over from the split.
+    assert entries[0].header == "Persistence Boundary"  # type: ignore[attr-defined]

--- a/tests/unit/scripts/test_check_convention_gate_inventory.py
+++ b/tests/unit/scripts/test_check_convention_gate_inventory.py
@@ -533,7 +533,7 @@ def test_load_inventory_raises_schema_error_on_unreadable_yaml(
 
 
 def test_gate_path_symlink_escape_treated_as_missing(
-    fake_repo: Path, tmp_path: Path
+    fake_repo: Path, tmp_path_factory: pytest.TempPathFactory
 ) -> None:
     """A gate path that is a symlink resolving outside repo_root is rejected.
 
@@ -542,7 +542,11 @@ def test_gate_path_symlink_escape_treated_as_missing(
     check, defeating the safe-relative-path guarantee that the YAML loader
     enforces statically.
     """
-    outside_target = tmp_path / "outside_target.py"
+    # ``fake_repo`` IS the test's ``tmp_path``, so its sibling-tempdir from
+    # ``tmp_path_factory`` is the only way to put the symlink target on a
+    # path that genuinely escapes the repo root.
+    outside_dir = tmp_path_factory.mktemp("outside_repo")
+    outside_target = outside_dir / "outside_target.py"
     outside_target.write_text("# outside repo\n", encoding="utf-8")
 
     gate_link = fake_repo / "scripts" / "check_escape.py"


### PR DESCRIPTION
## Summary

Adds the meta-gate that enforces CLAUDE.md "Convention Rollout (MANDATORY)": every `(MANDATORY)` paragraph in the canonical doc set must have either a registered enforcement script or an explicit exemption. The audit catches the first occurrence; this gate locks the second.

## Changes

- **`scripts/check_convention_gate_inventory.py`** (new). Walks `CLAUDE.md`, `web/CLAUDE.md`, `cli/CLAUDE.md`, `docs/reference/*.md`, `docs/design/*.md`. Extracts `## ... (MANDATORY)` headers and `**... (MANDATORY)**` inline subsections (incl. the `(MANDATORY for every store)` variant). Reconciles against an inventory YAML, verifies every `gate:` path exists, surfaces stale YAML entries. Three exit codes: 0 clean / 1 regression / 2 schema or setup error. `--verbose` prints extracted vs registered counts so a "broken glob" failure is distinguishable from "correctly empty".
- **`scripts/convention_gate_map.yaml`** (new). Inventory of every current MANDATORY paragraph: 26 rules total — 13 in `CLAUDE.md`, 9 in `web/CLAUDE.md`, 7 in `docs/reference/web-zustand-stores.md`. Mix of `gate:` (real enforcement script / config) and `exempt: { reason }` (process / workflow rules with documented enforcement chain).
- **`tests/unit/scripts/test_check_convention_gate_inventory.py`** (new). 28 tests covering extraction (header / inline-bold / variant phrase / line 1 / CRLF / multi-match-per-line), schema validation (empty reason, duplicates, gate XOR exempt, `mandatory_rules: null`, gate-path traversal), reconciliation (registered, unregistered, stale, missing-on-disk), the gate's "second occurrence" intent, and three CLI exit-code paths. The real-tree test asserts the seeded YAML matches the actual repo.
- **`.pre-commit-config.yaml`**. New `convention-gate-inventory` hook at pre-push. Files filter triggers on any canonical doc, the YAML, the script, or this config so weakening attempts cannot bypass the gate. Added to the `pre-commit.ci` skip list (uv-dependent).
- **`CLAUDE.md`** "Convention Rollout (MANDATORY)". Added a one-paragraph pointer at the new YAML and the meta-gate.
- **`docs/reference/conventions.md`** §17. New "Registering a new MANDATORY rule" section: gate-vs-exempt shapes, rule-id format (`<file-slug>::<header-slug>`), worked examples.

## Test plan

```bash
uv run python -m pytest tests/unit/scripts/test_check_convention_gate_inventory.py -m unit -n 8 -v
uv run python scripts/check_convention_gate_inventory.py --verbose
uv run python -m pytest tests/ -m unit -n 8 --ignore=tests/benchmarks/
uv run pre-commit run convention-gate-inventory --all-files
```

All green. Real-tree run: `extracted 26 MANDATORY entries, inventory has 26 registered rules`, exit 0.

## Review coverage

Pre-reviewed locally by 16 agents in parallel before this PR:
docs-consistency, comment-quality-rot, code-reviewer, python-reviewer,
pr-test-analyzer, silent-failure-hunter, comment-analyzer,
type-design-analyzer, conventions-enforcer, security-reviewer,
infra-reviewer, tool-parity-checker, test-quality-reviewer,
issue-resolution-verifier, mini-pass-missing-event-constants,
mini-pass-race-conditions.

22 valid findings surfaced (1 CRITICAL, 4 MAJOR, 9 MEDIUM, 6 MINOR, 2 INFO) — all implemented in the second commit on this branch. Highlights:

- Split `(FileNotFoundError, OSError)` in `main()` so `PermissionError` no longer mislabels as "does not exist".
- YAML parse errors now surface `problem_mark` line/column.
- `OSError` in `scan_repo()` uses `str(exc)` instead of unreliable `exc.strerror`.
- `_relative_posix()` catches symlink-escape `ValueError` as `InventorySchemaError`.
- `make_id()` rejects empty input loudly (no degenerate `"::"` ids).
- `MandatoryEntry.kind` tightened to `Literal["header", "inline"]`.
- `InventoryEntry.__post_init__` enforces the gate-XOR-exempt invariant.
- `_require_safe_relative_path` rejects `..` traversal and absolute paths in YAML gate refs.
- `reconcile()` split into `_check_extracted_against_inventory` + `_check_stale_inventory` (stays under the 50-line guideline).
- 6 new tests for the missing-coverage gaps surfaced by `pr-test-analyzer`; the four schema-rejection tests merged into one parametrized test.

issue-resolution-verifier rated all four task checkboxes RESOLVED at confidence ≥95. The single approved deviation from the issue body (`exempt: { reason }` YAML field instead of inline `<!-- convention-gate-exempt: ... -->` markdown comment) was confirmed via `AskUserQuestion` during planning — single source of truth, easier to audit.

Closes #1766