### PR TITLE
refactor: tighten settings → startup-trace baseline (8 → 0)

### DIFF
--- a/docs/reference/configuration-precedence.md
+++ b/docs/reference/configuration-precedence.md
@@ -212,26 +212,35 @@ the lint never flags a setting in isolation.
 
 - **Hardcoded-None ghost.** A service variable
   `x: T | None = None` paired with a conditional
-  `if x is not None: x.start()`. The guard always evaluates False.
-  Example: `ApprovalTimeoutScheduler` hardcoded in `api/app.py`.
+  `if x is not None: x.start()`. The guard always evaluates False,
+  so any setting consumed inside the would-be service is dead at
+  runtime even though the consumer code exists.
 - **Factory-gated ghost.** A factory `build_x(config) -> T | None`
   whose `None` branch fires when a registered default-disabled flag
-  is False. Example: `BackupService` gated on
-  `backup.enabled=False` (the registered default), making all 7
-  `backup.*` settings dead in default config.
+  is False -- in default config the factory returns `None`, the
+  start gate short-circuits, and every setting in the factory's
+  gating namespace is dead.
+
+**Fixing a ghost-wired service** means: drop the factory's early
+return (or the hardcoded `None`), construct the service
+unconditionally, gate the *behaviour* internally on the runtime
+flag, and wire a live `SettingsSubscriber` so operator changes take
+effect without restart. See `BackupService` (`backup/factory.py` +
+`backup/service.py` + `BackupSettingsSubscriber`) and
+`ApprovalTimeoutScheduler` (constructed in `api/app.py`, interval
+applied at boot via `_apply_security_timeout_interval` in
+`lifecycle_helpers.py`, live-tuned via
+`SecurityTimeoutSettingsSubscriber`) for end-to-end references.
 
 **Setting → ghost matchers** (run in order; first hit wins):
 
 1. **Gating-namespace match** (factory ghosts only). Every setting
    whose `namespace` equals the factory's gating namespace is
-   ghost-wired -- e.g. all `backup.*` settings flag when
-   `BackupService` is factory-gated by `backup.enabled=False`.
+   ghost-wired when the gating flag's registered default is False.
 2. **Class-file containment match** (hardcoded-None ghosts only).
    A setting is ghost-wired iff its `key` appears as a substring
    in the ghost class's source file AND its `namespace` appears
-   in that file's path. Catches the `ApprovalTimeoutScheduler`
-   case where `security.timeout_check_interval_seconds` is mentioned
-   in the scheduler's docstring.
+   in that file's path.
 3. **Direct ConfigResolver consumer match** (Pattern A; both ghost
    kinds). The lint scans the ghost class's source file for
    `ConfigResolver.get_*("<ns>", "<key>")` calls (resolving both

--- a/scripts/loop_bound_init_baseline.txt
+++ b/scripts/loop_bound_init_baseline.txt
@@ -6,7 +6,7 @@
 #   uv run python scripts/check_no_loop_bound_init.py --update-baseline
 
 src/synthorg/api/bus_bridge.py:102:MessageBusBridge:_lifecycle_lock:Lock
-src/synthorg/backup/service.py:74:BackupService:_backup_lock:Lock
+src/synthorg/backup/service.py:75:BackupService:_backup_lock:Lock
 src/synthorg/budget/quota_poller.py:64:QuotaPoller:_lifecycle_lock:Lock
 src/synthorg/client/continuous.py:65:ContinuousMode:_stop_event:Event
 src/synthorg/client/continuous.py:71:ContinuousMode:_lifecycle_lock:Lock

--- a/scripts/setting_to_startup_trace_baseline.txt
+++ b/scripts/setting_to_startup_trace_baseline.txt
@@ -8,11 +8,3 @@
 #
 # Regenerate (rare; requires explicit user approval) with:
 #   uv run python scripts/check_setting_to_startup_trace.py --update-baseline
-backup.compression:ghost-wired:BackupService
-backup.enabled:ghost-wired:BackupService
-backup.on_shutdown:ghost-wired:BackupService
-backup.on_startup:ghost-wired:BackupService
-backup.path:ghost-wired:BackupService
-backup.retention_days:ghost-wired:BackupService
-backup.schedule_hours:ghost-wired:BackupService
-security.timeout_check_interval_seconds:ghost-wired:ApprovalTimeoutScheduler

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -598,10 +598,9 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
         resolved_db_path=resolved_db_path,
         resolved_config_path=resolved_config_path,
     )
-    # Constructed here (rather than at the previous near-`_build_lifecycle`
-    # site) so ``_build_settings_dispatcher`` can wire the matching
-    # subscriber for ``security.timeout_check_interval_seconds`` against
-    # the same scheduler instance that the lifecycle starts.
+    # ``_build_settings_dispatcher`` needs the scheduler instance to
+    # wire the ``security.timeout_check_interval_seconds`` subscriber,
+    # so the scheduler must be in scope before the dispatcher is built.
     approval_timeout_scheduler = _build_default_approval_timeout_scheduler(
         approval_store=effective_approval_store,
     )
@@ -889,17 +888,15 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
         )
         app_state.set_review_gate_service(review_gate_service)
 
-    # Approval timeout scheduler is constructed earlier (next to the
-    # backup service) so the settings dispatcher can wire the matching
-    # ``security.timeout_check_interval_seconds`` subscriber against the
-    # same instance that the lifecycle starts. ``_apply_security_timeout_interval``
-    # in ``lifecycle_helpers.py`` resolves the operator-tuned interval
-    # from ``ConfigResolver`` after persistence connects and calls
-    # ``scheduler.reschedule(...)`` so the configured cadence takes
-    # effect on the next loop tick. The default policy is
-    # ``WaitForeverPolicy`` so the scheduler runs but never auto-decides;
-    # operators can swap in DenyOnTimeout / Tiered / EscalationChain via
-    # the security.* settings at runtime.
+    # ``approval_timeout_scheduler`` is built above (alongside the
+    # backup service and bridge); the lifecycle owns starting it.
+    # ``_apply_security_timeout_interval`` in ``lifecycle_helpers.py``
+    # resolves the operator-tuned interval from ``ConfigResolver`` after
+    # persistence connects and calls ``scheduler.reschedule(...)`` so the
+    # configured cadence takes effect on the next loop tick. Default
+    # policy is ``WaitForeverPolicy``: the scheduler runs but never
+    # auto-decides. Operators swap in DenyOnTimeout / Tiered /
+    # EscalationChain via the security.* settings at runtime.
 
     startup, shutdown = _build_lifecycle(
         persistence,

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -598,12 +598,20 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
         resolved_db_path=resolved_db_path,
         resolved_config_path=resolved_config_path,
     )
+    # Constructed here (rather than at the previous near-`_build_lifecycle`
+    # site) so ``_build_settings_dispatcher`` can wire the matching
+    # subscriber for ``security.timeout_check_interval_seconds`` against
+    # the same scheduler instance that the lifecycle starts.
+    approval_timeout_scheduler = _build_default_approval_timeout_scheduler(
+        approval_store=effective_approval_store,
+    )
     settings_dispatcher = _build_settings_dispatcher(
         message_bus,
         settings_service,
         effective_config,
         app_state,
         backup_service,
+        approval_timeout_scheduler,
     )
     plugins: list[ChannelsPlugin] = [channels_plugin]
     # Resolve api.rate_limiter_enabled at boot.  The flag is
@@ -881,15 +889,17 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
         )
         app_state.set_review_gate_service(review_gate_service)
 
-    # Approval timeout scheduler -- bootstrapped here with the
-    # operator-tunable interval from
-    # ``security.timeout_check_interval_seconds``. The default policy
-    # is ``WaitForeverPolicy`` so the scheduler runs but never
-    # auto-decides; operators can swap in DenyOnTimeout / Tiered /
-    # EscalationChain via the security.* settings at runtime.
-    approval_timeout_scheduler = _build_default_approval_timeout_scheduler(
-        approval_store=effective_approval_store,
-    )
+    # Approval timeout scheduler is constructed earlier (next to the
+    # backup service) so the settings dispatcher can wire the matching
+    # ``security.timeout_check_interval_seconds`` subscriber against the
+    # same instance that the lifecycle starts. ``_apply_security_timeout_interval``
+    # in ``lifecycle_helpers.py`` resolves the operator-tuned interval
+    # from ``ConfigResolver`` after persistence connects and calls
+    # ``scheduler.reschedule(...)`` so the configured cadence takes
+    # effect on the next loop tick. The default policy is
+    # ``WaitForeverPolicy`` so the scheduler runs but never auto-decides;
+    # operators can swap in DenyOnTimeout / Tiered / EscalationChain via
+    # the security.* settings at runtime.
 
     startup, shutdown = _build_lifecycle(
         persistence,

--- a/src/synthorg/api/auto_wire.py
+++ b/src/synthorg/api/auto_wire.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
     from synthorg.hr.registry import AgentRegistryService
     from synthorg.ontology.service import OntologyService
     from synthorg.persistence.protocol import PersistenceBackend
+    from synthorg.security.timeout.scheduler import ApprovalTimeoutScheduler
     from synthorg.settings.dispatcher import SettingsChangeDispatcher
     from synthorg.settings.service import SettingsService
     from synthorg.workers.claim import JetStreamTaskQueue
@@ -92,13 +93,14 @@ class MeetingWireResult(NamedTuple):
 class BuildDispatcherFn(Protocol):
     """Protocol for the dispatcher builder callback."""
 
-    def __call__(  # noqa: D102
+    def __call__(  # noqa: D102, PLR0913 -- mirrors _build_settings_dispatcher signature
         self,
         message_bus: MessageBus | None,
         settings_service: SettingsService | None,
         config: RootConfig,
         app_state: AppState,
         backup_service: BackupService | None = None,
+        approval_timeout_scheduler: ApprovalTimeoutScheduler | None = None,
     ) -> SettingsChangeDispatcher | None: ...
 
 
@@ -695,6 +697,7 @@ async def auto_wire_settings(  # noqa: PLR0913
     app_state: AppState,
     backup_service: BackupService | None,
     build_dispatcher: BuildDispatcherFn,
+    approval_timeout_scheduler: ApprovalTimeoutScheduler | None = None,
 ) -> SettingsChangeDispatcher | None:
     """On-startup auto-wire: create SettingsService after persistence connects.
 
@@ -710,6 +713,9 @@ async def auto_wire_settings(  # noqa: PLR0913
         app_state: Application state container.
         backup_service: Backup service (for settings subscriber wiring).
         build_dispatcher: Callable that builds a settings dispatcher.
+        approval_timeout_scheduler: Approval-timeout scheduler so the
+            dispatcher can wire the matching subscriber for
+            ``security.timeout_check_interval_seconds``.
 
     Returns:
         The started dispatcher, or ``None`` if ``build_dispatcher``
@@ -751,6 +757,7 @@ async def auto_wire_settings(  # noqa: PLR0913
             effective_config,
             app_state,
             backup_service,
+            approval_timeout_scheduler,
         )
     except Exception as exc:
         logger.error(

--- a/src/synthorg/api/lifecycle_builder.py
+++ b/src/synthorg/api/lifecycle_builder.py
@@ -16,6 +16,7 @@ from synthorg.api.lifecycle import (
 )
 from synthorg.api.lifecycle_helpers import (
     _apply_bridge_config,
+    _apply_security_timeout_interval,
     _audit_retention_loop,
     _build_settings_dispatcher,
     _maybe_bootstrap_agents,
@@ -492,6 +493,7 @@ def _build_lifecycle(  # noqa: PLR0913, PLR0915, C901
                     app_state,
                     backup_service,
                     _build_settings_dispatcher,
+                    approval_timeout_scheduler,
                 )
             except MemoryError, RecursionError:
                 raise
@@ -614,6 +616,7 @@ def _build_lifecycle(  # noqa: PLR0913, PLR0915, C901
             except Exception:  # noqa: S110 -- already logged via done-callback
                 pass
         await _apply_bridge_config(app_state, effective_config)
+        await _apply_security_timeout_interval(app_state, approval_timeout_scheduler)
 
         # Rebind the live ``MessageBusBridge`` to the now-wired
         # resolver. ``create_app`` captures the resolver eagerly when

--- a/src/synthorg/api/lifecycle_helpers.py
+++ b/src/synthorg/api/lifecycle_helpers.py
@@ -1024,6 +1024,10 @@ async def _apply_security_timeout_interval(
     """
     if scheduler is None or not app_state.has_config_resolver:
         return
+    fallback = registered_default_float(
+        SettingNamespace.SECURITY.value,
+        "timeout_check_interval_seconds",
+    )
     try:
         interval = await app_state.config_resolver.get_float(
             SettingNamespace.SECURITY.value,
@@ -1039,6 +1043,7 @@ async def _apply_security_timeout_interval(
             setting="security.timeout_check_interval_seconds",
             error_type=type(exc).__name__,
             error=safe_error_description(exc),
+            fallback_seconds=fallback,
         )
         return
     try:

--- a/src/synthorg/api/lifecycle_helpers.py
+++ b/src/synthorg/api/lifecycle_helpers.py
@@ -37,6 +37,7 @@ from synthorg.settings.subscribers import (
     ObservabilitySettingsSubscriber,
     PerOpRateLimitSettingsSubscriber,
     ProviderSettingsSubscriber,
+    SecurityTimeoutSettingsSubscriber,
 )
 
 if TYPE_CHECKING:
@@ -46,6 +47,7 @@ if TYPE_CHECKING:
     from synthorg.backup.service import BackupService
     from synthorg.communication.bus_protocol import MessageBus
     from synthorg.config.schema import RootConfig
+    from synthorg.security.timeout.scheduler import ApprovalTimeoutScheduler
     from synthorg.settings.bridge_configs import NotificationsBridgeConfig
     from synthorg.settings.service import SettingsService
     from synthorg.settings.subscriber import SettingsSubscriber
@@ -566,12 +568,13 @@ async def _maybe_bootstrap_agents(app_state: AppState) -> None:
         )
 
 
-def _build_settings_dispatcher(
+def _build_settings_dispatcher(  # noqa: PLR0913 -- one optional arg per subscriber the dispatcher carries
     message_bus: MessageBus | None,
     settings_service: SettingsService | None,
     config: RootConfig,
     app_state: AppState,
     backup_service: BackupService | None = None,
+    approval_timeout_scheduler: ApprovalTimeoutScheduler | None = None,
 ) -> SettingsChangeDispatcher | None:
     """Create settings change dispatcher if bus and settings are available."""
     if message_bus is None or settings_service is None:
@@ -606,6 +609,13 @@ def _build_settings_dispatcher(
         subs.append(
             BackupSettingsSubscriber(
                 backup_service=backup_service,
+                settings_service=settings_service,
+            ),
+        )
+    if approval_timeout_scheduler is not None:
+        subs.append(
+            SecurityTimeoutSettingsSubscriber(
+                scheduler=approval_timeout_scheduler,
                 settings_service=settings_service,
             ),
         )
@@ -991,6 +1001,56 @@ async def _apply_bridge_config(  # noqa: C901, PLR0912, PLR0915
     await _apply_notification_dispatcher_config(app_state, effective_config)
 
     app_state.mark_bridge_config_applied()
+
+
+async def _apply_security_timeout_interval(
+    app_state: AppState,
+    scheduler: ApprovalTimeoutScheduler | None,
+) -> None:
+    """Apply ``security.timeout_check_interval_seconds`` at startup.
+
+    The scheduler is bootstrapped with the registry default at app
+    construction time before persistence connects. Once the resolver
+    is wired (after ``_apply_bridge_config``), pull the operator-tuned
+    value via the canonical DB > env > YAML > default chain and call
+    ``scheduler.reschedule(...)`` so the configured cadence takes
+    effect on the next loop tick.
+
+    Resolver outage falls back to the *current* scheduler interval
+    (the registry default the scheduler was bootstrapped with). The
+    fail-safe-on-outage rule from the kill-switch idiom applies in
+    spirit: leaving the scheduler running with the bootstrap default
+    is safer than stopping it on a settings-backend hiccup.
+    """
+    if scheduler is None or not app_state.has_config_resolver:
+        return
+    try:
+        interval = await app_state.config_resolver.get_float(
+            SettingNamespace.SECURITY.value,
+            "timeout_check_interval_seconds",
+        )
+    except asyncio.CancelledError:
+        raise
+    except MemoryError, RecursionError:
+        raise
+    except Exception as exc:
+        logger.warning(
+            API_APP_STARTUP,
+            setting="security.timeout_check_interval_seconds",
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
+        )
+        return
+    try:
+        scheduler.reschedule(interval)
+    except ValueError as exc:
+        logger.warning(
+            API_APP_STARTUP,
+            setting="security.timeout_check_interval_seconds",
+            value=interval,
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
+        )
 
 
 async def _resolve_oauth_idempotency_retention(app_state: AppState) -> float:

--- a/src/synthorg/backup/factory.py
+++ b/src/synthorg/backup/factory.py
@@ -77,6 +77,13 @@ def build_backup_service(
     Uses resolved runtime paths when available so backups target
     the actual files the application opened at startup.
 
+    The service is always constructed regardless of ``backup.enabled``
+    so the registered ``backup.*`` settings have a live consumer at
+    boot. ``BackupService.start()`` honours ``self._config.enabled``
+    internally -- when disabled the scheduler does not run and the
+    settings subscriber path can flip the scheduler on at runtime
+    without rebuilding the service.
+
     Args:
         config: Root company configuration.
         resolved_db_path: Actual DB path used by the persistence
@@ -85,15 +92,10 @@ def build_backup_service(
             startup (falls back to SYNTHORG_CONFIG_PATH / company.yaml).
 
     Returns:
-        Configured backup service, or ``None`` if construction fails.
+        Configured backup service, or ``None`` if handler construction
+        fails (e.g. invalid component path).
     """
     backup_config = config.backup
-    if not backup_config.enabled:
-        logger.info(
-            API_APP_STARTUP,
-            note="Backup service disabled via config (enabled=false)",
-        )
-        return None
     try:
         handlers = build_backup_handlers(
             config,

--- a/src/synthorg/backup/factory.py
+++ b/src/synthorg/backup/factory.py
@@ -9,7 +9,7 @@ from synthorg.backup.handlers.memory import MemoryComponentHandler
 from synthorg.backup.handlers.persistence import PersistenceComponentHandler
 from synthorg.backup.models import BackupComponent
 from synthorg.backup.service import BackupService
-from synthorg.observability import get_logger
+from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.api import API_APP_STARTUP
 
 if TYPE_CHECKING:
@@ -106,9 +106,11 @@ def build_backup_service(
         return BackupService(backup_config, handlers)
     except MemoryError, RecursionError:
         raise
-    except Exception:
+    except Exception as exc:
         logger.warning(
             API_APP_STARTUP,
-            error="Failed to build backup service",
+            note="Failed to build backup service",
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
         )
         return None

--- a/src/synthorg/backup/service.py
+++ b/src/synthorg/backup/service.py
@@ -37,7 +37,7 @@ from synthorg.observability.events.backup import (
     BACKUP_RESTORE_ROLLBACK,
     BACKUP_RESTORE_STARTED,
     BACKUP_RETENTION_FAILED,
-    BACKUP_SCHEDULER_STOPPED,
+    BACKUP_SCHEDULER_DORMANT,
     BACKUP_STARTED,
 )
 
@@ -111,7 +111,7 @@ class BackupService(BackupServiceArchiveMixin):
             await self._scheduler.start()
             return
         logger.info(
-            BACKUP_SCHEDULER_STOPPED,
+            BACKUP_SCHEDULER_DORMANT,
             note="Backup scheduler dormant (backup.enabled=false)",
         )
 

--- a/src/synthorg/backup/service.py
+++ b/src/synthorg/backup/service.py
@@ -101,14 +101,19 @@ class BackupService(BackupServiceArchiveMixin):
         ``/settings``); the scheduler also services on-demand backups
         invoked through controllers and MCP handlers regardless of the
         scheduled-run gate.
+
+        The disabled branch logs at INFO so operators can confirm the
+        deliberate dormant state from the boot log alongside the
+        ``BACKUP_SCHEDULER_STARTED`` event the scheduler emits when
+        ``enabled`` is True.
         """
         if self._config.enabled:
             await self._scheduler.start()
-        else:
-            logger.info(
-                BACKUP_SCHEDULER_STOPPED,
-                note="Backup scheduler dormant (backup.enabled=false)",
-            )
+            return
+        logger.info(
+            BACKUP_SCHEDULER_STOPPED,
+            note="Backup scheduler dormant (backup.enabled=false)",
+        )
 
     async def stop(self) -> None:
         """Stop the backup scheduler."""

--- a/src/synthorg/backup/service.py
+++ b/src/synthorg/backup/service.py
@@ -37,6 +37,7 @@ from synthorg.observability.events.backup import (
     BACKUP_RESTORE_ROLLBACK,
     BACKUP_RESTORE_STARTED,
     BACKUP_RETENTION_FAILED,
+    BACKUP_SCHEDULER_STOPPED,
     BACKUP_STARTED,
 )
 
@@ -92,9 +93,22 @@ class BackupService(BackupServiceArchiveMixin):
         return self._config.on_shutdown
 
     async def start(self) -> None:
-        """Start the backup scheduler if backups are enabled."""
+        """Start the backup scheduler if backups are enabled.
+
+        When ``backup.enabled`` is ``False`` the scheduler is left
+        dormant and the service stays available for runtime opt-in via
+        ``BackupSettingsSubscriber`` (operator flips the flag through
+        ``/settings``); the scheduler also services on-demand backups
+        invoked through controllers and MCP handlers regardless of the
+        scheduled-run gate.
+        """
         if self._config.enabled:
             await self._scheduler.start()
+        else:
+            logger.info(
+                BACKUP_SCHEDULER_STOPPED,
+                note="Backup scheduler dormant (backup.enabled=false)",
+            )
 
     async def stop(self) -> None:
         """Stop the backup scheduler."""

--- a/src/synthorg/observability/events/backup.py
+++ b/src/synthorg/observability/events/backup.py
@@ -29,6 +29,7 @@ BACKUP_RETENTION_FAILED: Final[str] = "backup.retention.failed"
 # Scheduler events
 BACKUP_SCHEDULER_STARTED: Final[str] = "backup.scheduler.started"
 BACKUP_SCHEDULER_STOPPED: Final[str] = "backup.scheduler.stopped"
+BACKUP_SCHEDULER_DORMANT: Final[str] = "backup.scheduler.dormant"
 BACKUP_SCHEDULER_RESCHEDULED: Final[str] = "backup.scheduler.rescheduled"
 BACKUP_SCHEDULER_TICK: Final[str] = "backup.scheduler.tick"
 

--- a/src/synthorg/settings/subscribers/__init__.py
+++ b/src/synthorg/settings/subscribers/__init__.py
@@ -18,6 +18,9 @@ from synthorg.settings.subscribers.per_op_rate_limit_subscriber import (
 from synthorg.settings.subscribers.provider_subscriber import (
     ProviderSettingsSubscriber,
 )
+from synthorg.settings.subscribers.security_timeout_subscriber import (
+    SecurityTimeoutSettingsSubscriber,
+)
 
 __all__ = [
     "ApiBridgeSettingsSubscriber",
@@ -26,4 +29,5 @@ __all__ = [
     "ObservabilitySettingsSubscriber",
     "PerOpRateLimitSettingsSubscriber",
     "ProviderSettingsSubscriber",
+    "SecurityTimeoutSettingsSubscriber",
 ]

--- a/src/synthorg/settings/subscribers/security_timeout_subscriber.py
+++ b/src/synthorg/settings/subscribers/security_timeout_subscriber.py
@@ -94,13 +94,15 @@ class SecurityTimeoutSettingsSubscriber:
 
         try:
             interval = float(result.value)
-        except ValueError, TypeError:
+        except (ValueError, TypeError) as exc:
             logger.warning(
                 SETTINGS_SUBSCRIBER_NOTIFIED,
                 subscriber=self.subscriber_name,
                 namespace=namespace,
                 key=key,
                 value=result.value,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
                 note="invalid interval value",
             )
             return

--- a/src/synthorg/settings/subscribers/security_timeout_subscriber.py
+++ b/src/synthorg/settings/subscribers/security_timeout_subscriber.py
@@ -1,0 +1,129 @@
+"""Security timeout settings subscriber -- live reschedule on interval changes.
+
+Watches ``security.timeout_check_interval_seconds`` and calls
+``ApprovalTimeoutScheduler.reschedule(...)`` so operator overrides
+take effect on the next scheduler tick without restart. The
+startup-time application of the same setting lives in
+``synthorg.api.lifecycle_helpers._apply_security_timeout_interval``.
+"""
+
+from typing import TYPE_CHECKING
+
+from synthorg.observability import get_logger, safe_error_description
+from synthorg.observability.events.settings import SETTINGS_SUBSCRIBER_NOTIFIED
+
+if TYPE_CHECKING:
+    from synthorg.security.timeout.scheduler import ApprovalTimeoutScheduler
+    from synthorg.settings.service import SettingsService
+
+logger = get_logger(__name__)
+
+_WATCHED: frozenset[tuple[str, str]] = frozenset(
+    {("security", "timeout_check_interval_seconds")},
+)
+
+
+class SecurityTimeoutSettingsSubscriber:
+    """React to ``security.timeout_check_interval_seconds`` changes.
+
+    Reads the new interval via ``SettingsService`` and reschedules the
+    scheduler. Read failures and parse failures log + skip; the
+    scheduler keeps its current interval. Mirrors the
+    ``BackupSettingsSubscriber._reschedule`` discipline.
+
+    Args:
+        scheduler: The approval timeout scheduler to reschedule.
+        settings_service: Settings service for reading the current value.
+    """
+
+    def __init__(
+        self,
+        *,
+        scheduler: ApprovalTimeoutScheduler,
+        settings_service: SettingsService,
+    ) -> None:
+        self._scheduler = scheduler
+        self._settings_service = settings_service
+
+    @property
+    def watched_keys(self) -> frozenset[tuple[str, str]]:
+        """Return security-namespace keys this subscriber watches."""
+        return _WATCHED
+
+    @property
+    def subscriber_name(self) -> str:
+        """Human-readable subscriber name."""
+        return "security-timeout-settings"
+
+    async def on_settings_changed(
+        self,
+        namespace: str,
+        key: str,
+    ) -> None:
+        """Handle a change to the timeout-check-interval setting.
+
+        Args:
+            namespace: Changed setting namespace.
+            key: Changed setting key.
+        """
+        if (namespace, key) not in _WATCHED:
+            logger.warning(
+                SETTINGS_SUBSCRIBER_NOTIFIED,
+                subscriber=self.subscriber_name,
+                namespace=namespace,
+                key=key,
+                note="ignored unexpected key",
+            )
+            return
+
+        try:
+            result = await self._settings_service.get(namespace, key)
+        except MemoryError, RecursionError:
+            raise
+        except Exception as exc:
+            logger.error(
+                SETTINGS_SUBSCRIBER_NOTIFIED,
+                subscriber=self.subscriber_name,
+                namespace=namespace,
+                key=key,
+                note="failed to read setting",
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            return
+
+        try:
+            interval = float(result.value)
+        except ValueError, TypeError:
+            logger.warning(
+                SETTINGS_SUBSCRIBER_NOTIFIED,
+                subscriber=self.subscriber_name,
+                namespace=namespace,
+                key=key,
+                value=result.value,
+                note="invalid interval value",
+            )
+            return
+
+        try:
+            self._scheduler.reschedule(interval)
+        except ValueError as exc:
+            logger.warning(
+                SETTINGS_SUBSCRIBER_NOTIFIED,
+                subscriber=self.subscriber_name,
+                namespace=namespace,
+                key=key,
+                value=interval,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+                note="scheduler rejected interval",
+            )
+            return
+
+        logger.info(
+            SETTINGS_SUBSCRIBER_NOTIFIED,
+            subscriber=self.subscriber_name,
+            namespace=namespace,
+            key=key,
+            note="rescheduled",
+        )

--- a/tests/unit/api/test_apply_security_timeout_interval.py
+++ b/tests/unit/api/test_apply_security_timeout_interval.py
@@ -1,0 +1,100 @@
+"""Tests for the ``_apply_security_timeout_interval`` startup helper.
+
+The hardcoded ``_DEFAULT_TIMEOUT_CHECK_INTERVAL_SECONDS`` baked into
+``api/app.py`` only covers the registry-default leg of the
+DB > env > YAML > default chain. After persistence connects and
+``_apply_bridge_config`` wires the resolver, this helper pulls the
+operator-tuned value and calls ``scheduler.reschedule(...)`` so the
+configured cadence takes effect on the next tick without restart.
+"""
+
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from synthorg.api.approval_store import ApprovalStore
+from synthorg.api.lifecycle_helpers import _apply_security_timeout_interval
+from synthorg.api.state import AppState
+from synthorg.config.schema import RootConfig
+from synthorg.security.timeout.scheduler import ApprovalTimeoutScheduler
+from synthorg.settings.resolver import ConfigResolver
+
+pytestmark = pytest.mark.unit
+
+
+def _make_state(*, config_resolver: ConfigResolver | None) -> AppState:
+    state = AppState(
+        config=RootConfig(company_name="test"),
+        approval_store=ApprovalStore(),
+    )
+    state._config_resolver = config_resolver
+    return state
+
+
+def _make_scheduler() -> ApprovalTimeoutScheduler:
+    """Return a Mock that responds to ``reschedule(float)`` with ``spec=``."""
+    return cast(
+        "ApprovalTimeoutScheduler",
+        MagicMock(spec=ApprovalTimeoutScheduler),
+    )
+
+
+class TestApplySecurityTimeoutInterval:
+    """Resolves ``security.timeout_check_interval_seconds`` and reschedules."""
+
+    async def test_no_scheduler_is_noop(self) -> None:
+        state = _make_state(config_resolver=AsyncMock(spec=ConfigResolver))
+
+        await _apply_security_timeout_interval(state, scheduler=None)
+
+        # Resolver must NOT be hit when there's no scheduler to reschedule.
+        cast("AsyncMock", state.config_resolver).get_float.assert_not_awaited()
+
+    async def test_no_resolver_is_noop(self) -> None:
+        scheduler = _make_scheduler()
+        state = _make_state(config_resolver=None)
+
+        await _apply_security_timeout_interval(state, scheduler=scheduler)
+
+        cast("MagicMock", scheduler).reschedule.assert_not_called()
+
+    async def test_resolves_and_reschedules(self) -> None:
+        scheduler = _make_scheduler()
+        resolver = AsyncMock(spec=ConfigResolver)
+        resolver.get_float.return_value = 12.5
+        state = _make_state(config_resolver=resolver)
+
+        await _apply_security_timeout_interval(state, scheduler=scheduler)
+
+        resolver.get_float.assert_awaited_once_with(
+            "security",
+            "timeout_check_interval_seconds",
+        )
+        cast("MagicMock", scheduler).reschedule.assert_called_once_with(12.5)
+
+    async def test_resolver_outage_leaves_scheduler_unchanged(self) -> None:
+        scheduler = _make_scheduler()
+        resolver = AsyncMock(spec=ConfigResolver)
+        resolver.get_float.side_effect = ValueError("settings backend down")
+        state = _make_state(config_resolver=resolver)
+
+        await _apply_security_timeout_interval(state, scheduler=scheduler)
+
+        cast("MagicMock", scheduler).reschedule.assert_not_called()
+
+    async def test_invalid_resolved_value_skipped_with_warning(self) -> None:
+        scheduler = _make_scheduler()
+        # ``ApprovalTimeoutScheduler.reschedule`` raises ValueError on a
+        # non-positive interval. The helper must catch it so a bad
+        # operator override cannot kill startup.
+        cast("MagicMock", scheduler).reschedule.side_effect = ValueError(
+            "interval_seconds must be positive, got -1.0",
+        )
+        resolver = AsyncMock(spec=ConfigResolver)
+        resolver.get_float.return_value = -1.0
+        state = _make_state(config_resolver=resolver)
+
+        await _apply_security_timeout_interval(state, scheduler=scheduler)
+
+        cast("MagicMock", scheduler).reschedule.assert_called_once_with(-1.0)

--- a/tests/unit/backup/test_factory.py
+++ b/tests/unit/backup/test_factory.py
@@ -1,0 +1,73 @@
+"""Tests for the backup service factory.
+
+The factory always constructs a real ``BackupService`` so the
+registered ``backup.*`` settings have a live consumer at boot;
+``BackupService.start()`` honours the ``enabled`` flag internally
+without needing the factory to early-return ``None``.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from synthorg.backup.config import BackupConfig
+from synthorg.backup.factory import build_backup_service
+from synthorg.backup.service import BackupService
+from synthorg.config.schema import RootConfig
+
+
+@pytest.mark.unit
+class TestBuildBackupService:
+    """build_backup_service always constructs a real service."""
+
+    def test_returns_backup_service_when_disabled_by_default(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Disabled-by-default config still yields a real BackupService."""
+        config = RootConfig(company_name="test-co")
+        assert config.backup.enabled is False
+
+        service = build_backup_service(
+            config,
+            resolved_db_path=tmp_path / "synthorg.db",
+            resolved_config_path=tmp_path / "company.yaml",
+        )
+
+        assert isinstance(service, BackupService)
+        assert service.scheduler.is_running is False
+
+    def test_returns_backup_service_when_enabled(self, tmp_path: Path) -> None:
+        """Explicit ``backup.enabled=true`` still returns a real service."""
+        config = RootConfig(
+            company_name="test-co",
+            backup=BackupConfig(enabled=True, path=str(tmp_path / "backups")),
+        )
+
+        service = build_backup_service(
+            config,
+            resolved_db_path=tmp_path / "synthorg.db",
+            resolved_config_path=tmp_path / "company.yaml",
+        )
+
+        assert isinstance(service, BackupService)
+
+    def test_returns_none_when_handler_construction_fails(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Genuine handler-build failures still surface as ``None``."""
+        config = RootConfig(company_name="test-co")
+
+        with patch(
+            "synthorg.backup.factory.build_backup_handlers",
+            side_effect=ValueError("synthetic handler-build failure"),
+        ):
+            service = build_backup_service(
+                config,
+                resolved_db_path=tmp_path / "synthorg.db",
+                resolved_config_path=tmp_path / "company.yaml",
+            )
+
+        assert service is None

--- a/tests/unit/scripts/test_check_setting_to_startup_trace.py
+++ b/tests/unit/scripts/test_check_setting_to_startup_trace.py
@@ -166,16 +166,16 @@ def test_inventory_rejects_empty_suppression_justification(tmp_path: Path) -> No
 def test_real_repo_violations_match_expected() -> None:
     """Lint against the actual src/synthorg/ tree.
 
-    Asserts exactly the 7 expected ghost-wired violations: the
-    ``backup.*`` settings the BackupService factory still resolves
-    only when the operator opts in.  ``security.timeout_check_interval_seconds``
-    used to ghost-wire here as well; the audit-bucket PR wired
-    ``ApprovalTimeoutScheduler`` into the lifespan startup so the
-    setting is now resolved on every cold start, and the lint should
-    no longer flag it.
+    Asserts zero ghost-wired violations: ``BackupService`` is
+    constructed unconditionally by ``build_backup_service`` (the
+    factory no longer returns ``None`` on ``backup.enabled=false``,
+    so the registered ``backup.*`` settings have a live consumer at
+    boot), and ``ApprovalTimeoutScheduler`` is started by
+    ``_safe_startup`` with the operator-tuned interval applied via
+    ``_apply_security_timeout_interval`` after the resolver wires.
 
-    Asserts zero false positives on the negative ``security.*`` settings
-    (audit_enabled, post_tool_scanning_enabled, ...) and on
+    Also asserts zero false positives on the negative ``security.*``
+    settings (audit_enabled, post_tool_scanning_enabled, ...) and on
     ``engine.timeout_enforcement_enabled`` and the WS DoS settings.
 
     This test is the load-bearing assertion that the lint logic is
@@ -188,7 +188,7 @@ def test_real_repo_violations_match_expected() -> None:
     )
     flagged = {v.yaml_path for v in violations}
 
-    expected_positives = {
+    must_not_flag = {
         "backup.compression",
         "backup.enabled",
         "backup.on_shutdown",
@@ -196,12 +196,6 @@ def test_real_repo_violations_match_expected() -> None:
         "backup.path",
         "backup.retention_days",
         "backup.schedule_hours",
-    }
-    assert expected_positives.issubset(flagged), (
-        f"missing expected positives: {expected_positives - flagged}"
-    )
-
-    must_not_flag = {
         "security.enabled",
         "security.audit_enabled",
         "security.post_tool_scanning_enabled",
@@ -216,5 +210,4 @@ def test_real_repo_violations_match_expected() -> None:
     leaked = flagged & must_not_flag
     assert not leaked, f"false positives on negatives: {leaked}"
 
-    extras = flagged - expected_positives
-    assert not extras, f"unexpected extra flags: {extras}"
+    assert flagged == set(), f"unexpected flags: {flagged}"

--- a/tests/unit/settings/test_security_timeout_subscriber.py
+++ b/tests/unit/settings/test_security_timeout_subscriber.py
@@ -1,0 +1,117 @@
+"""Tests for SecurityTimeoutSettingsSubscriber.
+
+Watches ``security.timeout_check_interval_seconds`` and reschedules
+the approval-timeout scheduler on operator changes.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from synthorg.security.timeout.scheduler import ApprovalTimeoutScheduler
+from synthorg.settings.models import SettingValue
+from synthorg.settings.service import SettingsService
+from synthorg.settings.subscriber import SettingsSubscriber
+from synthorg.settings.subscribers.security_timeout_subscriber import (
+    SecurityTimeoutSettingsSubscriber,
+)
+
+
+def _make_subscriber(
+    *,
+    interval_value: str = "12.5",
+    raise_on_get: bool = False,
+    reschedule_raises: bool = False,
+) -> tuple[SecurityTimeoutSettingsSubscriber, MagicMock, MagicMock]:
+    """Create a subscriber with mock scheduler + settings service."""
+    scheduler = MagicMock(spec=ApprovalTimeoutScheduler)
+    if reschedule_raises:
+        scheduler.reschedule.side_effect = ValueError(
+            "interval_seconds must be positive",
+        )
+
+    settings_service = MagicMock(spec=SettingsService)
+
+    async def _mock_get(namespace: str, key: str) -> Any:
+        del namespace, key
+        if raise_on_get:
+            msg = "settings backend down"
+            raise RuntimeError(msg)
+        result = MagicMock(spec=SettingValue)
+        result.value = interval_value
+        return result
+
+    settings_service.get = AsyncMock(
+        spec=SettingsService.get,
+        side_effect=_mock_get,
+    )
+
+    sub = SecurityTimeoutSettingsSubscriber(
+        scheduler=scheduler,
+        settings_service=settings_service,
+    )
+    return sub, scheduler, settings_service
+
+
+@pytest.mark.unit
+class TestSubscriberProtocol:
+    """SecurityTimeoutSettingsSubscriber conforms to SettingsSubscriber."""
+
+    def test_isinstance_check(self) -> None:
+        sub, _, _ = _make_subscriber()
+        assert isinstance(sub, SettingsSubscriber)
+
+    def test_watched_keys(self) -> None:
+        sub, _, _ = _make_subscriber()
+        assert sub.watched_keys == frozenset(
+            {("security", "timeout_check_interval_seconds")},
+        )
+
+    def test_subscriber_name(self) -> None:
+        sub, _, _ = _make_subscriber()
+        assert sub.subscriber_name == "security-timeout-settings"
+
+
+@pytest.mark.unit
+class TestOnSettingsChanged:
+    """on_settings_changed reschedules the scheduler on the watched key."""
+
+    async def test_reschedules_on_watched_key(self) -> None:
+        sub, scheduler, _ = _make_subscriber(interval_value="42.0")
+
+        await sub.on_settings_changed("security", "timeout_check_interval_seconds")
+
+        scheduler.reschedule.assert_called_once_with(42.0)
+
+    async def test_unwatched_key_is_noop(self) -> None:
+        sub, scheduler, settings_service = _make_subscriber()
+
+        await sub.on_settings_changed("security", "audit_retention_days")
+
+        settings_service.get.assert_not_awaited()
+        scheduler.reschedule.assert_not_called()
+
+    async def test_invalid_value_skipped(self) -> None:
+        sub, scheduler, _ = _make_subscriber(interval_value="not-a-float")
+
+        await sub.on_settings_changed("security", "timeout_check_interval_seconds")
+
+        scheduler.reschedule.assert_not_called()
+
+    async def test_settings_read_failure_skipped(self) -> None:
+        sub, scheduler, _ = _make_subscriber(raise_on_get=True)
+
+        await sub.on_settings_changed("security", "timeout_check_interval_seconds")
+
+        scheduler.reschedule.assert_not_called()
+
+    async def test_scheduler_value_error_swallowed(self) -> None:
+        sub, scheduler, _ = _make_subscriber(
+            interval_value="-1.0",
+            reschedule_raises=True,
+        )
+
+        await sub.on_settings_changed("security", "timeout_check_interval_seconds")
+
+        scheduler.reschedule.assert_called_once_with(-1.0)


### PR DESCRIPTION
## Summary

`scripts/check_setting_to_startup_trace.py` froze 8 ghost-wired settings: 7 × `backup.*` and `security.timeout_check_interval_seconds`. Both owning services were either factory-gated to `None` in default config (`BackupService`) or bootstrapped with a hardcoded interval and never re-read at runtime (`ApprovalTimeoutScheduler`). The registered settings had no live consumer at boot.

This branch wires both services through the canonical DB > env > YAML > default chain and regenerates the baseline to header-only.

## Changes

**Phase 1 — `BackupService`**
- Drop the `if not backup_config.enabled: return None` early return in `build_backup_service`. The factory always returns a real `BackupService`. `BackupService.start()` already gates internally on `self._config.enabled`, so a deployment with `backup.enabled=false` still avoids scheduler ticks. Adds an INFO log on the dormant path so operators can confirm the deliberate state from the boot log.

**Phase 2 — `ApprovalTimeoutScheduler`**
- New `_apply_security_timeout_interval` helper in `lifecycle_helpers.py`, called after `_apply_bridge_config`, resolves `security.timeout_check_interval_seconds` via `ConfigResolver` and calls `scheduler.reschedule(...)`.
- New `SecurityTimeoutSettingsSubscriber` (mirrors `BackupSettingsSubscriber._reschedule`) handles live operator changes via the dispatcher.
- `_build_settings_dispatcher` + `BuildDispatcherFn` Protocol + `auto_wire_settings` extended with the new optional `approval_timeout_scheduler` parameter; scheduler construction in `app.py` moved earlier so the dispatcher can wire the matching subscriber against the same instance.

**Phase 3 — Baseline**
- `scripts/setting_to_startup_trace_baseline.txt` regenerated to header-only (`uv run python scripts/check_setting_to_startup_trace.py --update-baseline`).
- Smoke test `test_real_repo_violations_match_expected` updated to assert empty-violation set as the new ground truth.
- `scripts/loop_bound_init_baseline.txt` line 74 → 75 to track the shifted import in `backup/service.py`.

**Pre-PR review fixes (commit 4)**
- Drop now-stale ghost-service examples in `docs/reference/configuration-precedence.md`; replace with a generic "fixing a ghost-wired service" guide referencing both as end-to-end examples.
- Rewrite two app.py comments to explain the current architectural reason instead of framing the change relative to the prior site (CLAUDE.md no-migration-framing).
- Bind exception in `build_backup_service` failure path; log via `safe_error_description` + `error_type` per SEC-1 redaction.
- Bind float-parse failure in `SecurityTimeoutSettingsSubscriber`; add `error_type` so operators can distinguish a non-numeric value from a None value.
- Document `BACKUP_SCHEDULER_STARTED` as the started-branch's observable signal in `BackupService.start`'s docstring.

## Test Plan

- 16 new tests across 4 files: factory (3), helper (5), subscriber (8); plus updated lint smoke test.
- Full unit suite: 29,463 passed (50 skipped Windows / opt-in markers).
- Focused integration: 55 passed (3 skipped — Docker unavailable).
- Gates clean: `check_setting_to_startup_trace.py`, `check_no_loop_bound_init.py`, `check_logger_exception_str_exc.py`, `check_no_magic_numbers.py`, `check_mock_spec.py`.
- ruff + mypy strict + ruff format: clean.

## Review coverage

`/pre-pr-review` ran 17 specialized agents in parallel (code-reviewer, python-reviewer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, logging-audit, resilience-audit, conventions-enforcer, security-reviewer, test-quality-reviewer, async-concurrency-reviewer, comment-analyzer, docs-consistency, comment-quality-rot, api-contract-drift, plus 5 mini-pass agents from the codebase audit: missing-logger, missing-event-constants, missing-state-transition-log, unwired-settings, race-conditions). 6 valid findings retained and fixed; 1 false-positive cluster (PEP 758 `except A, B:` flagged as Python 2 syntax) discarded with rationale (CLAUDE.md explicitly permits this form).

## Notes

- No PR-tracked GitHub issue (per /pre-pr-review prompt: user chose to proceed without).
- Rebased onto `origin/main` to pull in `#1845` (unrelated test refactor) before pushing.