### PR TITLE
docs: fix CLAUDE.md inaccuracies and drop drift-prone counts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ PYTHONPATH=. uv run zensical build                  # docs
 
 ## Diagrams
 
-`d2` for architecture / nested containers, `mermaid` for flowcharts / sequence / pipelines. Markdown tables for tabular data. D2 theme 200 (Dark Mauve), CI pinned to v0.7.1.
+`d2` for architecture / nested containers, `mermaid` for flowcharts / sequence / pipelines. Markdown tables for tabular data. D2 theme 200 (Dark Mauve), D2 CLI pinned to v0.7.1 in CI.
 
 ## Code conventions (detail in [conventions.md](docs/reference/conventions.md))
 
@@ -100,8 +100,5 @@ PYTHONPATH=. uv run zensical build                  # docs
 
 ## Workflow
 
-- Finished issue → branch + commit + push (no auto-PR). Use `/pre-pr-review`.
 - After every squash merge → `/post-merge-cleanup`.
-- Always read `docs/design/` page before implementing. Plans require approval.
-- PR review: fix everything valid; never skip as out-of-scope.
 - CLI is Docker-only (init/start/stop/status); features go in dashboard + REST API.

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -36,7 +36,7 @@ This installs the pinned `golangci-lint` version that matches CI (`.github/workf
 ```text
 cli/
   cmd/            # Cobra commands (init, start, stop, status, logs, doctor, update, cleanup, wipe, config, etc.), global options, exit codes, env var constants
-  internal/       # version, config, docker, compose, health, diagnostics, images, selfupdate, completion, ui, verify
+  internal/       # version, config, docker, compose, health, diagnostics, images, selfupdate, completion, ui, verify, backup, scaffold
 ```
 
 ## Global Flags

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -32,7 +32,7 @@ Bundle-size budgets are declared in `web/.size-limit.cjs` (per-vendor-chunk gzip
 
 ## Package Structure
 
-`web/src/` follows the standard split: `api/` (Axios client + 38 endpoint domains), `components/` (`ui/` primitives + `layout/`), `hooks/`, `lib/`, `mocks/` (MSW), `pages/`, `router/`, `stores/` (Zustand), `styles/` (design tokens), `utils/`, `__tests__/`. Stores over ~600 lines are sliced into packages with one of two aggregation patterns (package-internal `index.ts` or sibling `.ts` aggregator).
+`web/src/` follows the standard split: `api/` (Axios client + endpoint domains), `components/` (`ui/` primitives + `layout/`), `hooks/`, `lib/`, `mocks/` (MSW), `pages/`, `router/`, `stores/` (Zustand), `styles/` (design tokens), `utils/`, `__tests__/`. Stores over ~600 lines are sliced into packages with one of two aggregation patterns (package-internal `index.ts` or sibling `.ts` aggregator).
 
 `web/e2e/` holds the Playwright suite: `factories/`, `fixtures/` (`mock-api.ts`, `websocket-harness.ts`), `flows/`, `helpers/`, `visual/`.
 
@@ -85,7 +85,7 @@ components in `web/src/components/ui/`):
 
 A PostToolUse hook (`scripts/check_web_design_system.py`) runs on every `web/src/` edit and flags hardcoded hex / rgba / fonts / Motion durations / locale literals / bare `.toLocale*String()` calls / missing Storybook stories / duplicate component patterns / complex `.map()` blocks. Fix every violation before proceeding.
 
-See [docs/reference/web-design-system.md](../docs/reference/web-design-system.md) for the full ~70-component inventory (badges, cards, forms, layout, feedback, animation, command palette, version rollback, provider picker), the design-token recipe book (colors, typography, spacing, shadows, responsive widths, chart SVG attributes), the Base UI integration recipe (Portal + Backdrop + Popup composition, animation state attributes, Tailwind v4 transition gotchas), and the "What NOT to do" anti-pattern list.
+See [docs/reference/web-design-system.md](../docs/reference/web-design-system.md) for the full component inventory (badges, cards, forms, layout, feedback, animation, command palette, version rollback, provider picker), the design-token recipe book (colors, typography, spacing, shadows, responsive widths, chart SVG attributes), the Base UI integration recipe (Portal + Backdrop + Popup composition, animation state attributes, Tailwind v4 transition gotchas), and the "What NOT to do" anti-pattern list.
 
 ### Component reuse: don't recreate these inline
 


### PR DESCRIPTION
## Summary

Audit pass over the three CLAUDE.md files (root, `web/`, `cli/`) to fix small inaccuracies and remove numeric counts that drift on every refactor.

- **`CLAUDE.md`**
  - Diagrams section: clarified `D2 CLI pinned to v0.7.1 in CI` (was ambiguously `CI pinned to v0.7.1`, which read like a project-version pin).
  - Workflow section: removed three bullets that duplicated the MANDATORY one-liners (Design Spec, Planning, Post-Implementation/Pre-PR Review). Net `-3` lines, no rule lost.
- **`web/CLAUDE.md`**
  - Package Structure: dropped `38 endpoint domains` count (actual: 45) in favor of `endpoint domains`. Avoids future drift.
  - Design System: dropped `~70-component inventory` count (actual: 55) in favor of `the full component inventory`. Linked `web-design-system.md` remains the authoritative inventory.
- **`cli/CLAUDE.md`**
  - Package Structure: added `backup`, `scaffold` to the `internal/` subdir list. Both are referenced later in the per-command flags table (`backup create`, `new <kind> <domain>`) but were missing from the structural overview.

## Verification

Spot-checked all paths, scripts, and numerics referenced in the three files. Items confirmed accurate (no edits needed):

- `35 enforcement gates + meta-gate` — `convention-gates.md` lists 36 entries (35 + meta).
- `200+ tools across 15 domain modules` — 15 domain modules under `meta/mcp/domains/`.
- `Hypothesis: 10 deterministic CI examples` — `tests/conftest.py:142` (`max_examples=10`).
- `parse_iso_utc / format_iso_utc from persistence._shared` — `_shared/` is a package, exports defined in `_shared/datetime_marshaller.py`.
- All web file paths (`slot.tsx`, `test-setup.tsx`, `ws-sanitize.ts`, `constants.ts`, `lib/logger.ts`).
- All CLI file paths (`state.go`, `dhi.go`, `compose_sync_test.go`).
- Workflows (`lighthouse.yml`, `codspeed.yml`, `__tests__/benchmarks/`).

## Test plan

Docs-only change — no code, no tests, no diagrams. Pre-commit hooks ran clean on push (em-dash check, secrets scan, trailing whitespace, EOL).

## Review coverage

Auto-skipped agent review per `/pre-pr-review` quick-mode rule (only `.md` text edits, no diagrams, no logic changes).

Net diff: `+4 / -7` across three files.