### PR TITLE
chore: disable Renovate vulnerabilityAlerts so security flows into normal updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,9 +22,7 @@
   "prHourlyLimit": 5,
   "separateMajorMinor": false,
   "vulnerabilityAlerts": {
-    "enabled": true,
-    "schedule": ["at any time"],
-    "labels": ["dependencies", "security"]
+    "enabled": false
   },
   "packageRules": [
     {


### PR DESCRIPTION
## What

Sets `vulnerabilityAlerts.enabled: false` in `renovate.json`. Removes the off-schedule `"at any time"` override and the dedicated `security` label.

## Why

Renovate's `vulnerabilityAlerts` and GitHub's Dependabot automated security fixes were both opening PRs for the same GHSA (e.g. `in-toto-golang 0.10.0 → 0.11.0` opened twice today: #1828 + #1829). The two bots don't coordinate, so every CVE that hits a manifest both can read produced a duplicate PR.

Resolution:
- Dependabot automated security fixes disabled at repo level (`DELETE /repos/Aureliolo/synthorg/automated-security-fixes`)
- Renovate `vulnerabilityAlerts.enabled: false` (this PR) — security bumps now fold into the normal weekly grouped Saturday batches (Python / Infrastructure / Web)

Dependabot **alerts** themselves remain enabled (visible at `/security/dependabot`); only automated PR creation is off. Manual triggering via the Renovate dashboard remains available at any time.