### PR TITLE
refactor(persistence): encapsulate SQLite write lock behind backend.write_context

### DIFF
--- a/cli/internal/scaffold/templates/persistence_sqlite_repo.py.tmpl
+++ b/cli/internal/scaffold/templates/persistence_sqlite_repo.py.tmpl
@@ -1,6 +1,5 @@
 """SQLite repository for {{.ModuleDocSlug}} items."""
 
-import asyncio
 import sqlite3
 
 import aiosqlite
@@ -15,6 +14,7 @@ from synthorg.observability.events.{{.Domain}}_repo import (
     {{shout .Domain}}_REPO_LISTED,
 )
 from synthorg.persistence._shared import coerce_row_timestamp, format_iso_utc
+from synthorg.persistence.sqlite._shared import WriteContext
 from synthorg.{{.Domain}}.models import {{.ClassName}}Item
 
 logger = get_logger(__name__)
@@ -61,24 +61,28 @@ class SQLite{{.ClassName}}Repository:
     Args:
         db: An open ``aiosqlite.Connection`` whose ``row_factory`` this
             repository owns.
-        write_lock: Optional shared write lock; falls back to a private
-            lock for standalone test construction.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
         self._db.row_factory = aiosqlite.Row
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, item: {{.ClassName}}Item) -> None:
         """Upsert a {{.ModuleDocSlug}} item."""
         params = (item.id, item.payload, format_iso_utc(item.created_at))
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(_UPSERT_SQL, params)
                 await self._db.commit()
@@ -152,7 +156,7 @@ class SQLite{{.ClassName}}Repository:
 
     async def delete(self, item_id: NotBlankStr) -> bool:
         """Delete an item by ID; returns ``True`` if a row was removed."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(_DELETE_SQL, (item_id,))
                 await self._db.commit()

--- a/cli/internal/scaffold/templates/persistence_wiring.md.tmpl
+++ b/cli/internal/scaffold/templates/persistence_wiring.md.tmpl
@@ -63,7 +63,7 @@ Then construct the repo in each backend's
 `PostgresPersistenceBackend`):
 
 ```python
-self.{{.Domain}}_items = SQLite{{.ClassName}}Repository(self._db, write_lock=self._write_lock)
+self.{{.Domain}}_items = SQLite{{.ClassName}}Repository(self._db, write_context=self.write_context)
 # or
 self.{{.Domain}}_items = Postgres{{.ClassName}}Repository(self._pool)
 ```

--- a/docs/reference/persistence-boundary.md
+++ b/docs/reference/persistence-boundary.md
@@ -62,6 +62,25 @@ Services:
 
 Repositories **must not** log mutations themselves (enforced by `scripts/check_persistence_boundary.py`). The service layer is the canonical logging point so audit trails do not duplicate when multiple callers share a repo. Repos may still log fetch telemetry (`*_FETCHED`, `*_LISTED`, `*_COUNTED`) and error paths (`*_SAVE_FAILED`, `*_DELETE_FAILED`, `*_DUPLICATE`); the rule targets entity-mutation audit specifically.
 
+## Cross-backend write_context
+
+`PersistenceBackend.write_context()` returns an async context manager that callers wrap around mutating SQL. The call shape is identical on both backends:
+
+```python
+async with backend.write_context():
+    await artifact_repo.save(artifact)
+    await project_repo.save(project)
+```
+
+The mutual-exclusion guarantee, however, is backend-specific:
+
+- **SQLite** acquires a shared in-process `asyncio.Lock`. The single `aiosqlite.Connection` is shared by every repository on that backend, so concurrent writers must serialize at the statement level. Repositories receive the backend's `write_context` bound method at construction and call `async with self._write_context():` around every multi-statement transaction.
+- **Postgres** yields immediately. Each repository operation checks out an independent connection from the async pool, so writers are isolated at the database level without an in-process lock. The method exists only to keep the cross-backend interface uniform; it does not provide mutual exclusion beyond what the pool already gives.
+
+Callers must not rely on `write_context()` for distributed mutual exclusion or cross-backend serializability; for true cross-process locking, use a database-side primitive.
+
+Repositories never own a private write lock. Tests that construct a repository in isolation use `tests._shared.persistence.make_private_write_context()` to satisfy the constructor; that helper returns a fresh per-call lock and is unsafe for production wiring.
+
 ## Migrations
 
 Adding a migration: read `docs/guides/persistence-migrations.md` first.  Never hand-edit a revision file that already exists on `origin/main`; yoyo's content-hash check refuses to re-apply an edited file.  Author a new revision with your delta instead.

--- a/scripts/check_persistence_protocol_return_types.py
+++ b/scripts/check_persistence_protocol_return_types.py
@@ -40,13 +40,29 @@ from typing import Final
 
 _PROTOCOL_PATH: Final[str] = "src/synthorg/persistence/protocol.py"
 _PROTOCOL_CLASS_NAME: Final[str] = "PersistenceBackend"
-# (path, expected concrete-class-name): the gate scans ONLY the named
-# class in each backend module so a future helper class with a
-# colliding ``@property`` name cannot silently overwrite the real
-# backend's annotation in the merged-properties view.
-_BACKEND_PATHS: Final[tuple[tuple[str, str], ...]] = (
-    ("src/synthorg/persistence/sqlite/backend.py", "SQLitePersistenceBackend"),
-    ("src/synthorg/persistence/postgres/backend.py", "PostgresPersistenceBackend"),
+# (path, expected concrete-class-name, accessor sidecars): the gate
+# scans the named backend class plus any explicitly-listed accessor
+# sidecars (mixin classes that contribute ``@property`` accessors to
+# the backend's public surface). A future helper class with a
+# colliding ``@property`` name still cannot silently overwrite the
+# real backend's annotation because the sidecar list is declared
+# here, not discovered.
+_BACKEND_PATHS: Final[tuple[tuple[str, str, tuple[tuple[str, str], ...]], ...]] = (
+    (
+        "src/synthorg/persistence/sqlite/backend.py",
+        "SQLitePersistenceBackend",
+        (
+            (
+                "src/synthorg/persistence/sqlite/_backend_accessors.py",
+                "_BackendRepositoryAccessors",
+            ),
+        ),
+    ),
+    (
+        "src/synthorg/persistence/postgres/backend.py",
+        "PostgresPersistenceBackend",
+        (),
+    ),
 )
 _SUPPRESSION_MARKER: Final[str] = "lint-allow: persistence-protocol-uniformity"
 
@@ -160,51 +176,137 @@ def _collect_backend_properties(
     return properties
 
 
+def _load_class_properties(
+    project_root: Path,
+    rel: str,
+    class_name: str,
+) -> tuple[dict[str, tuple[str, int]], str | None]:
+    """Return ``({property_name: (return, line)}, error)`` for one file+class.
+
+    A missing file returns an empty mapping with no error so sidecar
+    callers can treat a missing accessor module as "no contribution"
+    (callers that actually require the file present check it
+    separately before invoking this helper). Parse and read errors
+    return an error message for the caller to surface.
+    """
+    path = project_root / rel
+    if not path.is_file():
+        return {}, None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return {}, f"{rel}:0: unable to scan file: {exc}"
+    try:
+        tree = ast.parse(text, filename=str(path))
+    except SyntaxError as exc:
+        return {}, f"{rel}:{exc.lineno or 0}: unable to parse file: {exc.msg}"
+    return _collect_backend_properties(tree, class_name), None
+
+
+def _merge_accessor_surface(
+    project_root: Path,
+    backend_rel: str,
+    backend_props: dict[str, tuple[str, int]],
+    accessor_sidecars: tuple[tuple[str, str], ...],
+) -> tuple[dict[str, tuple[str, str, int]], list[str]]:
+    """Merge sidecar accessor properties on top of backend properties.
+
+    Returns ``(surface, sidecar_load_errors)`` where surface maps each
+    property name to ``(source_rel, annotation, line_number)``. Backend
+    properties win over any same-name sidecar entry.
+    """
+    surface: dict[str, tuple[str, str, int]] = {
+        name: (backend_rel, ann, lineno)
+        for name, (ann, lineno) in backend_props.items()
+    }
+    errors: list[str] = []
+    for sidecar_rel, sidecar_class in accessor_sidecars:
+        sidecar_props, sidecar_err = _load_class_properties(
+            project_root, sidecar_rel, sidecar_class
+        )
+        if sidecar_err is not None:
+            errors.append(sidecar_err)
+            continue
+        for name, (ann, lineno) in sidecar_props.items():
+            if name in surface:
+                continue
+            surface[name] = (sidecar_rel, ann, lineno)
+    return surface, errors
+
+
+def _format_mismatch(
+    source_rel: str,
+    prop_name: str,
+    actual: str,
+    expected: str,
+    lineno: int,
+) -> str:
+    """Format the property-return-type mismatch violation message."""
+    return (
+        f"{source_rel}:{lineno}: property {prop_name!r} returns {actual!r}; "
+        f"PersistenceBackend protocol declares {expected!r}. The public "
+        f"surface MUST hide the dialect choice from callers (see "
+        f"docs/reference/persistence-boundary.md). Either flip the return "
+        f"annotation to {expected!r} or add "
+        f"'# lint-allow: persistence-protocol-uniformity -- <reason>' on "
+        f"the property line."
+    )
+
+
+def _is_property_suppressed(project_root: Path, source_rel: str, lineno: int) -> bool:
+    """Return True if the property declaration line carries the marker."""
+    try:
+        text = (project_root / source_rel).read_text(encoding="utf-8")
+    except OSError, UnicodeDecodeError:
+        return False
+    lines = text.splitlines()
+    line = lines[lineno - 1] if 0 < lineno <= len(lines) else ""
+    return _line_has_trailing_marker(line)
+
+
 def _scan_backend(
-    backend_path: Path,
+    project_root: Path,
     rel: str,
     backend_class_name: str,
+    accessor_sidecars: tuple[tuple[str, str], ...],
     protocol_props: dict[str, str],
 ) -> list[str]:
-    """Return violation messages for one backend file."""
-    try:
-        text = backend_path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError) as exc:
-        return [f"{rel}:0: unable to scan file: {exc}"]
-    try:
-        tree = ast.parse(text, filename=str(backend_path))
-    except SyntaxError as exc:
-        return [f"{rel}:{exc.lineno or 0}: unable to parse file: {exc.msg}"]
-    backend_props = _collect_backend_properties(tree, backend_class_name)
+    """Return violation messages for one backend file + its accessor sidecars.
+
+    Accessor sidecars are mixin classes that contribute ``@property``
+    accessors to the backend's public surface. Their property
+    declarations are merged into the backend's view before comparison
+    against the protocol. Each property's source file is tracked so
+    violation messages point at the file that actually declares the
+    property.
+    """
+    backend_props, backend_err = _load_class_properties(
+        project_root, rel, backend_class_name
+    )
+    if backend_err is not None:
+        return [backend_err]
     if not backend_props:
         return [
             f"{rel}:0: concrete backend class {backend_class_name!r} not found "
             "in module; the gate has nothing to compare against."
         ]
-    lines = text.splitlines()
-    issues: list[str] = []
+
+    surface, issues = _merge_accessor_surface(
+        project_root, rel, backend_props, accessor_sidecars
+    )
     for prop_name, expected in protocol_props.items():
-        if prop_name not in backend_props:
+        if prop_name not in surface:
             issues.append(
                 f"{rel}:0: property {prop_name!r} declared on PersistenceBackend "
                 f"protocol is missing from this backend."
             )
             continue
-        actual, lineno = backend_props[prop_name]
+        source_rel, actual, lineno = surface[prop_name]
         if actual == expected:
             continue
-        line = lines[lineno - 1] if 0 < lineno <= len(lines) else ""
-        if _line_has_trailing_marker(line):
+        if _is_property_suppressed(project_root, source_rel, lineno):
             continue
-        issues.append(
-            f"{rel}:{lineno}: property {prop_name!r} returns {actual!r}; "
-            f"PersistenceBackend protocol declares {expected!r}. The public "
-            f"surface MUST hide the dialect choice from callers (see "
-            f"docs/reference/persistence-boundary.md). Either flip the return "
-            f"annotation to {expected!r} or add "
-            f"'# lint-allow: persistence-protocol-uniformity -- <reason>' on "
-            f"the property line."
-        )
+        issues.append(_format_mismatch(source_rel, prop_name, actual, expected, lineno))
     return issues
 
 
@@ -256,7 +358,7 @@ def _scan_all(project_root: Path) -> int:
         return 1
 
     total = 0
-    for rel, backend_class_name in _BACKEND_PATHS:
+    for rel, backend_class_name, accessor_sidecars in _BACKEND_PATHS:
         backend_path = project_root / rel
         if not backend_path.is_file():
             print(
@@ -267,9 +369,10 @@ def _scan_all(project_root: Path) -> int:
             total += 1
             continue
         violations = _scan_backend(
-            backend_path,
+            project_root,
             rel,
             backend_class_name,
+            accessor_sidecars,
             protocol_props,
         )
         for msg in violations:

--- a/src/synthorg/ontology/versioning.py
+++ b/src/synthorg/ontology/versioning.py
@@ -19,6 +19,7 @@ from synthorg.observability.events.ontology import (
 from synthorg.ontology.errors import OntologyError
 from synthorg.ontology.models import EntityDefinition
 from synthorg.persistence.postgres.version_repo import PostgresVersionRepository
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 from synthorg.persistence.sqlite.version_repo import SQLiteVersionRepository
 from synthorg.persistence.version_protocol import (
     VersionRepository,  # noqa: TC001 -- documented return type
@@ -58,6 +59,8 @@ def _safe_deserialize_snapshot_dict(data: object) -> EntityDefinition:
 
 def create_ontology_version_repo(
     db: Any,
+    *,
+    write_context: WriteContext,
 ) -> VersionRepository[EntityDefinition]:
     """Create a SQLite-backed VersionRepository for EntityDefinition.
 
@@ -67,6 +70,9 @@ def create_ontology_version_repo(
             ``aiosqlite`` outside ``persistence/`` would violate the
             boundary linter; the actual handle is passed straight
             through to the repository.
+        write_context: The backend's ``write_context`` callable,
+            forwarded to the repository so writes serialize with
+            sibling repos on the shared aiosqlite connection.
 
     Returns:
         A repository targeting the ``entity_definition_versions`` table.
@@ -78,21 +84,26 @@ def create_ontology_version_repo(
             m.model_dump(mode="json"),
         ),
         deserialize_snapshot=_safe_deserialize_snapshot_json,
+        write_context=write_context,
     )
 
 
 def create_ontology_versioning(
     db: Any,
+    *,
+    write_context: WriteContext,
 ) -> VersioningService[EntityDefinition]:
     """Create a SQLite-backed VersioningService for EntityDefinition.
 
     Args:
         db: An open aiosqlite connection (see above note on the type).
+        write_context: The backend's ``write_context`` callable,
+            forwarded to the underlying version repository.
 
     Returns:
         A versioning service for entity definitions.
     """
-    repo = create_ontology_version_repo(db)
+    repo = create_ontology_version_repo(db, write_context=write_context)
     return VersioningService(repo)
 
 

--- a/src/synthorg/ontology/versioning.py
+++ b/src/synthorg/ontology/versioning.py
@@ -8,6 +8,8 @@ backend; the caller picks the right factory for the active backend.
 """
 
 import json
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
 from typing import Any
 
 from pydantic import ValidationError
@@ -19,7 +21,6 @@ from synthorg.observability.events.ontology import (
 from synthorg.ontology.errors import OntologyError
 from synthorg.ontology.models import EntityDefinition
 from synthorg.persistence.postgres.version_repo import PostgresVersionRepository
-from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 from synthorg.persistence.sqlite.version_repo import SQLiteVersionRepository
 from synthorg.persistence.version_protocol import (
     VersionRepository,  # noqa: TC001 -- documented return type
@@ -27,6 +28,8 @@ from synthorg.persistence.version_protocol import (
 from synthorg.versioning.service import VersioningService
 
 logger = get_logger(__name__)
+
+type WriteContextFn = Callable[[], AbstractAsyncContextManager[None]]
 
 
 def _safe_deserialize_snapshot_json(raw: str) -> EntityDefinition:
@@ -60,7 +63,7 @@ def _safe_deserialize_snapshot_dict(data: object) -> EntityDefinition:
 def create_ontology_version_repo(
     db: Any,
     *,
-    write_context: WriteContext,
+    write_context: WriteContextFn,
 ) -> VersionRepository[EntityDefinition]:
     """Create a SQLite-backed VersionRepository for EntityDefinition.
 
@@ -91,7 +94,7 @@ def create_ontology_version_repo(
 def create_ontology_versioning(
     db: Any,
     *,
-    write_context: WriteContext,
+    write_context: WriteContextFn,
 ) -> VersioningService[EntityDefinition]:
     """Create a SQLite-backed VersioningService for EntityDefinition.
 

--- a/src/synthorg/persistence/postgres/backend.py
+++ b/src/synthorg/persistence/postgres/backend.py
@@ -3,9 +3,9 @@
 Implements the ``PersistenceBackend`` protocol on top of psycopg 3 and
 ``psycopg_pool.AsyncConnectionPool``.  Repositories are instantiated
 per-backend on ``connect()`` and receive the shared pool; each pool
-checkout is an independent transaction, so the Postgres backend does
-not need the ``shared_write_lock`` workaround that the SQLite backend
-uses to serialize writes across a single in-process connection.
+checkout is an independent transaction, so this backend's
+``write_context`` is a no-op rather than the in-process lock SQLite
+acquires to serialize writes across its single connection.
 
 The schema uses native Postgres types (JSONB, TIMESTAMPTZ, BIGINT,
 BOOLEAN) -- see ``src/synthorg/persistence/postgres/schema.sql``.  At
@@ -14,6 +14,8 @@ backend: callers get Pydantic models back either way.
 """
 
 import asyncio
+from collections.abc import AsyncIterator  # noqa: TC003
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -417,8 +419,9 @@ class PostgresPersistenceBackend(PostgresConnectionMixin, PostgresMigrationMixin
         self._role_versions = _ver_repo("role_versions", Role)
 
         # Append-only / security repositories.  Postgres per-connection
-        # transactions handle isolation without the SQLite shared
-        # write_lock workaround.
+        # transactions handle isolation at the database level, so this
+        # backend's ``write_context`` is a no-op and repositories do not
+        # take a ``write_context`` constructor argument.
         self._decision_records = PostgresDecisionRepository(pool)
         self._risk_overrides = PostgresRiskOverrideRepository(pool)
         self._ssrf_violations = PostgresSsrfViolationRepository(pool)
@@ -452,6 +455,19 @@ class PostgresPersistenceBackend(PostgresConnectionMixin, PostgresMigrationMixin
             logger.warning(PERSISTENCE_BACKEND_NOT_CONNECTED, error=msg)
             raise PersistenceConnectionError(msg)
         return self._pool
+
+    @asynccontextmanager
+    async def write_context(self) -> AsyncIterator[None]:
+        """No-op for Postgres.
+
+        Each repository checks out its own connection from the async
+        pool; transactions on different connections cannot interleave
+        at the statement level. Implementing the protocol method as a
+        no-op keeps the cross-backend interface honest and lets
+        callers write ``async with backend.write_context()`` without
+        backend-specific branching.
+        """
+        yield
 
     @property
     def is_connected(self) -> bool:

--- a/src/synthorg/persistence/postgres/session_repo.py
+++ b/src/synthorg/persistence/postgres/session_repo.py
@@ -188,8 +188,10 @@ class PostgresSessionRepository:
             count = cur.rowcount
         if count > 0:
             self._revoked.add(session_id)
-            # Audit emission moved to service/controller layer per the
-            # persistence-boundary rule.
+            # Audit logging lives above persistence so the
+            # SECURITY_SESSION_REVOKED event reflects the authorization
+            # decision rather than a storage-only update; the caller
+            # (service/controller) owns the emit.
             return True
         return False
 
@@ -218,8 +220,9 @@ class PostgresSessionRepository:
                 )
                 rows = await cur.fetchall()
         self._revoked.update(row["session_id"] for row in rows)
-        # Audit emission moved to service/controller layer per the
-        # persistence-boundary rule.
+        # Audit logging stays above persistence: the caller correlates the
+        # bulk-revoke event with the authorization context (which user
+        # initiated, why) that this layer does not see.
         return count
 
     async def enforce_session_limit(
@@ -239,9 +242,10 @@ class PostgresSessionRepository:
         for session in to_revoke:
             if await self.revoke(session.session_id):
                 revoked += 1
-        # Audit emission moved to service/controller layer per the
-        # persistence-boundary rule -- callers log
-        # SECURITY_SESSION_LIMIT_ENFORCED on ``revoked > 0``.
+        # SECURITY_SESSION_LIMIT_ENFORCED belongs in the caller so the
+        # audit entry sits with the policy decision (which limit fired,
+        # against which actor) rather than against a storage commit
+        # that has no visibility into authorization context.
         return revoked
 
     def is_revoked(self, session_id: str) -> bool:

--- a/src/synthorg/persistence/protocol.py
+++ b/src/synthorg/persistence/protocol.py
@@ -238,26 +238,39 @@ class PersistenceBackend(Protocol):
         ...
 
     def write_context(self) -> AbstractAsyncContextManager[None]:
-        """Async context manager that serializes mutating SQL on this backend.
+        """Async context manager around mutating SQL on this backend.
 
-        SQLite implementations acquire a shared in-process write lock so
-        multi-statement transactions on the single ``aiosqlite.Connection``
-        cannot interleave. Postgres implementations yield immediately
-        because per-checkout connections from the async pool isolate
-        writers at the database level.
+        The mutual-exclusion guarantee is backend-specific:
 
-        Use this in repository write paths::
+        - **SQLite** acquires a shared in-process write lock so that
+          multi-statement transactions on the single
+          ``aiosqlite.Connection`` cannot interleave at the statement
+          level. Concurrent writers on the same backend instance
+          serialize.
+        - **Postgres** yields immediately: each repository operation
+          checks out an independent connection from the async pool, so
+          writers are already isolated at the database level. The
+          method exists on this backend only to keep the cross-backend
+          interface uniform; it does not provide mutual exclusion
+          beyond what the pool already gives.
+
+        Use it in repository write paths so the same code path works
+        on both backends::
 
             async with backend.write_context():
                 await db.execute(...)
                 await db.commit()
 
-        Each call returns a fresh context manager; the underlying
-        primitive is shared across calls so concurrent writers
-        serialize correctly. Repositories are wired with this callable
-        at backend construction; callers that already hold a
+        Each call returns a fresh context manager. On SQLite, the
+        underlying lock primitive is shared across calls so concurrent
+        callers serialize. On Postgres, there is no shared primitive.
+        Repositories are wired with this method (as a callable) at
+        backend construction; callers that already hold a
         ``PersistenceBackend`` reference can use it directly for
         cross-repo transactional boundaries.
+
+        Callers must not rely on ``write_context`` for distributed
+        mutual exclusion or cross-backend serializability.
         """
         ...
 

--- a/src/synthorg/persistence/protocol.py
+++ b/src/synthorg/persistence/protocol.py
@@ -4,6 +4,7 @@ Application code depends on this protocol for storage lifecycle
 management.  Repository protocols provide entity-level access.
 """
 
+from contextlib import AbstractAsyncContextManager  # noqa: TC003
 from typing import Any, Protocol, runtime_checkable
 
 from synthorg.budget.config import BudgetConfig  # noqa: TC001
@@ -233,6 +234,30 @@ class PersistenceBackend(Protocol):
 
         Raises:
             PersistenceConnectionError: If not yet connected.
+        """
+        ...
+
+    def write_context(self) -> AbstractAsyncContextManager[None]:
+        """Async context manager that serializes mutating SQL on this backend.
+
+        SQLite implementations acquire a shared in-process write lock so
+        multi-statement transactions on the single ``aiosqlite.Connection``
+        cannot interleave. Postgres implementations yield immediately
+        because per-checkout connections from the async pool isolate
+        writers at the database level.
+
+        Use this in repository write paths::
+
+            async with backend.write_context():
+                await db.execute(...)
+                await db.commit()
+
+        Each call returns a fresh context manager; the underlying
+        primitive is shared across calls so concurrent writers
+        serialize correctly. Repositories are wired with this callable
+        at backend construction; callers that already hold a
+        ``PersistenceBackend`` reference can use it directly for
+        cross-repo transactional boundaries.
         """
         ...
 

--- a/src/synthorg/persistence/sqlite/_backend_accessors.py
+++ b/src/synthorg/persistence/sqlite/_backend_accessors.py
@@ -1,0 +1,516 @@
+"""Repository property accessors for the SQLite backend.
+
+This mixin holds the read-only ``@property`` accessors that
+``SQLitePersistenceBackend`` exposes for every domain repository. The
+accessors all share a single pattern (``_require_connected`` against a
+private ``_<name>`` attribute populated by ``_create_repositories``),
+so collecting them here keeps ``backend.py`` focused on lifecycle and
+wiring rather than ~330 lines of mechanical property forwarding.
+"""
+
+from typing import TYPE_CHECKING
+
+from synthorg.core.persistence_errors import PersistenceConnectionError
+from synthorg.core.types import NotBlankStr
+from synthorg.observability import get_logger
+from synthorg.observability.events.persistence import (
+    PERSISTENCE_BACKEND_NOT_CONNECTED,
+)
+
+if TYPE_CHECKING:
+    from synthorg.budget.config import BudgetConfig
+    from synthorg.core.agent import AgentIdentity
+    from synthorg.core.company import Company
+    from synthorg.core.role import Role
+    from synthorg.engine.workflow.definition import WorkflowDefinition
+    from synthorg.hr.evaluation.config import EvaluationConfig
+    from synthorg.hr.persistence_protocol import (
+        CollaborationMetricRepository,
+        LifecycleEventRepository,
+        TaskMetricRepository,
+    )
+    from synthorg.persistence.agent_state_protocol import AgentStateRepository
+    from synthorg.persistence.artifact_protocol import ArtifactRepository
+    from synthorg.persistence.audit_protocol import AuditRepository
+    from synthorg.persistence.auth_protocol import (
+        RefreshTokenRepository,
+        SessionRepository,
+    )
+    from synthorg.persistence.checkpoint_protocol import (
+        CheckpointRepository,
+        HeartbeatRepository,
+    )
+    from synthorg.persistence.circuit_breaker_protocol import (
+        CircuitBreakerStateRepository,
+    )
+    from synthorg.persistence.connection_protocol import (
+        ConnectionRepository,
+        ConnectionSecretRepository,
+        OAuthStateRepository,
+        WebhookReceiptRepository,
+    )
+    from synthorg.persistence.cost_record_protocol import CostRecordRepository
+    from synthorg.persistence.custom_rule_protocol import CustomRuleRepository
+    from synthorg.persistence.decision_protocol import DecisionRepository
+    from synthorg.persistence.fine_tune_protocol import (
+        FineTuneCheckpointRepository,
+        FineTuneRunRepository,
+    )
+    from synthorg.persistence.idempotency_protocol import IdempotencyRepository
+    from synthorg.persistence.mcp_protocol import McpInstallationRepository
+    from synthorg.persistence.memory_protocol import OrgFactRepository
+    from synthorg.persistence.message_protocol import MessageRepository
+    from synthorg.persistence.ontology_protocol import (
+        OntologyDriftReportRepository,
+        OntologyEntityRepository,
+    )
+    from synthorg.persistence.parked_context_protocol import (
+        ParkedContextRepository,
+    )
+    from synthorg.persistence.preset_override_protocol import PresetOverrideRepo
+    from synthorg.persistence.preset_protocol import PersonalityPresetRepository
+    from synthorg.persistence.project_cost_aggregate_protocol import (
+        ProjectCostAggregateRepository,
+    )
+    from synthorg.persistence.project_protocol import ProjectRepository
+    from synthorg.persistence.provider_audit_protocol import ProviderAuditRepo
+    from synthorg.persistence.risk_override_protocol import RiskOverrideRepository
+    from synthorg.persistence.settings_protocol import SettingsRepository
+    from synthorg.persistence.ssrf_violation_protocol import (
+        SsrfViolationRepository,
+    )
+    from synthorg.persistence.subworkflow_protocol import SubworkflowRepository
+    from synthorg.persistence.task_protocol import TaskRepository
+    from synthorg.persistence.training_protocol import (
+        TrainingPlanRepository,
+        TrainingResultRepository,
+    )
+    from synthorg.persistence.user_protocol import (
+        ApiKeyRepository,
+        UserRepository,
+    )
+    from synthorg.persistence.version_protocol import VersionRepository
+    from synthorg.persistence.workflow_definition_protocol import (
+        WorkflowDefinitionRepository,
+    )
+    from synthorg.persistence.workflow_execution_protocol import (
+        WorkflowExecutionRepository,
+    )
+
+logger = get_logger(__name__)
+
+
+class _BackendRepositoryAccessors:
+    """Mixin holding ``@property`` accessors for every repository.
+
+    The hosting class (``SQLitePersistenceBackend``) is responsible for
+    setting each ``_<name>`` attribute via ``__init__`` (``None`` until
+    ``connect()``) and populating it from ``_create_repositories``.
+    """
+
+    _tasks: TaskRepository | None
+    _cost_records: CostRecordRepository | None
+    _messages: MessageRepository | None
+    _lifecycle_events: LifecycleEventRepository | None
+    _task_metrics: TaskMetricRepository | None
+    _collaboration_metrics: CollaborationMetricRepository | None
+    _parked_contexts: ParkedContextRepository | None
+    _audit_entries: AuditRepository | None
+    _provider_audit_events: ProviderAuditRepo | None
+    _preset_overrides: PresetOverrideRepo | None
+    _decision_records: DecisionRepository | None
+    _users: UserRepository | None
+    _api_keys: ApiKeyRepository | None
+    _checkpoints: CheckpointRepository | None
+    _heartbeats: HeartbeatRepository | None
+    _agent_states: AgentStateRepository | None
+    _settings: SettingsRepository | None
+    _artifacts: ArtifactRepository | None
+    _projects: ProjectRepository | None
+    _project_cost_aggregates: ProjectCostAggregateRepository | None
+    _fine_tune_checkpoints: FineTuneCheckpointRepository | None
+    _fine_tune_runs: FineTuneRunRepository | None
+    _custom_presets: PersonalityPresetRepository | None
+    _workflow_definitions: WorkflowDefinitionRepository | None
+    _workflow_executions: WorkflowExecutionRepository | None
+    _subworkflows: SubworkflowRepository | None
+    _workflow_versions: VersionRepository[WorkflowDefinition] | None
+    _identity_versions: VersionRepository[AgentIdentity] | None
+    _evaluation_config_versions: VersionRepository[EvaluationConfig] | None
+    _budget_config_versions: VersionRepository[BudgetConfig] | None
+    _company_versions: VersionRepository[Company] | None
+    _role_versions: VersionRepository[Role] | None
+    _risk_overrides: RiskOverrideRepository | None
+    _ssrf_violations: SsrfViolationRepository | None
+    _circuit_breaker_state: CircuitBreakerStateRepository | None
+    _connections: ConnectionRepository | None
+    _connection_secrets: ConnectionSecretRepository | None
+    _oauth_states: OAuthStateRepository | None
+    _webhook_receipts: WebhookReceiptRepository | None
+    _training_plans: TrainingPlanRepository | None
+    _training_results: TrainingResultRepository | None
+    _custom_rules: CustomRuleRepository | None
+    _sessions: SessionRepository | None
+    _refresh_tokens: RefreshTokenRepository | None
+    _idempotency_keys: IdempotencyRepository | None
+    _mcp_installations: McpInstallationRepository | None
+    _org_facts: OrgFactRepository | None
+    _ontology_entities: OntologyEntityRepository | None
+    _ontology_drift: OntologyDriftReportRepository | None
+
+    @property
+    def backend_name(self) -> NotBlankStr:
+        """Human-readable backend identifier."""
+        return NotBlankStr("sqlite")
+
+    def _require_connected[T](self, repo: T | None, name: str) -> T:
+        """Return *repo* or raise if the backend is not connected.
+
+        Args:
+            repo: Repository instance (``None`` when disconnected).
+            name: Repository name for the error message.
+
+        Raises:
+            PersistenceConnectionError: If *repo* is ``None``.
+        """
+        if repo is None:
+            msg = f"Not connected -- call connect() before accessing {name}"
+            logger.warning(PERSISTENCE_BACKEND_NOT_CONNECTED, error=msg)
+            raise PersistenceConnectionError(msg)
+        return repo
+
+    @property
+    def tasks(self) -> TaskRepository:
+        """Repository for Task persistence."""
+        return self._require_connected(self._tasks, "tasks")
+
+    @property
+    def cost_records(self) -> CostRecordRepository:
+        """Repository for CostRecord persistence."""
+        return self._require_connected(self._cost_records, "cost_records")
+
+    @property
+    def messages(self) -> MessageRepository:
+        """Repository for Message persistence."""
+        return self._require_connected(self._messages, "messages")
+
+    @property
+    def lifecycle_events(self) -> LifecycleEventRepository:
+        """Repository for AgentLifecycleEvent persistence."""
+        return self._require_connected(self._lifecycle_events, "lifecycle_events")
+
+    @property
+    def task_metrics(self) -> TaskMetricRepository:
+        """Repository for TaskMetricRecord persistence."""
+        return self._require_connected(self._task_metrics, "task_metrics")
+
+    @property
+    def collaboration_metrics(self) -> CollaborationMetricRepository:
+        """Repository for CollaborationMetricRecord persistence."""
+        return self._require_connected(
+            self._collaboration_metrics, "collaboration_metrics"
+        )
+
+    @property
+    def parked_contexts(self) -> ParkedContextRepository:
+        """Repository for ParkedContext persistence."""
+        return self._require_connected(self._parked_contexts, "parked_contexts")
+
+    @property
+    def audit_entries(self) -> AuditRepository:
+        """Repository for AuditEntry persistence."""
+        return self._require_connected(self._audit_entries, "audit_entries")
+
+    @property
+    def provider_audit_events(self) -> ProviderAuditRepo:
+        """Repository for the provider mutation audit log."""
+        return self._require_connected(
+            self._provider_audit_events,
+            "provider_audit_events",
+        )
+
+    @property
+    def preset_overrides(self) -> PresetOverrideRepo:
+        """Repository for operator-authored provider preset overrides."""
+        return self._require_connected(
+            self._preset_overrides,
+            "preset_overrides",
+        )
+
+    @property
+    def decision_records(self) -> DecisionRepository:
+        """Repository for DecisionRecord persistence (decisions drop-box)."""
+        return self._require_connected(self._decision_records, "decision_records")
+
+    @property
+    def users(self) -> UserRepository:
+        """Repository for User persistence."""
+        return self._require_connected(self._users, "users")
+
+    @property
+    def api_keys(self) -> ApiKeyRepository:
+        """Repository for ApiKey persistence."""
+        return self._require_connected(self._api_keys, "api_keys")
+
+    @property
+    def checkpoints(self) -> CheckpointRepository:
+        """Repository for Checkpoint persistence."""
+        return self._require_connected(self._checkpoints, "checkpoints")
+
+    @property
+    def heartbeats(self) -> HeartbeatRepository:
+        """Repository for Heartbeat persistence."""
+        return self._require_connected(self._heartbeats, "heartbeats")
+
+    @property
+    def agent_states(self) -> AgentStateRepository:
+        """Repository for AgentRuntimeState persistence."""
+        return self._require_connected(self._agent_states, "agent_states")
+
+    @property
+    def settings(self) -> SettingsRepository:
+        """Repository for namespaced settings persistence."""
+        return self._require_connected(self._settings, "settings")
+
+    @property
+    def artifacts(self) -> ArtifactRepository:
+        """Repository for Artifact persistence."""
+        return self._require_connected(self._artifacts, "artifacts")
+
+    @property
+    def projects(self) -> ProjectRepository:
+        """Repository for Project persistence."""
+        return self._require_connected(self._projects, "projects")
+
+    @property
+    def project_cost_aggregates(self) -> ProjectCostAggregateRepository:
+        """Repository for durable project cost aggregates."""
+        return self._require_connected(
+            self._project_cost_aggregates,
+            "project_cost_aggregates",
+        )
+
+    @property
+    def fine_tune_checkpoints(self) -> FineTuneCheckpointRepository:
+        """Repository for fine-tune checkpoint persistence."""
+        return self._require_connected(
+            self._fine_tune_checkpoints,
+            "fine_tune_checkpoints",
+        )
+
+    @property
+    def fine_tune_runs(self) -> FineTuneRunRepository:
+        """Repository for fine-tune pipeline run persistence."""
+        return self._require_connected(
+            self._fine_tune_runs,
+            "fine_tune_runs",
+        )
+
+    @property
+    def custom_presets(self) -> PersonalityPresetRepository:
+        """Repository for custom personality preset persistence."""
+        return self._require_connected(self._custom_presets, "custom_presets")
+
+    @property
+    def workflow_definitions(self) -> WorkflowDefinitionRepository:
+        """Repository for workflow definition persistence."""
+        return self._require_connected(
+            self._workflow_definitions,
+            "workflow_definitions",
+        )
+
+    @property
+    def workflow_executions(self) -> WorkflowExecutionRepository:
+        """Repository for workflow execution persistence."""
+        return self._require_connected(
+            self._workflow_executions,
+            "workflow_executions",
+        )
+
+    @property
+    def subworkflows(self) -> SubworkflowRepository:
+        """Repository for versioned subworkflow persistence."""
+        return self._require_connected(
+            self._subworkflows,
+            "subworkflows",
+        )
+
+    @property
+    def workflow_versions(self) -> VersionRepository[WorkflowDefinition]:
+        """Repository for workflow definition version persistence."""
+        return self._require_connected(
+            self._workflow_versions,
+            "workflow_versions",
+        )
+
+    @property
+    def identity_versions(self) -> VersionRepository[AgentIdentity]:
+        """Repository for AgentIdentity version snapshot persistence."""
+        return self._require_connected(
+            self._identity_versions,
+            "identity_versions",
+        )
+
+    @property
+    def evaluation_config_versions(
+        self,
+    ) -> VersionRepository[EvaluationConfig]:
+        """Repository for EvaluationConfig version snapshot persistence."""
+        return self._require_connected(
+            self._evaluation_config_versions,
+            "evaluation_config_versions",
+        )
+
+    @property
+    def budget_config_versions(
+        self,
+    ) -> VersionRepository[BudgetConfig]:
+        """Repository for BudgetConfig version snapshot persistence."""
+        return self._require_connected(
+            self._budget_config_versions,
+            "budget_config_versions",
+        )
+
+    @property
+    def company_versions(
+        self,
+    ) -> VersionRepository[Company]:
+        """Repository for Company version snapshot persistence."""
+        return self._require_connected(
+            self._company_versions,
+            "company_versions",
+        )
+
+    @property
+    def role_versions(
+        self,
+    ) -> VersionRepository[Role]:
+        """Repository for Role version snapshot persistence."""
+        return self._require_connected(
+            self._role_versions,
+            "role_versions",
+        )
+
+    @property
+    def risk_overrides(self) -> RiskOverrideRepository:
+        """Repository for risk tier override persistence."""
+        return self._require_connected(
+            self._risk_overrides,
+            "risk_overrides",
+        )
+
+    @property
+    def ssrf_violations(self) -> SsrfViolationRepository:
+        """Repository for SSRF violation record persistence."""
+        return self._require_connected(
+            self._ssrf_violations,
+            "ssrf_violations",
+        )
+
+    @property
+    def circuit_breaker_state(self) -> CircuitBreakerStateRepository:
+        """Repository for circuit breaker state persistence."""
+        return self._require_connected(
+            self._circuit_breaker_state,
+            "circuit_breaker_state",
+        )
+
+    @property
+    def connections(self) -> ConnectionRepository:
+        """Repository for external service connection persistence."""
+        return self._require_connected(self._connections, "connections")
+
+    @property
+    def connection_secrets(self) -> ConnectionSecretRepository:
+        """Repository for encrypted connection secret persistence."""
+        return self._require_connected(
+            self._connection_secrets,
+            "connection_secrets",
+        )
+
+    @property
+    def oauth_states(self) -> OAuthStateRepository:
+        """Repository for transient OAuth state persistence."""
+        return self._require_connected(self._oauth_states, "oauth_states")
+
+    @property
+    def webhook_receipts(self) -> WebhookReceiptRepository:
+        """Repository for webhook receipt log persistence."""
+        return self._require_connected(
+            self._webhook_receipts,
+            "webhook_receipts",
+        )
+
+    @property
+    def training_plans(self) -> TrainingPlanRepository:
+        """Repository for training plan persistence."""
+        return self._require_connected(
+            self._training_plans,
+            "training_plans",
+        )
+
+    @property
+    def training_results(self) -> TrainingResultRepository:
+        """Repository for training result persistence."""
+        return self._require_connected(
+            self._training_results,
+            "training_results",
+        )
+
+    @property
+    def custom_rules(self) -> CustomRuleRepository:
+        """Repository for custom signal rule persistence."""
+        return self._require_connected(
+            self._custom_rules,
+            "custom_rules",
+        )
+
+    @property
+    def sessions(self) -> SessionRepository:
+        """Repository for hybrid session state (durable + in-memory cache)."""
+        return self._require_connected(self._sessions, "sessions")
+
+    @property
+    def refresh_tokens(self) -> RefreshTokenRepository:
+        """Repository for single-use refresh-token rotation."""
+        return self._require_connected(
+            self._refresh_tokens,
+            "refresh_tokens",
+        )
+
+    @property
+    def idempotency_keys(self) -> IdempotencyRepository:
+        """Repository for persistent idempotency keys."""
+        return self._require_connected(
+            self._idempotency_keys,
+            "idempotency_keys",
+        )
+
+    @property
+    def mcp_installations(self) -> McpInstallationRepository:
+        """Repository for MCP catalog installations."""
+        return self._require_connected(
+            self._mcp_installations,
+            "mcp_installations",
+        )
+
+    @property
+    def org_facts(self) -> OrgFactRepository:
+        """Repository for organizational fact persistence (MVCC)."""
+        return self._require_connected(self._org_facts, "org_facts")
+
+    @property
+    def ontology_entities(self) -> OntologyEntityRepository:
+        """Repository for ontology entity definitions."""
+        return self._require_connected(
+            self._ontology_entities,
+            "ontology_entities",
+        )
+
+    @property
+    def ontology_drift(self) -> OntologyDriftReportRepository:
+        """Repository for ontology drift reports."""
+        return self._require_connected(
+            self._ontology_drift,
+            "ontology_drift",
+        )

--- a/src/synthorg/persistence/sqlite/_shared.py
+++ b/src/synthorg/persistence/sqlite/_shared.py
@@ -1,18 +1,27 @@
 """Shared helpers for the SQLite persistence backend."""
 
 import sqlite3
-from collections.abc import Callable
-from contextlib import AbstractAsyncContextManager
+from typing import TYPE_CHECKING, Protocol
 
-WriteContext = Callable[[], AbstractAsyncContextManager[None]]
-"""Factory of a one-shot async context manager that serializes writes.
+if TYPE_CHECKING:
+    from contextlib import AbstractAsyncContextManager
 
-Repositories store one of these and call
-``async with self._write_context()`` around every multi-statement
-transaction. The backend wires its own ``write_context`` bound method,
-so each call returns a fresh CM whose underlying lock is shared across
-every repo on the connection.
-"""
+
+class WriteContext(Protocol):
+    """Factory of a one-shot async context manager that serializes writes.
+
+    Repositories store one of these and call
+    ``async with self._write_context()`` around every multi-statement
+    transaction. The backend wires its own ``write_context`` bound method
+    as the factory, so each call returns a fresh context manager whose
+    underlying lock is shared across every repo on the connection.
+
+    Modelled as a ``Protocol`` (rather than ``Callable[[], CM[None]]``)
+    so the name carries the intent (serializing-writes factory) at the
+    type level, not just the shape.
+    """
+
+    def __call__(self) -> AbstractAsyncContextManager[None]: ...
 
 
 def is_unique_constraint_error(exc: BaseException) -> bool:

--- a/src/synthorg/persistence/sqlite/_shared.py
+++ b/src/synthorg/persistence/sqlite/_shared.py
@@ -1,6 +1,18 @@
 """Shared helpers for the SQLite persistence backend."""
 
 import sqlite3
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+
+WriteContext = Callable[[], AbstractAsyncContextManager[None]]
+"""Factory of a one-shot async context manager that serializes writes.
+
+Repositories store one of these and call
+``async with self._write_context()`` around every multi-statement
+transaction. The backend wires its own ``write_context`` bound method,
+so each call returns a fresh CM whose underlying lock is shared across
+every repo on the connection.
+"""
 
 
 def is_unique_constraint_error(exc: BaseException) -> bool:

--- a/src/synthorg/persistence/sqlite/agent_state_repo.py
+++ b/src/synthorg/persistence/sqlite/agent_state_repo.py
@@ -31,6 +31,12 @@ class SQLiteAgentStateRepository:
 
     Args:
         db: An open aiosqlite connection.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(

--- a/src/synthorg/persistence/sqlite/agent_state_repo.py
+++ b/src/synthorg/persistence/sqlite/agent_state_repo.py
@@ -1,6 +1,5 @@
 """SQLite repository implementation for agent runtime state persistence."""
 
-import asyncio
 import contextlib
 import sqlite3
 
@@ -22,6 +21,7 @@ from synthorg.observability.events.persistence import (
     PERSISTENCE_AGENT_STATE_NOT_FOUND,
     PERSISTENCE_AGENT_STATE_SAVE_FAILED,
 )
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -37,18 +37,14 @@ class SQLiteAgentStateRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, state: AgentRuntimeState) -> None:
         """Persist an agent runtime state (upsert by agent_id)."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 data = state.model_dump(mode="json")
                 await self._db.execute(
@@ -141,7 +137,7 @@ INSERT OR REPLACE INTO agent_states (
 
     async def delete(self, agent_id: NotBlankStr) -> bool:
         """Delete an agent runtime state by agent ID."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM agent_states WHERE agent_id = ?",

--- a/src/synthorg/persistence/sqlite/approval_repo.py
+++ b/src/synthorg/persistence/sqlite/approval_repo.py
@@ -1,6 +1,5 @@
 """SQLite repository implementation for approval items."""
 
-import asyncio
 import json
 import sqlite3
 from typing import TYPE_CHECKING
@@ -28,6 +27,7 @@ from synthorg.persistence._shared import (
     coerce_row_timestamp,
     format_iso_utc,
 )
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -172,21 +172,23 @@ class SQLiteApprovalRepository:
 
     Args:
         db: An open aiosqlite connection.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
         self._db.row_factory = aiosqlite.Row
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, item: ApprovalItem) -> None:
         """Upsert an approval item.
@@ -220,7 +222,7 @@ class SQLiteApprovalRepository:
             evidence_json,
             json.dumps(item.metadata),
         )
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(_APPROVALS_UPSERT_SQL, params)
                 await self._db.commit()
@@ -286,7 +288,7 @@ class SQLiteApprovalRepository:
                     json.dumps(item.metadata),
                 ),
             )
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.executemany(_APPROVALS_UPSERT_SQL, param_rows)
                 await self._db.commit()
@@ -337,7 +339,7 @@ class SQLiteApprovalRepository:
             "RETURNING id"
         )
         params = (ApprovalStatus.EXPIRED.value, *ids, ApprovalStatus.PENDING.value)
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 async with self._db.execute(sql, params) as cursor:
                     rows = await cursor.fetchall()
@@ -537,7 +539,7 @@ class SQLiteApprovalRepository:
             QueryError: If the database operation fails.
         """
         sql = "DELETE FROM approvals WHERE id = ?"
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(sql, (approval_id,))
                 await self._db.commit()

--- a/src/synthorg/persistence/sqlite/artifact_repo.py
+++ b/src/synthorg/persistence/sqlite/artifact_repo.py
@@ -58,6 +58,12 @@ class SQLiteArtifactRepository:
     Args:
         db: An open aiosqlite connection with ``row_factory``
             set to ``aiosqlite.Row``.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(

--- a/src/synthorg/persistence/sqlite/artifact_repo.py
+++ b/src/synthorg/persistence/sqlite/artifact_repo.py
@@ -1,6 +1,5 @@
 """SQLite repository implementation for Artifact."""
 
-import asyncio
 import sqlite3
 from datetime import UTC, datetime
 
@@ -22,6 +21,7 @@ from synthorg.observability.events.persistence import (
     PERSISTENCE_ARTIFACT_SAVE_FAILED,
 )
 from synthorg.persistence._shared import DEFAULT_LIST_LIMIT
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -64,22 +64,10 @@ class SQLiteArtifactRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Serialise write transactions on the shared
-        # ``aiosqlite.Connection`` -- without this lock, concurrent
-        # writes from this repo or any *sibling* repo that shares the
-        # same connection can interleave their ``execute`` + ``commit``
-        # calls inside the same connection-scoped transaction context,
-        # breaking atomicity (one commit / rollback affects the other's
-        # writes).  Inject the shared
-        # ``SQLitePersistenceBackend._shared_write_lock`` so every repo
-        # talking to the same connection serializes through one lock;
-        # fall back to a private lock when constructed standalone (e.g.
-        # in unit tests that build a single repo against an in-memory
-        # connection).
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def _safe_rollback(
         self,
@@ -164,7 +152,7 @@ class SQLiteArtifactRepository:
             created_at_iso,
             artifact.project_id,
         )
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 insert_cursor = await self._db.execute(
                     """\
@@ -354,7 +342,7 @@ WHERE id=?""",
         Raises:
             QueryError: If the database operation fails.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM artifacts WHERE id = ?", (artifact_id,)

--- a/src/synthorg/persistence/sqlite/audit_repository.py
+++ b/src/synthorg/persistence/sqlite/audit_repository.py
@@ -1,6 +1,5 @@
 """SQLite repository implementation for security audit entries."""
 
-import asyncio
 import json
 import sqlite3
 from datetime import UTC
@@ -29,7 +28,10 @@ if TYPE_CHECKING:
     from synthorg.security.models import AuditEntry, AuditVerdictStr
 
 from synthorg.persistence._shared import DEFAULT_LIST_LIMIT
-from synthorg.persistence.sqlite._shared import is_unique_constraint_error
+from synthorg.persistence.sqlite._shared import (
+    WriteContext,
+    is_unique_constraint_error,
+)
 
 logger = get_logger(__name__)
 
@@ -47,20 +49,22 @@ class SQLiteAuditRepository:
 
     Args:
         db: An open aiosqlite connection.
+        write_context: Async context manager that serializes writes on
+            the shared ``aiosqlite.Connection``. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, entry: AuditEntry) -> None:
         """Persist an audit entry (append-only, no upsert).
@@ -79,7 +83,7 @@ class SQLiteAuditRepository:
         )
         placeholders = ", ".join(f":{c}" for c in AUDIT_COLUMNS)
         sql = f"INSERT INTO audit_entries ({_COL_LIST}) VALUES ({placeholders})"  # noqa: S608
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(sql, payload)
                 await self._db.commit()
@@ -277,7 +281,7 @@ class SQLiteAuditRepository:
             QueryError: If the DELETE fails.
         """
         utc_cutoff = cutoff.astimezone(UTC).isoformat()
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM audit_entries WHERE timestamp < ?",

--- a/src/synthorg/persistence/sqlite/backend.py
+++ b/src/synthorg/persistence/sqlite/backend.py
@@ -33,6 +33,9 @@ from synthorg.observability.events.persistence import (
     PERSISTENCE_BACKEND_WAL_MODE_FAILED,
 )
 from synthorg.persistence import migrations
+from synthorg.persistence.sqlite._backend_accessors import (
+    _BackendRepositoryAccessors,
+)
 from synthorg.persistence.sqlite.agent_state_repo import (
     SQLiteAgentStateRepository,
 )
@@ -153,90 +156,17 @@ from synthorg.persistence.sqlite.workflow_execution_repo import (
 
 if TYPE_CHECKING:
     from synthorg.core.auth.config import AuthConfig
-    from synthorg.hr.persistence_protocol import (
-        CollaborationMetricRepository,
-        LifecycleEventRepository,
-        TaskMetricRepository,
-    )
     from synthorg.ontology.models import EntityDefinition
-    from synthorg.persistence.agent_state_protocol import AgentStateRepository
-    from synthorg.persistence.artifact_protocol import ArtifactRepository
-    from synthorg.persistence.audit_protocol import AuditRepository
-    from synthorg.persistence.auth_protocol import (
-        LockoutRepository,
-        RefreshTokenRepository,
-        SessionRepository,
-    )
-    from synthorg.persistence.checkpoint_protocol import (
-        CheckpointRepository,
-        HeartbeatRepository,
-    )
-    from synthorg.persistence.circuit_breaker_protocol import (
-        CircuitBreakerStateRepository,
-    )
+    from synthorg.persistence.auth_protocol import LockoutRepository
     from synthorg.persistence.config import SQLiteConfig
-    from synthorg.persistence.connection_protocol import (
-        ConnectionRepository,
-        ConnectionSecretRepository,
-        OAuthStateRepository,
-        WebhookReceiptRepository,
-    )
-    from synthorg.persistence.cost_record_protocol import CostRecordRepository
-    from synthorg.persistence.custom_rule_protocol import CustomRuleRepository
-    from synthorg.persistence.decision_protocol import DecisionRepository
     from synthorg.persistence.escalation_protocol import EscalationQueueRepository
-    from synthorg.persistence.fine_tune_protocol import (
-        FineTuneCheckpointRepository,
-        FineTuneRunRepository,
-    )
-    from synthorg.persistence.idempotency_protocol import IdempotencyRepository
-    from synthorg.persistence.mcp_protocol import McpInstallationRepository
-    from synthorg.persistence.memory_protocol import OrgFactRepository
-    from synthorg.persistence.message_protocol import MessageRepository
-    from synthorg.persistence.ontology_protocol import (
-        OntologyDriftReportRepository,
-        OntologyEntityRepository,
-    )
-    from synthorg.persistence.parked_context_protocol import (
-        ParkedContextRepository,
-    )
-    from synthorg.persistence.preset_override_protocol import PresetOverrideRepo
-    from synthorg.persistence.preset_protocol import (
-        PersonalityPresetRepository,
-    )
-    from synthorg.persistence.project_cost_aggregate_protocol import (
-        ProjectCostAggregateRepository,
-    )
-    from synthorg.persistence.project_protocol import ProjectRepository
-    from synthorg.persistence.provider_audit_protocol import ProviderAuditRepo
-    from synthorg.persistence.risk_override_protocol import RiskOverrideRepository
-    from synthorg.persistence.settings_protocol import SettingsRepository
-    from synthorg.persistence.ssrf_violation_protocol import (
-        SsrfViolationRepository,
-    )
-    from synthorg.persistence.subworkflow_protocol import SubworkflowRepository
-    from synthorg.persistence.task_protocol import TaskRepository
-    from synthorg.persistence.training_protocol import (
-        TrainingPlanRepository,
-        TrainingResultRepository,
-    )
-    from synthorg.persistence.user_protocol import (
-        ApiKeyRepository,
-        UserRepository,
-    )
     from synthorg.persistence.version_protocol import VersionRepository
-    from synthorg.persistence.workflow_definition_protocol import (
-        WorkflowDefinitionRepository,
-    )
-    from synthorg.persistence.workflow_execution_protocol import (
-        WorkflowExecutionRepository,
-    )
     from synthorg.versioning.service import VersioningService
 
 logger = get_logger(__name__)
 
 
-class SQLitePersistenceBackend:
+class SQLitePersistenceBackend(_BackendRepositoryAccessors):
     """SQLite implementation of the PersistenceBackend protocol.
 
     Uses a single ``aiosqlite.Connection`` with WAL mode enabled by
@@ -291,8 +221,8 @@ class SQLitePersistenceBackend:
         self._project_cost_aggregates: SQLiteProjectCostAggregateRepository | None = (
             None
         )
-        self._fine_tune_checkpoints: FineTuneCheckpointRepository | None = None
-        self._fine_tune_runs: FineTuneRunRepository | None = None
+        self._fine_tune_checkpoints: SQLiteFineTuneCheckpointRepository | None = None
+        self._fine_tune_runs: SQLiteFineTuneRunRepository | None = None
         self._training_plans: SQLiteTrainingPlanRepository | None = None
         self._training_results: SQLiteTrainingResultRepository | None = None
         self._custom_rules: SQLiteCustomRuleRepository | None = None
@@ -766,363 +696,6 @@ class SQLitePersistenceBackend:
         """Whether the backend has an active connection."""
         return self._db is not None
 
-    @property
-    def backend_name(self) -> NotBlankStr:
-        """Human-readable backend identifier."""
-        return NotBlankStr("sqlite")
-
-    def _require_connected[T](self, repo: T | None, name: str) -> T:
-        """Return *repo* or raise if the backend is not connected.
-
-        Args:
-            repo: Repository instance (``None`` when disconnected).
-            name: Repository name for the error message.
-
-        Raises:
-            PersistenceConnectionError: If *repo* is ``None``.
-        """
-        if repo is None:
-            msg = f"Not connected -- call connect() before accessing {name}"
-            logger.warning(PERSISTENCE_BACKEND_NOT_CONNECTED, error=msg)
-            raise PersistenceConnectionError(msg)
-        return repo
-
-    @property
-    def tasks(self) -> TaskRepository:
-        """Repository for Task persistence."""
-        return self._require_connected(self._tasks, "tasks")
-
-    @property
-    def cost_records(self) -> CostRecordRepository:
-        """Repository for CostRecord persistence."""
-        return self._require_connected(self._cost_records, "cost_records")
-
-    @property
-    def messages(self) -> MessageRepository:
-        """Repository for Message persistence."""
-        return self._require_connected(self._messages, "messages")
-
-    @property
-    def lifecycle_events(self) -> LifecycleEventRepository:
-        """Repository for AgentLifecycleEvent persistence."""
-        return self._require_connected(self._lifecycle_events, "lifecycle_events")
-
-    @property
-    def task_metrics(self) -> TaskMetricRepository:
-        """Repository for TaskMetricRecord persistence."""
-        return self._require_connected(self._task_metrics, "task_metrics")
-
-    @property
-    def collaboration_metrics(self) -> CollaborationMetricRepository:
-        """Repository for CollaborationMetricRecord persistence."""
-        return self._require_connected(
-            self._collaboration_metrics, "collaboration_metrics"
-        )
-
-    @property
-    def parked_contexts(self) -> ParkedContextRepository:
-        """Repository for ParkedContext persistence."""
-        return self._require_connected(self._parked_contexts, "parked_contexts")
-
-    @property
-    def audit_entries(self) -> AuditRepository:
-        """Repository for AuditEntry persistence."""
-        return self._require_connected(self._audit_entries, "audit_entries")
-
-    @property
-    def provider_audit_events(self) -> ProviderAuditRepo:
-        """Repository for the provider mutation audit log."""
-        return self._require_connected(
-            self._provider_audit_events,
-            "provider_audit_events",
-        )
-
-    @property
-    def preset_overrides(self) -> PresetOverrideRepo:
-        """Repository for operator-authored provider preset overrides."""
-        return self._require_connected(
-            self._preset_overrides,
-            "preset_overrides",
-        )
-
-    @property
-    def decision_records(self) -> DecisionRepository:
-        """Repository for DecisionRecord persistence (decisions drop-box)."""
-        return self._require_connected(self._decision_records, "decision_records")
-
-    @property
-    def users(self) -> UserRepository:
-        """Repository for User persistence."""
-        return self._require_connected(self._users, "users")
-
-    @property
-    def api_keys(self) -> ApiKeyRepository:
-        """Repository for ApiKey persistence."""
-        return self._require_connected(self._api_keys, "api_keys")
-
-    @property
-    def checkpoints(self) -> CheckpointRepository:
-        """Repository for Checkpoint persistence."""
-        return self._require_connected(self._checkpoints, "checkpoints")
-
-    @property
-    def heartbeats(self) -> HeartbeatRepository:
-        """Repository for Heartbeat persistence."""
-        return self._require_connected(self._heartbeats, "heartbeats")
-
-    @property
-    def agent_states(self) -> AgentStateRepository:
-        """Repository for AgentRuntimeState persistence."""
-        return self._require_connected(self._agent_states, "agent_states")
-
-    @property
-    def settings(self) -> SettingsRepository:
-        """Repository for namespaced settings persistence."""
-        return self._require_connected(self._settings, "settings")
-
-    @property
-    def artifacts(self) -> ArtifactRepository:
-        """Repository for Artifact persistence."""
-        return self._require_connected(self._artifacts, "artifacts")
-
-    @property
-    def projects(self) -> ProjectRepository:
-        """Repository for Project persistence."""
-        return self._require_connected(self._projects, "projects")
-
-    @property
-    def project_cost_aggregates(self) -> ProjectCostAggregateRepository:
-        """Repository for durable project cost aggregates."""
-        return self._require_connected(
-            self._project_cost_aggregates,
-            "project_cost_aggregates",
-        )
-
-    @property
-    def fine_tune_checkpoints(self) -> FineTuneCheckpointRepository:
-        """Repository for fine-tune checkpoint persistence."""
-        return self._require_connected(
-            self._fine_tune_checkpoints,
-            "fine_tune_checkpoints",
-        )
-
-    @property
-    def fine_tune_runs(self) -> FineTuneRunRepository:
-        """Repository for fine-tune pipeline run persistence."""
-        return self._require_connected(
-            self._fine_tune_runs,
-            "fine_tune_runs",
-        )
-
-    @property
-    def custom_presets(self) -> PersonalityPresetRepository:
-        """Repository for custom personality preset persistence."""
-        return self._require_connected(self._custom_presets, "custom_presets")
-
-    @property
-    def workflow_definitions(self) -> WorkflowDefinitionRepository:
-        """Repository for workflow definition persistence."""
-        return self._require_connected(
-            self._workflow_definitions,
-            "workflow_definitions",
-        )
-
-    @property
-    def workflow_executions(self) -> WorkflowExecutionRepository:
-        """Repository for workflow execution persistence."""
-        return self._require_connected(
-            self._workflow_executions,
-            "workflow_executions",
-        )
-
-    @property
-    def subworkflows(self) -> SubworkflowRepository:
-        """Repository for versioned subworkflow persistence."""
-        return self._require_connected(
-            self._subworkflows,
-            "subworkflows",
-        )
-
-    @property
-    def workflow_versions(self) -> VersionRepository[WorkflowDefinition]:
-        """Repository for workflow definition version persistence."""
-        return self._require_connected(
-            self._workflow_versions,
-            "workflow_versions",
-        )
-
-    @property
-    def identity_versions(self) -> VersionRepository[AgentIdentity]:
-        """Repository for AgentIdentity version snapshot persistence."""
-        return self._require_connected(
-            self._identity_versions,
-            "identity_versions",
-        )
-
-    @property
-    def evaluation_config_versions(
-        self,
-    ) -> VersionRepository[EvaluationConfig]:
-        """Repository for EvaluationConfig version snapshot persistence."""
-        return self._require_connected(
-            self._evaluation_config_versions,
-            "evaluation_config_versions",
-        )
-
-    @property
-    def budget_config_versions(
-        self,
-    ) -> VersionRepository[BudgetConfig]:
-        """Repository for BudgetConfig version snapshot persistence."""
-        return self._require_connected(
-            self._budget_config_versions,
-            "budget_config_versions",
-        )
-
-    @property
-    def company_versions(
-        self,
-    ) -> VersionRepository[Company]:
-        """Repository for Company version snapshot persistence."""
-        return self._require_connected(
-            self._company_versions,
-            "company_versions",
-        )
-
-    @property
-    def role_versions(
-        self,
-    ) -> VersionRepository[Role]:
-        """Repository for Role version snapshot persistence."""
-        return self._require_connected(
-            self._role_versions,
-            "role_versions",
-        )
-
-    @property
-    def risk_overrides(self) -> RiskOverrideRepository:
-        """Repository for risk tier override persistence."""
-        return self._require_connected(
-            self._risk_overrides,
-            "risk_overrides",
-        )
-
-    @property
-    def ssrf_violations(self) -> SsrfViolationRepository:
-        """Repository for SSRF violation record persistence."""
-        return self._require_connected(
-            self._ssrf_violations,
-            "ssrf_violations",
-        )
-
-    @property
-    def circuit_breaker_state(self) -> CircuitBreakerStateRepository:
-        """Repository for circuit breaker state persistence."""
-        return self._require_connected(
-            self._circuit_breaker_state,
-            "circuit_breaker_state",
-        )
-
-    @property
-    def connections(self) -> ConnectionRepository:
-        """Repository for external service connection persistence."""
-        return self._require_connected(self._connections, "connections")
-
-    @property
-    def connection_secrets(self) -> ConnectionSecretRepository:
-        """Repository for encrypted connection secret persistence."""
-        return self._require_connected(
-            self._connection_secrets,
-            "connection_secrets",
-        )
-
-    @property
-    def oauth_states(self) -> OAuthStateRepository:
-        """Repository for transient OAuth state persistence."""
-        return self._require_connected(self._oauth_states, "oauth_states")
-
-    @property
-    def webhook_receipts(self) -> WebhookReceiptRepository:
-        """Repository for webhook receipt log persistence."""
-        return self._require_connected(
-            self._webhook_receipts,
-            "webhook_receipts",
-        )
-
-    @property
-    def training_plans(self) -> TrainingPlanRepository:
-        """Repository for training plan persistence."""
-        return self._require_connected(
-            self._training_plans,
-            "training_plans",
-        )
-
-    @property
-    def training_results(self) -> TrainingResultRepository:
-        """Repository for training result persistence."""
-        return self._require_connected(
-            self._training_results,
-            "training_results",
-        )
-
-    @property
-    def custom_rules(self) -> CustomRuleRepository:
-        """Repository for custom signal rule persistence."""
-        return self._require_connected(
-            self._custom_rules,
-            "custom_rules",
-        )
-
-    @property
-    def sessions(self) -> SessionRepository:
-        """Repository for hybrid session state (durable + in-memory cache)."""
-        return self._require_connected(self._sessions, "sessions")
-
-    @property
-    def refresh_tokens(self) -> RefreshTokenRepository:
-        """Repository for single-use refresh-token rotation."""
-        return self._require_connected(
-            self._refresh_tokens,
-            "refresh_tokens",
-        )
-
-    @property
-    def idempotency_keys(self) -> IdempotencyRepository:
-        """Repository for persistent idempotency keys."""
-        return self._require_connected(
-            self._idempotency_keys,
-            "idempotency_keys",
-        )
-
-    @property
-    def mcp_installations(self) -> McpInstallationRepository:
-        """Repository for MCP catalog installations."""
-        return self._require_connected(
-            self._mcp_installations,
-            "mcp_installations",
-        )
-
-    @property
-    def org_facts(self) -> OrgFactRepository:
-        """Repository for organizational fact persistence (MVCC)."""
-        return self._require_connected(self._org_facts, "org_facts")
-
-    @property
-    def ontology_entities(self) -> OntologyEntityRepository:
-        """Repository for ontology entity definitions."""
-        return self._require_connected(
-            self._ontology_entities,
-            "ontology_entities",
-        )
-
-    @property
-    def ontology_drift(self) -> OntologyDriftReportRepository:
-        """Repository for ontology drift reports."""
-        return self._require_connected(
-            self._ontology_drift,
-            "ontology_drift",
-        )
-
     def build_lockouts(self, auth_config: AuthConfig) -> LockoutRepository:
         """Return the cached lockout repository (built once per connection).
 
@@ -1152,8 +725,7 @@ class SQLitePersistenceBackend:
         ``notify_channel`` is ignored by SQLite (no cross-instance
         NOTIFY/LISTEN). The backend's ``write_context`` is passed
         through so escalation transactions serialize with other
-        repositories writing to the same aiosqlite connection
-        (previously omitted; escalations silently isolated).
+        repositories writing to the same aiosqlite connection.
         """
         from synthorg.persistence.sqlite.escalation_repo import (  # noqa: PLC0415
             SQLiteEscalationRepository,

--- a/src/synthorg/persistence/sqlite/backend.py
+++ b/src/synthorg/persistence/sqlite/backend.py
@@ -3,6 +3,8 @@
 import asyncio
 import json
 import sqlite3
+from collections.abc import AsyncIterator  # noqa: TC003
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -248,9 +250,9 @@ class SQLitePersistenceBackend:
     def __init__(self, config: SQLiteConfig) -> None:  # noqa: PLR0915 -- repo registry setup intentionally enumerates every attribute
         self._config = config
         self._lifecycle_lock = asyncio.Lock()
-        # Shared write lock for multi-statement transactions on the
-        # single aiosqlite connection.
-        self._shared_write_lock = asyncio.Lock()
+        # Serializes multi-statement transactions on the single
+        # aiosqlite connection. Exposed to repos via ``write_context``.
+        self._write_lock = asyncio.Lock()
         self._db: aiosqlite.Connection | None = None
         self._artifacts: SQLiteArtifactRepository | None = None
         self._projects: SQLiteProjectRepository | None = None
@@ -425,96 +427,109 @@ class SQLitePersistenceBackend:
             raise PersistenceConnectionError(msg)
         return self._db
 
+    @asynccontextmanager
+    async def write_context(self) -> AsyncIterator[None]:
+        """Acquire the shared write lock for the lifetime of the block.
+
+        Multi-statement transactions on the single ``aiosqlite.Connection``
+        must serialize so a sibling repo's INSERT cannot interleave
+        between this repo's INSERT and COMMIT. See
+        ``PersistenceBackend.write_context`` for the cross-backend
+        contract.
+        """
+        async with self._write_lock:
+            yield
+
     def _create_repositories(self) -> None:  # noqa: PLR0915
         """Instantiate all repository objects from the active connection."""
         assert self._db is not None  # noqa: S101
         self._artifacts = SQLiteArtifactRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._projects = SQLiteProjectRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._tasks = SQLiteTaskRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._cost_records = SQLiteCostRecordRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._messages = SQLiteMessageRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._lifecycle_events = SQLiteLifecycleEventRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._task_metrics = SQLiteTaskMetricRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._collaboration_metrics = SQLiteCollaborationMetricRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._parked_contexts = SQLiteParkedContextRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._audit_entries = SQLiteAuditRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._provider_audit_events = SQLiteProviderAuditRepo(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._preset_overrides = SQLitePresetOverrideRepo(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._users = SQLiteUserRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._api_keys = SQLiteApiKeyRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._checkpoints = SQLiteCheckpointRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._heartbeats = SQLiteHeartbeatRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._agent_states = SQLiteAgentStateRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._settings = SQLiteSettingsRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._custom_presets = SQLitePersonalityPresetRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._workflow_definitions = SQLiteWorkflowDefinitionRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._workflow_executions = SQLiteWorkflowExecutionRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._subworkflows = SQLiteSubworkflowRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
 
         def _ver_repo[T: BaseModel](
@@ -531,7 +546,7 @@ class SQLitePersistenceBackend:
                 deserialize_snapshot=lambda s: model_cls.model_validate(
                     json.loads(s),
                 ),
-                write_lock=self._shared_write_lock,
+                write_context=self.write_context,
             )
 
         self._workflow_versions = _ver_repo(
@@ -559,87 +574,87 @@ class SQLitePersistenceBackend:
             Role,
         )
         self._decision_records = SQLiteDecisionRepository(
-            self._db, write_lock=self._shared_write_lock
+            self._db, write_context=self.write_context
         )
         self._risk_overrides = SQLiteRiskOverrideRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._ssrf_violations = SQLiteSsrfViolationRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._circuit_breaker_state = SQLiteCircuitBreakerStateRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._project_cost_aggregates = SQLiteProjectCostAggregateRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._fine_tune_checkpoints = SQLiteFineTuneCheckpointRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._fine_tune_runs = SQLiteFineTuneRunRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._training_plans = SQLiteTrainingPlanRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._training_results = SQLiteTrainingResultRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._custom_rules = SQLiteCustomRuleRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._sessions = SQLiteSessionRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._refresh_tokens = SQLiteRefreshTokenRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._idempotency_keys = SQLiteIdempotencyRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._mcp_installations = SQLiteMcpInstallationRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._org_facts = SQLiteOrgFactRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._ontology_entities = SQLiteOntologyEntityRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._ontology_drift = SQLiteOntologyDriftReportRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._connections = SQLiteConnectionRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._connection_secrets = SQLiteConnectionSecretRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._oauth_states = SQLiteOAuthStateRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
         self._webhook_receipts = SQLiteWebhookReceiptRepository(
             self._db,
-            write_lock=self._shared_write_lock,
+            write_context=self.write_context,
         )
 
     async def _cleanup_failed_connect(self, exc: sqlite3.Error | OSError) -> None:
@@ -1115,15 +1130,15 @@ class SQLitePersistenceBackend:
         (``_locked``) on the auth hot path.  Returning a fresh instance
         on every call would reset that cache and silently "unlock"
         every user.  The cache is cleared on ``disconnect`` via
-        ``_clear_state``.  The shared write lock is passed through so
-        lockout transactions serialize with other repositories writing
-        to the same aiosqlite connection.
+        ``_clear_state``.  The backend's ``write_context`` is passed
+        through so lockout transactions serialize with other
+        repositories writing to the same aiosqlite connection.
         """
         if self._lockouts is None:
             self._lockouts = SQLiteLockoutRepository(
                 self.get_db(),
                 auth_config,
-                write_lock=self._shared_write_lock,
+                write_context=self.write_context,
             )
         return self._lockouts
 
@@ -1135,14 +1150,17 @@ class SQLitePersistenceBackend:
         """Construct an escalation queue repository.
 
         ``notify_channel`` is ignored by SQLite (no cross-instance
-        NOTIFY/LISTEN).
+        NOTIFY/LISTEN). The backend's ``write_context`` is passed
+        through so escalation transactions serialize with other
+        repositories writing to the same aiosqlite connection
+        (previously omitted; escalations silently isolated).
         """
         from synthorg.persistence.sqlite.escalation_repo import (  # noqa: PLC0415
             SQLiteEscalationRepository,
         )
 
         db = self.get_db()
-        return SQLiteEscalationRepository(db)
+        return SQLiteEscalationRepository(db, write_context=self.write_context)
 
     def build_ontology_versioning(
         self,
@@ -1152,7 +1170,10 @@ class SQLitePersistenceBackend:
             create_ontology_versioning,
         )
 
-        return create_ontology_versioning(self.get_db())
+        return create_ontology_versioning(
+            self.get_db(),
+            write_context=self.write_context,
+        )
 
     async def get_setting(self, key: NotBlankStr) -> str | None:
         """Retrieve a setting value by key from the ``_system`` namespace.

--- a/src/synthorg/persistence/sqlite/checkpoint_repo.py
+++ b/src/synthorg/persistence/sqlite/checkpoint_repo.py
@@ -29,6 +29,12 @@ class SQLiteCheckpointRepository:
 
     Args:
         db: An open aiosqlite connection.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(

--- a/src/synthorg/persistence/sqlite/checkpoint_repo.py
+++ b/src/synthorg/persistence/sqlite/checkpoint_repo.py
@@ -1,7 +1,6 @@
 """SQLite repository implementation for checkpoint persistence."""
 # ruff: noqa: S608 -- dynamic WHERE built from hardcoded column names only
 
-import asyncio
 import contextlib
 import sqlite3
 
@@ -20,6 +19,7 @@ from synthorg.observability.events.persistence import (
     PERSISTENCE_CHECKPOINT_QUERY_FAILED,
     PERSISTENCE_CHECKPOINT_SAVE_FAILED,
 )
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -35,18 +35,14 @@ class SQLiteCheckpointRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, checkpoint: Checkpoint) -> None:
         """Persist a checkpoint (upsert)."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 data = checkpoint.model_dump(mode="json")
                 await self._db.execute(
@@ -145,7 +141,7 @@ INSERT OR REPLACE INTO checkpoints (
 
     async def delete_by_execution(self, execution_id: NotBlankStr) -> int:
         """Delete all checkpoints for an execution."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM checkpoints WHERE execution_id = ?",

--- a/src/synthorg/persistence/sqlite/circuit_breaker_repo.py
+++ b/src/synthorg/persistence/sqlite/circuit_breaker_repo.py
@@ -1,6 +1,5 @@
 """SQLite repository for circuit breaker state persistence."""
 
-import asyncio
 import sqlite3
 
 import aiosqlite
@@ -17,6 +16,7 @@ from synthorg.observability.events.persistence import (
 from synthorg.persistence.circuit_breaker_protocol import (
     CircuitBreakerStateRecord,
 )
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -26,18 +26,22 @@ class SQLiteCircuitBreakerStateRepository:
 
     Args:
         db: An open aiosqlite connection.
-        write_lock: Optional shared write lock to serialize writes
-            across repositories on the same connection.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def _rollback_quietly(self, event: str) -> None:
         """Roll back the current transaction, swallowing errors."""
@@ -53,7 +57,7 @@ class SQLiteCircuitBreakerStateRepository:
 
     async def save(self, record: CircuitBreakerStateRecord) -> None:
         """Persist a circuit breaker state record (upsert by pair key)."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     """\
@@ -126,7 +130,7 @@ INSERT OR REPLACE INTO circuit_breaker_state (
 
     async def delete(self, pair_key_a: str, pair_key_b: str) -> bool:
         """Delete a circuit breaker state record."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM circuit_breaker_state "

--- a/src/synthorg/persistence/sqlite/connection_repo.py
+++ b/src/synthorg/persistence/sqlite/connection_repo.py
@@ -10,7 +10,6 @@ per the persistence-boundary rule documented in
 ``docs/reference/persistence-boundary.md``.
 """
 
-import asyncio
 import contextlib
 import json
 import sqlite3
@@ -41,6 +40,7 @@ from synthorg.persistence._shared import (
     coerce_row_timestamp,
     format_iso_utc,
 )
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -112,11 +112,11 @@ class SQLiteConnectionRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
-        """Bind to *db* and serialize writes via *write_lock*."""
+        """Bind to *db* and serialize writes via *write_context*."""
         self._db = db
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, connection: Connection) -> None:
         """Upsert a connection row keyed by ``name``."""
@@ -141,7 +141,7 @@ class SQLiteConnectionRepository:
             if connection.last_health_check_at is not None
             else None
         )
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     """
@@ -312,7 +312,7 @@ class SQLiteConnectionRepository:
 
     async def delete(self, name: NotBlankStr) -> bool:
         """Delete a connection by name; return ``True`` if a row was removed."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM connections WHERE name = ?",

--- a/src/synthorg/persistence/sqlite/connection_secret_repo.py
+++ b/src/synthorg/persistence/sqlite/connection_secret_repo.py
@@ -6,7 +6,6 @@ encrypts or decrypts -- callers pass already-encrypted bytes in and
 receive the same bytes back unchanged.
 """
 
-import asyncio
 import contextlib
 import sqlite3
 from datetime import UTC, datetime
@@ -22,6 +21,7 @@ from synthorg.observability.events.persistence import (
     PERSISTENCE_CONNECTION_SECRET_STORE_FAILED,
 )
 from synthorg.persistence._shared import format_iso_utc
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 if TYPE_CHECKING:
     from synthorg.core.types import NotBlankStr
@@ -36,11 +36,11 @@ class SQLiteConnectionSecretRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
-        """Bind to *db* and serialize writes via *write_lock*."""
+        """Bind to *db* and serialize writes via *write_context*."""
         self._db = db
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def store(
         self,
@@ -54,7 +54,7 @@ class SQLiteConnectionSecretRepository:
         at the secret-backend layer above.
         """
         now_iso = format_iso_utc(datetime.now(UTC))
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     """
@@ -106,7 +106,7 @@ class SQLiteConnectionSecretRepository:
 
     async def delete(self, secret_id: NotBlankStr) -> bool:
         """Delete an encrypted secret; return ``True`` if a row was removed."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM connection_secrets WHERE secret_id = ?",

--- a/src/synthorg/persistence/sqlite/custom_rule_repo.py
+++ b/src/synthorg/persistence/sqlite/custom_rule_repo.py
@@ -1,6 +1,5 @@
 """SQLite repository implementation for custom signal rules."""
 
-import asyncio
 import json
 import sqlite3
 from typing import TYPE_CHECKING
@@ -31,6 +30,7 @@ from synthorg.persistence._shared.pagination import (
     DEFAULT_LIST_LIMIT,
     validate_pagination_args,
 )
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 if TYPE_CHECKING:
     from aiosqlite import Row
@@ -95,27 +95,22 @@ class SQLiteCustomRuleRepository:
 
     Args:
         db: An open aiosqlite connection.
-        write_lock: Optional shared lock used to serialize writes on
-            the shared connection.  Inject the
-            :class:`SQLitePersistenceBackend._shared_write_lock` so
-            writes from this repo coordinate with sibling repos that
-            share the same connection.  Defaults to ``None``, in
-            which case the repo creates a private :class:`asyncio.Lock`
-            (suitable for standalone test construction).
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, rule: CustomRuleDefinition) -> None:
         """Persist a custom rule via upsert.
@@ -129,7 +124,7 @@ class SQLiteCustomRuleRepository:
             QueryError: If the database operation fails.
         """
         altitudes_json = json.dumps(serialize_altitudes(rule))
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     """\
@@ -333,7 +328,7 @@ ON CONFLICT(id) DO UPDATE SET
         Raises:
             QueryError: If the operation fails.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 async with self._db.execute(
                     "DELETE FROM custom_rules WHERE id = ?",

--- a/src/synthorg/persistence/sqlite/decision_repo.py
+++ b/src/synthorg/persistence/sqlite/decision_repo.py
@@ -7,7 +7,6 @@ to eliminate the TOCTOU race that a read-then-write pattern would
 create under concurrent review gate decisions.
 """
 
-import asyncio
 import copy
 import json
 import sqlite3
@@ -30,7 +29,10 @@ from synthorg.observability.events.persistence import (
 )
 from synthorg.persistence._shared import DEFAULT_LIST_LIMIT, validate_pagination_args
 from synthorg.persistence.decision_protocol import DecisionRole  # noqa: TC001
-from synthorg.persistence.sqlite._shared import is_unique_constraint_error
+from synthorg.persistence.sqlite._shared import (
+    WriteContext,
+    is_unique_constraint_error,
+)
 
 if TYPE_CHECKING:
     from synthorg.core.types import NotBlankStr
@@ -142,34 +144,31 @@ class SQLiteDecisionRepository:
     review gate decisions.  Timestamps are normalized to UTC before
     storage for consistent lexicographic ordering.
 
-    An ``asyncio.Lock`` serializes the multi-statement
+    The backend's ``write_context`` serializes the multi-statement
     INSERT -> SELECT -> commit/rollback sequence in
     ``append_with_next_version`` so concurrent coroutines cannot
     interleave their statements or have one coroutine's rollback
-    wipe another's in-flight INSERT.  Production callers should
-    inject the shared ``SQLitePersistenceBackend._shared_write_lock``
-    so this repository coordinates with OTHER repositories that
-    mutate the same underlying ``aiosqlite.Connection``.  When the
-    lock argument is omitted (primarily direct-instantiation tests),
-    a per-instance lock is created as a fallback that only protects
-    against this repository's own concurrent callers.
+    wipe another's in-flight INSERT.  Production callers receive the
+    shared backend write context so this repository coordinates with
+    OTHER repositories that mutate the same underlying
+    ``aiosqlite.Connection``; tests can pass
+    ``tests._shared.persistence.make_private_write_context()`` for
+    standalone construction.
 
     Args:
         db: An open aiosqlite connection.
-        write_lock: Optional shared lock protecting multi-statement
-            transactions on ``db``.  Defaults to a per-instance lock
-            for test ergonomics; production wiring injects the
-            backend's shared lock.
+        write_context: Async context manager that serializes
+            multi-statement transactions on ``db``.
     """
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def append_with_next_version(  # noqa: PLR0913
         self,
@@ -323,7 +322,7 @@ class SQLiteDecisionRepository:
                 error_type="TypeError",
             )
             raise
-        async with self._write_lock:
+        async with self._write_context():
             assigned_version = await self._execute_insert(record_id, params)
         return draft_record.model_copy(update={"version": assigned_version})
 
@@ -451,12 +450,12 @@ class SQLiteDecisionRepository:
     async def get(self, record_id: NotBlankStr) -> DecisionRecord | None:
         """Retrieve a decision record by ID.
 
-        Serialized against concurrent writers via ``_write_lock`` so
+        Serialized against concurrent writers via ``write_context`` so
         reads never observe rows from an in-flight ``INSERT -> SELECT
         -> commit`` sequence that has not yet committed.
         """
         try:
-            async with self._write_lock:
+            async with self._write_context():
                 cursor = await self._db.execute(
                     f"SELECT {_COLS} FROM decision_records WHERE id = ?",  # noqa: S608
                     (record_id,),
@@ -484,7 +483,7 @@ class SQLiteDecisionRepository:
     ) -> tuple[DecisionRecord, ...]:
         """List decision records for a task, oldest first.
 
-        Serialized against concurrent writers via ``_write_lock`` so
+        Serialized against concurrent writers via ``write_context`` so
         reads never observe phantom rows from a mid-transaction
         ``append_with_next_version``.
 
@@ -518,7 +517,7 @@ class SQLiteDecisionRepository:
         )
         effective_limit = min(limit, _MAX_PAGE_LIMIT)
         try:
-            async with self._write_lock:
+            async with self._write_context():
                 # ``recorded_at ASC, id ASC`` matches the protocol's
                 # "oldest first" contract; ``version ASC`` would
                 # mis-place a backfilled decision (low ``recorded_at``
@@ -561,7 +560,7 @@ class SQLiteDecisionRepository:
         ``role`` is validated via ``Literal`` at the type level, but we
         re-check at runtime to guard against bad callers that bypass
         type checking.  A rejected role is logged before raising.
-        Serialized against concurrent writers via ``_write_lock``.
+        Serialized against concurrent writers via ``write_context``.
 
         Args:
             agent_id: Identifier of the agent whose decisions are
@@ -645,7 +644,7 @@ class SQLiteDecisionRepository:
                 f"WHERE {column} = ? ORDER BY recorded_at DESC, id DESC "
                 f"LIMIT ? OFFSET ?"
             )
-            async with self._write_lock:
+            async with self._write_context():
                 cursor = await self._db.execute(
                     query,
                     (agent_id, effective_limit, offset),

--- a/src/synthorg/persistence/sqlite/escalation_repo.py
+++ b/src/synthorg/persistence/sqlite/escalation_repo.py
@@ -32,6 +32,7 @@ from synthorg.core.persistence_errors import ConstraintViolationError, QueryErro
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.api import API_REQUEST_ERROR
 from synthorg.persistence._shared import format_iso_utc, parse_iso_utc
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -99,22 +100,24 @@ class SQLiteEscalationRepository(EscalationQueueStore):
     Args:
         db: An open aiosqlite connection (typically the one shared by
             the :class:`SQLiteBackend` with all other SQLite repos).
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         """Initialise the repository with a shared aiosqlite connection."""
         self._db: aiosqlite.Connection = db
         self._db.row_factory = aiosqlite.Row
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def create(self, escalation: Escalation) -> None:
         """Insert a PENDING escalation row."""
@@ -132,7 +135,7 @@ class SQLiteEscalationRepository(EscalationQueueStore):
             None,
             None,
         )
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(_UPSERT_SQL, params)
                 await self._db.commit()
@@ -280,7 +283,7 @@ class SQLiteEscalationRepository(EscalationQueueStore):
             "AND expires_at <= ? "
             "RETURNING id"
         )
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(update_sql, (now_iso, now_iso))
                 rows = await cursor.fetchall()
@@ -368,7 +371,7 @@ class SQLiteEscalationRepository(EscalationQueueStore):
             decision_json,
             escalation_id,
         )
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(update_sql, params)
                 await self._db.commit()

--- a/src/synthorg/persistence/sqlite/escalation_repo.py
+++ b/src/synthorg/persistence/sqlite/escalation_repo.py
@@ -114,7 +114,6 @@ class SQLiteEscalationRepository(EscalationQueueStore):
         *,
         write_context: WriteContext,
     ) -> None:
-        """Initialise the repository with a shared aiosqlite connection."""
         self._db: aiosqlite.Connection = db
         self._db.row_factory = aiosqlite.Row
         self._write_context = write_context

--- a/src/synthorg/persistence/sqlite/fine_tune_repo.py
+++ b/src/synthorg/persistence/sqlite/fine_tune_repo.py
@@ -103,6 +103,12 @@ class SQLiteFineTuneRunRepository:
 
     Args:
         db: An open aiosqlite connection with row_factory set.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
@@ -324,6 +330,12 @@ class SQLiteFineTuneCheckpointRepository:
 
     Args:
         db: An open aiosqlite connection with row_factory set.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(

--- a/src/synthorg/persistence/sqlite/fine_tune_repo.py
+++ b/src/synthorg/persistence/sqlite/fine_tune_repo.py
@@ -1,6 +1,5 @@
 """SQLite repositories for fine-tuning pipeline runs and checkpoints."""
 
-import asyncio
 import contextlib
 import json
 import sqlite3
@@ -23,6 +22,7 @@ from synthorg.observability.events.memory import (
 )
 from synthorg.persistence._shared import coerce_row_timestamp, format_iso_utc
 from synthorg.persistence.fine_tune_protocol import _DEFAULT_LIST_LIMIT_50
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -109,18 +109,14 @@ class SQLiteFineTuneRunRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save_run(self, run: FineTuneRun) -> None:
         """Persist a run (upsert semantics)."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     "INSERT INTO fine_tune_runs "
@@ -245,7 +241,7 @@ class SQLiteFineTuneRunRepository:
 
     async def update_run(self, run: FineTuneRun) -> None:
         """Update all mutable fields for a run."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     "UPDATE fine_tune_runs SET "
@@ -293,7 +289,7 @@ class SQLiteFineTuneRunRepository:
             f"stage = ?, error = ?, updated_at = ?, completed_at = ? "
             f"WHERE stage IN ({placeholders})"
         )
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     query,
@@ -334,21 +330,17 @@ class SQLiteFineTuneCheckpointRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save_checkpoint(
         self,
         checkpoint: CheckpointRecord,
     ) -> None:
         """Persist a checkpoint (upsert semantics)."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     "INSERT INTO fine_tune_checkpoints "
@@ -458,7 +450,7 @@ class SQLiteFineTuneCheckpointRepository:
         Raises:
             QueryError: If the checkpoint does not exist or DB fails.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     "UPDATE fine_tune_checkpoints SET is_active = 0",
@@ -492,7 +484,7 @@ class SQLiteFineTuneCheckpointRepository:
 
     async def deactivate_all(self) -> None:
         """Deactivate all checkpoints (for rollback)."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     "UPDATE fine_tune_checkpoints SET is_active = 0",
@@ -516,7 +508,7 @@ class SQLiteFineTuneCheckpointRepository:
         Checks existence and active status before deleting to provide
         clear error messages without TOCTOU races.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 check = await self._db.execute(
                     "SELECT is_active FROM fine_tune_checkpoints WHERE id = ?",

--- a/src/synthorg/persistence/sqlite/heartbeat_repo.py
+++ b/src/synthorg/persistence/sqlite/heartbeat_repo.py
@@ -29,6 +29,12 @@ class SQLiteHeartbeatRepository:
 
     Args:
         db: An open aiosqlite connection.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(

--- a/src/synthorg/persistence/sqlite/heartbeat_repo.py
+++ b/src/synthorg/persistence/sqlite/heartbeat_repo.py
@@ -1,6 +1,5 @@
 """SQLite repository implementation for heartbeat persistence."""
 
-import asyncio
 import contextlib
 import sqlite3
 from datetime import UTC
@@ -20,6 +19,7 @@ from synthorg.observability.events.persistence import (
     PERSISTENCE_HEARTBEAT_QUERY_FAILED,
     PERSISTENCE_HEARTBEAT_SAVE_FAILED,
 )
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -35,18 +35,14 @@ class SQLiteHeartbeatRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, heartbeat: Heartbeat) -> None:
         """Persist a heartbeat (upsert by execution_id)."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 data = heartbeat.model_dump(mode="json")
                 # Normalize to UTC so lexicographic comparisons in
@@ -142,7 +138,7 @@ INSERT OR REPLACE INTO heartbeats (
 
     async def delete(self, execution_id: NotBlankStr) -> bool:
         """Delete a heartbeat by execution ID."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM heartbeats WHERE execution_id = ?",

--- a/src/synthorg/persistence/sqlite/hr_repositories.py
+++ b/src/synthorg/persistence/sqlite/hr_repositories.py
@@ -3,7 +3,6 @@
 LifecycleEvent, TaskMetric, and CollaborationMetric repositories.
 """
 
-import asyncio
 import json
 import sqlite3
 from typing import TYPE_CHECKING
@@ -37,6 +36,7 @@ from synthorg.persistence._shared.pagination import (
     DEFAULT_LIST_LIMIT,
     validate_pagination_args,
 )
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 if TYPE_CHECKING:
     from pydantic import AwareDatetime
@@ -55,18 +55,14 @@ class SQLiteLifecycleEventRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, event: AgentLifecycleEvent) -> None:
         """Persist a lifecycle event."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 data = event.model_dump(mode="json")
                 await self._db.execute(
@@ -179,18 +175,14 @@ class SQLiteTaskMetricRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, record: TaskMetricRecord) -> None:
         """Persist a task metric record."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 data = record.model_dump(mode="json")
                 await self._db.execute(
@@ -297,18 +289,14 @@ class SQLiteCollaborationMetricRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, record: CollaborationMetricRecord) -> None:
         """Persist a collaboration metric record."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 data = record.model_dump(mode="json")
                 await self._db.execute(

--- a/src/synthorg/persistence/sqlite/hr_repositories.py
+++ b/src/synthorg/persistence/sqlite/hr_repositories.py
@@ -49,6 +49,12 @@ class SQLiteLifecycleEventRepository:
 
     Args:
         db: An open aiosqlite connection.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
@@ -169,6 +175,12 @@ class SQLiteTaskMetricRepository:
 
     Args:
         db: An open aiosqlite connection.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
@@ -283,6 +295,12 @@ class SQLiteCollaborationMetricRepository:
 
     Args:
         db: An open aiosqlite connection.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(

--- a/src/synthorg/persistence/sqlite/idempotency_repo.py
+++ b/src/synthorg/persistence/sqlite/idempotency_repo.py
@@ -2,12 +2,11 @@
 
 Atomic claim semantics rely on ``INSERT OR IGNORE`` followed by an
 ``UPDATE`` of any pre-existing row that has expired or previously
-failed. The shared backend ``write_lock`` serialises writes so the
+failed. The shared backend ``write_context`` serialises writes so the
 discriminator returned to the caller never races against a concurrent
 claim of the same ``(scope, key)``.
 """
 
-import asyncio
 import contextlib
 import secrets
 import sqlite3
@@ -28,6 +27,7 @@ from synthorg.persistence.idempotency_protocol import (
     IdempotencyOutcome,
     IdempotencyRecord,
 )
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -49,10 +49,10 @@ class SQLiteIdempotencyRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def claim(
         self,
@@ -64,7 +64,7 @@ class SQLiteIdempotencyRepository:
     ) -> IdempotencyClaim:
         """Atomically claim ``(scope, key)`` for *ttl_seconds*.
 
-        Holds ``self._write_lock`` (asyncio) plus a ``BEGIN IMMEDIATE``
+        Holds ``self._write_context()`` (asyncio) plus a ``BEGIN IMMEDIATE``
         DB-level RESERVED write lock so competing claimants on
         *different* aiosqlite connections (e.g. a sibling repository
         sharing the pool) serialise -- otherwise each would perform
@@ -79,7 +79,7 @@ class SQLiteIdempotencyRepository:
         from datetime import timedelta  # noqa: PLC0415
 
         expires_at = now + timedelta(seconds=ttl_seconds)
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute("BEGIN IMMEDIATE")
                 row = await self._fetch_idempotency_row(scope, key)
@@ -246,7 +246,7 @@ class SQLiteIdempotencyRepository:
         worker MUST NOT recover by ignoring this -- the new lease
         owns the row).
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 # Gate on status = 'in_flight' so a stale worker cannot
                 # flip an already-completed row -- completed rows MUST
@@ -285,7 +285,7 @@ class SQLiteIdempotencyRepository:
         claim_token: NotBlankStr,
     ) -> bool:
         """Mark a claimed key as ``FAILED`` if *claim_token* matches."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 # Same status gate as ``complete``: only an in-flight
                 # row owned by the matching lease can transition to
@@ -369,7 +369,7 @@ class SQLiteIdempotencyRepository:
 
     async def cleanup_expired(self, now: AwareDatetime) -> int:
         """Delete expired rows and return the count removed."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM idempotency_keys WHERE expires_at <= ?",

--- a/src/synthorg/persistence/sqlite/lockout_repo.py
+++ b/src/synthorg/persistence/sqlite/lockout_repo.py
@@ -10,7 +10,6 @@ so horizontally-scaled deployments would see per-node drift.
 Multi-instance deployments require a shared lock store.
 """
 
-import asyncio
 import threading
 from datetime import datetime, timedelta
 
@@ -24,6 +23,7 @@ from synthorg.observability.events.api import (
     API_AUTH_LOCKOUT_RESTORED,
 )
 from synthorg.persistence._shared import format_iso_utc, parse_iso_utc
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -34,13 +34,12 @@ class SQLiteLockoutRepository:
     Args:
         db: Open aiosqlite connection with ``row_factory`` set.
         config: Auth configuration with lockout thresholds.
-        write_lock: Optional shared ``asyncio.Lock`` serializing
-            multi-statement write transactions against the backend's
-            single aiosqlite connection.  The backend owns this lock
-            and passes it to every repository that emits
-            ``BEGIN IMMEDIATE``; callers that construct the repo
-            directly (e.g. one-off tests) can omit it to get a
-            per-repo lock.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
@@ -48,7 +47,7 @@ class SQLiteLockoutRepository:
         db: aiosqlite.Connection,
         config: AuthConfig,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
         clock: Clock | None = None,
     ) -> None:
         self._db = db
@@ -59,7 +58,7 @@ class SQLiteLockoutRepository:
         self._clock: Clock = clock if clock is not None else SystemClock()
         self._locked: dict[str, float] = {}
         self._locked_lock: threading.Lock = threading.Lock()
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     @property
     def lockout_duration_seconds(self) -> int:
@@ -155,7 +154,7 @@ class SQLiteLockoutRepository:
         username = username.lower()
         now = self._clock.now()
         window_start = format_iso_utc(now - self._window)
-        async with self._write_lock:
+        async with self._write_context():
             await self._db.execute("BEGIN IMMEDIATE")
             try:
                 await self._db.execute(
@@ -179,7 +178,7 @@ class SQLiteLockoutRepository:
                 await self._db.rollback()
                 raise
             # Cache mutation MUST happen while still holding
-            # ``_write_lock`` so a concurrent ``record_success``
+            # ``write_context`` so a concurrent ``record_success``
             # cannot interleave between our commit and our cache
             # write -- otherwise two writers can commit DB-order
             # T1->T2 but mutate the cache T2->T1, leaving
@@ -206,7 +205,7 @@ class SQLiteLockoutRepository:
         when there was no prior lockout (no audit emission warranted).
         """
         username = username.lower()
-        async with self._write_lock:
+        async with self._write_context():
             await self._db.execute("BEGIN IMMEDIATE")
             try:
                 await self._db.execute(
@@ -219,7 +218,7 @@ class SQLiteLockoutRepository:
             except Exception:
                 await self._db.rollback()
                 raise
-            # Cache pop while still holding ``_write_lock`` so a
+            # Cache pop while still holding ``write_context`` so a
             # concurrent ``record_failure`` cannot insert + flip
             # ``_locked`` between our commit and our pop.
             with self._locked_lock:
@@ -237,7 +236,7 @@ class SQLiteLockoutRepository:
         """
         retention = self._window + self._duration
         cutoff = format_iso_utc(self._clock.now() - retention)
-        async with self._write_lock:
+        async with self._write_context():
             await self._db.execute("BEGIN IMMEDIATE")
             try:
                 cursor = await self._db.execute(

--- a/src/synthorg/persistence/sqlite/mcp_installation_repo.py
+++ b/src/synthorg/persistence/sqlite/mcp_installation_repo.py
@@ -5,7 +5,6 @@ table.  Bound to an open ``aiosqlite.Connection`` at construction;
 the persistence backend owns connection lifecycle.
 """
 
-import asyncio
 import contextlib
 import sqlite3
 
@@ -26,6 +25,7 @@ from synthorg.persistence._shared import (
     format_iso_utc,
 )
 from synthorg.persistence._shared.pagination import validate_pagination_args
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -37,19 +37,15 @@ class SQLiteMcpInstallationRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, installation: McpInstallation) -> None:
         """Upsert an installation row (idempotent on catalog_entry_id)."""
         installed_at_iso = format_iso_utc(installation.installed_at)
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     """
@@ -166,7 +162,7 @@ class SQLiteMcpInstallationRepository:
 
     async def delete(self, catalog_entry_id: NotBlankStr) -> bool:
         """Delete an installation.  Returns ``True`` if a row was removed."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM mcp_installations WHERE catalog_entry_id = ?",

--- a/src/synthorg/persistence/sqlite/oauth_state_repo.py
+++ b/src/synthorg/persistence/sqlite/oauth_state_repo.py
@@ -5,7 +5,6 @@ table.  States are short-lived (minutes) and consumed once on
 callback; ``cleanup_expired`` reclaims stale rows.
 """
 
-import asyncio
 import contextlib
 import sqlite3
 from datetime import UTC, datetime, timedelta
@@ -25,6 +24,7 @@ from synthorg.observability.events.persistence import (
     PERSISTENCE_OAUTH_STATE_SAVE_FAILED,
 )
 from synthorg.persistence._shared import coerce_row_timestamp, format_iso_utc
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -73,11 +73,11 @@ class SQLiteOAuthStateRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
-        """Bind to *db* and serialize writes via *write_lock*."""
+        """Bind to *db* and serialize writes via *write_context*."""
         self._db = db
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, state: OAuthState) -> None:
         """Upsert an OAuth state row keyed by ``state_token``.
@@ -87,7 +87,7 @@ class SQLiteOAuthStateRepository:
         ``connection_name_returned``). Flow-start callers set both
         to ``None``; post-callback snapshots carry them populated.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     """
@@ -175,7 +175,7 @@ class SQLiteOAuthStateRepository:
 
     async def delete(self, state_token: NotBlankStr) -> bool:
         """Delete an OAuth state; return ``True`` if a row was removed."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM oauth_states WHERE state_token = ?",
@@ -210,7 +210,7 @@ class SQLiteOAuthStateRepository:
         ``consumed_at`` and returns ``False`` so the handler can route
         it through the replay branch.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "UPDATE oauth_states "
@@ -255,7 +255,7 @@ class SQLiteOAuthStateRepository:
         consumed_cutoff_iso = format_iso_utc(
             now - timedelta(seconds=retention_seconds),
         )
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM oauth_states "

--- a/src/synthorg/persistence/sqlite/ontology_drift_repo.py
+++ b/src/synthorg/persistence/sqlite/ontology_drift_repo.py
@@ -1,6 +1,5 @@
 """SQLite-backed drift report repository."""
 
-import asyncio
 import contextlib
 import json
 import sqlite3
@@ -15,6 +14,7 @@ from synthorg.observability.events.ontology import (
 )
 from synthorg.ontology.models import AgentDrift, DriftAction, DriftReport
 from synthorg.persistence._shared import DEFAULT_LIST_LIMIT
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 if TYPE_CHECKING:
     from synthorg.core.types import NotBlankStr
@@ -56,20 +56,16 @@ def _row_to_report(row: Any) -> DriftReport:
 class SQLiteOntologyDriftReportRepository:
     """SQLite implementation of ``OntologyDriftReportRepository``."""
 
-    __slots__ = ("_db", "_write_lock")
+    __slots__ = ("_db", "_write_context")
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def store_report(self, report: DriftReport) -> None:
         """Persist a drift report."""
@@ -83,7 +79,7 @@ class SQLiteOntologyDriftReportRepository:
                 for a in report.divergent_agents
             ],
         )
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     "INSERT INTO drift_reports "

--- a/src/synthorg/persistence/sqlite/ontology_entity_repo.py
+++ b/src/synthorg/persistence/sqlite/ontology_entity_repo.py
@@ -172,45 +172,76 @@ class SQLiteOntologyEntityRepository:
         """Update an existing entity definition."""
         params = self._entity_to_params(entity)
         async with self._write_context():
-            cursor = await self._db.execute(
-                """UPDATE entity_definitions
-                   SET tier = :tier, source = :source,
-                       definition = :definition, fields = :fields,
-                       constraints = :constraints,
-                       disambiguation = :disambiguation,
-                       relationships = :relationships,
-                       updated_at = :updated_at
-                   WHERE name = :name""",
-                params,
-            )
-            if cursor.rowcount == 0:
-                # Roll back so the empty UPDATE does not leave the
-                # shared connection inside an open implicit transaction.
+            try:
+                cursor = await self._db.execute(
+                    """UPDATE entity_definitions
+                       SET tier = :tier, source = :source,
+                           definition = :definition, fields = :fields,
+                           constraints = :constraints,
+                           disambiguation = :disambiguation,
+                           relationships = :relationships,
+                           updated_at = :updated_at
+                       WHERE name = :name""",
+                    params,
+                )
+                if cursor.rowcount == 0:
+                    # Roll back so the empty UPDATE does not leave the
+                    # shared connection inside an open implicit
+                    # transaction.
+                    with contextlib.suppress(sqlite3.Error, aiosqlite.Error):
+                        await self._db.rollback()
+                    msg = f"Entity '{entity.name}' not found"
+                    logger.warning(
+                        ONTOLOGY_ENTITY_NOT_FOUND,
+                        entity_name=entity.name,
+                        op="update",
+                    )
+                    raise OntologyNotFoundError(msg)
+                await self._db.commit()
+            except (sqlite3.Error, aiosqlite.Error) as exc:
                 with contextlib.suppress(sqlite3.Error, aiosqlite.Error):
                     await self._db.rollback()
-                msg = f"Entity '{entity.name}' not found"
+                msg = f"Failed to update entity '{entity.name}'"
                 logger.warning(
-                    ONTOLOGY_ENTITY_NOT_FOUND,
+                    ONTOLOGY_ENTITY_DESERIALIZATION_FAILED,
                     entity_name=entity.name,
                     op="update",
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
                 )
-                raise OntologyNotFoundError(msg)
-            await self._db.commit()
+                raise OntologyError(msg) from exc
 
     async def delete(self, name: str) -> None:
         """Delete an entity definition by name."""
         async with self._write_context():
-            cursor = await self._db.execute(
-                "DELETE FROM entity_definitions WHERE name = :name",
-                {"name": name},
-            )
-            if cursor.rowcount == 0:
+            try:
+                cursor = await self._db.execute(
+                    "DELETE FROM entity_definitions WHERE name = :name",
+                    {"name": name},
+                )
+                if cursor.rowcount == 0:
+                    with contextlib.suppress(sqlite3.Error, aiosqlite.Error):
+                        await self._db.rollback()
+                    msg = f"Entity '{name}' not found"
+                    logger.warning(
+                        ONTOLOGY_ENTITY_NOT_FOUND,
+                        entity_name=name,
+                        op="delete",
+                    )
+                    raise OntologyNotFoundError(msg)
+                await self._db.commit()
+            except (sqlite3.Error, aiosqlite.Error) as exc:
                 with contextlib.suppress(sqlite3.Error, aiosqlite.Error):
                     await self._db.rollback()
-                msg = f"Entity '{name}' not found"
-                logger.warning(ONTOLOGY_ENTITY_NOT_FOUND, entity_name=name, op="delete")
-                raise OntologyNotFoundError(msg)
-            await self._db.commit()
+                msg = f"Failed to delete entity '{name}'"
+                logger.warning(
+                    ONTOLOGY_ENTITY_DESERIALIZATION_FAILED,
+                    entity_name=name,
+                    op="delete",
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
+                )
+                raise OntologyError(msg) from exc
 
     async def list_entities(
         self,

--- a/src/synthorg/persistence/sqlite/ontology_entity_repo.py
+++ b/src/synthorg/persistence/sqlite/ontology_entity_repo.py
@@ -1,6 +1,5 @@
 """SQLite-backed ontology entity repository."""
 
-import asyncio
 import contextlib
 import json
 import sqlite3
@@ -29,6 +28,7 @@ from synthorg.ontology.models import (
     EntityTier,
 )
 from synthorg.persistence._shared import DEFAULT_LIST_LIMIT
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -44,14 +44,10 @@ class SQLiteOntologyEntityRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     @property
     def backend_name(self) -> NotBlankStr:
@@ -110,7 +106,7 @@ class SQLiteOntologyEntityRepository:
     async def register(self, entity: EntityDefinition) -> None:
         """Register a new entity definition."""
         params = self._entity_to_params(entity)
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     """INSERT INTO entity_definitions
@@ -169,7 +165,7 @@ class SQLiteOntologyEntityRepository:
     async def update(self, entity: EntityDefinition) -> None:
         """Update an existing entity definition."""
         params = self._entity_to_params(entity)
-        async with self._write_lock:
+        async with self._write_context():
             cursor = await self._db.execute(
                 """UPDATE entity_definitions
                    SET tier = :tier, source = :source,
@@ -197,7 +193,7 @@ class SQLiteOntologyEntityRepository:
 
     async def delete(self, name: str) -> None:
         """Delete an entity definition by name."""
-        async with self._write_lock:
+        async with self._write_context():
             cursor = await self._db.execute(
                 "DELETE FROM entity_definitions WHERE name = :name",
                 {"name": name},

--- a/src/synthorg/persistence/sqlite/ontology_entity_repo.py
+++ b/src/synthorg/persistence/sqlite/ontology_entity_repo.py
@@ -38,6 +38,12 @@ class SQLiteOntologyEntityRepository:
 
     Args:
         db: Open aiosqlite connection with ``row_factory`` set.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(

--- a/src/synthorg/persistence/sqlite/org_fact_repo.py
+++ b/src/synthorg/persistence/sqlite/org_fact_repo.py
@@ -1,6 +1,5 @@
 """SQLite-backed org fact repository with MVCC (append-only log + snapshot)."""
 
-import asyncio
 import contextlib
 import json
 import sqlite3
@@ -43,6 +42,7 @@ from synthorg.persistence._shared import (
     format_iso_utc,
 )
 from synthorg.persistence.memory_protocol import _DEFAULT_LIST_LIMIT_5
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -195,27 +195,22 @@ class SQLiteOrgFactRepository:
 
     Args:
         db: Open aiosqlite connection with ``row_factory`` set.
-        write_lock: Optional shared lock used to serialize writes on
-            the shared connection.  Inject the
-            :class:`SQLitePersistenceBackend._shared_write_lock` so
-            writes from this repo coordinate with sibling repos that
-            share the same connection.  Defaults to ``None``, in
-            which case the repo creates a private :class:`asyncio.Lock`
-            (suitable for standalone test construction).
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def _append_to_operation_log(  # noqa: PLR0913
         self,
@@ -278,7 +273,7 @@ class SQLiteOrgFactRepository:
         # ``BEGIN IMMEDIATE`` transaction holding the write lock.
         created_at_iso = format_iso_utc(fact.created_at)
         tags_json = _tags_to_json(fact.tags)
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await db.execute("BEGIN IMMEDIATE")
                 version, _ = await self._append_to_operation_log(
@@ -360,7 +355,7 @@ class SQLiteOrgFactRepository:
     ) -> bool:
         """Retract a fact: append RETRACT to log, mark snapshot."""
         db = self._db
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await db.execute("BEGIN IMMEDIATE")
                 cursor = await db.execute(

--- a/src/synthorg/persistence/sqlite/parked_context_repo.py
+++ b/src/synthorg/persistence/sqlite/parked_context_repo.py
@@ -1,6 +1,5 @@
 """SQLite repository implementation for parked agent execution contexts."""
 
-import asyncio
 import contextlib
 import json
 import sqlite3
@@ -18,6 +17,7 @@ from synthorg.observability.events.persistence import (
     PERSISTENCE_PARKED_CONTEXT_QUERY_FAILED,
     PERSISTENCE_PARKED_CONTEXT_SAVE_FAILED,
 )
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 from synthorg.security.timeout.parked_context import ParkedContext
 
 logger = get_logger(__name__)
@@ -34,18 +34,14 @@ class SQLiteParkedContextRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, context: ParkedContext) -> None:
         """Persist a parked context."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 data = context.model_dump(mode="json")
                 await self._db.execute(
@@ -158,7 +154,7 @@ INSERT OR REPLACE INTO parked_contexts (
 
     async def delete(self, parked_id: str) -> bool:
         """Delete a parked context by ID."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM parked_contexts WHERE id = ?",

--- a/src/synthorg/persistence/sqlite/parked_context_repo.py
+++ b/src/synthorg/persistence/sqlite/parked_context_repo.py
@@ -169,6 +169,8 @@ INSERT OR REPLACE INTO parked_contexts (
                 await self._db.commit()
                 deleted = cursor.rowcount > 0
             except (sqlite3.Error, aiosqlite.Error) as exc:
+                with contextlib.suppress(sqlite3.Error, aiosqlite.Error):
+                    await self._db.rollback()
                 msg = f"Failed to delete parked context {parked_id!r}"
                 # Use the delete-specific event so audit dashboards
                 # can distinguish read-path failures (QUERY_FAILED)

--- a/src/synthorg/persistence/sqlite/parked_context_repo.py
+++ b/src/synthorg/persistence/sqlite/parked_context_repo.py
@@ -28,6 +28,12 @@ class SQLiteParkedContextRepository:
 
     Args:
         db: An open aiosqlite connection.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(

--- a/src/synthorg/persistence/sqlite/preset_override_repo.py
+++ b/src/synthorg/persistence/sqlite/preset_override_repo.py
@@ -1,6 +1,5 @@
 """SQLite repository for operator-authored preset overrides."""
 
-import asyncio
 import json
 import sqlite3
 from typing import TYPE_CHECKING
@@ -17,6 +16,7 @@ from synthorg.persistence._shared.datetime_marshaller import (
     format_iso_utc,
     parse_iso_utc,
 )
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 from synthorg.providers.enums import AuthType
 
 if TYPE_CHECKING:
@@ -31,18 +31,22 @@ class SQLitePresetOverrideRepo:
 
     Args:
         db: An open ``aiosqlite.Connection``.
-        write_lock: Shared backend write lock so writes serialise with
-            sibling repos sharing the same connection.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def get(self, preset_name: NotBlankStr) -> PresetOverride | None:
         """Read the override for ``preset_name``, if any."""
@@ -133,7 +137,7 @@ class SQLitePresetOverrideRepo:
             "candidate_urls, base_url, updated_at, updated_by) "
             "VALUES (?, ?, ?, ?, ?, ?, ?)"
         )
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(sql, params)
                 await self._db.commit()
@@ -151,7 +155,7 @@ class SQLitePresetOverrideRepo:
 
     async def delete(self, preset_name: NotBlankStr) -> bool:
         """Remove the override for ``preset_name``."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM preset_overrides WHERE preset_name = ?",

--- a/src/synthorg/persistence/sqlite/preset_repo.py
+++ b/src/synthorg/persistence/sqlite/preset_repo.py
@@ -35,6 +35,12 @@ class SQLitePersonalityPresetRepository:
 
     Args:
         db: An open aiosqlite connection.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(

--- a/src/synthorg/persistence/sqlite/preset_repo.py
+++ b/src/synthorg/persistence/sqlite/preset_repo.py
@@ -86,7 +86,7 @@ ON CONFLICT(name) DO UPDATE SET
                     (name, config_json, description, created_at, updated_at),
                 )
                 await self._db.commit()
-            except sqlite3.Error as exc:
+            except (sqlite3.Error, aiosqlite.Error) as exc:
                 with contextlib.suppress(sqlite3.Error, aiosqlite.Error):
                     await self._db.rollback()
                 msg = f"Failed to save custom preset {name!r}"
@@ -120,7 +120,7 @@ ON CONFLICT(name) DO UPDATE SET
                 (name,),
             ) as cursor:
                 row = await cursor.fetchone()
-        except sqlite3.Error as exc:
+        except (sqlite3.Error, aiosqlite.Error) as exc:
             msg = f"Failed to fetch custom preset {name!r}"
             logger.warning(
                 PRESET_CUSTOM_FETCH_FAILED,
@@ -162,7 +162,7 @@ ON CONFLICT(name) DO UPDATE SET
                 (limit,),
             ) as cursor:
                 rows = await cursor.fetchall()
-        except sqlite3.Error as exc:
+        except (sqlite3.Error, aiosqlite.Error) as exc:
             msg = "Failed to list custom presets"
             logger.warning(
                 PRESET_CUSTOM_LIST_FAILED,
@@ -196,7 +196,7 @@ ON CONFLICT(name) DO UPDATE SET
                 ) as cursor:
                     deleted = cursor.rowcount > 0
                 await self._db.commit()
-            except sqlite3.Error as exc:
+            except (sqlite3.Error, aiosqlite.Error) as exc:
                 with contextlib.suppress(sqlite3.Error, aiosqlite.Error):
                     await self._db.rollback()
                 msg = f"Failed to delete custom preset {name!r}"
@@ -220,7 +220,7 @@ ON CONFLICT(name) DO UPDATE SET
                 "SELECT COUNT(*) FROM custom_presets",
             ) as cursor:
                 row = await cursor.fetchone()
-        except sqlite3.Error as exc:
+        except (sqlite3.Error, aiosqlite.Error) as exc:
             msg = "Failed to count custom presets"
             logger.warning(
                 PRESET_CUSTOM_COUNT_FAILED,

--- a/src/synthorg/persistence/sqlite/preset_repo.py
+++ b/src/synthorg/persistence/sqlite/preset_repo.py
@@ -1,6 +1,5 @@
 """SQLite repository implementation for custom personality presets."""
 
-import asyncio
 import contextlib
 import sqlite3
 
@@ -23,6 +22,7 @@ from synthorg.persistence._shared.pagination import (
     validate_pagination_args,
 )
 from synthorg.persistence.preset_protocol import PresetListRow, PresetRow
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -41,14 +41,10 @@ class SQLitePersonalityPresetRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(
         self,
@@ -70,7 +66,7 @@ class SQLitePersonalityPresetRepository:
         Raises:
             QueryError: If the database operation fails.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     """\
@@ -186,7 +182,7 @@ ON CONFLICT(name) DO UPDATE SET
         Raises:
             QueryError: If the database operation fails.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 async with self._db.execute(
                     "DELETE FROM custom_presets WHERE name = ?",

--- a/src/synthorg/persistence/sqlite/project_cost_aggregate_repo.py
+++ b/src/synthorg/persistence/sqlite/project_cost_aggregate_repo.py
@@ -32,6 +32,7 @@ from synthorg.observability.events.persistence import (
     PERSISTENCE_PROJECT_COST_AGG_INCREMENTED,
 )
 from synthorg.persistence._shared import parse_iso_utc
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -130,18 +131,22 @@ class SQLiteProjectCostAggregateRepository:
     Args:
         db: An open aiosqlite connection with ``row_factory``
             set to ``aiosqlite.Row``.
-        write_lock: Optional shared write lock for serialising
-            multi-statement write operations.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
         self._pinned_currencies: dict[str, str] = {}
         # Per-project striped locks: each project_id gets its own
         # ``asyncio.Lock`` lazily created in ``_project_lock``.  This
@@ -336,7 +341,7 @@ class SQLiteProjectCostAggregateRepository:
             now = datetime.now(UTC).isoformat()
             db_committed = False
             try:
-                # Run the write inside the write_lock and validate the
+                # Run the write inside write_context and validate the
                 # RETURNING row BEFORE committing.  If deserialize
                 # fails the durable layer must remain unchanged so a
                 # retry doesn't double-count -- without this guard the
@@ -344,7 +349,7 @@ class SQLiteProjectCostAggregateRepository:
                 # would leave a phantom durable row whose currency the
                 # operator can no longer enforce in memory.
                 try:
-                    async with self._write_lock:
+                    async with self._write_context():
                         cursor = await self._db.execute(
                             _UPSERT_SQL,
                             (project_id, cost, input_tokens, output_tokens, now),

--- a/src/synthorg/persistence/sqlite/project_repo.py
+++ b/src/synthorg/persistence/sqlite/project_repo.py
@@ -1,6 +1,5 @@
 """SQLite repository implementation for Project."""
 
-import asyncio
 import json
 import sqlite3
 
@@ -29,7 +28,10 @@ from synthorg.persistence._shared.pagination import (
     DEFAULT_LIST_LIMIT,
     validate_pagination_args,
 )
-from synthorg.persistence.sqlite._shared import is_unique_constraint_error
+from synthorg.persistence.sqlite._shared import (
+    WriteContext,
+    is_unique_constraint_error,
+)
 
 logger = get_logger(__name__)
 
@@ -67,27 +69,10 @@ class SQLiteProjectRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # ``aiosqlite.Connection`` runs every command on a dedicated
-        # worker thread, but transactions are connection-scoped: two
-        # coroutines that share a Connection share the SAME transaction
-        # context.  Without a connection-wide lock, coroutine A's
-        # ``execute`` + ``commit`` can interleave with coroutine B's
-        # statements -- B's writes get committed by A's
-        # ``commit`` (or rolled back by A's ``rollback``), breaking
-        # transaction atomicity.  Inject the shared
-        # ``SQLitePersistenceBackend._shared_write_lock`` so that every
-        # repo using the same connection serializes through one lock;
-        # writes from a sibling repository (e.g. artifact + project
-        # under the same connection) cannot interleave their
-        # ``execute`` -> ``commit``/``rollback`` sequence.  Reads stay
-        # un-gated -- they don't open transactions in autocommit mode.
-        # Fall back to a private lock when constructed standalone (e.g.
-        # in unit tests that build a single repo against an in-memory
-        # connection).
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     @staticmethod
     def _row_params(project: Project) -> tuple[object, ...]:
@@ -113,7 +98,7 @@ class SQLiteProjectRepository:
             DuplicateRecordError: A project with the same id exists.
             QueryError: If the database operation fails.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     """\
@@ -188,7 +173,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             RecordNotFoundError: No project with this id exists.
             QueryError: If the database operation fails.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     """\
@@ -244,7 +229,7 @@ WHERE id=?""",
         Raises:
             QueryError: If the database operation fails.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     """\
@@ -399,7 +384,7 @@ ON CONFLICT(id) DO UPDATE SET
         Raises:
             QueryError: If the database operation fails.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM projects WHERE id = ?", (project_id,)

--- a/src/synthorg/persistence/sqlite/project_repo.py
+++ b/src/synthorg/persistence/sqlite/project_repo.py
@@ -63,6 +63,12 @@ class SQLiteProjectRepository:
     Args:
         db: An open aiosqlite connection with ``row_factory``
             set to ``aiosqlite.Row``.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(

--- a/src/synthorg/persistence/sqlite/provider_audit_repo.py
+++ b/src/synthorg/persistence/sqlite/provider_audit_repo.py
@@ -7,7 +7,6 @@ schema and a per-provider read API tailored to the dashboard's audit
 drawer.
 """
 
-import asyncio
 import json
 import sqlite3
 from typing import TYPE_CHECKING
@@ -29,6 +28,7 @@ from synthorg.persistence._shared.datetime_marshaller import (
     parse_iso_utc,
 )
 from synthorg.persistence.provider_audit_protocol import _DEFAULT_LIST_LIMIT_50
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 if TYPE_CHECKING:
     from synthorg.core.types import NotBlankStr
@@ -58,19 +58,21 @@ class SQLiteProviderAuditRepo:
 
     Args:
         db: An open ``aiosqlite.Connection``.
-        write_lock: Shared backend write lock so writes serialise
-            with sibling repos that share the same connection.  Falls
-            back to a private lock for standalone test construction.
+        write_context: Shared backend write context so writes
+            serialise with sibling repos on the same connection.
+            Tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def record(self, event: ProviderAuditEvent) -> ProviderAuditEvent:
         """Insert one audit event and return the saved row with id populated."""
@@ -91,7 +93,7 @@ class SQLiteProviderAuditRepo:
             json.dumps(serialized["payload"], sort_keys=True),
             format_iso_utc(event.occurred_at),
         )
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(_INSERT_SQL, params)
                 await self._db.commit()
@@ -174,7 +176,7 @@ class SQLiteProviderAuditRepo:
 
     async def purge_before_id(self, *, before_id: int) -> int:
         """Delete events with ``id < before_id``."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM provider_audit_events WHERE id < ?",

--- a/src/synthorg/persistence/sqlite/refresh_repo.py
+++ b/src/synthorg/persistence/sqlite/refresh_repo.py
@@ -5,7 +5,6 @@ Each token is single-use: consuming it atomically marks it as used
 and returns the associated session/user info for re-issuance.
 """
 
-import asyncio
 import contextlib
 import sqlite3
 from collections.abc import Callable  # noqa: TC003
@@ -24,6 +23,7 @@ from synthorg.observability.events.api import (
     API_AUTH_REFRESH_PERSISTENCE_ERROR,
 )
 from synthorg.persistence._shared import format_iso_utc, parse_iso_utc
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 # Persistence-boundary rule: SECURITY_AUTH_REFRESH_* events are
 # auth decisions, not storage facts. Repos must not emit them; the
@@ -46,14 +46,10 @@ class SQLiteRefreshTokenRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def create(
         self,
@@ -64,7 +60,7 @@ class SQLiteRefreshTokenRepository:
     ) -> None:
         """Store a new refresh token."""
         now = datetime.now(UTC)
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     "INSERT INTO refresh_tokens "
@@ -115,7 +111,7 @@ class SQLiteRefreshTokenRepository:
         """
         now = format_iso_utc(datetime.now(UTC))
         revoked = False
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "UPDATE refresh_tokens SET used = 1 "
@@ -188,7 +184,7 @@ class SQLiteRefreshTokenRepository:
 
     async def revoke_by_session(self, session_id: str) -> int:
         """Mark all refresh tokens for a session as used."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "UPDATE refresh_tokens SET used = 1 "
@@ -215,7 +211,7 @@ class SQLiteRefreshTokenRepository:
 
     async def revoke_by_user(self, user_id: str) -> int:
         """Mark all refresh tokens for a user as used."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "UPDATE refresh_tokens SET used = 1 WHERE user_id = ? AND used = 0",
@@ -249,7 +245,7 @@ class SQLiteRefreshTokenRepository:
         repositories do not emit operational events.
         """
         now = format_iso_utc(datetime.now(UTC))
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM refresh_tokens WHERE expires_at <= ?",

--- a/src/synthorg/persistence/sqlite/refresh_repo.py
+++ b/src/synthorg/persistence/sqlite/refresh_repo.py
@@ -40,6 +40,12 @@ class SQLiteRefreshTokenRepository:
 
     Args:
         db: Open aiosqlite connection with ``row_factory`` set.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(

--- a/src/synthorg/persistence/sqlite/repositories.py
+++ b/src/synthorg/persistence/sqlite/repositories.py
@@ -4,7 +4,6 @@ HR-related repositories (LifecycleEvent, TaskMetric, CollaborationMetric)
 are in ``hr_repositories.py`` within this package.
 """
 
-import asyncio
 import json
 import sqlite3
 
@@ -42,7 +41,10 @@ from synthorg.observability.events.persistence import (
     PERSISTENCE_TASK_SAVE_FAILED,
 )
 from synthorg.persistence._shared import DEFAULT_LIST_LIMIT
-from synthorg.persistence.sqlite._shared import is_unique_constraint_error
+from synthorg.persistence.sqlite._shared import (
+    WriteContext,
+    is_unique_constraint_error,
+)
 
 logger = get_logger(__name__)
 
@@ -66,24 +68,26 @@ class SQLiteTaskRepository:
 
     Args:
         db: An open aiosqlite connection.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, task: Task) -> None:
         """Persist a task (upsert semantics)."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 params = task.model_dump(mode="json")
                 # Tuple fields must be stored as JSON strings.
@@ -299,7 +303,7 @@ id, title, description, type, priority, project, created_by,
 
     async def delete(self, task_id: str) -> bool:
         """Delete a task by ID."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM tasks WHERE id = ?", (task_id,)
@@ -323,24 +327,26 @@ class SQLiteCostRecordRepository:
 
     Args:
         db: An open aiosqlite connection.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, record: CostRecord) -> None:
         """Persist a cost record (append-only)."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 data = record.model_dump(mode="json")
                 await self._db.execute(
@@ -502,20 +508,22 @@ class SQLiteMessageRepository:
 
     Args:
         db: An open aiosqlite connection.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def _safe_rollback(self, msg_id: str) -> None:
         """Best-effort rollback on the shared aiosqlite connection.
@@ -543,7 +551,7 @@ class SQLiteMessageRepository:
         data = message.model_dump(mode="json")
         msg_id = str(message.id)
 
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     """\
@@ -667,12 +675,12 @@ ORDER BY timestamp DESC"""
 
         Returns ``True`` when a row was removed, ``False`` when the id
         did not exist. Concurrent writes are serialized through the
-        shared backend write lock. The audit-grade mutation log is
+        shared backend write context. The audit-grade mutation log is
         emitted by :class:`MessageService.delete_message`; the
         repository never logs mutations itself (persistence-boundary
         rule, see ``docs/reference/persistence-boundary.md``).
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM messages WHERE id = ?",

--- a/src/synthorg/persistence/sqlite/risk_override_repo.py
+++ b/src/synthorg/persistence/sqlite/risk_override_repo.py
@@ -62,6 +62,8 @@ class SQLiteRiskOverrideRepository:
         """Roll back the current transaction, swallowing errors."""
         try:
             await self._db.rollback()
+        except MemoryError, RecursionError:
+            raise
         except Exception:
             logger.warning(
                 PERSISTENCE_RISK_OVERRIDE_SAVE_FAILED,

--- a/src/synthorg/persistence/sqlite/risk_override_repo.py
+++ b/src/synthorg/persistence/sqlite/risk_override_repo.py
@@ -86,8 +86,8 @@ class SQLiteRiskOverrideRepository:
             format_iso_utc(override.revoked_at) if override.revoked_at else None
         )
 
-        try:
-            async with self._write_context():
+        async with self._write_context():
+            try:
                 await self._db.execute(
                     f"INSERT INTO risk_overrides ({_COLS}) "  # noqa: S608
                     "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -105,27 +105,27 @@ class SQLiteRiskOverrideRepository:
                     ),
                 )
                 await self._db.commit()
-        except sqlite3.IntegrityError as exc:
-            await self._rollback_quietly()
-            if is_unique_constraint_error(exc):
-                msg = f"Risk override {override.id!r} already exists"
-                raise DuplicateRecordError(msg) from exc
-            msg = "Failed to save risk override"
-            logger.warning(
-                PERSISTENCE_RISK_OVERRIDE_SAVE_FAILED,
-                error_type=type(exc).__name__,
-                error=safe_error_description(exc),
-            )
-            raise PersistenceError(msg) from exc
-        except (sqlite3.Error, aiosqlite.Error) as exc:
-            await self._rollback_quietly()
-            msg = "Failed to save risk override"
-            logger.warning(
-                PERSISTENCE_RISK_OVERRIDE_SAVE_FAILED,
-                error_type=type(exc).__name__,
-                error=safe_error_description(exc),
-            )
-            raise PersistenceError(msg) from exc
+            except sqlite3.IntegrityError as exc:
+                await self._rollback_quietly()
+                if is_unique_constraint_error(exc):
+                    msg = f"Risk override {override.id!r} already exists"
+                    raise DuplicateRecordError(msg) from exc
+                msg = "Failed to save risk override"
+                logger.warning(
+                    PERSISTENCE_RISK_OVERRIDE_SAVE_FAILED,
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
+                )
+                raise PersistenceError(msg) from exc
+            except (sqlite3.Error, aiosqlite.Error) as exc:
+                await self._rollback_quietly()
+                msg = "Failed to save risk override"
+                logger.warning(
+                    PERSISTENCE_RISK_OVERRIDE_SAVE_FAILED,
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
+                )
+                raise PersistenceError(msg) from exc
 
     async def get(
         self,
@@ -218,8 +218,8 @@ class SQLiteRiskOverrideRepository:
     ) -> bool:
         """Mark an override as revoked."""
         revoked_at_utc = format_iso_utc(revoked_at)
-        try:
-            async with self._write_context():
+        async with self._write_context():
+            try:
                 cursor = await self._db.execute(
                     "UPDATE risk_overrides "
                     "SET revoked_at = ?, revoked_by = ? "
@@ -227,15 +227,15 @@ class SQLiteRiskOverrideRepository:
                     (revoked_at_utc, revoked_by, override_id),
                 )
                 await self._db.commit()
-        except (sqlite3.Error, aiosqlite.Error) as exc:
-            await self._rollback_quietly()
-            msg = "Failed to revoke risk override"
-            logger.warning(
-                PERSISTENCE_RISK_OVERRIDE_SAVE_FAILED,
-                error_type=type(exc).__name__,
-                error=safe_error_description(exc),
-            )
-            raise PersistenceError(msg) from exc
+            except (sqlite3.Error, aiosqlite.Error) as exc:
+                await self._rollback_quietly()
+                msg = "Failed to revoke risk override"
+                logger.warning(
+                    PERSISTENCE_RISK_OVERRIDE_SAVE_FAILED,
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
+                )
+                raise PersistenceError(msg) from exc
 
         return cursor.rowcount > 0
 

--- a/src/synthorg/persistence/sqlite/risk_override_repo.py
+++ b/src/synthorg/persistence/sqlite/risk_override_repo.py
@@ -1,6 +1,5 @@
 """SQLite repository implementation for risk tier overrides."""
 
-import asyncio
 import sqlite3
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -20,7 +19,10 @@ from synthorg.persistence._shared.pagination import (
     DEFAULT_LIST_LIMIT,
     validate_pagination_args,
 )
-from synthorg.persistence.sqlite._shared import is_unique_constraint_error
+from synthorg.persistence.sqlite._shared import (
+    WriteContext,
+    is_unique_constraint_error,
+)
 from synthorg.security.rules.risk_override import RiskTierOverride
 
 if TYPE_CHECKING:
@@ -39,20 +41,22 @@ class SQLiteRiskOverrideRepository:
 
     Args:
         db: An open aiosqlite connection.
-        write_lock: Optional shared lock protecting multi-statement
-            transactions.  Defaults to a per-instance lock for test
-            ergonomics; production wiring injects the backend's
-            shared lock.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def _rollback_quietly(self) -> None:
         """Roll back the current transaction, swallowing errors."""
@@ -81,7 +85,7 @@ class SQLiteRiskOverrideRepository:
         )
 
         try:
-            async with self._write_lock:
+            async with self._write_context():
                 await self._db.execute(
                     f"INSERT INTO risk_overrides ({_COLS}) "  # noqa: S608
                     "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -213,7 +217,7 @@ class SQLiteRiskOverrideRepository:
         """Mark an override as revoked."""
         revoked_at_utc = format_iso_utc(revoked_at)
         try:
-            async with self._write_lock:
+            async with self._write_context():
                 cursor = await self._db.execute(
                     "UPDATE risk_overrides "
                     "SET revoked_at = ?, revoked_by = ? "

--- a/src/synthorg/persistence/sqlite/session_repo.py
+++ b/src/synthorg/persistence/sqlite/session_repo.py
@@ -212,9 +212,10 @@ class SQLiteSessionRepository:
                     error=safe_error_description(exc),
                 )
                 raise QueryError(msg) from exc
-        # Audit emission moved to service/controller layer per the
-        # persistence-boundary rule -- controllers that call ``revoke``
-        # are responsible for logging SECURITY_SESSION_REVOKED.
+        # Audit logging lives above persistence so the SECURITY_SESSION_REVOKED
+        # event reflects the authorization decision rather than a
+        # storage-only update; the caller (service/controller) owns the
+        # emit.
         return rowcount > 0
 
     async def revoke_all_for_user(self, user_id: str) -> int:
@@ -262,8 +263,9 @@ class SQLiteSessionRepository:
                     error=safe_error_description(exc),
                 )
                 raise QueryError(msg) from exc
-        # Audit emission moved to service/controller layer per the
-        # persistence-boundary rule.
+        # Audit logging stays above persistence: the caller correlates the
+        # bulk-revoke event with the authorization context (which user
+        # initiated, why) that this layer does not see.
         return count
 
     async def enforce_session_limit(
@@ -283,11 +285,10 @@ class SQLiteSessionRepository:
         for session in to_revoke:
             if await self.revoke(session.session_id):
                 revoked += 1
-        # Audit emission moved to service/controller layer per the
-        # persistence-boundary rule -- callers that invoke
-        # ``enforce_session_limit`` log SECURITY_SESSION_LIMIT_ENFORCED
-        # when ``revoked > 0`` so the auth chain entry sits with the
-        # decision rather than the storage commit.
+        # SECURITY_SESSION_LIMIT_ENFORCED belongs in the caller so the
+        # audit entry sits with the policy decision (which limit fired,
+        # against which actor) rather than against a storage commit
+        # that has no visibility into authorization context.
         return revoked
 
     def is_revoked(self, session_id: str) -> bool:

--- a/src/synthorg/persistence/sqlite/session_repo.py
+++ b/src/synthorg/persistence/sqlite/session_repo.py
@@ -120,6 +120,8 @@ class SQLiteSessionRepository:
                     ),
                 )
                 await self._db.commit()
+                if session.revoked:
+                    self._revoked.add(session.session_id)
             except (sqlite3.Error, aiosqlite.Error) as exc:
                 with contextlib.suppress(sqlite3.Error, aiosqlite.Error):
                     await self._db.rollback()
@@ -132,8 +134,6 @@ class SQLiteSessionRepository:
                     error=safe_error_description(exc),
                 )
                 raise QueryError(msg) from exc
-        if session.revoked:
-            self._revoked.add(session.session_id)
 
     async def get(self, session_id: str) -> Session | None:
         """Look up a session by ID."""
@@ -199,6 +199,8 @@ class SQLiteSessionRepository:
                 )
                 await self._db.commit()
                 rowcount = cursor.rowcount
+                if rowcount > 0:
+                    self._revoked.add(session_id)
             except (sqlite3.Error, aiosqlite.Error) as exc:
                 with contextlib.suppress(sqlite3.Error, aiosqlite.Error):
                     await self._db.rollback()
@@ -210,14 +212,10 @@ class SQLiteSessionRepository:
                     error=safe_error_description(exc),
                 )
                 raise QueryError(msg) from exc
-        if rowcount > 0:
-            self._revoked.add(session_id)
-            # Audit emission moved to service/controller layer per the
-            # persistence-boundary rule -- controllers that call
-            # ``revoke`` are responsible for logging
-            # SECURITY_SESSION_REVOKED.
-            return True
-        return False
+        # Audit emission moved to service/controller layer per the
+        # persistence-boundary rule -- controllers that call ``revoke``
+        # are responsible for logging SECURITY_SESSION_REVOKED.
+        return rowcount > 0
 
     async def revoke_all_for_user(self, user_id: str) -> int:
         """Revoke all active sessions for a user.
@@ -252,6 +250,7 @@ class SQLiteSessionRepository:
                 # UPDATE succeeded; in-memory mutation only happens
                 # after a successful commit.
                 await self._db.commit()
+                self._revoked.update(row["session_id"] for row in rows)
             except (sqlite3.Error, aiosqlite.Error) as exc:
                 with contextlib.suppress(sqlite3.Error, aiosqlite.Error):
                     await self._db.rollback()
@@ -263,7 +262,6 @@ class SQLiteSessionRepository:
                     error=safe_error_description(exc),
                 )
                 raise QueryError(msg) from exc
-        self._revoked.update(row["session_id"] for row in rows)
         # Audit emission moved to service/controller layer per the
         # persistence-boundary rule.
         return count
@@ -314,6 +312,7 @@ class SQLiteSessionRepository:
                     (now,),
                 )
                 await self._db.commit()
+                self._revoked -= ids
             except (sqlite3.Error, aiosqlite.Error) as exc:
                 with contextlib.suppress(sqlite3.Error, aiosqlite.Error):
                     await self._db.rollback()
@@ -325,6 +324,5 @@ class SQLiteSessionRepository:
                     error=safe_error_description(exc),
                 )
                 raise QueryError(msg) from exc
-        self._revoked -= ids
         logger.debug(API_SESSION_CLEANUP, removed=len(ids))
         return len(ids)

--- a/src/synthorg/persistence/sqlite/session_repo.py
+++ b/src/synthorg/persistence/sqlite/session_repo.py
@@ -5,7 +5,6 @@ set provides O(1) sync lookups for the auth middleware hot path; the
 SQLite connection provides survival across restarts.
 """
 
-import asyncio
 import contextlib
 import sqlite3
 from datetime import UTC, datetime
@@ -28,6 +27,7 @@ from synthorg.persistence._shared import (
     coerce_row_timestamp,
     format_iso_utc,
 )
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -70,14 +70,10 @@ class SQLiteSessionRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
         self._revoked: set[str] = set()
 
     async def load_revoked(self) -> None:
@@ -97,7 +93,7 @@ class SQLiteSessionRepository:
 
     async def create(self, session: Session) -> None:
         """Persist a new session."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     "INSERT INTO sessions "
@@ -188,7 +184,7 @@ class SQLiteSessionRepository:
 
     async def revoke(self, session_id: str) -> bool:
         """Revoke a session by ID."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "UPDATE sessions SET revoked = 1 "
@@ -227,7 +223,7 @@ class SQLiteSessionRepository:
         through the auth fast path until the next ``load_revoked``.
         """
         now = format_iso_utc(datetime.now(UTC))
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 # SELECT first: capture the ids that WILL be revoked
                 # while they are still pending.  If this read fails we
@@ -297,7 +293,7 @@ class SQLiteSessionRepository:
     async def cleanup_expired(self) -> int:
         """Remove expired sessions from the database."""
         now = format_iso_utc(datetime.now(UTC))
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "SELECT session_id FROM sessions WHERE expires_at <= ?",

--- a/src/synthorg/persistence/sqlite/session_repo.py
+++ b/src/synthorg/persistence/sqlite/session_repo.py
@@ -64,6 +64,12 @@ class SQLiteSessionRepository:
 
     Args:
         db: Open aiosqlite connection with ``row_factory`` set.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(

--- a/src/synthorg/persistence/sqlite/settings_repo.py
+++ b/src/synthorg/persistence/sqlite/settings_repo.py
@@ -1,6 +1,5 @@
 """SQLite implementation of the SettingsRepository protocol."""
 
-import asyncio
 import sqlite3
 from collections.abc import Mapping, Sequence  # noqa: TC003
 
@@ -16,6 +15,7 @@ from synthorg.observability.events.settings import (
     SETTINGS_VALUE_SET,
 )
 from synthorg.persistence.settings_protocol import _DEFAULT_LIST_LIMIT_200
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -34,14 +34,10 @@ class SQLiteSettingsRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def get(
         self,
@@ -162,7 +158,7 @@ class SQLiteSettingsRepository:
             ``True`` if the write succeeded, ``False`` if the
             compare-and-swap condition was not met.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 if expected_updated_at is not None:
                     cursor = await self._db.execute(
@@ -222,7 +218,7 @@ class SQLiteSettingsRepository:
         if not items:
             return True
         cas_map: Mapping[tuple[str, str], str] = expected_updated_at_map or {}
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute("BEGIN IMMEDIATE")
                 try:
@@ -303,7 +299,7 @@ class SQLiteSettingsRepository:
         key: NotBlankStr,
     ) -> bool:
         """Delete a setting. Return True if deleted."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM settings WHERE namespace = ? AND key = ?",
@@ -325,7 +321,7 @@ class SQLiteSettingsRepository:
 
     async def delete_namespace(self, namespace: NotBlankStr) -> int:
         """Delete all settings in a namespace. Return count."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM settings WHERE namespace = ?",
@@ -355,7 +351,7 @@ class SQLiteSettingsRepository:
         concurrent ``set`` -- the returned tuple is exactly the set of
         keys whose override row was removed by *this* call.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM settings WHERE namespace = ? RETURNING key",

--- a/src/synthorg/persistence/sqlite/settings_repo.py
+++ b/src/synthorg/persistence/sqlite/settings_repo.py
@@ -28,6 +28,12 @@ class SQLiteSettingsRepository:
 
     Args:
         db: An open aiosqlite connection with row_factory set.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(

--- a/src/synthorg/persistence/sqlite/ssrf_violation_repo.py
+++ b/src/synthorg/persistence/sqlite/ssrf_violation_repo.py
@@ -1,6 +1,5 @@
 """SQLite repository implementation for SSRF violation records."""
 
-import asyncio
 import sqlite3
 from typing import TYPE_CHECKING, Any
 
@@ -18,7 +17,10 @@ from synthorg.persistence._shared import (
     coerce_row_timestamp,
     format_iso_utc,
 )
-from synthorg.persistence.sqlite._shared import is_unique_constraint_error
+from synthorg.persistence.sqlite._shared import (
+    WriteContext,
+    is_unique_constraint_error,
+)
 from synthorg.security.ssrf_violation import SsrfViolation, SsrfViolationStatus
 
 if TYPE_CHECKING:
@@ -37,19 +39,22 @@ class SQLiteSsrfViolationRepository:
 
     Args:
         db: An open aiosqlite connection.
-        write_lock: Optional shared lock protecting multi-statement
-            transactions.  Defaults to a per-instance lock for test
-            ergonomics.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def _rollback_quietly(self) -> None:
         """Roll back the current transaction, swallowing errors."""
@@ -77,7 +82,7 @@ class SQLiteSsrfViolationRepository:
         )
 
         try:
-            async with self._write_lock:
+            async with self._write_context():
                 await self._db.execute(
                     f"INSERT INTO ssrf_violations ({_COLS}) "  # noqa: S608
                     "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -244,7 +249,7 @@ class SQLiteSsrfViolationRepository:
 
         resolved_at_utc = format_iso_utc(resolved_at)
         try:
-            async with self._write_lock:
+            async with self._write_context():
                 cursor = await self._db.execute(
                     "UPDATE ssrf_violations "
                     "SET status = ?, resolved_by = ?, resolved_at = ? "

--- a/src/synthorg/persistence/sqlite/ssrf_violation_repo.py
+++ b/src/synthorg/persistence/sqlite/ssrf_violation_repo.py
@@ -60,6 +60,8 @@ class SQLiteSsrfViolationRepository:
         """Roll back the current transaction, swallowing errors."""
         try:
             await self._db.rollback()
+        except MemoryError, RecursionError:
+            raise
         except Exception:
             logger.warning(
                 PERSISTENCE_SSRF_VIOLATION_SAVE_FAILED,

--- a/src/synthorg/persistence/sqlite/ssrf_violation_repo.py
+++ b/src/synthorg/persistence/sqlite/ssrf_violation_repo.py
@@ -83,8 +83,8 @@ class SQLiteSsrfViolationRepository:
             format_iso_utc(violation.resolved_at) if violation.resolved_at else None
         )
 
-        try:
-            async with self._write_context():
+        async with self._write_context():
+            try:
                 await self._db.execute(
                     f"INSERT INTO ssrf_violations ({_COLS}) "  # noqa: S608
                     "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -103,27 +103,27 @@ class SQLiteSsrfViolationRepository:
                     ),
                 )
                 await self._db.commit()
-        except sqlite3.IntegrityError as exc:
-            await self._rollback_quietly()
-            if is_unique_constraint_error(exc):
-                msg = f"SSRF violation {violation.id!r} already exists"
-                raise DuplicateRecordError(msg) from exc
-            msg = "Failed to save SSRF violation"
-            logger.warning(
-                PERSISTENCE_SSRF_VIOLATION_SAVE_FAILED,
-                error_type=type(exc).__name__,
-                error=safe_error_description(exc),
-            )
-            raise PersistenceError(msg) from exc
-        except (sqlite3.Error, aiosqlite.Error) as exc:
-            await self._rollback_quietly()
-            msg = "Failed to save SSRF violation"
-            logger.warning(
-                PERSISTENCE_SSRF_VIOLATION_SAVE_FAILED,
-                error_type=type(exc).__name__,
-                error=safe_error_description(exc),
-            )
-            raise PersistenceError(msg) from exc
+            except sqlite3.IntegrityError as exc:
+                await self._rollback_quietly()
+                if is_unique_constraint_error(exc):
+                    msg = f"SSRF violation {violation.id!r} already exists"
+                    raise DuplicateRecordError(msg) from exc
+                msg = "Failed to save SSRF violation"
+                logger.warning(
+                    PERSISTENCE_SSRF_VIOLATION_SAVE_FAILED,
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
+                )
+                raise PersistenceError(msg) from exc
+            except (sqlite3.Error, aiosqlite.Error) as exc:
+                await self._rollback_quietly()
+                msg = "Failed to save SSRF violation"
+                logger.warning(
+                    PERSISTENCE_SSRF_VIOLATION_SAVE_FAILED,
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
+                )
+                raise PersistenceError(msg) from exc
 
     async def get(
         self,
@@ -250,8 +250,8 @@ class SQLiteSsrfViolationRepository:
             raise ValueError(msg)
 
         resolved_at_utc = format_iso_utc(resolved_at)
-        try:
-            async with self._write_context():
+        async with self._write_context():
+            try:
                 cursor = await self._db.execute(
                     "UPDATE ssrf_violations "
                     "SET status = ?, resolved_by = ?, resolved_at = ? "
@@ -264,15 +264,15 @@ class SQLiteSsrfViolationRepository:
                     ),
                 )
                 await self._db.commit()
-        except (sqlite3.Error, aiosqlite.Error) as exc:
-            await self._rollback_quietly()
-            msg = "Failed to update SSRF violation status"
-            logger.warning(
-                PERSISTENCE_SSRF_VIOLATION_SAVE_FAILED,
-                error_type=type(exc).__name__,
-                error=safe_error_description(exc),
-            )
-            raise PersistenceError(msg) from exc
+            except (sqlite3.Error, aiosqlite.Error) as exc:
+                await self._rollback_quietly()
+                msg = "Failed to update SSRF violation status"
+                logger.warning(
+                    PERSISTENCE_SSRF_VIOLATION_SAVE_FAILED,
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
+                )
+                raise PersistenceError(msg) from exc
 
         return cursor.rowcount > 0
 

--- a/src/synthorg/persistence/sqlite/subworkflow_repo.py
+++ b/src/synthorg/persistence/sqlite/subworkflow_repo.py
@@ -5,7 +5,6 @@ in their own table keyed by ``(subworkflow_id, semver)``.  See
 ``src/synthorg/persistence/subworkflow_repo.py`` for the protocol.
 """
 
-import asyncio
 import json
 import sqlite3
 from collections.abc import Iterable  # noqa: TC003
@@ -45,6 +44,7 @@ from synthorg.persistence._shared.pagination import (
     DEFAULT_LIST_LIMIT,
     validate_pagination_args,
 )
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -210,20 +210,22 @@ class SQLiteSubworkflowRepository:
 
     Args:
         db: An open aiosqlite connection.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, definition: WorkflowDefinition) -> None:
         """Insert a new subworkflow version row.
@@ -249,7 +251,7 @@ class SQLiteSubworkflowRepository:
         outputs_json = json.dumps(
             [o.model_dump(mode="json") for o in definition.outputs],
         )
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     """\
@@ -484,7 +486,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         version: NotBlankStr,
     ) -> bool:
         """Delete a subworkflow version, returning ``True`` on success."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM subworkflows WHERE subworkflow_id = ? AND semver = ?",
@@ -511,7 +513,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         version: NotBlankStr,
     ) -> tuple[bool, tuple[ParentReference, ...]]:
         """Atomically check-and-delete inside a single transaction."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 # find_parents already uses self._db so we wrap the
                 # whole check + delete in an explicit transaction.

--- a/src/synthorg/persistence/sqlite/training_plan_repo.py
+++ b/src/synthorg/persistence/sqlite/training_plan_repo.py
@@ -4,7 +4,6 @@ Provides ``SQLiteTrainingPlanRepository`` which persists
 ``TrainingPlan`` models via aiosqlite with upsert semantics.
 """
 
-import asyncio
 import contextlib
 import json
 import sqlite3
@@ -29,6 +28,7 @@ from synthorg.persistence._shared.pagination import (
     DEFAULT_LIST_LIMIT,
     validate_pagination_args,
 )
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -168,14 +168,10 @@ class SQLiteTrainingPlanRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, plan: TrainingPlan) -> None:
         """Persist a training plan via upsert.
@@ -186,7 +182,7 @@ class SQLiteTrainingPlanRepository:
         Raises:
             QueryError: If the database operation fails.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(_UPSERT_SQL, _plan_to_params(plan))
                 await self._db.commit()

--- a/src/synthorg/persistence/sqlite/training_plan_repo.py
+++ b/src/synthorg/persistence/sqlite/training_plan_repo.py
@@ -162,6 +162,12 @@ class SQLiteTrainingPlanRepository:
     Args:
         db: An open aiosqlite connection with ``row_factory``
             set to ``aiosqlite.Row``.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(

--- a/src/synthorg/persistence/sqlite/training_result_repo.py
+++ b/src/synthorg/persistence/sqlite/training_result_repo.py
@@ -4,7 +4,6 @@ Provides ``SQLiteTrainingResultRepository`` which persists
 ``TrainingResult`` models via aiosqlite with upsert semantics.
 """
 
-import asyncio
 import contextlib
 import json
 import sqlite3
@@ -24,6 +23,7 @@ from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.training import (
     HR_TRAINING_PERSISTENCE_ERROR,
 )
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -193,27 +193,22 @@ class SQLiteTrainingResultRepository:
     Args:
         db: An open aiosqlite connection with ``row_factory``
             set to ``aiosqlite.Row``.
-        write_lock: Optional shared lock used to serialize writes on
-            the shared connection.  Inject the
-            :class:`SQLitePersistenceBackend._shared_write_lock` so
-            writes from this repo coordinate with sibling repos that
-            share the same connection.  Defaults to ``None``, in
-            which case the repo creates a private :class:`asyncio.Lock`
-            (suitable for standalone test construction).
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, result: TrainingResult) -> None:
         """Persist a training result via upsert.
@@ -224,7 +219,7 @@ class SQLiteTrainingResultRepository:
         Raises:
             QueryError: If the database operation fails.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     _UPSERT_SQL,

--- a/src/synthorg/persistence/sqlite/user_repo.py
+++ b/src/synthorg/persistence/sqlite/user_repo.py
@@ -5,7 +5,6 @@ persist ``User`` and ``ApiKey`` domain models to SQLite via aiosqlite.
 Both use upsert semantics for ``save`` operations.
 """
 
-import asyncio
 import contextlib
 import json
 import sqlite3
@@ -48,6 +47,7 @@ from synthorg.persistence.constraint_tokens import (
     LAST_OWNER_TRIGGER,
     USERS_USERNAME_UNIQUE,
 )
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 
 def _classify_sqlite_user_error(message: str) -> str | None:
@@ -148,14 +148,10 @@ class SQLiteUserRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, user: User) -> None:
         """Persist a user via upsert (insert or update on conflict).
@@ -166,7 +162,7 @@ class SQLiteUserRepository:
         Raises:
             QueryError: If the database operation fails.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     """\
@@ -495,7 +491,7 @@ ON CONFLICT(id) DO UPDATE SET
                 error=msg,
             )
             raise QueryError(msg)
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM users WHERE id = ?", (user_id,)
@@ -546,14 +542,10 @@ class SQLiteApiKeyRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, key: ApiKey) -> None:
         """Persist an API key via upsert (insert or update on conflict).
@@ -564,7 +556,7 @@ class SQLiteApiKeyRepository:
         Raises:
             QueryError: If the database operation fails.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     """\
@@ -763,7 +755,7 @@ ON CONFLICT(id) DO UPDATE SET
         Raises:
             QueryError: If the database operation fails.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM api_keys WHERE id = ?", (key_id,)

--- a/src/synthorg/persistence/sqlite/user_repo.py
+++ b/src/synthorg/persistence/sqlite/user_repo.py
@@ -142,6 +142,12 @@ class SQLiteUserRepository:
     Args:
         db: An open aiosqlite connection with ``row_factory``
             set to ``aiosqlite.Row``.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
@@ -536,6 +542,12 @@ class SQLiteApiKeyRepository:
     Args:
         db: An open aiosqlite connection with ``row_factory``
             set to ``aiosqlite.Row``.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(

--- a/src/synthorg/persistence/sqlite/version_repo.py
+++ b/src/synthorg/persistence/sqlite/version_repo.py
@@ -69,6 +69,12 @@ class SQLiteVersionRepository[T: BaseModel]:
             a JSON string for persistence.
         deserialize_snapshot: Callable that converts a stored JSON
             string back to a ``T`` instance.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(

--- a/src/synthorg/persistence/sqlite/version_repo.py
+++ b/src/synthorg/persistence/sqlite/version_repo.py
@@ -17,7 +17,6 @@ Example::
     )
 """
 
-import asyncio
 import json
 import re
 import sqlite3
@@ -38,6 +37,7 @@ from synthorg.observability.events.versioning import (
     VERSION_LISTED,
     VERSION_SAVE_FAILED,
 )
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 from synthorg.persistence.version_protocol import _DEFAULT_LIST_LIMIT_50
 from synthorg.versioning.models import VersionSnapshot
 
@@ -78,7 +78,7 @@ class SQLiteVersionRepository[T: BaseModel]:
         table_name: str,
         serialize_snapshot: Callable[[T], str],
         deserialize_snapshot: Callable[[str], T],
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         if not _TABLE_NAME_RE.match(table_name):
             msg = f"Invalid table name: {table_name!r} (must match [a-z][a-z0-9_]*)"
@@ -87,11 +87,7 @@ class SQLiteVersionRepository[T: BaseModel]:
         self._table = table_name
         self._serialize = serialize_snapshot
         self._deserialize = deserialize_snapshot
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
         _t = self._table
         _c = _SELECT_COLUMNS
         self._insert_sql = (
@@ -216,7 +212,7 @@ class SQLiteVersionRepository[T: BaseModel]:
                 error=safe_error_description(exc),
             )
             raise QueryError(msg) from exc
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     self._insert_sql,
@@ -382,7 +378,7 @@ class SQLiteVersionRepository[T: BaseModel]:
 
     async def delete_versions_for_entity(self, entity_id: NotBlankStr) -> int:
         """Delete all version snapshots for an entity."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(self._delete_sql, (entity_id,))
                 await self._db.commit()

--- a/src/synthorg/persistence/sqlite/webhook_receipt_repo.py
+++ b/src/synthorg/persistence/sqlite/webhook_receipt_repo.py
@@ -5,7 +5,6 @@ table for after-the-fact debugging and replay.  Reads are
 newest-first and bounded by an explicit ``limit``.
 """
 
-import asyncio
 import contextlib
 import sqlite3
 from datetime import UTC, datetime, timedelta
@@ -28,6 +27,7 @@ from synthorg.persistence._shared import (
     coerce_row_timestamp,
     format_iso_utc,
 )
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -69,15 +69,15 @@ class SQLiteWebhookReceiptRepository:
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
-        """Bind to *db* and serialize writes via *write_lock*."""
+        """Bind to *db* and serialize writes via *write_context*."""
         self._db = db
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def log(self, receipt: WebhookReceipt) -> None:
         """Append a webhook receipt row (idempotent on receipt id)."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 await self._db.execute(
                     """
@@ -172,7 +172,7 @@ class SQLiteWebhookReceiptRepository:
         ``retention_days <= 0`` is treated as a no-op so callers cannot
         accidentally truncate the log via misconfiguration.
 
-        Note: holds ``self._write_lock`` for the duration of the DELETE
+        Note: holds ``self._write_context()`` for the duration of the DELETE
         + COMMIT.  On a large ``webhook_receipts`` table this can
         briefly block other writers (the daily sweep is serialised
         against the rest of the SQLite write traffic by design).
@@ -184,7 +184,7 @@ class SQLiteWebhookReceiptRepository:
             return 0
         cutoff = datetime.now(UTC) - timedelta(days=retention_days)
         cutoff_iso = format_iso_utc(cutoff)
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM webhook_receipts "

--- a/src/synthorg/persistence/sqlite/workflow_definition_repo.py
+++ b/src/synthorg/persistence/sqlite/workflow_definition_repo.py
@@ -1,6 +1,5 @@
 """SQLite repository implementation for WorkflowDefinition."""
 
-import asyncio
 import json
 import sqlite3
 from datetime import UTC, datetime
@@ -37,6 +36,7 @@ from synthorg.persistence._shared.pagination import (
     DEFAULT_LIST_LIMIT,
     validate_pagination_args,
 )
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -130,20 +130,22 @@ class SQLiteWorkflowDefinitionRepository:
     Args:
         db: An open aiosqlite connection with ``row_factory``
             set to ``aiosqlite.Row``.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     def _require_valid_revision(self, definition: WorkflowDefinition) -> None:
         """Reject obviously-invalid revisions before hitting the DB.
@@ -189,7 +191,7 @@ class SQLiteWorkflowDefinitionRepository:
         outputs_json = json.dumps(
             [o.model_dump(mode="json") for o in definition.outputs],
         )
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     """\
@@ -269,7 +271,7 @@ WHERE id = ? AND revision = ?""",
         outputs_json = json.dumps(
             [o.model_dump(mode="json") for o in definition.outputs],
         )
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     """\
@@ -337,7 +339,7 @@ ON CONFLICT(id) DO NOTHING""",
         outputs_json = json.dumps(
             [o.model_dump(mode="json") for o in definition.outputs],
         )
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     """\
@@ -528,7 +530,7 @@ WHERE workflow_definitions.revision = excluded.revision - 1""",
         Raises:
             QueryError: If the database operation fails.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM workflow_definitions WHERE id = ?",

--- a/src/synthorg/persistence/sqlite/workflow_execution_repo.py
+++ b/src/synthorg/persistence/sqlite/workflow_execution_repo.py
@@ -1,6 +1,5 @@
 """SQLite repository implementation for WorkflowExecution."""
 
-import asyncio
 import json
 import sqlite3
 from datetime import UTC, datetime
@@ -43,6 +42,7 @@ from synthorg.persistence._shared.pagination import (
     DEFAULT_LIST_LIMIT,
     validate_pagination_args,
 )
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 
 logger = get_logger(__name__)
 
@@ -140,20 +140,22 @@ class SQLiteWorkflowExecutionRepository:
     Args:
         db: An open aiosqlite connection with ``row_factory``
             set to ``aiosqlite.Row``.
+        write_context: Async context manager that serializes writes on
+            the shared connection. Supplied by
+            ``SQLitePersistenceBackend.write_context`` in production;
+            tests can pass
+            ``tests._shared.persistence.make_private_write_context()``
+            for standalone construction.
     """
 
     def __init__(
         self,
         db: aiosqlite.Connection,
         *,
-        write_lock: asyncio.Lock | None = None,
+        write_context: WriteContext,
     ) -> None:
         self._db = db
-        # Inject the shared backend write lock so writes from this repo
-        # serialize with sibling repos that share the same
-        # ``aiosqlite.Connection``; fall back to a private lock for
-        # standalone test construction.
-        self._write_lock = write_lock if write_lock is not None else asyncio.Lock()
+        self._write_context = write_context
 
     async def save(self, execution: WorkflowExecution) -> None:
         """Persist a workflow execution (insert or update).
@@ -208,7 +210,7 @@ class SQLiteWorkflowExecutionRepository:
     async def _insert(self, execution: WorkflowExecution) -> None:
         """Insert a new workflow execution row."""
         params = self._serialize_execution(execution)
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     """\
@@ -264,7 +266,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
     async def _update(self, execution: WorkflowExecution) -> None:
         """Update an existing workflow execution with version check."""
         params = self._serialize_execution(execution)
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     """\
@@ -550,7 +552,7 @@ WHERE id = ? AND version = ?""",
         Raises:
             QueryError: If the database operation fails.
         """
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM workflow_executions WHERE id = ?",

--- a/tests/_shared/persistence.py
+++ b/tests/_shared/persistence.py
@@ -24,9 +24,13 @@ def make_private_write_context() -> WriteContext:
     """Return a ``WriteContext`` backed by a fresh private ``asyncio.Lock``.
 
     Each call returns a new context-manager factory closed over its
-    own lock; multiple calls produce independent serialization
-    domains. Use one per repository per test so concurrent operations
-    on the same repo still serialize correctly.
+    own lock; multiple calls produce independent serialization domains.
+    Create one private write-context per shared connection per test:
+    every repository attached to that connection MUST receive the same
+    context so writes serialize across siblings, matching production
+    where the backend hands out a single shared context. See the
+    module-level warning above for why mixing contexts on one
+    connection is unsafe.
     """
     lock = asyncio.Lock()
 

--- a/tests/_shared/persistence.py
+++ b/tests/_shared/persistence.py
@@ -6,6 +6,11 @@ serialize across the shared ``aiosqlite.Connection``. Tests that
 exercise a single repository in isolation (no sibling repos on the
 connection) use :func:`make_private_write_context` to satisfy the
 required ``write_context`` constructor argument.
+
+DO NOT import this module from application code. Each
+``make_private_write_context()`` call returns its own isolated lock,
+so two repositories that should share the backend write lock will
+silently fail to serialize if both are constructed via this helper.
 """
 
 import asyncio

--- a/tests/_shared/persistence.py
+++ b/tests/_shared/persistence.py
@@ -1,0 +1,33 @@
+"""Test-only helpers for direct SQLite repository construction.
+
+Production code never builds a private write context: every SQLite
+repository receives its ``write_context`` from the backend so writes
+serialize across the shared ``aiosqlite.Connection``. Tests that
+exercise a single repository in isolation (no sibling repos on the
+connection) use :func:`make_private_write_context` to satisfy the
+required ``write_context`` constructor argument.
+"""
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from synthorg.persistence.sqlite._shared import WriteContext
+
+
+def make_private_write_context() -> WriteContext:
+    """Return a ``WriteContext`` backed by a fresh private ``asyncio.Lock``.
+
+    Each call returns a new context-manager factory closed over its
+    own lock; multiple calls produce independent serialization
+    domains. Use one per repository per test so concurrent operations
+    on the same repo still serialize correctly.
+    """
+    lock = asyncio.Lock()
+
+    @asynccontextmanager
+    async def _cm() -> AsyncIterator[None]:
+        async with lock:
+            yield
+
+    return _cm

--- a/tests/conformance/persistence/test_approval_repository.py
+++ b/tests/conformance/persistence/test_approval_repository.py
@@ -40,7 +40,10 @@ def _approval_repo(backend: PersistenceBackend) -> ApprovalRepository:
     name = backend.backend_name
     handle = backend.get_db()
     if name == "sqlite":
-        return SQLiteApprovalRepository(cast("aiosqlite.Connection", handle))
+        return SQLiteApprovalRepository(
+            cast("aiosqlite.Connection", handle),
+            write_context=backend.write_context,
+        )
     if name == "postgres":
         from psycopg_pool import AsyncConnectionPool
 

--- a/tests/conformance/persistence/test_sqlite_write_context_serializes.py
+++ b/tests/conformance/persistence/test_sqlite_write_context_serializes.py
@@ -1,0 +1,56 @@
+"""SQLite ``write_context`` enforces strict mutual exclusion.
+
+The Postgres arm of ``write_context`` is a no-op (pool checkouts
+isolate writers at the database level), so a cross-backend test
+cannot assert serialization. This file constructs a SQLite backend
+directly and asserts that concurrent workers observe strict
+interleave: every worker fully exits before the next enters.
+"""
+# lint-allow: dual-backend-parity -- write_context serialization is backend-specific by contract  # noqa: E501
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from synthorg.persistence import migrations
+from synthorg.persistence.config import SQLiteConfig
+from synthorg.persistence.sqlite.backend import SQLitePersistenceBackend
+
+_WORKER_COUNT = 4
+
+
+@pytest.mark.integration
+async def test_sqlite_write_context_strictly_serializes_writers(
+    tmp_path: Path,
+) -> None:  # lint-allow: dual-backend-parity -- SQLite-only by design
+    db_path = tmp_path / "serialization.db"
+    rev_path = migrations.copy_revisions(tmp_path / "revisions", backend="sqlite")
+    await migrations.migrate_apply(
+        migrations.to_sqlite_url(str(db_path)),
+        revisions_path=rev_path,
+    )
+    backend = SQLitePersistenceBackend(SQLiteConfig(path=str(db_path)))
+    await backend.connect()
+    try:
+        events: list[tuple[str, int]] = []
+
+        async def worker(idx: int) -> None:
+            async with backend.write_context():
+                events.append(("enter", idx))
+                await asyncio.sleep(0)
+                events.append(("exit", idx))
+
+        async with asyncio.TaskGroup() as tg:
+            for i in range(_WORKER_COUNT):
+                tg.create_task(worker(i))
+
+        assert len(events) == 2 * _WORKER_COUNT
+        for n in range(0, len(events), 2):
+            assert events[n][0] == "enter"
+            assert events[n + 1] == ("exit", events[n][1]), (
+                f"Worker {events[n][1]} did not fully exit before the next "
+                f"writer entered: events={events}"
+            )
+    finally:
+        await backend.disconnect()

--- a/tests/conformance/persistence/test_write_context.py
+++ b/tests/conformance/persistence/test_write_context.py
@@ -1,0 +1,26 @@
+"""Conformance tests for ``PersistenceBackend.write_context``.
+
+Both backends must expose ``write_context`` as a one-shot async
+context manager that enters, yields ``None``, and exits cleanly.
+Each call returns a fresh context manager (re-entry across separate
+calls is supported).
+
+This file covers the cross-backend contract. SQLite's stricter
+mutual-exclusion guarantee is exercised in
+``test_sqlite_write_context_serializes.py`` (single-arm by design;
+Postgres ``write_context`` is a no-op).
+"""
+
+import pytest
+
+from synthorg.persistence.protocol import PersistenceBackend
+
+
+@pytest.mark.integration
+async def test_write_context_enters_and_exits(
+    backend: PersistenceBackend,
+) -> None:
+    async with backend.write_context():
+        pass
+    async with backend.write_context():
+        pass

--- a/tests/conformance/persistence/test_write_context.py
+++ b/tests/conformance/persistence/test_write_context.py
@@ -20,7 +20,7 @@ from synthorg.persistence.protocol import PersistenceBackend
 async def test_write_context_enters_and_exits(
     backend: PersistenceBackend,
 ) -> None:
-    async with backend.write_context():
-        pass
-    async with backend.write_context():
-        pass
+    async with backend.write_context() as first:
+        assert first is None
+    async with backend.write_context() as second:
+        assert second is None

--- a/tests/integration/engine/identity/test_identity_versioning.py
+++ b/tests/integration/engine/identity/test_identity_versioning.py
@@ -28,6 +28,7 @@ from synthorg.persistence.decision_protocol import DecisionRepository
 from synthorg.persistence.protocol import PersistenceBackend
 from synthorg.persistence.sqlite.version_repo import SQLiteVersionRepository
 from synthorg.versioning.service import VersioningService
+from tests._shared.persistence import make_private_write_context
 
 _MODEL = ModelConfig(provider="test-provider", model_id="test-medium-001")
 _HIRE = date(2026, 1, 1)
@@ -70,6 +71,7 @@ async def version_repo(
         table_name="agent_identity_versions",
         serialize_snapshot=lambda m: json.dumps(m.model_dump(mode="json")),
         deserialize_snapshot=lambda s: AgentIdentity.model_validate(json.loads(s)),
+        write_context=make_private_write_context(),
     )
 
 

--- a/tests/integration/engine/workflow/test_subworkflows_e2e.py
+++ b/tests/integration/engine/workflow/test_subworkflows_e2e.py
@@ -32,6 +32,7 @@ from synthorg.persistence.sqlite.subworkflow_repo import (
 from synthorg.persistence.sqlite.workflow_definition_repo import (
     SQLiteWorkflowDefinitionRepository,
 )
+from tests._shared.persistence import make_private_write_context
 
 _TS = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
 
@@ -58,12 +59,14 @@ async def db(tmp_path: Path) -> AsyncGenerator[aiosqlite.Connection]:
 
 @pytest.fixture
 def sub_repo(db: aiosqlite.Connection) -> SQLiteSubworkflowRepository:
-    return SQLiteSubworkflowRepository(db)
+    return SQLiteSubworkflowRepository(db, write_context=make_private_write_context())
 
 
 @pytest.fixture
 def def_repo(db: aiosqlite.Connection) -> SQLiteWorkflowDefinitionRepository:
-    return SQLiteWorkflowDefinitionRepository(db)
+    return SQLiteWorkflowDefinitionRepository(
+        db, write_context=make_private_write_context()
+    )
 
 
 @pytest.fixture

--- a/tests/integration/engine/workflow/test_subworkflows_e2e.py
+++ b/tests/integration/engine/workflow/test_subworkflows_e2e.py
@@ -26,6 +26,7 @@ from synthorg.engine.workflow.definition import (
 from synthorg.engine.workflow.subworkflow_registry import SubworkflowRegistry
 from synthorg.engine.workflow.yaml_export import export_workflow_yaml
 from synthorg.persistence import migrations
+from synthorg.persistence.sqlite._shared import WriteContext
 from synthorg.persistence.sqlite.subworkflow_repo import (
     SQLiteSubworkflowRepository,
 )
@@ -58,15 +59,24 @@ async def db(tmp_path: Path) -> AsyncGenerator[aiosqlite.Connection]:
 
 
 @pytest.fixture
-def sub_repo(db: aiosqlite.Connection) -> SQLiteSubworkflowRepository:
-    return SQLiteSubworkflowRepository(db, write_context=make_private_write_context())
+def write_context() -> WriteContext:
+    return make_private_write_context()
 
 
 @pytest.fixture
-def def_repo(db: aiosqlite.Connection) -> SQLiteWorkflowDefinitionRepository:
-    return SQLiteWorkflowDefinitionRepository(
-        db, write_context=make_private_write_context()
-    )
+def sub_repo(
+    db: aiosqlite.Connection,
+    write_context: WriteContext,
+) -> SQLiteSubworkflowRepository:
+    return SQLiteSubworkflowRepository(db, write_context=write_context)
+
+
+@pytest.fixture
+def def_repo(
+    db: aiosqlite.Connection,
+    write_context: WriteContext,
+) -> SQLiteWorkflowDefinitionRepository:
+    return SQLiteWorkflowDefinitionRepository(db, write_context=write_context)
 
 
 @pytest.fixture

--- a/tests/integration/hr/training/test_training_persistence.py
+++ b/tests/integration/hr/training/test_training_persistence.py
@@ -30,6 +30,7 @@ from synthorg.persistence.sqlite.training_result_repo import (
     SQLiteTrainingResultRepository,
 )
 from tests._shared import mock_of
+from tests._shared.persistence import make_private_write_context
 
 
 def _make_item(
@@ -54,8 +55,12 @@ class TestTrainingPersistencePipeline:
         migrated_db: aiosqlite.Connection,
     ) -> None:
         """Plan -> execute -> persist result -> fetch result."""
-        plan_repo = SQLiteTrainingPlanRepository(migrated_db)
-        result_repo = SQLiteTrainingResultRepository(migrated_db)
+        plan_repo = SQLiteTrainingPlanRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
+        result_repo = SQLiteTrainingResultRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
 
         # 1. Create and persist a training plan.
         plan = TrainingPlan(

--- a/tests/integration/hr/training/test_training_persistence.py
+++ b/tests/integration/hr/training/test_training_persistence.py
@@ -55,11 +55,12 @@ class TestTrainingPersistencePipeline:
         migrated_db: aiosqlite.Connection,
     ) -> None:
         """Plan -> execute -> persist result -> fetch result."""
+        write_context = make_private_write_context()
         plan_repo = SQLiteTrainingPlanRepository(
-            migrated_db, write_context=make_private_write_context()
+            migrated_db, write_context=write_context
         )
         result_repo = SQLiteTrainingResultRepository(
-            migrated_db, write_context=make_private_write_context()
+            migrated_db, write_context=write_context
         )
 
         # 1. Create and persist a training plan.

--- a/tests/unit/api/auth/test_lockout_store.py
+++ b/tests/unit/api/auth/test_lockout_store.py
@@ -10,6 +10,7 @@ from synthorg.core.auth.config import AuthConfig
 from synthorg.persistence.sqlite.lockout_repo import (
     SQLiteLockoutRepository as LockoutStore,
 )
+from tests._shared.persistence import make_private_write_context
 
 pytestmark = pytest.mark.unit
 
@@ -35,7 +36,7 @@ def db(migrated_db: aiosqlite.Connection) -> aiosqlite.Connection:
 
 @pytest.fixture
 async def store(db: aiosqlite.Connection) -> LockoutStore:
-    return LockoutStore(db, _make_config())
+    return LockoutStore(db, _make_config(), write_context=make_private_write_context())
 
 
 class TestLockoutIsLocked:
@@ -103,7 +104,7 @@ class TestLockoutCleanup:
         db: aiosqlite.Connection,
     ) -> None:
         config = _make_config(window_minutes=1)
-        store = LockoutStore(db, config)
+        store = LockoutStore(db, config, write_context=make_private_write_context())
 
         # Insert an old record directly
         await db.execute(
@@ -121,7 +122,7 @@ class TestLockoutCleanup:
 class TestLockoutDurationSeconds:
     async def test_returns_correct_duration(self, db: aiosqlite.Connection) -> None:
         config = _make_config(duration_minutes=15)
-        store_obj = LockoutStore(db, config)
+        store_obj = LockoutStore(db, config, write_context=make_private_write_context())
         assert store_obj.lockout_duration_seconds == 900
 
 
@@ -132,7 +133,7 @@ class TestLockoutWithMockedTime:
     ) -> None:
         """Lock expires when monotonic time passes the duration."""
         config = _make_config(threshold=2, duration_minutes=5)
-        store = LockoutStore(db, config)
+        store = LockoutStore(db, config, write_context=make_private_write_context())
 
         # Trigger lockout
         await store.record_failure("alice")

--- a/tests/unit/api/auth/test_postgres_session_store.py
+++ b/tests/unit/api/auth/test_postgres_session_store.py
@@ -25,6 +25,7 @@ from synthorg.persistence.sqlite.session_repo import (
     SQLiteSessionRepository as SqliteSessionStore,
 )
 from tests._shared import mock_of
+from tests._shared.persistence import make_private_write_context
 
 pytestmark = pytest.mark.unit
 
@@ -121,7 +122,9 @@ def test_concrete_stores_expose_protocol_shape() -> None:
     pg_pool = MagicMock()
     sqlite_db = mock_of[Connection]()
     pg_store = PostgresSessionStore(pg_pool)
-    sqlite_store = SqliteSessionStore(sqlite_db)
+    sqlite_store = SqliteSessionStore(
+        sqlite_db, write_context=make_private_write_context()
+    )
     assert isinstance(pg_store, SessionStore)
     assert isinstance(sqlite_store, SessionStore)
     # Every SessionStore method must exist on both concretes (catches a

--- a/tests/unit/api/auth/test_refresh_store.py
+++ b/tests/unit/api/auth/test_refresh_store.py
@@ -9,6 +9,7 @@ from synthorg.core.auth.refresh_record import RefreshRejectReason
 from synthorg.persistence.sqlite.refresh_repo import (
     SQLiteRefreshTokenRepository as RefreshStore,
 )
+from tests._shared.persistence import make_private_write_context
 
 pytestmark = pytest.mark.unit
 
@@ -25,7 +26,7 @@ def db(migrated_db: aiosqlite.Connection) -> aiosqlite.Connection:
 
 @pytest.fixture
 async def store(db: aiosqlite.Connection) -> RefreshStore:
-    return RefreshStore(db)
+    return RefreshStore(db, write_context=make_private_write_context())
 
 
 class TestRefreshCreate:
@@ -187,7 +188,7 @@ class TestRefreshCleanup:
         self,
         db: aiosqlite.Connection,
     ) -> None:
-        store = RefreshStore(db)
+        store = RefreshStore(db, write_context=make_private_write_context())
         # Expired token -- will be removed
         await store.create(
             token_hash="expired",

--- a/tests/unit/api/auth/test_session_store.py
+++ b/tests/unit/api/auth/test_session_store.py
@@ -17,6 +17,7 @@ from synthorg.persistence.auth_protocol import SessionRepository as SessionStore
 from synthorg.persistence.sqlite.session_repo import (
     SQLiteSessionRepository as SqliteSessionStore,
 )
+from tests._shared.persistence import make_private_write_context
 
 pytestmark = pytest.mark.unit
 
@@ -102,7 +103,7 @@ async def db(migrated_db: aiosqlite.Connection) -> aiosqlite.Connection:
 
 @pytest.fixture
 async def store(db: aiosqlite.Connection) -> SessionStore:
-    s = SqliteSessionStore(db)
+    s = SqliteSessionStore(db, write_context=make_private_write_context())
     await s.load_revoked()
     return s
 
@@ -384,14 +385,14 @@ class TestSessionStoreLoadRevoked:
         db: aiosqlite.Connection,
     ) -> None:
         """Revocations survive store recreation (simulates restart)."""
-        store1 = SqliteSessionStore(db)
+        store1 = SqliteSessionStore(db, write_context=make_private_write_context())
         with _patch_now():
             await store1.load_revoked()
         await store1.create(_make_session())
         await store1.revoke("sess-1")
 
         # Create a new store (simulates restart).
-        store2 = SqliteSessionStore(db)
+        store2 = SqliteSessionStore(db, write_context=make_private_write_context())
         assert store2.is_revoked("sess-1") is False
         with _patch_now():
             await store2.load_revoked()

--- a/tests/unit/hr/test_persistence.py
+++ b/tests/unit/hr/test_persistence.py
@@ -18,6 +18,7 @@ from synthorg.persistence.sqlite.hr_repositories import (
     SQLiteLifecycleEventRepository,
     SQLiteTaskMetricRepository,
 )
+from tests._shared.persistence import make_private_write_context
 
 
 @pytest.fixture
@@ -106,7 +107,9 @@ def _make_collab_metric(  # noqa: PLR0913
 @pytest.mark.unit
 class TestSQLiteLifecycleEventRepository:
     async def test_save_and_list_all(self, db: aiosqlite.Connection) -> None:
-        repo = SQLiteLifecycleEventRepository(db)
+        repo = SQLiteLifecycleEventRepository(
+            db, write_context=make_private_write_context()
+        )
         event = _make_lifecycle_event()
         await repo.save(event)
 
@@ -116,7 +119,9 @@ class TestSQLiteLifecycleEventRepository:
         assert events[0].event_type == LifecycleEventType.HIRED
 
     async def test_list_filter_by_agent_id(self, db: aiosqlite.Connection) -> None:
-        repo = SQLiteLifecycleEventRepository(db)
+        repo = SQLiteLifecycleEventRepository(
+            db, write_context=make_private_write_context()
+        )
         await repo.save(_make_lifecycle_event(agent_id="agent-001"))
         await repo.save(_make_lifecycle_event(agent_id="agent-002"))
 
@@ -125,7 +130,9 @@ class TestSQLiteLifecycleEventRepository:
         assert events[0].agent_id == "agent-001"
 
     async def test_list_filter_by_event_type(self, db: aiosqlite.Connection) -> None:
-        repo = SQLiteLifecycleEventRepository(db)
+        repo = SQLiteLifecycleEventRepository(
+            db, write_context=make_private_write_context()
+        )
         await repo.save(_make_lifecycle_event(event_type=LifecycleEventType.HIRED))
         await repo.save(_make_lifecycle_event(event_type=LifecycleEventType.FIRED))
 
@@ -135,7 +142,9 @@ class TestSQLiteLifecycleEventRepository:
 
     async def test_list_combined_filters(self, db: aiosqlite.Connection) -> None:
         """agent_id + event_type filters combine with AND logic."""
-        repo = SQLiteLifecycleEventRepository(db)
+        repo = SQLiteLifecycleEventRepository(
+            db, write_context=make_private_write_context()
+        )
         await repo.save(
             _make_lifecycle_event(
                 agent_id="agent-001",
@@ -165,7 +174,9 @@ class TestSQLiteLifecycleEventRepository:
 
     async def test_round_trip_metadata(self, db: aiosqlite.Connection) -> None:
         """Metadata dict survives JSON serialization round-trip."""
-        repo = SQLiteLifecycleEventRepository(db)
+        repo = SQLiteLifecycleEventRepository(
+            db, write_context=make_private_write_context()
+        )
         event = _make_lifecycle_event(
             metadata={"reason": "budget", "department": "engineering"}
         )
@@ -178,13 +189,17 @@ class TestSQLiteLifecycleEventRepository:
         }
 
     async def test_list_empty(self, db: aiosqlite.Connection) -> None:
-        repo = SQLiteLifecycleEventRepository(db)
+        repo = SQLiteLifecycleEventRepository(
+            db, write_context=make_private_write_context()
+        )
         events = await repo.list_events()
         assert events == ()
 
     async def test_list_filter_by_since(self, db: aiosqlite.Connection) -> None:
         """Events before 'since' are excluded."""
-        repo = SQLiteLifecycleEventRepository(db)
+        repo = SQLiteLifecycleEventRepository(
+            db, write_context=make_private_write_context()
+        )
         old_event = _make_lifecycle_event(
             agent_id="agent-001",
             timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC),
@@ -208,7 +223,9 @@ class TestSQLiteLifecycleEventRepository:
 @pytest.mark.unit
 class TestSQLiteTaskMetricRepository:
     async def test_save_and_query_all(self, db: aiosqlite.Connection) -> None:
-        repo = SQLiteTaskMetricRepository(db)
+        repo = SQLiteTaskMetricRepository(
+            db, write_context=make_private_write_context()
+        )
         record = _make_task_metric()
         await repo.save(record)
 
@@ -220,7 +237,9 @@ class TestSQLiteTaskMetricRepository:
         assert records[0].complexity == Complexity.MEDIUM
 
     async def test_query_filter_by_agent_id(self, db: aiosqlite.Connection) -> None:
-        repo = SQLiteTaskMetricRepository(db)
+        repo = SQLiteTaskMetricRepository(
+            db, write_context=make_private_write_context()
+        )
         await repo.save(_make_task_metric(agent_id="agent-001"))
         await repo.save(_make_task_metric(agent_id="agent-002"))
 
@@ -229,14 +248,18 @@ class TestSQLiteTaskMetricRepository:
         assert records[0].agent_id == "agent-001"
 
     async def test_query_empty(self, db: aiosqlite.Connection) -> None:
-        repo = SQLiteTaskMetricRepository(db)
+        repo = SQLiteTaskMetricRepository(
+            db, write_context=make_private_write_context()
+        )
         records = await repo.query()
         assert records == ()
 
     async def test_round_trip_null_quality_score(
         self, db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteTaskMetricRepository(db)
+        repo = SQLiteTaskMetricRepository(
+            db, write_context=make_private_write_context()
+        )
         record = _make_task_metric(quality_score=None)
         await repo.save(record)
 
@@ -246,7 +269,9 @@ class TestSQLiteTaskMetricRepository:
     async def test_round_trip_task_type_and_complexity(
         self, db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteTaskMetricRepository(db)
+        repo = SQLiteTaskMetricRepository(
+            db, write_context=make_private_write_context()
+        )
         record = _make_task_metric(
             task_type=TaskType.RESEARCH,
             complexity=Complexity.COMPLEX,
@@ -261,7 +286,9 @@ class TestSQLiteTaskMetricRepository:
         self, db: aiosqlite.Connection
     ) -> None:
         """Records outside the since/until range are excluded."""
-        repo = SQLiteTaskMetricRepository(db)
+        repo = SQLiteTaskMetricRepository(
+            db, write_context=make_private_write_context()
+        )
         early = _make_task_metric(
             task_id="task-early",
             completed_at=datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC),
@@ -291,7 +318,9 @@ class TestSQLiteTaskMetricRepository:
 @pytest.mark.unit
 class TestSQLiteCollaborationMetricRepository:
     async def test_save_and_query_all(self, db: aiosqlite.Connection) -> None:
-        repo = SQLiteCollaborationMetricRepository(db)
+        repo = SQLiteCollaborationMetricRepository(
+            db, write_context=make_private_write_context()
+        )
         record = _make_collab_metric()
         await repo.save(record)
 
@@ -302,7 +331,9 @@ class TestSQLiteCollaborationMetricRepository:
         assert records[0].loop_triggered is False
 
     async def test_query_filter_by_agent_id(self, db: aiosqlite.Connection) -> None:
-        repo = SQLiteCollaborationMetricRepository(db)
+        repo = SQLiteCollaborationMetricRepository(
+            db, write_context=make_private_write_context()
+        )
         await repo.save(_make_collab_metric(agent_id="agent-001"))
         await repo.save(_make_collab_metric(agent_id="agent-002"))
 
@@ -311,13 +342,17 @@ class TestSQLiteCollaborationMetricRepository:
         assert records[0].agent_id == "agent-001"
 
     async def test_query_empty(self, db: aiosqlite.Connection) -> None:
-        repo = SQLiteCollaborationMetricRepository(db)
+        repo = SQLiteCollaborationMetricRepository(
+            db, write_context=make_private_write_context()
+        )
         records = await repo.query()
         assert records == ()
 
     async def test_round_trip_nullable_fields(self, db: aiosqlite.Connection) -> None:
         """Nullable float/bool fields survive round-trip as None."""
-        repo = SQLiteCollaborationMetricRepository(db)
+        repo = SQLiteCollaborationMetricRepository(
+            db, write_context=make_private_write_context()
+        )
         record = _make_collab_metric(
             delegation_success=None,
             delegation_response_seconds=None,
@@ -338,7 +373,9 @@ class TestSQLiteCollaborationMetricRepository:
         self, db: aiosqlite.Connection
     ) -> None:
         """Boolean loop_triggered=True survives SQLite integer round-trip."""
-        repo = SQLiteCollaborationMetricRepository(db)
+        repo = SQLiteCollaborationMetricRepository(
+            db, write_context=make_private_write_context()
+        )
         record = _make_collab_metric(loop_triggered=True)
         await repo.save(record)
 
@@ -347,7 +384,9 @@ class TestSQLiteCollaborationMetricRepository:
 
     async def test_query_filter_by_since(self, db: aiosqlite.Connection) -> None:
         """Records before 'since' are excluded."""
-        repo = SQLiteCollaborationMetricRepository(db)
+        repo = SQLiteCollaborationMetricRepository(
+            db, write_context=make_private_write_context()
+        )
         old_record = _make_collab_metric(
             recorded_at=datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC),
         )

--- a/tests/unit/memory/embedding/test_fine_tune_orchestrator.py
+++ b/tests/unit/memory/embedding/test_fine_tune_orchestrator.py
@@ -27,6 +27,7 @@ from synthorg.persistence.sqlite.fine_tune_repo import (
     SQLiteFineTuneRunRepository,
 )
 from tests._shared.fake_clock import FakeClock
+from tests._shared.persistence import make_private_write_context
 
 _SCHEMA_PATH = Path("src/synthorg/persistence/sqlite/schema.sql")
 
@@ -44,14 +45,16 @@ async def db() -> AsyncGenerator[aiosqlite.Connection]:
 
 @pytest.fixture
 def run_repo(db: aiosqlite.Connection) -> SQLiteFineTuneRunRepository:
-    return SQLiteFineTuneRunRepository(db)
+    return SQLiteFineTuneRunRepository(db, write_context=make_private_write_context())
 
 
 @pytest.fixture
 def cp_repo(
     db: aiosqlite.Connection,
 ) -> SQLiteFineTuneCheckpointRepository:
-    return SQLiteFineTuneCheckpointRepository(db)
+    return SQLiteFineTuneCheckpointRepository(
+        db, write_context=make_private_write_context()
+    )
 
 
 @pytest.fixture

--- a/tests/unit/meta/test_approval_repo.py
+++ b/tests/unit/meta/test_approval_repo.py
@@ -9,6 +9,7 @@ import pytest
 from synthorg.core.approval import ApprovalItem
 from synthorg.core.enums import ApprovalRiskLevel, ApprovalStatus
 from synthorg.persistence.sqlite.approval_repo import SQLiteApprovalRepository
+from tests._shared.persistence import make_private_write_context
 
 pytestmark = pytest.mark.unit
 
@@ -66,7 +67,7 @@ async def repo() -> AsyncGenerator[SQLiteApprovalRepository]:
     db = await aiosqlite.connect(":memory:")
     await db.execute(_CREATE_TABLE)
     await db.commit()
-    repo = SQLiteApprovalRepository(db)
+    repo = SQLiteApprovalRepository(db, write_context=make_private_write_context())
     yield repo
     await db.close()
 

--- a/tests/unit/persistence/sqlite/test_agent_state_repo.py
+++ b/tests/unit/persistence/sqlite/test_agent_state_repo.py
@@ -10,6 +10,7 @@ from synthorg.engine.agent_state import AgentRuntimeState
 from synthorg.persistence.sqlite.agent_state_repo import (
     SQLiteAgentStateRepository,
 )
+from tests._shared.persistence import make_private_write_context
 
 if TYPE_CHECKING:
     import aiosqlite
@@ -65,7 +66,9 @@ class TestSQLiteAgentStateRepository:
     async def test_save_and_get_roundtrip(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteAgentStateRepository(migrated_db)
+        repo = SQLiteAgentStateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         state = _make_state()
         await repo.save(state)
 
@@ -82,7 +85,9 @@ class TestSQLiteAgentStateRepository:
         assert result.started_at == state.started_at
 
     async def test_save_idle_roundtrip(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteAgentStateRepository(migrated_db)
+        repo = SQLiteAgentStateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         state = _make_state(
             agent_id="agent-idle",
             status=ExecutionStatus.IDLE,
@@ -100,7 +105,9 @@ class TestSQLiteAgentStateRepository:
         assert result.currency == "USD"
 
     async def test_upsert_overwrites(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteAgentStateRepository(migrated_db)
+        repo = SQLiteAgentStateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         v1 = _make_state(turn_count=1)
         await repo.save(v1)
 
@@ -115,14 +122,18 @@ class TestSQLiteAgentStateRepository:
     async def test_get_returns_none_when_not_found(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteAgentStateRepository(migrated_db)
+        repo = SQLiteAgentStateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         result = await repo.get("nonexistent")
         assert result is None
 
     async def test_get_active_filters_idle(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteAgentStateRepository(migrated_db)
+        repo = SQLiteAgentStateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         executing = _make_state(agent_id="active-1", last_activity_at=_T1)
         paused = _make_state(
             agent_id="paused-1",
@@ -147,7 +158,9 @@ class TestSQLiteAgentStateRepository:
     async def test_get_active_ordered_by_last_activity_desc(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteAgentStateRepository(migrated_db)
+        repo = SQLiteAgentStateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         older = _make_state(agent_id="older", last_activity_at=_T0)
         newer = _make_state(agent_id="newer", last_activity_at=_T2)
         middle = _make_state(agent_id="middle", last_activity_at=_T1)
@@ -161,7 +174,9 @@ class TestSQLiteAgentStateRepository:
     async def test_get_active_returns_empty_when_all_idle(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteAgentStateRepository(migrated_db)
+        repo = SQLiteAgentStateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         idle = _make_state(agent_id="idle-only", status=ExecutionStatus.IDLE)
         await repo.save(idle)
 
@@ -169,7 +184,9 @@ class TestSQLiteAgentStateRepository:
         assert active == ()
 
     async def test_delete_existing(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteAgentStateRepository(migrated_db)
+        repo = SQLiteAgentStateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         state = _make_state()
         await repo.save(state)
 
@@ -178,14 +195,18 @@ class TestSQLiteAgentStateRepository:
         assert await repo.get("agent-001") is None
 
     async def test_delete_nonexistent(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteAgentStateRepository(migrated_db)
+        repo = SQLiteAgentStateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         deleted = await repo.delete("nonexistent")
         assert deleted is False
 
     async def test_delete_does_not_affect_other_agents(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteAgentStateRepository(migrated_db)
+        repo = SQLiteAgentStateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         keep = _make_state(agent_id="keep")
         remove = _make_state(agent_id="remove")
         await repo.save(keep)
@@ -198,7 +219,9 @@ class TestSQLiteAgentStateRepository:
     async def test_get_active_returns_empty_on_empty_table(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteAgentStateRepository(migrated_db)
+        repo = SQLiteAgentStateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         active = await repo.get_active()
         assert active == ()
 
@@ -206,7 +229,9 @@ class TestSQLiteAgentStateRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Full lifecycle: idle → executing → idle roundtrip."""
-        repo = SQLiteAgentStateRepository(migrated_db)
+        repo = SQLiteAgentStateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         idle = _make_state(agent_id="lifecycle", status=ExecutionStatus.IDLE)
         await repo.save(idle)
 
@@ -266,7 +291,9 @@ class TestSQLiteAgentStateRepositoryErrors:
     ) -> None:
         from synthorg.core.persistence_errors import QueryError
 
-        repo = SQLiteAgentStateRepository(memory_db)
+        repo = SQLiteAgentStateRepository(
+            memory_db, write_context=make_private_write_context()
+        )
         with pytest.raises(QueryError, match=match) as exc_info:
             await getattr(repo, method)(*args)
         assert exc_info.value.__cause__ is not None
@@ -276,7 +303,9 @@ class TestSQLiteAgentStateRepositoryErrors:
     ) -> None:
         from synthorg.core.persistence_errors import QueryError
 
-        repo = SQLiteAgentStateRepository(migrated_db)
+        repo = SQLiteAgentStateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         # Insert a row with a malformed datetime to trigger deserialization
         # failure (passes CHECK constraints but fails Pydantic AwareDatetime)
         await migrated_db.execute(
@@ -306,7 +335,9 @@ class TestSQLiteAgentStateRepositoryErrors:
         """get_active() fails when any row has corrupt data."""
         from synthorg.core.persistence_errors import QueryError
 
-        repo = SQLiteAgentStateRepository(migrated_db)
+        repo = SQLiteAgentStateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         # Insert a valid executing row
         valid = _make_state(agent_id="agent-ok")
         await repo.save(valid)

--- a/tests/unit/persistence/sqlite/test_artifact_repo.py
+++ b/tests/unit/persistence/sqlite/test_artifact_repo.py
@@ -8,6 +8,7 @@ import pytest
 from synthorg.core.artifact import Artifact
 from synthorg.core.enums import ArtifactType
 from synthorg.persistence.sqlite.artifact_repo import SQLiteArtifactRepository
+from tests._shared.persistence import make_private_write_context
 
 
 def _make_artifact(  # noqa: PLR0913
@@ -37,7 +38,9 @@ def _make_artifact(  # noqa: PLR0913
 
 @pytest.fixture
 def repo(migrated_db: aiosqlite.Connection) -> SQLiteArtifactRepository:
-    return SQLiteArtifactRepository(migrated_db)
+    return SQLiteArtifactRepository(
+        migrated_db, write_context=make_private_write_context()
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/persistence/sqlite/test_audit_repository.py
+++ b/tests/unit/persistence/sqlite/test_audit_repository.py
@@ -14,6 +14,7 @@ from synthorg.persistence.sqlite.audit_repository import (
     SQLiteAuditRepository,
 )
 from synthorg.security.models import AuditEntry, AuditVerdictStr
+from tests._shared.persistence import make_private_write_context
 
 if TYPE_CHECKING:
     import aiosqlite
@@ -60,7 +61,9 @@ def _make_entry(  # noqa: PLR0913
 class TestSQLiteAuditRepository:
     async def test_save_and_query_all(self, migrated_db: aiosqlite.Connection) -> None:
         """Save 2 entries, query without filters, verify both returned."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         e1 = _make_entry(entry_id="ae-001")
         e2 = _make_entry(entry_id="ae-002")
         await repo.save(e1)
@@ -76,7 +79,9 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Entries with different timestamps are returned DESC order."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         now = datetime.now(UTC)
         earlier = now - timedelta(hours=1)
 
@@ -95,7 +100,9 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Filter matches only entries with matching agent_id."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         e1 = _make_entry(entry_id="ae-a1", agent_id="agent-a")
         e2 = _make_entry(entry_id="ae-b1", agent_id="agent-b")
         await repo.save(e1)
@@ -109,7 +116,9 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Filter by action_type string."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         e1 = _make_entry(entry_id="ae-cw", action_type="code:write")
         e2 = _make_entry(entry_id="ae-cr", action_type="code:read")
         await repo.save(e1)
@@ -123,7 +132,9 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Filter by verdict (allow/deny/escalate/output_scan)."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         e1 = _make_entry(entry_id="ae-allow", verdict="allow")
         e2 = _make_entry(entry_id="ae-deny", verdict="deny")
         await repo.save(e1)
@@ -137,7 +148,9 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Filter by ApprovalRiskLevel enum."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         e1 = _make_entry(entry_id="ae-low", risk_level=ApprovalRiskLevel.LOW)
         e2 = _make_entry(entry_id="ae-high", risk_level=ApprovalRiskLevel.HIGH)
         await repo.save(e1)
@@ -151,7 +164,9 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Entries before cutoff are excluded."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         now = datetime.now(UTC)
         old = now - timedelta(hours=2)
         cutoff = now - timedelta(hours=1)
@@ -169,7 +184,9 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Multiple filters are AND-combined."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         e1 = _make_entry(
             entry_id="ae-match",
             agent_id="agent-x",
@@ -195,7 +212,9 @@ class TestSQLiteAuditRepository:
 
     async def test_query_limit(self, migrated_db: aiosqlite.Connection) -> None:
         """Limit returns the N newest entries."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         base = datetime(2026, 3, 1, tzinfo=UTC)
         for i in range(5):
             await repo.save(
@@ -210,7 +229,9 @@ class TestSQLiteAuditRepository:
 
     async def test_query_empty(self, migrated_db: aiosqlite.Connection) -> None:
         """Returns empty tuple when no entries."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         results = await repo.query()
         assert results == ()
 
@@ -218,7 +239,9 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """limit < 1 raises QueryError."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         with pytest.raises(QueryError, match="limit"):
             await repo.query(limit=0)
         with pytest.raises(QueryError, match="limit"):
@@ -228,7 +251,9 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Full model round-trip including optional fields."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         entry = _make_entry(
             entry_id="ae-rt",
             agent_id="agent-rt",
@@ -267,7 +292,9 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """None for agent_id, task_id, approval_id survives round-trip."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         entry = _make_entry(
             entry_id="ae-null",
             agent_id=None,
@@ -287,7 +314,9 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Tuple of rules survives JSON serialization round-trip."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         rules = ("rule-alpha", "rule-beta", "rule-gamma")
         entry = _make_entry(entry_id="ae-rules", matched_rules=rules)
         await repo.save(entry)
@@ -325,7 +354,9 @@ class TestSQLiteAuditRepository:
         )
         await migrated_db.commit()
 
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         with pytest.raises(QueryError, match="deserialize"):
             await repo.query()
 
@@ -333,7 +364,9 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """agent_id=None means 'no filter', not 'filter for NULL'."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         e1 = _make_entry(entry_id="ae-with", agent_id="agent-x")
         e2 = _make_entry(entry_id="ae-without", agent_id=None)
         await repo.save(e1)
@@ -344,7 +377,9 @@ class TestSQLiteAuditRepository:
 
     async def test_save_append_only(self, migrated_db: aiosqlite.Connection) -> None:
         """Saving same ID twice raises DuplicateRecordError (no upsert)."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         entry = _make_entry(entry_id="ae-dup")
         await repo.save(entry)
 
@@ -355,7 +390,9 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Entries after until are excluded."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         now = datetime.now(UTC)
         future = now + timedelta(hours=2)
         cutoff = now + timedelta(hours=1)
@@ -373,7 +410,9 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """since + until creates a bounded time range."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         base = datetime(2026, 3, 1, tzinfo=UTC)
         for i in range(5):
             await repo.save(
@@ -393,7 +432,9 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """until < since raises QueryError."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         now = datetime.now(UTC)
         with pytest.raises(QueryError, match="until"):
             await repo.query(since=now, until=now - timedelta(hours=1))
@@ -402,7 +443,9 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Entry with timestamp == since is included (>= semantics)."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         cutoff = datetime(2026, 3, 1, 12, 0, 0, tzinfo=UTC)
         entry = _make_entry(entry_id="ae-boundary", timestamp=cutoff)
         await repo.save(entry)
@@ -415,7 +458,9 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Non-UTC timestamps are stored as UTC for correct ordering."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         # Use timezone offset +05:30
         offset = timezone(timedelta(hours=5, minutes=30))
         ts = datetime(2026, 3, 10, 12, 0, 0, tzinfo=offset)
@@ -434,7 +479,9 @@ class TestSQLiteAuditRepository:
         """Generic sqlite3.Error during save raises QueryError."""
         import sqlite3
 
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         entry = _make_entry(entry_id="ae-err")
 
         with (
@@ -454,7 +501,9 @@ class TestSQLiteAuditRepository:
         """Generic sqlite3.Error during query raises QueryError."""
         import sqlite3
 
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
 
         with (
             patch.object(
@@ -471,14 +520,18 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """SQLiteAuditRepository is an AuditRepository."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         assert isinstance(repo, AuditRepository)
 
     async def test_purge_before_deletes_older_entries(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Rows strictly older than the cutoff are removed (CFG-1)."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         now = datetime.now(UTC)
         cutoff = now - timedelta(hours=1)
         e_old = _make_entry(
@@ -500,7 +553,9 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Rows with timestamp == cutoff are preserved (strict <)."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         ts = datetime.now(UTC)
         entry = _make_entry(entry_id="ae-at-cutoff", timestamp=ts)
         await repo.save(entry)
@@ -515,7 +570,9 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Cutoff in the past with only newer rows returns 0."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         now = datetime.now(UTC)
         entry = _make_entry(entry_id="ae-recent", timestamp=now)
         await repo.save(entry)
@@ -528,7 +585,9 @@ class TestSQLiteAuditRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Non-UTC cutoff is converted to UTC before comparison."""
-        repo = SQLiteAuditRepository(migrated_db)
+        repo = SQLiteAuditRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         utc_now = datetime.now(UTC)
         # Save one row an hour before "now" in UTC
         entry = _make_entry(

--- a/tests/unit/persistence/sqlite/test_checkpoint_repo.py
+++ b/tests/unit/persistence/sqlite/test_checkpoint_repo.py
@@ -8,6 +8,7 @@ from synthorg.engine.checkpoint.models import Checkpoint
 from synthorg.persistence.sqlite.checkpoint_repo import (
     SQLiteCheckpointRepository,
 )
+from tests._shared.persistence import make_private_write_context
 
 if TYPE_CHECKING:
     import aiosqlite
@@ -46,7 +47,9 @@ class TestSQLiteCheckpointRepository:
     async def test_save_and_get_latest_roundtrip(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteCheckpointRepository(migrated_db)
+        repo = SQLiteCheckpointRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         cp = _make_checkpoint(checkpoint_id="cp-rt-001")
         await repo.save(cp)
 
@@ -63,7 +66,9 @@ class TestSQLiteCheckpointRepository:
     async def test_get_latest_returns_highest_turn_number(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteCheckpointRepository(migrated_db)
+        repo = SQLiteCheckpointRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         cp_low = _make_checkpoint(
             checkpoint_id="cp-low",
             turn_number=1,
@@ -89,7 +94,9 @@ class TestSQLiteCheckpointRepository:
     async def test_get_latest_filter_by_task_id(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteCheckpointRepository(migrated_db)
+        repo = SQLiteCheckpointRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         cp_a = _make_checkpoint(
             checkpoint_id="cp-a",
             task_id="task-alpha",
@@ -111,7 +118,9 @@ class TestSQLiteCheckpointRepository:
     async def test_get_latest_filter_by_execution_id(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteCheckpointRepository(migrated_db)
+        repo = SQLiteCheckpointRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         cp_a = _make_checkpoint(
             checkpoint_id="cp-exec-a",
             execution_id="exec-alpha",
@@ -133,7 +142,9 @@ class TestSQLiteCheckpointRepository:
     async def test_get_latest_both_filters(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteCheckpointRepository(migrated_db)
+        repo = SQLiteCheckpointRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         cp_match = _make_checkpoint(
             checkpoint_id="cp-match",
             execution_id="exec-m",
@@ -156,19 +167,25 @@ class TestSQLiteCheckpointRepository:
     async def test_get_latest_returns_none_when_no_match(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteCheckpointRepository(migrated_db)
+        repo = SQLiteCheckpointRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         result = await repo.get_latest(execution_id="nonexistent")
         assert result is None
 
     async def test_get_latest_raises_when_no_filter(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteCheckpointRepository(migrated_db)
+        repo = SQLiteCheckpointRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         with pytest.raises(ValueError, match="At least one"):
             await repo.get_latest()
 
     async def test_upsert_same_id(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteCheckpointRepository(migrated_db)
+        repo = SQLiteCheckpointRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         cp_v1 = _make_checkpoint(
             checkpoint_id="cp-upsert",
             context_json='{"version": 1}',
@@ -192,7 +209,9 @@ class TestSQLiteCheckpointRepository:
     async def test_delete_by_execution_returns_count(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteCheckpointRepository(migrated_db)
+        repo = SQLiteCheckpointRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         for i in range(3):
             cp = _make_checkpoint(
                 checkpoint_id=f"cp-del-{i}",
@@ -210,14 +229,18 @@ class TestSQLiteCheckpointRepository:
     async def test_delete_by_execution_returns_zero_when_none_exist(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteCheckpointRepository(migrated_db)
+        repo = SQLiteCheckpointRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         count = await repo.delete_by_execution("nonexistent")
         assert count == 0
 
     async def test_delete_by_execution_does_not_affect_other_executions(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteCheckpointRepository(migrated_db)
+        repo = SQLiteCheckpointRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         cp_keep = _make_checkpoint(
             checkpoint_id="cp-keep",
             execution_id="exec-keep",
@@ -246,7 +269,9 @@ class TestSQLiteCheckpointRepositoryErrors:
         from synthorg.core.persistence_errors import QueryError
 
         # No migrations → table doesn't exist → sqlite error
-        repo = SQLiteCheckpointRepository(memory_db)
+        repo = SQLiteCheckpointRepository(
+            memory_db, write_context=make_private_write_context()
+        )
         cp = _make_checkpoint()
         with pytest.raises(QueryError, match="Failed to save"):
             await repo.save(cp)
@@ -257,7 +282,9 @@ class TestSQLiteCheckpointRepositoryErrors:
         """get_latest() wraps sqlite errors into QueryError."""
         from synthorg.core.persistence_errors import QueryError
 
-        repo = SQLiteCheckpointRepository(memory_db)
+        repo = SQLiteCheckpointRepository(
+            memory_db, write_context=make_private_write_context()
+        )
         with pytest.raises(QueryError, match="Failed to query"):
             await repo.get_latest(execution_id="exec-001")
 
@@ -267,7 +294,9 @@ class TestSQLiteCheckpointRepositoryErrors:
         """delete_by_execution() wraps sqlite errors into QueryError."""
         from synthorg.core.persistence_errors import QueryError
 
-        repo = SQLiteCheckpointRepository(memory_db)
+        repo = SQLiteCheckpointRepository(
+            memory_db, write_context=make_private_write_context()
+        )
         with pytest.raises(QueryError, match="Failed to delete"):
             await repo.delete_by_execution("exec-001")
 
@@ -277,7 +306,9 @@ class TestSQLiteCheckpointRepositoryErrors:
         """_row_to_model() wraps ValidationError into QueryError."""
         from synthorg.core.persistence_errors import QueryError
 
-        repo = SQLiteCheckpointRepository(migrated_db)
+        repo = SQLiteCheckpointRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         # Manually insert a row with invalid data (missing required fields)
         await migrated_db.execute(
             "INSERT INTO checkpoints "

--- a/tests/unit/persistence/sqlite/test_circuit_breaker_repo.py
+++ b/tests/unit/persistence/sqlite/test_circuit_breaker_repo.py
@@ -9,6 +9,7 @@ from synthorg.persistence.circuit_breaker_protocol import (
 from synthorg.persistence.sqlite.circuit_breaker_repo import (
     SQLiteCircuitBreakerStateRepository,
 )
+from tests._shared.persistence import make_private_write_context
 
 
 @pytest.mark.unit
@@ -17,7 +18,9 @@ class TestSQLiteCircuitBreakerStateRepository:
     def repo(
         self, migrated_db: aiosqlite.Connection
     ) -> SQLiteCircuitBreakerStateRepository:
-        return SQLiteCircuitBreakerStateRepository(migrated_db)
+        return SQLiteCircuitBreakerStateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
 
     async def test_save_and_load_all(
         self,

--- a/tests/unit/persistence/sqlite/test_custom_rule_repo.py
+++ b/tests/unit/persistence/sqlite/test_custom_rule_repo.py
@@ -12,6 +12,7 @@ from synthorg.meta.rules.custom import Comparator, CustomRuleDefinition
 from synthorg.persistence.sqlite.custom_rule_repo import (
     SQLiteCustomRuleRepository,
 )
+from tests._shared.persistence import make_private_write_context
 
 pytestmark = pytest.mark.unit
 
@@ -20,7 +21,9 @@ pytestmark = pytest.mark.unit
 def repo(
     migrated_db: aiosqlite.Connection,
 ) -> SQLiteCustomRuleRepository:
-    return SQLiteCustomRuleRepository(migrated_db)
+    return SQLiteCustomRuleRepository(
+        migrated_db, write_context=make_private_write_context()
+    )
 
 
 def _now() -> datetime:

--- a/tests/unit/persistence/sqlite/test_decision_repo.py
+++ b/tests/unit/persistence/sqlite/test_decision_repo.py
@@ -11,6 +11,7 @@ from synthorg.core.persistence_errors import DuplicateRecordError, QueryError
 from synthorg.engine.decisions import DecisionRecord
 from synthorg.persistence.decision_protocol import DecisionRepository
 from synthorg.persistence.sqlite.decision_repo import SQLiteDecisionRepository
+from tests._shared.persistence import make_private_write_context
 
 if TYPE_CHECKING:
     import aiosqlite
@@ -49,7 +50,9 @@ async def _append(  # noqa: PLR0913
 class TestSQLiteDecisionRepositoryAppendAndGet:
     async def test_append_and_get(self, migrated_db: aiosqlite.Connection) -> None:
         """Append a record, retrieve by ID, fields match."""
-        repo = SQLiteDecisionRepository(migrated_db)
+        repo = SQLiteDecisionRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         record = await _append(
             repo,
             record_id="dr-001",
@@ -75,14 +78,18 @@ class TestSQLiteDecisionRepositoryAppendAndGet:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """get returns None for unknown ID."""
-        repo = SQLiteDecisionRepository(migrated_db)
+        repo = SQLiteDecisionRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         assert await repo.get("nonexistent") is None
 
     async def test_append_duplicate_id_raises(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Appending with an existing ID raises DuplicateRecordError."""
-        repo = SQLiteDecisionRepository(migrated_db)
+        repo = SQLiteDecisionRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await _append(repo, record_id="dr-dup")
         with pytest.raises(DuplicateRecordError):
             await _append(repo, record_id="dr-dup", task_id="task-2")
@@ -91,7 +98,9 @@ class TestSQLiteDecisionRepositoryAppendAndGet:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Multiple appends on the same task yield versions 1, 2, 3."""
-        repo = SQLiteDecisionRepository(migrated_db)
+        repo = SQLiteDecisionRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         r1 = await _append(repo, record_id="dr-a", task_id="task-1")
         r2 = await _append(
             repo,
@@ -113,7 +122,9 @@ class TestSQLiteDecisionRepositoryAppendAndGet:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Version counters are independent per task_id."""
-        repo = SQLiteDecisionRepository(migrated_db)
+        repo = SQLiteDecisionRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         a1 = await _append(repo, record_id="dr-a1", task_id="task-A")
         b1 = await _append(repo, record_id="dr-b1", task_id="task-B")
         a2 = await _append(
@@ -143,7 +154,9 @@ class TestSQLiteDecisionRepositoryListByTask:
         fails the old query and passes the new one, which is the
         regression the test exists to catch.
         """
-        repo = SQLiteDecisionRepository(migrated_db)
+        repo = SQLiteDecisionRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         anchor = datetime(2026, 1, 1, tzinfo=UTC)
         # Two regular decisions, recorded_at increasing in line with
         # version assignment (the normal happy path).
@@ -182,7 +195,9 @@ class TestSQLiteDecisionRepositoryListByTask:
 
     async def test_list_by_task_empty(self, migrated_db: aiosqlite.Connection) -> None:
         """list_by_task returns empty tuple for unknown task."""
-        repo = SQLiteDecisionRepository(migrated_db)
+        repo = SQLiteDecisionRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         assert await repo.list_by_task("task-nope") == ()
 
 
@@ -195,7 +210,9 @@ class TestSQLiteDecisionRepositoryListByAgent:
 
         Uses two matching records to also verify DESC recorded_at ordering.
         """
-        repo = SQLiteDecisionRepository(migrated_db)
+        repo = SQLiteDecisionRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         now = datetime.now(UTC)
         await _append(
             repo,
@@ -230,7 +247,9 @@ class TestSQLiteDecisionRepositoryListByAgent:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """list_by_agent with role='reviewer' filters by reviewer_agent_id."""
-        repo = SQLiteDecisionRepository(migrated_db)
+        repo = SQLiteDecisionRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         now = datetime.now(UTC)
         await _append(
             repo,
@@ -259,7 +278,9 @@ class TestSQLiteDecisionRepositoryListByAgent:
         """Invalid role raises QueryError (matches pagination-arg behaviour)."""
         from synthorg.core.persistence_errors import QueryError
 
-        repo = SQLiteDecisionRepository(migrated_db)
+        repo = SQLiteDecisionRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         with pytest.raises(QueryError, match="role must be"):
             await repo.list_by_agent("alice", role="observer")  # type: ignore[arg-type]
 
@@ -268,7 +289,9 @@ class TestSQLiteDecisionRepositoryListByAgent:
 class TestSQLiteDecisionRepositoryProtocol:
     def test_satisfies_protocol(self, migrated_db: aiosqlite.Connection) -> None:
         """SQLiteDecisionRepository is a DecisionRepository."""
-        repo = SQLiteDecisionRepository(migrated_db)
+        repo = SQLiteDecisionRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         assert isinstance(repo, DecisionRepository)
 
 
@@ -284,7 +307,9 @@ class TestSQLiteDecisionRepositorySerialization:
         append-only contract; this test compares via ``dict(...)``
         to avoid depending on the exact container type.
         """
-        repo = SQLiteDecisionRepository(migrated_db)
+        repo = SQLiteDecisionRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await _append(
             repo,
             record_id="dr-1",
@@ -301,7 +326,9 @@ class TestSQLiteDecisionRepositorySerialization:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Corrupted criteria_snapshot JSON raises QueryError on read."""
-        repo = SQLiteDecisionRepository(migrated_db)
+        repo = SQLiteDecisionRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await _append(repo, record_id="dr-1")
         await migrated_db.execute(
             "UPDATE decision_records SET criteria_snapshot = ? WHERE id = ?",
@@ -315,7 +342,9 @@ class TestSQLiteDecisionRepositorySerialization:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Corrupted metadata JSON raises QueryError on read."""
-        repo = SQLiteDecisionRepository(migrated_db)
+        repo = SQLiteDecisionRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await _append(repo, record_id="dr-1")
         await migrated_db.execute(
             "UPDATE decision_records SET metadata = ? WHERE id = ?",
@@ -337,7 +366,9 @@ class TestSQLiteDecisionRepositorySerialization:
         """
         import sqlite3
 
-        repo = SQLiteDecisionRepository(migrated_db)
+        repo = SQLiteDecisionRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await _append(repo, record_id="dr-1")
 
         async def _attempt_bogus_update() -> None:
@@ -362,7 +393,9 @@ class TestSQLiteDecisionRepositorySerialization:
         verifies the read-time guard wraps the resulting
         ValidationError as QueryError.
         """
-        repo = SQLiteDecisionRepository(migrated_db)
+        repo = SQLiteDecisionRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await _append(repo, record_id="dr-1")
         # Disable CHECK constraints only for this direct UPDATE so we
         # can inject an invalid enum value and exercise the read-time
@@ -394,7 +427,9 @@ class TestSQLiteDecisionRepositorySerialization:
         """
         import asyncio
 
-        repo = SQLiteDecisionRepository(migrated_db)
+        repo = SQLiteDecisionRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         writer_count = 20
 
         async def _one(i: int) -> int:

--- a/tests/unit/persistence/sqlite/test_entity_version_repos.py
+++ b/tests/unit/persistence/sqlite/test_entity_version_repos.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 from synthorg.persistence.sqlite.version_repo import SQLiteVersionRepository
 from synthorg.versioning.hashing import compute_content_hash
 from synthorg.versioning.models import VersionSnapshot
+from tests._shared.persistence import make_private_write_context
 
 _NOW = datetime(2026, 4, 8, 12, 0, tzinfo=UTC)
 
@@ -64,6 +65,7 @@ async def _make_repo[T: BaseModel](
         deserialize_snapshot=lambda s: model_cls.model_validate(
             json.loads(s),
         ),
+        write_context=make_private_write_context(),
     )
 
 

--- a/tests/unit/persistence/sqlite/test_escalation_repo.py
+++ b/tests/unit/persistence/sqlite/test_escalation_repo.py
@@ -21,6 +21,7 @@ from synthorg.core.enums import SeniorityLevel
 from synthorg.persistence.config import SQLiteConfig
 from synthorg.persistence.sqlite.backend import SQLitePersistenceBackend
 from synthorg.persistence.sqlite.escalation_repo import SQLiteEscalationRepository
+from tests._shared.persistence import make_private_write_context
 
 pytestmark = pytest.mark.unit
 
@@ -103,7 +104,9 @@ async def backend() -> AsyncIterator[SQLitePersistenceBackend]:
 
 async def test_create_and_get(backend: SQLitePersistenceBackend) -> None:
     assert backend._db is not None
-    repo = SQLiteEscalationRepository(backend._db)
+    repo = SQLiteEscalationRepository(
+        backend._db, write_context=make_private_write_context()
+    )
     row = _make_escalation(escalation_id="escalation-sql-01")
     await repo.create(row)
     fetched = await repo.get("escalation-sql-01")
@@ -115,7 +118,9 @@ async def test_create_and_get(backend: SQLitePersistenceBackend) -> None:
 
 async def test_list_items_filters_by_status(backend: SQLitePersistenceBackend) -> None:
     assert backend._db is not None
-    repo = SQLiteEscalationRepository(backend._db)
+    repo = SQLiteEscalationRepository(
+        backend._db, write_context=make_private_write_context()
+    )
     await repo.create(_make_escalation(escalation_id="escalation-sql-a"))
     await repo.create(_make_escalation(escalation_id="escalation-sql-b"))
     pending, total_pending = await repo.list_items(
@@ -134,7 +139,9 @@ async def test_apply_winner_decision_transitions_to_decided(
     backend: SQLitePersistenceBackend,
 ) -> None:
     assert backend._db is not None
-    repo = SQLiteEscalationRepository(backend._db)
+    repo = SQLiteEscalationRepository(
+        backend._db, write_context=make_private_write_context()
+    )
     await repo.create(_make_escalation(escalation_id="escalation-sql-win"))
     decision = WinnerDecision(
         winning_agent_id="agent-a",
@@ -159,7 +166,9 @@ async def test_apply_reject_decision_round_trips(
     backend: SQLitePersistenceBackend,
 ) -> None:
     assert backend._db is not None
-    repo = SQLiteEscalationRepository(backend._db)
+    repo = SQLiteEscalationRepository(
+        backend._db, write_context=make_private_write_context()
+    )
     await repo.create(_make_escalation(escalation_id="escalation-sql-rej"))
     decision = RejectDecision(reasoning="Both positions off-strategy")
     updated = await repo.apply_decision(
@@ -175,7 +184,9 @@ async def test_apply_decision_on_missing_row_raises_keyerror(
     backend: SQLitePersistenceBackend,
 ) -> None:
     assert backend._db is not None
-    repo = SQLiteEscalationRepository(backend._db)
+    repo = SQLiteEscalationRepository(
+        backend._db, write_context=make_private_write_context()
+    )
     with pytest.raises(KeyError):
         await repo.apply_decision(
             "missing",
@@ -188,7 +199,9 @@ async def test_apply_decision_on_decided_row_raises_valueerror(
     backend: SQLitePersistenceBackend,
 ) -> None:
     assert backend._db is not None
-    repo = SQLiteEscalationRepository(backend._db)
+    repo = SQLiteEscalationRepository(
+        backend._db, write_context=make_private_write_context()
+    )
     await repo.create(_make_escalation(escalation_id="escalation-sql-dbl"))
     decision = WinnerDecision(winning_agent_id="agent-a", reasoning="ok")
     await repo.apply_decision(
@@ -208,7 +221,9 @@ async def test_cancel_transitions_to_cancelled(
     backend: SQLitePersistenceBackend,
 ) -> None:
     assert backend._db is not None
-    repo = SQLiteEscalationRepository(backend._db)
+    repo = SQLiteEscalationRepository(
+        backend._db, write_context=make_private_write_context()
+    )
     await repo.create(_make_escalation(escalation_id="escalation-sql-canc"))
     updated = await repo.cancel("escalation-sql-canc", cancelled_by="human:op-3")
     assert updated.status == EscalationStatus.CANCELLED
@@ -219,7 +234,9 @@ async def test_mark_expired_transitions_stale_rows(
     backend: SQLitePersistenceBackend,
 ) -> None:
     assert backend._db is not None
-    repo = SQLiteEscalationRepository(backend._db)
+    repo = SQLiteEscalationRepository(
+        backend._db, write_context=make_private_write_context()
+    )
     past = datetime.now(UTC) - timedelta(seconds=30)
     future = datetime.now(UTC) + timedelta(seconds=3600)
     await repo.create(
@@ -242,7 +259,9 @@ async def test_list_items_respects_limit_and_offset(
     backend: SQLitePersistenceBackend,
 ) -> None:
     assert backend._db is not None
-    repo = SQLiteEscalationRepository(backend._db)
+    repo = SQLiteEscalationRepository(
+        backend._db, write_context=make_private_write_context()
+    )
     for i in range(5):
         await repo.create(_make_escalation(escalation_id=f"escalation-sql-p-{i}"))
     page_a, total = await repo.list_items(limit=2, offset=0)
@@ -257,7 +276,9 @@ async def test_list_items_respects_limit_and_offset(
 
 async def test_invalid_limit_raises(backend: SQLitePersistenceBackend) -> None:
     assert backend._db is not None
-    repo = SQLiteEscalationRepository(backend._db)
+    repo = SQLiteEscalationRepository(
+        backend._db, write_context=make_private_write_context()
+    )
     with pytest.raises(ValueError, match="limit"):
         await repo.list_items(limit=0)
     with pytest.raises(ValueError, match="offset"):

--- a/tests/unit/persistence/sqlite/test_escalation_repo.py
+++ b/tests/unit/persistence/sqlite/test_escalation_repo.py
@@ -1,5 +1,6 @@
 """SQLite escalation queue repository tests."""
 
+import asyncio
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
 
@@ -283,3 +284,54 @@ async def test_invalid_limit_raises(backend: SQLitePersistenceBackend) -> None:
         await repo.list_items(limit=0)
     with pytest.raises(ValueError, match="offset"):
         await repo.list_items(offset=-1)
+
+
+async def test_build_escalations_serializes_with_backend_write_context(
+    backend: SQLitePersistenceBackend,
+) -> None:
+    """``build_escalations`` must wire the backend's shared write lock.
+
+    The factory previously constructed ``SQLiteEscalationRepository``
+    without a shared lock, so escalation writes could interleave with
+    sibling repos' writes on the single ``aiosqlite.Connection``. This
+    regression test asserts that an escalation operation started while
+    another task already holds ``backend.write_context()`` blocks until
+    the holder releases, proving both sides contend on the same lock.
+    """
+    escalation_repo = backend.build_escalations()
+    assert isinstance(escalation_repo, SQLiteEscalationRepository)
+
+    events: list[str] = []
+    backend_holding = asyncio.Event()
+    release_backend = asyncio.Event()
+    escalation_contender_started = asyncio.Event()
+
+    async def hold_backend_lock() -> None:
+        async with backend.write_context():
+            events.append("backend-acquired")
+            backend_holding.set()
+            await release_backend.wait()
+            events.append("backend-released")
+
+    async def try_escalation_lock() -> None:
+        await backend_holding.wait()
+        escalation_contender_started.set()
+        async with escalation_repo._write_context():
+            events.append("escalation-acquired")
+
+    async with asyncio.TaskGroup() as tg:
+        tg.create_task(hold_backend_lock())
+        tg.create_task(try_escalation_lock())
+        await escalation_contender_started.wait()
+        for _ in range(5):
+            await asyncio.sleep(0)
+        assert "escalation-acquired" not in events, (
+            f"escalation_repo acquired the lock while backend held it; events={events}"
+        )
+        release_backend.set()
+
+    assert events == [
+        "backend-acquired",
+        "backend-released",
+        "escalation-acquired",
+    ], events

--- a/tests/unit/persistence/sqlite/test_heartbeat_repo.py
+++ b/tests/unit/persistence/sqlite/test_heartbeat_repo.py
@@ -9,6 +9,7 @@ from synthorg.engine.checkpoint.models import Heartbeat
 from synthorg.persistence.sqlite.heartbeat_repo import (
     SQLiteHeartbeatRepository,
 )
+from tests._shared.persistence import make_private_write_context
 
 if TYPE_CHECKING:
     import aiosqlite
@@ -43,7 +44,9 @@ class TestSQLiteHeartbeatRepository:
     async def test_save_and_get_roundtrip(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteHeartbeatRepository(migrated_db)
+        repo = SQLiteHeartbeatRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         hb = _make_heartbeat(execution_id="exec-hb-001")
         await repo.save(hb)
 
@@ -57,14 +60,18 @@ class TestSQLiteHeartbeatRepository:
     async def test_get_returns_none_for_missing(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteHeartbeatRepository(migrated_db)
+        repo = SQLiteHeartbeatRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         result = await repo.get("nonexistent")
         assert result is None
 
     async def test_upsert_updates_existing(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteHeartbeatRepository(migrated_db)
+        repo = SQLiteHeartbeatRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         now = datetime.now(UTC)
         later = now + timedelta(minutes=5)
 
@@ -87,7 +94,9 @@ class TestSQLiteHeartbeatRepository:
     async def test_get_stale_returns_old_heartbeats(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteHeartbeatRepository(migrated_db)
+        repo = SQLiteHeartbeatRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         now = datetime.now(UTC)
         old = now - timedelta(hours=1)
         very_old = now - timedelta(hours=2)
@@ -119,7 +128,9 @@ class TestSQLiteHeartbeatRepository:
     async def test_get_stale_returns_empty_when_none_stale(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteHeartbeatRepository(migrated_db)
+        repo = SQLiteHeartbeatRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         now = datetime.now(UTC)
         hb = _make_heartbeat(
             execution_id="exec-fresh",
@@ -136,7 +147,9 @@ class TestSQLiteHeartbeatRepository:
     async def test_get_stale_ordered_by_timestamp(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteHeartbeatRepository(migrated_db)
+        repo = SQLiteHeartbeatRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         now = datetime.now(UTC)
         t1 = now - timedelta(hours=3)
         t2 = now - timedelta(hours=2)
@@ -163,7 +176,9 @@ class TestSQLiteHeartbeatRepository:
     async def test_delete_returns_true_when_found(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteHeartbeatRepository(migrated_db)
+        repo = SQLiteHeartbeatRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         hb = _make_heartbeat(execution_id="exec-del")
         await repo.save(hb)
 
@@ -173,13 +188,17 @@ class TestSQLiteHeartbeatRepository:
     async def test_delete_returns_false_when_not_found(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteHeartbeatRepository(migrated_db)
+        repo = SQLiteHeartbeatRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         assert await repo.delete("nonexistent") is False
 
     async def test_delete_does_not_affect_other_heartbeats(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteHeartbeatRepository(migrated_db)
+        repo = SQLiteHeartbeatRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         hb_keep = _make_heartbeat(execution_id="exec-keep")
         hb_delete = _make_heartbeat(execution_id="exec-delete")
         await repo.save(hb_keep)
@@ -200,7 +219,9 @@ class TestSQLiteHeartbeatRepositoryErrors:
     ) -> None:
         from synthorg.core.persistence_errors import QueryError
 
-        repo = SQLiteHeartbeatRepository(memory_db)
+        repo = SQLiteHeartbeatRepository(
+            memory_db, write_context=make_private_write_context()
+        )
         hb = _make_heartbeat()
         with pytest.raises(QueryError, match="Failed to save"):
             await repo.save(hb)
@@ -210,7 +231,9 @@ class TestSQLiteHeartbeatRepositoryErrors:
     ) -> None:
         from synthorg.core.persistence_errors import QueryError
 
-        repo = SQLiteHeartbeatRepository(memory_db)
+        repo = SQLiteHeartbeatRepository(
+            memory_db, write_context=make_private_write_context()
+        )
         with pytest.raises(QueryError, match="Failed to query"):
             await repo.get("exec-001")
 
@@ -219,7 +242,9 @@ class TestSQLiteHeartbeatRepositoryErrors:
     ) -> None:
         from synthorg.core.persistence_errors import QueryError
 
-        repo = SQLiteHeartbeatRepository(memory_db)
+        repo = SQLiteHeartbeatRepository(
+            memory_db, write_context=make_private_write_context()
+        )
         threshold = datetime.now(UTC) - timedelta(minutes=5)
         with pytest.raises(QueryError, match="Failed to query"):
             await repo.get_stale(threshold)
@@ -229,7 +254,9 @@ class TestSQLiteHeartbeatRepositoryErrors:
     ) -> None:
         from synthorg.core.persistence_errors import QueryError
 
-        repo = SQLiteHeartbeatRepository(memory_db)
+        repo = SQLiteHeartbeatRepository(
+            memory_db, write_context=make_private_write_context()
+        )
         with pytest.raises(QueryError, match="Failed to delete"):
             await repo.delete("exec-001")
 
@@ -238,7 +265,9 @@ class TestSQLiteHeartbeatRepositoryErrors:
     ) -> None:
         from synthorg.core.persistence_errors import QueryError
 
-        repo = SQLiteHeartbeatRepository(migrated_db)
+        repo = SQLiteHeartbeatRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         # Insert row with invalid timestamp
         await migrated_db.execute(
             "INSERT INTO heartbeats "

--- a/tests/unit/persistence/sqlite/test_identity_version_repo.py
+++ b/tests/unit/persistence/sqlite/test_identity_version_repo.py
@@ -14,6 +14,7 @@ from synthorg.core.agent import AgentIdentity, ModelConfig
 from synthorg.persistence.sqlite.version_repo import SQLiteVersionRepository
 from synthorg.versioning.hashing import compute_content_hash
 from synthorg.versioning.models import VersionSnapshot
+from tests._shared.persistence import make_private_write_context
 
 _NOW = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
 
@@ -52,6 +53,7 @@ async def repo(
         table_name="agent_identity_versions",
         serialize_snapshot=_serialize,
         deserialize_snapshot=_deserialize,
+        write_context=make_private_write_context(),
     )
 
 

--- a/tests/unit/persistence/sqlite/test_parked_context_repo.py
+++ b/tests/unit/persistence/sqlite/test_parked_context_repo.py
@@ -11,6 +11,7 @@ from synthorg.persistence.sqlite.parked_context_repo import (
     SQLiteParkedContextRepository,
 )
 from synthorg.security.timeout.parked_context import ParkedContext
+from tests._shared.persistence import make_private_write_context
 
 if TYPE_CHECKING:
     import aiosqlite
@@ -42,7 +43,9 @@ def _make_context(  # noqa: PLR0913
 @pytest.mark.unit
 class TestSQLiteParkedContextRepository:
     async def test_save_and_get(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteParkedContextRepository(migrated_db)
+        repo = SQLiteParkedContextRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         ctx = _make_context(parked_id="parked-001")
         await repo.save(ctx)
 
@@ -60,11 +63,15 @@ class TestSQLiteParkedContextRepository:
     async def test_get_returns_none_for_missing(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteParkedContextRepository(migrated_db)
+        repo = SQLiteParkedContextRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         assert await repo.get("nonexistent") is None
 
     async def test_get_by_approval(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteParkedContextRepository(migrated_db)
+        repo = SQLiteParkedContextRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         ctx = _make_context(approval_id="approval-xyz")
         await repo.save(ctx)
 
@@ -76,11 +83,15 @@ class TestSQLiteParkedContextRepository:
     async def test_get_by_approval_returns_none(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteParkedContextRepository(migrated_db)
+        repo = SQLiteParkedContextRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         assert await repo.get_by_approval("nonexistent") is None
 
     async def test_get_by_agent(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteParkedContextRepository(migrated_db)
+        repo = SQLiteParkedContextRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         ctx1 = _make_context(agent_id="agent-a", approval_id="ap-1")
         ctx2 = _make_context(agent_id="agent-a", approval_id="ap-2")
         await repo.save(ctx1)
@@ -95,14 +106,18 @@ class TestSQLiteParkedContextRepository:
     async def test_get_by_agent_returns_empty(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteParkedContextRepository(migrated_db)
+        repo = SQLiteParkedContextRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         results = await repo.get_by_agent("nonexistent")
         assert results == ()
 
     async def test_get_by_agent_ordered_by_parked_at_desc(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteParkedContextRepository(migrated_db)
+        repo = SQLiteParkedContextRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         now = datetime.now(UTC)
         earlier = now - timedelta(hours=1)
 
@@ -127,7 +142,9 @@ class TestSQLiteParkedContextRepository:
         assert results[1].id == ctx_old.id
 
     async def test_delete(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteParkedContextRepository(migrated_db)
+        repo = SQLiteParkedContextRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         ctx = _make_context(parked_id="del-me")
         await repo.save(ctx)
 
@@ -137,11 +154,15 @@ class TestSQLiteParkedContextRepository:
     async def test_delete_returns_false_for_missing(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteParkedContextRepository(migrated_db)
+        repo = SQLiteParkedContextRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         assert await repo.delete("nonexistent") is False
 
     async def test_save_upsert(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteParkedContextRepository(migrated_db)
+        repo = SQLiteParkedContextRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         ctx = _make_context(
             parked_id="upsert-id",
             context_json='{"step": 1}',
@@ -170,7 +191,9 @@ class TestSQLiteParkedContextRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Metadata dict survives JSON serialization round-trip."""
-        repo = SQLiteParkedContextRepository(migrated_db)
+        repo = SQLiteParkedContextRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         ctx = _make_context(
             parked_id="meta-rt",
             metadata={"tool": "shell", "action": "execute"},
@@ -197,6 +220,8 @@ INSERT INTO parked_contexts (
         )
         await migrated_db.commit()
 
-        repo = SQLiteParkedContextRepository(migrated_db)
+        repo = SQLiteParkedContextRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         with pytest.raises(QueryError, match="deserialize parked context"):
             await repo.get("corrupt-1")

--- a/tests/unit/persistence/sqlite/test_preset_override_repo.py
+++ b/tests/unit/persistence/sqlite/test_preset_override_repo.py
@@ -18,6 +18,7 @@ from synthorg.core.persistence_errors import QueryError
 from synthorg.persistence.sqlite.preset_override_repo import (
     SQLitePresetOverrideRepo,
 )
+from tests._shared.persistence import make_private_write_context
 
 pytestmark = pytest.mark.unit
 
@@ -49,7 +50,7 @@ def _make_row(  # noqa: PLR0913 -- test factory with explicit knobs
 def _build_repo() -> SQLitePresetOverrideRepo:
     """Build a repo with a no-op connection (we only call _row_to_override)."""
     db = AsyncMock(spec=Connection)
-    return SQLitePresetOverrideRepo(db=db)
+    return SQLitePresetOverrideRepo(db=db, write_context=make_private_write_context())
 
 
 class TestRowToOverrideHappy:
@@ -178,6 +179,8 @@ class TestGetWrapsCorruptionAsQueryError:
         db = MagicMock(spec=Connection)
         db.execute = AsyncMock(return_value=cursor)
 
-        repo = SQLitePresetOverrideRepo(db=db)
+        repo = SQLitePresetOverrideRepo(
+            db=db, write_context=make_private_write_context()
+        )
         with pytest.raises(QueryError):
             await repo.get("test-provider")

--- a/tests/unit/persistence/sqlite/test_preset_repo.py
+++ b/tests/unit/persistence/sqlite/test_preset_repo.py
@@ -9,13 +9,16 @@ from synthorg.core.persistence_errors import QueryError
 from synthorg.persistence.sqlite.preset_repo import (
     SQLitePersonalityPresetRepository,
 )
+from tests._shared.persistence import make_private_write_context
 
 
 @pytest.fixture
 def repo(
     migrated_db: aiosqlite.Connection,
 ) -> SQLitePersonalityPresetRepository:
-    return SQLitePersonalityPresetRepository(migrated_db)
+    return SQLitePersonalityPresetRepository(
+        migrated_db, write_context=make_private_write_context()
+    )
 
 
 def _sample_config_json() -> str:
@@ -166,7 +169,9 @@ class TestSQLitePersonalityPresetRepository:
 def unmigrated_repo(
     memory_db: aiosqlite.Connection,
 ) -> SQLitePersonalityPresetRepository:
-    return SQLitePersonalityPresetRepository(memory_db)
+    return SQLitePersonalityPresetRepository(
+        memory_db, write_context=make_private_write_context()
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/persistence/sqlite/test_project_cost_aggregate_repo.py
+++ b/tests/unit/persistence/sqlite/test_project_cost_aggregate_repo.py
@@ -10,6 +10,7 @@ from synthorg.core.persistence_errors import QueryError
 from synthorg.persistence.sqlite.project_cost_aggregate_repo import (
     SQLiteProjectCostAggregateRepository,
 )
+from tests._shared.persistence import make_private_write_context
 
 if TYPE_CHECKING:
     import aiosqlite
@@ -23,7 +24,9 @@ class TestSQLiteProjectCostAggregateRepository:
         self,
         migrated_db: aiosqlite.Connection,
     ) -> None:
-        repo = SQLiteProjectCostAggregateRepository(migrated_db)
+        repo = SQLiteProjectCostAggregateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         result = await repo.get("proj-nonexistent")
         assert result is None
 
@@ -31,7 +34,9 @@ class TestSQLiteProjectCostAggregateRepository:
         self,
         migrated_db: aiosqlite.Connection,
     ) -> None:
-        repo = SQLiteProjectCostAggregateRepository(migrated_db)
+        repo = SQLiteProjectCostAggregateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         agg = await repo.increment("proj-1", 1.5, 100, 50, currency="USD")
 
         assert agg.project_id == "proj-1"
@@ -45,7 +50,9 @@ class TestSQLiteProjectCostAggregateRepository:
         self,
         migrated_db: aiosqlite.Connection,
     ) -> None:
-        repo = SQLiteProjectCostAggregateRepository(migrated_db)
+        repo = SQLiteProjectCostAggregateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.increment("proj-1", 1.0, 100, 50, currency="USD")
         agg = await repo.increment("proj-1", 2.0, 200, 100, currency="USD")
 
@@ -59,7 +66,9 @@ class TestSQLiteProjectCostAggregateRepository:
         self,
         migrated_db: aiosqlite.Connection,
     ) -> None:
-        repo = SQLiteProjectCostAggregateRepository(migrated_db)
+        repo = SQLiteProjectCostAggregateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         for _ in range(5):
             await repo.increment("proj-1", 0.1, 10, 5, currency="USD")
 
@@ -74,7 +83,9 @@ class TestSQLiteProjectCostAggregateRepository:
         self,
         migrated_db: aiosqlite.Connection,
     ) -> None:
-        repo = SQLiteProjectCostAggregateRepository(migrated_db)
+        repo = SQLiteProjectCostAggregateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.increment("proj-1", 3.0, 500, 200, currency="USD")
 
         agg = await repo.get("proj-1")
@@ -89,7 +100,9 @@ class TestSQLiteProjectCostAggregateRepository:
         self,
         migrated_db: aiosqlite.Connection,
     ) -> None:
-        repo = SQLiteProjectCostAggregateRepository(migrated_db)
+        repo = SQLiteProjectCostAggregateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.increment("proj-a", 10.0, 1000, 500, currency="USD")
         await repo.increment("proj-b", 5.0, 200, 100, currency="USD")
 
@@ -105,7 +118,9 @@ class TestSQLiteProjectCostAggregateRepository:
         self,
         migrated_db: aiosqlite.Connection,
     ) -> None:
-        repo = SQLiteProjectCostAggregateRepository(migrated_db)
+        repo = SQLiteProjectCostAggregateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         agg1 = await repo.increment("proj-1", 1.0, 10, 5, currency="USD")
         agg2 = await repo.increment("proj-1", 1.0, 10, 5, currency="USD")
 
@@ -115,7 +130,9 @@ class TestSQLiteProjectCostAggregateRepository:
         self,
         migrated_db: aiosqlite.Connection,
     ) -> None:
-        repo = SQLiteProjectCostAggregateRepository(migrated_db)
+        repo = SQLiteProjectCostAggregateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         agg = await repo.increment("proj-1", 0.0, 0, 0, currency="USD")
 
         assert agg.total_cost == 0.0
@@ -132,7 +149,9 @@ class TestSQLiteProjectCostAggregateRepository:
             MixedCurrencyAggregationError,
         )
 
-        repo = SQLiteProjectCostAggregateRepository(migrated_db)
+        repo = SQLiteProjectCostAggregateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.increment("proj-1", 1.0, 10, 5, currency="USD")
         with pytest.raises(MixedCurrencyAggregationError) as exc_info:
             await repo.increment("proj-1", 1.0, 10, 5, currency="EUR")
@@ -156,7 +175,9 @@ class TestSQLiteProjectCostAggregateRepository:
         self,
         migrated_db: aiosqlite.Connection,
     ) -> None:
-        repo = SQLiteProjectCostAggregateRepository(migrated_db)
+        repo = SQLiteProjectCostAggregateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         with (
             patch.object(
                 migrated_db,
@@ -172,7 +193,9 @@ class TestSQLiteProjectCostAggregateRepository:
         self,
         migrated_db: aiosqlite.Connection,
     ) -> None:
-        repo = SQLiteProjectCostAggregateRepository(migrated_db)
+        repo = SQLiteProjectCostAggregateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         with (
             patch.object(
                 migrated_db,
@@ -208,7 +231,9 @@ class TestSQLiteProjectCostAggregateRepository:
         input_tokens: int,
         output_tokens: int,
     ) -> None:
-        repo = SQLiteProjectCostAggregateRepository(migrated_db)
+        repo = SQLiteProjectCostAggregateRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         with pytest.raises(ValueError, match="non-negative"):
             await repo.increment(
                 "proj-1", cost, input_tokens, output_tokens, currency="USD"

--- a/tests/unit/persistence/sqlite/test_project_repo.py
+++ b/tests/unit/persistence/sqlite/test_project_repo.py
@@ -6,6 +6,7 @@ import pytest
 from synthorg.core.enums import ProjectStatus
 from synthorg.core.project import Project
 from synthorg.persistence.sqlite.project_repo import SQLiteProjectRepository
+from tests._shared.persistence import make_private_write_context
 
 
 def _make_project(  # noqa: PLR0913
@@ -35,7 +36,9 @@ def _make_project(  # noqa: PLR0913
 
 @pytest.fixture
 def repo(migrated_db: aiosqlite.Connection) -> SQLiteProjectRepository:
-    return SQLiteProjectRepository(migrated_db)
+    return SQLiteProjectRepository(
+        migrated_db, write_context=make_private_write_context()
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/persistence/sqlite/test_repositories.py
+++ b/tests/unit/persistence/sqlite/test_repositories.py
@@ -30,6 +30,7 @@ from synthorg.persistence.sqlite.repositories import (
     SQLiteMessageRepository,
     SQLiteTaskRepository,
 )
+from tests._shared.persistence import make_private_write_context
 from tests.unit.persistence.conftest import make_message, make_task
 
 # ── TaskRepository ───────────────────────────────────────────────
@@ -38,7 +39,9 @@ from tests.unit.persistence.conftest import make_message, make_task
 @pytest.mark.unit
 class TestSQLiteTaskRepository:
     async def test_save_and_get(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteTaskRepository(migrated_db)
+        repo = SQLiteTaskRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         task = make_task()
         await repo.save(task)
 
@@ -52,13 +55,17 @@ class TestSQLiteTaskRepository:
     async def test_get_returns_none_for_missing(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteTaskRepository(migrated_db)
+        repo = SQLiteTaskRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         assert await repo.get("nonexistent") is None
 
     async def test_save_upsert_updates_existing(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteTaskRepository(migrated_db)
+        repo = SQLiteTaskRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         task = make_task()
         await repo.save(task)
 
@@ -71,7 +78,9 @@ class TestSQLiteTaskRepository:
         assert result.assigned_to == "bob"
 
     async def test_list_all(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteTaskRepository(migrated_db)
+        repo = SQLiteTaskRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.save(make_task(task_id="t1"))
         await repo.save(make_task(task_id="t2"))
 
@@ -81,7 +90,9 @@ class TestSQLiteTaskRepository:
     async def test_list_filter_by_status(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteTaskRepository(migrated_db)
+        repo = SQLiteTaskRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.save(make_task(task_id="t1"))
         t2 = make_task(task_id="t2").with_transition(
             TaskStatus.ASSIGNED, assigned_to="bob"
@@ -95,7 +106,9 @@ class TestSQLiteTaskRepository:
     async def test_list_filter_by_assigned_to(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteTaskRepository(migrated_db)
+        repo = SQLiteTaskRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         t = make_task().with_transition(TaskStatus.ASSIGNED, assigned_to="bob")
         await repo.save(t)
 
@@ -106,7 +119,9 @@ class TestSQLiteTaskRepository:
     async def test_list_filter_by_project(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteTaskRepository(migrated_db)
+        repo = SQLiteTaskRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.save(make_task(task_id="t1", project="proj-a"))
         await repo.save(make_task(task_id="t2", project="proj-b"))
 
@@ -115,20 +130,26 @@ class TestSQLiteTaskRepository:
         assert result[0].project == "proj-a"
 
     async def test_delete_existing(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteTaskRepository(migrated_db)
+        repo = SQLiteTaskRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.save(make_task())
         assert await repo.delete("task-001") is True
         assert await repo.get("task-001") is None
 
     async def test_delete_nonexistent(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteTaskRepository(migrated_db)
+        repo = SQLiteTaskRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         assert await repo.delete("nonexistent") is False
 
     async def test_list_with_combined_filters(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Multiple filters combine with AND logic."""
-        repo = SQLiteTaskRepository(migrated_db)
+        repo = SQLiteTaskRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         t1 = make_task(task_id="t1", project="proj-a")
         t2 = make_task(task_id="t2", project="proj-a").with_transition(
             TaskStatus.ASSIGNED, assigned_to="bob"
@@ -176,7 +197,9 @@ class TestSQLiteTaskRepository:
             ),
             delegation_chain=("manager", "lead"),
         )
-        repo = SQLiteTaskRepository(migrated_db)
+        repo = SQLiteTaskRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.save(task)
 
         result = await repo.get("task-complex")
@@ -222,7 +245,9 @@ class TestSQLiteCostRecordRepository:
         )
 
     async def test_save_and_query(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteCostRecordRepository(migrated_db)
+        repo = SQLiteCostRecordRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         record = self._make_record()
         await repo.save(record)
 
@@ -232,7 +257,9 @@ class TestSQLiteCostRecordRepository:
         assert results[0].cost == 0.05
 
     async def test_query_by_agent(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteCostRecordRepository(migrated_db)
+        repo = SQLiteCostRecordRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.save(self._make_record(agent_id="alice"))
         await repo.save(self._make_record(agent_id="bob"))
 
@@ -241,7 +268,9 @@ class TestSQLiteCostRecordRepository:
         assert results[0].agent_id == "alice"
 
     async def test_query_by_task(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteCostRecordRepository(migrated_db)
+        repo = SQLiteCostRecordRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.save(self._make_record(task_id="t1"))
         await repo.save(self._make_record(task_id="t2"))
 
@@ -250,7 +279,9 @@ class TestSQLiteCostRecordRepository:
         assert results[0].task_id == "t1"
 
     async def test_aggregate_all(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteCostRecordRepository(migrated_db)
+        repo = SQLiteCostRecordRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.save(self._make_record(cost=0.10))
         await repo.save(self._make_record(cost=0.20))
 
@@ -258,7 +289,9 @@ class TestSQLiteCostRecordRepository:
         assert abs(total - 0.30) < 1e-9
 
     async def test_aggregate_by_agent(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteCostRecordRepository(migrated_db)
+        repo = SQLiteCostRecordRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.save(self._make_record(agent_id="alice", cost=0.10))
         await repo.save(self._make_record(agent_id="bob", cost=0.20))
 
@@ -266,7 +299,9 @@ class TestSQLiteCostRecordRepository:
         assert abs(total - 0.10) < 1e-9
 
     async def test_aggregate_by_task(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteCostRecordRepository(migrated_db)
+        repo = SQLiteCostRecordRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.save(self._make_record(task_id="t1", cost=0.10))
         await repo.save(self._make_record(task_id="t2", cost=0.20))
 
@@ -276,7 +311,9 @@ class TestSQLiteCostRecordRepository:
     async def test_aggregate_by_agent_and_task(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteCostRecordRepository(migrated_db)
+        repo = SQLiteCostRecordRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.save(self._make_record(agent_id="alice", task_id="t1", cost=0.10))
         await repo.save(self._make_record(agent_id="alice", task_id="t2", cost=0.20))
         await repo.save(self._make_record(agent_id="bob", task_id="t1", cost=0.30))
@@ -285,7 +322,9 @@ class TestSQLiteCostRecordRepository:
         assert abs(total - 0.10) < 1e-9
 
     async def test_aggregate_empty(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteCostRecordRepository(migrated_db)
+        repo = SQLiteCostRecordRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         total = await repo.aggregate()
         assert total == 0.0
 
@@ -293,7 +332,9 @@ class TestSQLiteCostRecordRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Aggregating across USD + EUR rows raises rather than summing."""
-        repo = SQLiteCostRecordRepository(migrated_db)
+        repo = SQLiteCostRecordRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.save(self._make_record(task_id="t1", currency="USD", cost=0.10))
         await repo.save(self._make_record(task_id="t2", currency="EUR", cost=0.20))
 
@@ -305,7 +346,9 @@ class TestSQLiteCostRecordRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Filters narrow the aggregation scope before the invariant fires."""
-        repo = SQLiteCostRecordRepository(migrated_db)
+        repo = SQLiteCostRecordRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.save(self._make_record(agent_id="alice", currency="USD", cost=0.10))
         await repo.save(self._make_record(agent_id="bob", currency="EUR", cost=0.20))
 
@@ -317,7 +360,9 @@ class TestSQLiteCostRecordRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Mixed-currency rows under the same task_id still raise."""
-        repo = SQLiteCostRecordRepository(migrated_db)
+        repo = SQLiteCostRecordRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.save(
             self._make_record(
                 agent_id="alice", task_id="shared", currency="USD", cost=0.10
@@ -336,7 +381,9 @@ class TestSQLiteCostRecordRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """agent_id + task_id filters combine correctly."""
-        repo = SQLiteCostRecordRepository(migrated_db)
+        repo = SQLiteCostRecordRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.save(self._make_record(agent_id="alice", task_id="t1"))
         await repo.save(self._make_record(agent_id="alice", task_id="t2"))
         await repo.save(self._make_record(agent_id="bob", task_id="t1"))
@@ -363,7 +410,9 @@ class TestSQLiteCostRecordRepository:
             timestamp=datetime(2026, 3, 1, 12, 0, 0, tzinfo=UTC),
             call_category=LLMCallCategory.PRODUCTIVE,
         )
-        repo = SQLiteCostRecordRepository(migrated_db)
+        repo = SQLiteCostRecordRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.save(record)
 
         results = await repo.query()
@@ -372,7 +421,9 @@ class TestSQLiteCostRecordRepository:
     async def test_round_trip_null_call_category(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteCostRecordRepository(migrated_db)
+        repo = SQLiteCostRecordRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.save(self._make_record())
 
         results = await repo.query()
@@ -387,7 +438,9 @@ class TestSQLiteMessageRepository:
     async def test_save_and_get_history(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteMessageRepository(migrated_db)
+        repo = SQLiteMessageRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         msg = make_message()
         await repo.save(msg)
 
@@ -398,7 +451,9 @@ class TestSQLiteMessageRepository:
     async def test_history_ordered_newest_first(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteMessageRepository(migrated_db)
+        repo = SQLiteMessageRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         msg1 = make_message(
             timestamp=datetime(2026, 3, 1, 10, 0, 0, tzinfo=UTC),
             content="first",
@@ -416,7 +471,9 @@ class TestSQLiteMessageRepository:
         assert history[1].text == "first"
 
     async def test_history_with_limit(self, migrated_db: aiosqlite.Connection) -> None:
-        repo = SQLiteMessageRepository(migrated_db)
+        repo = SQLiteMessageRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         for i in range(5):
             await repo.save(
                 make_message(
@@ -431,7 +488,9 @@ class TestSQLiteMessageRepository:
     async def test_history_filters_by_channel(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteMessageRepository(migrated_db)
+        repo = SQLiteMessageRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.save(make_message(channel="general"))
         await repo.save(make_message(channel="engineering"))
 
@@ -442,7 +501,9 @@ class TestSQLiteMessageRepository:
     async def test_duplicate_message_rejected(
         self, migrated_db: aiosqlite.Connection
     ) -> None:
-        repo = SQLiteMessageRepository(migrated_db)
+        repo = SQLiteMessageRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         fixed_id = uuid4()
         msg = make_message(msg_id=fixed_id)
         await repo.save(msg)
@@ -454,7 +515,9 @@ class TestSQLiteMessageRepository:
         self, migrated_db: aiosqlite.Connection
     ) -> None:
         """Verify the sender/'from' alias round-trips correctly."""
-        repo = SQLiteMessageRepository(migrated_db)
+        repo = SQLiteMessageRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         msg = make_message(sender="charlie")
         await repo.save(msg)
 
@@ -474,7 +537,9 @@ class TestSQLiteMessageRepository:
                 extra=(("key1", "val1"),),
             ),
         )
-        repo = SQLiteMessageRepository(migrated_db)
+        repo = SQLiteMessageRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         await repo.save(msg)
 
         history = await repo.get_history("general")
@@ -487,7 +552,9 @@ class TestSQLiteMessageRepository:
 
     async def test_round_trip_uuid_id(self, migrated_db: aiosqlite.Connection) -> None:
         """Verify UUID id survives round-trip."""
-        repo = SQLiteMessageRepository(migrated_db)
+        repo = SQLiteMessageRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         msg = make_message()
         original_id = msg.id
         await repo.save(msg)
@@ -501,7 +568,9 @@ class TestSQLiteMessageRepository:
         """Negative or zero limit raises QueryError."""
         from synthorg.core.persistence_errors import QueryError
 
-        repo = SQLiteMessageRepository(migrated_db)
+        repo = SQLiteMessageRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         with pytest.raises(QueryError, match="positive integer"):
             await repo.get_history("general", limit=0)
         with pytest.raises(QueryError, match="positive integer"):
@@ -517,7 +586,9 @@ class TestSQLiteRepoProtocolCompliance:
     ) -> None:
         from synthorg.persistence.task_protocol import TaskRepository
 
-        repo = SQLiteTaskRepository(migrated_db)
+        repo = SQLiteTaskRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         assert isinstance(repo, TaskRepository)
 
     async def test_cost_record_repo_implements_protocol(
@@ -527,7 +598,9 @@ class TestSQLiteRepoProtocolCompliance:
             CostRecordRepository,
         )
 
-        repo = SQLiteCostRecordRepository(migrated_db)
+        repo = SQLiteCostRecordRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         assert isinstance(repo, CostRecordRepository)
 
     async def test_message_repo_implements_protocol(
@@ -535,7 +608,9 @@ class TestSQLiteRepoProtocolCompliance:
     ) -> None:
         from synthorg.persistence.message_protocol import MessageRepository
 
-        repo = SQLiteMessageRepository(migrated_db)
+        repo = SQLiteMessageRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         assert isinstance(repo, MessageRepository)
 
 
@@ -561,7 +636,9 @@ INSERT INTO tasks (
         )
         await migrated_db.commit()
 
-        repo = SQLiteTaskRepository(migrated_db)
+        repo = SQLiteTaskRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         with pytest.raises(QueryError, match="deserialize task"):
             await repo.get("corrupt-1")
 
@@ -584,6 +661,8 @@ INSERT INTO messages (
         )
         await migrated_db.commit()
 
-        repo = SQLiteMessageRepository(migrated_db)
+        repo = SQLiteMessageRepository(
+            migrated_db, write_context=make_private_write_context()
+        )
         with pytest.raises(QueryError, match="deserialize message"):
             await repo.get_history("general")

--- a/tests/unit/persistence/sqlite/test_settings_repo.py
+++ b/tests/unit/persistence/sqlite/test_settings_repo.py
@@ -4,12 +4,15 @@ import aiosqlite
 import pytest
 
 from synthorg.persistence.sqlite.settings_repo import SQLiteSettingsRepository
+from tests._shared.persistence import make_private_write_context
 
 
 @pytest.fixture
 def repo(migrated_db: aiosqlite.Connection) -> SQLiteSettingsRepository:
     """Settings repo backed by the shared migrated_db fixture."""
-    return SQLiteSettingsRepository(migrated_db)
+    return SQLiteSettingsRepository(
+        migrated_db, write_context=make_private_write_context()
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/persistence/sqlite/test_subworkflow_repo.py
+++ b/tests/unit/persistence/sqlite/test_subworkflow_repo.py
@@ -21,6 +21,7 @@ from synthorg.engine.workflow.definition import (
 from synthorg.persistence.sqlite.subworkflow_repo import (
     SQLiteSubworkflowRepository,
 )
+from tests._shared.persistence import make_private_write_context
 
 _DEFAULT_TS = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
 
@@ -29,7 +30,9 @@ _DEFAULT_TS = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
 def repo(
     migrated_db: aiosqlite.Connection,
 ) -> SQLiteSubworkflowRepository:
-    return SQLiteSubworkflowRepository(migrated_db)
+    return SQLiteSubworkflowRepository(
+        migrated_db, write_context=make_private_write_context()
+    )
 
 
 def _make_nodes() -> tuple[WorkflowNode, ...]:

--- a/tests/unit/persistence/sqlite/test_training_plan_repo.py
+++ b/tests/unit/persistence/sqlite/test_training_plan_repo.py
@@ -10,6 +10,7 @@ from synthorg.hr.training.models import ContentType, TrainingPlan, TrainingPlanS
 from synthorg.persistence.sqlite.training_plan_repo import (
     SQLiteTrainingPlanRepository,
 )
+from tests._shared.persistence import make_private_write_context
 
 
 def _make_plan(  # noqa: PLR0913
@@ -46,7 +47,9 @@ def _make_plan(  # noqa: PLR0913
 
 @pytest.fixture
 def repo(migrated_db: aiosqlite.Connection) -> SQLiteTrainingPlanRepository:
-    return SQLiteTrainingPlanRepository(migrated_db)
+    return SQLiteTrainingPlanRepository(
+        migrated_db, write_context=make_private_write_context()
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/persistence/sqlite/test_training_result_repo.py
+++ b/tests/unit/persistence/sqlite/test_training_result_repo.py
@@ -18,6 +18,7 @@ from synthorg.persistence.sqlite.training_plan_repo import (
 from synthorg.persistence.sqlite.training_result_repo import (
     SQLiteTrainingResultRepository,
 )
+from tests._shared.persistence import make_private_write_context
 
 
 def _make_plan(
@@ -79,8 +80,12 @@ def _make_result(  # noqa: PLR0913
 async def repos(
     migrated_db: aiosqlite.Connection,
 ) -> tuple[SQLiteTrainingPlanRepository, SQLiteTrainingResultRepository]:
-    plan_repo = SQLiteTrainingPlanRepository(migrated_db)
-    result_repo = SQLiteTrainingResultRepository(migrated_db)
+    plan_repo = SQLiteTrainingPlanRepository(
+        migrated_db, write_context=make_private_write_context()
+    )
+    result_repo = SQLiteTrainingResultRepository(
+        migrated_db, write_context=make_private_write_context()
+    )
     return plan_repo, result_repo
 
 

--- a/tests/unit/persistence/sqlite/test_training_result_repo.py
+++ b/tests/unit/persistence/sqlite/test_training_result_repo.py
@@ -80,11 +80,10 @@ def _make_result(  # noqa: PLR0913
 async def repos(
     migrated_db: aiosqlite.Connection,
 ) -> tuple[SQLiteTrainingPlanRepository, SQLiteTrainingResultRepository]:
-    plan_repo = SQLiteTrainingPlanRepository(
-        migrated_db, write_context=make_private_write_context()
-    )
+    write_context = make_private_write_context()
+    plan_repo = SQLiteTrainingPlanRepository(migrated_db, write_context=write_context)
     result_repo = SQLiteTrainingResultRepository(
-        migrated_db, write_context=make_private_write_context()
+        migrated_db, write_context=write_context
     )
     return plan_repo, result_repo
 

--- a/tests/unit/persistence/sqlite/test_user_repo.py
+++ b/tests/unit/persistence/sqlite/test_user_repo.py
@@ -13,6 +13,7 @@ from synthorg.persistence.sqlite.user_repo import (
     SQLiteApiKeyRepository,
     SQLiteUserRepository,
 )
+from tests._shared.persistence import make_private_write_context
 
 
 @pytest.fixture
@@ -23,12 +24,12 @@ def db(migrated_db: aiosqlite.Connection) -> aiosqlite.Connection:
 
 @pytest.fixture
 def user_repo(db: aiosqlite.Connection) -> SQLiteUserRepository:
-    return SQLiteUserRepository(db)
+    return SQLiteUserRepository(db, write_context=make_private_write_context())
 
 
 @pytest.fixture
 def api_key_repo(db: aiosqlite.Connection) -> SQLiteApiKeyRepository:
-    return SQLiteApiKeyRepository(db)
+    return SQLiteApiKeyRepository(db, write_context=make_private_write_context())
 
 
 def _make_user(

--- a/tests/unit/persistence/sqlite/test_version_repo.py
+++ b/tests/unit/persistence/sqlite/test_version_repo.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, ConfigDict
 from synthorg.persistence.sqlite.version_repo import SQLiteVersionRepository
 from synthorg.versioning.hashing import compute_content_hash
 from synthorg.versioning.models import VersionSnapshot
+from tests._shared.persistence import make_private_write_context
 
 _NOW = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
 
@@ -79,6 +80,7 @@ async def repo(
         table_name="test_versions",
         serialize_snapshot=_serialize,
         deserialize_snapshot=_deserialize,
+        write_context=make_private_write_context(),
     )
 
 
@@ -95,6 +97,7 @@ class TestTableNameValidation:
                 table_name="bad name!",
                 serialize_snapshot=_serialize,
                 deserialize_snapshot=_deserialize,
+                write_context=make_private_write_context(),
             )
 
     @pytest.mark.unit
@@ -107,6 +110,7 @@ class TestTableNameValidation:
                 table_name="TestVersions",
                 serialize_snapshot=_serialize,
                 deserialize_snapshot=_deserialize,
+                write_context=make_private_write_context(),
             )
 
     @pytest.mark.unit
@@ -125,6 +129,7 @@ class TestTableNameValidation:
             table_name="agent_identity_versions",
             serialize_snapshot=_serialize,
             deserialize_snapshot=_deserialize,
+            write_context=make_private_write_context(),
         )
 
 
@@ -336,6 +341,7 @@ class TestTableNameValidationEdgeCases:
                 table_name="",
                 serialize_snapshot=_serialize,
                 deserialize_snapshot=_deserialize,
+                write_context=make_private_write_context(),
             )
 
     @pytest.mark.unit
@@ -348,6 +354,7 @@ class TestTableNameValidationEdgeCases:
                 table_name="1_versions",
                 serialize_snapshot=_serialize,
                 deserialize_snapshot=_deserialize,
+                write_context=make_private_write_context(),
             )
 
 

--- a/tests/unit/persistence/sqlite/test_workflow_definition_repo.py
+++ b/tests/unit/persistence/sqlite/test_workflow_definition_repo.py
@@ -19,13 +19,16 @@ from synthorg.engine.workflow.definition import (
 from synthorg.persistence.sqlite.workflow_definition_repo import (
     SQLiteWorkflowDefinitionRepository,
 )
+from tests._shared.persistence import make_private_write_context
 
 
 @pytest.fixture
 def repo(
     migrated_db: aiosqlite.Connection,
 ) -> SQLiteWorkflowDefinitionRepository:
-    return SQLiteWorkflowDefinitionRepository(migrated_db)
+    return SQLiteWorkflowDefinitionRepository(
+        migrated_db, write_context=make_private_write_context()
+    )
 
 
 def _make_nodes(

--- a/tests/unit/persistence/sqlite/test_workflow_execution_repo.py
+++ b/tests/unit/persistence/sqlite/test_workflow_execution_repo.py
@@ -21,13 +21,16 @@ from synthorg.engine.workflow.execution_models import (
 from synthorg.persistence.sqlite.workflow_execution_repo import (
     SQLiteWorkflowExecutionRepository,
 )
+from tests._shared.persistence import make_private_write_context
 
 
 @pytest.fixture
 def repo(
     migrated_db: aiosqlite.Connection,
 ) -> SQLiteWorkflowExecutionRepository:
-    return SQLiteWorkflowExecutionRepository(migrated_db)
+    return SQLiteWorkflowExecutionRepository(
+        migrated_db, write_context=make_private_write_context()
+    )
 
 
 def _make_execution(

--- a/tests/unit/persistence/test_protocol.py
+++ b/tests/unit/persistence/test_protocol.py
@@ -1,6 +1,7 @@
 """Tests for persistence protocol compliance."""
 
-from collections.abc import Mapping, Sequence
+from collections.abc import AsyncIterator, Mapping, Sequence
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -651,6 +652,10 @@ class _FakeBackend:
     def get_db(self) -> object:
         msg = "Not supported"
         raise NotImplementedError(msg)
+
+    @asynccontextmanager
+    async def write_context(self) -> AsyncIterator[None]:
+        yield
 
     @property
     def is_connected(self) -> bool:


### PR DESCRIPTION
## Summary

Replaces the `write_lock: asyncio.Lock` constructor parameter that was threaded through 45 SQLite repositories with a `write_context()` async context manager on `PersistenceBackend`.

- SQLite acquires the shared in-process lock so multi-statement transactions on the single `aiosqlite.Connection` cannot interleave at the statement level.
- Postgres yields immediately (`@asynccontextmanager` no-op) because each repository operation checks out an independent connection from the async pool; the method exists only to keep the cross-backend interface uniform.

Also fixes a latent bug in `build_escalations()`: `SQLiteEscalationRepository` was previously constructed without the shared lock, so escalation writes did not serialize with sibling repos on the shared connection. The factory now routes escalations through `self.write_context` like every other repo.

`write_context` is a required keyword-only argument on every SQLite repo. Tests use `tests._shared.persistence.make_private_write_context()` for standalone construction; production callers receive the backend's bound method.

## Changes

- **Protocol**: `PersistenceBackend.write_context()` returns `AbstractAsyncContextManager[None]`; cross-backend contract documented (SQLite serializes, Postgres yields).
- **SQLite backend**: new `_write_lock: asyncio.Lock` owned by the backend; `@asynccontextmanager async def write_context()` acquires it. The 45 SQLite repos now take `write_context: WriteContext` keyword-only and wrap multi-statement transactions in `async with self._write_context():`.
- **Postgres backend**: `@asynccontextmanager async def write_context()` is a single-`yield` no-op.
- **Ontology factory**: `create_ontology_versioning(db, *, write_context)` threads the CM through `SQLiteVersionRepository`.
- **CLI scaffold templates**: updated to generate code that uses `write_context=WriteContext` and the `async with self._write_context():` pattern.
- **Backend split**: property accessors moved into `_BackendRepositoryAccessors` mixin (`_backend_accessors.py`); `backend.py` drops from 1203 to 775 lines, back under the 800-line guideline.
- **Type design**: `WriteContext` promoted from `Callable[[], AbstractAsyncContextManager[None]]` to a `Protocol` so the name carries the intent (a factory yielding a serializing CM) at the type level.

## Test plan

- New `tests/conformance/persistence/test_write_context.py` exercises the cross-backend contract on both SQLite and Postgres arms.
- New `tests/conformance/persistence/test_sqlite_write_context_serializes.py` (`# lint-allow: dual-backend-parity`) launches 4 concurrent writers under `asyncio.TaskGroup` and asserts strict enter/exit serialization.
- New regression test in `tests/unit/persistence/sqlite/test_escalation_repo.py` asserts that `build_escalations()` wires the backend's shared `write_context`; if the latent-bug reappears, this test fails.
- All 38 modified existing tests pass with `make_private_write_context()` injected into repository constructors.

## Pre-PR review

20 review agents ran in parallel (docs-consistency, comment-quality-rot, code-reviewer, python-reviewer, persistence-reviewer, security-reviewer, async-concurrency-reviewer, test-quality-reviewer, conventions-enforcer, logging-audit, resilience-audit, silent-failure-hunter, type-design-analyzer, pr-test-analyzer, comment-analyzer, issue-resolution-verifier, plus four mini-pass audits). 11 valid findings surfaced (4 MAJOR, 1 MEDIUM, 5 SUGGESTION, 1 INFO); the polish commit on this branch addresses every one. 2 agent false-positives dismissed (one PEP 758 misread, one out-of-scope file).

## Verification

- `uv run ruff check src/ tests/` — clean
- `uv run ruff format --check src/ tests/` — clean
- `uv run mypy src/ tests/` — `Success: no issues found in 3714 source files`
- `uv run python -m pytest tests/ -m unit` — `28386 passed, 18 skipped`
- `uv run python scripts/check_persistence_protocol_return_types.py` — exit 0
- `uv run python scripts/check_dual_backend_test_parity.py` — exit 0

Closes #1887