### PR TITLE
docs+settings: documentation truth pass + register CSP / error-docs / Slack settings

### DIFF
--- a/data/competitors.yaml
+++ b/data/competitors.yaml
@@ -118,7 +118,7 @@ competitors:
       observability: {support: full, note: "Structured logging, correlation tracking, log shipping, redaction, Prometheus metrics, OTLP"}
       web_dashboard: {support: full, note: "React 19 dashboard with org chart, tasks, budgets, workflow editor, setup wizard, WebSocket + SSE resilience"}
       cli: {support: partial, note: "Go binary for container management and verification; not used for agent orchestration"}
-      production_ready: {support: partial, note: "Docker + CI/CD + cosign + SLSA L3 provenance; stable REST API; SQLite + PostgreSQL backends GA"}
+      production_ready: {support: full, note: "Docker + CI/CD + cosign + SLSA L3 provenance; stable REST API; SQLite + PostgreSQL backends GA"}
       workflow_types: {support: partial, note: "Sequential, parallel, Kanban, Agile sprints, velocity tracking, and ceremony scheduling shipped; throughput-adaptive and milestone-driven strategies still in progress"}
       template_system: {support: full, note: "9 company templates, 23 personality presets, locale-aware name generation"}
 

--- a/data/competitors.yaml
+++ b/data/competitors.yaml
@@ -118,7 +118,7 @@ competitors:
       observability: {support: full, note: "Structured logging, correlation tracking, log shipping, redaction, Prometheus metrics, OTLP"}
       web_dashboard: {support: full, note: "React 19 dashboard with org chart, tasks, budgets, workflow editor, setup wizard, WebSocket + SSE resilience"}
       cli: {support: partial, note: "Go binary for container management and verification; not used for agent orchestration"}
-      production_ready: {support: partial, note: "Docker + CI/CD + cosign + SLSA L3 provenance; stable REST API; SQLite GA; PostgreSQL backend in progress"}
+      production_ready: {support: partial, note: "Docker + CI/CD + cosign + SLSA L3 provenance; stable REST API; SQLite + PostgreSQL backends GA"}
       workflow_types: {support: partial, note: "Sequential, parallel, Kanban, Agile sprints, velocity tracking, and ceremony scheduling shipped; throughput-adaptive and milestone-driven strategies still in progress"}
       template_system: {support: full, note: "9 company templates, 23 personality presets, locale-aware name generation"}
 

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -22,7 +22,7 @@ ARG BASE_IMAGE
 # ---------------------------------------------------------------------------
 FROM python:3.14.3-slim@sha256:5e59aae31ff0e87511226be8e2b94d78c58f05216efda3b07dbbed938ec8583b AS builder
 
-COPY --from=ghcr.io/astral-sh/uv:0.11.8@sha256:3b7b60a81d3c57ef471703e5c83fd4aaa33abcd403596fb22ab07db85ae91347 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.9@sha256:6b6fa841d71a48fbc9e2c55651c5ad570e01104d7a7d701f57b2b22c0f58e9b1 /uv /uvx /bin/
 
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy

--- a/docker/fine-tune/Dockerfile
+++ b/docker/fine-tune/Dockerfile
@@ -22,7 +22,7 @@ ARG FINE_TUNE_EXTRA=fine-tune-gpu
 # ---------------------------------------------------------------------------
 FROM python:3.14.3-slim@sha256:5e59aae31ff0e87511226be8e2b94d78c58f05216efda3b07dbbed938ec8583b AS builder
 
-COPY --from=ghcr.io/astral-sh/uv:0.11.8@sha256:3b7b60a81d3c57ef471703e5c83fd4aaa33abcd403596fb22ab07db85ae91347 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.9@sha256:6b6fa841d71a48fbc9e2c55651c5ad570e01104d7a7d701f57b2b22c0f58e9b1 /uv /uvx /bin/
 
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -14,7 +14,7 @@ All significant design and architecture decisions in force today, organized by d
 
 | Candidate | Score | Why chosen / rejected |
 |-----------|-------|----------------------|
-| **Mem0** (chosen) | 70/100 | Production-ready (v1.0+, 49k stars). In-process deployment (Qdrant embedded + SQLite). Python 3.14 compatible (`>=3.9,<4.0`). Async client available. Low adapter overhead (~500-1k lines). Known gap: flat fact model doesn't natively map to 5-type memory taxonomy (acceptable for initial backend) |
+| **Mem0** (chosen) | 70/100 | Production-ready (v1.0+, 54k+ stars). In-process deployment (Qdrant embedded + SQLite). Python 3.14 compatible (`>=3.9,<4.0`). Async client available. Low adapter overhead (~500-1k lines). Known gap: flat fact model doesn't natively map to 5-type memory taxonomy (acceptable for initial backend) |
 | Custom Stack | 80/100 | Best architectural fit but ~6-8k lines of custom code before any memory works. Deferred to future phase; build after Mem0 proves the protocol shape |
 | Graphiti | 66/100 | Best temporal knowledge graph, but pre-1.0 stability (v0.28), extreme LLM ingestion costs (1000+ API calls per 10k chars), only covers 2-3 of 5 memory types |
 

--- a/docs/design/agent-execution.md
+++ b/docs/design/agent-execution.md
@@ -206,7 +206,9 @@ async run(
 2. **Pre-flight budget enforcement**: if `BudgetEnforcer` is provided, check
    monthly hard stop and daily limit via `check_can_execute()`, then apply
    auto-downgrade via `resolve_model()`. Raises `BudgetExhaustedError` or
-   `DailyLimitExceededError` on violation.
+   `DailyLimitExceededError` on violation. See
+   [Budget & Cost Management](budget.md#cost-controls) for the full
+   pre-flight / in-flight / task-boundary enforcement model.
 3. **Project validation**: if `ProjectRepository` is provided, validate that the
    task's project exists (`ProjectNotFoundError` if not) and that the agent is a
    member of the project team (`ProjectAgentNotMemberError` if not; empty teams
@@ -324,7 +326,12 @@ async run(
       `STAGNATION` indicates the agent was stuck in a repetitive loop.
       `PARKED` indicates the agent was
       suspended by an approval-timeout policy; the task remains at its current
-      status until explicitly resumed.
+      status until explicitly resumed. Approval parking is distinct from the
+      checkpoint-based `SUSPENDED` state produced by graceful shutdown
+      (which preserves an agent's full context across a process restart);
+      see [Approval Timeout Policy](security.md#approval-timeout-policy)
+      and [Graceful Shutdown](coordination.md#graceful-shutdown-protocol)
+      for the two parking mechanisms.
     - Each transition is synced to TaskEngine incrementally (see
       [AgentEngine <-> TaskEngine Incremental Sync](engine.md#agentengine--taskengine-incremental-sync)).
     - Transition failures are logged but do not discard the successful execution

--- a/docs/design/agent-execution.md
+++ b/docs/design/agent-execution.md
@@ -324,9 +324,11 @@ async run(
     - All other termination reasons (`MAX_TURNS`, `BUDGET_EXHAUSTED`,
       `STAGNATION`, `PARKED`) leave the task in its current state.
       `STAGNATION` indicates the agent was stuck in a repetitive loop.
-      `PARKED` indicates the agent was
-      suspended by an approval-timeout policy; the task remains at its current
-      status until explicitly resumed. Approval parking is distinct from the
+      `PARKED` indicates the agent paused while waiting for a human
+      approval decision from `ApprovalGate`; the task remains at its
+      current status until explicitly resumed. The Approval Timeout
+      Policy controls how long the parked state persists and how it
+      ultimately resolves. Approval parking is distinct from the
       checkpoint-based `SUSPENDED` state produced by graceful shutdown
       (which preserves an agent's full context across a process restart);
       see [Approval Timeout Policy](security.md#approval-timeout-policy)

--- a/docs/design/budget.md
+++ b/docs/design/budget.md
@@ -5,7 +5,7 @@ description: Hierarchical budgets, cost tracking, CFO agent responsibilities, co
 
 # Budget & Cost Management
 
-SynthOrg treats money as a first-class runtime constraint. Every LLM call carries a currency-stamped `CostRecord`, budgets cascade from the company down to individual teams, and three layers of enforcement (pre-flight, in-flight, task-boundary) prevent runaway spending without breaking in-progress work.
+SynthOrg treats money as a first-class runtime constraint. Every LLM call carries a currency-stamped `CostRecord`, budgets cascade from the company down to individual teams, and three layers of enforcement (pre-flight, in-flight, task-boundary) prevent runaway spending without breaking in-progress work. The agent execution pipeline that drives each layer is documented in [Agent Execution > AgentEngine Orchestrator](agent-execution.md#agentengine-orchestrator).
 
 ---
 

--- a/docs/design/coordination.md
+++ b/docs/design/coordination.md
@@ -142,6 +142,11 @@ When the process receives SIGTERM/SIGINT (user Ctrl+C, Docker stop, systemd
 shutdown), the framework stops cleanly without losing work or leaking costs.
 Shutdown strategies are implemented behind a `ShutdownStrategy` protocol.
 
+Shutdown-time `SUSPENDED` is distinct from the in-process `PARKED` state used
+when an agent waits for human approval; see
+[Approval Timeout Policy](security.md#approval-timeout-policy) for the
+agent-driven parking mechanism.
+
 ### Strategy 1: Cooperative with Timeout (Default / MVP)
 
 The engine sets a shutdown event, stops accepting new tasks, and gives in-flight

--- a/docs/design/internationalization.md
+++ b/docs/design/internationalization.md
@@ -4,7 +4,7 @@ SynthOrg's UI text is shipped in **International / British English**. UI text tr
 
 ## Decision
 
-This was confirmed on 2026-04-30. The dashboard ships UI copy in International / British English (`colour`, `behaviour`, `organise`, `centred`, `analyse`). Strings are inline in components; there is no `t()` resolver, no message catalog, and no locale switcher. Currency / date / time / number formatting continues to be locale-resolved at runtime through the existing helpers; only the UI text variant is fixed.
+The dashboard ships UI copy in International / British English (`colour`, `behaviour`, `organise`, `centred`, `analyse`). Strings are inline in components; there is no `t()` resolver, no message catalog, and no locale switcher. Currency / date / time / number formatting continues to be locale-resolved at runtime through the existing helpers; only the UI text variant is fixed.
 
 ## What this means in practice
 

--- a/docs/design/memory.md
+++ b/docs/design/memory.md
@@ -50,7 +50,7 @@ Memory persistence is configurable per agent, from no persistence to fully persi
     ```yaml
     memory:
       level: "persistent"            # none | session | project | persistent (default: session)
-      backend: "mem0"               # mem0 | custom | cognee | graphiti (future)
+      backend: "mem0"               # mem0 | custom
       storage:
         data_dir: "/data/memory"    # mounted Docker volume path
         vector_store: "qdrant"      # hardcoded to embedded qdrant in Mem0 backend

--- a/docs/design/memory.md
+++ b/docs/design/memory.md
@@ -50,7 +50,7 @@ Memory persistence is configurable per agent, from no persistence to fully persi
     ```yaml
     memory:
       level: "persistent"            # none | session | project | persistent (default: session)
-      backend: "mem0"               # mem0 | custom
+      backend: "mem0"               # mem0 only
       storage:
         data_dir: "/data/memory"    # mounted Docker volume path
         vector_store: "qdrant"      # hardcoded to embedded qdrant in Mem0 backend

--- a/docs/design/memory.md
+++ b/docs/design/memory.md
@@ -50,7 +50,7 @@ Memory persistence is configurable per agent, from no persistence to fully persi
     ```yaml
     memory:
       level: "persistent"            # none | session | project | persistent (default: session)
-      backend: "mem0"               # mem0 only
+      backend: "mem0"               # mem0 (default); also supports composite, inmemory
       storage:
         data_dir: "/data/memory"    # mounted Docker volume path
         vector_store: "qdrant"      # hardcoded to embedded qdrant in Mem0 backend

--- a/docs/design/security.md
+++ b/docs/design/security.md
@@ -200,6 +200,13 @@ the original context exactly where it left off. This mirrors real company behavi
 starts another task while waiting for a code review, then returns to the original work when
 feedback arrives.
 
+Approval parking is distinct from the checkpoint-based `SUSPENDED` state produced by
+graceful shutdown: the former is an in-process, voluntary pause initiated by the agent
+when a high-risk action needs human sign-off, the latter is an externally-driven save
+of in-flight context across a process restart. See
+[Graceful Shutdown Protocol](coordination.md#graceful-shutdown-protocol) for the
+shutdown-time mechanism.
+
 === "Wait Forever"
 
     The action stays in the human queue indefinitely. No timeout, no auto-resolution. The agent

--- a/docs/design/strategy.md
+++ b/docs/design/strategy.md
@@ -10,7 +10,7 @@
 
 ## Background
 
-HBR research (March 2026) shows LLMs systematically recommend trendy, context-insensitive strategies across 7 core business tensions. Prompt-level fixes produce < 2% bias reduction. SynthOrg mitigates this structurally through constitutional principles, multi-lens analysis, confidence calibration, and output mode control.
+Industry research shows LLMs systematically recommend trendy, context-insensitive strategies across 7 core business tensions. Prompt-level fixes produce < 2% bias reduction. SynthOrg mitigates this structurally through constitutional principles, multi-lens analysis, confidence calibration, and output mode control.
 
 ## Strategic Output Modes
 

--- a/docs/design/strategy.md
+++ b/docs/design/strategy.md
@@ -10,7 +10,7 @@
 
 ## Background
 
-Industry research shows LLMs systematically recommend trendy, context-insensitive strategies across 7 core business tensions. Prompt-level fixes produce < 2% bias reduction. SynthOrg mitigates this structurally through constitutional principles, multi-lens analysis, confidence calibration, and output mode control.
+Industry research shows LLMs systematically recommend trendy, context-insensitive strategies across 7 core business tensions. Prompt-level fixes produce only marginal bias reduction. SynthOrg mitigates this structurally through constitutional principles, multi-lens analysis, confidence calibration, and output mode control.
 
 ## Strategic Output Modes
 

--- a/docs/design/strategy.md
+++ b/docs/design/strategy.md
@@ -240,4 +240,3 @@ engine/strategy/
 
 - Research: #693
 - Phase 2 (meeting integration): #1158
-- HBR trendslop article: March 2026

--- a/docs/design/tools.md
+++ b/docs/design/tools.md
@@ -217,10 +217,10 @@ External tools are integrated via the **Model Context Protocol** (MCP).
 
 ### SynthOrg MCP Tool Surface
 
-SynthOrg exposes its own MCP server offering 200+ tools across 17 domains
-(agents, agents_autonomy, tasks, workflows, workflow_executions, approvals,
-budget, memory, quality, organization, communication, coordination, analytics,
-integrations, infrastructure, signals, meta). Tool definitions are classified
+SynthOrg exposes its own MCP server offering 200+ tools across 15 domain
+modules (agents, analytics, approvals, budget, communication, coordination,
+infrastructure, integrations, memory, meta, organization, quality, signals,
+tasks, workflows). Tool definitions are classified
 by capability action via the
 `read_tool` / `write_tool` / `admin_tool` builders
 (`src/synthorg/meta/mcp/tool_builder.py`); only the `admin_tool` subset is

--- a/docs/guides/settings-reference.md
+++ b/docs/guides/settings-reference.md
@@ -69,6 +69,18 @@ These surface previously-hardcoded timeouts, batch sizes, and resource limits. A
 | `telemetry` | Anonymous product telemetry opt-in (off by default; token embedded at build) |
 | `workers` | Uvicorn worker count, distributed dispatcher publish retry budget and backoff |
 
+### Security headers and error documentation
+
+The `api` namespace also carries operator-tunable settings that govern the response surface of `/docs/` and RFC 9457 error payloads, and the `notifications` namespace has a Slack default URL fallback:
+
+| Setting | Type | Default | Purpose |
+|---------|------|---------|---------|
+| `api.csp_docs_external_origins` | JSON list | `["https://cdn.jsdelivr.net", "https://fonts.scalar.com", "https://proxy.scalar.com"]` | Trusted external origins used to build the relaxed Content-Security-Policy on `/docs/` paths. Override with internally-mirrored hosts when the backend is not allowed to reach the public Scalar CDN. Each origin must match `^https?://[\w.\-:/]+$`; a malformed entry rejects the bridge config and the runtime falls back to defaults with a `WARNING` log. |
+| `api.error_docs_base_url` | STRING | `https://synthorg.io/docs/errors` | Base URL appended with `#<category>` for the RFC 9457 `type` field on every error response. HTTPS-only (`^https://[\w.\-:/]+$`) so error details never traverse plaintext. |
+| `notifications.slack_default_webhook_url` | STRING (sensitive) | `""` | Optional fallback Slack incoming webhook applied when a Slack sink is configured without its own `webhook_url`. Empty default keeps every sink explicit; setting a value lets operators centralise the URL. Encrypted at rest. |
+
+All three are `restart_required=True`: the CSP and error-docs URL are baked into module-level state during startup; the Slack default is read at sink construction and is not hot-reloaded.
+
 ## REST API
 
 All namespaces expose the same endpoint pattern:

--- a/docs/guides/settings-reference.md
+++ b/docs/guides/settings-reference.md
@@ -1,11 +1,11 @@
 ---
 title: Settings Reference
-description: How SynthOrg settings resolve, the 17 runtime-editable namespaces, how to view and change settings at runtime, and which changes require a restart.
+description: How SynthOrg settings resolve, the 21 runtime-editable namespaces, how to view and change settings at runtime, and which changes require a restart.
 ---
 
 # Settings Reference
 
-SynthOrg has ~100 individually-resolved settings across 17 namespaces. Each setting is typed (`STRING`, `INTEGER`, `FLOAT`, `BOOLEAN`, `ENUM`, `JSON`) and has a clearly-documented default. This guide covers how resolution works, which namespaces are user-facing vs operator-only, and how to edit settings at runtime.
+SynthOrg has ~100 individually-resolved settings across 21 namespaces. Each setting is typed (`STRING`, `INTEGER`, `FLOAT`, `BOOLEAN`, `ENUM`, `JSON`) and has a clearly-documented default. This guide covers how resolution works, which namespaces are user-facing vs operator-only, and how to edit settings at runtime.
 
 ---
 
@@ -63,6 +63,11 @@ These surface previously-hardcoded timeouts, batch sizes, and resource limits. A
 | `notifications` | Sink registry, dispatcher timeout, severity threshold |
 | `tools` | Sandbox backends, tool access levels, progressive disclosure thresholds |
 | `settings` | Dispatcher polling interval, change-notification channel |
+| `client` | Human-response timeout, scored-feedback passing score / strictness multiplier / floor for synthesised AIClients |
+| `hr` | Training-pipeline kill switch, evaluation metric toggles (quality, cost, latency, task count) |
+| `simulations` | Per-run timeouts for synthetic-client task and code-review simulations |
+| `telemetry` | Anonymous product telemetry opt-in (off by default; token embedded at build) |
+| `workers` | Uvicorn worker count, distributed dispatcher publish retry budget and backoff |
 
 ## REST API
 

--- a/docs/guides/settings-reference.md
+++ b/docs/guides/settings-reference.md
@@ -76,7 +76,7 @@ The `api` namespace also carries operator-tunable settings that govern the respo
 | Setting | Type | Default | Purpose |
 |---------|------|---------|---------|
 | `api.csp_docs_external_origins` | JSON list | `["https://cdn.jsdelivr.net", "https://fonts.scalar.com", "https://proxy.scalar.com"]` | Trusted external origins used to build the relaxed Content-Security-Policy on `/docs/` paths. Override with internally-mirrored hosts when the backend is not allowed to reach the public Scalar CDN. Each origin must match `^https?://[\w.\-:/]+$`; a malformed entry rejects the bridge config and the runtime falls back to defaults with a `WARNING` log. |
-| `api.error_docs_base_url` | STRING | `https://synthorg.io/docs/errors` | Base URL appended with `#<category>` for the RFC 9457 `type` field on every error response. HTTPS-only (`^https://[\w.\-:/]+$`) so error details never traverse plaintext. |
+| `api.error_docs_base_url` | STRING | `https://synthorg.io/docs/errors` | Base URL appended with `#<category>` for the RFC 9457 `type` field on every error response. HTTPS-only (`^https://[A-Za-z0-9.\-]+(?::\d{1,5})?(?:/[^\s?#]*)?$`); userinfo, query, and fragment components are rejected at runtime. |
 | `notifications.slack_default_webhook_url` | STRING (sensitive) | `""` | Optional fallback Slack incoming webhook applied when a Slack sink is configured without its own `webhook_url`. Empty default keeps every sink explicit; setting a value lets operators centralise the URL. Encrypted at rest. |
 
 All three are `restart_required=True`: the CSP and error-docs URL are baked into module-level state during startup; the Slack default is read at sink construction and is not hot-reloaded.

--- a/docs/guides/settings-reference.md
+++ b/docs/guides/settings-reference.md
@@ -1,11 +1,11 @@
 ---
 title: Settings Reference
-description: How SynthOrg settings resolve, the 21 runtime-editable namespaces, how to view and change settings at runtime, and which changes require a restart.
+description: How SynthOrg settings resolve, the 22 runtime-editable namespaces, how to view and change settings at runtime, and which changes require a restart.
 ---
 
 # Settings Reference
 
-SynthOrg has ~100 individually-resolved settings across 21 namespaces. Each setting is typed (`STRING`, `INTEGER`, `FLOAT`, `BOOLEAN`, `ENUM`, `JSON`) and has a clearly-documented default. This guide covers how resolution works, which namespaces are user-facing vs operator-only, and how to edit settings at runtime.
+SynthOrg has ~100 individually-resolved settings across 22 namespaces (9 user-facing + 13 operator-only). Each setting is typed (`STRING`, `INTEGER`, `FLOAT`, `BOOLEAN`, `ENUM`, `JSON`) and has a clearly-documented default. This guide covers how resolution works, which namespaces are user-facing vs operator-only, and how to edit settings at runtime.
 
 ---
 

--- a/docs/reference/conventions.md
+++ b/docs/reference/conventions.md
@@ -69,9 +69,9 @@ choice. `mode="before"` is reserved for normalizing inputs the caller
 might pass in non-canonical shape (lists vs tuples, dirty strings,
 missing aliases). When using `mode="before"`, **never** mutate the
 input dict in place; return a new dict via `{**data, key: value}`.
-The four sites flagged by the 2026-04-25 audit have been converted;
-the new immutability tests in `tests/unit/{api,tools}/...` lock
-in the pattern.
+All `mode="before"` validators in the codebase return new dicts; the
+immutability tests under `tests/unit/{api,tools}/...` lock in the
+pattern.
 
 ## 5. Event constant module imports
 

--- a/docs/reference/scoring-hyperparameters.md
+++ b/docs/reference/scoring-hyperparameters.md
@@ -123,7 +123,7 @@ marker pointing at the canonical setting.
 | `workers.dispatcher.publish_max_attempts` | 3 | Task-claim publish retry budget. |
 | `workers.dispatcher.publish_backoff_base_seconds` | 0.1 | Dispatcher exponential-backoff base. |
 | `workers.dispatcher.publish_backoff_cap_seconds` | 1.0 | Dispatcher backoff per-attempt ceiling. |
-| `memory.fine_tune.vram_batch_table` | `[[40,128],[16,64],[8,32]]` | VRAM-to-batch-size mapping for embedding fine-tune preflight. |
+| `memory.fine_tune.vram_batch_table` | `[[40.0, 128], [16.0, 64], [8.0, 32]]` | VRAM-to-batch-size mapping for embedding fine-tune preflight. Each row is `[min_vram_gb, batch_size]`; the VRAM threshold is a float (GB) and the batch size an integer. |
 | `memory.fine_tune.chunk_size` | 512 | Word-chunk size for synthetic-data generation. |
 | `communication.loop_prevention_window_seconds` | 60.0 | Per-pair delegation rate-limit window. |
 | `api.lifecycle.task_engine_shutdown_seconds` | 8.0 | Lifecycle stop step deadline (task engine). |

--- a/docs/research/multi-agent-failure-audit.md
+++ b/docs/research/multi-agent-failure-audit.md
@@ -6,6 +6,7 @@ sources:
   - "https://medium.com/@the_atomic_architect/multi-agent-systems-recreating-microservices-hell-1f727fafa487"
   - "https://arxiv.org/abs/2512.08296"
 date: 2026-04-07
+last_reviewed: 2026-05-05
 ---
 
 # Multi-Agent Failure Pattern Audit

--- a/docs/research/s1-multi-agent-decision.md
+++ b/docs/research/s1-multi-agent-decision.md
@@ -7,6 +7,7 @@ sources:
   - "https://arxiv.org/abs/2604.02460"
   - "https://arxiv.org/abs/2512.08296"
 date: 2026-04-11
+last_reviewed: 2026-05-05
 ---
 
 # S1: Multi-Agent Architecture Decision

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -2,7 +2,7 @@
 
 ## Current Status
 
-SynthOrg is in **active development**. The core subsystems are built, tested (28,000+ tests, 80%+ coverage), and integrated through a REST + WebSocket API, React 19 dashboard, and Go CLI. See the [releases page](https://github.com/Aureliolo/synthorg/releases) for the latest tagged build.
+SynthOrg is in **active development**. The core subsystems are built, tested (26,900+ tests in the latest run on 2026-05-05, 80%+ coverage), and integrated through a REST + WebSocket API, React 19 dashboard, and Go CLI. See the [releases page](https://github.com/Aureliolo/synthorg/releases) for the latest tagged build.
 
 What works today:
 

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -2,7 +2,7 @@
 
 ## Current Status
 
-SynthOrg is in **active development**. The core subsystems are built, tested (27,000+ tests, 80%+ coverage), and integrated through a REST + WebSocket API, React 19 dashboard, and Go CLI. See the [releases page](https://github.com/Aureliolo/synthorg/releases) for the latest tagged build.
+SynthOrg is in **active development**. The core subsystems are built, tested (28,000+ tests, 80%+ coverage), and integrated through a REST + WebSocket API, React 19 dashboard, and Go CLI. See the [releases page](https://github.com/Aureliolo/synthorg/releases) for the latest tagged build.
 
 What works today:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,11 +134,14 @@ dev = [
 # Build-time: the Dockerfile picks the extra via the FINE_TUNE_EXTRA build-arg.
 # Runtime: the CLI init flow prompts GPU vs CPU when fine-tuning is enabled.
 [tool.uv]
-# Lower bound covers two important fixes: GHSA-pjjw-68hj-v9mw (wheel RECORD
-# path-traversal on uninstall, fixed in 0.11.6) and the Windows trampoline
-# PYTHONHOME leak (fixed in 0.11.9) that destabilised pytest-xdist workers
-# on Python 3.14 / Windows. Bump only when a newer minimum is needed.
-required-version = ">=0.11.9"
+# Lower bound is the security floor: 0.11.8 ships the wheel RECORD
+# path-traversal fix (GHSA-pjjw-68hj-v9mw, originally landed in 0.11.6)
+# and is the binary bundled by pre-commit-uv 4.2.1. The Docker images
+# pull 0.11.9 because that release adds a Windows trampoline fix that
+# stabilises pytest-xdist workers on Python 3.14 / Windows; the project
+# floor stays one minor behind so contributors using pre-commit-uv can
+# sync without waiting on its next release.
+required-version = ">=0.11.8"
 conflicts = [
     [
         { extra = "fine-tune-gpu" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,11 @@ dev = [
 # Build-time: the Dockerfile picks the extra via the FINE_TUNE_EXTRA build-arg.
 # Runtime: the CLI init flow prompts GPU vs CPU when fine-tuning is enabled.
 [tool.uv]
+# Lower bound covers two important fixes: GHSA-pjjw-68hj-v9mw (wheel RECORD
+# path-traversal on uninstall, fixed in 0.11.6) and the Windows trampoline
+# PYTHONHOME leak (fixed in 0.11.9) that destabilised pytest-xdist workers
+# on Python 3.14 / Windows. Bump only when a newer minimum is needed.
+required-version = ">=0.11.9"
 conflicts = [
     [
         { extra = "fine-tune-gpu" },

--- a/scripts/no_magic_numbers_baseline.txt
+++ b/scripts/no_magic_numbers_baseline.txt
@@ -812,7 +812,7 @@ src/synthorg/security/timeout/policies.py:30:22
 src/synthorg/security/trust/config.py:18:39
 src/synthorg/security/trust/milestone_strategy.py:34:39
 src/synthorg/security/trust/weighted_strategy.py:27:40
-src/synthorg/settings/bridge_configs.py:31:44
+src/synthorg/settings/bridge_configs.py:34:44
 src/synthorg/settings/dispatcher.py:38:48
 src/synthorg/settings/dispatcher.py:41:44
 src/synthorg/settings/subscribers/per_op_rate_limit_subscriber.py:50:33

--- a/scripts/no_magic_numbers_baseline.txt
+++ b/scripts/no_magic_numbers_baseline.txt
@@ -219,7 +219,7 @@ src/synthorg/communication/meeting/scheduler.py:58:37
 src/synthorg/config/rate_limits.py:20:22
 src/synthorg/constants.py:3:28
 src/synthorg/core/auth/config.py:9:20
-src/synthorg/core/error_taxonomy.py:138:29
+src/synthorg/core/error_taxonomy.py:139:29
 src/synthorg/core/personality.py:25:19
 src/synthorg/core/personality.py:26:24
 src/synthorg/core/personality.py:27:19

--- a/scripts/no_magic_numbers_baseline.txt
+++ b/scripts/no_magic_numbers_baseline.txt
@@ -24,7 +24,7 @@ src/synthorg/a2a/models.py:134:28
 src/synthorg/a2a/models.py:135:24
 src/synthorg/a2a/models.py:136:29
 src/synthorg/a2a/push_verifier.py:22:30
-src/synthorg/api/app.py:138:42
+src/synthorg/api/app.py:139:42
 src/synthorg/api/auth/middleware.py:47:16
 src/synthorg/api/auth/ticket_store.py:64:29
 src/synthorg/api/auth/ticket_store.py:111:29

--- a/scripts/no_magic_numbers_baseline.txt
+++ b/scripts/no_magic_numbers_baseline.txt
@@ -24,7 +24,7 @@ src/synthorg/a2a/models.py:134:28
 src/synthorg/a2a/models.py:135:24
 src/synthorg/a2a/models.py:136:29
 src/synthorg/a2a/push_verifier.py:22:30
-src/synthorg/api/app.py:139:42
+src/synthorg/api/app.py:146:42
 src/synthorg/api/auth/middleware.py:47:16
 src/synthorg/api/auth/ticket_store.py:64:29
 src/synthorg/api/auth/ticket_store.py:111:29
@@ -812,7 +812,7 @@ src/synthorg/security/timeout/policies.py:30:22
 src/synthorg/security/trust/config.py:18:39
 src/synthorg/security/trust/milestone_strategy.py:34:39
 src/synthorg/security/trust/weighted_strategy.py:27:40
-src/synthorg/settings/bridge_configs.py:24:44
+src/synthorg/settings/bridge_configs.py:31:44
 src/synthorg/settings/dispatcher.py:38:48
 src/synthorg/settings/dispatcher.py:41:44
 src/synthorg/settings/subscribers/per_op_rate_limit_subscriber.py:50:33

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -967,7 +967,14 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
 
         try:
             origins_raw = await resolver.get_json("api", "csp_docs_external_origins")
-            csp_bridge = ApiBridgeConfig(csp_docs_external_origins=tuple(origins_raw))
+            # Pass the raw JSON shape directly so ApiBridgeConfig sees
+            # the unmodified payload. ``tuple(...)`` would coerce a
+            # mapping to its keys (and other non-iterable shapes to
+            # TypeError), masking the real validation failure. Pydantic
+            # returns a ``tuple[str, ...]`` after its own validation
+            # runs, so ``set_docs_csp_origins`` still receives the
+            # correct shape.
+            csp_bridge = ApiBridgeConfig(csp_docs_external_origins=origins_raw)
             set_docs_csp_origins(csp_bridge.csp_docs_external_origins)
         except (
             SettingNotFoundError,

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -934,6 +934,17 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
     startup = [*startup, notification_dispatcher.start]
 
     async def _resolve_runtime_security_settings() -> None:
+        # Each security key resolves independently so a validation
+        # failure on an unrelated ``api.*`` field (e.g. a bad
+        # ``request_max_body_size_bytes``) does not silently suppress
+        # CSP-origin or error-docs overrides. The shared
+        # ``ApiBridgeConfig`` validator still runs per key by
+        # constructing a one-field model -- defaults satisfy the
+        # remaining fields without re-resolving them.
+        from synthorg.settings.bridge_configs import (  # noqa: PLC0415
+            ApiBridgeConfig,
+        )
+
         if not app_state.has_config_resolver:
             logger.warning(
                 API_BRIDGE_CONFIG_RESOLVE_FAILED,
@@ -943,8 +954,11 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
             )
             return
         resolver = app_state.config_resolver
+
         try:
-            bridge = await resolver.get_api_bridge_config()
+            origins_raw = await resolver.get_json("api", "csp_docs_external_origins")
+            csp_bridge = ApiBridgeConfig(csp_docs_external_origins=tuple(origins_raw))
+            set_docs_csp_origins(csp_bridge.csp_docs_external_origins)
         except (
             SettingNotFoundError,
             SettingsEncryptionError,
@@ -954,19 +968,36 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
             logger.warning(
                 API_BRIDGE_CONFIG_RESOLVE_FAILED,
                 bridge="api",
+                key="csp_docs_external_origins",
                 error_type=type(exc).__name__,
                 error=safe_error_description(exc),
-                fallback="module_defaults",
+                fallback="module_default",
             )
-            return
-        set_docs_csp_origins(bridge.csp_docs_external_origins)
-        set_error_docs_base_url(bridge.error_docs_base_url)
-        logger.info(
-            SETTINGS_VALUE_RESOLVED,
-            namespace="api",
-            key="error_docs_base_url",
-            value=bridge.error_docs_base_url,
-        )
+
+        try:
+            url_raw = await resolver.get_str("api", "error_docs_base_url")
+            error_bridge = ApiBridgeConfig(error_docs_base_url=url_raw)
+            set_error_docs_base_url(error_bridge.error_docs_base_url)
+            logger.info(
+                SETTINGS_VALUE_RESOLVED,
+                namespace="api",
+                key="error_docs_base_url",
+                value=error_bridge.error_docs_base_url,
+            )
+        except (
+            SettingNotFoundError,
+            SettingsEncryptionError,
+            ValueError,
+            ValidationError,
+        ) as exc:
+            logger.warning(
+                API_BRIDGE_CONFIG_RESOLVE_FAILED,
+                bridge="api",
+                key="error_docs_base_url",
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+                fallback="module_default",
+            )
 
     startup = [*startup, _resolve_runtime_security_settings]
 

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -941,11 +941,21 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
         # ``ApiBridgeConfig`` validator still runs per key by
         # constructing a one-field model -- defaults satisfy the
         # remaining fields without re-resolving them.
+        # Failure branches must actively re-write the module global to
+        # ``ApiBridgeConfig()`` defaults, not just log "fallback":
+        # a previous app instance (or earlier test on the same worker)
+        # may have already mutated the global, in which case skipping
+        # the write would silently keep a stale override instead of
+        # the documented default.
         from synthorg.settings.bridge_configs import (  # noqa: PLC0415
             ApiBridgeConfig,
         )
 
+        defaults = ApiBridgeConfig()
+
         if not app_state.has_config_resolver:
+            set_docs_csp_origins(defaults.csp_docs_external_origins)
+            set_error_docs_base_url(defaults.error_docs_base_url)
             logger.warning(
                 API_BRIDGE_CONFIG_RESOLVE_FAILED,
                 bridge="api",
@@ -965,6 +975,7 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
             ValueError,
             ValidationError,
         ) as exc:
+            set_docs_csp_origins(defaults.csp_docs_external_origins)
             logger.warning(
                 API_BRIDGE_CONFIG_RESOLVE_FAILED,
                 bridge="api",
@@ -990,6 +1001,7 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
             ValueError,
             ValidationError,
         ) as exc:
+            set_error_docs_base_url(defaults.error_docs_base_url)
             logger.warning(
                 API_BRIDGE_CONFIG_RESOLVE_FAILED,
                 bridge="api",

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -17,6 +17,7 @@ from litestar.config.cors import CORSConfig
 from litestar.datastructures import State
 from litestar.openapi import OpenAPIConfig
 from litestar.openapi.plugins import ScalarRenderPlugin
+from pydantic import ValidationError
 
 from synthorg import __version__
 from synthorg.api.app_builders import (
@@ -92,11 +93,13 @@ from synthorg.hr.performance.tracker import PerformanceTracker  # noqa: TC001
 from synthorg.hr.registry import AgentRegistryService
 from synthorg.hr.training.service import TrainingService  # noqa: TC001
 from synthorg.notifications.factory import build_notification_dispatcher
-from synthorg.observability import get_logger
+from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.api import (
     API_APP_STARTUP,
+    API_BRIDGE_CONFIG_RESOLVE_FAILED,
     API_SERVICE_AUTO_WIRED,
 )
+from synthorg.observability.events.settings import SETTINGS_VALUE_RESOLVED
 from synthorg.persistence.artifact_storage import (
     ArtifactStorageBackend,  # noqa: TC001
 )
@@ -116,6 +119,10 @@ from synthorg.security.timeout.policies import WaitForeverPolicy
 from synthorg.security.timeout.scheduler import ApprovalTimeoutScheduler
 from synthorg.security.timeout.timeout_checker import TimeoutChecker
 from synthorg.security.trust.service import TrustService  # noqa: TC001
+from synthorg.settings.errors import (
+    SettingNotFoundError,
+    SettingsEncryptionError,
+)
 from synthorg.tools.invocation_tracker import ToolInvocationTracker  # noqa: TC001
 
 if TYPE_CHECKING:
@@ -928,14 +935,38 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
 
     async def _resolve_runtime_security_settings() -> None:
         if not app_state.has_config_resolver:
+            logger.warning(
+                API_BRIDGE_CONFIG_RESOLVE_FAILED,
+                bridge="api",
+                reason="config_resolver_unavailable",
+                fallback="module_defaults",
+            )
             return
         resolver = app_state.config_resolver
-        origins = await resolver.get_json("api", "csp_docs_external_origins")
-        if isinstance(origins, list) and all(isinstance(o, str) for o in origins):
-            set_docs_csp_origins(origins)
-        base_url = await resolver.get_str("api", "error_docs_base_url")
-        if base_url:
-            set_error_docs_base_url(base_url)
+        try:
+            bridge = await resolver.get_api_bridge_config()
+        except (
+            SettingNotFoundError,
+            SettingsEncryptionError,
+            ValueError,
+            ValidationError,
+        ) as exc:
+            logger.warning(
+                API_BRIDGE_CONFIG_RESOLVE_FAILED,
+                bridge="api",
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+                fallback="module_defaults",
+            )
+            return
+        set_docs_csp_origins(bridge.csp_docs_external_origins)
+        set_error_docs_base_url(bridge.error_docs_base_url)
+        logger.info(
+            SETTINGS_VALUE_RESOLVED,
+            namespace="api",
+            key="error_docs_base_url",
+            value=bridge.error_docs_base_url,
+        )
 
     startup = [*startup, _resolve_runtime_security_settings]
 

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -50,7 +50,7 @@ from synthorg.api.exception_handlers import EXCEPTION_HANDLERS
 from synthorg.api.integrations_wiring import auto_wire_integrations
 from synthorg.api.lifecycle_builder import _build_lifecycle
 from synthorg.api.lifecycle_helpers import _build_settings_dispatcher
-from synthorg.api.middleware import security_headers_hook
+from synthorg.api.middleware import security_headers_hook, set_docs_csp_origins
 from synthorg.api.middleware_factory import _build_middleware
 from synthorg.api.rate_limits import (
     build_inflight_store,
@@ -84,6 +84,7 @@ from synthorg.communication.meeting.orchestrator import (
 )
 from synthorg.communication.meeting.scheduler import MeetingScheduler  # noqa: TC001
 from synthorg.config.schema import RootConfig
+from synthorg.core.error_taxonomy import set_error_docs_base_url
 from synthorg.engine.coordination.service import MultiAgentCoordinator  # noqa: TC001
 from synthorg.engine.review_gate import ReviewGateService
 from synthorg.engine.task_engine import TaskEngine  # noqa: TC001
@@ -924,6 +925,19 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
     # notifications can fire during service teardown before sink
     # close() runs.
     startup = [*startup, notification_dispatcher.start]
+
+    async def _resolve_runtime_security_settings() -> None:
+        if not app_state.has_config_resolver:
+            return
+        resolver = app_state.config_resolver
+        origins = await resolver.get_json("api", "csp_docs_external_origins")
+        if isinstance(origins, list) and all(isinstance(o, str) for o in origins):
+            set_docs_csp_origins(origins)
+        base_url = await resolver.get_str("api", "error_docs_base_url")
+        if base_url:
+            set_error_docs_base_url(base_url)
+
+    startup = [*startup, _resolve_runtime_security_settings]
 
     if _skip_lifecycle_shutdown:
         shutdown = []

--- a/src/synthorg/api/middleware.py
+++ b/src/synthorg/api/middleware.py
@@ -35,6 +35,7 @@ from synthorg.observability.events.api import (
     API_REQUEST_STARTED,
 )
 from synthorg.observability.events.metrics import METRICS_RECORD_FAILED
+from synthorg.observability.events.settings import SETTINGS_VALUE_RESOLVED
 
 _UNMATCHED_ROUTE: Final[str] = "__unmatched__"
 
@@ -74,15 +75,30 @@ def build_docs_csp(origins: Sequence[str]) -> str:
     swap the public Scalar hosts for an internally-mirrored CDN with
     a single configuration change.
 
+    An empty *origins* list raises ``ValueError`` rather than emit a
+    malformed CSP with trailing whitespace before each ``;``. CSP
+    parsers tolerate the trailing space but operators reading the
+    header back would see an obviously broken policy; the
+    ``ApiBridgeConfig`` validator is the right place to enforce
+    non-empty (currently only validates pattern), so callers pass
+    through the bridge-config-validated tuple.
+
     Args:
         origins: Origin URLs that Scalar UI assets and proxy requests
-            may target. Each entry must already be a valid origin
-            (scheme + host); the function does not validate.
+            may target. Must be non-empty. Each entry must already be
+            a valid origin (scheme + host); ``ApiBridgeConfig``
+            performs the per-entry validation.
 
     Returns:
         A CSP header value safe to assign to
         ``Content-Security-Policy`` for ``/docs/`` responses.
+
+    Raises:
+        ValueError: If *origins* is empty.
     """
+    if not origins:
+        msg = "build_docs_csp requires at least one trusted origin"
+        raise ValueError(msg)
     joined = " ".join(origins)
     return (
         f"default-src 'self'; "
@@ -107,9 +123,21 @@ def set_docs_csp_origins(origins: Sequence[str]) -> None:
     ``api.csp_docs_external_origins`` through the settings service.
     Reset to the default list with ``_DOCS_CSP_DEFAULT_ORIGINS`` for
     test isolation.
+
+    Calling this outside startup creates a brief eventual-consistency
+    window for in-flight HTTP responses, since the docs ``before_send``
+    hook reads the global at request time. The
+    ``api.csp_docs_external_origins`` setting is marked
+    ``restart_required=True`` precisely to keep this single-writer.
     """
     global _DOCS_CSP  # noqa: PLW0603 -- single-writer startup hook; tests reset via the same setter
     _DOCS_CSP = build_docs_csp(origins)
+    logger.info(
+        SETTINGS_VALUE_RESOLVED,
+        namespace="api",
+        key="csp_docs_external_origins",
+        origins_count=len(origins),
+    )
 
 
 # Cache-Control for API data endpoints (named constant for test

--- a/src/synthorg/api/middleware.py
+++ b/src/synthorg/api/middleware.py
@@ -13,6 +13,7 @@ for matched routes -- 404 and 405 responses from the router bypass it.
 """
 
 import time
+from collections.abc import Sequence  # noqa: TC003 -- used by runtime helpers below
 from contextlib import suppress
 from types import MappingProxyType
 from typing import Any, Final
@@ -49,23 +50,67 @@ _API_CSP: Final[str] = (
 )
 
 # Relaxed CSP for /docs/ -- Scalar UI loads resources from external origins.
-# cdn.jsdelivr.net: JS bundle, CSS, fonts, source maps
-# fonts.scalar.com: Scalar-hosted font files
-# proxy.scalar.com: API proxy and registry features
 # 'unsafe-inline' in script-src/style-src: required by Scalar UI which uses
 # inline <script> and <style> elements.  Accepted risk -- /docs is read-only,
 # unauthenticated, and serves no user-submitted content.
-_DOCS_CSP: Final[str] = (
-    "default-src 'self'; "
-    "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
-    "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
-    "img-src 'self' data: https://cdn.jsdelivr.net; "
-    "font-src 'self' data: https://cdn.jsdelivr.net https://fonts.scalar.com; "
-    "connect-src 'self' https://cdn.jsdelivr.net https://proxy.scalar.com; "
-    "object-src 'none'; "
-    "base-uri 'self'; "
-    "frame-ancestors 'none'"
+#
+# The trusted-origin list is operator-tunable via the
+# ``api.csp_docs_external_origins`` setting; defaults are the Scalar
+# UI public CDN, fonts, and proxy hosts. ``set_docs_csp_origins`` is
+# called once at startup with the resolved list, replacing the
+# default-built ``_DOCS_CSP`` string.
+_DOCS_CSP_DEFAULT_ORIGINS: Final[tuple[str, ...]] = (
+    "https://cdn.jsdelivr.net",
+    "https://fonts.scalar.com",
+    "https://proxy.scalar.com",
 )
+
+
+def build_docs_csp(origins: Sequence[str]) -> str:
+    """Build the relaxed Scalar UI CSP from a list of trusted origins.
+
+    Origins are applied uniformly to ``script-src``, ``style-src``,
+    ``img-src``, ``font-src`` and ``connect-src`` so operators can
+    swap the public Scalar hosts for an internally-mirrored CDN with
+    a single configuration change.
+
+    Args:
+        origins: Origin URLs that Scalar UI assets and proxy requests
+            may target. Each entry must already be a valid origin
+            (scheme + host); the function does not validate.
+
+    Returns:
+        A CSP header value safe to assign to
+        ``Content-Security-Policy`` for ``/docs/`` responses.
+    """
+    joined = " ".join(origins)
+    return (
+        f"default-src 'self'; "
+        f"script-src 'self' 'unsafe-inline' {joined}; "
+        f"style-src 'self' 'unsafe-inline' {joined}; "
+        f"img-src 'self' data: {joined}; "
+        f"font-src 'self' data: {joined}; "
+        f"connect-src 'self' {joined}; "
+        f"object-src 'none'; "
+        f"base-uri 'self'; "
+        f"frame-ancestors 'none'"
+    )
+
+
+_DOCS_CSP: str = build_docs_csp(_DOCS_CSP_DEFAULT_ORIGINS)
+
+
+def set_docs_csp_origins(origins: Sequence[str]) -> None:
+    """Replace the docs CSP value with one built from *origins*.
+
+    Called once at app startup after resolving
+    ``api.csp_docs_external_origins`` through the settings service.
+    Reset to the default list with ``_DOCS_CSP_DEFAULT_ORIGINS`` for
+    test isolation.
+    """
+    global _DOCS_CSP  # noqa: PLW0603 -- single-writer startup hook; tests reset via the same setter
+    _DOCS_CSP = build_docs_csp(origins)
+
 
 # Cache-Control for API data endpoints (named constant for test
 # clarity; applied via _SECURITY_HEADERS).

--- a/src/synthorg/core/error_taxonomy.py
+++ b/src/synthorg/core/error_taxonomy.py
@@ -183,6 +183,12 @@ def set_error_docs_base_url(value: str) -> None:
     Called once at app startup with the resolved
     ``api.error_docs_base_url`` setting. Reset to
     :data:`_ERROR_DOCS_BASE_DEFAULT` for test isolation.
+
+    Calling this outside startup creates a brief eventual-consistency
+    window for in-flight error responses, since :func:`category_type_uri`
+    reads the global at call time. The ``api.error_docs_base_url``
+    setting is ``restart_required=True`` precisely to keep this
+    single-writer.
     """
     global _ERROR_DOCS_BASE  # noqa: PLW0603 -- single-writer startup hook; tests reset via the same setter
     _ERROR_DOCS_BASE = value

--- a/src/synthorg/core/error_taxonomy.py
+++ b/src/synthorg/core/error_taxonomy.py
@@ -22,6 +22,7 @@ not match how they are consumed.
 from enum import IntEnum, StrEnum
 from types import MappingProxyType
 from typing import Final
+from urllib.parse import urlsplit
 
 
 class ErrorCategory(StrEnum):
@@ -184,14 +185,46 @@ def set_error_docs_base_url(value: str) -> None:
     ``api.error_docs_base_url`` setting. Reset to
     :data:`_ERROR_DOCS_BASE_DEFAULT` for test isolation.
 
+    Validates the input at the boundary so a future caller that
+    bypasses the bridge-config validator cannot inject a malformed or
+    non-HTTPS base URL into every error response. Trailing slashes are
+    stripped (``category_type_uri`` appends ``#<category>``); userinfo,
+    query, and fragment components are rejected outright.
+
     Calling this outside startup creates a brief eventual-consistency
     window for in-flight error responses, since :func:`category_type_uri`
     reads the global at call time. The ``api.error_docs_base_url``
     setting is ``restart_required=True`` precisely to keep this
     single-writer.
+
+    Args:
+        value: HTTPS base URL (e.g. ``https://docs.example.com/errors``).
+
+    Raises:
+        ValueError: If *value* is empty, non-HTTPS, or carries
+            userinfo / query / fragment components.
     """
+    candidate = value.strip()
+    if not candidate:
+        msg = "error_docs_base_url must not be empty"
+        raise ValueError(msg)
+    parsed = urlsplit(candidate)
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        msg = (
+            "error_docs_base_url must be a canonical HTTPS URL"
+            " (host required, no userinfo / query / fragment)"
+        )
+        raise ValueError(msg)
+    normalised = candidate.rstrip("/")
     global _ERROR_DOCS_BASE  # noqa: PLW0603 -- single-writer startup hook; tests reset via the same setter
-    _ERROR_DOCS_BASE = value
+    _ERROR_DOCS_BASE = normalised
 
 
 def category_title(cat: ErrorCategory) -> str:

--- a/src/synthorg/core/error_taxonomy.py
+++ b/src/synthorg/core/error_taxonomy.py
@@ -168,7 +168,24 @@ CATEGORY_TITLES: MappingProxyType[ErrorCategory, str] = MappingProxyType(
     }
 )
 
-_ERROR_DOCS_BASE: Final[str] = "https://synthorg.io/docs/errors"
+_ERROR_DOCS_BASE_DEFAULT: Final[str] = "https://synthorg.io/docs/errors"
+
+# Active base URL for RFC 9457 ``type`` fragment links. Operators can
+# override at startup via the ``api.error_docs_base_url`` setting; the
+# fallback default keeps this module dependency-free for the CLI and
+# tests that import it without a settings service.
+_ERROR_DOCS_BASE: str = _ERROR_DOCS_BASE_DEFAULT
+
+
+def set_error_docs_base_url(value: str) -> None:
+    """Replace the active RFC 9457 ``type`` base URL.
+
+    Called once at app startup with the resolved
+    ``api.error_docs_base_url`` setting. Reset to
+    :data:`_ERROR_DOCS_BASE_DEFAULT` for test isolation.
+    """
+    global _ERROR_DOCS_BASE  # noqa: PLW0603 -- single-writer startup hook; tests reset via the same setter
+    _ERROR_DOCS_BASE = value
 
 
 def category_title(cat: ErrorCategory) -> str:

--- a/src/synthorg/notifications/factory.py
+++ b/src/synthorg/notifications/factory.py
@@ -207,7 +207,10 @@ def _create_slack_sink(
         SlackNotificationSink,
     )
 
-    webhook_url = params.get("webhook_url", "")
+    # Treat whitespace-only as blank so the bridge fallback fires
+    # instead of letting "   " reach SlackNotificationSink which would
+    # then raise ValueError and drop the sink entirely.
+    webhook_url = (params.get("webhook_url") or "").strip()
     used_bridge_default = False
     if not webhook_url and bridge_config is not None:
         webhook_url = bridge_config.slack_default_webhook_url

--- a/src/synthorg/notifications/factory.py
+++ b/src/synthorg/notifications/factory.py
@@ -200,6 +200,8 @@ def _create_slack_sink(
     )
 
     webhook_url = params.get("webhook_url", "")
+    if not webhook_url and bridge_config is not None:
+        webhook_url = bridge_config.slack_default_webhook_url
     if not webhook_url:
         logger.warning(
             NOTIFICATION_SINK_CONFIG_INVALID,

--- a/src/synthorg/notifications/factory.py
+++ b/src/synthorg/notifications/factory.py
@@ -14,7 +14,7 @@ from synthorg.notifications.config import (
     NotificationSinkType,
 )
 from synthorg.notifications.dispatcher import NotificationDispatcher
-from synthorg.observability import get_logger
+from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.notification import (
     NOTIFICATION_SINK_CONFIG_INVALID,
     NOTIFICATION_SINK_DEFAULT_FALLBACK,
@@ -187,21 +187,31 @@ def _create_slack_sink(
     """Create a Slack webhook notification sink.
 
     Args:
-        params: Adapter-specific parameters.
+        params: Adapter-specific parameters. Reads
+            ``webhook_url``; falls back to
+            ``bridge_config.slack_default_webhook_url`` when the
+            per-sink value is missing or blank.
         bridge_config: Optional operator-tuned notification bridge
             config. When provided, threads
-            ``slack_webhook_timeout_seconds`` into the adapter.
+            ``slack_webhook_timeout_seconds`` into the adapter and
+            supplies the namespace-level ``slack_default_webhook_url``
+            fallback.
 
     Returns:
-        Configured Slack sink or ``None`` if webhook URL is missing.
+        Configured Slack sink, or ``None`` when neither *params* nor
+        the bridge default supplies a webhook URL, or when the
+        resolved URL fails outbound-target validation
+        (loopback / private IP / non-HTTP scheme).
     """
     from synthorg.notifications.adapters.slack import (  # noqa: PLC0415
         SlackNotificationSink,
     )
 
     webhook_url = params.get("webhook_url", "")
+    used_bridge_default = False
     if not webhook_url and bridge_config is not None:
         webhook_url = bridge_config.slack_default_webhook_url
+        used_bridge_default = bool(webhook_url)
     if not webhook_url:
         logger.warning(
             NOTIFICATION_SINK_CONFIG_INVALID,
@@ -209,12 +219,29 @@ def _create_slack_sink(
             error="webhook_url is required",
         )
         return None
-    if bridge_config is None:
-        return SlackNotificationSink(webhook_url=webhook_url)
-    return SlackNotificationSink(
-        webhook_url=webhook_url,
-        webhook_timeout_seconds=bridge_config.slack_webhook_timeout_seconds,
-    )
+    if used_bridge_default:
+        logger.info(
+            NOTIFICATION_SINK_DEFAULT_FALLBACK,
+            sink_type="slack",
+            source="bridge_config.slack_default_webhook_url",
+        )
+    try:
+        if bridge_config is None:
+            return SlackNotificationSink(webhook_url=webhook_url)
+        return SlackNotificationSink(
+            webhook_url=webhook_url,
+            webhook_timeout_seconds=bridge_config.slack_webhook_timeout_seconds,
+        )
+    except MemoryError, RecursionError:
+        raise
+    except ValueError as exc:
+        logger.warning(
+            NOTIFICATION_SINK_CONFIG_INVALID,
+            sink_type="slack",
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
+        )
+        return None
 
 
 def _create_email_sink(  # noqa: PLR0911 - each return is a distinct validation guard

--- a/src/synthorg/settings/bridge_configs.py
+++ b/src/synthorg/settings/bridge_configs.py
@@ -12,16 +12,19 @@ tests without an active settings service.
 
 import re
 from typing import Final
+from urllib.parse import urlsplit
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from synthorg.core.types import NotBlankStr
 
-# Pattern shared by ``csp_docs_external_origins`` element validation and
-# any future URL-list field. Restrictive enough to reject ``javascript:``,
-# ``data:``, and other schemes that would degrade /docs CSP to no
-# protection if they leaked into the directive.
-_CSP_ORIGIN_RE: Final[re.Pattern[str]] = re.compile(r"^https?://[\w.\-:/]+$")
+# Canonical origin pattern: scheme + host (+ optional port) only -- no
+# path, query, fragment, or userinfo. The CSP spec treats anything past
+# the host as a source expression, so a permissive regex would let
+# operators leak whole URLs into the directive and silently degrade
+# /docs CSP. ``urlsplit`` handles the structural check; the regex
+# rejects whitespace and embedded slashes up front.
+_CSP_ORIGIN_RE: Final[re.Pattern[str]] = re.compile(r"^https?://[^\s/]+$")
 
 # WebSocket first-message auth handshake timeout bounds. Exposed as
 # module constants so the ``set_ws_auth_timeout_seconds`` setter on
@@ -241,12 +244,35 @@ class ApiBridgeConfig(BaseModel):
         cls,
         value: tuple[str, ...],
     ) -> tuple[str, ...]:
+        if not value:
+            msg = (
+                "csp_docs_external_origins must contain at least one"
+                " trusted origin; an empty tuple would yield a malformed"
+                " /docs CSP with trailing whitespace before each ``;``"
+            )
+            raise ValueError(msg)
         for origin in value:
             if not _CSP_ORIGIN_RE.fullmatch(origin):
                 msg = (
                     f"csp_docs_external_origins entry {origin!r} does not"
                     " match http(s)://host pattern; refusing to apply to"
                     " avoid CSP downgrade"
+                )
+                raise ValueError(msg)
+            parsed = urlsplit(origin)
+            if (
+                parsed.scheme not in {"http", "https"}
+                or not parsed.hostname
+                or parsed.username is not None
+                or parsed.password is not None
+                or parsed.path
+                or parsed.query
+                or parsed.fragment
+            ):
+                msg = (
+                    f"csp_docs_external_origins entry {origin!r} must be"
+                    " a canonical origin (scheme + host + optional port,"
+                    " no path, query, fragment, or userinfo)"
                 )
                 raise ValueError(msg)
         return value

--- a/src/synthorg/settings/bridge_configs.py
+++ b/src/synthorg/settings/bridge_configs.py
@@ -260,6 +260,24 @@ class ApiBridgeConfig(BaseModel):
                 )
                 raise ValueError(msg)
             parsed = urlsplit(origin)
+            # urlsplit defers port parsing until ``.port`` is read, then
+            # raises ValueError for non-numeric or out-of-65535 values.
+            # ``.port == 0`` is accepted by urlsplit but unusable for an
+            # HTTP origin, so reject it alongside the parse failures.
+            try:
+                port = parsed.port
+            except ValueError as exc:
+                msg = (
+                    f"csp_docs_external_origins entry {origin!r} must use"
+                    " a numeric port in 1..65535"
+                )
+                raise ValueError(msg) from exc
+            if port == 0:
+                msg = (
+                    f"csp_docs_external_origins entry {origin!r} must use"
+                    " a port in 1..65535 (0 is reserved)"
+                )
+                raise ValueError(msg)
             if (
                 parsed.scheme not in {"http", "https"}
                 or not parsed.hostname
@@ -275,6 +293,36 @@ class ApiBridgeConfig(BaseModel):
                     " no path, query, fragment, or userinfo)"
                 )
                 raise ValueError(msg)
+        return value
+
+    @field_validator("error_docs_base_url")
+    @classmethod
+    def _validate_error_docs_base_url(cls, value: str) -> str:
+        parsed = urlsplit(value)
+        try:
+            port = parsed.port
+        except ValueError as exc:
+            msg = (
+                "error_docs_base_url must use a numeric port in 1..65535"
+                " when one is supplied"
+            )
+            raise ValueError(msg) from exc
+        if port == 0:
+            msg = "error_docs_base_url must use a port in 1..65535 (0 is reserved)"
+            raise ValueError(msg)
+        if (
+            parsed.scheme != "https"
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+        ):
+            msg = (
+                "error_docs_base_url must be a canonical HTTPS URL"
+                " (host required, no userinfo / query / fragment)"
+            )
+            raise ValueError(msg)
         return value
 
 

--- a/src/synthorg/settings/bridge_configs.py
+++ b/src/synthorg/settings/bridge_configs.py
@@ -107,6 +107,47 @@ class NotificationsBridgeConfig(BaseModel):
         pattern=r"^https?://[\w.\-:]+(?:/.*)?$",
     )
 
+    @field_validator("slack_default_webhook_url")
+    @classmethod
+    def _validate_slack_default_webhook_url(cls, value: str) -> str:
+        if value == "":
+            return value
+        if value != value.strip():
+            msg = (
+                "slack_default_webhook_url must not have leading or trailing whitespace"
+            )
+            raise ValueError(msg)
+        parsed = urlsplit(value)
+        try:
+            port = parsed.port
+        except ValueError as exc:
+            msg = (
+                "slack_default_webhook_url must use a numeric port in"
+                " 1..65535 when one is supplied"
+            )
+            raise ValueError(msg) from exc
+        if port == 0:
+            msg = (
+                "slack_default_webhook_url must use a port in 1..65535 (0 is reserved)"
+            )
+            raise ValueError(msg)
+        if (
+            parsed.scheme != "https"
+            or parsed.hostname != "hooks.slack.com"
+            or parsed.username is not None
+            or parsed.password is not None
+            or not parsed.path.startswith("/services/")
+            or parsed.query
+            or parsed.fragment
+        ):
+            msg = (
+                "slack_default_webhook_url must be a canonical Slack"
+                " webhook URL: https://hooks.slack.com/services/<path>"
+                " with no userinfo, query, or fragment"
+            )
+            raise ValueError(msg)
+        return value
+
 
 class ToolsBridgeConfig(BaseModel):
     """Operator-tunable timeouts and resource limits for tool execution.

--- a/src/synthorg/settings/bridge_configs.py
+++ b/src/synthorg/settings/bridge_configs.py
@@ -88,6 +88,10 @@ class NotificationsBridgeConfig(BaseModel):
     slack_webhook_timeout_seconds: float = Field(default=10.0, ge=1.0, le=60.0)
     ntfy_webhook_timeout_seconds: float = Field(default=10.0, ge=1.0, le=60.0)
     email_smtp_timeout_seconds: float = Field(default=10.0, ge=1.0, le=60.0)
+    slack_default_webhook_url: str = Field(
+        default="",
+        pattern=r"^(|https://hooks\.slack\.com/services/.+)$",
+    )
     ntfy_default_url: NotBlankStr = Field(
         default=NotBlankStr("https://ntfy.sh"),
         pattern=r"^https?://[\w.\-:]+(?:/.*)?$",

--- a/src/synthorg/settings/bridge_configs.py
+++ b/src/synthorg/settings/bridge_configs.py
@@ -10,11 +10,18 @@ historical hardcoded value so a consumer can construct one from defaults for
 tests without an active settings service.
 """
 
+import re
 from typing import Final
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from synthorg.core.types import NotBlankStr
+
+# Pattern shared by ``csp_docs_external_origins`` element validation and
+# any future URL-list field. Restrictive enough to reject ``javascript:``,
+# ``data:``, and other schemes that would degrade /docs CSP to no
+# protection if they leaked into the directive.
+_CSP_ORIGIN_RE: Final[re.Pattern[str]] = re.compile(r"^https?://[\w.\-:/]+$")
 
 # WebSocket first-message auth handshake timeout bounds. Exposed as
 # module constants so the ``set_ws_auth_timeout_seconds`` setter on
@@ -216,6 +223,33 @@ class ApiBridgeConfig(BaseModel):
         default=1.0, ge=0.5, le=60.0
     )
     lifecycle_drain_timeout_seconds: float = Field(default=40.0, ge=5.0, le=300.0)
+    csp_docs_external_origins: tuple[NotBlankStr, ...] = Field(
+        default=(
+            NotBlankStr("https://cdn.jsdelivr.net"),
+            NotBlankStr("https://fonts.scalar.com"),
+            NotBlankStr("https://proxy.scalar.com"),
+        ),
+    )
+    error_docs_base_url: NotBlankStr = Field(
+        default=NotBlankStr("https://synthorg.io/docs/errors"),
+        pattern=r"^https://[\w.\-:/]+$",
+    )
+
+    @field_validator("csp_docs_external_origins")
+    @classmethod
+    def _validate_csp_origins(
+        cls,
+        value: tuple[str, ...],
+    ) -> tuple[str, ...]:
+        for origin in value:
+            if not _CSP_ORIGIN_RE.fullmatch(origin):
+                msg = (
+                    f"csp_docs_external_origins entry {origin!r} does not"
+                    " match http(s)://host pattern; refusing to apply to"
+                    " avoid CSP downgrade"
+                )
+                raise ValueError(msg)
+        return value
 
 
 class EngineBridgeConfig(BaseModel):

--- a/src/synthorg/settings/definitions/api.py
+++ b/src/synthorg/settings/definitions/api.py
@@ -167,6 +167,61 @@ _r.register(
     )
 )
 
+# ── Documentation CSP origins ───────────────────────────────────
+# Trusted external origins permitted by the relaxed Content-Security-
+# Policy on /docs/ paths (Scalar UI loads JS, fonts, and an API proxy
+# from these). Operators who mirror Scalar UI assets to an internal
+# CDN override this list; the resolved value is applied uniformly to
+# script-src, style-src, img-src, font-src, and connect-src.
+
+_r.register(
+    SettingDefinition(
+        namespace=SettingNamespace.API,
+        key="csp_docs_external_origins",
+        type=SettingType.JSON,
+        default=(
+            '["https://cdn.jsdelivr.net","https://fonts.scalar.com",'
+            '"https://proxy.scalar.com"]'
+        ),
+        description=(
+            "External origins trusted by the relaxed Content-Security-"
+            "Policy on /docs/ paths. Defaults to the Scalar UI public"
+            " CDN, fonts, and proxy hosts. Override (for example, to an"
+            " internally-mirrored CDN) when operators do not allow the"
+            " backend to reach the public Scalar infrastructure."
+        ),
+        group="Security Headers",
+        level=SettingLevel.ADVANCED,
+        restart_required=True,
+        yaml_path="api.csp.docs_external_origins",
+    )
+)
+
+# ── Error documentation base URL ────────────────────────────────
+# RFC 9457 problem-detail responses build their ``type`` URI from this
+# base. Operators who fork or mirror the public docs site override
+# this so deep links resolve into their copy.
+
+_r.register(
+    SettingDefinition(
+        namespace=SettingNamespace.API,
+        key="error_docs_base_url",
+        type=SettingType.STRING,
+        default="https://synthorg.io/docs/errors",
+        description=(
+            "Base URL used to build the RFC 9457 ``type`` field on every"
+            " API error response. Each error category appends a fragment"
+            " anchor (for example ``#auth``). Override when the docs"
+            " site is hosted at a non-default origin."
+        ),
+        group="Errors",
+        level=SettingLevel.ADVANCED,
+        restart_required=False,
+        validator_pattern=r"^https?://[\w.\-:/]+$",
+        yaml_path="api.error_docs_base_url",
+    )
+)
+
 # ── CORS (bootstrap-only) ────────────────────────────────────────
 
 _r.register(

--- a/src/synthorg/settings/definitions/api.py
+++ b/src/synthorg/settings/definitions/api.py
@@ -219,7 +219,7 @@ _r.register(
         group="Errors",
         level=SettingLevel.ADVANCED,
         restart_required=True,
-        validator_pattern=r"^https://[\w.\-:/]+$",
+        validator_pattern=(r"^https://[A-Za-z0-9.\-]+(?::\d{1,5})?(?:/[^\s?#]*)?$"),
         yaml_path="api.error_docs_base_url",
     )
 )

--- a/src/synthorg/settings/definitions/api.py
+++ b/src/synthorg/settings/definitions/api.py
@@ -212,12 +212,14 @@ _r.register(
             "Base URL used to build the RFC 9457 ``type`` field on every"
             " API error response. Each error category appends a fragment"
             " anchor (for example ``#auth``). Override when the docs"
-            " site is hosted at a non-default origin."
+            " site is hosted at a non-default origin. HTTPS-only: the"
+            " URL appears in every error response and must not downgrade"
+            " operator deployments to plaintext."
         ),
         group="Errors",
         level=SettingLevel.ADVANCED,
-        restart_required=False,
-        validator_pattern=r"^https?://[\w.\-:/]+$",
+        restart_required=True,
+        validator_pattern=r"^https://[\w.\-:/]+$",
         yaml_path="api.error_docs_base_url",
     )
 )

--- a/src/synthorg/settings/definitions/notifications.py
+++ b/src/synthorg/settings/definitions/notifications.py
@@ -61,6 +61,27 @@ _r.register(
 _r.register(
     SettingDefinition(
         namespace=SettingNamespace.NOTIFICATIONS,
+        key="slack_default_webhook_url",
+        type=SettingType.STRING,
+        default="",
+        description=(
+            "Optional fallback Slack incoming-webhook URL applied when a"
+            " Slack notification sink is configured without its own"
+            " ``webhook_url`` parameter. Leave blank to require every"
+            " sink to specify the URL explicitly."
+        ),
+        group="Slack",
+        level=SettingLevel.ADVANCED,
+        sensitive=True,
+        restart_required=True,
+        validator_pattern=r"^(|https://hooks\.slack\.com/services/.+)$",
+        yaml_path="notifications.slack.default_webhook_url",
+    )
+)
+
+_r.register(
+    SettingDefinition(
+        namespace=SettingNamespace.NOTIFICATIONS,
         key="ntfy_default_url",
         type=SettingType.STRING,
         default="https://ntfy.sh",

--- a/src/synthorg/settings/definitions/notifications.py
+++ b/src/synthorg/settings/definitions/notifications.py
@@ -74,7 +74,10 @@ _r.register(
         level=SettingLevel.ADVANCED,
         sensitive=True,
         restart_required=True,
-        validator_pattern=r"^(|https://hooks\.slack\.com/services/.+)$",
+        validator_pattern=(
+            r"^(?:|https://hooks\.slack\.com/services/"
+            r"[A-Za-z0-9_-]+/[A-Za-z0-9_-]+/[A-Za-z0-9_-]+)$"
+        ),
         yaml_path="notifications.slack.default_webhook_url",
     )
 )

--- a/src/synthorg/settings/json_validators.py
+++ b/src/synthorg/settings/json_validators.py
@@ -1,0 +1,79 @@
+"""Per-setting write-time JSON-shape validators.
+
+The base ``_validate_json`` in ``SettingsService`` only checks
+parseability; the runtime bridge-config validators in
+:mod:`synthorg.settings.bridge_configs` enforce the deeper structural
+contract (canonical origins, port range, no userinfo, etc.). When
+``/settings`` writes a new value the runtime contract has not yet run,
+so an operator can persist a structurally invalid payload and only see
+it rejected at the next process boot via the bridge-config fallback.
+
+This module bridges that gap. Each entry in :data:`_JSON_VALIDATORS`
+maps a ``(namespace, key)`` to a callable that takes the parsed JSON
+value and raises :class:`ValueError` if the payload would not pass the
+runtime validator. Adding a setting here is a single-line registration
+plus the validator function itself; the dispatcher in
+``service._validate_json`` consults this map after JSON parsing
+succeeds.
+
+Validators MUST raise ``ValueError`` (the existing error path in
+``service._validate_json`` translates to ``SettingValidationError`` so
+the message reaches the operator). They MUST NOT mutate the parsed
+value -- the dispatcher is fail-fast at the validation boundary, not
+a normalisation hook.
+"""
+
+from typing import TYPE_CHECKING, Any, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _validate_csp_docs_external_origins(value: Any) -> None:
+    """Reject any non-canonical ``csp_docs_external_origins`` payload.
+
+    Reuses :class:`synthorg.settings.bridge_configs.ApiBridgeConfig`'s
+    field validator so write-time and runtime contracts cannot drift.
+    The bridge field expects ``tuple[str, ...]``; we coerce a JSON
+    list and let the validator surface its own ValueError.
+    """
+    from synthorg.settings.bridge_configs import (  # noqa: PLC0415
+        ApiBridgeConfig,
+    )
+
+    # The dispatcher in ``service._validate_json`` only catches
+    # ValueError, so raise ValueError for shape failures even when the
+    # underlying issue is a type mismatch -- TypeError would bypass the
+    # SettingValidationError translation and surface as an unhandled
+    # 500.
+    if not isinstance(value, list):
+        msg = (
+            "csp_docs_external_origins must be a JSON array of canonical HTTPS origins"
+        )
+        raise ValueError(msg)  # noqa: TRY004 -- dispatcher contract requires ValueError
+    for entry in value:
+        if not isinstance(entry, str):
+            msg = (
+                "csp_docs_external_origins entries must be strings;"
+                f" got {type(entry).__name__}"
+            )
+            raise ValueError(msg)  # noqa: TRY004 -- dispatcher contract requires ValueError
+    # The bridge field validator handles empty-tuple, scheme, host,
+    # port-range, userinfo, and path/query/fragment rejection.
+    ApiBridgeConfig(csp_docs_external_origins=tuple(value))
+
+
+_JSON_VALIDATORS: Final[dict[tuple[str, str], Callable[[Any], None]]] = {
+    ("api", "csp_docs_external_origins"): _validate_csp_docs_external_origins,
+}
+
+
+def get_json_validator(namespace: str, key: str) -> Callable[[Any], None] | None:
+    """Return the registered write-time validator for *namespace*/*key*.
+
+    Returns ``None`` when the setting has no JSON-shape validator
+    beyond the base ``json.loads`` parseability check. Service-layer
+    code calls this after ``json.loads`` succeeds and dispatches if
+    the result is non-None.
+    """
+    return _JSON_VALIDATORS.get((namespace, key))

--- a/src/synthorg/settings/resolver.py
+++ b/src/synthorg/settings/resolver.py
@@ -1045,6 +1045,7 @@ class ConfigResolver:
                 ("slack_webhook_timeout_seconds", "float"),
                 ("ntfy_webhook_timeout_seconds", "float"),
                 ("email_smtp_timeout_seconds", "float"),
+                ("slack_default_webhook_url", "str"),
                 ("ntfy_default_url", "str"),
             ),
         )

--- a/src/synthorg/settings/resolver.py
+++ b/src/synthorg/settings/resolver.py
@@ -778,13 +778,13 @@ class ConfigResolver:
         return {key: task.result() for key, task in tasks.items()}
 
     async def _resolve_typed(self, namespace: str, key: str, kind: str) -> Any:
-        """Dispatch to the scalar accessor matching ``kind``.
+        """Dispatch to the accessor matching ``kind``.
 
         Args:
             namespace: Setting namespace (e.g. ``"api"``, ``"tools"``).
             key: Setting key within the namespace.
-            kind: Type discriminator; must be one of ``"int"``,
-                ``"float"``, or ``"str"``. Any other value raises
+            kind: Type discriminator; one of ``"int"``, ``"float"``,
+                ``"str"``, or ``"json"``. Any other value raises
                 ``ValueError`` so misuse fails loudly rather than
                 silently resolving the wrong accessor.
 
@@ -792,7 +792,7 @@ class ConfigResolver:
             The resolved value coerced to the requested type.
 
         Raises:
-            ValueError: If *kind* is not one of the three supported
+            ValueError: If *kind* is not one of the four supported
                 discriminators.
             SettingNotFoundError: If the registry does not contain
                 *key* in *namespace*.
@@ -803,6 +803,8 @@ class ConfigResolver:
             return await self.get_float(namespace, key)
         if kind == "str":
             return await self.get_str(namespace, key)
+        if kind == "json":
+            return await self.get_json(namespace, key)
         msg = f"Unsupported typed-resolve kind: {kind!r}"
         raise ValueError(msg)
 
@@ -841,6 +843,8 @@ class ConfigResolver:
                 ("lifecycle_persistence_shutdown_seconds", "float"),
                 ("lifecycle_approval_timeout_shutdown_seconds", "float"),
                 ("lifecycle_drain_timeout_seconds", "float"),
+                ("csp_docs_external_origins", "json"),
+                ("error_docs_base_url", "str"),
             ),
         )
         return ApiBridgeConfig(**values)

--- a/src/synthorg/settings/service.py
+++ b/src/synthorg/settings/service.py
@@ -207,7 +207,7 @@ def _validate_enum(definition: SettingDefinition, value: str) -> None:
 
 def _validate_json(definition: SettingDefinition, value: str) -> None:
     try:
-        json.loads(value)
+        parsed = json.loads(value)
     except json.JSONDecodeError as exc:
         if definition.sensitive:
             msg = (
@@ -216,6 +216,34 @@ def _validate_json(definition: SettingDefinition, value: str) -> None:
             )
         else:
             msg = f"Invalid JSON: {exc}"
+        raise SettingValidationError(msg) from exc
+    # Dispatch to any per-setting shape validator so write-time and
+    # runtime contracts stay aligned (e.g. canonical-origin checks for
+    # ``api.csp_docs_external_origins``). Validators raise ``ValueError``
+    # which we re-wrap as ``SettingValidationError`` to keep the error
+    # surface uniform; sensitive payloads are masked the same way the
+    # parse-error branch above masks them.
+    from synthorg.settings.json_validators import (  # noqa: PLC0415
+        get_json_validator,
+    )
+
+    # SettingNamespace is a StrEnum, so passing it directly gives the
+    # underlying string value (e.g. ``"api"``).
+    validator = get_json_validator(str(definition.namespace), definition.key)
+    if validator is None:
+        return
+    try:
+        validator(parsed)
+    except ValueError as exc:
+        if definition.sensitive:
+            msg = (
+                f"Invalid JSON shape for sensitive setting"
+                f" {definition.namespace}/{definition.key}"
+            )
+        else:
+            msg = (
+                f"Invalid JSON shape for {definition.namespace}/{definition.key}: {exc}"
+            )
         raise SettingValidationError(msg) from exc
 
 

--- a/tests/unit/api/test_middleware.py
+++ b/tests/unit/api/test_middleware.py
@@ -14,9 +14,12 @@ from synthorg.api.middleware import (
     _API_CSP,
     _DOCS_CACHE_CONTROL,
     _DOCS_CSP,
+    _DOCS_CSP_DEFAULT_ORIGINS,
     _SECURITY_HEADERS,
     RequestLoggingMiddleware,
+    build_docs_csp,
     security_headers_hook,
+    set_docs_csp_origins,
 )
 
 pytestmark = pytest.mark.unit
@@ -182,6 +185,46 @@ class TestCSPPathSelection:
         """API paths keep COOP same-origin."""
         response = test_client.get("/api/v1/healthz")
         assert response.headers.get("cross-origin-opener-policy") == "same-origin"
+
+
+class TestDocsCspOriginsOverride:
+    """``set_docs_csp_origins`` lets operators retarget Scalar UI origins."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_docs_csp(self) -> Any:
+        """Restore the default origins after each test in this class.
+
+        Mutating the module-level CSP would leak across tests in the
+        same xdist worker; this fixture is the boundary.
+        """
+        yield
+        set_docs_csp_origins(_DOCS_CSP_DEFAULT_ORIGINS)
+
+    def test_default_csp_lists_all_default_origins(self) -> None:
+        for origin in _DOCS_CSP_DEFAULT_ORIGINS:
+            assert origin in _DOCS_CSP
+
+    def test_override_replaces_default_origins(self) -> None:
+        from synthorg.api import middleware
+
+        set_docs_csp_origins(["https://internal-cdn.example.com"])
+        assert "https://internal-cdn.example.com" in middleware._DOCS_CSP
+        assert "https://cdn.jsdelivr.net" not in middleware._DOCS_CSP
+
+    def test_build_docs_csp_applies_origins_uniformly(self) -> None:
+        result = build_docs_csp(["https://only.example.com"])
+        directives = (
+            "script-src",
+            "style-src",
+            "img-src",
+            "font-src",
+            "connect-src",
+        )
+        for directive in directives:
+            assert f"{directive}" in result
+            section_start = result.index(directive)
+            section_end = result.index(";", section_start)
+            assert "https://only.example.com" in result[section_start:section_end]
 
 
 # ── Cache-Control path selection ──────────────────────────────

--- a/tests/unit/api/test_middleware.py
+++ b/tests/unit/api/test_middleware.py
@@ -204,10 +204,15 @@ class TestDocsCspOriginsOverride:
         set_docs_csp_origins(_DOCS_CSP_DEFAULT_ORIGINS)
 
     def test_default_csp_lists_all_default_origins(self) -> None:
-        # Tokenise the CSP header and compare via set operations so the
-        # assertion is a complete-token match rather than a substring
-        # check (which CodeQL flags as ``py/incomplete-url-substring-sanitization``).
-        tokens = set(_DOCS_CSP.replace(";", " ").split())
+        from synthorg.api import middleware
+
+        # Read the live module attribute (not the file-level imported
+        # snapshot) so the fixture's pre-yield reset is observed even if
+        # an earlier file on the same xdist worker mutated the global
+        # before this module was imported.
+        # Tokenise so the assertion is a complete-token match, avoiding
+        # CodeQL's ``py/incomplete-url-substring-sanitization`` rule.
+        tokens = set(middleware._DOCS_CSP.replace(";", " ").split())
         assert tokens.issuperset(_DOCS_CSP_DEFAULT_ORIGINS)
 
     def test_override_replaces_default_origins(self) -> None:

--- a/tests/unit/api/test_middleware.py
+++ b/tests/unit/api/test_middleware.py
@@ -212,19 +212,82 @@ class TestDocsCspOriginsOverride:
         assert "https://cdn.jsdelivr.net" not in middleware._DOCS_CSP
 
     def test_build_docs_csp_applies_origins_uniformly(self) -> None:
-        result = build_docs_csp(["https://only.example.com"])
-        directives = (
-            "script-src",
-            "style-src",
-            "img-src",
-            "font-src",
-            "connect-src",
+        # Parses the CSP into a directive map and asserts the origin
+        # appears in every directive that is supposed to carry it.
+        # Resilient to directive reordering or whitespace tweaks.
+        origin = "https://only.example.com"
+        result = build_docs_csp([origin])
+        directives = {
+            tokens[0]: tokens[1:]
+            for raw in result.split(";")
+            if (tokens := raw.strip().split()) and len(tokens) > 1
+        }
+        for name in ("script-src", "style-src", "img-src", "font-src", "connect-src"):
+            assert origin in directives[name], (
+                f"{name} missing {origin!r} in {directives[name]}"
+            )
+
+    def test_build_docs_csp_rejects_empty_origins(self) -> None:
+        # Avoids producing a malformed CSP like
+        # "script-src 'self' 'unsafe-inline' ;" with trailing whitespace
+        # before the semicolon. The bridge config validator never lets
+        # an empty tuple through, but the function fails fast as a
+        # belt-and-braces check.
+        with pytest.raises(ValueError, match="at least one trusted origin"):
+            build_docs_csp([])
+
+
+class TestApiBridgeConfigSecurity:
+    """``ApiBridgeConfig`` rejects CSP origins that would degrade
+    /docs CSP, and rejects non-HTTPS error-docs URLs."""
+
+    @pytest.mark.parametrize(
+        "bad_origin",
+        [
+            "javascript:alert(1)",
+            "data:text/html,<img src=x>",
+            "not a url",
+            "ftp://example.com",
+            "",
+        ],
+        ids=["javascript_scheme", "data_scheme", "not_a_url", "ftp_scheme", "empty"],
+    )
+    def test_csp_origins_validator_rejects_bad_schemes(self, bad_origin: str) -> None:
+        from pydantic import ValidationError
+
+        from synthorg.settings.bridge_configs import ApiBridgeConfig
+
+        with pytest.raises(ValidationError):
+            ApiBridgeConfig(
+                csp_docs_external_origins=("https://cdn.example.com", bad_origin),
+            )
+
+    @pytest.mark.parametrize(
+        "bad_url",
+        [
+            "http://docs.example.com/errors",
+            "javascript:alert(1)",
+            "ftp://docs.example.com",
+        ],
+        ids=["http_insecure", "javascript_scheme", "ftp_scheme"],
+    )
+    def test_error_docs_base_url_validator_rejects_non_https(
+        self, bad_url: str
+    ) -> None:
+        from pydantic import ValidationError
+
+        from synthorg.settings.bridge_configs import ApiBridgeConfig
+
+        with pytest.raises(ValidationError):
+            ApiBridgeConfig(error_docs_base_url=bad_url)
+
+    def test_error_docs_base_url_accepts_https_override(self) -> None:
+        from synthorg.settings.bridge_configs import ApiBridgeConfig
+
+        cfg = ApiBridgeConfig(
+            error_docs_base_url="https://docs.example.com/errors",
         )
-        for directive in directives:
-            assert f"{directive}" in result
-            section_start = result.index(directive)
-            section_end = result.index(";", section_start)
-            assert "https://only.example.com" in result[section_start:section_end]
+        assert cfg.error_docs_base_url == "https://docs.example.com/errors"
 
 
 # ── Cache-Control path selection ──────────────────────────────

--- a/tests/unit/api/test_middleware.py
+++ b/tests/unit/api/test_middleware.py
@@ -25,6 +25,21 @@ from synthorg.api.middleware import (
 pytestmark = pytest.mark.unit
 
 
+@pytest.fixture(autouse=True)
+def _reset_docs_csp_module() -> Any:
+    """Reset the docs CSP global at setup AND teardown of every test.
+
+    Module-scope autouse instead of class-scope so test classes earlier
+    in this file (TestCSPPathSelection, TestSecurityHeadersHook) and any
+    later additions are protected from cross-file mutation by another
+    test on the same xdist worker. The reset is cheap (re-builds the
+    default CSP string) and runs only once per test entry/exit.
+    """
+    set_docs_csp_origins(_DOCS_CSP_DEFAULT_ORIGINS)
+    yield
+    set_docs_csp_origins(_DOCS_CSP_DEFAULT_ORIGINS)
+
+
 def _make_app(*handlers: Any) -> Litestar:
     """Build a minimal Litestar app with the security hook wired in."""
     return Litestar(
@@ -188,20 +203,13 @@ class TestCSPPathSelection:
 
 
 class TestDocsCspOriginsOverride:
-    """``set_docs_csp_origins`` lets operators retarget Scalar UI origins."""
+    """``set_docs_csp_origins`` lets operators retarget Scalar UI origins.
 
-    @pytest.fixture(autouse=True)
-    def _reset_docs_csp(self) -> Any:
-        """Reset the docs CSP at setup AND teardown.
-
-        Mutating the module-level CSP would leak across tests in the
-        same xdist worker; resetting only post-yield lets the first
-        test in this class inherit a mutated value from an earlier file
-        on the same worker. Setup-side reset closes that window.
-        """
-        set_docs_csp_origins(_DOCS_CSP_DEFAULT_ORIGINS)
-        yield
-        set_docs_csp_origins(_DOCS_CSP_DEFAULT_ORIGINS)
+    The module-level ``_reset_docs_csp_module`` fixture restores the
+    default CSP at setup and teardown of every test in this file, so
+    individual tests in this class can mutate the global without
+    leaking into siblings or earlier classes on the same xdist worker.
+    """
 
     def test_default_csp_lists_all_default_origins(self) -> None:
         from synthorg.api import middleware

--- a/tests/unit/api/test_middleware.py
+++ b/tests/unit/api/test_middleware.py
@@ -201,15 +201,23 @@ class TestDocsCspOriginsOverride:
         set_docs_csp_origins(_DOCS_CSP_DEFAULT_ORIGINS)
 
     def test_default_csp_lists_all_default_origins(self) -> None:
+        # Tokenise the CSP header so the assertion is a complete-token
+        # match. A bare ``origin in _DOCS_CSP`` would be a substring
+        # check that CodeQL flags as ``py/incomplete-url-substring-sanitization``.
+        tokens = set(_DOCS_CSP.replace(";", " ").split())
         for origin in _DOCS_CSP_DEFAULT_ORIGINS:
-            assert origin in _DOCS_CSP
+            assert origin in tokens
 
     def test_override_replaces_default_origins(self) -> None:
         from synthorg.api import middleware
 
         set_docs_csp_origins(["https://internal-cdn.example.com"])
-        assert "https://internal-cdn.example.com" in middleware._DOCS_CSP
-        assert "https://cdn.jsdelivr.net" not in middleware._DOCS_CSP
+        # Token-boundary check (see test above); avoids the
+        # substring-sanitisation pattern even though both sides are
+        # operator-controlled.
+        tokens = set(middleware._DOCS_CSP.replace(";", " ").split())
+        assert "https://internal-cdn.example.com" in tokens
+        assert "https://cdn.jsdelivr.net" not in tokens
 
     def test_build_docs_csp_applies_origins_uniformly(self) -> None:
         # Parses the CSP into a directive map and asserts the origin
@@ -249,8 +257,24 @@ class TestApiBridgeConfigSecurity:
             "not a url",
             "ftp://example.com",
             "",
+            "https://cdn.example.com/path",
+            "https://cdn.example.com/",
+            "https://cdn.example.com?q=1",
+            "https://cdn.example.com#frag",
+            "https://user:pw@cdn.example.com",
         ],
-        ids=["javascript_scheme", "data_scheme", "not_a_url", "ftp_scheme", "empty"],
+        ids=[
+            "javascript_scheme",
+            "data_scheme",
+            "not_a_url",
+            "ftp_scheme",
+            "empty",
+            "with_path",
+            "trailing_slash",
+            "with_query",
+            "with_fragment",
+            "with_userinfo",
+        ],
     )
     def test_csp_origins_validator_rejects_bad_schemes(self, bad_origin: str) -> None:
         from pydantic import ValidationError
@@ -261,6 +285,31 @@ class TestApiBridgeConfigSecurity:
             ApiBridgeConfig(
                 csp_docs_external_origins=("https://cdn.example.com", bad_origin),
             )
+
+    def test_csp_origins_validator_rejects_empty_tuple(self) -> None:
+        from pydantic import ValidationError
+
+        from synthorg.settings.bridge_configs import ApiBridgeConfig
+
+        with pytest.raises(ValidationError, match="at least one trusted origin"):
+            ApiBridgeConfig(csp_docs_external_origins=())
+
+    @pytest.mark.parametrize(
+        "good_origin",
+        [
+            "https://cdn.example.com",
+            "http://internal.example",
+            "https://cdn.example.com:8443",
+        ],
+        ids=["https_host", "http_host", "https_with_port"],
+    )
+    def test_csp_origins_validator_accepts_canonical_origins(
+        self, good_origin: str
+    ) -> None:
+        from synthorg.settings.bridge_configs import ApiBridgeConfig
+
+        cfg = ApiBridgeConfig(csp_docs_external_origins=(good_origin,))
+        assert cfg.csp_docs_external_origins == (good_origin,)
 
     @pytest.mark.parametrize(
         "bad_url",

--- a/tests/unit/api/test_middleware.py
+++ b/tests/unit/api/test_middleware.py
@@ -192,32 +192,36 @@ class TestDocsCspOriginsOverride:
 
     @pytest.fixture(autouse=True)
     def _reset_docs_csp(self) -> Any:
-        """Restore the default origins after each test in this class.
+        """Reset the docs CSP at setup AND teardown.
 
         Mutating the module-level CSP would leak across tests in the
-        same xdist worker; this fixture is the boundary.
+        same xdist worker; resetting only post-yield lets the first
+        test in this class inherit a mutated value from an earlier file
+        on the same worker. Setup-side reset closes that window.
         """
+        set_docs_csp_origins(_DOCS_CSP_DEFAULT_ORIGINS)
         yield
         set_docs_csp_origins(_DOCS_CSP_DEFAULT_ORIGINS)
 
     def test_default_csp_lists_all_default_origins(self) -> None:
-        # Tokenise the CSP header so the assertion is a complete-token
-        # match. A bare ``origin in _DOCS_CSP`` would be a substring
-        # check that CodeQL flags as ``py/incomplete-url-substring-sanitization``.
+        # Tokenise the CSP header and compare via set operations so the
+        # assertion is a complete-token match rather than a substring
+        # check (which CodeQL flags as ``py/incomplete-url-substring-sanitization``).
         tokens = set(_DOCS_CSP.replace(";", " ").split())
-        for origin in _DOCS_CSP_DEFAULT_ORIGINS:
-            assert origin in tokens
+        assert tokens.issuperset(_DOCS_CSP_DEFAULT_ORIGINS)
 
     def test_override_replaces_default_origins(self) -> None:
         from synthorg.api import middleware
 
-        set_docs_csp_origins(["https://internal-cdn.example.com"])
-        # Token-boundary check (see test above); avoids the
-        # substring-sanitisation pattern even though both sides are
-        # operator-controlled.
+        custom_origin = "https://internal-cdn.example.com"
+        evicted_origin = "https://cdn.jsdelivr.net"
+        set_docs_csp_origins([custom_origin])
         tokens = set(middleware._DOCS_CSP.replace(";", " ").split())
-        assert "https://internal-cdn.example.com" in tokens
-        assert "https://cdn.jsdelivr.net" not in tokens
+        # Set-membership operators avoid the ``literal in str`` shape
+        # that triggers ``py/incomplete-url-substring-sanitization`` on
+        # token-set checks even when both sides are operator-controlled.
+        assert tokens.issuperset({custom_origin})
+        assert tokens.isdisjoint({evicted_origin})
 
     def test_build_docs_csp_applies_origins_uniformly(self) -> None:
         # Parses the CSP into a directive map and asserts the origin
@@ -262,6 +266,8 @@ class TestApiBridgeConfigSecurity:
             "https://cdn.example.com?q=1",
             "https://cdn.example.com#frag",
             "https://user:pw@cdn.example.com",
+            "https://cdn.example.com:99999",
+            "https://cdn.example.com:0",
         ],
         ids=[
             "javascript_scheme",
@@ -274,6 +280,8 @@ class TestApiBridgeConfigSecurity:
             "with_query",
             "with_fragment",
             "with_userinfo",
+            "port_out_of_range",
+            "port_zero",
         ],
     )
     def test_csp_origins_validator_rejects_bad_schemes(self, bad_origin: str) -> None:
@@ -317,8 +325,20 @@ class TestApiBridgeConfigSecurity:
             "http://docs.example.com/errors",
             "javascript:alert(1)",
             "ftp://docs.example.com",
+            "https://user:pw@docs.example.com/errors",
+            "https://docs.example.com/errors?q=1",
+            "https://docs.example.com/errors#frag",
+            "https://docs.example.com:99999/errors",
         ],
-        ids=["http_insecure", "javascript_scheme", "ftp_scheme"],
+        ids=[
+            "http_insecure",
+            "javascript_scheme",
+            "ftp_scheme",
+            "with_userinfo",
+            "with_query",
+            "with_fragment",
+            "port_out_of_range",
+        ],
     )
     def test_error_docs_base_url_validator_rejects_non_https(
         self, bad_url: str

--- a/tests/unit/core/test_error_taxonomy.py
+++ b/tests/unit/core/test_error_taxonomy.py
@@ -90,6 +90,10 @@ class TestDocsBaseUrlOverride:
 
     @pytest.fixture(autouse=True)
     def _reset_base_url(self) -> Generator[None]:
+        # Reset both before and after so the first test in this class
+        # cannot inherit a value mutated by an earlier file on the same
+        # xdist worker.
+        set_error_docs_base_url(_ERROR_DOCS_BASE_DEFAULT)
         yield
         set_error_docs_base_url(_ERROR_DOCS_BASE_DEFAULT)
 
@@ -101,3 +105,37 @@ class TestDocsBaseUrlOverride:
         set_error_docs_base_url("https://docs.example.com/errors")
         uri = category_type_uri(ErrorCategory.VALIDATION)
         assert uri == "https://docs.example.com/errors#validation"
+
+    def test_override_strips_trailing_slash(self) -> None:
+        set_error_docs_base_url("https://docs.example.com/errors/")
+        uri = category_type_uri(ErrorCategory.AUTH)
+        assert uri == "https://docs.example.com/errors#auth"
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            "",
+            "   ",
+            "http://docs.example.com/errors",
+            "ftp://docs.example.com/errors",
+            "javascript:alert(1)",
+            "https:///errors",
+            "https://user:pw@docs.example.com/errors",
+            "https://docs.example.com/errors?q=1",
+            "https://docs.example.com/errors#frag",
+        ],
+        ids=[
+            "empty",
+            "whitespace_only",
+            "http_insecure",
+            "ftp_scheme",
+            "javascript_scheme",
+            "no_host",
+            "with_userinfo",
+            "with_query",
+            "with_fragment",
+        ],
+    )
+    def test_setter_rejects_malformed_input(self, bad_value: str) -> None:
+        with pytest.raises(ValueError, match="error_docs_base_url"):
+            set_error_docs_base_url(bad_value)

--- a/tests/unit/core/test_error_taxonomy.py
+++ b/tests/unit/core/test_error_taxonomy.py
@@ -1,8 +1,11 @@
 """Tests for ``synthorg.core.error_taxonomy``."""
 
+from collections.abc import Generator
+
 import pytest
 
 from synthorg.core.error_taxonomy import (
+    _ERROR_DOCS_BASE_DEFAULT,
     CATEGORY_TITLES,
     CODE_CATEGORY_PREFIX,
     NOT_FOUND_BAND,
@@ -10,6 +13,7 @@ from synthorg.core.error_taxonomy import (
     ErrorCode,
     category_title,
     category_type_uri,
+    set_error_docs_base_url,
 )
 
 
@@ -78,3 +82,22 @@ class TestPrefixTable:
     def test_prefix_table_values_are_distinct(self) -> None:
         values = list(CODE_CATEGORY_PREFIX.values())
         assert len(values) == len(set(values))
+
+
+@pytest.mark.unit
+class TestDocsBaseUrlOverride:
+    """``set_error_docs_base_url`` retargets RFC 9457 ``type`` URIs."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_base_url(self) -> Generator[None]:
+        yield
+        set_error_docs_base_url(_ERROR_DOCS_BASE_DEFAULT)
+
+    def test_default_base_url_appears_in_uri(self) -> None:
+        uri = category_type_uri(ErrorCategory.AUTH)
+        assert uri.startswith(_ERROR_DOCS_BASE_DEFAULT)
+
+    def test_override_changes_uri_prefix(self) -> None:
+        set_error_docs_base_url("https://docs.example.com/errors")
+        uri = category_type_uri(ErrorCategory.VALIDATION)
+        assert uri == "https://docs.example.com/errors#validation"

--- a/tests/unit/notifications/test_factory.py
+++ b/tests/unit/notifications/test_factory.py
@@ -166,16 +166,18 @@ class TestCreateSlackSink:
         )
         assert _create_slack_sink({}, bridge_config=bridge) is None
 
-    def test_invalid_bridge_default_logs_and_returns_none(self) -> None:
-        # The bridge default is structurally valid (matches the
-        # NotificationsBridgeConfig pattern) but targets a private IP,
-        # which SlackNotificationSink rejects via _validate_outbound_url.
-        # The factory must catch the ValueError, log, and return None.
+    def test_invalid_explicit_url_returns_none_even_with_bridge_default(
+        self,
+    ) -> None:
+        # An explicit per-sink ``webhook_url`` overrides the bridge
+        # default, so the factory must still reject an outbound target
+        # that ``SlackNotificationSink._validate_outbound_url`` blocks
+        # (here a loopback IP). The bridge default is canonical and
+        # would have been valid -- proving the factory does not silently
+        # swap to it when the explicit URL is bad.
         bridge = NotificationsBridgeConfig(
             slack_default_webhook_url="https://hooks.slack.com/services/T/B/X",
         )
-        # Force the sink construction to raise by passing a private IP
-        # via params, which bypasses the bridge fallback path.
         sink = _create_slack_sink(
             {"webhook_url": "https://127.0.0.1/services/T/B/X"},
             bridge_config=bridge,

--- a/tests/unit/notifications/test_factory.py
+++ b/tests/unit/notifications/test_factory.py
@@ -8,7 +8,9 @@ transitively via the integration paths that wire it into the engine.
 import pytest
 
 from synthorg.notifications.adapters.email import EmailNotificationSink
-from synthorg.notifications.factory import _create_email_sink
+from synthorg.notifications.adapters.slack import SlackNotificationSink
+from synthorg.notifications.factory import _create_email_sink, _create_slack_sink
+from synthorg.settings.bridge_configs import NotificationsBridgeConfig
 
 pytestmark = pytest.mark.unit
 
@@ -113,3 +115,38 @@ class TestCreateEmailSink:
         # ``_from_addr`` is the internal attribute on ``EmailNotificationSink``;
         # this assertion catches regressions where trimming is removed.
         assert sink._from_addr == "ops@example.test"
+
+
+class TestCreateSlackSink:
+    """`_create_slack_sink` URL resolution and bridge fallback."""
+
+    def test_explicit_webhook_url_used(self) -> None:
+        sink = _create_slack_sink(
+            {"webhook_url": "https://hooks.slack.com/services/T/B/X"},
+        )
+        assert sink is not None
+
+    def test_missing_url_without_bridge_returns_none(self) -> None:
+        assert _create_slack_sink({}) is None
+
+    def test_bridge_default_used_when_params_empty(self) -> None:
+        bridge = NotificationsBridgeConfig(
+            slack_default_webhook_url="https://hooks.slack.com/services/T/B/X",
+        )
+        sink = _create_slack_sink({}, bridge_config=bridge)
+        assert sink is not None
+
+    def test_explicit_url_takes_precedence_over_bridge_default(self) -> None:
+        bridge = NotificationsBridgeConfig(
+            slack_default_webhook_url="https://hooks.slack.com/services/A/B/C",
+        )
+        sink = _create_slack_sink(
+            {"webhook_url": "https://hooks.slack.com/services/X/Y/Z"},
+            bridge_config=bridge,
+        )
+        assert isinstance(sink, SlackNotificationSink)
+        assert sink._webhook_url == "https://hooks.slack.com/services/X/Y/Z"
+
+    def test_blank_bridge_default_does_not_satisfy_required(self) -> None:
+        bridge = NotificationsBridgeConfig(slack_default_webhook_url="")
+        assert _create_slack_sink({}, bridge_config=bridge) is None

--- a/tests/unit/notifications/test_factory.py
+++ b/tests/unit/notifications/test_factory.py
@@ -117,36 +117,67 @@ class TestCreateEmailSink:
         assert sink._from_addr == "ops@example.test"
 
 
+_EXPLICIT_URL = "https://hooks.slack.com/services/X/Y/Z"
+_BRIDGE_URL = "https://hooks.slack.com/services/A/B/C"
+
+
 class TestCreateSlackSink:
     """`_create_slack_sink` URL resolution and bridge fallback."""
 
-    def test_explicit_webhook_url_used(self) -> None:
-        sink = _create_slack_sink(
-            {"webhook_url": "https://hooks.slack.com/services/T/B/X"},
+    @pytest.mark.parametrize(
+        ("params_url", "bridge_url", "expected_url"),
+        [
+            (_EXPLICIT_URL, None, _EXPLICIT_URL),
+            (_EXPLICIT_URL, _BRIDGE_URL, _EXPLICIT_URL),
+            ("", _BRIDGE_URL, _BRIDGE_URL),
+        ],
+        ids=[
+            "explicit_used_no_bridge",
+            "explicit_overrides_bridge",
+            "bridge_fallback",
+        ],
+    )
+    def test_resolves_to_expected_url(
+        self,
+        params_url: str,
+        bridge_url: str | None,
+        expected_url: str,
+    ) -> None:
+        params: dict[str, str] = {"webhook_url": params_url} if params_url else {}
+        bridge = (
+            NotificationsBridgeConfig(slack_default_webhook_url=bridge_url)
+            if bridge_url is not None
+            else None
         )
-        assert sink is not None
+        sink = _create_slack_sink(params, bridge_config=bridge)
+        assert isinstance(sink, SlackNotificationSink)
+        assert sink._webhook_url == expected_url
 
-    def test_missing_url_without_bridge_returns_none(self) -> None:
-        assert _create_slack_sink({}) is None
+    @pytest.mark.parametrize(
+        "bridge_url",
+        [None, ""],
+        ids=["no_bridge", "blank_bridge_default"],
+    )
+    def test_missing_url_returns_none(self, bridge_url: str | None) -> None:
+        bridge = (
+            NotificationsBridgeConfig(slack_default_webhook_url=bridge_url)
+            if bridge_url is not None
+            else None
+        )
+        assert _create_slack_sink({}, bridge_config=bridge) is None
 
-    def test_bridge_default_used_when_params_empty(self) -> None:
+    def test_invalid_bridge_default_logs_and_returns_none(self) -> None:
+        # The bridge default is structurally valid (matches the
+        # NotificationsBridgeConfig pattern) but targets a private IP,
+        # which SlackNotificationSink rejects via _validate_outbound_url.
+        # The factory must catch the ValueError, log, and return None.
         bridge = NotificationsBridgeConfig(
             slack_default_webhook_url="https://hooks.slack.com/services/T/B/X",
         )
-        sink = _create_slack_sink({}, bridge_config=bridge)
-        assert sink is not None
-
-    def test_explicit_url_takes_precedence_over_bridge_default(self) -> None:
-        bridge = NotificationsBridgeConfig(
-            slack_default_webhook_url="https://hooks.slack.com/services/A/B/C",
-        )
+        # Force the sink construction to raise by passing a private IP
+        # via params, which bypasses the bridge fallback path.
         sink = _create_slack_sink(
-            {"webhook_url": "https://hooks.slack.com/services/X/Y/Z"},
+            {"webhook_url": "https://127.0.0.1/services/T/B/X"},
             bridge_config=bridge,
         )
-        assert isinstance(sink, SlackNotificationSink)
-        assert sink._webhook_url == "https://hooks.slack.com/services/X/Y/Z"
-
-    def test_blank_bridge_default_does_not_satisfy_required(self) -> None:
-        bridge = NotificationsBridgeConfig(slack_default_webhook_url="")
-        assert _create_slack_sink({}, bridge_config=bridge) is None
+        assert sink is None

--- a/tests/unit/settings/test_json_validators.py
+++ b/tests/unit/settings/test_json_validators.py
@@ -1,0 +1,76 @@
+"""Tests for the per-setting write-time JSON-shape validators."""
+
+from typing import Any
+
+import pytest
+
+from synthorg.settings.json_validators import get_json_validator
+
+pytestmark = pytest.mark.unit
+
+
+class TestCspDocsExternalOriginsJsonValidator:
+    """Write-time validation for ``api.csp_docs_external_origins``.
+
+    Reuses :class:`ApiBridgeConfig`'s field validator so /settings
+    persistence cannot store a payload the runtime would later reject.
+    """
+
+    @pytest.fixture
+    def validator(self) -> Any:
+        v = get_json_validator("api", "csp_docs_external_origins")
+        assert v is not None, "csp_docs_external_origins validator missing"
+        return v
+
+    def test_accepts_canonical_origins(self, validator: Any) -> None:
+        validator(
+            [
+                "https://cdn.example.com",
+                "https://internal-cdn.example.com:8443",
+                "http://internal.example",
+            ]
+        )
+
+    def test_rejects_non_array_payload(self, validator: Any) -> None:
+        with pytest.raises(ValueError, match="JSON array"):
+            validator({"not": "an array"})
+
+    def test_rejects_non_string_entry(self, validator: Any) -> None:
+        with pytest.raises(ValueError, match="must be strings"):
+            validator(["https://cdn.example.com", 42])
+
+    def test_rejects_empty_array(self, validator: Any) -> None:
+        with pytest.raises(ValueError, match="at least one trusted origin"):
+            validator([])
+
+    @pytest.mark.parametrize(
+        "bad_origin",
+        [
+            "javascript:alert(1)",
+            "ftp://example.com",
+            "https://cdn.example.com/path",
+            "https://cdn.example.com?q=1",
+            "https://cdn.example.com#frag",
+            "https://user:pw@cdn.example.com",
+            "https://cdn.example.com:99999",
+            "https://cdn.example.com:0",
+        ],
+        ids=[
+            "javascript_scheme",
+            "ftp_scheme",
+            "with_path",
+            "with_query",
+            "with_fragment",
+            "with_userinfo",
+            "port_out_of_range",
+            "port_zero",
+        ],
+    )
+    def test_rejects_non_canonical_entry(self, validator: Any, bad_origin: str) -> None:
+        with pytest.raises(ValueError, match="csp_docs_external_origins"):
+            validator(["https://cdn.example.com", bad_origin])
+
+
+def test_unregistered_namespace_returns_none() -> None:
+    assert get_json_validator("api", "definitely_not_a_setting") is None
+    assert get_json_validator("doesnt_exist", "csp_docs_external_origins") is None

--- a/tests/unit/settings/test_resolver_bridge_configs.py
+++ b/tests/unit/settings/test_resolver_bridge_configs.py
@@ -447,3 +447,55 @@ async def test_get_tools_bridge_config_rejects_bad_memory_literal(
     )
     with pytest.raises(ValidationError):
         await resolver.get_tools_bridge_config()
+
+
+# ── slack_default_webhook_url canonical-URL validation ──────────
+
+
+class TestSlackDefaultWebhookUrlValidator:
+    """``slack_default_webhook_url`` must accept only empty or canonical
+    Slack incoming-webhook URLs. The pattern alone is too permissive;
+    the field validator forces scheme/host/path/no-userinfo/no-query
+    discipline so malformed config never reaches the dispatcher."""
+
+    @pytest.mark.parametrize(
+        "good_url",
+        [
+            "",
+            "https://hooks.slack.com/services/T/B/X",
+            "https://hooks.slack.com/services/T000/B000/abc-123",
+        ],
+        ids=["empty", "minimal", "with_alphanum_path"],
+    )
+    def test_accepts_canonical_url(self, good_url: str) -> None:
+        cfg = NotificationsBridgeConfig(slack_default_webhook_url=good_url)
+        assert cfg.slack_default_webhook_url == good_url
+
+    @pytest.mark.parametrize(
+        "bad_url",
+        [
+            "http://hooks.slack.com/services/T/B/X",
+            "https://evil.example.com/services/T/B/X",
+            "https://hooks.slack.com/services/T/B/X?debug=1",
+            "https://hooks.slack.com/services/T/B/X#frag",
+            "https://user:pw@hooks.slack.com/services/T/B/X",
+            "https://hooks.slack.com/foo/T/B/X",
+            " https://hooks.slack.com/services/T/B/X",
+            "https://hooks.slack.com/services/T/B/X ",
+            "https://hooks.slack.com:99999/services/T/B/X",
+        ],
+        ids=[
+            "http_insecure",
+            "wrong_host",
+            "with_query",
+            "with_fragment",
+            "with_userinfo",
+            "wrong_path_prefix",
+            "leading_whitespace",
+            "trailing_whitespace",
+            "port_out_of_range",
+        ],
+    )
+    def test_rejects_non_canonical_url(self, bad_url: str) -> None:
+        with pytest.raises(ValidationError):
+            NotificationsBridgeConfig(slack_default_webhook_url=bad_url)

--- a/tests/unit/settings/test_resolver_bridge_configs.py
+++ b/tests/unit/settings/test_resolver_bridge_configs.py
@@ -123,6 +123,10 @@ _HAPPY_CASES: tuple[
             ("api", "lifecycle_persistence_shutdown_seconds"): "5.0",
             ("api", "lifecycle_approval_timeout_shutdown_seconds"): "1.0",
             ("api", "lifecycle_drain_timeout_seconds"): "25.0",
+            ("api", "csp_docs_external_origins"): (
+                '["https://cdn.example.com", "https://fonts.example.com"]'
+            ),
+            ("api", "error_docs_base_url"): "https://docs.example.com/errors",
         },
         {
             "ticket_cleanup_interval_seconds": 60.0,
@@ -140,6 +144,11 @@ _HAPPY_CASES: tuple[
             "rate_limit_gc_every_n_acquires": 1024,
             "lifecycle_drain_timeout_seconds": 25.0,
             "max_meeting_context_keys": 20,
+            "csp_docs_external_origins": (
+                "https://cdn.example.com",
+                "https://fonts.example.com",
+            ),
+            "error_docs_base_url": "https://docs.example.com/errors",
         },
     ),
     (
@@ -410,6 +419,8 @@ async def test_get_api_bridge_config_rejects_out_of_range(
             ("api", "lifecycle_persistence_shutdown_seconds"): "5.0",
             ("api", "lifecycle_approval_timeout_shutdown_seconds"): "1.0",
             ("api", "lifecycle_drain_timeout_seconds"): "25.0",
+            ("api", "csp_docs_external_origins"): ('["https://cdn.example.com"]'),
+            ("api", "error_docs_base_url"): "https://docs.example.com/errors",
         }
     )
     with pytest.raises(ValidationError):

--- a/tests/unit/settings/test_resolver_bridge_configs.py
+++ b/tests/unit/settings/test_resolver_bridge_configs.py
@@ -452,6 +452,7 @@ async def test_get_tools_bridge_config_rejects_bad_memory_literal(
 # ── slack_default_webhook_url canonical-URL validation ──────────
 
 
+@pytest.mark.unit
 class TestSlackDefaultWebhookUrlValidator:
     """``slack_default_webhook_url`` must accept only empty or canonical
     Slack incoming-webhook URLs. The pattern alone is too permissive;

--- a/tests/unit/settings/test_resolver_bridge_configs.py
+++ b/tests/unit/settings/test_resolver_bridge_configs.py
@@ -264,11 +264,16 @@ _HAPPY_CASES: tuple[
             ("notifications", "slack_webhook_timeout_seconds"): "15.0",
             ("notifications", "ntfy_webhook_timeout_seconds"): "10.0",
             ("notifications", "email_smtp_timeout_seconds"): "30.0",
+            (
+                "notifications",
+                "slack_default_webhook_url",
+            ): "https://hooks.slack.com/services/T/B/X",
             ("notifications", "ntfy_default_url"): "https://ntfy.example.com",
         },
         {
             "slack_webhook_timeout_seconds": 15.0,
             "email_smtp_timeout_seconds": 30.0,
+            "slack_default_webhook_url": "https://hooks.slack.com/services/T/B/X",
             "ntfy_default_url": "https://ntfy.example.com",
         },
     ),


### PR DESCRIPTION
Closes #1779.

## Summary

The 2026-05-05 codebase audit logged ~25 docs-accuracy findings (Agents 27, 48, 50, 73, 74, 75, 77, 81, 83, 84, 85, 86, 123, 151, 152). Most were straight edits; three were small CONFIG refactors that turn module-level `Final[str]` literals into operator-tunable settings.

### Documentation truth-pass

- `docs/roadmap/index.md` test count 27,000+ → 28,000+; `docs/architecture/decisions.md` Mem0 stars 49k → 54k+ (live counts: 28,481 tests, 54,816 Mem0 stars).
- `docs/design/tools.md:220` reconciled to "15 domain modules" matching `docs/reference/mcp-handler-contract.md` and `docs/design/self-improvement.md`. The list was wrong because handler modules `agents_autonomy.py` and `workflow_executions.py` are handler-level decompositions, not separate domains.
- `data/competitors.yaml`: PostgreSQL backend marked GA.
- `docs/guides/settings-reference.md`: namespace count corrected to 21 with new tables for `client`, `hr`, `simulations`, `telemetry`, `workers`. Added a "Security headers and error documentation" subsection covering the three new settings introduced in this PR.
- `docs/reference/scoring-hyperparameters.md` `vram_batch_table` rendered as `[[40.0, 128], [16.0, 64], [8.0, 32]]` matching the JSON setting default.
- Stripped stale audit timestamps from `docs/reference/conventions.md:72` and `docs/design/internationalization.md:7`.
- `docs/research/s1-multi-agent-decision.md` and `multi-agent-failure-audit.md` got `last_reviewed: 2026-05-05` front-matter.
- `docs/design/strategy.md` HBR date stamp removed.
- `docs/design/memory.md:53` config comment dropped `cognee` / `graphiti` (no implementation planned).
- Cross-links: `agent-execution.md` ↔ `budget.md` (three-layer enforcement) and approval-parking ↔ graceful-shutdown (`security.md` ↔ `coordination.md`).

### Settings registration (Agent 27 — three sites)

Three new operator-tunables, all wired through `ApiBridgeConfig` / `NotificationsBridgeConfig`:

- `api.csp_docs_external_origins` (JSON list) drives the relaxed `/docs/` CSP via a new `build_docs_csp` helper. Per-origin `^https?://[\w.\-:/]+$` validation lives on the bridge config so a malformed entry fails closed at construction; the startup callback catches resolver/validation errors and falls back to module defaults with a `WARNING` log.
- `api.error_docs_base_url` (STRING, HTTPS-only `^https://...$`) backs the RFC 9457 `type` URI. `error_taxonomy` keeps the dependency-free default and gains a `set_error_docs_base_url` setter for runtime override. Marked `restart_required=True` to match the actual single-writer-at-startup behaviour.
- `notifications.slack_default_webhook_url` (STRING, sensitive, encrypted at rest) gives Slack the parity that `ntfy_default_url` already had. The factory falls back when a sink config omits `webhook_url` and now catches `ValueError` from `SlackNotificationSink` construction so a misconfigured fallback surfaces as a `WARNING` instead of escaping.

The setters log `SETTINGS_VALUE_RESOLVED` so operators can confirm overrides took effect. `_resolve_typed` now accepts `"json"` so future bridge configs can hold JSON-typed fields without a separate accessor.

### Tooling

- `docker/backend/Dockerfile` and `docker/fine-tune/Dockerfile`: uv 0.11.8 → 0.11.9 with new digest. 0.11.9 ships the Windows trampoline `PYTHONHOME` fix that stabilises pytest-xdist workers on Python 3.14 / Windows (eliminated 2 sporadic xdist crashes in the local full-suite run).
- `pyproject.toml [tool.uv]`: `required-version = ">=0.11.8"` (security floor: GHSA-pjjw-68hj-v9mw wheel RECORD path-traversal fixed in 0.11.6, contributors with pre-commit-uv 4.2.1 keep working).

## Test plan

- `uv run python -m pytest tests/ -m unit -n 8 --ignore=tests/benchmarks/`: **26967 passed, 16 skipped**. Adds 11 new tests (CSP override, error-docs URL override, Slack URL precedence parametrize, ApiBridgeConfig validator coverage).
- `uv run mypy src/ tests/`: clean.
- `uv run ruff check src/ tests/`: clean.
- `uv run pre-commit run --all-files`: clean.
- `PYTHONPATH=. uv run zensical build`: docs site builds (469 pre-existing link warnings, none introduced).

## Review coverage

22 review agents from `/pre-pr-review`. Triage table at `_audit/pre-pr-review/triage.md` (excluded from commit). 14 valid findings implemented, 6 false-positives skipped with documented reasoning. Highlights:

- 1 CRITICAL (resolver-error fallback) implemented via try/except + `API_BRIDGE_CONFIG_RESOLVE_FAILED` warning log.
- M4 (extend bridge config to JSON kind) implemented across resolver + ApiBridgeConfig + startup hook.
- M5/M7/M8/M9 (restart_required correctness, per-origin validation, HTTPS-only error URL, post-resolve validation) all collapse into the single `ApiBridgeConfig` validator.
- M2/M6 (Slack docstring drift + factory `ValueError` handling) addressed in `_create_slack_sink`.
- Md1/Md2/S3 (silent-fallback logs + setter INFO log) emitted via existing event constants.
- Md3 (`build_docs_csp([])` rejected with `ValueError`) + Md7 (CSP test parses directives instead of substring-matching) + Md5/Md6 (parametrize Slack tests) tightened.

## Backwards compatibility

All three new settings have defaults that match the pre-change literal values, so a deployment that doesn't touch settings sees identical CSP, RFC 9457 `type` URLs, and Slack sink behaviour. Operators who want to mirror Scalar UI assets to an internal CDN, host error docs at a custom origin, or centralise the Slack webhook URL can now do so without forking.