### PR TITLE
ci: tidy dev-release notes + stagger renovate lockfile day

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -153,17 +153,19 @@ jobs:
           set -euo pipefail
           SHORT_SHA="${GITHUB_SHA::7}"
 
-          # Pull the commit subject + body from the local checkout so the
-          # release notes show what landed in this dev build. Squash-merges
-          # carry the PR title as the subject and the PR description as
-          # the body; ad-hoc pushes carry whatever the contributor wrote.
+          # Pull only the commit subject from the local checkout. Squash
+          # merges set the subject to "<PR title> (#NNN)", so the PR
+          # number is already present and auto-linked by GitHub. We
+          # deliberately do NOT include the commit body: for squash
+          # merges that body is the full PR description (tables,
+          # nested markdown, hundreds of lines), which renders poorly
+          # on the release page and buries what changed.
           # Variables are NOT interpolated into the gh --notes argument
           # directly: a backtick or `$()` in a commit subject would trigger
           # command substitution inside the double-quoted string. Build
           # the notes via printf into a tmpfile and pass --notes-file
           # instead.
           COMMIT_SUBJECT=$(git log -1 --format='%s' "$GITHUB_SHA")
-          COMMIT_BODY=$(git log -1 --format='%b' "$GITHUB_SHA")
 
           NOTES_FILE=$(mktemp /tmp/dev-release-notes.XXXXXX)
           trap 'rm -f "$NOTES_FILE"' EXIT
@@ -171,10 +173,6 @@ jobs:
             printf 'Dev build #%s toward v%s\n\n' "$DEV_NUM" "$NEXT_VERSION"
             printf '**Commit:** `%s`\n' "$SHORT_SHA"
             printf '**Subject:** %s\n\n' "$COMMIT_SUBJECT"
-            if [ -n "$COMMIT_BODY" ]; then
-              # Keep the body as-is; markdown renderers handle it.
-              printf '%s\n\n' "$COMMIT_BODY"
-            fi
             printf '**Full pipeline:** Docker images, CLI binaries, cosign signatures, and SLSA provenance will be attached by downstream workflows.\n\n'
             printf '> This is a pre-release for testing. Use `synthorg config set channel dev` to opt in.\n'
           } > "$NOTES_FILE"

--- a/renovate.json
+++ b/renovate.json
@@ -96,7 +96,7 @@
   ],
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["* 0-6 * * 6"]
+    "schedule": ["* 0-6 * * 0"]
   },
   "customManagers": [
     {


### PR DESCRIPTION
## Summary

Two small, independent CI hygiene tweaks:

1. **Dev-release notes** — drop the commit body from the release page; keep only the subject (which already includes the auto-linked PR number from squash merges). Squash-merge bodies are full PR descriptions: tables, nested markdown, and hundreds of lines that render poorly on the GitHub release page and bury what actually changed in the build.

2. **Renovate schedule** — shift `lockFileMaintenance` to Sunday 0-6 UTC (cron dow `0`); keep the three dependency groups (Python, Web, Infrastructure) on Saturday 0-6 UTC via the unchanged top-level `schedule`. Spreads the four weekly PRs across two mornings instead of stacking them all on Saturday.

## Before / after (release notes)

**Before** — full PR description dumped in:

```
Dev build #8 toward v0.8.2

**Commit:** `d01e624`
**Subject:** fix: correctness / safety fixes from 2026-05-05 audit (Wave 28) (#1823)

Closes #1774.

Implements the eight critical-logic and safety fixes flagged by the
2026-05-05 audit (Wave 28) — confirmed bugs that no existing gate
would catch, surfaced as code-quality drift in newer feature work.

## What changed

| Phase | Subsystem | Fix |
|-------|-----------|-----|
| 1 | `api/lifecycle_builder.py` | Bound the three janitor-task awaits ...
[hundreds of lines of nested tables and code-block snippets that render mangled]
```

**After** — tight 4-line block:

```
Dev build #8 toward v0.8.2

**Commit:** `d01e624`
**Subject:** fix: correctness / safety fixes from 2026-05-05 audit (Wave 28) (#1823)

**Full pipeline:** Docker images, CLI binaries, cosign signatures, and SLSA provenance will be attached by downstream workflows.

> This is a pre-release for testing. Use `synthorg config set channel dev` to opt in.
```

The `(#1823)` from the squash subject auto-links, so anyone wanting the full body still has one click.

## Scope

- `.github/workflows/dev-release.yml`: drop `COMMIT_BODY` capture and the conditional printf that emitted it
- `renovate.json`: `lockFileMaintenance.schedule` `* 0-6 * * 6` → `* 0-6 * * 0`

`finalize-release.yml` is untouched — it still appends the Verification section (CLI checksums, cosign, SLSA, SBOM) to dev release bodies; AI Highlights propagation remains gated on stable tags only via the existing `^v[0-9]+\.[0-9]+\.[0-9]+$` regex.

## Test plan

CI-only changes — verification happens on the next push to main (next dev-release run produces a clean body) and on the next Renovate cycle (lockfile PR opens Sunday morning UTC instead of Saturday). No automated check applies to this diff (no Python, web, or Go files touched).
