### PR TITLE
fix(ci): retry Docker push on Go net/http deadline + cancellation errors

### DIFF
--- a/.github/scripts/docker_push_with_retry.sh
+++ b/.github/scripts/docker_push_with_retry.sh
@@ -36,12 +36,15 @@ set -euo pipefail
 # `tls: failed to verify certificate` or `tls: bad certificate`.
 #
 # `context deadline exceeded` / `Client.Timeout exceeded` / `timeout awaiting
-# response headers` / `request canceled` cover Go ``net/http`` client-side
-# timeout strings emitted by Docker / buildx when GHCR fails to respond to a
-# request within the per-request deadline. These are the canonical transient
-# signatures `i/o timeout` misses on the GHCR HTTP path: the underlying
-# socket may be healthy while the HTTP response just never arrives in time.
-TRANSIENT_RE='page is taking too long|unknown blob|blob unknown|blob upload invalid|manifest unknown|received unexpected HTTP status: 5[0-9]{2}|HTTP/[0-9.]+ 5[0-9]{2}|HTTP 5[0-9]{2}|status: 5[0-9]{2}|429 Too Many Requests|temporarily unavailable|server is currently unable|service unavailable|bad gateway|gateway time-?out|i/o timeout|tls handshake|connection reset|connection refused|EOF|unexpected EOF|read: connection|net/http: TLS handshake|context deadline exceeded|Client\.Timeout exceeded|timeout awaiting response headers|request canceled'
+# response headers` / `timeout awaiting response body` / `request canceled`
+# cover Go ``net/http`` client-side timeout strings emitted by Docker / buildx
+# when GHCR fails to respond to a request within the per-request deadline.
+# These are the canonical transient signatures `i/o timeout` misses on the
+# GHCR HTTP path: the underlying socket may be healthy while the HTTP
+# response just never arrives in time. Both the headers and body variants
+# are kept so a stall after the upload starts streaming also retries --
+# `docker push` is idempotent, so re-pushing on a body-timeout is safe.
+TRANSIENT_RE='page is taking too long|unknown blob|blob unknown|blob upload invalid|manifest unknown|received unexpected HTTP status: 5[0-9]{2}|HTTP/[0-9.]+ 5[0-9]{2}|HTTP 5[0-9]{2}|status: 5[0-9]{2}|429 Too Many Requests|temporarily unavailable|server is currently unable|service unavailable|bad gateway|gateway time-?out|i/o timeout|tls handshake|connection reset|connection refused|EOF|unexpected EOF|read: connection|net/http: TLS handshake|context deadline exceeded|Client\.Timeout exceeded|timeout awaiting response headers|timeout awaiting response body|request canceled'
 
 # Discovery flag: callers that need to share the same regex (for example the
 # inline retag-inspect retry loop, which must drop a couple of patterns the

--- a/.github/scripts/docker_push_with_retry.sh
+++ b/.github/scripts/docker_push_with_retry.sh
@@ -34,7 +34,14 @@ set -euo pipefail
 # failures); a bare `tls: ` is intentionally NOT included because it would
 # also match non-transient configuration errors like
 # `tls: failed to verify certificate` or `tls: bad certificate`.
-TRANSIENT_RE='page is taking too long|unknown blob|blob unknown|blob upload invalid|manifest unknown|received unexpected HTTP status: 5[0-9]{2}|HTTP/[0-9.]+ 5[0-9]{2}|HTTP 5[0-9]{2}|status: 5[0-9]{2}|429 Too Many Requests|temporarily unavailable|server is currently unable|service unavailable|bad gateway|gateway time-?out|i/o timeout|tls handshake|connection reset|connection refused|EOF|unexpected EOF|read: connection|net/http: TLS handshake'
+#
+# `context deadline exceeded` / `Client.Timeout exceeded` / `timeout awaiting
+# response headers` / `request canceled` cover Go ``net/http`` client-side
+# timeout strings emitted by Docker / buildx when GHCR fails to respond to a
+# request within the per-request deadline. These are the canonical transient
+# signatures `i/o timeout` misses on the GHCR HTTP path: the underlying
+# socket may be healthy while the HTTP response just never arrives in time.
+TRANSIENT_RE='page is taking too long|unknown blob|blob unknown|blob upload invalid|manifest unknown|received unexpected HTTP status: 5[0-9]{2}|HTTP/[0-9.]+ 5[0-9]{2}|HTTP 5[0-9]{2}|status: 5[0-9]{2}|429 Too Many Requests|temporarily unavailable|server is currently unable|service unavailable|bad gateway|gateway time-?out|i/o timeout|tls handshake|connection reset|connection refused|EOF|unexpected EOF|read: connection|net/http: TLS handshake|context deadline exceeded|Client\.Timeout exceeded|timeout awaiting response headers|request canceled'
 
 # Discovery flag: callers that need to share the same regex (for example the
 # inline retag-inspect retry loop, which must drop a couple of patterns the


### PR DESCRIPTION
## Summary

Closes a coverage gap in `.github/scripts/docker_push_with_retry.sh` that caused PR #1876's squash-merge push to fail on the `Publish Backend Base (apko)` arm64 leg. The retry wrapper saw a real transient GHCR HTTP timeout, did not match it against `TRANSIENT_RE`, classified it as non-transient, and bailed on attempt 1 of 4.

**Failure that motivated the fix:**
```
Get "https://ghcr.io/v2/": context deadline exceeded
(Client.Timeout exceeded while awaiting headers)
```

That string is Go's `net/http` client-side request-timeout shape, semantically identical to `i/o timeout` (already retried) but syntactically different. The wrapper's regex did not match it.

Five Go `net/http` deadline / cancellation signatures are now in `TRANSIENT_RE`:

- `context deadline exceeded` — Go context deadline elapsed before headers received
- `Client\.Timeout exceeded` — Go `http.Client.Timeout` field exceeded (literal dot kept to avoid `ClientXTimeout` false-match)
- `timeout awaiting response headers` — header read stalled
- `timeout awaiting response body` — body read stalled mid-stream (`docker push` is idempotent, so retrying after a partial-upload body timeout is safe)
- `request canceled` — context cancellation; in GitHub Actions there is no interactive `docker push` cancellation vector

The wrapper's `--print-transient-re` consumer at `.github/actions/publish-image-retag/action.yml:109` reuses the same regex (stripping `manifest unknown` and `blob upload invalid`, neither of which is affected here), so the new patterns automatically propagate to the retag-inspect retry loop.

## Verification

Spot-tested the regex against the real PR-#1876 failure string and against a battery of patterns that must stay fail-fast:

```
TRANSIENT:  Get "https://ghcr.io/v2/": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
TRANSIENT:  net/http: timeout awaiting response body
TRANSIENT:  net/http: request canceled while waiting for connection
TRANSIENT:  Client.Timeout exceeded while reading body
TRANSIENT:  i/o timeout                          (existing pattern, unchanged)
FAIL-FAST:  denied: insufficient_scope
FAIL-FAST:  tls: bad certificate
FAIL-FAST:  denied: name is reserved
```

`bash -n .github/scripts/docker_push_with_retry.sh` clean.

## Review coverage

Pre-PR review pipeline: 4 agents (`docs-consistency`, `comment-quality-rot`, `comment-analyzer`, `infra-reviewer`).

- docs-consistency: no drift, no doc page describes this script.
- comment-quality-rot: zero violations; CI-infra file exempted from origin-citation rules; new comments are functional documentation, not narrative.
- comment-analyzer: comment is appropriate as-is, explains WHY, follows existing comment-block precedent.
- infra-reviewer: 3 findings -- 1 fixed (added `timeout awaiting response body`), 2 skipped with recorded reasons (`request canceled` substring-match risk is zero on GitHub Actions; regex line length cannot be reduced without re-quoting). Pattern correctness against the PR-#1876 failure string ✓; no auth/permission masking ✓; retag-inspect propagation ✓; backoff math (~1m45s worst case) acceptable ✓.

Full triage at `_audit/pre-pr-review/triage.md` in the worktree (not committed).

## Test plan

The patched wrapper will be exercised on the next Docker workflow run that hits a GHCR timeout. Until then, the regex changes are covered by the inline shell tests above; no Python / Go / Web test surface to add.