### PR TITLE
fix(cli): render running-no-probe containers as healthy in doctor

### DIFF
--- a/cli/cmd/doctor.go
+++ b/cli/cmd/doctor.go
@@ -433,6 +433,11 @@ func renderDoctorContainers(out *ui.UI, r diagnostics.Report) {
 			out.Error(fmt.Sprintf("%-24s %s", c.Name, status))
 		case c.Health != "":
 			out.Warn(fmt.Sprintf("%-24s %s (%s)", c.Name, c.State, c.Health))
+		case c.State == "running":
+			// No docker-level healthcheck declared (e.g. NATS). Treat
+			// running as healthy so the row matches probed-healthy peers
+			// instead of looking indefinitely "in progress".
+			out.Success(fmt.Sprintf("%-24s healthy", c.Name))
 		default:
 			out.Step(fmt.Sprintf("%-24s %s", c.Name, c.State))
 		}


### PR DESCRIPTION
## Summary

`synthorg doctor` was rendering NATS as `● running` (blue step icon) while peers with docker-level healthchecks rendered as `✓ healthy` (green success icon). NATS has no docker healthcheck declared; application-level liveness is surfaced via `/api/v1/readyz` instead.

Before:
```
✓ synthorg-backend-1       healthy
● synthorg-nats-1          running
✓ synthorg-postgres-1      healthy
✓ synthorg-web-1           healthy
```

After:
```
✓ synthorg-backend-1       healthy
✓ synthorg-nats-1          healthy
✓ synthorg-postgres-1      healthy
✓ synthorg-web-1           healthy
```

## Change

Add an explicit `case c.State == "running"` arm in `renderDoctorContainers` (`cli/cmd/doctor.go:436-440`) ahead of the catch-all default, rendering with `out.Success(...)` and label `"healthy"`. The case is only reached when `Health == ""` (all non-empty Health values are caught upstream).

## Cross-file parity

`cli/cmd/status.go:252-269` `healthIcon()` already does the same thing (running + empty Health -> `IconSuccess`) with a doc-comment explaining the rationale. Doctor was inconsistent with status; this aligns them.

## Test plan

- `go -C cli build ./...`: clean.
- `go -C cli vet ./...`: clean.
- `go -C cli test ./...`: all packages pass (cmd, completion, compose, config, diagnostics, docker, health, images, scaffold, selfupdate, ui, verify).
- Manual: `synthorg doctor` against a running stack renders NATS row as green check + "healthy" matching the other services.

## Review coverage

Pre-PR review pipeline (`/pre-pr-review`) ran 4 applicable agents (go-reviewer, go-conventions-enforcer, docs-consistency, comment-quality-rot). Zero findings; all agents approved. Triage record at `_audit/pre-pr-review/triage.md`.

Restarting / paused / created / dead states with empty Health still fall through to the default `out.Step(...)` arm and render with the in-progress icon, matching `healthIcon()`'s behaviour for the same states.
