### PR TITLE
fix: symmetric SynthOrg/DHI image verification cache

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -205,7 +205,7 @@ jobs:
 
       - name: Run CLI bench A/B (HEAD vs merge-base)
         env:
-          BENCH_COUNT: 5
+          BENCH_COUNT: 10
           THRESHOLD_PCT: 15
         run: bash scripts/check_cli_bench_regression.sh
 

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -94,7 +94,7 @@ See [docs/reference/cli-env-vars.md](../docs/reference/cli-env-vars.md) for the 
 
 ## Config Subcommands
 
-`synthorg config <subcommand>` exposes `show` / `get <key>` / `set <key> <value>` / `unset <key>` / `list` / `path` / `edit`. There are 37 settable keys (e.g. `backend_port`, `web_port`, `sandbox`, `image_tag`, `log_level`, `fine_tuning`, `telemetry_opt_in`, `channel`, plus all the tunables listed above). Compose-affecting keys trigger automatic `compose.yml` regeneration; toggling `fine_tuning` on requires `sandbox=true` and amd64.
+`synthorg config <subcommand>` exposes `show` / `get <key>` / `set <key> <value>` / `unset <key>` / `list` / `path` / `edit`. There are 40 settable keys (e.g. `backend_port`, `web_port`, `sandbox`, `image_tag`, `log_level`, `fine_tuning`, `telemetry_opt_in`, `channel`, plus all the tunables listed above). Compose-affecting keys trigger automatic `compose.yml` regeneration; toggling `fine_tuning` on requires `sandbox=true` and amd64.
 
 Overriding any of `registry_host`, `image_repo_prefix`, `dhi_registry`, `postgres_image_tag`, or `nats_image_tag` disables image signature + SLSA verification **for that invocation only** and writes a stderr warning on every invocation (not suppressed by `--quiet` or `--json`).
 
@@ -152,4 +152,4 @@ Port layout: `3000` web / `3001` backend / `3002` postgres / `3003` NATS client.
 
 `synthorg status` renders a verdict banner (`OK` / `DEGRADED` / `CRITICAL`) computed by `computeVerdict()` in `cli/cmd/status.go`. `CRITICAL` wins over `DEGRADED`; signals are gated on install expectations so an internal-bus install is not flagged `DEGRADED` merely because the health response omits `message_bus`.
 
-See [docs/reference/cli-persistence-backends.md](../docs/reference/cli-persistence-backends.md) for the per-step Postgres orchestration (random-password generation, `SYNTHORG_POSTGRES_SSL_MODE` defaults, depends_on health gate), DHI cosign + SLSA verification cache (`verified_digests`), the NATS config file shape (`max_payload: 16MB`), and the verdict-banner escalation rules.
+See [docs/reference/cli-persistence-backends.md](../docs/reference/cli-persistence-backends.md) for the per-step Postgres orchestration (random-password generation, `SYNTHORG_POSTGRES_SSL_MODE` defaults, depends_on health gate), the image verification cache (`verified_digests` map shared by SynthOrg + DHI pins, with `verified_image_tag` as the SynthOrg-side cache sentinel), the NATS config file shape (`max_payload: 16MB`), and the verdict-banner escalation rules.

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -408,7 +408,10 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 	}
 
 	if invalidatesVerifiedDigests(key) {
-		state.VerifiedDigests = nil // old pins are bound to the previous registry/prefix/tags
+		// Old pins are bound to the previous registry/prefix/tags; the
+		// sentinel that proves they are current must drop with them.
+		state.VerifiedDigests = nil
+		state.VerifiedImageTag = ""
 	}
 	if composeAffectingKeys[key] {
 		if err := regenerateCompose(state); err != nil {
@@ -682,6 +685,7 @@ func runConfigUnset(cmd *cobra.Command, args []string) error {
 	}
 	if invalidatesVerifiedDigests(key) {
 		state.VerifiedDigests = nil
+		state.VerifiedImageTag = ""
 	}
 
 	if composeAffectingKeys[key] {

--- a/cli/cmd/config_test.go
+++ b/cli/cmd/config_test.go
@@ -142,6 +142,43 @@ func TestConfigSetChannel(t *testing.T) {
 	}
 }
 
+func TestConfigSetImageTag_ClearsVerifiedDigestsAndImageTag(t *testing.T) {
+	dir := t.TempDir()
+	state := config.DefaultState()
+	state.DataDir = dir
+	state.VerifiedDigests = map[string]string{
+		"backend":                  "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		"web":                      "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+		"dhi:dhi.io/postgres:17.2": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+	}
+	state.VerifiedImageTag = state.ImageTag
+	if err := config.Save(state); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"config", "set", "image_tag", "0.0.0-fake", "--data-dir", dir})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	loaded, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("Load after set: %v", err)
+	}
+	if loaded.ImageTag != "0.0.0-fake" {
+		t.Errorf("ImageTag = %q, want 0.0.0-fake", loaded.ImageTag)
+	}
+	if len(loaded.VerifiedDigests) != 0 {
+		t.Errorf("VerifiedDigests must be cleared after image_tag change, got %v", loaded.VerifiedDigests)
+	}
+	if loaded.VerifiedImageTag != "" {
+		t.Errorf("VerifiedImageTag must be cleared after image_tag change, got %q", loaded.VerifiedImageTag)
+	}
+}
+
 func TestConfigSetRejectsInvalidChannel(t *testing.T) {
 	dir := t.TempDir()
 	state := config.DefaultState()

--- a/cli/cmd/config_test.go
+++ b/cli/cmd/config_test.go
@@ -307,7 +307,7 @@ func TestConfigShowAutoCleanup(t *testing.T) {
 
 	out := buf.String()
 	found := false
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		if strings.Contains(line, "Auto cleanup") {
 			found = true
 			if !strings.Contains(line, "false") {

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -167,64 +166,41 @@ func startContainers(cmd *cobra.Command, ctx context.Context, state config.State
 	return startDetached(ctx, info, safeDir, state, out, errOut, healthTimeout)
 }
 
-func verifyAndPullStartImages(cmd *cobra.Command, ctx context.Context, info docker.Info, state config.State, safeDir string, out, errOut *ui.UI) (config.State, error) {
-	skipVerify := GetGlobalOpts(ctx).SkipVerify
-
-	if !skipVerify {
-		// SynthOrg images: check cache independently.
-		if hasSynthOrgDigests(state) {
-			renderCachedSynthOrgBox(out, state)
-		} else {
-			if err := verifyAndPinImages(ctx, cmd, state, safeDir, out, errOut); err != nil {
-				return state, err
-			}
-			// Reload state since verifyAndPinImages saved it.
-			reloaded, reloadErr := config.Load(GetGlobalOpts(ctx).DataDir)
-			if reloadErr != nil {
-				return state, fmt.Errorf("reloading config after verification: %w", reloadErr)
-			}
-			state = reloaded
-		}
-
-		// DHI images: check cache independently.
-		if hasDHIDigests(state) {
-			renderCachedDHIBox(out, state)
-		} else {
-			results, err := verifyDHIImages(ctx, info, state, out, errOut)
-			if err != nil {
-				return state, fmt.Errorf("DHI image verification failed: %w", err)
-			}
-			if state.VerifiedDigests == nil {
-				state.VerifiedDigests = make(map[string]string)
-			}
-			for _, r := range results {
-				if indexDigest, ok := verify.DHIPinnedIndexDigest(r.Image); ok {
-					state.VerifiedDigests["dhi:"+r.Image] = indexDigest
-				}
-				if r.Digest != "" {
-					state.VerifiedDigests["dhi:"+r.Image+":platform"] = r.Digest
-				}
-				if r.AttDigest != "" {
-					state.VerifiedDigests["dhi:"+r.Image+":attestation"] = r.AttDigest
-				}
-				if r.SigDigest != "" {
-					state.VerifiedDigests["dhi:"+r.Image+":signature"] = r.SigDigest
-				}
-			}
-			if err := config.Save(state); err != nil {
-				errOut.Warn(fmt.Sprintf("Could not cache DHI verification results: %v", err))
-			}
-		}
-	} else {
+func verifyAndPullStartImages(_ *cobra.Command, ctx context.Context, info docker.Info, state config.State, safeDir string, out, errOut *ui.UI) (config.State, error) {
+	if GetGlobalOpts(ctx).SkipVerify {
 		errOut.Warn("Image verification skipped (--skip-verify). Containers are NOT verified.")
+		out.Blank()
+		return pullAllImages(ctx, info, safeDir, state, out)
 	}
 
-	out.Blank()
-	refreshed, err := pullAllImages(ctx, info, safeDir, state, out)
+	verifyCtx, cancel := context.WithTimeout(ctx, GetGlobalOpts(ctx).Tunables.ImageVerifyTimeout)
+	defer cancel()
+	result, err := verifyImagesWithCache(verifyCtx, info, state, out, errOut)
 	if err != nil {
 		return state, err
 	}
-	return refreshed, nil
+
+	if result.SynthOrgReverified {
+		if err := writeDigestPinnedCompose(state, synthOrgPins(result.Pins), safeDir); err != nil {
+			return state, fmt.Errorf("pinning verified digests: %w", err)
+		}
+	}
+
+	if result.SynthOrgReverified || result.DHIReverified {
+		state.VerifiedDigests = result.Pins
+		state.VerifiedImageTag = state.ImageTag
+		if err := config.Save(state); err != nil {
+			errOut.Warn(fmt.Sprintf("Could not cache verified digests: %v", err))
+		}
+		reloaded, reloadErr := config.Load(GetGlobalOpts(ctx).DataDir)
+		if reloadErr != nil {
+			return state, fmt.Errorf("reloading config after verification: %w", reloadErr)
+		}
+		state = reloaded
+	}
+
+	out.Blank()
+	return pullAllImages(ctx, info, safeDir, state, out)
 }
 
 func startDetached(ctx context.Context, info docker.Info, safeDir string, state config.State, out, errOut *ui.UI, healthTimeout time.Duration) error {
@@ -528,61 +504,19 @@ func dockerRunQuiet(ctx context.Context, info docker.Info, args ...string) error
 	return nil
 }
 
-// verifyAndPinImages verifies image signatures (unless --skip-verify) and
-// pins the verified digests in the compose file and config.
-func verifyAndPinImages(ctx context.Context, _ *cobra.Command, state config.State, safeDir string, out, errOut *ui.UI) error {
-	if GetGlobalOpts(ctx).SkipVerify {
-		errOut.Warn("Image verification skipped (--skip-verify). Containers are NOT verified.")
-		return nil
-	}
-
-	imageRefs := verify.BuildImageRefs(state.ImageTag, state.Sandbox, state.FineTuning, state.FineTuneVariantOrDefault())
-	labels := make([]string, len(imageRefs))
-	for i, ref := range imageRefs {
-		labels[i] = ref.Name()
-	}
-	lb := out.NewLiveBox("Verify SynthOrg Images", labels)
-
-	verifyCtx, cancel := context.WithTimeout(ctx, GetGlobalOpts(ctx).Tunables.ImageVerifyTimeout)
-	defer cancel()
-	results, err := verify.VerifyImages(verifyCtx, verify.VerifyOptions{
-		Images: imageRefs,
-		Output: io.Discard,
-		OnResult: func(i int, r verify.VerifyResult) {
-			slsaIcon := ui.IconSuccess
-			if !r.ProvenanceVerified {
-				slsaIcon = ui.IconWarning
-			}
-			lb.UpdateLine(i, fmt.Sprintf("sig %s  slsa %s", ui.IconSuccess, slsaIcon))
-		},
-	})
-	lb.Finish()
-
-	if err != nil {
-		if isTransportError(err) {
-			errOut.HintError("Use --skip-verify for air-gapped environments")
-		}
-		return fmt.Errorf("image verification failed: %w", err)
-	}
-
-	pins, err := digestPinMap(results)
-	if err != nil {
-		return fmt.Errorf("digest pin map: %w", err)
-	}
-
-	if err := writeDigestPinnedCompose(state, pins, safeDir); err != nil {
-		return fmt.Errorf("pinning verified digests: %w", err)
-	}
-
-	state.VerifiedDigests = pins
-	if err := config.Save(state); err != nil {
-		errOut.Warn(fmt.Sprintf("Could not cache verified digests: %v", err))
-	}
-	return nil
-}
-
-// hasSynthOrgDigests returns true if all SynthOrg image digests are cached.
+// hasSynthOrgDigests reports whether the SynthOrg pin cache is current.
+//
+// Two conditions must hold: state.VerifiedImageTag must equal the current
+// state.ImageTag (the pin values would otherwise describe images of the
+// wrong tag), and a pin must be present for every SynthOrg image enabled
+// by the current configuration. The first check mirrors the pin-comparison
+// strictness of hasDHIDigests so SynthOrg and DHI cache validity move
+// together: either both groups hit, both miss, or each invalidates for an
+// independent reason; never one stale and one fresh.
 func hasSynthOrgDigests(state config.State) bool {
+	if state.VerifiedImageTag != state.ImageTag {
+		return false
+	}
 	if len(state.VerifiedDigests) == 0 {
 		return false
 	}
@@ -729,24 +663,6 @@ func digestPinMap(results []verify.VerifyResult) (map[string]string, error) {
 		pins[r.Ref.Name()] = r.Ref.Digest
 	}
 	return pins, nil
-}
-
-// renderVerifyBox displays image verification results in a bordered box.
-// Shared by start.go and update.go verification flows.
-// Uses plain glyph constants (not ANSI-styled icons) because Box()
-// sanitizes content with stripControlStrict which removes ESC bytes.
-func renderVerifyBox(out *ui.UI, results []verify.VerifyResult) {
-	boxLines := make([]string, 0, len(results))
-	for _, r := range results {
-		sigIcon := ui.IconSuccess
-		slsaIcon := ui.IconSuccess
-		if !r.ProvenanceVerified {
-			slsaIcon = ui.IconWarning
-		}
-		boxLines = append(boxLines, fmt.Sprintf("  %-12s sig %s  slsa %s",
-			r.Ref.Name(), sigIcon, slsaIcon))
-	}
-	out.Box("Verify SynthOrg Images", boxLines)
 }
 
 // composeRun runs a docker compose command with output forwarded to the

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -191,12 +191,13 @@ func verifyAndPullStartImages(_ *cobra.Command, ctx context.Context, info docker
 		state.VerifiedImageTag = state.ImageTag
 		if err := config.Save(state); err != nil {
 			errOut.Warn(fmt.Sprintf("Could not cache verified digests: %v", err))
+		} else {
+			reloaded, reloadErr := config.Load(GetGlobalOpts(ctx).DataDir)
+			if reloadErr != nil {
+				return state, fmt.Errorf("reloading config after verification: %w", reloadErr)
+			}
+			state = reloaded
 		}
-		reloaded, reloadErr := config.Load(GetGlobalOpts(ctx).DataDir)
-		if reloadErr != nil {
-			return state, fmt.Errorf("reloading config after verification: %w", reloadErr)
-		}
-		state = reloaded
 	}
 
 	out.Blank()

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -395,8 +395,7 @@ func reexecUpdate(cmd *cobra.Command) error {
 
 	if runErr := c.Run(); runErr != nil {
 		// Preserve the child's exit code so the parent can propagate it.
-		var exitErr *exec.ExitError
-		if errors.As(runErr, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](runErr); ok {
 			return &ChildExitError{Code: exitErr.ExitCode()}
 		}
 		return fmt.Errorf("re-launching updated CLI: %w", runErr)

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,7 +18,6 @@ import (
 	"github.com/Aureliolo/synthorg/cli/internal/health"
 	"github.com/Aureliolo/synthorg/cli/internal/selfupdate"
 	"github.com/Aureliolo/synthorg/cli/internal/ui"
-	"github.com/Aureliolo/synthorg/cli/internal/verify"
 	"github.com/Aureliolo/synthorg/cli/internal/version"
 	"github.com/spf13/cobra"
 )
@@ -579,17 +578,21 @@ func pullAndPersist(ctx context.Context, cmd *cobra.Command, info docker.Info, s
 
 	// Verify + write compose atomically: compose.yml is only updated after
 	// verification succeeds (or when --skip-verify explicitly skips it).
-	digestPins, err := verifyAndPinForUpdate(ctx, state, tag, safeDir, preserveCompose, out, errOut)
+	digestPins, err := verifyAndPinForUpdate(ctx, info, state, tag, safeDir, preserveCompose, out, errOut)
 	if err != nil {
 		rollback()
 		return state, err
 	}
 
 	// Use newly verified digest pins for the pull so standalone images
-	// (sandbox, sidecar, fine-tune) resolve to pinned references.
+	// (sandbox, sidecar, fine-tune) resolve to pinned references. Merge
+	// fresh pins on top of any existing ones (e.g. cached DHI keys when
+	// the verify step hit the DHI cache) so the pull sees the union, not
+	// just the freshly-verified subset.
+	mergedPins := mergeVerifiedDigests(state.VerifiedDigests, digestPins)
 	pullState := state
 	pullState.ImageTag = tag
-	pullState.VerifiedDigests = digestPins
+	pullState.VerifiedDigests = mergedPins
 	if _, err := pullAllImages(ctx, info, safeDir, pullState, out); err != nil {
 		rollback()
 		return state, err
@@ -597,9 +600,12 @@ func pullAndPersist(ctx context.Context, cmd *cobra.Command, info docker.Info, s
 
 	// Persist config only after successful pull so a failed pull
 	// doesn't leave state claiming images are at the new version.
+	// VerifiedImageTag tracks which tag the SynthOrg pins were verified
+	// against; hasSynthOrgDigests rejects the cache when this drifts.
 	updatedState := state
 	updatedState.ImageTag = tag
-	updatedState.VerifiedDigests = digestPins
+	updatedState.VerifiedDigests = mergedPins
+	updatedState.VerifiedImageTag = tag
 	if err := config.Save(updatedState); err != nil {
 		rollback()
 		return state, fmt.Errorf("saving config: %w", err)
@@ -607,10 +613,33 @@ func pullAndPersist(ctx context.Context, cmd *cobra.Command, info docker.Info, s
 	return updatedState, nil
 }
 
-// verifyAndPinForUpdate runs image verification and updates the compose
-// file with new image references. When preserveCompose is true, only
-// image lines are patched; otherwise the full compose is regenerated.
-func verifyAndPinForUpdate(ctx context.Context, state config.State, tag, safeDir string, preserveCompose bool, out *ui.UI, errOut *ui.UI) (map[string]string, error) {
+// mergeVerifiedDigests overlays fresh pins on top of existing ones, returning
+// a new map so the caller can assign without aliasing the original. Returns
+// nil only when both inputs are nil/empty (lets compose.ParamsFromState's
+// nil-pin fallback path fire when there is nothing to write).
+func mergeVerifiedDigests(existing, fresh map[string]string) map[string]string {
+	if len(existing) == 0 && len(fresh) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(existing)+len(fresh))
+	maps.Copy(out, existing)
+	maps.Copy(out, fresh)
+	return out
+}
+
+// verifyAndPinForUpdate runs cache-aware verification of both SynthOrg and
+// DHI images using the new tag, writes the compose file with the verified
+// SynthOrg pins, and returns the merged pin map (SynthOrg bare-name keys
+// plus "dhi:*" keys) ready for pullAndPersist to merge into state.
+//
+// The compose file is always (re)written -- update's job is to point the
+// running stack at the new tag, even when verification was a cache hit.
+//
+// Precedence on the verification deadline: --timeout flag wins when set
+// (operator-level intent for this invocation), otherwise the resolved
+// Tunables.ImageVerifyTimeout applies. The tunable is validated at
+// PersistentPreRunE so an unparseable override fails fast upstream.
+func verifyAndPinForUpdate(ctx context.Context, info docker.Info, state config.State, tag, safeDir string, preserveCompose bool, out *ui.UI, errOut *ui.UI) (map[string]string, error) {
 	updatedState := state
 	updatedState.ImageTag = tag
 
@@ -622,43 +651,22 @@ func verifyAndPinForUpdate(ctx context.Context, state config.State, tag, safeDir
 		return nil, nil
 	}
 
-	sp := out.StartSpinner("Verifying container image signatures...")
-	// Precedence: --timeout flag wins if supplied (operator-level
-	// intent for this invocation); otherwise fall back to the
-	// resolved config.Tunables.ImageVerifyTimeout.  The tunable is
-	// validated at PersistentPreRunE so an unparseable override
-	// fails fast before we reach this code.
 	verifyTimeout, _ := time.ParseDuration(updateTimeout)
 	if verifyTimeout <= 0 {
 		verifyTimeout = GetGlobalOpts(ctx).Tunables.ImageVerifyTimeout
 	}
 	verifyCtx, cancel := context.WithTimeout(ctx, verifyTimeout)
 	defer cancel()
-	var buf bytes.Buffer
-	results, err := verify.VerifyImages(verifyCtx, verify.VerifyOptions{
-		Images: verify.BuildImageRefs(tag, state.Sandbox, state.FineTuning, state.FineTuneVariantOrDefault()),
-		Output: &buf,
-	})
-	if err != nil {
-		sp.Error("Image verification failed")
-		if isTransportError(err) {
-			errOut.HintError("Use --skip-verify for air-gapped environments")
-		}
-		return nil, fmt.Errorf("image verification failed: %w", err)
-	}
-	sp.Stop()
-	renderVerifyBox(out, results)
-	out.Blank()
 
-	pins, err := digestPinMap(results)
+	result, err := verifyImagesWithCache(verifyCtx, info, updatedState, out, errOut)
 	if err != nil {
-		return nil, fmt.Errorf("digest pin map: %w", err)
-	}
-
-	if err := writeOrPatchCompose(updatedState, pins, safeDir, preserveCompose); err != nil {
 		return nil, err
 	}
-	return pins, nil
+
+	if err := writeOrPatchCompose(updatedState, synthOrgPins(result.Pins), safeDir, preserveCompose); err != nil {
+		return nil, err
+	}
+	return result.Pins, nil
 }
 
 // restartIfRunning checks if containers are running and offers a restart.

--- a/cli/cmd/verify_pipeline.go
+++ b/cli/cmd/verify_pipeline.go
@@ -61,11 +61,9 @@ func verifyImagesWithCache(
 		// A miss replaces every prior SynthOrg pin (the bare-name keys),
 		// because the new tag's images have new digests and the OLD pin
 		// values are no longer trusted for the new refs.
-		for k := range merged {
-			if !strings.HasPrefix(k, "dhi:") {
-				delete(merged, k)
-			}
-		}
+		maps.DeleteFunc(merged, func(k, _ string) bool {
+			return !strings.HasPrefix(k, "dhi:")
+		})
 		maps.Copy(merged, pins)
 		res.SynthOrgReverified = true
 	}
@@ -81,11 +79,9 @@ func verifyImagesWithCache(
 		// moved (Renovate bump) or this is the first verification on
 		// this install. Either way OLD dhi:* values do not describe the
 		// images we just verified.
-		for k := range merged {
-			if strings.HasPrefix(k, "dhi:") {
-				delete(merged, k)
-			}
-		}
+		maps.DeleteFunc(merged, func(k, _ string) bool {
+			return strings.HasPrefix(k, "dhi:")
+		})
 		for _, r := range dhiResults {
 			if indexDigest, ok := verify.DHIPinnedIndexDigest(r.Image); ok {
 				merged["dhi:"+r.Image] = indexDigest

--- a/cli/cmd/verify_pipeline.go
+++ b/cli/cmd/verify_pipeline.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"maps"
+	"strings"
+
+	"github.com/Aureliolo/synthorg/cli/internal/config"
+	"github.com/Aureliolo/synthorg/cli/internal/docker"
+	"github.com/Aureliolo/synthorg/cli/internal/ui"
+	"github.com/Aureliolo/synthorg/cli/internal/verify"
+)
+
+// imagesVerifyResult carries the outcome of running cache-aware verification
+// over both SynthOrg and DHI image groups. Pins is the merged pin map
+// containing bare-name SynthOrg keys ("backend", "web", ...) plus
+// "dhi:<image>" / "dhi:<image>:platform|attestation|signature" DHI keys.
+//
+// The *Reverified flags tell callers which group was actually verified
+// (cache miss). start writes compose only when SynthOrg was reverified;
+// update always writes; callers also use the flags to skip an unnecessary
+// state-save round-trip when nothing changed.
+type imagesVerifyResult struct {
+	Pins               map[string]string
+	SynthOrgReverified bool
+	DHIReverified      bool
+}
+
+// verifyImagesWithCache runs cache-aware verification of both image groups
+// for the given state and renders the matching UI box per group:
+//   - cache hit: "Verify <Group> Images (cached)" rendered, existing pins
+//     for the group preserved into the returned merged map.
+//   - cache miss: live verification box rendered, fresh pins folded in.
+//
+// Does NOT write compose or persist state. Callers own those side effects
+// because their atomicity rules differ (start persists immediately, update
+// defers persistence until after a successful pull). Callers MUST set
+// state.VerifiedImageTag = state.ImageTag whenever they persist a result
+// where SynthOrgReverified is true, otherwise hasSynthOrgDigests will
+// reject the cache on the next invocation.
+func verifyImagesWithCache(
+	ctx context.Context,
+	info docker.Info,
+	state config.State,
+	out, errOut *ui.UI,
+) (imagesVerifyResult, error) {
+	merged := make(map[string]string, len(state.VerifiedDigests))
+	maps.Copy(merged, state.VerifiedDigests)
+
+	res := imagesVerifyResult{Pins: merged}
+
+	if hasSynthOrgDigests(state) {
+		renderCachedSynthOrgBox(out, state)
+	} else {
+		pins, err := verifySynthOrgGroup(ctx, state, out, errOut)
+		if err != nil {
+			return imagesVerifyResult{}, err
+		}
+		// A miss replaces every prior SynthOrg pin (the bare-name keys),
+		// because the new tag's images have new digests and the OLD pin
+		// values are no longer trusted for the new refs.
+		for k := range merged {
+			if !strings.HasPrefix(k, "dhi:") {
+				delete(merged, k)
+			}
+		}
+		maps.Copy(merged, pins)
+		res.SynthOrgReverified = true
+	}
+
+	if hasDHIDigests(state) {
+		renderCachedDHIBox(out, state)
+	} else {
+		dhiResults, err := verifyDHIImages(ctx, info, state, out, errOut)
+		if err != nil {
+			return imagesVerifyResult{}, fmt.Errorf("DHI image verification failed: %w", err)
+		}
+		// A miss replaces every prior DHI pin: the binary-pinned index
+		// moved (Renovate bump) or this is the first verification on
+		// this install. Either way OLD dhi:* values do not describe the
+		// images we just verified.
+		for k := range merged {
+			if strings.HasPrefix(k, "dhi:") {
+				delete(merged, k)
+			}
+		}
+		for _, r := range dhiResults {
+			if indexDigest, ok := verify.DHIPinnedIndexDigest(r.Image); ok {
+				merged["dhi:"+r.Image] = indexDigest
+			}
+			if r.Digest != "" {
+				merged["dhi:"+r.Image+":platform"] = r.Digest
+			}
+			if r.AttDigest != "" {
+				merged["dhi:"+r.Image+":attestation"] = r.AttDigest
+			}
+			if r.SigDigest != "" {
+				merged["dhi:"+r.Image+":signature"] = r.SigDigest
+			}
+		}
+		res.DHIReverified = true
+	}
+
+	res.Pins = merged
+	return res, nil
+}
+
+// verifySynthOrgGroup runs SynthOrg cosign + SLSA verification for every
+// SynthOrg image enabled by the given state and returns a bare-name pin
+// map ready to be merged into state.VerifiedDigests. Renders the live
+// "Verify SynthOrg Images" box.
+//
+// The provided ctx governs the verification deadline. Callers are
+// responsible for applying any operator-specific timeout (the start path
+// uses Tunables.ImageVerifyTimeout, the update path honours its
+// --timeout flag).
+func verifySynthOrgGroup(ctx context.Context, state config.State, out, errOut *ui.UI) (map[string]string, error) {
+	imageRefs := verify.BuildImageRefs(state.ImageTag, state.Sandbox, state.FineTuning, state.FineTuneVariantOrDefault())
+	labels := make([]string, len(imageRefs))
+	for i, ref := range imageRefs {
+		labels[i] = ref.Name()
+	}
+	lb := out.NewLiveBox("Verify SynthOrg Images", labels)
+
+	results, err := verify.VerifyImages(ctx, verify.VerifyOptions{
+		Images: imageRefs,
+		Output: io.Discard,
+		OnResult: func(i int, r verify.VerifyResult) {
+			slsaIcon := ui.IconSuccess
+			if !r.ProvenanceVerified {
+				slsaIcon = ui.IconWarning
+			}
+			lb.UpdateLine(i, fmt.Sprintf("sig %s  slsa %s", ui.IconSuccess, slsaIcon))
+		},
+	})
+	lb.Finish()
+
+	if err != nil {
+		if isTransportError(err) {
+			errOut.HintError("Use --skip-verify for air-gapped environments")
+		}
+		return nil, fmt.Errorf("image verification failed: %w", err)
+	}
+
+	pins, err := digestPinMap(results)
+	if err != nil {
+		return nil, fmt.Errorf("digest pin map: %w", err)
+	}
+	return pins, nil
+}
+
+// synthOrgPins returns the bare-name subset of pins (the keys the compose
+// template actually looks up). DHI keys ("dhi:*") are excluded because the
+// compose template reads DHI digests via verify.DHIPinnedIndexDigest from
+// the binary, not from this map. Dropping them here keeps the compose
+// generator's input shape identical to the pre-merge contract.
+func synthOrgPins(allPins map[string]string) map[string]string {
+	out := make(map[string]string, len(allPins))
+	for k, v := range allPins {
+		if strings.HasPrefix(k, "dhi:") {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}

--- a/cli/cmd/verify_pipeline_test.go
+++ b/cli/cmd/verify_pipeline_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"maps"
 	"testing"
 
 	"github.com/Aureliolo/synthorg/cli/internal/config"
@@ -30,9 +31,6 @@ func fullSandboxedPins(fineTuning bool, variant string) map[string]string {
 func TestHasSynthOrgDigests(t *testing.T) {
 	t.Parallel()
 
-	missingSidecar := fullSandboxedPins(false, "")
-	delete(missingSidecar, "sidecar")
-
 	cases := []struct {
 		name  string
 		state config.State
@@ -60,9 +58,14 @@ func TestHasSynthOrgDigests(t *testing.T) {
 		{
 			name: "rejects missing pin for enabled image",
 			state: config.State{
-				ImageTag:         "0.8.3-dev.15",
-				Sandbox:          true,
-				VerifiedDigests:  missingSidecar,
+				ImageTag: "0.8.3-dev.15",
+				Sandbox:  true,
+				VerifiedDigests: map[string]string{
+					"backend": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+					"web":     "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+					"sandbox": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+					// sidecar intentionally missing
+				},
 				VerifiedImageTag: "0.8.3-dev.15",
 			},
 			want: false,
@@ -167,15 +170,23 @@ func TestMergeVerifiedDigests_NilInputsReturnNil(t *testing.T) {
 
 func TestMergeVerifiedDigests_DoesNotMutateInputs(t *testing.T) {
 	t.Parallel()
-	existing := map[string]string{"backend": "sha256:0000000000000000000000000000000000000000000000000000000000000000"}
-	fresh := map[string]string{"backend": "sha256:1111111111111111111111111111111111111111111111111111111111111111"}
+	existing := map[string]string{
+		"backend":                  "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		"dhi:dhi.io/postgres:17.2": "sha256:aaaa000000000000000000000000000000000000000000000000000000000000",
+	}
+	fresh := map[string]string{
+		"backend": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		"web":     "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+	}
+	originalExisting := maps.Clone(existing)
+	originalFresh := maps.Clone(fresh)
 
 	_ = mergeVerifiedDigests(existing, fresh)
 
-	if existing["backend"] != "sha256:0000000000000000000000000000000000000000000000000000000000000000" {
-		t.Error("mergeVerifiedDigests must not mutate the existing map")
+	if !maps.Equal(existing, originalExisting) {
+		t.Errorf("mergeVerifiedDigests must not mutate the existing map; got %v, want %v", existing, originalExisting)
 	}
-	if fresh["backend"] != "sha256:1111111111111111111111111111111111111111111111111111111111111111" {
-		t.Error("mergeVerifiedDigests must not mutate the fresh map")
+	if !maps.Equal(fresh, originalFresh) {
+		t.Errorf("mergeVerifiedDigests must not mutate the fresh map; got %v, want %v", fresh, originalFresh)
 	}
 }

--- a/cli/cmd/verify_pipeline_test.go
+++ b/cli/cmd/verify_pipeline_test.go
@@ -27,73 +27,79 @@ func fullSandboxedPins(fineTuning bool, variant string) map[string]string {
 	return pins
 }
 
-func TestHasSynthOrgDigests_RejectsTagMismatch(t *testing.T) {
+func TestHasSynthOrgDigests(t *testing.T) {
 	t.Parallel()
-	state := config.State{
-		ImageTag:         "0.8.3-dev.15",
-		Sandbox:          true,
-		VerifiedDigests:  fullSandboxedPins(false, ""),
-		VerifiedImageTag: "0.8.3-dev.14",
-	}
-	if hasSynthOrgDigests(state) {
-		t.Fatal("hasSynthOrgDigests must return false when VerifiedImageTag != ImageTag")
-	}
-}
 
-func TestHasSynthOrgDigests_RejectsMissingSentinel(t *testing.T) {
-	t.Parallel()
-	state := config.State{
-		ImageTag:        "0.8.3-dev.15",
-		Sandbox:         true,
-		VerifiedDigests: fullSandboxedPins(false, ""),
-	}
-	if hasSynthOrgDigests(state) {
-		t.Fatal("hasSynthOrgDigests must return false when VerifiedImageTag is empty (legacy state)")
-	}
-}
+	missingSidecar := fullSandboxedPins(false, "")
+	delete(missingSidecar, "sidecar")
 
-func TestHasSynthOrgDigests_RejectsMissingPin(t *testing.T) {
-	t.Parallel()
-	pins := fullSandboxedPins(false, "")
-	delete(pins, "sidecar")
-	state := config.State{
-		ImageTag:         "0.8.3-dev.15",
-		Sandbox:          true,
-		VerifiedDigests:  pins,
-		VerifiedImageTag: "0.8.3-dev.15",
-	}
-	if hasSynthOrgDigests(state) {
-		t.Fatal("hasSynthOrgDigests must return false when an enabled-image pin is missing")
-	}
-}
-
-func TestHasSynthOrgDigests_HitsWhenSentinelAndKeysMatch(t *testing.T) {
-	t.Parallel()
-	state := config.State{
-		ImageTag:         "0.8.3-dev.15",
-		Sandbox:          true,
-		FineTuning:       true,
-		VerifiedDigests:  fullSandboxedPins(true, config.FineTuneVariantGPU),
-		VerifiedImageTag: "0.8.3-dev.15",
-	}
-	if !hasSynthOrgDigests(state) {
-		t.Fatal("hasSynthOrgDigests must return true when sentinel and all enabled-image pins match")
-	}
-}
-
-func TestHasSynthOrgDigests_NoSandboxOnlyRequiresCoreImages(t *testing.T) {
-	t.Parallel()
-	state := config.State{
-		ImageTag: "0.8.3-dev.15",
-		Sandbox:  false,
-		VerifiedDigests: map[string]string{
-			"backend": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
-			"web":     "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+	cases := []struct {
+		name  string
+		state config.State
+		want  bool
+	}{
+		{
+			name: "rejects tag mismatch",
+			state: config.State{
+				ImageTag:         "0.8.3-dev.15",
+				Sandbox:          true,
+				VerifiedDigests:  fullSandboxedPins(false, ""),
+				VerifiedImageTag: "0.8.3-dev.14",
+			},
+			want: false,
 		},
-		VerifiedImageTag: "0.8.3-dev.15",
+		{
+			name: "rejects missing sentinel (legacy state)",
+			state: config.State{
+				ImageTag:        "0.8.3-dev.15",
+				Sandbox:         true,
+				VerifiedDigests: fullSandboxedPins(false, ""),
+			},
+			want: false,
+		},
+		{
+			name: "rejects missing pin for enabled image",
+			state: config.State{
+				ImageTag:         "0.8.3-dev.15",
+				Sandbox:          true,
+				VerifiedDigests:  missingSidecar,
+				VerifiedImageTag: "0.8.3-dev.15",
+			},
+			want: false,
+		},
+		{
+			name: "hits when sentinel and all enabled-image pins match",
+			state: config.State{
+				ImageTag:         "0.8.3-dev.15",
+				Sandbox:          true,
+				FineTuning:       true,
+				VerifiedDigests:  fullSandboxedPins(true, config.FineTuneVariantGPU),
+				VerifiedImageTag: "0.8.3-dev.15",
+			},
+			want: true,
+		},
+		{
+			name: "hits when sandbox disabled and only core images pinned",
+			state: config.State{
+				ImageTag: "0.8.3-dev.15",
+				Sandbox:  false,
+				VerifiedDigests: map[string]string{
+					"backend": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+					"web":     "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+				},
+				VerifiedImageTag: "0.8.3-dev.15",
+			},
+			want: true,
+		},
 	}
-	if !hasSynthOrgDigests(state) {
-		t.Fatal("hasSynthOrgDigests must hit when sandbox is disabled and core images are pinned")
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := hasSynthOrgDigests(tc.state); got != tc.want {
+				t.Errorf("hasSynthOrgDigests() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/cli/cmd/verify_pipeline_test.go
+++ b/cli/cmd/verify_pipeline_test.go
@@ -1,0 +1,175 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/Aureliolo/synthorg/cli/internal/config"
+)
+
+// fullSandboxedPins returns a pin map populated with valid sha256 digests
+// for every SynthOrg image of a sandbox-enabled config (backend / web /
+// sandbox / sidecar, optionally fine-tune). Used to construct fixtures
+// where hasSynthOrgDigests would otherwise reject for missing keys.
+func fullSandboxedPins(fineTuning bool, variant string) map[string]string {
+	pins := map[string]string{
+		"backend": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		"web":     "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+		"sandbox": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+		"sidecar": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+	}
+	if fineTuning {
+		svc := "fine-tune-gpu"
+		if variant == config.FineTuneVariantCPU {
+			svc = "fine-tune-cpu"
+		}
+		pins[svc] = "sha256:5555555555555555555555555555555555555555555555555555555555555555"
+	}
+	return pins
+}
+
+func TestHasSynthOrgDigests_RejectsTagMismatch(t *testing.T) {
+	t.Parallel()
+	state := config.State{
+		ImageTag:         "0.8.3-dev.15",
+		Sandbox:          true,
+		VerifiedDigests:  fullSandboxedPins(false, ""),
+		VerifiedImageTag: "0.8.3-dev.14",
+	}
+	if hasSynthOrgDigests(state) {
+		t.Fatal("hasSynthOrgDigests must return false when VerifiedImageTag != ImageTag")
+	}
+}
+
+func TestHasSynthOrgDigests_RejectsMissingSentinel(t *testing.T) {
+	t.Parallel()
+	state := config.State{
+		ImageTag:        "0.8.3-dev.15",
+		Sandbox:         true,
+		VerifiedDigests: fullSandboxedPins(false, ""),
+	}
+	if hasSynthOrgDigests(state) {
+		t.Fatal("hasSynthOrgDigests must return false when VerifiedImageTag is empty (legacy state)")
+	}
+}
+
+func TestHasSynthOrgDigests_RejectsMissingPin(t *testing.T) {
+	t.Parallel()
+	pins := fullSandboxedPins(false, "")
+	delete(pins, "sidecar")
+	state := config.State{
+		ImageTag:         "0.8.3-dev.15",
+		Sandbox:          true,
+		VerifiedDigests:  pins,
+		VerifiedImageTag: "0.8.3-dev.15",
+	}
+	if hasSynthOrgDigests(state) {
+		t.Fatal("hasSynthOrgDigests must return false when an enabled-image pin is missing")
+	}
+}
+
+func TestHasSynthOrgDigests_HitsWhenSentinelAndKeysMatch(t *testing.T) {
+	t.Parallel()
+	state := config.State{
+		ImageTag:         "0.8.3-dev.15",
+		Sandbox:          true,
+		FineTuning:       true,
+		VerifiedDigests:  fullSandboxedPins(true, config.FineTuneVariantGPU),
+		VerifiedImageTag: "0.8.3-dev.15",
+	}
+	if !hasSynthOrgDigests(state) {
+		t.Fatal("hasSynthOrgDigests must return true when sentinel and all enabled-image pins match")
+	}
+}
+
+func TestHasSynthOrgDigests_NoSandboxOnlyRequiresCoreImages(t *testing.T) {
+	t.Parallel()
+	state := config.State{
+		ImageTag: "0.8.3-dev.15",
+		Sandbox:  false,
+		VerifiedDigests: map[string]string{
+			"backend": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+			"web":     "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+		},
+		VerifiedImageTag: "0.8.3-dev.15",
+	}
+	if !hasSynthOrgDigests(state) {
+		t.Fatal("hasSynthOrgDigests must hit when sandbox is disabled and core images are pinned")
+	}
+}
+
+func TestSynthOrgPins_ExcludesDHIKeys(t *testing.T) {
+	t.Parallel()
+	merged := map[string]string{
+		"backend":                              "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		"web":                                  "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+		"dhi:dhi.io/postgres:17.2":             "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+		"dhi:dhi.io/postgres:17.2:platform":    "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+		"dhi:dhi.io/postgres:17.2:attestation": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+		"dhi:dhi.io/postgres:17.2:signature":   "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+		"dhi:dhi.io/nats:2.11":                 "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+	}
+	got := synthOrgPins(merged)
+	if len(got) != 2 {
+		t.Fatalf("synthOrgPins returned %d keys, want 2 (only bare-name keys); got %v", len(got), got)
+	}
+	if _, ok := got["backend"]; !ok {
+		t.Error("synthOrgPins dropped 'backend' key")
+	}
+	if _, ok := got["web"]; !ok {
+		t.Error("synthOrgPins dropped 'web' key")
+	}
+	for k := range got {
+		if len(k) >= 4 && k[:4] == "dhi:" {
+			t.Errorf("synthOrgPins leaked DHI key %q", k)
+		}
+	}
+}
+
+func TestMergeVerifiedDigests_PreservesDHIKeys(t *testing.T) {
+	t.Parallel()
+	existing := map[string]string{
+		"backend":                  "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		"dhi:dhi.io/postgres:17.2": "sha256:aaaa000000000000000000000000000000000000000000000000000000000000",
+		"dhi:dhi.io/nats:2.11":     "sha256:bbbb000000000000000000000000000000000000000000000000000000000000",
+	}
+	fresh := map[string]string{
+		"backend": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		"web":     "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+	}
+	got := mergeVerifiedDigests(existing, fresh)
+
+	if got["backend"] != fresh["backend"] {
+		t.Errorf("merge must overlay fresh on existing for shared key; got backend=%q, want %q", got["backend"], fresh["backend"])
+	}
+	if got["web"] != fresh["web"] {
+		t.Errorf("merge must include new fresh keys; web=%q missing", got["web"])
+	}
+	if got["dhi:dhi.io/postgres:17.2"] != existing["dhi:dhi.io/postgres:17.2"] {
+		t.Errorf("merge must preserve existing DHI postgres pin; got %q", got["dhi:dhi.io/postgres:17.2"])
+	}
+	if got["dhi:dhi.io/nats:2.11"] != existing["dhi:dhi.io/nats:2.11"] {
+		t.Errorf("merge must preserve existing DHI nats pin; got %q", got["dhi:dhi.io/nats:2.11"])
+	}
+}
+
+func TestMergeVerifiedDigests_NilInputsReturnNil(t *testing.T) {
+	t.Parallel()
+	if got := mergeVerifiedDigests(nil, nil); got != nil {
+		t.Errorf("mergeVerifiedDigests(nil, nil) = %v, want nil so compose's nil-pin fallback path can fire", got)
+	}
+}
+
+func TestMergeVerifiedDigests_DoesNotMutateInputs(t *testing.T) {
+	t.Parallel()
+	existing := map[string]string{"backend": "sha256:0000000000000000000000000000000000000000000000000000000000000000"}
+	fresh := map[string]string{"backend": "sha256:1111111111111111111111111111111111111111111111111111111111111111"}
+
+	_ = mergeVerifiedDigests(existing, fresh)
+
+	if existing["backend"] != "sha256:0000000000000000000000000000000000000000000000000000000000000000" {
+		t.Error("mergeVerifiedDigests must not mutate the existing map")
+	}
+	if fresh["backend"] != "sha256:1111111111111111111111111111111111111111111111111111111111111111" {
+		t.Error("mergeVerifiedDigests must not mutate the fresh map")
+	}
+}

--- a/cli/cmd/wipe.go
+++ b/cli/cmd/wipe.go
@@ -375,11 +375,54 @@ func (wc *wipeContext) containersRunning() (bool, error) {
 // the backend to become healthy.
 func (wc *wipeContext) startContainers() error {
 	wc.out.Blank()
-	if err := verifyAndPinImages(wc.ctx, wc.cmd, wc.state, wc.safeDir, wc.out, wc.errOut); err != nil {
+	if err := wc.verifyAndPin(); err != nil {
 		return err
 	}
 	wc.out.Blank()
 	return pullStartAndWait(wc.ctx, wc.info, wc.safeDir, wc.state, wc.out, wc.errOut)
+}
+
+// verifyAndPin runs cache-aware verification of both image groups, writes
+// the digest-pinned compose if SynthOrg was reverified, persists fresh
+// pins + the new VerifiedImageTag sentinel, and reloads wc.state from
+// disk so the subsequent pull sees the freshly-pinned references.
+//
+// On --skip-verify it warns and returns immediately, leaving wc.state
+// untouched (matching the start path's behaviour).
+func (wc *wipeContext) verifyAndPin() error {
+	if GetGlobalOpts(wc.ctx).SkipVerify {
+		wc.errOut.Warn("Image verification skipped (--skip-verify). Containers are NOT verified.")
+		return nil
+	}
+
+	verifyCtx, cancel := context.WithTimeout(wc.ctx, GetGlobalOpts(wc.ctx).Tunables.ImageVerifyTimeout)
+	defer cancel()
+	result, err := verifyImagesWithCache(verifyCtx, wc.info, wc.state, wc.out, wc.errOut)
+	if err != nil {
+		return err
+	}
+
+	if result.SynthOrgReverified {
+		if err := writeDigestPinnedCompose(wc.state, synthOrgPins(result.Pins), wc.safeDir); err != nil {
+			return fmt.Errorf("pinning verified digests: %w", err)
+		}
+	}
+
+	if !result.SynthOrgReverified && !result.DHIReverified {
+		return nil
+	}
+
+	wc.state.VerifiedDigests = result.Pins
+	wc.state.VerifiedImageTag = wc.state.ImageTag
+	if err := config.Save(wc.state); err != nil {
+		wc.errOut.Warn(fmt.Sprintf("Could not cache verified digests: %v", err))
+	}
+	reloaded, err := config.Load(GetGlobalOpts(wc.ctx).DataDir)
+	if err != nil {
+		return fmt.Errorf("reloading config after verification: %w", err)
+	}
+	wc.state = reloaded
+	return nil
 }
 
 // waitForBackendHealth waits for the backend to become healthy.

--- a/cli/internal/config/state.go
+++ b/cli/internal/config/state.go
@@ -61,6 +61,14 @@ type State struct {
 	PostgresPassword   string            `json:"postgres_password,omitempty"`
 	AutoCleanup        bool              `json:"auto_cleanup"`
 	VerifiedDigests    map[string]string `json:"verified_digests,omitempty"`
+	// VerifiedImageTag records the ImageTag value the SynthOrg pins in
+	// VerifiedDigests were verified against. hasSynthOrgDigests treats the
+	// SynthOrg cache as stale whenever this does not match the current
+	// ImageTag, mirroring the strictness of the DHI pin-comparison check
+	// (see hasDHIDigests in cli/cmd/start.go). DHI pins are validated
+	// independently against the binary-baked Renovate map and do not use
+	// this field.
+	VerifiedImageTag string `json:"verified_image_tag,omitempty"`
 
 	// Display preferences (empty = use default).
 	Color         string `json:"color,omitempty"`          // always/auto/never

--- a/docs/reference/cli-config-subcommands.md
+++ b/docs/reference/cli-config-subcommands.md
@@ -12,8 +12,8 @@ On-demand reference for `synthorg config` operators. The short summary in `cli/C
 | Subcommand | Description |
 |------------|-------------|
 | `show` | Display all current settings (default when no subcommand) |
-| `get <key>` | Get a single config value (37 gettable keys) |
-| `set <key> <value>` | Set a config value (37 settable keys; compose-affecting keys trigger regeneration) |
+| `get <key>` | Get a single config value (40 gettable keys) |
+| `set <key> <value>` | Set a config value (40 settable keys; compose-affecting keys trigger regeneration) |
 | `unset <key>` | Reset a key to its default value |
 | `list` | Show all keys with resolved value and source (env / config / default) |
 | `path` | Print the config file path |
@@ -23,11 +23,11 @@ On-demand reference for `synthorg config` operators. The short summary in `cli/C
 
 `auto_apply_compose`, `auto_cleanup`, `auto_pull`, `auto_restart`, `auto_start_after_wipe`, `auto_update_cli`, `backend_port`, `changelog_view`, `channel`, `color`, `docker_sock`, `fine_tuning`, `fine_tuning_variant`, `hints`, `image_tag`, `log_level`, `output`, `sandbox`, `telemetry_opt_in`, `timestamps`, `web_port`.
 
-Plus the tunables: `registry_host`, `image_repo_prefix`, `dhi_registry`, `postgres_image_tag`, `nats_image_tag`, `default_nats_url`, `default_nats_stream_prefix`, `backup_create_timeout`, `backup_restore_timeout`, `health_check_timeout`, `self_update_http_timeout`, `self_update_api_timeout`, `tuf_fetch_timeout`, `attestation_http_timeout`, `image_verify_timeout`, `image_pull_attempts`, `image_pull_retry_delay`, `max_api_response_bytes`, `max_binary_bytes`, `max_archive_entry_bytes`.
+Plus the tunables: `registry_host`, `image_repo_prefix`, `dhi_registry`, `postgres_image_tag`, `nats_image_tag`, `default_nats_stream_prefix`, `backup_create_timeout`, `backup_restore_timeout`, `health_check_timeout`, `self_update_http_timeout`, `self_update_api_timeout`, `tuf_fetch_timeout`, `attestation_http_timeout`, `image_verify_timeout`, `image_pull_attempts`, `image_pull_retry_delay`, `max_api_response_bytes`, `max_binary_bytes`, `max_archive_entry_bytes`.
 
 ### Compose-affecting keys (trigger automatic `compose.yml` regeneration)
 
-`backend_port`, `web_port`, `sandbox`, `docker_sock`, `image_tag`, `log_level`, `telemetry_opt_in`, `fine_tuning`, `fine_tuning_variant`, `registry_host`, `image_repo_prefix`, `dhi_registry`, `postgres_image_tag`, `nats_image_tag`, `default_nats_url`, `default_nats_stream_prefix`.
+`backend_port`, `web_port`, `sandbox`, `docker_sock`, `image_tag`, `log_level`, `telemetry_opt_in`, `fine_tuning`, `fine_tuning_variant`, `registry_host`, `image_repo_prefix`, `dhi_registry`, `postgres_image_tag`, `nats_image_tag`, `default_nats_stream_prefix`.
 
 Toggling `fine_tuning` on requires `sandbox=true` and amd64; validation runs at `config set` time so inconsistent combinations fail before the next `start`.
 

--- a/docs/reference/cli-config-subcommands.md
+++ b/docs/reference/cli-config-subcommands.md
@@ -12,7 +12,7 @@ On-demand reference for `synthorg config` operators. The short summary in `cli/C
 | Subcommand | Description |
 |------------|-------------|
 | `show` | Display all current settings (default when no subcommand) |
-| `get <key>` | Get a single config value (40 gettable keys) |
+| `get <key>` | Get a single config value (42 gettable keys; includes the read-only `memory_backend` and `persistence_backend`) |
 | `set <key> <value>` | Set a config value (40 settable keys; compose-affecting keys trigger regeneration) |
 | `unset <key>` | Reset a key to its default value |
 | `list` | Show all keys with resolved value and source (env / config / default) |

--- a/docs/reference/cli-persistence-backends.md
+++ b/docs/reference/cli-persistence-backends.md
@@ -45,13 +45,13 @@ In `src/synthorg/api/app.py`: when both `SYNTHORG_DATABASE_URL` and `SYNTHORG_DB
 
 `synthorg start` brings up Postgres first (via compose ordering), then the backend applies yoyo migrations on connection.  Yoyo runs in-process via the project's Python venv (no external binary in the runtime image); the `synthorg.persistence.migrations` module wraps it and routes through psycopg 3 via the `postgresql+psycopg://` URL scheme.  `synthorg stop` preserves `synthorg-pgdata` unless `--volumes` is passed.  `synthorg status --wide` reports Postgres container health plus the `synthorg-pgdata` volume size.
 
-### DHI verification
+### Image verification
 
-DHI images are verified before pulling via cosign ECDSA signature + SLSA v1 provenance attestation + Rekor transparency log. Verification results are cached in `config.json` (`verified_digests`) and invalidated when Renovate bumps the pinned index digest.
+Container images are verified before pulling. SynthOrg images (backend / web / sandbox / sidecar / fine-tune) are verified via cosign signature + SLSA provenance against the project's pinned Sigstore identity. DHI images (postgres, nats) are verified via cosign ECDSA signature + SLSA v1 provenance attestation + Rekor transparency log against Docker's pinned public key.
 
-### Image verification cache parity
+Both groups share one cache map in `config.json` (`verified_digests`): SynthOrg pins are keyed by bare service name (`backend`, `web`, ...), DHI pins are namespaced under `dhi:<image>` (plus `:platform` / `:attestation` / `:signature` siblings). The companion `verified_image_tag` field records which `image_tag` the SynthOrg pins were verified against; `hasSynthOrgDigests` rejects the cache whenever it differs from the current `image_tag`, mirroring the binary-pin comparison `hasDHIDigests` performs against `verify.DHIPinnedIndexDigest` (which invalidates DHI pins when Renovate bumps the pinned index digest).
 
-SynthOrg image verification results sit alongside the DHI pins in the same `verified_digests` map. The companion `verified_image_tag` field records which `image_tag` the SynthOrg pins were verified against; `hasSynthOrgDigests` rejects the cache whenever it differs from the current `image_tag`, mirroring the binary-pin comparison used by `hasDHIDigests`. `synthorg update` and `synthorg start` route through the same `verifyImagesWithCache` helper so the two groups always cache (or invalidate) symmetrically: an `update` writes both groups under one tag and the next `start` shows both as `(cached)`. `synthorg config set image_tag <new>` clears both `verified_digests` and `verified_image_tag` together so the next `start` re-verifies cleanly.
+`synthorg update` and `synthorg start` route through the same `verifyImagesWithCache` helper so the two groups always cache (or invalidate) symmetrically: an `update` writes both groups under one tag and the next `start` shows both as `(cached)`. `synthorg config set image_tag <new>` clears both `verified_digests` and `verified_image_tag` together so the next `start` re-verifies cleanly.
 
 ### Port layout
 

--- a/docs/reference/cli-persistence-backends.md
+++ b/docs/reference/cli-persistence-backends.md
@@ -49,6 +49,10 @@ In `src/synthorg/api/app.py`: when both `SYNTHORG_DATABASE_URL` and `SYNTHORG_DB
 
 DHI images are verified before pulling via cosign ECDSA signature + SLSA v1 provenance attestation + Rekor transparency log. Verification results are cached in `config.json` (`verified_digests`) and invalidated when Renovate bumps the pinned index digest.
 
+### Image verification cache parity
+
+SynthOrg image verification results sit alongside the DHI pins in the same `verified_digests` map. The companion `verified_image_tag` field records which `image_tag` the SynthOrg pins were verified against; `hasSynthOrgDigests` rejects the cache whenever it differs from the current `image_tag`, mirroring the binary-pin comparison used by `hasDHIDigests`. `synthorg update` and `synthorg start` route through the same `verifyImagesWithCache` helper so the two groups always cache (or invalidate) symmetrically: an `update` writes both groups under one tag and the next `start` shows both as `(cached)`. `synthorg config set image_tag <new>` clears both `verified_digests` and `verified_image_tag` together so the next `start` re-verifies cleanly.
+
 ### Port layout
 
 `3000` web / `3001` backend / `3002` postgres / `3003` NATS client. `generate.go` validates port collisions: web vs backend always; postgres vs web/backend/NATS when postgres enabled; NATS vs web/backend when distributed bus mode is active.

--- a/scripts/check_cli_bench_regression.sh
+++ b/scripts/check_cli_bench_regression.sh
@@ -34,7 +34,12 @@ BENCH_PKGS=(
     "./internal/verify/"
 )
 
-BENCH_COUNT="${BENCH_COUNT:-5}"
+# BENCH_COUNT defaults to 10 so benchstat clears its n>=6 floor for
+# 95% confidence intervals; sub-100ns microbenchmarks otherwise produce
+# unbounded ±∞ rows on shared CI runners and a single ~10ns wobble
+# trips the gate even when the function under test is byte-identical
+# across base and HEAD.
+BENCH_COUNT="${BENCH_COUNT:-10}"
 THRESHOLD_PCT="${THRESHOLD_PCT:-15}"
 
 # Resolve merge-base. CI runs on a detached PR HEAD; the merge-base


### PR DESCRIPTION
## Why

After `synthorg update` to v0.8.3-dev.15, the next `synthorg start` showed `Verify SynthOrg Images (cached)` while DHI images re-verified. The two image groups should always cache (or invalidate) symmetrically: either both `(cached)` or both fresh.

## Root cause (3 stacked bugs)

1. **`hasSynthOrgDigests`** (`cli/cmd/start.go`) only checked key presence by bare service name. `hasDHIDigests` was much stricter: it compared the cached digest against `verify.DHIPinnedIndexDigest` (the Renovate-baked binary pin). On a tag bump, SynthOrg cache would silently go stale across `ImageTag` changes (masked today only because the update path always overwrites the map; accidental safety).
2. **`verifyAndPinForUpdate`** (`cli/cmd/update.go`) only verified SynthOrg images via `verify.BuildImageRefs`, never DHI. DHI images were pulled by `pullAllImages` but skipped verification entirely during update.
3. **`pullAndPersist`** (`cli/cmd/update.go`) did `updatedState.VerifiedDigests = digestPins`, replacing the whole map. Every `dhi:*` key was wiped on every update. Combined with bug 2, the post-update cache contained only SynthOrg pins, so the next `start` found DHI keys missing and re-verified.

The wipe path (`cli/cmd/wipe.go`) had the same Bug-1 shape and a latent state-aliasing issue (`wc.state` was loaded once and never reloaded after the persist, so subsequent pulls fell back to floating tag refs for sandbox/sidecar/fine-tune).

## What changed

- **`cli/internal/config/state.go`**: new `VerifiedImageTag string` sentinel field (`json:"verified_image_tag,omitempty"`). Records which `ImageTag` the SynthOrg pins were verified against. Existing on-disk `state.json` files unmarshal it as `""`, which never matches a real tag, so the first `start` after upgrade triggers a one-time re-verify and the cache becomes self-healing.
- **`cli/cmd/verify_pipeline.go`** (new): `imagesVerifyResult` struct + `verifyImagesWithCache` helper + `verifySynthOrgGroup` + `synthOrgPins` filter. One cache-aware verification helper for both SynthOrg and DHI image groups, reused by start / update / wipe.
- **`cli/cmd/start.go`**: `hasSynthOrgDigests` now requires `state.VerifiedImageTag == state.ImageTag` (mirrors `hasDHIDigests`'s strictness). `verifyAndPullStartImages` refactored to route through the new helper. Dead helpers (`verifyAndPinImages`, `renderVerifyBox`) deleted.
- **`cli/cmd/update.go`**: `verifyAndPinForUpdate` routes through the new helper (now also verifies DHI during update). `pullAndPersist` merges pins via a new `mergeVerifiedDigests` helper instead of replacing, and sets `VerifiedImageTag = tag`.
- **`cli/cmd/wipe.go`**: extracted `wipeContext.verifyAndPin`, routes through the new helper, reloads state after persist (fixes the floating-tag-pull latent bug).
- **`cli/cmd/config.go`**: `invalidatesVerifiedDigests` paths now also clear `state.VerifiedImageTag` so the sentinel drops alongside the pin map.
- **`docs/reference/cli-persistence-backends.md`** + **`cli/CLAUDE.md`**: describe the shared `verified_digests` map and the new `verified_image_tag` sentinel.

Plus pre-existing docs drift surfaced by the pre-PR docs-consistency review: `default_nats_url` removed from the settable/compose-affecting lists (env-only); settable-key count corrected from 37 to 40 to match `supportedConfigKeys`.

## Behaviour after this PR

- Clean update then start: helper writes both groups, sentinel set; next `start` shows both panels as `(cached)`. **Symmetric.**
- Update where Renovate also moved a DHI pin: SynthOrg re-verifies (tag changed), DHI cache misses (binary pin moved), both re-verified during update, both persisted. Next start: both `(cached)`. Symmetric.
- `synthorg config set image_tag X.Y.Z`: clears `verified_digests` AND `verified_image_tag`; next start re-verifies both. Symmetric.

## Test plan

- Added `cli/cmd/verify_pipeline_test.go` with a table-driven `TestHasSynthOrgDigests` covering sentinel-mismatch, missing-sentinel (legacy state shape), missing-pin, full cache hit, sandbox-disabled hit. Plus `TestSynthOrgPins_ExcludesDHIKeys`, three `TestMergeVerifiedDigests_*` cases (preserves DHI, nil-in/nil-out, non-mutation).
- Added `TestConfigSetImageTag_ClearsVerifiedDigestsAndImageTag` in `cli/cmd/config_test.go`.
- `go -C cli vet ./...` clean.
- `golangci-lint run` 0 issues.
- `go -C cli test ./...` all packages pass.
- `go -C cli build ./...` succeeds.

End-to-end manual verification suggested after merge:
1. `synthorg update` to a new dev release; observe both panels verified DURING update.
2. `synthorg start`; both panels should show `(cached)`.
3. `synthorg config set image_tag 0.0.0-fake && synthorg start`; both panels should re-verify (sentinel mismatch).
4. Restore real tag and `synthorg start`; both panels cached again.

## Review coverage

Pre-reviewed by 4 agents:
- `docs-consistency`: surfaced 4 docs drift items; all 4 fixed (2 caused by this PR's code change, 2 pre-existing).
- `comment-quality-rot`: clean.
- `go-reviewer`: clean ("no critical findings, ready for merge").
- `go-conventions-enforcer`: surfaced 4 items; 1 valid (table-driven consolidation, applied), 3 misapplied (flagged in triage as NOT VALID with rationale).

Total: 5 valid findings, all 5 implemented in this PR.