### PR TITLE
feat(web): eye-toggle on every password / secret field

### DIFF
--- a/docs/reference/web-design-system.md
+++ b/docs/reference/web-design-system.md
@@ -55,7 +55,8 @@ Every shared building block in `web/src/components/ui/`. Reuse before creating n
 | Component | Import | Use for |
 |-----------|--------|---------|
 | `Button` | `@/components/ui/button` | Standard button (shadcn). |
-| `InputField` | `@/components/ui/input-field` | Labeled text input with error / hint display, optional multiline textarea mode, optional `leadingIcon` (decorative, pointer-events-none) / `trailingElement` (interactive slot, e.g. clear button) positioned relative to the input box, not the labeled wrapper. |
+| `InputField` | `@/components/ui/input-field` | Labeled text input with error / hint display, optional multiline textarea mode, optional `leadingIcon` (decorative, pointer-events-none) / `trailingElement` (interactive slot, e.g. clear button) positioned relative to the input box, not the labeled wrapper. When `type="password"`, automatically renders a built-in eye / eye-off visibility toggle as the trailing element; opt out via `hidePasswordToggle?: boolean`, or override entirely by supplying your own `trailingElement` (which takes precedence). |
+| `PasswordVisibilityGroup` | `@/components/ui/input-field` | Context provider co-located with `InputField`. Wraps semantically-paired password / secret fields (e.g. Password + Confirm Password on the Create Admin Account screen) so a single eye toggle reveals or hides every field in the group at once. Independent secrets in the same dialog (e.g. an OAuth client secret next to a header value) should stay outside the provider so each toggles on its own. |
 | `SelectField` | `@/components/ui/select-field` | Labeled select dropdown with error / hint and placeholder support. |
 | `SliderField` | `@/components/ui/slider-field` | Labeled range slider with custom value formatter and aria-live display. |
 | `ToggleField` | `@/components/ui/toggle-field` | Labeled toggle switch (`role="switch"`) with optional description text. |

--- a/docs/security.md
+++ b/docs/security.md
@@ -161,7 +161,11 @@ retain the narrowly-scoped `'unsafe-inline'` permission they need for layout pos
    from Go's `crypto/rand`. It is cryptographically random.
 2. **Injection.** The `templates` directive in the Caddyfile processes `web/index.html` at
    response time, substituting `{{placeholder "http.request.uuid"}}` with the per-request
-   UUID. Every HTML response ships with a unique nonce in `<meta name="csp-nonce" content="...">`.
+   UUID. The meta tag uses single-quoted attribute syntax (`content='{{placeholder "http.request.uuid"}}'`)
+   so the embedded double-quoted Go template placeholder parses cleanly under HTML parsers
+   (parse5, browsers, Vite); the Caddy `templates` engine substitutes the `{{...}}` token
+   regardless of outer-quote style. Every HTML response ships with a unique nonce in
+   `<meta name="csp-nonce" content='...'>`.
 3. **Header.** The `(spa_csp)` snippet in `web/Caddyfile` emits the CSP with the matching
    nonce: `style-src-elem 'self' 'nonce-{http.request.uuid}'; style-src-attr 'unsafe-inline'`.
 4. **Runtime read.** On page load, `web/src/lib/csp.ts` (`getCspNonce()`) reads the meta tag,

--- a/web/index.html
+++ b/web/index.html
@@ -8,7 +8,7 @@
          serve time; read at runtime by lib/csp.ts and propagated to
          CSPProvider (Base UI) and MotionConfig (Motion) for inline
          <style> tag signing. -->
-    <meta name="csp-nonce" content="{{placeholder "http.request.uuid"}}" />
+    <meta name="csp-nonce" content='{{placeholder "http.request.uuid"}}' />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>SynthOrg Dashboard</title>
   </head>

--- a/web/src/__tests__/components/ui/input-field.test.tsx
+++ b/web/src/__tests__/components/ui/input-field.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { InputField } from '@/components/ui/input-field'
+import { InputField, PasswordVisibilityGroup } from '@/components/ui/input-field'
 
 describe('InputField', () => {
   it('renders label text', () => {
@@ -112,5 +112,111 @@ describe('InputField', () => {
     const input = screen.getByLabelText('Plain')
     expect(input).not.toHaveClass('pl-8')
     expect(input).not.toHaveClass('pr-8')
+  })
+
+  describe('password visibility toggle', () => {
+    it('renders an eye toggle button when type="password"', () => {
+      render(<InputField label="Password" type="password" />)
+      const button = screen.getByRole('button', { name: 'Show password' })
+      expect(button).toBeInTheDocument()
+      expect(button).toHaveAttribute('aria-pressed', 'false')
+      expect(button).toHaveAttribute('type', 'button')
+    })
+
+    it('starts hidden (type="password" on the input)', () => {
+      render(<InputField label="Password" type="password" />)
+      expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'password')
+    })
+
+    it('reveals the value when the toggle is clicked', async () => {
+      const user = userEvent.setup()
+      render(<InputField label="Password" type="password" />)
+      await user.click(screen.getByRole('button', { name: 'Show password' }))
+      expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'text')
+      const button = screen.getByRole('button', { name: 'Hide password' })
+      expect(button).toHaveAttribute('aria-pressed', 'true')
+    })
+
+    it('hides the value when toggled twice', async () => {
+      const user = userEvent.setup()
+      render(<InputField label="Password" type="password" />)
+      const initial = screen.getByRole('button', { name: 'Show password' })
+      await user.click(initial)
+      await user.click(screen.getByRole('button', { name: 'Hide password' }))
+      expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'password')
+    })
+
+    it('does not render the toggle when hidePasswordToggle is set', () => {
+      render(<InputField label="Password" type="password" hidePasswordToggle />)
+      expect(screen.queryByRole('button', { name: 'Show password' })).not.toBeInTheDocument()
+    })
+
+    it('does not render the toggle when caller supplies trailingElement', () => {
+      render(
+        <InputField
+          label="Password"
+          type="password"
+          trailingElement={<span data-testid="custom-trail">x</span>}
+        />,
+      )
+      expect(screen.queryByRole('button', { name: 'Show password' })).not.toBeInTheDocument()
+      expect(screen.getByTestId('custom-trail')).toBeInTheDocument()
+    })
+
+    it('does not render the toggle on non-password fields', () => {
+      render(<InputField label="Username" type="text" />)
+      expect(screen.queryByRole('button', { name: 'Show password' })).not.toBeInTheDocument()
+    })
+
+    it('disables the toggle when the field is disabled', () => {
+      render(<InputField label="Password" type="password" disabled />)
+      expect(screen.getByRole('button', { name: 'Show password' })).toBeDisabled()
+    })
+
+    it('does not submit a wrapping form when clicked', async () => {
+      const user = userEvent.setup()
+      const onSubmit = vi.fn((e: React.FormEvent) => e.preventDefault())
+      render(
+        <form onSubmit={onSubmit}>
+          <InputField label="Password" type="password" />
+        </form>,
+      )
+      await user.click(screen.getByRole('button', { name: 'Show password' }))
+      expect(onSubmit).not.toHaveBeenCalled()
+    })
+
+    it('shares visibility across fields inside PasswordVisibilityGroup', async () => {
+      const user = userEvent.setup()
+      render(
+        <PasswordVisibilityGroup>
+          <InputField label="Password" type="password" />
+          <InputField label="Confirm Password" type="password" />
+        </PasswordVisibilityGroup>,
+      )
+      const toggles = screen.getAllByRole('button', { name: 'Show password' })
+      expect(toggles).toHaveLength(2)
+      const [firstToggle] = toggles
+      if (!firstToggle) throw new Error('expected toggle button')
+      await user.click(firstToggle)
+      expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'text')
+      expect(screen.getByLabelText('Confirm Password')).toHaveAttribute('type', 'text')
+      expect(screen.getAllByRole('button', { name: 'Hide password' })).toHaveLength(2)
+    })
+
+    it('keeps fields independent when not wrapped in a group', async () => {
+      const user = userEvent.setup()
+      render(
+        <>
+          <InputField label="Password" type="password" />
+          <InputField label="Confirm Password" type="password" />
+        </>,
+      )
+      const toggles = screen.getAllByRole('button', { name: 'Show password' })
+      const [firstToggle] = toggles
+      if (!firstToggle) throw new Error('expected toggle button')
+      await user.click(firstToggle)
+      expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'text')
+      expect(screen.getByLabelText('Confirm Password')).toHaveAttribute('type', 'password')
+    })
   })
 })

--- a/web/src/__tests__/components/ui/input-field.test.tsx
+++ b/web/src/__tests__/components/ui/input-field.test.tsx
@@ -146,6 +146,27 @@ describe('InputField', () => {
       expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'password')
     })
 
+    it('activates the toggle via keyboard (Enter and Space)', async () => {
+      const user = userEvent.setup()
+      render(<InputField label="Password" type="password" />)
+      const button = screen.getByRole('button', { name: 'Show password' })
+      button.focus()
+      await user.keyboard('{Enter}')
+      expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'text')
+      screen.getByRole('button', { name: 'Hide password' }).focus()
+      await user.keyboard(' ')
+      expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'password')
+    })
+
+    it('captures typed value while the field is revealed', async () => {
+      const user = userEvent.setup()
+      render(<InputField label="Password" type="password" />)
+      await user.click(screen.getByRole('button', { name: 'Show password' }))
+      const input = screen.getByLabelText('Password')
+      await user.type(input, 'SecurePass123')
+      expect(input).toHaveValue('SecurePass123')
+    })
+
     it('does not render the toggle when hidePasswordToggle is set', () => {
       render(<InputField label="Password" type="password" hidePasswordToggle />)
       expect(screen.queryByRole('button', { name: 'Show password' })).not.toBeInTheDocument()

--- a/web/src/components/ui/input-field.stories.tsx
+++ b/web/src/components/ui/input-field.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { InputField } from './input-field'
+import { InputField, PasswordVisibilityGroup } from './input-field'
 
 const meta = {
   title: 'UI/InputField',
@@ -39,4 +39,33 @@ export const Multiline: Story = {
 
 export const Password: Story = {
   args: { label: 'Password', type: 'password', required: true, placeholder: 'Enter password' },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Password fields render an eye / eye-off toggle by default; pressing it reveals the value while keeping the original `type="password"` semantic at the call site.',
+      },
+    },
+  },
+}
+
+export const PasswordGrouped: Story = {
+  args: { label: 'Password', type: 'password', required: true, placeholder: 'Enter password' },
+  render: () => (
+    <PasswordVisibilityGroup>
+      <div className="flex flex-col gap-4">
+        <InputField label="Password" type="password" required placeholder="Enter password" />
+        <InputField label="Confirm Password" type="password" required placeholder="Repeat password" />
+      </div>
+    </PasswordVisibilityGroup>
+  ),
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story:
+          'Wrap semantically-paired password fields in `<PasswordVisibilityGroup>` so a single toggle reveals or hides every field in the group at once. Args are ignored; this story renders its own composition.',
+      },
+    },
+  },
 }

--- a/web/src/components/ui/input-field.stories.tsx
+++ b/web/src/components/ui/input-field.stories.tsx
@@ -49,6 +49,62 @@ export const Password: Story = {
   },
 }
 
+export const PasswordDisabled: Story = {
+  args: {
+    label: 'Password',
+    type: 'password',
+    disabled: true,
+    value: 'unchanged',
+  },
+}
+
+export const PasswordWithError: Story = {
+  args: {
+    label: 'Password',
+    type: 'password',
+    required: true,
+    value: 'short',
+    error: 'Password must be at least 12 characters',
+  },
+}
+
+export const PasswordNoToggle: Story = {
+  args: {
+    label: 'Recovery code',
+    type: 'password',
+    hidePasswordToggle: true,
+    placeholder: 'Toggle suppressed',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Opt out of the built-in eye toggle with `hidePasswordToggle`. Reserved for the rare caller that supplies its own visibility affordance; every other password / secret field MUST keep the default toggle.',
+      },
+    },
+  },
+}
+
+export const PasswordCustomTrailing: Story = {
+  args: {
+    label: 'API key',
+    type: 'password',
+    trailingElement: (
+      <button type="button" aria-label="Copy">
+        <span aria-hidden="true">⧉</span>
+      </button>
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Supplying a `trailingElement` on a `type="password"` field replaces the built-in eye toggle entirely. Use this for fields where a different secondary action (copy, regenerate) takes priority.',
+      },
+    },
+  },
+}
+
 export const PasswordGrouped: Story = {
   args: { label: 'Password', type: 'password', required: true, placeholder: 'Enter password' },
   render: () => (

--- a/web/src/components/ui/input-field.tsx
+++ b/web/src/components/ui/input-field.tsx
@@ -1,4 +1,4 @@
-import { createContext, use, useId, useMemo, useState } from 'react'
+import { createContext, use, useCallback, useId, useMemo, useState } from 'react'
 import { Eye, EyeOff } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
@@ -229,13 +229,13 @@ function InputVariant(props: InputProps) {
   const showPasswordToggle = isPassword && !hidePasswordToggle && !callerProvidedTrailing
 
   const visible = groupContext !== null ? groupContext.visible : localVisible
-  const toggleVisible = () => {
+  const toggleVisible = useCallback(() => {
     if (groupContext !== null) {
       groupContext.setVisible(!groupContext.visible)
     } else {
       setLocalVisible((prev) => !prev)
     }
-  }
+  }, [groupContext])
 
   const effectiveType = isPassword && visible ? 'text' : type
   const renderedTrailing: React.ReactNode = callerProvidedTrailing

--- a/web/src/components/ui/input-field.tsx
+++ b/web/src/components/ui/input-field.tsx
@@ -1,4 +1,5 @@
-import { useId } from 'react'
+import { createContext, use, useId, useMemo, useState } from 'react'
+import { Eye, EyeOff } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 interface BaseFieldProps {
@@ -20,10 +21,19 @@ interface InputProps extends BaseFieldProps, Omit<React.ComponentProps<'input'>,
   leadingIcon?: React.ReactNode
   /**
    * Trailing element rendered inside the input (e.g. a clear button).
-   * Unlike `leadingIcon`, pointer events pass through -- consumers are
-   * responsible for interactivity.
+   * Unlike `leadingIcon`, pointer events pass through; consumers are
+   * responsible for interactivity. Supplying a `trailingElement` on a
+   * `type="password"` field replaces the built-in eye toggle.
    */
   trailingElement?: React.ReactNode
+  /**
+   * Suppress the built-in eye / eye-off visibility toggle on
+   * `type="password"` fields. Default: false (toggle is shown). The
+   * UX rule across the whole dashboard is that every password / secret
+   * input MUST have a toggle; flip this only for the rare case where a
+   * caller already supplies its own visibility affordance.
+   */
+  hidePasswordToggle?: boolean
 }
 
 interface TextareaProps extends BaseFieldProps, Omit<React.ComponentProps<'textarea'>, 'id'> {
@@ -32,6 +42,35 @@ interface TextareaProps extends BaseFieldProps, Omit<React.ComponentProps<'texta
 }
 
 export type InputFieldProps = InputProps | TextareaProps
+
+interface PasswordVisibilityContextValue {
+  visible: boolean
+  setVisible: (next: boolean) => void
+}
+
+const PasswordVisibilityContext = createContext<PasswordVisibilityContextValue | null>(null)
+
+/**
+ * Wraps a group of password / secret `<InputField>`s so a single eye
+ * toggle reveals or hides every field in the group at once. Use it
+ * for semantically-paired fields (e.g. Password + Confirm Password on
+ * the Create Account screen) where independent toggles would be
+ * surprising. Unrelated secrets (e.g. an OAuth client secret next to
+ * a header value) should stay outside the provider so each toggles
+ * on its own.
+ */
+export function PasswordVisibilityGroup({ children }: { children: React.ReactNode }) {
+  const [visible, setVisible] = useState(false)
+  const value = useMemo<PasswordVisibilityContextValue>(
+    () => ({ visible, setVisible }),
+    [visible],
+  )
+  return (
+    <PasswordVisibilityContext value={value}>
+      {children}
+    </PasswordVisibilityContext>
+  )
+}
 
 /**
  * Merge a caller-supplied ARIA id token list with a component-managed
@@ -131,6 +170,36 @@ function FieldHelp({
   )
 }
 
+function PasswordToggleButton({
+  visible,
+  onToggle,
+  disabled,
+}: {
+  visible: boolean
+  onToggle: () => void
+  disabled: boolean
+}) {
+  const Icon = visible ? EyeOff : Eye
+  const label = visible ? 'Hide password' : 'Show password'
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-label={label}
+      aria-pressed={visible}
+      disabled={disabled}
+      className={cn(
+        'pointer-events-auto inline-flex items-center justify-center',
+        'text-muted-foreground hover:text-foreground',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded',
+        'disabled:cursor-not-allowed disabled:opacity-60',
+      )}
+    >
+      <Icon className="h-4 w-4" aria-hidden="true" />
+    </button>
+  )
+}
+
 function InputVariant(props: InputProps) {
   const {
     label,
@@ -142,6 +211,8 @@ function InputVariant(props: InputProps) {
     onChange,
     leadingIcon,
     trailingElement,
+    hidePasswordToggle,
+    type,
     multiline: _multiline,
     ...domProps
   } = props
@@ -151,6 +222,34 @@ function InputVariant(props: InputProps) {
   const hintId = `${id}-hint`
   const hasError = !!error
 
+  const groupContext = use(PasswordVisibilityContext)
+  const [localVisible, setLocalVisible] = useState(false)
+  const isPassword = type === 'password'
+  const callerProvidedTrailing = trailingElement != null && trailingElement !== false
+  const showPasswordToggle = isPassword && !hidePasswordToggle && !callerProvidedTrailing
+
+  const visible = groupContext !== null ? groupContext.visible : localVisible
+  const toggleVisible = () => {
+    if (groupContext !== null) {
+      groupContext.setVisible(!groupContext.visible)
+    } else {
+      setLocalVisible((prev) => !prev)
+    }
+  }
+
+  const effectiveType = isPassword && visible ? 'text' : type
+  const renderedTrailing: React.ReactNode = callerProvidedTrailing
+    ? trailingElement
+    : showPasswordToggle
+      ? (
+          <PasswordToggleButton
+            visible={visible}
+            onToggle={toggleVisible}
+            disabled={Boolean(domProps.disabled)}
+          />
+        )
+      : null
+
   const inputClasses = buildInputClasses({
     hasError,
     // Match the ``leadingIcon != null && leadingIcon !== false`` render
@@ -158,7 +257,7 @@ function InputVariant(props: InputProps) {
     // actual JSX presence agree on every legal ReactNode value (incl.
     // ``0`` / ``''`` / ``false``).
     hasLeadingIcon: leadingIcon != null && leadingIcon !== false,
-    hasTrailingElement: trailingElement != null && trailingElement !== false,
+    hasTrailingElement: renderedTrailing !== null,
     className,
   })
 
@@ -187,6 +286,7 @@ function InputVariant(props: InputProps) {
           id={id}
           ref={ref}
           {...domProps}
+          type={effectiveType}
           aria-invalid={hasError ? true : (domProps['aria-invalid'] ?? false)}
           aria-errormessage={mergeAriaToken(
             domProps['aria-errormessage'],
@@ -199,9 +299,9 @@ function InputVariant(props: InputProps) {
           className={inputClasses}
           onChange={handleChange}
         />
-        {trailingElement != null && trailingElement !== false && (
+        {renderedTrailing !== null && (
           <span className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center">
-            {trailingElement}
+            {renderedTrailing}
           </span>
         )}
       </div>

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -132,7 +132,7 @@ export default function LoginPage() {
       <div className="w-full max-w-sm">
         <form
           onSubmit={handleSubmit}
-          className="rounded-lg border border-border bg-card p-8 space-y-6"
+          className="rounded-lg border border-border bg-card p-8 space-y-section-gap"
         >
           {/* Wordmark */}
           <p className="text-center font-sans text-2xl font-bold text-accent">

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { InputField } from '@/components/ui/input-field'
+import { InputField, PasswordVisibilityGroup } from '@/components/ui/input-field'
 import { Button } from '@/components/ui/button'
 import { useAuthStore } from '@/stores/auth'
 import { useLoginLockout } from '@/hooks/useLoginLockout'
@@ -169,26 +169,28 @@ export default function LoginPage() {
                   autoFocus
                 />
 
-                <InputField
-                  label="Password"
-                  type="password"
-                  value={password}
-                  onChange={(e) => setPassword(e.currentTarget.value)}
-                  disabled={disabled}
-                  autoComplete={mode === 'setup' ? 'new-password' : 'current-password'}
-                  hint={mode === 'setup' ? `At least ${minPasswordLength} characters` : undefined}
-                />
-
-                {mode === 'setup' && (
+                <PasswordVisibilityGroup>
                   <InputField
-                    label="Confirm Password"
+                    label="Password"
                     type="password"
-                    value={confirmPassword}
-                    onChange={(e) => setConfirmPassword(e.currentTarget.value)}
+                    value={password}
+                    onChange={(e) => setPassword(e.currentTarget.value)}
                     disabled={disabled}
-                    autoComplete="new-password"
+                    autoComplete={mode === 'setup' ? 'new-password' : 'current-password'}
+                    hint={mode === 'setup' ? `At least ${minPasswordLength} characters` : undefined}
                   />
-                )}
+
+                  {mode === 'setup' && (
+                    <InputField
+                      label="Confirm Password"
+                      type="password"
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.currentTarget.value)}
+                      disabled={disabled}
+                      autoComplete="new-password"
+                    />
+                  )}
+                </PasswordVisibilityGroup>
               </div>
 
               {/* Error */}

--- a/web/src/pages/setup/AccountStep.tsx
+++ b/web/src/pages/setup/AccountStep.tsx
@@ -158,6 +158,7 @@ export function AccountStep() {
               placeholder={`Min ${minPasswordLength} characters`}
               disabled={loading}
               hint={`Min ${minPasswordLength} characters`}
+              autoComplete="new-password"
             />
             {password.length > 0 && (
               <div className="flex items-center gap-2">
@@ -181,6 +182,7 @@ export function AccountStep() {
             placeholder="Repeat password"
             disabled={loading}
             error={confirmPassword.length > 0 && password !== confirmPassword ? 'Passwords do not match' : null}
+            autoComplete="new-password"
           />
         </PasswordVisibilityGroup>
 

--- a/web/src/pages/setup/AccountStep.tsx
+++ b/web/src/pages/setup/AccountStep.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createLogger } from '@/lib/logger'
-import { InputField } from '@/components/ui/input-field'
+import { InputField, PasswordVisibilityGroup } from '@/components/ui/input-field'
 import { Button } from '@/components/ui/button'
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { useAuthStore } from '@/stores/auth'
@@ -147,40 +147,42 @@ export function AccountStep() {
           disabled={loading}
         />
 
-        <div className="space-y-1.5">
+        <PasswordVisibilityGroup>
+          <div className="space-y-1.5">
+            <InputField
+              label="Password"
+              type="password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.currentTarget.value)}
+              placeholder={`Min ${minPasswordLength} characters`}
+              disabled={loading}
+              hint={`Min ${minPasswordLength} characters`}
+            />
+            {password.length > 0 && (
+              <div className="flex items-center gap-2">
+                <div className="h-1.5 flex-1 rounded-full bg-border">
+                  <div
+                    className={cn('h-full rounded-full transition-all', strength.color)}
+                    style={{ width: `${strength.percent}%` }}
+                  />
+                </div>
+                <span className="text-compact text-muted-foreground">{strength.label}</span>
+              </div>
+            )}
+          </div>
+
           <InputField
-            label="Password"
+            label="Confirm Password"
             type="password"
             required
-            value={password}
-            onChange={(e) => setPassword(e.currentTarget.value)}
-            placeholder={`Min ${minPasswordLength} characters`}
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.currentTarget.value)}
+            placeholder="Repeat password"
             disabled={loading}
-            hint={`Min ${minPasswordLength} characters`}
+            error={confirmPassword.length > 0 && password !== confirmPassword ? 'Passwords do not match' : null}
           />
-          {password.length > 0 && (
-            <div className="flex items-center gap-2">
-              <div className="h-1.5 flex-1 rounded-full bg-border">
-                <div
-                  className={cn('h-full rounded-full transition-all', strength.color)}
-                  style={{ width: `${strength.percent}%` }}
-                />
-              </div>
-              <span className="text-compact text-muted-foreground">{strength.label}</span>
-            </div>
-          )}
-        </div>
-
-        <InputField
-          label="Confirm Password"
-          type="password"
-          required
-          value={confirmPassword}
-          onChange={(e) => setConfirmPassword(e.currentTarget.value)}
-          placeholder="Repeat password"
-          disabled={loading}
-          error={confirmPassword.length > 0 && password !== confirmPassword ? 'Passwords do not match' : null}
-        />
+        </PasswordVisibilityGroup>
 
         {policyError && (
           <ErrorBanner


### PR DESCRIPTION
## Summary

Adds a built-in show / hide affordance to every password / secret input across the dashboard.

- `web/src/components/ui/input-field.tsx`: when `type="password"`, renders an `Eye` / `EyeOff` button as the trailing element. Internally derives `effectiveType` so the caller's `type="password"` semantic stays put. Co-locates a `PasswordVisibilityGroup` React Context provider so paired fields share a single toggle.
- `web/src/pages/setup/AccountStep.tsx` and `web/src/pages/LoginPage.tsx` (setup mode) wrap their Password + Confirm Password fields in `<PasswordVisibilityGroup>` so toggling one reveals both.
- All other 17 sensitive call sites (provider modal, credentials rotate, every connection-form credential field via `connection-type-fields.ts`) inherit the toggle automatically with independent state per field, because they all flow `type="password"` through the same primitive.
- Storybook gets `Password`, `PasswordGrouped`, `PasswordDisabled`, `PasswordWithError`, `PasswordNoToggle`, `PasswordCustomTrailing` stories.
- 13 new test cases cover toggle rendering, accessibility (`aria-pressed`, `aria-label`, `type="button"`), keyboard activation (Enter / Space), value capture while revealed, opt-out, caller-supplied `trailingElement`, grouped vs independent visibility, and form-submission safety.

## Adjacent fixes folded in (caught during pre-PR review)

- `web/index.html`: switched the CSP-nonce meta tag to single-quoted attribute syntax so the embedded Caddy template `{{placeholder "http.request.uuid"}}` parses cleanly under parse5 / Vite (no behavioural change at serve time, the Caddy `templates` engine substitutes the token regardless of outer-quote style).
- `web/src/pages/LoginPage.tsx`: form container now uses `space-y-section-gap` instead of hardcoded `space-y-6` so the layout respects density tokens.
- `web/src/pages/setup/AccountStep.tsx`: password and confirm-password fields now set `autoComplete="new-password"` so password managers categorise them correctly during initial setup.
- `docs/reference/web-design-system.md`: documents the new `InputField` toggle, `hidePasswordToggle` opt-out, and `PasswordVisibilityGroup`.
- `docs/security.md`: notes the meta tag's single-quoted attribute syntax in the CSP Nonce Infrastructure section.

## Test plan

- `npm --prefix web run lint` (ESLint, zero warnings).
- `npm --prefix web run type-check` (tsc).
- `npm --prefix web run test -- --run` (3060 tests pass).
- Manual: dev server + click-through on Create Admin Account (paired toggle), Login (single toggle), Provider modal API key (independent toggle), Connections form Slack token + signing secret (each independent). All confirmed.

## Review coverage

Pre-reviewed by 6 agents (frontend-reviewer, design-token-audit, security-reviewer with frontend supplemental checks, test-quality-reviewer, docs-consistency, comment-quality-rot). 8 valid findings; all 8 implemented in commit `059d868e2`.

## Tooling note

The `/pre-pr-review` run surfaced an unrelated harness bug: three sub-agents (`pr-test-analyzer`, `silent-failure-hunter`, `comment-analyzer`) declared in `.claude/agents/` are not loaded by the Claude Code harness, so the skill's `subagent_type: pr-test-analyzer` dispatch fails. Filed as #1871; falls back to `code-reviewer` with a custom prompt for now.
