### PR TITLE
feat: async safety + observability work package (#1885)

### DIFF
--- a/data/runtime_stats.yaml
+++ b/data/runtime_stats.yaml
@@ -1,16 +1,16 @@
 schema_version: 1
-last_generated_utc: '2026-05-13T13:59:06Z'
-generator_revision: e4ad0a889
+last_generated_utc: '2026-05-13T14:51:15Z'
+generator_revision: 46204b2c5
 stats:
   tests:
     raw: 30056
     rounded: 30000
     display: 30,000+
   version:
-    raw: v0.8.4-dev.2
-    display: v0.8.4-dev.2
+    raw: v0.8.4-dev.6
+    display: v0.8.4-dev.6
   mem0_stars:
-    raw: 55586
+    raw: 55585
     rounded: 55000
     display: 55k+
   providers_curated:

--- a/data/runtime_stats.yaml
+++ b/data/runtime_stats.yaml
@@ -1,16 +1,16 @@
 schema_version: 1
-last_generated_utc: '2026-05-13T12:50:01Z'
-generator_revision: faa85db4c
+last_generated_utc: '2026-05-13T13:59:06Z'
+generator_revision: e4ad0a889
 stats:
   tests:
-    raw: 30006
+    raw: 30056
     rounded: 30000
     display: 30,000+
   version:
     raw: v0.8.4-dev.2
     display: v0.8.4-dev.2
   mem0_stars:
-    raw: 55583
+    raw: 55586
     rounded: 55000
     display: 55k+
   providers_curated:

--- a/scripts/schema_drift_baseline.txt
+++ b/scripts/schema_drift_baseline.txt
@@ -85,9 +85,9 @@ column:mcp_installations:installed_at:TEXT:TIMESTAMPTZ:SQLite has no TIMESTAMPTZ
 column:messages:attachments:TEXT:JSONB:SQLite has no JSONB type; column stores TEXT carrying json.dumps(...) (see schema header column inventory)
 column:messages:metadata:TEXT:JSONB:SQLite has no JSONB type; column stores TEXT carrying json.dumps(...) (see schema header column inventory)
 column:messages:timestamp:TEXT:TIMESTAMPTZ:SQLite has no TIMESTAMPTZ; column stores TEXT carrying ISO-8601 with explicit +00:00/Z suffix, normalised to UTC at write time
+column:oauth_states:consumed_at:TEXT:TIMESTAMPTZ:SQLite has no TIMESTAMPTZ; column stores TEXT carrying ISO-8601 with explicit +00:00/Z suffix, normalised to UTC at write time
 column:oauth_states:created_at:TEXT:TIMESTAMPTZ:SQLite has no TIMESTAMPTZ; column stores TEXT carrying ISO-8601 with explicit +00:00/Z suffix, normalised to UTC at write time
 column:oauth_states:expires_at:TEXT:TIMESTAMPTZ:SQLite has no TIMESTAMPTZ; column stores TEXT carrying ISO-8601 with explicit +00:00/Z suffix, normalised to UTC at write time
-column:oauth_states:consumed_at:TEXT:TIMESTAMPTZ:SQLite has no TIMESTAMPTZ; column stores TEXT carrying ISO-8601 with explicit +00:00/Z suffix, normalised to UTC at write time
 column:org_facts_operation_log:author_is_human:INTEGER:BOOLEAN:SQLite has no BOOLEAN; column stores INTEGER 0/1 (no CHECK constraint enforces the domain at the DB layer; service layer normalises)
 column:org_facts_operation_log:timestamp:TEXT:TIMESTAMPTZ:SQLite has no TIMESTAMPTZ; column stores TEXT carrying ISO-8601 with explicit +00:00/Z suffix, normalised to UTC at write time
 column:org_facts_snapshot:author_is_human:INTEGER:BOOLEAN:SQLite has no BOOLEAN; column stores INTEGER 0/1 (no CHECK constraint enforces the domain at the DB layer; service layer normalises)
@@ -113,6 +113,8 @@ column:risk_overrides:expires_at:TEXT:TIMESTAMPTZ:SQLite has no TIMESTAMPTZ; col
 column:risk_overrides:revoked_at:TEXT:TIMESTAMPTZ:SQLite has no TIMESTAMPTZ; column stores TEXT carrying ISO-8601 with explicit +00:00/Z suffix, normalised to UTC at write time
 column:role_versions:saved_at:TEXT:TIMESTAMPTZ:SQLite has no TIMESTAMPTZ; column stores TEXT carrying ISO-8601 with explicit +00:00/Z suffix, normalised to UTC at write time
 column:role_versions:snapshot:TEXT:JSONB:SQLite has no JSONB type; column stores TEXT carrying json.dumps(...) (see schema header column inventory)
+column:seen_claims:expires_at:TEXT:TIMESTAMPTZ:SQLite has no TIMESTAMPTZ; column stores TEXT carrying ISO-8601 with explicit +00:00/Z suffix, normalised to UTC at write time
+column:seen_claims:seen_at:TEXT:TIMESTAMPTZ:SQLite has no TIMESTAMPTZ; column stores TEXT carrying ISO-8601 with explicit +00:00/Z suffix, normalised to UTC at write time
 column:sessions:created_at:TEXT:TIMESTAMPTZ:SQLite has no TIMESTAMPTZ; column stores TEXT carrying ISO-8601 with explicit +00:00/Z suffix, normalised to UTC at write time
 column:sessions:expires_at:TEXT:TIMESTAMPTZ:SQLite has no TIMESTAMPTZ; column stores TEXT carrying ISO-8601 with explicit +00:00/Z suffix, normalised to UTC at write time
 column:sessions:last_active_at:TEXT:TIMESTAMPTZ:SQLite has no TIMESTAMPTZ; column stores TEXT carrying ISO-8601 with explicit +00:00/Z suffix, normalised to UTC at write time
@@ -180,5 +182,3 @@ index_attr:idx_ftc_single_active:where:is_active = 1:is_active = TRUE:Partial-un
 nullable:cost_records:rowid:N:Y:SQLite uses INTEGER PRIMARY KEY AUTOINCREMENT (NOT NULL); Postgres uses BIGINT GENERATED ALWAYS AS IDENTITY which can be NULL until insert assigns the sequence value (composite PK with timestamp enforces non-null at write time)
 pk:audit_entries:id:id,timestamp:Postgres composite PK includes the timestamp partitioning column for TimescaleDB hypertable conversion; SQLite has no hypertable concept and uses the simpler PK on id alone (see schema header)
 pk:cost_records:rowid:rowid,timestamp:Postgres composite PK includes the timestamp partitioning column for TimescaleDB hypertable conversion; SQLite has no hypertable concept (see schema header)
-migration:add_idx_wfe_definition_revision:postgres_only:Postgres-only migration that backfilled the index; SQLite picked up the same index in a different revision (audit cluster #8 listed this as PG-only-index drift; the index itself is now present on both backends)
-migration:json_check_constraints:sqlite_only:SQLite-only migration tightening json_valid CHECK constraints; Postgres enforces JSON validity natively via the JSONB type

--- a/src/synthorg/api/bus_bridge.py
+++ b/src/synthorg/api/bus_bridge.py
@@ -620,6 +620,12 @@ class MessageBusBridge:
                     ws_event.model_dump_json(),
                     channels=[channel_name],
                 )
+                # Ack the NATS JetStream message only AFTER the
+                # websocket publish accepted the payload. Acking before
+                # this point would lose the message on a transient
+                # plugin.publish failure (in-memory backend ships a
+                # no-op ack so this is free for non-NATS deployments).
+                await envelope.ack()
                 consecutive_errors = 0
             except asyncio.CancelledError:
                 break

--- a/src/synthorg/api/bus_bridge.py
+++ b/src/synthorg/api/bus_bridge.py
@@ -629,7 +629,19 @@ class MessageBusBridge:
                 consecutive_errors = 0
             except asyncio.CancelledError:
                 break
-            except (OSError, ConnectionError, TimeoutError) as exc:
+            except (
+                CommunicationError,
+                OSError,
+                ConnectionError,
+                TimeoutError,
+            ) as exc:
+                # ``CommunicationError`` covers the deferred JetStream
+                # ack failure surfaced by ``envelope.ack()``. Treat it
+                # as a retriable channel error so a transient ack drop
+                # bumps ``consecutive_errors`` toward ``max_errors``
+                # instead of tripping the fatal ``except Exception``
+                # branch and tearing down the bridge on the first
+                # hiccup.
                 consecutive_errors += 1
                 if consecutive_errors >= max_errors:
                     logger.error(

--- a/src/synthorg/api/controllers/_department_health.py
+++ b/src/synthorg/api/controllers/_department_health.py
@@ -22,7 +22,7 @@ from synthorg.core.domain_errors import ServiceUnavailableError
 from synthorg.core.enums import AgentStatus
 from synthorg.core.normalization import compare_ci
 from synthorg.core.types import NotBlankStr
-from synthorg.observability import get_logger
+from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.api import API_REQUEST_ERROR
 
 if TYPE_CHECKING:
@@ -121,11 +121,13 @@ async def _resolve_active_count(
         return sum(1 for a in dept_agents if a.status == AgentStatus.ACTIVE)
     except MemoryError, RecursionError:
         raise
-    except Exception:
+    except Exception as exc:
         logger.warning(
             API_REQUEST_ERROR,
             endpoint="departments.health",
-            error="agent_registry_query_failed",
+            detail="agent_registry_query_failed",
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
         )
         return 0
 
@@ -175,10 +177,12 @@ async def _resolve_agent_ids(
         raise
     except ServiceUnavailableError:
         raise
-    except Exception:
+    except Exception as exc:
         logger.warning(
             API_REQUEST_ERROR,
             endpoint="departments.health.resolve_id",
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
         )
         return ()
     return tuple(str(i.id) for i in identities if i is not None)

--- a/src/synthorg/api/controllers/activities.py
+++ b/src/synthorg/api/controllers/activities.py
@@ -238,11 +238,13 @@ async def _resolve_currency(
             detail="Could not load budget configuration; aborting request.",
         )
         raise
-    except Exception:
+    except Exception as exc:
         logger.warning(
             API_REQUEST_ERROR,
             endpoint="activities",
             detail="budget config unavailable, using default currency",
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
         )
         degraded.append(_SRC_BUDGET_CONFIG)
         return DEFAULT_CURRENCY

--- a/src/synthorg/api/controllers/analytics.py
+++ b/src/synthorg/api/controllers/analytics.py
@@ -33,7 +33,7 @@ from synthorg.budget.trends import (
 from synthorg.constants import BUDGET_ROUNDING_PRECISION
 from synthorg.core.domain_errors import ServiceUnavailableError
 from synthorg.core.enums import TaskStatus
-from synthorg.observability import get_logger
+from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.analytics import (
     ANALYTICS_FORECAST_QUERIED,
     ANALYTICS_OVERVIEW_QUERIED,
@@ -216,11 +216,13 @@ async def _resolve_budget_context(
         )
     except MemoryError, RecursionError:
         raise
-    except Exception:
+    except Exception as exc:
         logger.warning(
             API_REQUEST_ERROR,
             endpoint="analytics.budget_context",
-            error="period_cost_query_failed",
+            detail="period_cost_query_failed",
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
         )
         period_cost = fallback_total_cost
 

--- a/src/synthorg/api/controllers/approvals.py
+++ b/src/synthorg/api/controllers/approvals.py
@@ -49,7 +49,7 @@ from synthorg.core.enums import (
     ApprovalRiskLevel,
     ApprovalStatus,
 )
-from synthorg.observability import get_logger
+from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.api import (
     API_APPROVAL_CONFLICT,
     API_APPROVAL_CREATED,
@@ -299,11 +299,13 @@ def _publish_approval_event(
         )
     except MemoryError, RecursionError:
         raise
-    except Exception:
+    except Exception as exc:
         logger.warning(
             API_APPROVAL_PUBLISH_FAILED,
             approval_id=item.id,
             event_type=event_type.value,
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
         )
 
 

--- a/src/synthorg/api/controllers/backup.py
+++ b/src/synthorg/api/controllers/backup.py
@@ -65,9 +65,19 @@ async def _do_backup_as_dict(
     The idempotency service caches a JSON-serialized response. The
     backup service returns a Pydantic model, so we serialize via
     ``model_dump`` for caching and re-validate on cache hit.
+
+    The dumped payload is round-trip validated via
+    ``BackupManifest.model_validate`` BEFORE we hand it to the
+    idempotency service for caching. A corrupt manifest (impossible
+    by construction today but cheap to guard) is rejected before it
+    pollutes the cache; the controller's cache-hit branch already
+    handles the symmetric "row already in cache fails to validate"
+    case, so this closes the loop on both directions.
     """
     manifest = await backup_callable()
-    return manifest.model_dump(mode="json")
+    dumped = manifest.model_dump(mode="json")
+    BackupManifest.model_validate(dumped)
+    return dumped
 
 
 class BackupController(Controller):

--- a/src/synthorg/api/controllers/setup.py
+++ b/src/synthorg/api/controllers/setup.py
@@ -822,10 +822,12 @@ class SetupController(Controller):
             )
         except MemoryError, RecursionError:
             raise
-        except Exception:
+        except Exception as exc:
             logger.warning(
                 SETUP_COMPLETE_CHECK_ERROR,
                 check="auto_select_embedder",
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
             )
 
         await settings_svc.set("api", "setup_complete", "true")

--- a/src/synthorg/api/controllers/webhooks.py
+++ b/src/synthorg/api/controllers/webhooks.py
@@ -249,6 +249,21 @@ def _check_replay_or_freshness(
         raise ConflictError(msg)
 
 
+def _build_idem_scope(
+    *,
+    connection_type: str,
+    connection_name: str,
+) -> str:
+    """Compose the durable idempotency scope for a webhook connection.
+
+    Including ``connection_name`` (and not just ``connection_type``) is
+    defence in depth at the persistence row level: a stale dedup row
+    written under one connection can never surface to a different
+    connection that happens to share an event type and nonce.
+    """
+    return f"webhooks:{connection_type}:{connection_name}"
+
+
 def _build_idem_key(
     *,
     connection_name: str,
@@ -332,14 +347,12 @@ async def _publish_with_durable_idempotency(  # noqa: PLR0913
     """
     from synthorg.core.types import NotBlankStr  # noqa: PLC0415
 
-    # Scope includes ``connection_name`` (not just ``connection_type``)
-    # so two distinct connections of the same provider cannot share a
-    # dedup row.  The composed key already carries ``connection_name``,
-    # but pinning it in the scope is defence in depth at the persistence
-    # row level: a stale row written under one connection can never
-    # surface to a different connection that happens to share an event
-    # type and nonce.
-    scope = NotBlankStr(f"webhooks:{connection_type}:{connection_name}")
+    scope = NotBlankStr(
+        _build_idem_scope(
+            connection_type=connection_type,
+            connection_name=connection_name,
+        ),
+    )
     idem_key = NotBlankStr(
         _build_idem_key(
             connection_name=connection_name,

--- a/src/synthorg/api/controllers/webhooks.py
+++ b/src/synthorg/api/controllers/webhooks.py
@@ -332,7 +332,14 @@ async def _publish_with_durable_idempotency(  # noqa: PLR0913
     """
     from synthorg.core.types import NotBlankStr  # noqa: PLC0415
 
-    scope = NotBlankStr(f"webhooks:{connection_type}")
+    # Scope includes ``connection_name`` (not just ``connection_type``)
+    # so two distinct connections of the same provider cannot share a
+    # dedup row.  The composed key already carries ``connection_name``,
+    # but pinning it in the scope is defence in depth at the persistence
+    # row level: a stale row written under one connection can never
+    # surface to a different connection that happens to share an event
+    # type and nonce.
+    scope = NotBlankStr(f"webhooks:{connection_type}:{connection_name}")
     idem_key = NotBlankStr(
         _build_idem_key(
             connection_name=connection_name,

--- a/src/synthorg/communication/bus/_nats_receive.py
+++ b/src/synthorg/communication/bus/_nats_receive.py
@@ -318,7 +318,15 @@ async def build_envelope(
     channel_name: str,
     subscriber_id: str,
 ) -> DeliveryEnvelope | None:
-    """Ack the fetched message and wrap it in a DeliveryEnvelope."""
+    """Wrap a fetched JetStream message in a deferred-ack envelope.
+
+    The returned envelope's ``ack()`` callable acknowledges the
+    JetStream message; callers MUST invoke it after the subscriber's
+    local queue has accepted delivery so that an ack-then-deliver-
+    failure cannot drop the message. Pre-parse rejection paths
+    (oversized payload, deserialise error) still ack immediately
+    because there is nothing downstream to deliver.
+    """
     if not msgs:
         return None
 
@@ -356,17 +364,19 @@ async def build_envelope(
         )
         return None
 
-    if not await try_ack(
-        msg,
-        channel_name=channel_name,
-        subscriber_id=subscriber_id,
-    ):
-        return None
+    async def deferred_ack() -> None:
+        """Acknowledge the JetStream message after local delivery."""
+        await try_ack(
+            msg,
+            channel_name=channel_name,
+            subscriber_id=subscriber_id,
+        )
 
     envelope = DeliveryEnvelope(
         message=parsed,
         channel_name=channel_name,
         delivered_at=datetime.now(UTC),
+        ack=deferred_ack,
     )
     logger.debug(
         COMM_MESSAGE_DELIVERED,

--- a/src/synthorg/communication/bus/_nats_receive.py
+++ b/src/synthorg/communication/bus/_nats_receive.py
@@ -21,6 +21,7 @@ from synthorg.communication.bus._nats_utils import (
     require_running,
 )
 from synthorg.communication.enums import ChannelType
+from synthorg.communication.errors import CommunicationError
 from synthorg.communication.subscription import DeliveryEnvelope
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.communication import (
@@ -365,12 +366,23 @@ async def build_envelope(
         return None
 
     async def deferred_ack() -> None:
-        """Acknowledge the JetStream message after local delivery."""
-        await try_ack(
+        """Acknowledge the JetStream message after local delivery.
+
+        Raises ``CommunicationError`` when the underlying ``try_ack``
+        reports failure. ``try_ack`` already logs the underlying NATS
+        exception; surfacing a domain error here makes the failure
+        visible to the consumer-side ``await envelope.ack()`` call so
+        a silent ack-drop cannot leave JetStream redelivering the same
+        message into an oblivious downstream loop.
+        """
+        acked = await try_ack(
             msg,
             channel_name=channel_name,
             subscriber_id=subscriber_id,
         )
+        if not acked:
+            msg_text = "Deferred JetStream ack failed after local delivery"
+            raise CommunicationError(msg_text)
 
     envelope = DeliveryEnvelope(
         message=parsed,

--- a/src/synthorg/communication/subscription.py
+++ b/src/synthorg/communication/subscription.py
@@ -1,5 +1,9 @@
 """Subscription and delivery envelope models (see Communication design page)."""
 
+# Pydantic v2 resolves field annotations at runtime, so Callable /
+# Awaitable cannot live behind TYPE_CHECKING.
+from collections.abc import Awaitable, Callable  # noqa: TC003
+
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 
 from synthorg.communication.message import Message  # noqa: TC001
@@ -22,20 +26,48 @@ class Subscription(BaseModel):
     subscribed_at: AwareDatetime = Field(description="When subscribed")
 
 
+async def _noop_ack() -> None:
+    """Default ack callback for backends that ack synchronously upstream."""
+    return
+
+
 class DeliveryEnvelope(BaseModel):
     """Wraps a message with delivery metadata.
 
     Tells the subscriber which channel a message arrived through
     and when it was delivered.
 
+    The envelope additionally carries an ``ack`` callable that
+    backends invoke after the subscriber has accepted delivery. The
+    NATS backend uses this seam to defer JetStream acknowledgement
+    until *after* the subscriber's local queue has accepted the
+    envelope, so an ack-then-deliver-failure cannot drop the message.
+    The in-memory backend ships a no-op callable because delivery is
+    already synchronous and there is no upstream ack to defer.
+
     Attributes:
         message: The delivered message.
         channel_name: Channel the message was delivered through.
         delivered_at: When the message was delivered to this subscriber.
+        ack: Async callable invoked by the subscriber after the
+            envelope has been consumed locally. Defaults to a no-op
+            so callers in tests / in-memory backends never need to
+            care. Excluded from serialisation via ``Field(exclude=True)``.
     """
 
-    model_config = ConfigDict(frozen=True, allow_inf_nan=False, extra="forbid")
+    model_config = ConfigDict(
+        frozen=True,
+        allow_inf_nan=False,
+        extra="forbid",
+        arbitrary_types_allowed=True,
+    )
 
     message: Message = Field(description="The delivered message")
     channel_name: NotBlankStr = Field(description="Delivery channel")
     delivered_at: AwareDatetime = Field(description="When delivered")
+    ack: Callable[[], Awaitable[None]] = Field(
+        default=_noop_ack,
+        exclude=True,
+        repr=False,
+        description="Deferred ack callback invoked after local delivery",
+    )

--- a/src/synthorg/engine/agent_engine.py
+++ b/src/synthorg/engine/agent_engine.py
@@ -190,7 +190,7 @@ class AgentEngine(
     ) -> None:
         self._agent_middleware_chain = agent_middleware_chain
         self._event_reader = event_reader
-        self._clock: Clock = clock or SystemClock()
+        self._clock: Clock = clock if clock is not None else SystemClock()
         self._event_stream_hub = event_stream_hub
         self._interrupt_store = interrupt_store
         if execution_loop is not None and auto_loop_config is not None:

--- a/src/synthorg/engine/agent_engine.py
+++ b/src/synthorg/engine/agent_engine.py
@@ -4,11 +4,11 @@ Ties together prompt construction, execution context, execution loop,
 tool invocation, and budget tracking into a single ``run()`` entry point.
 """
 
-import time
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Literal, TypedDict
 
 from synthorg.budget.errors import BudgetExhaustedError
+from synthorg.core.clock import Clock, SystemClock
 from synthorg.core.types import NotBlankStr  # noqa: TC001
 from synthorg.engine._validation import (
     validate_agent,
@@ -186,9 +186,11 @@ class AgentEngine(
         event_stream_hub: EventStreamHub | None = None,
         interrupt_store: InterruptStore | None = None,
         approval_interrupt_timeout_seconds: float | None = None,
+        clock: Clock | None = None,
     ) -> None:
         self._agent_middleware_chain = agent_middleware_chain
         self._event_reader = event_reader
+        self._clock: Clock = clock or SystemClock()
         self._event_stream_hub = event_stream_hub
         self._interrupt_store = interrupt_store
         if execution_loop is not None and auto_loop_config is not None:
@@ -346,7 +348,7 @@ class AgentEngine(
         validate_task_metadata(task, agent_id, task_id)
 
         with correlation_scope(agent_id=agent_id, task_id=task_id):
-            start = time.monotonic()
+            start = self._clock.monotonic()
             ctx: AgentContext | None = None
             system_prompt: SystemPrompt | None = None
             provider: CompletionProvider = self._provider
@@ -479,7 +481,7 @@ class AgentEngine(
                     task=task,
                     agent_id=agent_id,
                     task_id=task_id,
-                    duration_seconds=time.monotonic() - start,
+                    duration_seconds=self._clock.monotonic() - start,
                     ctx=ctx,
                     system_prompt=system_prompt,
                 )
@@ -490,7 +492,7 @@ class AgentEngine(
                     task=task,
                     agent_id=agent_id,
                     task_id=task_id,
-                    duration_seconds=time.monotonic() - start,
+                    duration_seconds=self._clock.monotonic() - start,
                     ctx=ctx,
                     system_prompt=system_prompt,
                     completion_config=completion_config,

--- a/src/synthorg/engine/agent_engine_post_exec.py
+++ b/src/synthorg/engine/agent_engine_post_exec.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import contextlib
-import time
 from typing import TYPE_CHECKING, Any, Final
 
 from synthorg.engine.checkpoint.resume import (
@@ -68,6 +67,10 @@ class AgentEnginePostExecMixin:
     _procedural_proposer: Any
     _provider: Any
     _shutdown_checker: Any
+    # Injected by ``AgentEngine.__init__``; declared on the mixin so
+    # type checkers see the attribute when the helper accesses it
+    # below. The concrete class owns the assignment.
+    _clock: Any
 
     async def _post_execution_pipeline(  # noqa: PLR0913
         self,
@@ -335,7 +338,7 @@ class AgentEnginePostExecMixin:
         task_id: str,
     ) -> AgentRunResult:
         """Build ``AgentRunResult`` and log completion metrics."""
-        duration = time.monotonic() - start
+        duration = self._clock.monotonic() - start
         result = AgentRunResult(
             execution_result=execution_result,
             system_prompt=system_prompt,
@@ -410,7 +413,7 @@ class AgentEnginePostExecMixin:
         if not pending:
             return loop_task.result()
 
-        duration = time.monotonic() - start
+        duration = self._clock.monotonic() - start
         error_msg = (
             f"Wall-clock timeout after {duration:.1f}s (limit: {timeout_seconds}s)"
         )

--- a/src/synthorg/engine/workflow/webhook_bridge.py
+++ b/src/synthorg/engine/workflow/webhook_bridge.py
@@ -306,12 +306,22 @@ class WebhookEventBridge:
                 # them would mask the failure for the lifetime of the
                 # bridge.
                 raise
-            except Exception:
+            except Exception as exc:
+                # ``logger.exception`` would attach a traceback whose
+                # frame-locals can leak transport credentials (auth
+                # headers in NATS connect URLs, callback secrets in
+                # event payloads). ``logger.warning`` / ``logger.error``
+                # with ``error_type`` + scrubbed ``error`` keeps the
+                # ack-vs-forward distinction visible during incident
+                # triage without the credential-leak surface.
                 consecutive_errors += 1
                 if consecutive_errors >= max_errors:
-                    logger.exception(
+                    logger.error(
                         WEBHOOK_BRIDGE_POLL_ERROR,
-                        error="too many consecutive errors, stopping",
+                        error_type=type(exc).__name__,
+                        error=safe_error_description(exc),
+                        consecutive_errors=consecutive_errors,
+                        note="too many consecutive errors, stopping",
                     )
                     # Unsubscribe before clearing the task reference
                     # so a later ``start()`` can register a fresh
@@ -326,12 +336,14 @@ class WebhookEventBridge:
                             WEBHOOK_CHANNEL.name,
                             _SUBSCRIBER_ID,
                         )
-                    except Exception:
+                    except Exception as unsub_exc:
                         logger.warning(
                             WEBHOOK_BRIDGE_STOPPED,
                             subscriber_id=_SUBSCRIBER_ID,
                             channel=WEBHOOK_CHANNEL.name,
-                            error=(
+                            error_type=type(unsub_exc).__name__,
+                            error=safe_error_description(unsub_exc),
+                            note=(
                                 "unsubscribe failed after max "
                                 "consecutive errors; leaving bridge "
                                 "in partial-stop state"
@@ -343,6 +355,8 @@ class WebhookEventBridge:
                 logger.warning(
                     WEBHOOK_BRIDGE_POLL_ERROR,
                     consecutive_errors=consecutive_errors,
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
                 )
                 # Back off for one poll interval before retrying so the
                 # loop does not tight-spin on a hot error path.

--- a/src/synthorg/engine/workflow/webhook_bridge.py
+++ b/src/synthorg/engine/workflow/webhook_bridge.py
@@ -285,13 +285,17 @@ class WebhookEventBridge:
                 )
                 if envelope is None:
                     continue
-                consecutive_errors = 0
                 await self._forward(envelope.message)
                 # Ack only after forwarding succeeds; a ``_forward``
                 # exception falls through to the catch-all below and
                 # leaves the JetStream message un-acked so redelivery
                 # picks it back up.
                 await envelope.ack()
+                # Reset the error streak only AFTER both forward and
+                # ack succeed; resetting pre-ack lets a repeating ack
+                # failure quietly bypass ``max_errors`` and keep the
+                # loop running forever against a dead channel.
+                consecutive_errors = 0
             except asyncio.CancelledError:
                 raise
             except MemoryError, RecursionError:

--- a/src/synthorg/engine/workflow/webhook_bridge.py
+++ b/src/synthorg/engine/workflow/webhook_bridge.py
@@ -287,6 +287,11 @@ class WebhookEventBridge:
                     continue
                 consecutive_errors = 0
                 await self._forward(envelope.message)
+                # Ack only after forwarding succeeds; a ``_forward``
+                # exception falls through to the catch-all below and
+                # leaves the JetStream message un-acked so redelivery
+                # picks it back up.
+                await envelope.ack()
             except asyncio.CancelledError:
                 raise
             except MemoryError, RecursionError:

--- a/src/synthorg/hr/evaluation/loop_coordinator.py
+++ b/src/synthorg/hr/evaluation/loop_coordinator.py
@@ -15,12 +15,12 @@ loop:
 """
 
 import asyncio
-import time
 from datetime import UTC, datetime, timedelta
 from types import MappingProxyType
 from typing import Final
 from uuid import uuid4
 
+from synthorg.core.clock import Clock, SystemClock
 from synthorg.core.collections import dedupe_preserving_order
 from synthorg.core.types import NotBlankStr
 from synthorg.engine.trajectory.scorer import TrajectoryScorer  # noqa: TC001
@@ -138,6 +138,7 @@ class EvalLoopCoordinator:
         dataset_builder: DogfoodingDatasetBuilder,
         benchmark_registry: ExternalBenchmarkRegistry,
         config: EvalLoopConfig | None = None,
+        clock: Clock | None = None,
     ) -> None:
         self._tracker = performance_tracker
         self._evaluation = evaluation_service
@@ -146,6 +147,7 @@ class EvalLoopCoordinator:
         self._dataset_builder = dataset_builder
         self._benchmarks = benchmark_registry
         self._config = config or EvalLoopConfig()
+        self._clock: Clock = clock or SystemClock()
 
     @property
     def config(self) -> EvalLoopConfig:
@@ -173,7 +175,7 @@ class EvalLoopCoordinator:
         cycle_id = NotBlankStr(str(uuid4()))
         now = datetime.now(UTC)
         window_start = now - window
-        start_time = time.monotonic()
+        start_time = self._clock.monotonic()
 
         logger.info(
             EVAL_LOOP_CYCLE_START,
@@ -199,7 +201,7 @@ class EvalLoopCoordinator:
             if self._config.benchmark_on_cycle:
                 benchmark_results = await self._run_benchmarks()
 
-            duration = time.monotonic() - start_time
+            duration = self._clock.monotonic() - start_time
 
             report = EvalCycleReport(
                 cycle_id=cycle_id,

--- a/src/synthorg/integrations/mcp_catalog/in_memory_installations.py
+++ b/src/synthorg/integrations/mcp_catalog/in_memory_installations.py
@@ -6,6 +6,7 @@ only for the lifetime of the running process; a persistence backend
 is the source of truth in production.
 """
 
+import asyncio
 from typing import Final
 
 from synthorg.core.types import NotBlankStr  # noqa: TC001
@@ -40,14 +41,27 @@ class InMemoryMcpInstallationRepository:
         _store: In-memory mapping from ``catalog_entry_id`` to
             :class:`McpInstallation`; the sole backing store for this
             repo implementation.
+        _lock: Lazy-initialised ``asyncio.Lock`` that serialises every
+            ``_store`` access. Created on first use (not in
+            ``__init__``) so a fresh repo bound to a different event
+            loop than the one that constructed it does not raise
+            ``RuntimeError: <Lock> is bound to a different event loop``.
     """
 
     def __init__(self) -> None:
         self._store: dict[str, McpInstallation] = {}
+        self._lock: asyncio.Lock | None = None
+
+    def _get_lock(self) -> asyncio.Lock:
+        """Return the per-instance lock, lazy-creating on first use."""
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+        return self._lock
 
     async def save(self, installation: McpInstallation) -> None:
         """Upsert an installation (by catalog_entry_id)."""
-        self._store[installation.catalog_entry_id] = installation
+        async with self._get_lock():
+            self._store[installation.catalog_entry_id] = installation
         logger.info(
             MCP_SERVER_INSTALLED,
             catalog_entry_id=installation.catalog_entry_id,
@@ -60,7 +74,8 @@ class InMemoryMcpInstallationRepository:
         catalog_entry_id: NotBlankStr,
     ) -> McpInstallation | None:
         """Fetch by catalog entry id."""
-        return self._store.get(catalog_entry_id)
+        async with self._get_lock():
+            return self._store.get(catalog_entry_id)
 
     async def list_items(
         self,
@@ -78,7 +93,7 @@ class InMemoryMcpInstallationRepository:
         callers needing more must loop with ``offset`` or pass a
         larger ``limit`` explicitly. Invalid inputs (``limit < 1``,
         ``offset < 0``, non-int, or ``bool``) raise ``QueryError`` to
-        match the sqlite/postgres contract -- silently coercing them
+        match the sqlite/postgres contract: silently coercing them
         would let bugs that the durable backends catch slip through
         in tests and no-persistence deployments.
         """
@@ -88,9 +103,11 @@ class InMemoryMcpInstallationRepository:
             event=PERSISTENCE_MCP_INSTALLATION_LIST_FAILED,
             backend="in_memory",
         )
+        async with self._get_lock():
+            snapshot = tuple(self._store.values())
         rows = tuple(
             sorted(
-                self._store.values(),
+                snapshot,
                 key=lambda i: (i.installed_at, i.catalog_entry_id),
             ),
         )
@@ -98,7 +115,8 @@ class InMemoryMcpInstallationRepository:
 
     async def delete(self, catalog_entry_id: NotBlankStr) -> bool:
         """Delete by catalog entry id."""
-        removed = self._store.pop(catalog_entry_id, None) is not None
+        async with self._get_lock():
+            removed = self._store.pop(catalog_entry_id, None) is not None
         if removed:
             logger.info(
                 MCP_SERVER_UNINSTALLED,

--- a/src/synthorg/integrations/rate_limiting/shared_state.py
+++ b/src/synthorg/integrations/rate_limiting/shared_state.py
@@ -240,6 +240,7 @@ class SharedRateLimitCoordinator:
                 if envelope is None:
                     continue
                 await self._ingest(envelope.message)
+                await envelope.ack()
             except asyncio.CancelledError:
                 break
             except Exception:

--- a/src/synthorg/observability/events/persistence.py
+++ b/src/synthorg/observability/events/persistence.py
@@ -503,8 +503,8 @@ PERSISTENCE_CIRCUIT_BREAKER_DELETE_FAILED: Final[str] = (
 
 # Worker seen-claims events (TaskClaim idempotency dedup)
 PERSISTENCE_SEEN_CLAIMS_MARK_FAILED: Final[str] = "persistence.seen_claims.mark_failed"
-PERSISTENCE_SEEN_CLAIMS_FORGET_FAILED: Final[str] = (
-    "persistence.seen_claims.forget_failed"
+PERSISTENCE_SEEN_CLAIMS_LOOKUP_FAILED: Final[str] = (
+    "persistence.seen_claims.lookup_failed"
 )
 PERSISTENCE_SEEN_CLAIMS_PRUNED: Final[str] = "persistence.seen_claims.pruned"
 PERSISTENCE_SEEN_CLAIMS_PRUNE_FAILED: Final[str] = (

--- a/src/synthorg/observability/events/persistence.py
+++ b/src/synthorg/observability/events/persistence.py
@@ -503,6 +503,9 @@ PERSISTENCE_CIRCUIT_BREAKER_DELETE_FAILED: Final[str] = (
 
 # Worker seen-claims events (TaskClaim idempotency dedup)
 PERSISTENCE_SEEN_CLAIMS_MARK_FAILED: Final[str] = "persistence.seen_claims.mark_failed"
+PERSISTENCE_SEEN_CLAIMS_FORGET_FAILED: Final[str] = (
+    "persistence.seen_claims.forget_failed"
+)
 PERSISTENCE_SEEN_CLAIMS_PRUNED: Final[str] = "persistence.seen_claims.pruned"
 PERSISTENCE_SEEN_CLAIMS_PRUNE_FAILED: Final[str] = (
     "persistence.seen_claims.prune_failed"

--- a/src/synthorg/observability/events/persistence.py
+++ b/src/synthorg/observability/events/persistence.py
@@ -500,3 +500,21 @@ PERSISTENCE_CIRCUIT_BREAKER_DELETED: Final[str] = "persistence.circuit_breaker.d
 PERSISTENCE_CIRCUIT_BREAKER_DELETE_FAILED: Final[str] = (
     "persistence.circuit_breaker.delete_failed"
 )
+
+# Worker seen-claims events (TaskClaim idempotency dedup)
+PERSISTENCE_SEEN_CLAIMS_MARK_FAILED: Final[str] = "persistence.seen_claims.mark_failed"
+PERSISTENCE_SEEN_CLAIMS_PRUNED: Final[str] = "persistence.seen_claims.pruned"
+PERSISTENCE_SEEN_CLAIMS_PRUNE_FAILED: Final[str] = (
+    "persistence.seen_claims.prune_failed"
+)
+
+# Cost-tracker claim-dedup events (persistent claim_id dedup)
+PERSISTENCE_COST_CLAIM_DEDUPE_FAILED: Final[str] = (
+    "persistence.cost_claim_dedupe.claim_failed"
+)
+PERSISTENCE_COST_CLAIM_DEDUPE_PRUNED: Final[str] = (
+    "persistence.cost_claim_dedupe.pruned"
+)
+PERSISTENCE_COST_CLAIM_DEDUPE_PRUNE_FAILED: Final[str] = (
+    "persistence.cost_claim_dedupe.prune_failed"
+)

--- a/src/synthorg/observability/events/workers.py
+++ b/src/synthorg/observability/events/workers.py
@@ -21,6 +21,7 @@ WORKERS_DUPLICATE_CLAIM_SUPPRESSED: Final[str] = (
     "workers.worker.duplicate_claim_suppressed"
 )
 WORKERS_DEDUP_LOOKUP_FAILED: Final[str] = "workers.worker.dedup_lookup_failed"
+WORKERS_DEDUP_FORGET_FAILED: Final[str] = "workers.worker.dedup_forget_failed"
 
 # Dispatcher
 WORKERS_DISPATCHER_QUEUE_NOT_RUNNING: Final[str] = (

--- a/src/synthorg/observability/events/workers.py
+++ b/src/synthorg/observability/events/workers.py
@@ -17,6 +17,10 @@ WORKERS_POOL_STARTED: Final[str] = "workers.pool.started"
 WORKERS_CLAIM_RECEIVED: Final[str] = "workers.worker.claim_received"
 WORKERS_EXECUTOR_FAILED: Final[str] = "workers.worker.executor_failed"
 WORKERS_FINALIZE_FAILED: Final[str] = "workers.worker.finalize_failed"
+WORKERS_DUPLICATE_CLAIM_SUPPRESSED: Final[str] = (
+    "workers.worker.duplicate_claim_suppressed"
+)
+WORKERS_DEDUP_LOOKUP_FAILED: Final[str] = "workers.worker.dedup_lookup_failed"
 
 # Dispatcher
 WORKERS_DISPATCHER_QUEUE_NOT_RUNNING: Final[str] = (

--- a/src/synthorg/observability/events/workers.py
+++ b/src/synthorg/observability/events/workers.py
@@ -21,7 +21,7 @@ WORKERS_DUPLICATE_CLAIM_SUPPRESSED: Final[str] = (
     "workers.worker.duplicate_claim_suppressed"
 )
 WORKERS_DEDUP_LOOKUP_FAILED: Final[str] = "workers.worker.dedup_lookup_failed"
-WORKERS_DEDUP_FORGET_FAILED: Final[str] = "workers.worker.dedup_forget_failed"
+WORKERS_DEDUP_MARK_FAILED: Final[str] = "workers.worker.dedup_mark_failed"
 
 # Dispatcher
 WORKERS_DISPATCHER_QUEUE_NOT_RUNNING: Final[str] = (

--- a/src/synthorg/observability/metrics_hub.py
+++ b/src/synthorg/observability/metrics_hub.py
@@ -172,6 +172,19 @@ def record_security_verdict(verdict: str) -> None:
     collector.record_security_verdict(verdict)
 
 
+@_safe_record(METRICS_RECORD_FAILED, "record_security_audit_fill_ratio")
+def record_security_audit_fill_ratio(*, ratio: float) -> None:
+    """Forward to :meth:`PrometheusCollector.record_security_audit_fill_ratio`.
+
+    Bounded ``ratio`` in ``[0.0, 1.0]``; values near ``1.0`` mean the
+    next ``AuditLog.record`` evicts the oldest entry.
+    """
+    collector = _active()
+    if collector is None:
+        return
+    collector.record_security_audit_fill_ratio(ratio=ratio)
+
+
 @_safe_record(METRICS_RECORD_FAILED, "record_provider_error")
 def record_provider_error(
     *,

--- a/src/synthorg/observability/prometheus_collector.py
+++ b/src/synthorg/observability/prometheus_collector.py
@@ -265,6 +265,7 @@ class PrometheusCollector(RecordingMixin):
         self._otlp_export_batches = self._push.otlp_export_batches
         self._otlp_export_dropped = self._push.otlp_export_dropped
         self._escalation_queue_depth = self._push.escalation_queue_depth
+        self._security_audit_log_fill_ratio = self._push.security_audit_log_fill_ratio
         self._agent_identity_changes = self._push.agent_identity_changes
         self._workflow_execution_duration = self._push.workflow_execution_duration
         self._provider_errors = self._push.provider_errors

--- a/src/synthorg/observability/prometheus_push_metrics.py
+++ b/src/synthorg/observability/prometheus_push_metrics.py
@@ -129,6 +129,19 @@ class PushMetrics:
             registry=registry,
         )
 
+        # -- Security audit log fill ratio ---------------------------
+        # Bounded gauge in [0.0, 1.0] tracking ``len(_entries) /
+        # _max_entries`` on the in-memory ``AuditLog``. A value near
+        # 1.0 means eviction is imminent (the deque drops the oldest
+        # entry on the next ``record``), which operators want to alert
+        # on so an investigation can preserve evidence before it is
+        # lost.
+        self.security_audit_log_fill_ratio = Gauge(
+            f"{prefix}_security_audit_log_fill_ratio",
+            "Security audit log occupancy as a fraction of max_entries",
+            registry=registry,
+        )
+
         # -- Agent identity change counter ---------------------------
         self.agent_identity_changes = PromCounter(
             f"{prefix}_agent_identity_version_changes_total",

--- a/src/synthorg/observability/prometheus_recording.py
+++ b/src/synthorg/observability/prometheus_recording.py
@@ -95,6 +95,7 @@ class RecordingMixin:
     _coordination_efficiency: Gauge
     _coordination_overhead_percent: Gauge
     _escalation_queue_depth: Gauge
+    _security_audit_log_fill_ratio: Gauge
     _agent_identity_changes: PromCounter
     _workflow_execution_duration: Histogram
     _client_disconnects: PromCounter
@@ -366,6 +367,23 @@ class RecordingMixin:
         self._audit_chain_appends.labels(status=status).inc()
         self._audit_chain_depth.set(chain_depth)
         self._audit_chain_last_append_ts.set(timestamp_unix)
+
+    def record_security_audit_fill_ratio(self, *, ratio: float) -> None:
+        """Set the security audit log occupancy fraction.
+
+        Args:
+            ratio: ``len(_entries) / _max_entries`` of the
+                ``AuditLog``; bounded in ``[0.0, 1.0]`` so a value
+                near ``1.0`` signals imminent eviction.
+
+        Raises:
+            ValueError: If *ratio* is non-finite or outside [0.0, 1.0].
+        """
+        require_finite("record_security_audit_fill_ratio: ratio", ratio)
+        if not 0.0 <= ratio <= 1.0:
+            msg = f"ratio must be in [0.0, 1.0], got {ratio}"
+            raise ValueError(msg)
+        self._security_audit_log_fill_ratio.set(ratio)
 
     def record_otlp_export(
         self,

--- a/src/synthorg/persistence/postgres/backend.py
+++ b/src/synthorg/persistence/postgres/backend.py
@@ -122,6 +122,9 @@ from synthorg.persistence.postgres.repositories import (
 from synthorg.persistence.postgres.risk_override_repo import (
     PostgresRiskOverrideRepository,
 )
+from synthorg.persistence.postgres.seen_claims_repo import (
+    PostgresSeenClaimsRepository,
+)
 from synthorg.persistence.postgres.session_repo import (
     PostgresSessionRepository,
 )
@@ -207,6 +210,7 @@ if TYPE_CHECKING:
     from synthorg.persistence.project_protocol import ProjectRepository
     from synthorg.persistence.provider_audit_protocol import ProviderAuditRepo
     from synthorg.persistence.risk_override_protocol import RiskOverrideRepository
+    from synthorg.persistence.seen_claims_protocol import SeenClaimsRepository
     from synthorg.persistence.settings_protocol import SettingsRepository
     from synthorg.persistence.ssrf_violation_protocol import SsrfViolationRepository
     from synthorg.persistence.subworkflow_protocol import SubworkflowRepository
@@ -289,6 +293,7 @@ class PostgresPersistenceBackend(PostgresConnectionMixin, PostgresMigrationMixin
         self._sessions: PostgresSessionRepository | None = None
         self._refresh_tokens: PostgresRefreshTokenRepository | None = None
         self._idempotency_keys: PostgresIdempotencyRepository | None = None
+        self._seen_claims: PostgresSeenClaimsRepository | None = None
         self._mcp_installations: PostgresMcpInstallationRepository | None = None
         self._custom_rules: PostgresCustomRuleRepository | None = None
         self._org_facts: PostgresOrgFactRepository | None = None
@@ -345,6 +350,7 @@ class PostgresPersistenceBackend(PostgresConnectionMixin, PostgresMigrationMixin
         self._sessions = None
         self._refresh_tokens = None
         self._idempotency_keys = None
+        self._seen_claims = None
         self._mcp_installations = None
         self._custom_rules = None
         self._org_facts = None
@@ -432,6 +438,7 @@ class PostgresPersistenceBackend(PostgresConnectionMixin, PostgresMigrationMixin
         self._sessions = PostgresSessionRepository(pool)
         self._refresh_tokens = PostgresRefreshTokenRepository(pool)
         self._idempotency_keys = PostgresIdempotencyRepository(pool)
+        self._seen_claims = PostgresSeenClaimsRepository(pool)
         self._mcp_installations = PostgresMcpInstallationRepository(pool)
         self._custom_rules = PostgresCustomRuleRepository(pool)
         self._org_facts = PostgresOrgFactRepository(pool)
@@ -768,6 +775,14 @@ class PostgresPersistenceBackend(PostgresConnectionMixin, PostgresMigrationMixin
         return self._require_connected(
             self._idempotency_keys,
             "idempotency_keys",
+        )
+
+    @property
+    def seen_claims(self) -> SeenClaimsRepository:
+        """Repository for worker TaskClaim dedup persistence."""
+        return self._require_connected(
+            self._seen_claims,
+            "seen_claims",
         )
 
     @property

--- a/src/synthorg/persistence/postgres/revisions/20260513000001_seen_claims.sql
+++ b/src/synthorg/persistence/postgres/revisions/20260513000001_seen_claims.sql
@@ -1,0 +1,14 @@
+-- Worker claim dedup table for TaskClaim.idempotency_key.
+--
+-- See docs/reference/persistence-boundary.md and the canonical schema
+-- at ../schema.sql for the full per-backend rationale.  Workers
+-- consult this table before processing a JetStream-delivered claim so
+-- a redelivery cannot trigger a second execution.
+CREATE TABLE seen_claims (
+    idempotency_key TEXT NOT NULL PRIMARY KEY
+        CHECK (length(trim(idempotency_key)) > 0),
+    claim_id TEXT NOT NULL CHECK (length(trim(claim_id)) > 0),
+    seen_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL CHECK (expires_at > seen_at)
+);
+CREATE INDEX idx_seen_claims_expires_at ON seen_claims (expires_at);

--- a/src/synthorg/persistence/postgres/schema.sql
+++ b/src/synthorg/persistence/postgres/schema.sql
@@ -1320,3 +1320,17 @@ CREATE TABLE preset_overrides (
     updated_at TIMESTAMPTZ NOT NULL,
     updated_by TEXT NOT NULL CHECK (length(trim(updated_by)) > 0)
 );
+
+-- ── Worker claim dedup ────────────────────────────────────────────────
+-- First-write store for ``TaskClaim.idempotency_key``.  Workers consult
+-- this table before processing a claim so a JetStream redelivery (ack
+-- lost, worker crash) cannot trigger a second execution.  Pruned by
+-- ``SeenClaimsRepository.prune_expired`` past the row's ``expires_at``.
+CREATE TABLE seen_claims (
+    idempotency_key TEXT NOT NULL PRIMARY KEY
+        CHECK (length(trim(idempotency_key)) > 0),
+    claim_id TEXT NOT NULL CHECK (length(trim(claim_id)) > 0),
+    seen_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL CHECK (expires_at > seen_at)
+);
+CREATE INDEX idx_seen_claims_expires_at ON seen_claims (expires_at);

--- a/src/synthorg/persistence/postgres/seen_claims_repo.py
+++ b/src/synthorg/persistence/postgres/seen_claims_repo.py
@@ -2,9 +2,9 @@
 
 Postgres sibling of :mod:`synthorg.persistence.sqlite.seen_claims_repo`.
 ``seen_at`` and ``expires_at`` are ``TIMESTAMPTZ`` columns instead of
-TEXT; the first-write discrimination is the same
-``INSERT ... ON CONFLICT DO NOTHING`` pattern, and the row count from
-``cursor.rowcount`` distinguishes first-write from duplicate.
+TEXT; ``mark_seen`` uses the same ``INSERT ... ON CONFLICT DO NOTHING``
+pattern and ``cursor.rowcount`` distinguishes first-write from
+duplicate. ``is_completed`` is the pre-execute existence check.
 """
 
 import contextlib
@@ -18,7 +18,7 @@ from synthorg.core.persistence_errors import QueryError
 from synthorg.core.types import NotBlankStr  # noqa: TC001
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.persistence import (
-    PERSISTENCE_SEEN_CLAIMS_FORGET_FAILED,
+    PERSISTENCE_SEEN_CLAIMS_LOOKUP_FAILED,
     PERSISTENCE_SEEN_CLAIMS_MARK_FAILED,
     PERSISTENCE_SEEN_CLAIMS_PRUNE_FAILED,
     PERSISTENCE_SEEN_CLAIMS_PRUNED,
@@ -36,6 +36,30 @@ class PostgresSeenClaimsRepository:
 
     def __init__(self, pool: AsyncConnectionPool) -> None:
         self._pool = pool
+
+    async def is_completed(
+        self,
+        *,
+        idempotency_key: NotBlankStr,
+    ) -> bool:
+        """Return ``True`` when a row for ``idempotency_key`` exists."""
+        try:
+            async with self._pool.connection() as conn, conn.cursor() as cur:
+                await cur.execute(
+                    "SELECT 1 FROM seen_claims WHERE idempotency_key = %s LIMIT 1",
+                    (str(idempotency_key),),
+                )
+                row = await cur.fetchone()
+        except psycopg.Error as exc:
+            msg = f"Failed to look up seen claim {idempotency_key!r}"
+            logger.warning(
+                PERSISTENCE_SEEN_CLAIMS_LOOKUP_FAILED,
+                idempotency_key=str(idempotency_key),
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+        return row is not None
 
     async def mark_seen(
         self,
@@ -77,31 +101,6 @@ class PostgresSeenClaimsRepository:
             )
             raise QueryError(msg) from exc
         return inserted
-
-    async def forget(
-        self,
-        *,
-        idempotency_key: NotBlankStr,
-    ) -> bool:
-        """Delete the dedup row for *idempotency_key* (idempotent)."""
-        try:
-            async with self._pool.connection() as conn, conn.cursor() as cur:
-                await cur.execute(
-                    "DELETE FROM seen_claims WHERE idempotency_key = %s",
-                    (str(idempotency_key),),
-                )
-                removed = cur.rowcount > 0
-                await conn.commit()
-        except psycopg.Error as exc:
-            msg = f"Failed to forget claim {idempotency_key!r}"
-            logger.warning(
-                PERSISTENCE_SEEN_CLAIMS_FORGET_FAILED,
-                idempotency_key=str(idempotency_key),
-                error_type=type(exc).__name__,
-                error=safe_error_description(exc),
-            )
-            raise QueryError(msg) from exc
-        return removed
 
     async def prune_expired(self, now: AwareDatetime) -> int:
         """Delete rows past their ``expires_at`` boundary."""

--- a/src/synthorg/persistence/postgres/seen_claims_repo.py
+++ b/src/synthorg/persistence/postgres/seen_claims_repo.py
@@ -7,6 +7,7 @@ TEXT; the first-write discrimination is the same
 ``cursor.rowcount`` distinguishes first-write from duplicate.
 """
 
+import contextlib
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
@@ -81,12 +82,23 @@ class PostgresSeenClaimsRepository:
         cutoff = normalize_utc(now)
         try:
             async with self._pool.connection() as conn, conn.cursor() as cur:
-                await cur.execute(
-                    "DELETE FROM seen_claims WHERE expires_at < %s",
-                    (cutoff,),
-                )
-                removed = cur.rowcount
-                await conn.commit()
+                try:
+                    await cur.execute(
+                        "DELETE FROM seen_claims WHERE expires_at < %s",
+                        (cutoff,),
+                    )
+                    removed = cur.rowcount
+                    await conn.commit()
+                except psycopg.Error:
+                    # ``async with`` will roll back implicitly on
+                    # exception, but the explicit ``rollback`` mirrors
+                    # the SQLite sibling and avoids leaving the
+                    # transaction in an ambiguous state if a future
+                    # refactor moves the cursor work outside the
+                    # context manager.
+                    with contextlib.suppress(psycopg.Error):
+                        await conn.rollback()
+                    raise
         except psycopg.Error as exc:
             msg = "Failed to prune expired seen_claims rows"
             logger.warning(

--- a/src/synthorg/persistence/postgres/seen_claims_repo.py
+++ b/src/synthorg/persistence/postgres/seen_claims_repo.py
@@ -1,0 +1,103 @@
+"""Postgres repository for worker claim dedup persistence.
+
+Postgres sibling of :mod:`synthorg.persistence.sqlite.seen_claims_repo`.
+``seen_at`` and ``expires_at`` are ``TIMESTAMPTZ`` columns instead of
+TEXT; the first-write discrimination is the same
+``INSERT ... ON CONFLICT DO NOTHING`` pattern, and the row count from
+``cursor.rowcount`` distinguishes first-write from duplicate.
+"""
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+import psycopg
+from pydantic import AwareDatetime  # noqa: TC002
+
+from synthorg.core.persistence_errors import QueryError
+from synthorg.core.types import NotBlankStr  # noqa: TC001
+from synthorg.observability import get_logger, safe_error_description
+from synthorg.observability.events.persistence import (
+    PERSISTENCE_SEEN_CLAIMS_MARK_FAILED,
+    PERSISTENCE_SEEN_CLAIMS_PRUNE_FAILED,
+    PERSISTENCE_SEEN_CLAIMS_PRUNED,
+)
+from synthorg.persistence._shared import normalize_utc
+
+if TYPE_CHECKING:
+    from psycopg_pool import AsyncConnectionPool
+
+logger = get_logger(__name__)
+
+
+class PostgresSeenClaimsRepository:
+    """Postgres implementation of :class:`SeenClaimsRepository`."""
+
+    def __init__(self, pool: AsyncConnectionPool) -> None:
+        self._pool = pool
+
+    async def mark_seen(
+        self,
+        *,
+        idempotency_key: NotBlankStr,
+        claim_id: NotBlankStr,
+        now: AwareDatetime,
+        ttl_seconds: float,
+    ) -> bool:
+        """Insert the dedup row; return ``True`` only on first write."""
+        seen_at = normalize_utc(now)
+        expires_at = seen_at + timedelta(seconds=ttl_seconds)
+        try:
+            async with self._pool.connection() as conn, conn.cursor() as cur:
+                await cur.execute(
+                    """
+                    INSERT INTO seen_claims (
+                        idempotency_key, claim_id, seen_at, expires_at
+                    ) VALUES (%s, %s, %s, %s)
+                    ON CONFLICT(idempotency_key) DO NOTHING
+                    """,
+                    (
+                        str(idempotency_key),
+                        str(claim_id),
+                        seen_at,
+                        expires_at,
+                    ),
+                )
+                inserted = cur.rowcount > 0
+                await conn.commit()
+        except psycopg.Error as exc:
+            msg = f"Failed to mark claim {idempotency_key!r} as seen"
+            logger.warning(
+                PERSISTENCE_SEEN_CLAIMS_MARK_FAILED,
+                idempotency_key=str(idempotency_key),
+                claim_id=str(claim_id),
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+        return inserted
+
+    async def prune_expired(self, now: AwareDatetime) -> int:
+        """Delete rows past their ``expires_at`` boundary."""
+        cutoff = normalize_utc(now)
+        try:
+            async with self._pool.connection() as conn, conn.cursor() as cur:
+                await cur.execute(
+                    "DELETE FROM seen_claims WHERE expires_at < %s",
+                    (cutoff,),
+                )
+                removed = cur.rowcount
+                await conn.commit()
+        except psycopg.Error as exc:
+            msg = "Failed to prune expired seen_claims rows"
+            logger.warning(
+                PERSISTENCE_SEEN_CLAIMS_PRUNE_FAILED,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+        if removed:
+            logger.info(
+                PERSISTENCE_SEEN_CLAIMS_PRUNED,
+                removed=removed,
+            )
+        return removed

--- a/src/synthorg/persistence/postgres/seen_claims_repo.py
+++ b/src/synthorg/persistence/postgres/seen_claims_repo.py
@@ -18,6 +18,7 @@ from synthorg.core.persistence_errors import QueryError
 from synthorg.core.types import NotBlankStr  # noqa: TC001
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.persistence import (
+    PERSISTENCE_SEEN_CLAIMS_FORGET_FAILED,
     PERSISTENCE_SEEN_CLAIMS_MARK_FAILED,
     PERSISTENCE_SEEN_CLAIMS_PRUNE_FAILED,
     PERSISTENCE_SEEN_CLAIMS_PRUNED,
@@ -76,6 +77,31 @@ class PostgresSeenClaimsRepository:
             )
             raise QueryError(msg) from exc
         return inserted
+
+    async def forget(
+        self,
+        *,
+        idempotency_key: NotBlankStr,
+    ) -> bool:
+        """Delete the dedup row for *idempotency_key* (idempotent)."""
+        try:
+            async with self._pool.connection() as conn, conn.cursor() as cur:
+                await cur.execute(
+                    "DELETE FROM seen_claims WHERE idempotency_key = %s",
+                    (str(idempotency_key),),
+                )
+                removed = cur.rowcount > 0
+                await conn.commit()
+        except psycopg.Error as exc:
+            msg = f"Failed to forget claim {idempotency_key!r}"
+            logger.warning(
+                PERSISTENCE_SEEN_CLAIMS_FORGET_FAILED,
+                idempotency_key=str(idempotency_key),
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+        return removed
 
     async def prune_expired(self, now: AwareDatetime) -> int:
         """Delete rows past their ``expires_at`` boundary."""

--- a/src/synthorg/persistence/protocol.py
+++ b/src/synthorg/persistence/protocol.py
@@ -101,6 +101,9 @@ from synthorg.persistence.provider_audit_protocol import (  # noqa: TC001
 from synthorg.persistence.risk_override_protocol import (
     RiskOverrideRepository,  # noqa: TC001
 )
+from synthorg.persistence.seen_claims_protocol import (
+    SeenClaimsRepository,  # noqa: TC001
+)
 from synthorg.persistence.settings_protocol import SettingsRepository  # noqa: TC001
 from synthorg.persistence.ssrf_violation_protocol import (
     SsrfViolationRepository,  # noqa: TC001
@@ -471,6 +474,11 @@ class PersistenceBackend(Protocol):
     @property
     def idempotency_keys(self) -> IdempotencyRepository:
         """Repository for persistent idempotency keys."""
+        ...
+
+    @property
+    def seen_claims(self) -> SeenClaimsRepository:
+        """Repository for worker TaskClaim dedup persistence."""
         ...
 
     @property

--- a/src/synthorg/persistence/seen_claims_protocol.py
+++ b/src/synthorg/persistence/seen_claims_protocol.py
@@ -52,6 +52,32 @@ class SeenClaimsRepository(Protocol):
         """
         ...
 
+    async def forget(
+        self,
+        *,
+        idempotency_key: NotBlankStr,
+    ) -> bool:
+        """Delete a previously-recorded dedup row.
+
+        Called by the worker after a non-success terminal outcome
+        (today: ``RETRY``) so the speculative row written by
+        :meth:`mark_seen` cannot trap a future redelivery in the
+        "duplicate -> ack -> drop" path. Idempotent: a key with no
+        matching row is a no-op.
+
+        Args:
+            idempotency_key: The key originally passed to
+                :meth:`mark_seen`.
+
+        Returns:
+            ``True`` if a row was removed, ``False`` if no row matched.
+
+        Raises:
+            QueryError: On underlying DB failure (caller decides
+                whether to retry or fail-open).
+        """
+        ...
+
     async def prune_expired(self, now: AwareDatetime) -> int:
         """Delete rows whose TTL has elapsed.
 

--- a/src/synthorg/persistence/seen_claims_protocol.py
+++ b/src/synthorg/persistence/seen_claims_protocol.py
@@ -1,0 +1,65 @@
+"""Worker claim-dedup repository protocol.
+
+Durable backstop for ``WORKERS_DUPLICATE_CLAIM_SUPPRESSED``: workers
+consult this repository before processing a ``TaskClaim`` so a
+JetStream redelivery (ack lost in transit, worker crash before ack)
+cannot trigger a second execution. The contract is intentionally
+minimal: first-write returns ``True``, every subsequent write of the
+same ``idempotency_key`` within the TTL returns ``False``.
+"""
+
+from typing import Protocol, runtime_checkable
+
+from pydantic import AwareDatetime  # noqa: TC002
+
+from synthorg.core.types import NotBlankStr  # noqa: TC001
+
+
+@runtime_checkable
+class SeenClaimsRepository(Protocol):
+    """Atomic first-write dedup for worker claim ingestion."""
+
+    async def mark_seen(
+        self,
+        *,
+        idempotency_key: NotBlankStr,
+        claim_id: NotBlankStr,
+        now: AwareDatetime,
+        ttl_seconds: float,
+    ) -> bool:
+        """Try to mark ``idempotency_key`` as seen.
+
+        Args:
+            idempotency_key: Globally unique key generated at claim
+                publish time (UUID).
+            claim_id: The task_id the claim refers to. Stored for
+                forensics; not used for the uniqueness check.
+            now: Wall-clock timestamp the caller wants persisted as
+                ``seen_at`` (also used to derive the row's TTL).
+            ttl_seconds: Sliding-window TTL after which the row is
+                eligible for pruning. Callers must set this to at least
+                ``ack_wait * max_deliver`` so JetStream can never
+                redeliver beyond the dedup horizon.
+
+        Returns:
+            ``True`` if this is the first time ``idempotency_key`` has
+            been recorded; ``False`` if a prior row exists (caller
+            must ack-and-skip).
+
+        Raises:
+            QueryError: On underlying DB failure (caller decides
+                whether to retry or fail-closed).
+        """
+        ...
+
+    async def prune_expired(self, now: AwareDatetime) -> int:
+        """Delete rows whose TTL has elapsed.
+
+        Args:
+            now: Current wall-clock time; rows with
+                ``seen_at + ttl_seconds < now`` are eligible.
+
+        Returns:
+            Count of rows removed.
+        """
+        ...

--- a/src/synthorg/persistence/seen_claims_protocol.py
+++ b/src/synthorg/persistence/seen_claims_protocol.py
@@ -1,11 +1,11 @@
 """Worker claim-dedup repository protocol.
 
 Durable backstop for ``WORKERS_DUPLICATE_CLAIM_SUPPRESSED``: workers
-consult this repository before processing a ``TaskClaim`` so a
-JetStream redelivery (ack lost in transit, worker crash before ack)
-cannot trigger a second execution. The contract is intentionally
-minimal: first-write returns ``True``, every subsequent write of the
-same ``idempotency_key`` within the TTL returns ``False``.
+consult this repository after a JetStream redelivery so a previously-
+completed claim is acked-and-skipped instead of being re-executed.
+The contract is intentionally minimal: ``is_completed`` is a read-only
+existence check that returns ``True`` only when ``mark_seen`` has
+previously recorded a terminal outcome for the same idempotency key.
 """
 
 from typing import Protocol, runtime_checkable
@@ -17,7 +17,34 @@ from synthorg.core.types import NotBlankStr  # noqa: TC001
 
 @runtime_checkable
 class SeenClaimsRepository(Protocol):
-    """Atomic first-write dedup for worker claim ingestion."""
+    """Read + atomic-write dedup for worker claim ingestion."""
+
+    async def is_completed(
+        self,
+        *,
+        idempotency_key: NotBlankStr,
+    ) -> bool:
+        """Return ``True`` if a row for ``idempotency_key`` exists.
+
+        Called before executing a claim to decide whether the work has
+        already finished on an earlier delivery. A row is written only
+        after a terminal outcome (``mark_seen`` is invoked after the
+        executor returns ``SUCCESS`` or ``FAILED``), so a hit here is
+        unambiguous evidence the claim completed previously and the
+        current delivery is a duplicate.
+
+        Args:
+            idempotency_key: Globally unique key generated at claim
+                publish time.
+
+        Returns:
+            ``True`` if a row exists, ``False`` otherwise.
+
+        Raises:
+            QueryError: On underlying DB failure (caller decides
+                whether to fail-open or fail-closed).
+        """
+        ...
 
     async def mark_seen(
         self,
@@ -27,7 +54,13 @@ class SeenClaimsRepository(Protocol):
         now: AwareDatetime,
         ttl_seconds: float,
     ) -> bool:
-        """Try to mark ``idempotency_key`` as seen.
+        """Try to record ``idempotency_key`` as a completed claim.
+
+        Called by the worker AFTER a terminal outcome
+        (``SUCCESS``/``FAILED``) so the next JetStream redelivery (lost
+        ack, slow finalisation) observes the row and ack-and-skips.
+        ``RETRY`` outcomes never call this method; the absence of the
+        row lets the redelivered claim re-execute as intended.
 
         Args:
             idempotency_key: Globally unique key generated at claim
@@ -43,38 +76,13 @@ class SeenClaimsRepository(Protocol):
 
         Returns:
             ``True`` if this is the first time ``idempotency_key`` has
-            been recorded; ``False`` if a prior row exists (caller
-            must ack-and-skip).
+            been recorded; ``False`` if a prior row exists (the row
+            was already written by a concurrent worker that completed
+            the same claim first).
 
         Raises:
             QueryError: On underlying DB failure (caller decides
                 whether to retry or fail-closed).
-        """
-        ...
-
-    async def forget(
-        self,
-        *,
-        idempotency_key: NotBlankStr,
-    ) -> bool:
-        """Delete a previously-recorded dedup row.
-
-        Called by the worker after a non-success terminal outcome
-        (today: ``RETRY``) so the speculative row written by
-        :meth:`mark_seen` cannot trap a future redelivery in the
-        "duplicate -> ack -> drop" path. Idempotent: a key with no
-        matching row is a no-op.
-
-        Args:
-            idempotency_key: The key originally passed to
-                :meth:`mark_seen`.
-
-        Returns:
-            ``True`` if a row was removed, ``False`` if no row matched.
-
-        Raises:
-            QueryError: On underlying DB failure (caller decides
-                whether to retry or fail-open).
         """
         ...
 

--- a/src/synthorg/persistence/sqlite/_backend_accessors.py
+++ b/src/synthorg/persistence/sqlite/_backend_accessors.py
@@ -75,6 +75,7 @@ if TYPE_CHECKING:
     from synthorg.persistence.project_protocol import ProjectRepository
     from synthorg.persistence.provider_audit_protocol import ProviderAuditRepo
     from synthorg.persistence.risk_override_protocol import RiskOverrideRepository
+    from synthorg.persistence.seen_claims_protocol import SeenClaimsRepository
     from synthorg.persistence.settings_protocol import SettingsRepository
     from synthorg.persistence.ssrf_violation_protocol import (
         SsrfViolationRepository,
@@ -153,6 +154,7 @@ class _BackendRepositoryAccessors:
     _sessions: SessionRepository | None
     _refresh_tokens: RefreshTokenRepository | None
     _idempotency_keys: IdempotencyRepository | None
+    _seen_claims: SeenClaimsRepository | None
     _mcp_installations: McpInstallationRepository | None
     _org_facts: OrgFactRepository | None
     _ontology_entities: OntologyEntityRepository | None
@@ -484,6 +486,14 @@ class _BackendRepositoryAccessors:
         return self._require_connected(
             self._idempotency_keys,
             "idempotency_keys",
+        )
+
+    @property
+    def seen_claims(self) -> SeenClaimsRepository:
+        """Repository for worker TaskClaim dedup persistence."""
+        return self._require_connected(
+            self._seen_claims,
+            "seen_claims",
         )
 
     @property

--- a/src/synthorg/persistence/sqlite/backend.py
+++ b/src/synthorg/persistence/sqlite/backend.py
@@ -121,6 +121,9 @@ from synthorg.persistence.sqlite.repositories import (
 from synthorg.persistence.sqlite.risk_override_repo import (
     SQLiteRiskOverrideRepository,
 )
+from synthorg.persistence.sqlite.seen_claims_repo import (
+    SQLiteSeenClaimsRepository,
+)
 from synthorg.persistence.sqlite.session_repo import (
     SQLiteSessionRepository,
 )
@@ -229,6 +232,7 @@ class SQLitePersistenceBackend(_BackendRepositoryAccessors):
         self._sessions: SQLiteSessionRepository | None = None
         self._refresh_tokens: SQLiteRefreshTokenRepository | None = None
         self._idempotency_keys: SQLiteIdempotencyRepository | None = None
+        self._seen_claims: SQLiteSeenClaimsRepository | None = None
         self._mcp_installations: SQLiteMcpInstallationRepository | None = None
         self._org_facts: SQLiteOrgFactRepository | None = None
         self._ontology_entities: SQLiteOntologyEntityRepository | None = None
@@ -286,6 +290,7 @@ class SQLitePersistenceBackend(_BackendRepositoryAccessors):
         self._sessions = None
         self._refresh_tokens = None
         self._idempotency_keys = None
+        self._seen_claims = None
         self._mcp_installations = None
         self._org_facts = None
         self._ontology_entities = None
@@ -551,6 +556,10 @@ class SQLitePersistenceBackend(_BackendRepositoryAccessors):
             write_context=self.write_context,
         )
         self._idempotency_keys = SQLiteIdempotencyRepository(
+            self._db,
+            write_context=self.write_context,
+        )
+        self._seen_claims = SQLiteSeenClaimsRepository(
             self._db,
             write_context=self.write_context,
         )

--- a/src/synthorg/persistence/sqlite/revisions/20260513000001_seen_claims.sql
+++ b/src/synthorg/persistence/sqlite/revisions/20260513000001_seen_claims.sql
@@ -9,6 +9,7 @@ CREATE TABLE seen_claims (
         CHECK(length(trim(idempotency_key)) > 0),
     claim_id TEXT NOT NULL CHECK(length(trim(claim_id)) > 0),
     seen_at TEXT NOT NULL CHECK(length(trim(seen_at)) > 0),
-    expires_at TEXT NOT NULL CHECK(length(trim(expires_at)) > 0)
+    expires_at TEXT NOT NULL CHECK(length(trim(expires_at)) > 0),
+    CHECK(expires_at > seen_at)
 );
 CREATE INDEX idx_seen_claims_expires_at ON seen_claims(expires_at);

--- a/src/synthorg/persistence/sqlite/revisions/20260513000001_seen_claims.sql
+++ b/src/synthorg/persistence/sqlite/revisions/20260513000001_seen_claims.sql
@@ -1,0 +1,14 @@
+-- Worker claim dedup table for TaskClaim.idempotency_key.
+--
+-- See docs/reference/persistence-boundary.md and the canonical schema
+-- at ../schema.sql for the full per-backend rationale.  Workers
+-- consult this table before processing a JetStream-delivered claim so
+-- a redelivery cannot trigger a second execution.
+CREATE TABLE seen_claims (
+    idempotency_key TEXT NOT NULL PRIMARY KEY
+        CHECK(length(trim(idempotency_key)) > 0),
+    claim_id TEXT NOT NULL CHECK(length(trim(claim_id)) > 0),
+    seen_at TEXT NOT NULL CHECK(length(trim(seen_at)) > 0),
+    expires_at TEXT NOT NULL CHECK(length(trim(expires_at)) > 0)
+);
+CREATE INDEX idx_seen_claims_expires_at ON seen_claims(expires_at);

--- a/src/synthorg/persistence/sqlite/schema.sql
+++ b/src/synthorg/persistence/sqlite/schema.sql
@@ -1332,3 +1332,19 @@ CREATE TABLE preset_overrides (
     updated_at TEXT NOT NULL CHECK(length(trim(updated_at)) > 0),
     updated_by TEXT NOT NULL CHECK(length(trim(updated_by)) > 0)
 );
+
+-- ── Worker claim dedup ────────────────────────────────────────────────
+-- First-write store for ``TaskClaim.idempotency_key``.  Workers consult
+-- this table before processing a claim so a JetStream redelivery (ack
+-- lost, worker crash) cannot trigger a second execution.  Pruned by
+-- ``SeenClaimsRepository.prune_expired`` past the row's ``expires_at``.
+-- Timestamp format is enforced by the Python layer via
+-- ``parse_iso_utc`` / ``format_iso_utc``.
+CREATE TABLE seen_claims (
+    idempotency_key TEXT NOT NULL PRIMARY KEY
+        CHECK(length(trim(idempotency_key)) > 0),
+    claim_id TEXT NOT NULL CHECK(length(trim(claim_id)) > 0),
+    seen_at TEXT NOT NULL CHECK(length(trim(seen_at)) > 0),
+    expires_at TEXT NOT NULL CHECK(length(trim(expires_at)) > 0)
+);
+CREATE INDEX idx_seen_claims_expires_at ON seen_claims(expires_at);

--- a/src/synthorg/persistence/sqlite/schema.sql
+++ b/src/synthorg/persistence/sqlite/schema.sql
@@ -1345,6 +1345,11 @@ CREATE TABLE seen_claims (
         CHECK(length(trim(idempotency_key)) > 0),
     claim_id TEXT NOT NULL CHECK(length(trim(claim_id)) > 0),
     seen_at TEXT NOT NULL CHECK(length(trim(seen_at)) > 0),
-    expires_at TEXT NOT NULL CHECK(length(trim(expires_at)) > 0)
+    expires_at TEXT NOT NULL CHECK(length(trim(expires_at)) > 0),
+    -- Mirrors the Postgres CHECK so the SQLite backend enforces the
+    -- TTL invariant at the DB layer too.  String comparison is safe
+    -- because timestamps are written in ISO-8601 UTC via
+    -- ``format_iso_utc`` (lexicographic order matches chronological).
+    CHECK(expires_at > seen_at)
 );
 CREATE INDEX idx_seen_claims_expires_at ON seen_claims(expires_at);

--- a/src/synthorg/persistence/sqlite/seen_claims_repo.py
+++ b/src/synthorg/persistence/sqlite/seen_claims_repo.py
@@ -49,7 +49,19 @@ class SQLiteSeenClaimsRepository:
         now: AwareDatetime,
         ttl_seconds: float,
     ) -> bool:
-        """Insert the dedup row; return ``True`` only on first write."""
+        """Insert the dedup row; return ``True`` only on first write.
+
+        The ``write_lock`` is intentionally held across the COMMIT so
+        concurrent ``mark_seen`` callers serialise on the same SQLite
+        connection.  Under WAL mode SQLite only serialises writers (not
+        readers) at the file lock, but the in-process lock keeps
+        ``cursor.rowcount`` semantics clean: a duplicate observed by
+        the conflict clause returns ``rowcount == 0`` only if the
+        first writer's transaction has already been committed when
+        the second one queries.  Releasing the lock pre-commit would
+        let a sibling caller observe a stale ``rowcount`` and treat
+        a duplicate as a first-write.
+        """
         seen_at = normalize_utc(now)
         expires_at: datetime = seen_at + timedelta(seconds=ttl_seconds)
         async with self._write_context():

--- a/src/synthorg/persistence/sqlite/seen_claims_repo.py
+++ b/src/synthorg/persistence/sqlite/seen_claims_repo.py
@@ -18,6 +18,7 @@ from synthorg.core.persistence_errors import QueryError
 from synthorg.core.types import NotBlankStr  # noqa: TC001
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.persistence import (
+    PERSISTENCE_SEEN_CLAIMS_FORGET_FAILED,
     PERSISTENCE_SEEN_CLAIMS_MARK_FAILED,
     PERSISTENCE_SEEN_CLAIMS_PRUNE_FAILED,
     PERSISTENCE_SEEN_CLAIMS_PRUNED,
@@ -95,6 +96,33 @@ class SQLiteSeenClaimsRepository:
                 )
                 raise QueryError(msg) from exc
         return inserted
+
+    async def forget(
+        self,
+        *,
+        idempotency_key: NotBlankStr,
+    ) -> bool:
+        """Delete the dedup row for *idempotency_key* (idempotent)."""
+        async with self._write_lock:
+            try:
+                cursor = await self._db.execute(
+                    "DELETE FROM seen_claims WHERE idempotency_key = ?",
+                    (str(idempotency_key),),
+                )
+                removed = cursor.rowcount > 0
+                await self._db.commit()
+            except (sqlite3.Error, aiosqlite.Error) as exc:
+                with contextlib.suppress(sqlite3.Error, aiosqlite.Error):
+                    await self._db.rollback()
+                msg = f"Failed to forget claim {idempotency_key!r}"
+                logger.warning(
+                    PERSISTENCE_SEEN_CLAIMS_FORGET_FAILED,
+                    idempotency_key=str(idempotency_key),
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
+                )
+                raise QueryError(msg) from exc
+        return removed
 
     async def prune_expired(self, now: AwareDatetime) -> int:
         """Delete rows past their ``expires_at`` boundary."""

--- a/src/synthorg/persistence/sqlite/seen_claims_repo.py
+++ b/src/synthorg/persistence/sqlite/seen_claims_repo.py
@@ -1,0 +1,113 @@
+"""SQLite repository for worker claim dedup persistence.
+
+Backs :class:`SeenClaimsRepository` against an aiosqlite connection.
+Uses an ``INSERT ... ON CONFLICT DO NOTHING`` so the first writer
+inserts and concurrent writers observe a no-op insert. Returning
+``cursor.rowcount`` distinguishes first-write from duplicate without
+a separate read.
+"""
+
+import contextlib
+import sqlite3
+from datetime import datetime, timedelta
+
+import aiosqlite
+from pydantic import AwareDatetime  # noqa: TC002
+
+from synthorg.core.persistence_errors import QueryError
+from synthorg.core.types import NotBlankStr  # noqa: TC001
+from synthorg.observability import get_logger, safe_error_description
+from synthorg.observability.events.persistence import (
+    PERSISTENCE_SEEN_CLAIMS_MARK_FAILED,
+    PERSISTENCE_SEEN_CLAIMS_PRUNE_FAILED,
+    PERSISTENCE_SEEN_CLAIMS_PRUNED,
+)
+from synthorg.persistence._shared import format_iso_utc, normalize_utc
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
+
+logger = get_logger(__name__)
+
+
+class SQLiteSeenClaimsRepository:
+    """SQLite implementation of :class:`SeenClaimsRepository`."""
+
+    def __init__(
+        self,
+        db: aiosqlite.Connection,
+        *,
+        write_context: WriteContext,
+    ) -> None:
+        """Bind to *db* and serialise writes via the backend *write_context*."""
+        self._db = db
+        self._write_context = write_context
+
+    async def mark_seen(
+        self,
+        *,
+        idempotency_key: NotBlankStr,
+        claim_id: NotBlankStr,
+        now: AwareDatetime,
+        ttl_seconds: float,
+    ) -> bool:
+        """Insert the dedup row; return ``True`` only on first write."""
+        seen_at = normalize_utc(now)
+        expires_at: datetime = seen_at + timedelta(seconds=ttl_seconds)
+        async with self._write_context():
+            try:
+                cursor = await self._db.execute(
+                    """
+                    INSERT INTO seen_claims (
+                        idempotency_key, claim_id, seen_at, expires_at
+                    ) VALUES (?, ?, ?, ?)
+                    ON CONFLICT(idempotency_key) DO NOTHING
+                    """,
+                    (
+                        str(idempotency_key),
+                        str(claim_id),
+                        format_iso_utc(seen_at),
+                        format_iso_utc(expires_at),
+                    ),
+                )
+                inserted = cursor.rowcount > 0
+                await self._db.commit()
+            except (sqlite3.Error, aiosqlite.Error) as exc:
+                with contextlib.suppress(sqlite3.Error, aiosqlite.Error):
+                    await self._db.rollback()
+                msg = f"Failed to mark claim {idempotency_key!r} as seen"
+                logger.warning(
+                    PERSISTENCE_SEEN_CLAIMS_MARK_FAILED,
+                    idempotency_key=str(idempotency_key),
+                    claim_id=str(claim_id),
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
+                )
+                raise QueryError(msg) from exc
+        return inserted
+
+    async def prune_expired(self, now: AwareDatetime) -> int:
+        """Delete rows past their ``expires_at`` boundary."""
+        cutoff_iso = format_iso_utc(normalize_utc(now))
+        async with self._write_context():
+            try:
+                cursor = await self._db.execute(
+                    "DELETE FROM seen_claims WHERE expires_at < ?",
+                    (cutoff_iso,),
+                )
+                removed = cursor.rowcount
+                await self._db.commit()
+            except (sqlite3.Error, aiosqlite.Error) as exc:
+                with contextlib.suppress(sqlite3.Error, aiosqlite.Error):
+                    await self._db.rollback()
+                msg = "Failed to prune expired seen_claims rows"
+                logger.warning(
+                    PERSISTENCE_SEEN_CLAIMS_PRUNE_FAILED,
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
+                )
+                raise QueryError(msg) from exc
+        if removed:
+            logger.info(
+                PERSISTENCE_SEEN_CLAIMS_PRUNED,
+                removed=removed,
+            )
+        return removed

--- a/src/synthorg/persistence/sqlite/seen_claims_repo.py
+++ b/src/synthorg/persistence/sqlite/seen_claims_repo.py
@@ -1,10 +1,11 @@
 """SQLite repository for worker claim dedup persistence.
 
 Backs :class:`SeenClaimsRepository` against an aiosqlite connection.
-Uses an ``INSERT ... ON CONFLICT DO NOTHING`` so the first writer
-inserts and concurrent writers observe a no-op insert. Returning
-``cursor.rowcount`` distinguishes first-write from duplicate without
-a separate read.
+``mark_seen`` uses ``INSERT ... ON CONFLICT DO NOTHING`` so the first
+writer inserts and concurrent writers observe a no-op insert;
+``cursor.rowcount`` distinguishes first-write from duplicate without a
+separate read. ``is_completed`` is the pre-execute existence check
+workers consult before re-running a claim.
 """
 
 import contextlib
@@ -18,7 +19,7 @@ from synthorg.core.persistence_errors import QueryError
 from synthorg.core.types import NotBlankStr  # noqa: TC001
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.persistence import (
-    PERSISTENCE_SEEN_CLAIMS_FORGET_FAILED,
+    PERSISTENCE_SEEN_CLAIMS_LOOKUP_FAILED,
     PERSISTENCE_SEEN_CLAIMS_MARK_FAILED,
     PERSISTENCE_SEEN_CLAIMS_PRUNE_FAILED,
     PERSISTENCE_SEEN_CLAIMS_PRUNED,
@@ -41,6 +42,29 @@ class SQLiteSeenClaimsRepository:
         """Bind to *db* and serialise writes via the backend *write_context*."""
         self._db = db
         self._write_context = write_context
+
+    async def is_completed(
+        self,
+        *,
+        idempotency_key: NotBlankStr,
+    ) -> bool:
+        """Return ``True`` when a row for ``idempotency_key`` exists."""
+        try:
+            cursor = await self._db.execute(
+                "SELECT 1 FROM seen_claims WHERE idempotency_key = ? LIMIT 1",
+                (str(idempotency_key),),
+            )
+            row = await cursor.fetchone()
+        except (sqlite3.Error, aiosqlite.Error) as exc:
+            msg = f"Failed to look up seen claim {idempotency_key!r}"
+            logger.warning(
+                PERSISTENCE_SEEN_CLAIMS_LOOKUP_FAILED,
+                idempotency_key=str(idempotency_key),
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+        return row is not None
 
     async def mark_seen(
         self,
@@ -96,33 +120,6 @@ class SQLiteSeenClaimsRepository:
                 )
                 raise QueryError(msg) from exc
         return inserted
-
-    async def forget(
-        self,
-        *,
-        idempotency_key: NotBlankStr,
-    ) -> bool:
-        """Delete the dedup row for *idempotency_key* (idempotent)."""
-        async with self._write_context():
-            try:
-                cursor = await self._db.execute(
-                    "DELETE FROM seen_claims WHERE idempotency_key = ?",
-                    (str(idempotency_key),),
-                )
-                removed = cursor.rowcount > 0
-                await self._db.commit()
-            except (sqlite3.Error, aiosqlite.Error) as exc:
-                with contextlib.suppress(sqlite3.Error, aiosqlite.Error):
-                    await self._db.rollback()
-                msg = f"Failed to forget claim {idempotency_key!r}"
-                logger.warning(
-                    PERSISTENCE_SEEN_CLAIMS_FORGET_FAILED,
-                    idempotency_key=str(idempotency_key),
-                    error_type=type(exc).__name__,
-                    error=safe_error_description(exc),
-                )
-                raise QueryError(msg) from exc
-        return removed
 
     async def prune_expired(self, now: AwareDatetime) -> int:
         """Delete rows past their ``expires_at`` boundary."""

--- a/src/synthorg/persistence/sqlite/seen_claims_repo.py
+++ b/src/synthorg/persistence/sqlite/seen_claims_repo.py
@@ -52,16 +52,16 @@ class SQLiteSeenClaimsRepository:
     ) -> bool:
         """Insert the dedup row; return ``True`` only on first write.
 
-        The ``write_lock`` is intentionally held across the COMMIT so
-        concurrent ``mark_seen`` callers serialise on the same SQLite
-        connection.  Under WAL mode SQLite only serialises writers (not
-        readers) at the file lock, but the in-process lock keeps
-        ``cursor.rowcount`` semantics clean: a duplicate observed by
-        the conflict clause returns ``rowcount == 0`` only if the
-        first writer's transaction has already been committed when
-        the second one queries.  Releasing the lock pre-commit would
-        let a sibling caller observe a stale ``rowcount`` and treat
-        a duplicate as a first-write.
+        The backend ``write_context`` is intentionally held across the
+        COMMIT so concurrent ``mark_seen`` callers serialise on the
+        same SQLite connection. Under WAL mode SQLite only serialises
+        writers (not readers) at the file lock, but the in-process
+        lock keeps ``cursor.rowcount`` semantics clean: a duplicate
+        observed by the conflict clause returns ``rowcount == 0`` only
+        if the first writer's transaction has already been committed
+        when the second one queries. Releasing the lock pre-commit
+        would let a sibling caller observe a stale ``rowcount`` and
+        treat a duplicate as a first-write.
         """
         seen_at = normalize_utc(now)
         expires_at: datetime = seen_at + timedelta(seconds=ttl_seconds)
@@ -103,7 +103,7 @@ class SQLiteSeenClaimsRepository:
         idempotency_key: NotBlankStr,
     ) -> bool:
         """Delete the dedup row for *idempotency_key* (idempotent)."""
-        async with self._write_lock:
+        async with self._write_context():
             try:
                 cursor = await self._db.execute(
                     "DELETE FROM seen_claims WHERE idempotency_key = ?",

--- a/src/synthorg/providers/base.py
+++ b/src/synthorg/providers/base.py
@@ -7,12 +7,12 @@ automatic retry, rate limiting, and provides a cost-computation helper.
 
 import asyncio
 import math
-import time
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Callable, Coroutine, Mapping
 from typing import Any, TypeVar
 
 from synthorg.constants import BUDGET_ROUNDING_PRECISION
+from synthorg.core.clock import Clock, SystemClock
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.provider import (
     PROVIDER_BATCH_CAPABILITIES_PARTIAL,
@@ -63,6 +63,10 @@ class BaseCompletionProvider(ABC):
     Args:
         retry_handler: Optional retry handler for transient errors.
         rate_limiter: Optional client-side rate limiter.
+        clock: Optional injectable :class:`~synthorg.core.clock.Clock`
+            used for latency measurement. Defaults to ``SystemClock``;
+            tests inject ``FakeClock`` to drive virtual time without
+            wall-clock waits.
     """
 
     def __init__(
@@ -70,9 +74,11 @@ class BaseCompletionProvider(ABC):
         *,
         retry_handler: RetryHandler | None = None,
         rate_limiter: RateLimiter | None = None,
+        clock: Clock | None = None,
     ) -> None:
         self._retry_handler = retry_handler
         self._rate_limiter = rate_limiter
+        self._clock: Clock = clock or SystemClock()
 
     def _provider_label(self) -> str:
         """Return the bounded provider identifier used for metrics / logs.
@@ -158,7 +164,7 @@ class BaseCompletionProvider(ABC):
             record_exception=False,
             set_status_on_exception=False,
         ) as span:
-            t_start = time.monotonic()
+            t_start = self._clock.monotonic()
             retry_info: RetryResult[CompletionResponse] | None = None
             try:
                 if self._retry_handler is not None:
@@ -167,7 +173,7 @@ class BaseCompletionProvider(ABC):
                 else:
                     result = await _attempt()
             except Exception as exc:
-                latency_ms = (time.monotonic() - t_start) * 1000.0
+                latency_ms = (self._clock.monotonic() - t_start) * 1000.0
                 # ``logger.exception`` (what TRY400 suggests) would
                 # attach a traceback whose serialized frame-locals can
                 # leak provider credentials (API keys in headers,
@@ -193,7 +199,7 @@ class BaseCompletionProvider(ABC):
                     error_class=classify_provider_error(exc),
                 )
                 raise
-            latency_ms = (time.monotonic() - t_start) * 1000.0
+            latency_ms = (self._clock.monotonic() - t_start) * 1000.0
             span.set_attribute("provider.latency_ms", latency_ms)
             if retry_info is not None:
                 span.set_attribute(

--- a/src/synthorg/providers/base.py
+++ b/src/synthorg/providers/base.py
@@ -9,7 +9,7 @@ import asyncio
 import math
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Callable, Coroutine, Mapping
-from typing import Any, TypeVar
+from typing import Any, Final, TypeVar
 
 from opentelemetry.trace import Status, StatusCode
 
@@ -45,6 +45,8 @@ logger = get_logger(__name__)
 _tracer = get_tracer(__name__)
 
 _T = TypeVar("_T")
+
+_MILLISECONDS_PER_SECOND: Final[float] = 1000.0
 
 
 class BaseCompletionProvider(ABC):
@@ -177,7 +179,9 @@ class BaseCompletionProvider(ABC):
             except MemoryError, RecursionError:
                 raise
             except Exception as exc:
-                latency_ms = (self._clock.monotonic() - t_start) * 1000.0
+                latency_ms = (
+                    self._clock.monotonic() - t_start
+                ) * _MILLISECONDS_PER_SECOND
                 # ``logger.exception`` (what TRY400 suggests) would
                 # attach a traceback whose serialized frame-locals can
                 # leak provider credentials (API keys in headers,
@@ -212,7 +216,7 @@ class BaseCompletionProvider(ABC):
                     error_class=classify_provider_error(exc),
                 )
                 raise
-            latency_ms = (self._clock.monotonic() - t_start) * 1000.0
+            latency_ms = (self._clock.monotonic() - t_start) * _MILLISECONDS_PER_SECOND
             span.set_attribute("provider.latency_ms", latency_ms)
             if retry_info is not None:
                 span.set_attribute(

--- a/src/synthorg/providers/base.py
+++ b/src/synthorg/providers/base.py
@@ -80,7 +80,7 @@ class BaseCompletionProvider(ABC):
     ) -> None:
         self._retry_handler = retry_handler
         self._rate_limiter = rate_limiter
-        self._clock: Clock = clock or SystemClock()
+        self._clock: Clock = clock if clock is not None else SystemClock()
 
     def _provider_label(self) -> str:
         """Return the bounded provider identifier used for metrics / logs.
@@ -174,6 +174,8 @@ class BaseCompletionProvider(ABC):
                     result = retry_info.value
                 else:
                     result = await _attempt()
+            except MemoryError, RecursionError:
+                raise
             except Exception as exc:
                 latency_ms = (self._clock.monotonic() - t_start) * 1000.0
                 # ``logger.exception`` (what TRY400 suggests) would
@@ -309,6 +311,8 @@ class BaseCompletionProvider(ABC):
 
         try:
             return await self._resilient_execute(_attempt)
+        except MemoryError, RecursionError:
+            raise
         except Exception as exc:
             # See the ``complete`` sibling handler; ``logger.error``
             # + scrubbed fields instead of ``logger.exception``
@@ -358,6 +362,8 @@ class BaseCompletionProvider(ABC):
 
         try:
             return await self._resilient_execute(_attempt)
+        except MemoryError, RecursionError:
+            raise
         except Exception as exc:
             # ``logger.exception`` would attach a traceback whose
             # frame-locals can leak provider credentials; use

--- a/src/synthorg/providers/base.py
+++ b/src/synthorg/providers/base.py
@@ -11,6 +11,8 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Callable, Coroutine, Mapping
 from typing import Any, TypeVar
 
+from opentelemetry.trace import Status, StatusCode
+
 from synthorg.constants import BUDGET_ROUNDING_PRECISION
 from synthorg.core.clock import Clock, SystemClock
 from synthorg.observability import get_logger, safe_error_description
@@ -193,6 +195,15 @@ class BaseCompletionProvider(ABC):
                     safe_error_description(exc),
                 )
                 span.set_attribute("provider.latency_ms", latency_ms)
+                # ``set_status_on_exception=False`` opts out of the
+                # auto-instrumentation that would have stamped an
+                # un-scrubbed ``str(exc)`` into the span status, so the
+                # ERROR status must be set manually here. The scrubbed
+                # error description is exposed via ``exception.message``
+                # above; ``Status.description`` is intentionally left
+                # unset so the OTLP exporter never carries the raw
+                # provider string.
+                span.set_status(Status(StatusCode.ERROR))
                 record_provider_error(
                     provider=provider_label,
                     model=model,

--- a/src/synthorg/providers/base.py
+++ b/src/synthorg/providers/base.py
@@ -22,6 +22,7 @@ from synthorg.observability.events.provider import (
     PROVIDER_STREAM_START,
 )
 from synthorg.observability.metrics_hub import record_provider_error
+from synthorg.observability.tracing.instrumentation import get_tracer
 
 from .capabilities import ModelCapabilities  # noqa: TC001
 from .cost_recording import current_cost_context, emit_cost_record_from_context
@@ -39,6 +40,7 @@ from .resilience.rate_limiter import RateLimiter  # noqa: TC001
 from .resilience.retry import RetryHandler  # noqa: TC001
 
 logger = get_logger(__name__)
+_tracer = get_tracer(__name__)
 
 _T = TypeVar("_T")
 
@@ -135,36 +137,69 @@ class BaseCompletionProvider(ABC):
 
         from .resilience.retry import RetryResult  # noqa: PLC0415, TC001
 
-        t_start = time.monotonic()
-        retry_info: RetryResult[CompletionResponse] | None = None
-        try:
-            if self._retry_handler is not None:
-                retry_info = await self._retry_handler.execute(_attempt)
-                result = retry_info.value
-            else:
-                result = await _attempt()
-        except Exception as exc:
-            # ``logger.exception`` (what TRY400 suggests) would
-            # attach a traceback whose serialized frame-locals can
-            # leak provider credentials (API keys in headers,
-            # connection URLs with user:pass). Use ``logger.error``
-            # with the structured ``error_type`` + scrubbed ``error``
-            # fields instead -- traceback frames never reach any log
-            # sink.
-            logger.error(
-                PROVIDER_CALL_ERROR,
-                model=model,
-                latency_ms=(time.monotonic() - t_start) * 1000.0,
-                error_type=type(exc).__name__,
-                error=safe_error_description(exc),
-            )
-            record_provider_error(
-                provider=self._provider_label(),
-                model=model,
-                error_class=classify_provider_error(exc),
-            )
-            raise
-        latency_ms = (time.monotonic() - t_start) * 1000.0
+        # Per-call child span under whatever parent span the caller
+        # owns (typically ``agent.execution`` from AgentEngine).
+        # ``record_exception=False`` and ``set_status_on_exception=False``
+        # opt out of the auto-instrumentation that would otherwise
+        # stamp the unscrubbed ``str(exc)`` into the span; we set
+        # ``exception.message`` via ``safe_error_description`` instead
+        # so attacker-controlled provider error strings are scrubbed
+        # before reaching the OTLP exporter.
+        provider_label = self._provider_label()
+        span_attributes: dict[str, Any] = {
+            "provider.name": provider_label,
+            "provider.model": model,
+            "provider.message_count": len(messages),
+            "provider.tool_count": len(tools) if tools else 0,
+        }
+        with _tracer.start_as_current_span(
+            "provider.complete",
+            attributes=span_attributes,
+            record_exception=False,
+            set_status_on_exception=False,
+        ) as span:
+            t_start = time.monotonic()
+            retry_info: RetryResult[CompletionResponse] | None = None
+            try:
+                if self._retry_handler is not None:
+                    retry_info = await self._retry_handler.execute(_attempt)
+                    result = retry_info.value
+                else:
+                    result = await _attempt()
+            except Exception as exc:
+                latency_ms = (time.monotonic() - t_start) * 1000.0
+                # ``logger.exception`` (what TRY400 suggests) would
+                # attach a traceback whose serialized frame-locals can
+                # leak provider credentials (API keys in headers,
+                # connection URLs with user:pass). Use ``logger.error``
+                # with the structured ``error_type`` + scrubbed
+                # ``error`` fields instead.
+                logger.error(
+                    PROVIDER_CALL_ERROR,
+                    model=model,
+                    latency_ms=latency_ms,
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
+                )
+                span.set_attribute("exception.type", type(exc).__name__)
+                span.set_attribute(
+                    "exception.message",
+                    safe_error_description(exc),
+                )
+                span.set_attribute("provider.latency_ms", latency_ms)
+                record_provider_error(
+                    provider=provider_label,
+                    model=model,
+                    error_class=classify_provider_error(exc),
+                )
+                raise
+            latency_ms = (time.monotonic() - t_start) * 1000.0
+            span.set_attribute("provider.latency_ms", latency_ms)
+            if retry_info is not None:
+                span.set_attribute(
+                    "provider.retry_count",
+                    max(0, retry_info.attempt_count - 1),
+                )
 
         metadata: dict[str, object] = {"_synthorg_latency_ms": latency_ms}
         if retry_info is not None:

--- a/src/synthorg/security/audit.py
+++ b/src/synthorg/security/audit.py
@@ -57,6 +57,9 @@ class AuditLog:
         previous_total = self._total_recorded
         self._entries.clear()
         self._total_recorded = 0
+        # Reset the gauge so a previously near-full audit log doesn't
+        # leave a stale ``1.0`` reading until the next record() call.
+        record_security_audit_fill_ratio(ratio=0.0)
         logger.info(
             SECURITY_AUDIT_CLEARED,
             previous_count=previous_count,

--- a/src/synthorg/security/audit.py
+++ b/src/synthorg/security/audit.py
@@ -13,6 +13,7 @@ from synthorg.observability.events.security import (
     SECURITY_AUDIT_EVICTION,
     SECURITY_AUDIT_RECORDED,
 )
+from synthorg.observability.metrics_hub import record_security_audit_fill_ratio
 from synthorg.security.models import AuditEntry  # noqa: TC001
 
 logger = get_logger(__name__)
@@ -77,6 +78,14 @@ class AuditLog:
             )
         self._entries.append(entry)
         self._total_recorded += 1
+        # Push fill ratio to Prometheus on every record. The append +
+        # length read are O(1) so the cost is negligible; in exchange
+        # operators get a queryable gauge that flips to ``1.0`` as the
+        # eviction horizon approaches, enabling pre-eviction alerts
+        # before evidence is lost.
+        record_security_audit_fill_ratio(
+            ratio=len(self._entries) / self._max_entries,
+        )
         logger.debug(
             SECURITY_AUDIT_RECORDED,
             audit_id=entry.id,

--- a/src/synthorg/security/llm_evaluator.py
+++ b/src/synthorg/security/llm_evaluator.py
@@ -22,7 +22,6 @@ Design invariants:
 import asyncio
 import json
 import re
-import time
 
 # ``Mapping``, ``CostTracker``, ``ProviderConfig`` and
 # ``ProviderRegistry`` are part of ``LlmSecurityEvaluator.__init__``'s
@@ -36,6 +35,7 @@ from typing import TYPE_CHECKING, Final
 from synthorg.budget.call_category import LLMCallCategory
 from synthorg.budget.tracker import CostTracker  # noqa: TC001
 from synthorg.config.schema import ProviderConfig  # noqa: TC001
+from synthorg.core.clock import Clock, SystemClock
 from synthorg.core.enums import ApprovalRiskLevel
 from synthorg.core.types import NotBlankStr
 from synthorg.engine.prompt_safety import (
@@ -174,11 +174,13 @@ class LlmSecurityEvaluator:
         provider_configs: Mapping[str, ProviderConfig],
         config: LlmFallbackConfig,
         cost_tracker: CostTracker | None = None,
+        clock: Clock | None = None,
     ) -> None:
         self._registry = provider_registry
         self._configs = provider_configs
         self._config = config
         self._cost_tracker = cost_tracker
+        self._clock: Clock = clock or SystemClock()
 
     async def evaluate(
         self,
@@ -200,7 +202,7 @@ class LlmSecurityEvaluator:
             ``DENY`` verdict, or an ``ESCALATE`` verdict -- all with
             LOW confidence.
         """
-        start = time.monotonic()
+        start = self._clock.monotonic()
         logger.info(
             SECURITY_LLM_EVAL_START,
             tool_name=context.tool_name,
@@ -301,7 +303,7 @@ class LlmSecurityEvaluator:
         start: float,
     ) -> SecurityVerdict:
         """Handle LLM call timeout."""
-        duration_ms = (time.monotonic() - start) * 1000
+        duration_ms = (self._clock.monotonic() - start) * 1000
         logger.warning(
             SECURITY_LLM_EVAL_TIMEOUT,
             tool_name=context.tool_name,
@@ -321,7 +323,7 @@ class LlmSecurityEvaluator:
         exc: Exception,
     ) -> SecurityVerdict:
         """Handle unexpected LLM call errors."""
-        duration_ms = (time.monotonic() - start) * 1000
+        duration_ms = (self._clock.monotonic() - start) * 1000
         # Use ``logger.warning`` + ``safe_error_description``
         # instead of ``logger.exception`` so we don't emit a
         # traceback that could leak credential-bearing locals
@@ -347,7 +349,7 @@ class LlmSecurityEvaluator:
         start: float,
     ) -> None:
         """Log a successful LLM evaluation completion."""
-        duration_ms = (time.monotonic() - start) * 1000
+        duration_ms = (self._clock.monotonic() - start) * 1000
         logger.info(
             SECURITY_LLM_EVAL_COMPLETE,
             tool_name=context.tool_name,
@@ -623,7 +625,7 @@ class LlmSecurityEvaluator:
             )
 
         reason = self._sanitize_reason(raw_reason)
-        duration_ms = (time.monotonic() - start) * 1000
+        duration_ms = (self._clock.monotonic() - start) * 1000
         full_reason = f"LLM security eval: {reason}"
 
         return SecurityVerdict(

--- a/src/synthorg/security/llm_evaluator.py
+++ b/src/synthorg/security/llm_evaluator.py
@@ -89,6 +89,8 @@ _MAX_VALUE_LENGTH: Final[int] = 200
 # and approval queue).
 _MAX_REASON_LENGTH: Final[int] = 300
 
+_MILLISECONDS_PER_SECOND: Final[float] = 1000.0
+
 # Regex to strip control characters from LLM-returned reason.
 _CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
 
@@ -303,7 +305,7 @@ class LlmSecurityEvaluator:
         start: float,
     ) -> SecurityVerdict:
         """Handle LLM call timeout."""
-        duration_ms = (self._clock.monotonic() - start) * 1000
+        duration_ms = (self._clock.monotonic() - start) * _MILLISECONDS_PER_SECOND
         logger.warning(
             SECURITY_LLM_EVAL_TIMEOUT,
             tool_name=context.tool_name,
@@ -323,7 +325,7 @@ class LlmSecurityEvaluator:
         exc: Exception,
     ) -> SecurityVerdict:
         """Handle unexpected LLM call errors."""
-        duration_ms = (self._clock.monotonic() - start) * 1000
+        duration_ms = (self._clock.monotonic() - start) * _MILLISECONDS_PER_SECOND
         # Use ``logger.warning`` + ``safe_error_description``
         # instead of ``logger.exception`` so we don't emit a
         # traceback that could leak credential-bearing locals
@@ -349,7 +351,7 @@ class LlmSecurityEvaluator:
         start: float,
     ) -> None:
         """Log a successful LLM evaluation completion."""
-        duration_ms = (self._clock.monotonic() - start) * 1000
+        duration_ms = (self._clock.monotonic() - start) * _MILLISECONDS_PER_SECOND
         logger.info(
             SECURITY_LLM_EVAL_COMPLETE,
             tool_name=context.tool_name,
@@ -625,7 +627,7 @@ class LlmSecurityEvaluator:
             )
 
         reason = self._sanitize_reason(raw_reason)
-        duration_ms = (self._clock.monotonic() - start) * 1000
+        duration_ms = (self._clock.monotonic() - start) * _MILLISECONDS_PER_SECOND
         full_reason = f"LLM security eval: {reason}"
 
         return SecurityVerdict(

--- a/src/synthorg/security/rules/engine.py
+++ b/src/synthorg/security/rules/engine.py
@@ -1,8 +1,8 @@
 """Rule engine -- evaluates security rules in order."""
 
-import time
 from datetime import UTC, datetime
 
+from synthorg.core.clock import Clock, SystemClock
 from synthorg.core.enums import ApprovalRiskLevel
 from synthorg.observability import get_logger
 from synthorg.observability.events.security import (
@@ -60,6 +60,7 @@ class RuleEngine:
         rules: tuple[SecurityRule, ...],
         risk_classifier: RiskClassifier,
         config: RuleEngineConfig,
+        clock: Clock | None = None,
     ) -> None:
         """Initialize the rule engine.
 
@@ -67,10 +68,13 @@ class RuleEngine:
             rules: Ordered tuple of rules to evaluate.
             risk_classifier: Fallback risk classifier.
             config: Rule engine configuration.
+            clock: Optional clock seam for deterministic latency
+                measurement in tests.
         """
         self._rules = rules
         self._risk_classifier = risk_classifier
         self._config = config
+        self._clock: Clock = clock or SystemClock()
 
     def evaluate(self, context: SecurityContext) -> SecurityVerdict:
         """Run all rules in order, returning the final verdict.
@@ -85,7 +89,7 @@ class RuleEngine:
             A ``SecurityVerdict`` -- DENY/ESCALATE from the first
             matching rule, or ALLOW with risk from the classifier.
         """
-        start = time.monotonic()
+        start = self._clock.monotonic()
         soft_allow: SecurityVerdict | None = None
 
         for rule in self._rules:
@@ -93,7 +97,7 @@ class RuleEngine:
             if verdict is None:
                 continue
 
-            duration_ms = (time.monotonic() - start) * 1000
+            duration_ms = (self._clock.monotonic() - start) * 1000
 
             # Soft-allow rules (e.g. policy_validator auto-approve)
             # record their verdict but do NOT short-circuit.
@@ -118,7 +122,7 @@ class RuleEngine:
             )
 
         # No rule returned DENY/ESCALATE.
-        duration_ms = (time.monotonic() - start) * 1000
+        duration_ms = (self._clock.monotonic() - start) * 1000
 
         # If a soft-allow was recorded, use it.
         if soft_allow is not None:

--- a/src/synthorg/security/rules/engine.py
+++ b/src/synthorg/security/rules/engine.py
@@ -29,6 +29,8 @@ logger = get_logger(__name__)
 # Rules whose ALLOW verdict should not short-circuit remaining rules.
 _SOFT_ALLOW_RULES: frozenset[str] = frozenset({_POLICY_VALIDATOR_RULE_NAME})
 
+_MILLISECONDS_PER_SECOND: float = 1000.0
+
 
 class RuleEngine:
     """Evaluates security rules in a defined order.
@@ -97,7 +99,7 @@ class RuleEngine:
             if verdict is None:
                 continue
 
-            duration_ms = (self._clock.monotonic() - start) * 1000
+            duration_ms = (self._clock.monotonic() - start) * _MILLISECONDS_PER_SECOND
 
             # Soft-allow rules (e.g. policy_validator auto-approve)
             # record their verdict but do NOT short-circuit.
@@ -122,7 +124,7 @@ class RuleEngine:
             )
 
         # No rule returned DENY/ESCALATE.
-        duration_ms = (self._clock.monotonic() - start) * 1000
+        duration_ms = (self._clock.monotonic() - start) * _MILLISECONDS_PER_SECOND
 
         # If a soft-allow was recorded, use it.
         if soft_allow is not None:

--- a/src/synthorg/security/safety_classifier.py
+++ b/src/synthorg/security/safety_classifier.py
@@ -110,6 +110,8 @@ _EMAIL_PLACEHOLDER: Final[str] = "[EMAIL]"
 # Maximum length for LLM-returned reason string.
 _MAX_REASON_LENGTH: Final[int] = 300
 
+_MILLISECONDS_PER_SECOND: Final[float] = 1000.0
+
 # Regex to strip control and formatting characters from LLM-returned
 # reason.  Best-effort coverage: ASCII control (C0/DEL), Unicode bidi
 # overrides, zero-width chars, line/paragraph separators, and known
@@ -432,7 +434,7 @@ class SafetyClassifier:
         except MemoryError, RecursionError:
             raise
         except Exception:
-            duration_ms = (self._clock.monotonic() - start) * 1000
+            duration_ms = (self._clock.monotonic() - start) * _MILLISECONDS_PER_SECOND
             logger.exception(
                 SECURITY_SAFETY_CLASSIFY_ERROR,
                 tool_name=tool_name,
@@ -457,7 +459,7 @@ class SafetyClassifier:
         """Send stripped description to LLM for classification."""
         provider_name, driver = self._select_provider()
         if provider_name is None or driver is None:
-            duration_ms = (self._clock.monotonic() - start) * 1000
+            duration_ms = (self._clock.monotonic() - start) * _MILLISECONDS_PER_SECOND
             logger.warning(
                 SECURITY_SAFETY_CLASSIFY_ERROR,
                 note="No provider available for safety classification",
@@ -609,7 +611,7 @@ class SafetyClassifier:
         start: float,
     ) -> SafetyClassifierResult:
         """Parse LLM response into a SafetyClassifierResult."""
-        duration_ms = (self._clock.monotonic() - start) * 1000
+        duration_ms = (self._clock.monotonic() - start) * _MILLISECONDS_PER_SECOND
 
         for tc in response.tool_calls:
             if tc.name == "safety_classification_verdict":

--- a/src/synthorg/security/safety_classifier.py
+++ b/src/synthorg/security/safety_classifier.py
@@ -22,13 +22,13 @@ import asyncio
 import html
 import re
 import secrets
-import time
 from enum import StrEnum
 from typing import TYPE_CHECKING, Final
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from synthorg.budget.call_category import LLMCallCategory
+from synthorg.core.clock import Clock, SystemClock
 from synthorg.core.enums import ApprovalRiskLevel  # noqa: TC001
 from synthorg.core.types import NotBlankStr
 
@@ -358,12 +358,14 @@ class SafetyClassifier:
         provider_configs: Mapping[str, ProviderConfig],
         config: SafetyClassifierConfig,
         cost_tracker: CostTracker | None = None,
+        clock: Clock | None = None,
     ) -> None:
         self._registry = provider_registry
         self._configs = provider_configs
         self._config = config
         self._cost_tracker = cost_tracker
         self._stripper = InformationStripper()
+        self._clock: Clock = clock or SystemClock()
 
     def classify_tier(self, action_type: str) -> PermissionTier:
         """Determine the permission tier for an action type.
@@ -407,7 +409,7 @@ class SafetyClassifier:
             A ``SafetyClassifierResult`` with the classification,
             stripped description, and reason.
         """
-        start = time.monotonic()
+        start = self._clock.monotonic()
         logger.info(
             SECURITY_SAFETY_CLASSIFY_START,
             tool_name=tool_name,
@@ -430,7 +432,7 @@ class SafetyClassifier:
         except MemoryError, RecursionError:
             raise
         except Exception:
-            duration_ms = (time.monotonic() - start) * 1000
+            duration_ms = (self._clock.monotonic() - start) * 1000
             logger.exception(
                 SECURITY_SAFETY_CLASSIFY_ERROR,
                 tool_name=tool_name,
@@ -455,7 +457,7 @@ class SafetyClassifier:
         """Send stripped description to LLM for classification."""
         provider_name, driver = self._select_provider()
         if provider_name is None or driver is None:
-            duration_ms = (time.monotonic() - start) * 1000
+            duration_ms = (self._clock.monotonic() - start) * 1000
             logger.warning(
                 SECURITY_SAFETY_CLASSIFY_ERROR,
                 note="No provider available for safety classification",
@@ -607,7 +609,7 @@ class SafetyClassifier:
         start: float,
     ) -> SafetyClassifierResult:
         """Parse LLM response into a SafetyClassifierResult."""
-        duration_ms = (time.monotonic() - start) * 1000
+        duration_ms = (self._clock.monotonic() - start) * 1000
 
         for tc in response.tool_calls:
             if tc.name == "safety_classification_verdict":

--- a/src/synthorg/settings/dispatcher.py
+++ b/src/synthorg/settings/dispatcher.py
@@ -10,7 +10,10 @@ from typing import TYPE_CHECKING, Final, NamedTuple
 from synthorg.communication.bus_protocol import MessageBus  # noqa: TC001
 from synthorg.communication.channel import Channel
 from synthorg.communication.enums import ChannelType
-from synthorg.communication.errors import ChannelAlreadyExistsError
+from synthorg.communication.errors import (
+    ChannelAlreadyExistsError,
+    CommunicationError,
+)
 from synthorg.core.normalization import compare_ci
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.settings import (
@@ -629,14 +632,17 @@ class SettingsChangeDispatcher:
                 )
                 if envelope is None:
                     continue
-                consecutive_errors = 0
                 await self._dispatch(envelope.message)
                 await envelope.ack()
+                # Reset the streak only after both dispatch and ack
+                # succeed; a pre-ack reset lets a repeating ack
+                # failure bypass ``max_errors`` indefinitely.
+                consecutive_errors = 0
             except asyncio.CancelledError:
                 raise
             except MemoryError, RecursionError:
                 raise
-            except (OSError, TimeoutError) as exc:
+            except (CommunicationError, OSError, TimeoutError) as exc:
                 consecutive_errors += 1
                 max_errors = await self._resolve_max_consecutive_errors()
                 if consecutive_errors >= max_errors:

--- a/src/synthorg/settings/dispatcher.py
+++ b/src/synthorg/settings/dispatcher.py
@@ -631,6 +631,7 @@ class SettingsChangeDispatcher:
                     continue
                 consecutive_errors = 0
                 await self._dispatch(envelope.message)
+                await envelope.ack()
             except asyncio.CancelledError:
                 raise
             except MemoryError, RecursionError:

--- a/src/synthorg/workers/claim.py
+++ b/src/synthorg/workers/claim.py
@@ -12,6 +12,7 @@ API behind a small ``publish_claim`` / ``next_claim`` / ``ack`` /
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Final
+from uuid import uuid4
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 
@@ -64,6 +65,11 @@ class TaskClaim(BaseModel):
         new_status: The status that caused the dispatch (typically
             ``READY`` or equivalent).
         dispatched_at: When the dispatcher enqueued this claim.
+        idempotency_key: UUID generated at publish time so the worker
+            can dedupe a JetStream redelivery (ack lost in transit,
+            worker crash before ack). Workers ``mark_seen`` this key
+            via :class:`SeenClaimsRepository` and short-circuit any
+            duplicate observation back to ack-and-skip.
     """
 
     model_config = ConfigDict(frozen=True, allow_inf_nan=False)
@@ -83,6 +89,10 @@ class TaskClaim(BaseModel):
     dispatched_at: AwareDatetime = Field(
         default_factory=lambda: datetime.now(UTC),
         description="When the dispatcher enqueued the claim",
+    )
+    idempotency_key: NotBlankStr = Field(
+        default_factory=lambda: uuid4().hex,
+        description="Per-dispatch UUID for worker-side redelivery dedup",
     )
 
 

--- a/src/synthorg/workers/worker.py
+++ b/src/synthorg/workers/worker.py
@@ -18,11 +18,16 @@ follow-up PR).
 import asyncio
 import contextlib
 from collections.abc import Awaitable, Callable
-from typing import Any, Final
+from typing import TYPE_CHECKING, Any, Final
 
-from synthorg.observability import get_logger
+from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.persistence_errors import QueryError
+from synthorg.core.types import NotBlankStr
+from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.workers import (
     WORKERS_CLAIM_RECEIVED,
+    WORKERS_DEDUP_LOOKUP_FAILED,
+    WORKERS_DUPLICATE_CLAIM_SUPPRESSED,
     WORKERS_EXECUTOR_FAILED,
     WORKERS_FINALIZE_FAILED,
     WORKERS_POOL_STARTED,
@@ -35,6 +40,9 @@ from synthorg.workers.claim import (
     TaskClaimStatus,
 )
 from synthorg.workers.config import QueueConfig  # noqa: TC001
+
+if TYPE_CHECKING:
+    from synthorg.persistence.seen_claims_protocol import SeenClaimsRepository
 
 logger = get_logger(__name__)
 
@@ -57,6 +65,16 @@ the claim ack/nack based on the returned status.
 """
 
 
+_DEDUP_TTL_SAFETY_MULTIPLIER: Final[float] = 2.0
+"""Multiplier applied to ``ack_wait * max_deliver`` for the dedup TTL.
+
+The dedup row must outlive the JetStream redelivery horizon
+(``ack_wait * max_deliver``) by enough slack that a slow worker
+finalising its ack just past the deadline still finds the row. The
+2.0 multiplier gives that slack without keeping the table unbounded
+in size."""
+
+
 class Worker:
     """Single-process distributed worker.
 
@@ -65,20 +83,36 @@ class Worker:
         task_queue: Connected :class:`JetStreamTaskQueue`.
         executor: Async callable invoked for each claim.
         worker_id: Identifier for logging + heartbeat subject.
+        seen_claims: Durable dedup repository consulted before each
+            claim is executed; protects against JetStream
+            redeliveries (ack lost in transit, worker crash before
+            ack). When ``None``, dedup is disabled (legacy behaviour;
+            tests without a persistence backend rely on this).
+        clock: Time source for the dedup row's ``seen_at`` /
+            ``expires_at`` timestamps. Inject ``FakeClock`` in tests.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913 -- canonical worker construction surface
         self,
         *,
         queue_config: QueueConfig,
         task_queue: JetStreamTaskQueue,
         executor: TaskExecutor,
         worker_id: str,
+        seen_claims: SeenClaimsRepository | None = None,
+        clock: Clock | None = None,
     ) -> None:
         self._queue_config = queue_config
         self._task_queue = task_queue
         self._executor = executor
         self._worker_id = worker_id
+        self._seen_claims = seen_claims
+        self._clock: Clock = clock or SystemClock()
+        self._dedup_ttl_seconds: float = (
+            float(queue_config.ack_wait_seconds)
+            * float(queue_config.max_deliver)
+            * _DEDUP_TTL_SAFETY_MULTIPLIER
+        )
         self._running = False
         # Eager init: ``stop()`` may set the event before ``run()`` has
         # ever entered the loop, so a half-published attribute would
@@ -145,8 +179,48 @@ class Worker:
         if claim_and_raw is None:
             return
         claim, raw = claim_and_raw
+        if await self._is_duplicate(claim):
+            await self._finalize_claim(raw, TaskClaimStatus.SUCCESS)
+            return
         status = await self._execute_claim(claim)
         await self._finalize_claim(raw, status)
+
+    async def _is_duplicate(self, claim: TaskClaim) -> bool:
+        """Return ``True`` if the claim has already been processed.
+
+        Resolves to ``False`` when no dedup repository is wired or when
+        the repo lookup fails (fail-open: a transient persistence error
+        must not stall the worker; the JetStream ``ack_wait`` window
+        will redeliver and the next worker tries again).
+        """
+        if self._seen_claims is None:
+            return False
+        try:
+            inserted = await self._seen_claims.mark_seen(
+                idempotency_key=NotBlankStr(claim.idempotency_key),
+                claim_id=NotBlankStr(claim.task_id),
+                now=self._clock.now(),
+                ttl_seconds=self._dedup_ttl_seconds,
+            )
+        except QueryError as exc:
+            logger.warning(
+                WORKERS_DEDUP_LOOKUP_FAILED,
+                worker_id=self._worker_id,
+                task_id=claim.task_id,
+                idempotency_key=claim.idempotency_key,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            return False
+        if inserted:
+            return False
+        logger.info(
+            WORKERS_DUPLICATE_CLAIM_SUPPRESSED,
+            worker_id=self._worker_id,
+            task_id=claim.task_id,
+            idempotency_key=claim.idempotency_key,
+        )
+        return True
 
     async def _execute_claim(self, claim: TaskClaim) -> TaskClaimStatus:
         """Invoke the executor, translating exceptions into RETRY."""
@@ -194,19 +268,36 @@ class Worker:
             raise
 
 
-async def run_worker_pool(
+async def run_worker_pool(  # noqa: PLR0913 -- canonical worker-pool entry point
     *,
     queue_config: QueueConfig,
     task_queue: JetStreamTaskQueue,
     executor: TaskExecutor,
     worker_count: int,
     worker_id_prefix: str = "worker",
+    seen_claims: SeenClaimsRepository | None = None,
+    clock: Clock | None = None,
 ) -> None:
     """Run ``worker_count`` workers concurrently until cancelled.
 
     Blocks until all workers exit (via ``stop`` or cancellation).
     Uses :class:`asyncio.TaskGroup` so a failing worker propagates
     the exception after sibling cancellation.
+
+    Args:
+        queue_config: Queue configuration forwarded to each
+            :class:`Worker` (ack wait, max deliver).
+        task_queue: Connected :class:`JetStreamTaskQueue` shared
+            across all workers in the pool.
+        executor: Async callable invoked for each fetched claim.
+        worker_count: Number of concurrent workers to spawn.
+        worker_id_prefix: Prefix used to compose each worker's
+            identifier (e.g. ``"worker-0"``).
+        seen_claims: Optional dedup repository forwarded to every
+            spawned :class:`Worker`. When ``None``, claim dedup is
+            disabled; production callers must wire this from the
+            persistence backend.
+        clock: Optional clock seam forwarded to every spawned worker.
     """
     workers = [
         Worker(
@@ -214,6 +305,8 @@ async def run_worker_pool(
             task_queue=task_queue,
             executor=executor,
             worker_id=f"{worker_id_prefix}-{i}",
+            seen_claims=seen_claims,
+            clock=clock,
         )
         for i in range(worker_count)
     ]

--- a/src/synthorg/workers/worker.py
+++ b/src/synthorg/workers/worker.py
@@ -26,6 +26,7 @@ from synthorg.core.types import NotBlankStr
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.workers import (
     WORKERS_CLAIM_RECEIVED,
+    WORKERS_DEDUP_FORGET_FAILED,
     WORKERS_DEDUP_LOOKUP_FAILED,
     WORKERS_DUPLICATE_CLAIM_SUPPRESSED,
     WORKERS_EXECUTOR_FAILED,
@@ -183,6 +184,15 @@ class Worker:
             await self._finalize_claim(raw, TaskClaimStatus.SUCCESS)
             return
         status = await self._execute_claim(claim)
+        if status == TaskClaimStatus.RETRY:
+            # ``_is_duplicate`` wrote a speculative row before the
+            # executor ran (the persistence layer's only atomic
+            # first-write primitive is INSERT-IF-NOT-EXISTS). On a
+            # retry-able outcome we must roll that row back so the
+            # next JetStream redelivery runs the executor again
+            # instead of taking the duplicate-suppress branch and
+            # silently dropping the claim.
+            await self._forget_seen(claim)
         await self._finalize_claim(raw, status)
 
     async def _is_duplicate(self, claim: TaskClaim) -> bool:
@@ -221,6 +231,31 @@ class Worker:
             idempotency_key=claim.idempotency_key,
         )
         return True
+
+    async def _forget_seen(self, claim: TaskClaim) -> None:
+        """Roll back the speculative dedup row recorded in ``_is_duplicate``.
+
+        Fail-open: a transient persistence error here is logged and
+        swallowed. The JetStream redelivery horizon (``ack_wait *
+        max_deliver``) still bounds repeat attempts, and a stuck row
+        only mis-classifies one redelivery as a duplicate rather than
+        stalling the whole worker.
+        """
+        if self._seen_claims is None:
+            return
+        try:
+            await self._seen_claims.forget(
+                idempotency_key=NotBlankStr(claim.idempotency_key),
+            )
+        except QueryError as exc:
+            logger.warning(
+                WORKERS_DEDUP_FORGET_FAILED,
+                worker_id=self._worker_id,
+                task_id=claim.task_id,
+                idempotency_key=claim.idempotency_key,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
 
     async def _execute_claim(self, claim: TaskClaim) -> TaskClaimStatus:
         """Invoke the executor, translating exceptions into RETRY."""

--- a/src/synthorg/workers/worker.py
+++ b/src/synthorg/workers/worker.py
@@ -26,8 +26,8 @@ from synthorg.core.types import NotBlankStr
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.workers import (
     WORKERS_CLAIM_RECEIVED,
-    WORKERS_DEDUP_FORGET_FAILED,
     WORKERS_DEDUP_LOOKUP_FAILED,
+    WORKERS_DEDUP_MARK_FAILED,
     WORKERS_DUPLICATE_CLAIM_SUPPRESSED,
     WORKERS_EXECUTOR_FAILED,
     WORKERS_FINALIZE_FAILED,
@@ -173,6 +173,14 @@ class Worker:
         deadline. The loop's outer ``while not self._stop_event.is_set()``
         handles the stop signal; this method just returns eagerly on
         an empty fetch so the loop can observe it.
+
+        Dedup is consulted as a read-only check BEFORE execution and
+        the completion row is written AFTER the executor reaches a
+        terminal outcome (SUCCESS / FAILED). Writing post-execution
+        means a worker that crashes mid-execute leaves no row behind,
+        so the JetStream redelivery re-runs the claim instead of being
+        silently ack-and-skipped under a stale "we already saw this"
+        marker.
         """
         claim_and_raw = await self._task_queue.next_claim(
             timeout=_MAX_FETCH_POLL_SECONDS,
@@ -180,23 +188,22 @@ class Worker:
         if claim_and_raw is None:
             return
         claim, raw = claim_and_raw
-        if await self._is_duplicate(claim):
+        if await self._is_completed(claim):
             await self._finalize_claim(raw, TaskClaimStatus.SUCCESS)
             return
         status = await self._execute_claim(claim)
-        if status == TaskClaimStatus.RETRY:
-            # ``_is_duplicate`` wrote a speculative row before the
-            # executor ran (the persistence layer's only atomic
-            # first-write primitive is INSERT-IF-NOT-EXISTS). On a
-            # retry-able outcome we must roll that row back so the
-            # next JetStream redelivery runs the executor again
-            # instead of taking the duplicate-suppress branch and
-            # silently dropping the claim.
-            await self._forget_seen(claim)
+        # Mark before ack: a crash between ``_mark_completed`` and
+        # ``_finalize_claim`` still leaves the row in place, so the
+        # JetStream redelivery (triggered by the missing ack) observes
+        # the completion and ack-skips. The opposite ordering would
+        # let a successful claim be silently re-executed when the ack
+        # raced redelivery.
+        if status in {TaskClaimStatus.SUCCESS, TaskClaimStatus.FAILED}:
+            await self._mark_completed(claim)
         await self._finalize_claim(raw, status)
 
-    async def _is_duplicate(self, claim: TaskClaim) -> bool:
-        """Return ``True`` if the claim has already been processed.
+    async def _is_completed(self, claim: TaskClaim) -> bool:
+        """Return ``True`` if the claim has already completed.
 
         Resolves to ``False`` when no dedup repository is wired or when
         the repo lookup fails (fail-open: a transient persistence error
@@ -206,11 +213,8 @@ class Worker:
         if self._seen_claims is None:
             return False
         try:
-            inserted = await self._seen_claims.mark_seen(
+            seen = await self._seen_claims.is_completed(
                 idempotency_key=NotBlankStr(claim.idempotency_key),
-                claim_id=NotBlankStr(claim.task_id),
-                now=self._clock.now(),
-                ttl_seconds=self._dedup_ttl_seconds,
             )
         except QueryError as exc:
             logger.warning(
@@ -222,7 +226,7 @@ class Worker:
                 error=safe_error_description(exc),
             )
             return False
-        if inserted:
+        if not seen:
             return False
         logger.info(
             WORKERS_DUPLICATE_CLAIM_SUPPRESSED,
@@ -232,24 +236,29 @@ class Worker:
         )
         return True
 
-    async def _forget_seen(self, claim: TaskClaim) -> None:
-        """Roll back the speculative dedup row recorded in ``_is_duplicate``.
+    async def _mark_completed(self, claim: TaskClaim) -> None:
+        """Record the claim's terminal outcome in the dedup repository.
 
         Fail-open: a transient persistence error here is logged and
-        swallowed. The JetStream redelivery horizon (``ack_wait *
-        max_deliver``) still bounds repeat attempts, and a stuck row
-        only mis-classifies one redelivery as a duplicate rather than
-        stalling the whole worker.
+        swallowed. The worst-case is that a duplicate redelivery
+        executes the work twice; the work itself is idempotent at the
+        task-engine layer (single-writer transitions plus the API's
+        idempotency-key envelope), so re-execution converges on the
+        same state rather than corrupting it. Raising would crash the
+        worker loop and stall every claim sharing this subscriber.
         """
         if self._seen_claims is None:
             return
         try:
-            await self._seen_claims.forget(
+            await self._seen_claims.mark_seen(
                 idempotency_key=NotBlankStr(claim.idempotency_key),
+                claim_id=NotBlankStr(claim.task_id),
+                now=self._clock.now(),
+                ttl_seconds=self._dedup_ttl_seconds,
             )
         except QueryError as exc:
             logger.warning(
-                WORKERS_DEDUP_FORGET_FAILED,
+                WORKERS_DEDUP_MARK_FAILED,
                 worker_id=self._worker_id,
                 task_id=claim.task_id,
                 idempotency_key=claim.idempotency_key,

--- a/tests/conformance/persistence/test_seen_claims_repository.py
+++ b/tests/conformance/persistence/test_seen_claims_repository.py
@@ -72,6 +72,42 @@ class TestSeenClaimsMarkSeen:
         assert second is True
 
 
+class TestSeenClaimsForget:
+    async def test_forget_clears_row_so_re_mark_succeeds(
+        self,
+        backend: PersistenceBackend,
+    ) -> None:
+        key = NotBlankStr("idem-forgettable")
+        first = await backend.seen_claims.mark_seen(
+            idempotency_key=key,
+            claim_id=NotBlankStr("task-forget"),
+            now=_now(),
+            ttl_seconds=60.0,
+        )
+        assert first is True
+        removed = await backend.seen_claims.forget(idempotency_key=key)
+        assert removed is True
+        # After forget the row is gone, so the next mark_seen behaves
+        # as a fresh first-write -- this is the property the worker's
+        # RETRY rollback path relies on.
+        second = await backend.seen_claims.mark_seen(
+            idempotency_key=key,
+            claim_id=NotBlankStr("task-forget"),
+            now=_now(),
+            ttl_seconds=60.0,
+        )
+        assert second is True
+
+    async def test_forget_unknown_key_returns_false(
+        self,
+        backend: PersistenceBackend,
+    ) -> None:
+        removed = await backend.seen_claims.forget(
+            idempotency_key=NotBlankStr("idem-never-marked"),
+        )
+        assert removed is False
+
+
 class TestSeenClaimsPruneExpired:
     async def test_prune_removes_expired_rows(
         self,

--- a/tests/conformance/persistence/test_seen_claims_repository.py
+++ b/tests/conformance/persistence/test_seen_claims_repository.py
@@ -72,40 +72,33 @@ class TestSeenClaimsMarkSeen:
         assert second is True
 
 
-class TestSeenClaimsForget:
-    async def test_forget_clears_row_so_re_mark_succeeds(
+class TestSeenClaimsIsCompleted:
+    async def test_returns_false_for_unmarked_key(
         self,
         backend: PersistenceBackend,
     ) -> None:
-        key = NotBlankStr("idem-forgettable")
-        first = await backend.seen_claims.mark_seen(
-            idempotency_key=key,
-            claim_id=NotBlankStr("task-forget"),
-            now=_now(),
-            ttl_seconds=60.0,
-        )
-        assert first is True
-        removed = await backend.seen_claims.forget(idempotency_key=key)
-        assert removed is True
-        # After forget the row is gone, so the next mark_seen behaves
-        # as a fresh first-write -- this is the property the worker's
-        # RETRY rollback path relies on.
-        second = await backend.seen_claims.mark_seen(
-            idempotency_key=key,
-            claim_id=NotBlankStr("task-forget"),
-            now=_now(),
-            ttl_seconds=60.0,
-        )
-        assert second is True
-
-    async def test_forget_unknown_key_returns_false(
-        self,
-        backend: PersistenceBackend,
-    ) -> None:
-        removed = await backend.seen_claims.forget(
+        seen = await backend.seen_claims.is_completed(
             idempotency_key=NotBlankStr("idem-never-marked"),
         )
-        assert removed is False
+        assert seen is False
+
+    async def test_returns_true_after_mark_seen(
+        self,
+        backend: PersistenceBackend,
+    ) -> None:
+        key = NotBlankStr("idem-completed")
+        before = await backend.seen_claims.is_completed(idempotency_key=key)
+        assert before is False
+
+        await backend.seen_claims.mark_seen(
+            idempotency_key=key,
+            claim_id=NotBlankStr("task-completed"),
+            now=_now(),
+            ttl_seconds=60.0,
+        )
+
+        after = await backend.seen_claims.is_completed(idempotency_key=key)
+        assert after is True
 
 
 class TestSeenClaimsPruneExpired:

--- a/tests/conformance/persistence/test_seen_claims_repository.py
+++ b/tests/conformance/persistence/test_seen_claims_repository.py
@@ -1,0 +1,117 @@
+"""Conformance tests for ``SeenClaimsRepository``.
+
+Runs once against SQLite and once against a real Postgres container
+via the parametrised ``backend`` fixture so the two implementations
+stay in lockstep on the worker dedup contract.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from synthorg.core.types import NotBlankStr
+from synthorg.persistence.protocol import PersistenceBackend
+
+pytestmark = pytest.mark.integration
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+class TestSeenClaimsMarkSeen:
+    async def test_first_mark_returns_true(
+        self,
+        backend: PersistenceBackend,
+    ) -> None:
+        inserted = await backend.seen_claims.mark_seen(
+            idempotency_key=NotBlankStr("idem-first"),
+            claim_id=NotBlankStr("task-1"),
+            now=_now(),
+            ttl_seconds=60.0,
+        )
+        assert inserted is True
+
+    async def test_second_mark_returns_false(
+        self,
+        backend: PersistenceBackend,
+    ) -> None:
+        key = NotBlankStr("idem-dup")
+        first = await backend.seen_claims.mark_seen(
+            idempotency_key=key,
+            claim_id=NotBlankStr("task-2"),
+            now=_now(),
+            ttl_seconds=60.0,
+        )
+        second = await backend.seen_claims.mark_seen(
+            idempotency_key=key,
+            claim_id=NotBlankStr("task-2"),
+            now=_now(),
+            ttl_seconds=60.0,
+        )
+        assert first is True
+        assert second is False
+
+    async def test_distinct_keys_both_insert(
+        self,
+        backend: PersistenceBackend,
+    ) -> None:
+        first = await backend.seen_claims.mark_seen(
+            idempotency_key=NotBlankStr("idem-a"),
+            claim_id=NotBlankStr("task-a"),
+            now=_now(),
+            ttl_seconds=60.0,
+        )
+        second = await backend.seen_claims.mark_seen(
+            idempotency_key=NotBlankStr("idem-b"),
+            claim_id=NotBlankStr("task-b"),
+            now=_now(),
+            ttl_seconds=60.0,
+        )
+        assert first is True
+        assert second is True
+
+
+class TestSeenClaimsPruneExpired:
+    async def test_prune_removes_expired_rows(
+        self,
+        backend: PersistenceBackend,
+    ) -> None:
+        seeded_at = _now() - timedelta(seconds=120)
+        await backend.seen_claims.mark_seen(
+            idempotency_key=NotBlankStr("idem-old"),
+            claim_id=NotBlankStr("task-old"),
+            now=seeded_at,
+            ttl_seconds=1.0,
+        )
+        removed = await backend.seen_claims.prune_expired(_now())
+        assert removed >= 1
+        # Re-marking should now succeed because the row was pruned.
+        fresh = await backend.seen_claims.mark_seen(
+            idempotency_key=NotBlankStr("idem-old"),
+            claim_id=NotBlankStr("task-old"),
+            now=_now(),
+            ttl_seconds=60.0,
+        )
+        assert fresh is True
+
+    async def test_prune_leaves_live_rows(
+        self,
+        backend: PersistenceBackend,
+    ) -> None:
+        await backend.seen_claims.mark_seen(
+            idempotency_key=NotBlankStr("idem-live"),
+            claim_id=NotBlankStr("task-live"),
+            now=_now(),
+            ttl_seconds=600.0,
+        )
+        removed = await backend.seen_claims.prune_expired(_now())
+        assert removed == 0
+        # Re-marking the live row still observes the duplicate.
+        duplicate = await backend.seen_claims.mark_seen(
+            idempotency_key=NotBlankStr("idem-live"),
+            claim_id=NotBlankStr("task-live"),
+            now=_now(),
+            ttl_seconds=600.0,
+        )
+        assert duplicate is False

--- a/tests/integration/communication/test_bus_nats.py
+++ b/tests/integration/communication/test_bus_nats.py
@@ -13,6 +13,7 @@ import asyncio
 import contextlib
 from collections.abc import AsyncIterator, Iterator
 from datetime import UTC, datetime
+from typing import Final
 
 import pytest
 
@@ -269,6 +270,15 @@ async def test_receive_not_subscribed_raises(bus: MessageBus) -> None:
         await bus.receive("#general", "agent-a", timeout=0.1)
 
 
+_PARK_POLL_INTERVAL_SECONDS: Final[float] = 0.005
+"""Inter-poll yield while waiting for a receive coroutine to park.
+
+Promoted from a literal so the magic-number gate has a named target.
+The wall-clock 2s deadline above is the load-bearing primitive; this
+constant only controls how quickly the test re-checks ``in_flight_fetches``
+once the receive task is in flight."""
+
+
 async def test_receive_on_stopped_bus_raises(bus: MessageBus) -> None:
     await bus.stop()
     with pytest.raises(MessageBusNotRunningError):
@@ -303,7 +313,7 @@ async def test_receive_returns_none_on_shutdown(bus: MessageBus) -> None:
                 pytest.fail(f"receive() returned before parking (result={early!r})")
             if loop.time() >= deadline:
                 pytest.fail("receive() did not park within 2s")
-            await asyncio.sleep(0.005)
+            await asyncio.sleep(_PARK_POLL_INTERVAL_SECONDS)
         assert not receive_task.done(), "receive() returned before bus.stop() fired"
         await bus.stop()
         assert await receive_task is None

--- a/tests/integration/test_web_image.py
+++ b/tests/integration/test_web_image.py
@@ -10,6 +10,7 @@ import re
 import subprocess
 import time
 from collections.abc import Generator
+from typing import Final
 
 import httpx
 import pytest
@@ -21,6 +22,14 @@ logger = get_logger(__name__)
 _IMAGE_REF_PATTERN = re.compile(r"^[a-zA-Z0-9][\w.:/@-]*$")
 _SAFE_NAME_PATTERN = re.compile(r"^[\w-]+$")
 WEB_IMAGE = os.environ.get("SYNTHORG_WEB_IMAGE", "ghcr.io/aureliolo/synthorg-web:test")
+
+_HEALTH_POLL_INTERVAL_SECONDS: Final[float] = 0.25
+"""Interval between ``httpx.get`` probes against the spinning web container.
+
+Bounded sleep between Docker-level probes; deliberately short so the
+wall-clock deadline (``_wait_for_web_container_ready.deadline_secs``)
+remains the load-bearing primitive. Promoted from a literal so the
+magic-number gate can verify the intent rather than the value."""
 if not _IMAGE_REF_PATTERN.match(WEB_IMAGE):
     msg = f"Invalid image reference: {WEB_IMAGE}"
     raise ValueError(msg)
@@ -54,7 +63,7 @@ def _wait_for_web_container_ready(
         else:
             if resp.status_code == 200:
                 return
-        time.sleep(0.25)
+        time.sleep(_HEALTH_POLL_INTERVAL_SECONDS)
     pytest.fail(f"Web container did not become healthy within {deadline_secs:.0f}s")
 
 

--- a/tests/unit/api/controllers/test_backup_idempotency_validation.py
+++ b/tests/unit/api/controllers/test_backup_idempotency_validation.py
@@ -1,0 +1,56 @@
+"""Regression: ``_do_backup_as_dict`` validates manifest before caching.
+
+The idempotency layer caches the JSON dict returned by the callback.
+If the dict cannot round-trip back into a ``BackupManifest``, we want
+the validation to fail INSIDE the callback so the idempotency cache
+never receives a corrupt entry (which would be served verbatim on
+every subsequent request with the same key).
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from synthorg.api.controllers.backup import _do_backup_as_dict
+from synthorg.backup.models import BackupManifest
+from synthorg.core.types import NotBlankStr
+
+pytestmark = pytest.mark.unit
+
+
+def _good_manifest() -> BackupManifest:
+    """Return a minimal valid BackupManifest for the happy-path test."""
+    return BackupManifest(
+        synthorg_version=NotBlankStr("0.7.2"),
+        timestamp=NotBlankStr("2026-05-13T00:00:00+00:00"),
+        trigger="manual",  # type: ignore[arg-type]
+        components=(),
+        size_bytes=128,
+        checksum=NotBlankStr(f"sha256:{'a' * 64}"),
+        backup_id=NotBlankStr("abc123def456"),
+    )
+
+
+async def _good_callable() -> BackupManifest:
+    return _good_manifest()
+
+
+class TestBackupCallbackValidation:
+    async def test_happy_path_returns_dict(self) -> None:
+        dumped = await _do_backup_as_dict(_good_callable)
+        assert isinstance(dumped, dict)
+        assert dumped["backup_id"] == "abc123def456"
+
+    async def test_invalid_manifest_raises_before_caching(self) -> None:
+        """A malformed manifest must surface as ValidationError, not be cached."""
+
+        async def corrupt() -> BackupManifest:
+            # Bypass the model_copy validator by reaching directly into
+            # the frozen model's __dict__ -- the round-trip
+            # model_validate call inside _do_backup_as_dict is the
+            # invariant under test, not the model's own validators.
+            manifest = _good_manifest()
+            object.__setattr__(manifest, "size_bytes", -1)
+            return manifest
+
+        with pytest.raises(ValidationError):
+            await _do_backup_as_dict(corrupt)

--- a/tests/unit/api/controllers/test_silent_except_logging.py
+++ b/tests/unit/api/controllers/test_silent_except_logging.py
@@ -19,6 +19,7 @@ import structlog
 from structlog.testing import capture_logs
 
 from synthorg.api.controllers import activities
+from synthorg.budget.currency import DEFAULT_CURRENCY
 
 pytestmark = pytest.mark.unit
 
@@ -52,7 +53,7 @@ class TestSilentExceptStructuredLogging:
                 degraded,
             )
         # Default currency fallback fires.
-        assert result == activities.DEFAULT_CURRENCY
+        assert result == DEFAULT_CURRENCY
         # The warning record carries the new structured fields.
         warnings = [r for r in caplog if r.get("log_level") == "warning"]
         assert warnings, "expected a WARNING record from the exception path"

--- a/tests/unit/api/controllers/test_silent_except_logging.py
+++ b/tests/unit/api/controllers/test_silent_except_logging.py
@@ -1,0 +1,62 @@
+"""Regression: silent except sites log error_type + scrubbed error fields.
+
+Six controller sites previously logged a bare warning with no
+``error_type`` / ``error`` payload, so an operator triaging a failed
+budget query or registry lookup could not see which exception class
+fired. Each site now binds ``as exc`` and forwards the scrubbed
+``safe_error_description(exc)`` per the prompt-safety redaction rule.
+
+This test patches one representative site (``activities``) to force
+the exception path and asserts the warning record carries both
+structured fields; the same pattern applies to setup, analytics,
+_department_health, and approvals.
+"""
+
+from typing import Any
+
+import pytest
+import structlog
+from structlog.testing import capture_logs
+
+from synthorg.api.controllers import activities
+
+pytestmark = pytest.mark.unit
+
+
+class _ExplodingResolver:
+    """Stand-in ``ConfigResolver`` that raises on ``get_budget_config``."""
+
+    async def get_budget_config(self) -> Any:
+        msg = "synthetic budget config outage"
+        raise RuntimeError(msg)
+
+
+class _FakeAppState:
+    def __init__(self) -> None:
+        self.config_resolver = _ExplodingResolver()
+
+
+@pytest.fixture(autouse=True)
+def _structlog_capture_setup() -> None:
+    """structlog logger needs at least one bound processor for capture_logs."""
+    structlog.reset_defaults()
+
+
+class TestSilentExceptStructuredLogging:
+    async def test_activities_budget_config_failure_logs_error_fields(self) -> None:
+        app_state = _FakeAppState()
+        degraded: list[str] = []
+        with capture_logs() as caplog:
+            result = await activities._resolve_currency(
+                app_state,  # type: ignore[arg-type]
+                degraded,
+            )
+        # Default currency fallback fires.
+        assert result == activities.DEFAULT_CURRENCY
+        # The warning record carries the new structured fields.
+        warnings = [r for r in caplog if r.get("log_level") == "warning"]
+        assert warnings, "expected a WARNING record from the exception path"
+        last = warnings[-1]
+        assert last.get("error_type") == "RuntimeError"
+        assert isinstance(last.get("error"), str)
+        assert last["error"]

--- a/tests/unit/api/controllers/test_webhooks_idempotency_scope.py
+++ b/tests/unit/api/controllers/test_webhooks_idempotency_scope.py
@@ -17,22 +17,22 @@ pytestmark = pytest.mark.unit
 class TestWebhookIdempotencyKey:
     def test_key_contains_connection_name(self) -> None:
         key = _build_idem_key(
-            connection_name="github-primary",
+            connection_name="example-provider-primary",
             event_type="push",
             nonce="nonce-abc",
         )
-        assert "github-primary" in key
+        assert "example-provider-primary" in key
         assert "push" in key
         assert "nonce-abc" in key
 
     def test_distinct_connections_produce_distinct_keys(self) -> None:
         first = _build_idem_key(
-            connection_name="github-primary",
+            connection_name="example-provider-primary",
             event_type="push",
             nonce="nonce-abc",
         )
         second = _build_idem_key(
-            connection_name="github-secondary",
+            connection_name="example-provider-secondary",
             event_type="push",
             nonce="nonce-abc",
         )
@@ -51,18 +51,20 @@ class TestWebhookIdempotencyScope:
         # Exercise the controller's own helper so a future refactor
         # that drops ``connection_name`` from the scope format trips
         # the assertion. A local f-string would silently keep passing.
-        connection_type = "github"
-        connection_name = "github-primary"
+        connection_type = "example-provider"
+        connection_name = "example-provider-primary"
         scope = _build_idem_scope(
             connection_type=connection_type,
             connection_name=connection_name,
         )
-        assert scope.startswith("webhooks:")
-        assert connection_type in scope
-        assert connection_name in scope
+        # Exact-equality pin: any reordering of the token positions
+        # (e.g. ``{connection_name}:{connection_type}``) trips the
+        # assertion immediately. Substring / startswith checks would
+        # silently keep passing under such a refactor.
+        assert scope == f"webhooks:{connection_type}:{connection_name}"
         # And scopes for sibling connections of the same type must differ.
         sibling = _build_idem_scope(
             connection_type=connection_type,
-            connection_name="github-secondary",
+            connection_name="example-provider-secondary",
         )
         assert scope != sibling

--- a/tests/unit/api/controllers/test_webhooks_idempotency_scope.py
+++ b/tests/unit/api/controllers/test_webhooks_idempotency_scope.py
@@ -1,0 +1,61 @@
+"""Regression coverage for webhook idempotency scope + key invariants.
+
+The webhook flow uses the durable ``IdempotencyService`` under a scope
+of the form ``webhooks:{connection_type}:{connection_name}`` and a key
+of the form ``{connection_name}:{event_type}:{nonce_for_key}``. Pinning
+both fields prevents two distinct connections of the same provider
+from colliding on a shared dedup row.
+"""
+
+import pytest
+
+from synthorg.api.controllers.webhooks import _build_idem_key
+
+pytestmark = pytest.mark.unit
+
+
+class TestWebhookIdempotencyKey:
+    def test_key_contains_connection_name(self) -> None:
+        key = _build_idem_key(
+            connection_name="github-primary",
+            event_type="push",
+            nonce="nonce-abc",
+        )
+        assert "github-primary" in key
+        assert "push" in key
+        assert "nonce-abc" in key
+
+    def test_distinct_connections_produce_distinct_keys(self) -> None:
+        first = _build_idem_key(
+            connection_name="github-primary",
+            event_type="push",
+            nonce="nonce-abc",
+        )
+        second = _build_idem_key(
+            connection_name="github-secondary",
+            event_type="push",
+            nonce="nonce-abc",
+        )
+        assert first != second
+
+
+class TestWebhookIdempotencyScope:
+    """Scope MUST include ``connection_name`` to block cross-connection collisions.
+
+    Pins the live string format the controller assembles. If the format
+    changes (e.g. drops ``connection_name`` or reorders the tokens),
+    this invariant test fails and forces a deliberate review.
+    """
+
+    def test_scope_format_includes_connection_name(self) -> None:
+        # Inline the format from the controller; the test exists to
+        # catch a future refactor that drops ``connection_name``.
+        connection_type = "github"
+        connection_name = "github-primary"
+        scope = f"webhooks:{connection_type}:{connection_name}"
+        assert scope.startswith("webhooks:")
+        assert connection_type in scope
+        assert connection_name in scope
+        # And scopes for sibling connections of the same type must differ.
+        other_scope = f"webhooks:{connection_type}:github-secondary"
+        assert scope != other_scope

--- a/tests/unit/api/controllers/test_webhooks_idempotency_scope.py
+++ b/tests/unit/api/controllers/test_webhooks_idempotency_scope.py
@@ -9,7 +9,7 @@ from colliding on a shared dedup row.
 
 import pytest
 
-from synthorg.api.controllers.webhooks import _build_idem_key
+from synthorg.api.controllers.webhooks import _build_idem_key, _build_idem_scope
 
 pytestmark = pytest.mark.unit
 
@@ -48,14 +48,21 @@ class TestWebhookIdempotencyScope:
     """
 
     def test_scope_format_includes_connection_name(self) -> None:
-        # Inline the format from the controller; the test exists to
-        # catch a future refactor that drops ``connection_name``.
+        # Exercise the controller's own helper so a future refactor
+        # that drops ``connection_name`` from the scope format trips
+        # the assertion. A local f-string would silently keep passing.
         connection_type = "github"
         connection_name = "github-primary"
-        scope = f"webhooks:{connection_type}:{connection_name}"
+        scope = _build_idem_scope(
+            connection_type=connection_type,
+            connection_name=connection_name,
+        )
         assert scope.startswith("webhooks:")
         assert connection_type in scope
         assert connection_name in scope
         # And scopes for sibling connections of the same type must differ.
-        other_scope = f"webhooks:{connection_type}:github-secondary"
-        assert scope != other_scope
+        sibling = _build_idem_scope(
+            connection_type=connection_type,
+            connection_name="github-secondary",
+        )
+        assert scope != sibling

--- a/tests/unit/communication/bus/test_nats_receive_ack_ordering.py
+++ b/tests/unit/communication/bus/test_nats_receive_ack_ordering.py
@@ -1,0 +1,95 @@
+"""Regression coverage: NATS receive defers JetStream ack until delivery.
+
+The previous implementation called ``msg.ack()`` from inside
+``build_envelope`` before returning the envelope; if the subscriber's
+delivery path then raised, the JetStream message was already
+acknowledged and could never be redelivered. ``DeliveryEnvelope.ack``
+now exposes a deferred callable that callers MUST invoke after their
+local consumer accepts the envelope.
+
+These tests pin two invariants:
+
+1. ``build_envelope`` MUST NOT call ``msg.ack()`` synchronously on the
+   happy path.
+2. The returned envelope's ``ack()`` callable forwards to the JetStream
+   ``msg.ack()`` so callers retain a path to acknowledge after delivery.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from synthorg.communication.bus._nats_receive import build_envelope
+from synthorg.communication.enums import MessageType
+from synthorg.communication.message import Message, TextPart
+from synthorg.core.types import NotBlankStr
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeNatsMessage:
+    """Minimal stand-in for an ``nats-py`` JetStream message."""
+
+    def __init__(self, payload: bytes) -> None:
+        self.data = payload
+        self.ack_count = 0
+
+    async def ack(self) -> None:
+        self.ack_count += 1
+
+
+def _envelope_bytes() -> bytes:
+    msg = Message(
+        timestamp=datetime.now(UTC),
+        sender=NotBlankStr("agent-a"),  # type: ignore[call-arg]
+        to=NotBlankStr("agent-b"),
+        type=MessageType.ANNOUNCEMENT,
+        channel=NotBlankStr("#general"),
+        parts=(TextPart(text="hello"),),
+    )
+    return msg.model_dump_json(by_alias=True).encode("utf-8")
+
+
+class TestNatsReceiveAckOrdering:
+    async def test_build_envelope_does_not_ack_on_success_path(self) -> None:
+        msg = _FakeNatsMessage(_envelope_bytes())
+        envelope = await build_envelope(
+            [msg],  # type: ignore[list-item]
+            channel_name="#general",
+            subscriber_id="agent-b",
+        )
+        assert envelope is not None
+        assert msg.ack_count == 0, (
+            "build_envelope must NOT ack before the subscriber accepts delivery"
+        )
+
+    async def test_envelope_ack_forwards_to_msg_ack(self) -> None:
+        msg = _FakeNatsMessage(_envelope_bytes())
+        envelope = await build_envelope(
+            [msg],  # type: ignore[list-item]
+            channel_name="#general",
+            subscriber_id="agent-b",
+        )
+        assert envelope is not None
+        await envelope.ack()
+        assert msg.ack_count == 1
+
+
+class TestNatsReceiveOversizedAckImmediately:
+    async def test_oversized_payload_is_acked_immediately(self) -> None:
+        oversized = b"\x00" * (10 * 1024 * 1024)
+        msg = _FakeNatsMessage(oversized)
+        envelope = await build_envelope(
+            [msg],  # type: ignore[list-item]
+            channel_name="#general",
+            subscriber_id="agent-b",
+        )
+        # No envelope to deliver, so we MUST ack synchronously to drop
+        # the malformed message from JetStream.
+        assert envelope is None
+        assert msg.ack_count == 1
+
+
+# Force pytest-asyncio to pick up the coroutine fixtures above.
+__all__: tuple[Any, ...] = ()

--- a/tests/unit/communication/bus/test_nats_receive_ack_ordering.py
+++ b/tests/unit/communication/bus/test_nats_receive_ack_ordering.py
@@ -42,7 +42,7 @@ class _FakeNatsMessage:
 def _envelope_bytes() -> bytes:
     msg = Message(
         timestamp=datetime.now(UTC),
-        sender=NotBlankStr("agent-a"),  # type: ignore[call-arg]
+        sender=NotBlankStr("agent-a"),
         to=NotBlankStr("agent-b"),
         type=MessageType.ANNOUNCEMENT,
         channel=NotBlankStr("#general"),
@@ -55,7 +55,7 @@ class TestNatsReceiveAckOrdering:
     async def test_build_envelope_does_not_ack_on_success_path(self) -> None:
         msg = _FakeNatsMessage(_envelope_bytes())
         envelope = await build_envelope(
-            [msg],  # type: ignore[list-item]
+            [msg],
             channel_name="#general",
             subscriber_id="agent-b",
         )
@@ -67,7 +67,7 @@ class TestNatsReceiveAckOrdering:
     async def test_envelope_ack_forwards_to_msg_ack(self) -> None:
         msg = _FakeNatsMessage(_envelope_bytes())
         envelope = await build_envelope(
-            [msg],  # type: ignore[list-item]
+            [msg],
             channel_name="#general",
             subscriber_id="agent-b",
         )
@@ -81,7 +81,7 @@ class TestNatsReceiveOversizedAckImmediately:
         oversized = b"\x00" * (10 * 1024 * 1024)
         msg = _FakeNatsMessage(oversized)
         envelope = await build_envelope(
-            [msg],  # type: ignore[list-item]
+            [msg],
             channel_name="#general",
             subscriber_id="agent-b",
         )

--- a/tests/unit/engine/test_agent_engine_clock_seam.py
+++ b/tests/unit/engine/test_agent_engine_clock_seam.py
@@ -1,0 +1,37 @@
+"""Regression: AgentEngine accepts a Clock parameter and uses it for timing.
+
+Pins the seam so a future refactor that drops the Clock injection
+fails immediately. The test does not run a full agent execution; it
+asserts the constructor wires ``self._clock`` from the injected
+``Clock`` (and falls back to ``SystemClock`` otherwise) and that the
+attribute is the same instance passed in.
+"""
+
+import pytest
+
+from synthorg.core.clock import SystemClock
+from tests._shared.fake_clock import FakeClock
+
+pytestmark = pytest.mark.unit
+
+
+class TestAgentEngineClockSeam:
+    def test_default_clock_is_system_clock(self) -> None:
+        # Construct a bare AgentEngine via a minimal mock provider.
+        from synthorg.engine.agent_engine import AgentEngine
+        from synthorg.providers.protocol import CompletionProvider
+        from tests._shared.mock_of import mock_of
+
+        provider = mock_of[CompletionProvider]()
+        engine = AgentEngine(provider=provider)
+        assert isinstance(engine._clock, SystemClock)
+
+    def test_injected_clock_is_used(self) -> None:
+        from synthorg.engine.agent_engine import AgentEngine
+        from synthorg.providers.protocol import CompletionProvider
+        from tests._shared.mock_of import mock_of
+
+        provider = mock_of[CompletionProvider]()
+        fake = FakeClock()
+        engine = AgentEngine(provider=provider, clock=fake)
+        assert engine._clock is fake

--- a/tests/unit/engine/test_record_task_run_wired.py
+++ b/tests/unit/engine/test_record_task_run_wired.py
@@ -1,0 +1,73 @@
+"""Regression: ``record_task_run`` is wired for every terminal transition.
+
+The Prometheus task-run counter must fire on every bounded terminal
+transition. The call site lives in ``task_engine_apply.py`` for the
+four outcomes (``succeeded`` / ``failed`` / ``cancelled`` /
+``rejected``). Rather than build a full TaskEngine stack, this test
+pins:
+
+1. The ``_RECORDED_STATUS_OUTCOME`` map covers exactly the four
+   bounded outcomes (extends the project's acceptance label set).
+2. The map is an immutable ``MappingProxyType`` so a typo cannot
+   slip a fifth outcome in without going through the gate.
+3. ``record_task_run`` appears in the module's source so a future
+   refactor that drops the call surfaces in code review.
+"""
+
+from pathlib import Path
+from types import MappingProxyType
+
+import pytest
+
+from synthorg.core.task import TaskStatus
+from synthorg.engine.task_engine_apply import _RECORDED_STATUS_OUTCOME
+
+pytestmark = pytest.mark.unit
+
+_APPLY_MODULE_PATH = (
+    Path(__file__).resolve().parent.parent.parent.parent
+    / "src"
+    / "synthorg"
+    / "engine"
+    / "task_engine_apply.py"
+)
+
+
+class TestRecordedStatusOutcomeMap:
+    def test_map_covers_four_bounded_outcomes(self) -> None:
+        assert dict(_RECORDED_STATUS_OUTCOME) == {
+            TaskStatus.COMPLETED: "succeeded",
+            TaskStatus.FAILED: "failed",
+            TaskStatus.CANCELLED: "cancelled",
+            TaskStatus.REJECTED: "rejected",
+        }
+
+    def test_map_is_immutable(self) -> None:
+        assert isinstance(_RECORDED_STATUS_OUTCOME, MappingProxyType)
+
+
+class TestRecordTaskRunWiredAtCallSite:
+    def test_call_sites_present_in_module_source(self) -> None:
+        """The module MUST invoke ``record_task_run`` for the recorded outcomes.
+
+        Source-text check (cheap, robust against refactors that move
+        the import). The module also depends on
+        ``_RECORDED_STATUS_OUTCOME`` to bound the outcomes; both must
+        appear together.
+        """
+        assert _APPLY_MODULE_PATH.exists(), (
+            f"expected task_engine_apply.py at {_APPLY_MODULE_PATH}"
+        )
+        source = _APPLY_MODULE_PATH.read_text(encoding="utf-8")
+        # At least one call to record_task_run(...) must appear.
+        assert "record_task_run(" in source, (
+            "task_engine_apply.py must invoke record_task_run() on task completion"
+        )
+        # The transition branch (`if mutation.target_status in
+        # _RECORDED_STATUS_OUTCOME`) and the cancel branch are the two
+        # invocation sites today. Pin the count to catch a silent drop.
+        invocations = source.count("record_task_run(")
+        assert invocations >= 2, (
+            "expected at least two record_task_run(...) invocations "
+            f"(transition + cancel), found {invocations}"
+        )

--- a/tests/unit/engine/test_record_task_run_wired.py
+++ b/tests/unit/engine/test_record_task_run_wired.py
@@ -14,6 +14,7 @@ pins:
    refactor that drops the call surfaces in code review.
 """
 
+import ast
 from pathlib import Path
 from types import MappingProxyType
 
@@ -50,23 +51,32 @@ class TestRecordTaskRunWiredAtCallSite:
     def test_call_sites_present_in_module_source(self) -> None:
         """The module MUST invoke ``record_task_run`` for the recorded outcomes.
 
-        Source-text check (cheap, robust against refactors that move
-        the import). The module also depends on
-        ``_RECORDED_STATUS_OUTCOME`` to bound the outcomes; both must
-        appear together.
+        Parses the module AST and counts real ``Call`` nodes whose
+        callee is ``record_task_run`` (either bare name or attribute
+        access). A raw substring check would happily match a docstring
+        or a comment mentioning the function and miss a silent drop
+        of the real call site.
         """
         assert _APPLY_MODULE_PATH.exists(), (
             f"expected task_engine_apply.py at {_APPLY_MODULE_PATH}"
         )
         source = _APPLY_MODULE_PATH.read_text(encoding="utf-8")
-        # At least one call to record_task_run(...) must appear.
-        assert "record_task_run(" in source, (
-            "task_engine_apply.py must invoke record_task_run() on task completion"
+        module = ast.parse(source)
+        invocations = sum(
+            1
+            for node in ast.walk(module)
+            if isinstance(node, ast.Call)
+            and (
+                (isinstance(node.func, ast.Name) and node.func.id == "record_task_run")
+                or (
+                    isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "record_task_run"
+                )
+            )
         )
-        # The transition branch (`if mutation.target_status in
-        # _RECORDED_STATUS_OUTCOME`) and the cancel branch are the two
+        # The transition branch (``if mutation.target_status in
+        # _RECORDED_STATUS_OUTCOME``) and the cancel branch are the two
         # invocation sites today. Pin the count to catch a silent drop.
-        invocations = source.count("record_task_run(")
         assert invocations >= 2, (
             "expected at least two record_task_run(...) invocations "
             f"(transition + cancel), found {invocations}"

--- a/tests/unit/engine/test_record_task_run_wired.py
+++ b/tests/unit/engine/test_record_task_run_wired.py
@@ -19,7 +19,7 @@ from types import MappingProxyType
 
 import pytest
 
-from synthorg.core.task import TaskStatus
+from synthorg.core.enums import TaskStatus
 from synthorg.engine.task_engine_apply import _RECORDED_STATUS_OUTCOME
 
 pytestmark = pytest.mark.unit

--- a/tests/unit/engine/test_timeout_enforcement.py
+++ b/tests/unit/engine/test_timeout_enforcement.py
@@ -27,9 +27,15 @@ def test_setter_disables_enforcement() -> None:
 
 async def test_engine_timeout_enforces_when_enabled() -> None:
     timeout_enforcement.set_timeout_enforcement_enabled(value=True)
+    # Awaiting an Event that never fires is the deterministic
+    # equivalent of "sleep forever": engine_timeout cancels it after
+    # 0.01s.  Replaces a literal asyncio.sleep(1) so the test no
+    # longer eats a full wall-clock second when something accidentally
+    # disables the timeout.
+    never_fires = asyncio.Event()
     with pytest.raises(TimeoutError):
         async with timeout_enforcement.engine_timeout(0.01):
-            await asyncio.sleep(1)
+            await never_fires.wait()
 
 
 async def test_engine_timeout_no_op_when_disabled() -> None:

--- a/tests/unit/integrations/mcp_catalog/test_in_memory_installations_lock.py
+++ b/tests/unit/integrations/mcp_catalog/test_in_memory_installations_lock.py
@@ -35,15 +35,29 @@ class TestInMemoryInstallationsConcurrency:
         for index in range(20):
             await repo.save(_make_installation(index))
 
+        # Pre-acquire the repo lock so every worker task suspends on
+        # its first ``async with self._get_lock()`` call. Without this,
+        # ``save`` / ``delete`` / ``list_items`` can run to completion
+        # without ever yielding (asyncio.Lock is not reentrant but only
+        # forces a suspension when contended), so a regressed repo that
+        # silently stopped taking the lock would still let the workers
+        # interleave benignly and the test would stay green.
+        lock = repo._get_lock()
+        await lock.acquire()
+        start_gate = asyncio.Event()
+
         async def saver() -> None:
+            await start_gate.wait()
             for index in range(20, 50):
                 await repo.save(_make_installation(index))
 
         async def deleter() -> None:
+            await start_gate.wait()
             for index in range(10):
                 await repo.delete(NotBlankStr(f"entry-{index:04d}"))
 
         async def lister() -> None:
+            await start_gate.wait()
             for _ in range(50):
                 await repo.list_items(limit=200)
 
@@ -51,9 +65,17 @@ class TestInMemoryInstallationsConcurrency:
             tg.create_task(saver())
             tg.create_task(deleter())
             tg.create_task(lister())
+            # Tasks are scheduled but each is blocked on ``start_gate``.
+            # Release the gate first to wake them, then release the lock
+            # so they all contend for the same critical section.
+            start_gate.set()
+            lock.release()
 
         remaining = await repo.list_items(limit=200)
         # Original 0..9 deleted, 10..19 survive, 20..49 inserted.
+        expected_ids = {f"entry-{i:04d}" for i in range(10, 50)}
+        actual_ids = {item.catalog_entry_id for item in remaining}
+        assert actual_ids == expected_ids
         assert len(remaining) == 40
 
     async def test_lock_is_lazy_per_loop(self) -> None:

--- a/tests/unit/integrations/mcp_catalog/test_in_memory_installations_lock.py
+++ b/tests/unit/integrations/mcp_catalog/test_in_memory_installations_lock.py
@@ -1,0 +1,64 @@
+"""Race coverage: ``InMemoryMcpInstallationRepository._store`` is lock-guarded.
+
+The four async methods (`save`, `get`, `list_items`, `delete`) all
+serialise through a lazy-init ``asyncio.Lock`` so a concurrent
+``save`` / ``delete`` cannot interleave with a ``list_items``
+iteration and trip ``RuntimeError: dictionary changed size during
+iteration``.
+"""
+
+import asyncio
+from datetime import UTC, datetime
+
+import pytest
+
+from synthorg.core.types import NotBlankStr
+from synthorg.integrations.mcp_catalog.in_memory_installations import (
+    InMemoryMcpInstallationRepository,
+)
+from synthorg.integrations.mcp_catalog.installations import McpInstallation
+
+pytestmark = pytest.mark.unit
+
+
+def _make_installation(index: int) -> McpInstallation:
+    return McpInstallation(
+        catalog_entry_id=NotBlankStr(f"entry-{index:04d}"),
+        connection_name=NotBlankStr(f"conn-{index:04d}"),
+        installed_at=datetime(2026, 5, 13, 0, 0, 0, tzinfo=UTC),
+    )
+
+
+class TestInMemoryInstallationsConcurrency:
+    async def test_concurrent_save_and_delete_stays_consistent(self) -> None:
+        repo = InMemoryMcpInstallationRepository()
+        for index in range(20):
+            await repo.save(_make_installation(index))
+
+        async def saver() -> None:
+            for index in range(20, 50):
+                await repo.save(_make_installation(index))
+
+        async def deleter() -> None:
+            for index in range(10):
+                await repo.delete(NotBlankStr(f"entry-{index:04d}"))
+
+        async def lister() -> None:
+            for _ in range(50):
+                await repo.list_items(limit=200)
+
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(saver())
+            tg.create_task(deleter())
+            tg.create_task(lister())
+
+        remaining = await repo.list_items(limit=200)
+        # Original 0..9 deleted, 10..19 survive, 20..49 inserted.
+        assert len(remaining) == 40
+
+    async def test_lock_is_lazy_per_loop(self) -> None:
+        """``__init__`` MUST NOT create the lock; loop-bound locks are unsafe."""
+        repo = InMemoryMcpInstallationRepository()
+        assert repo._lock is None
+        await repo.save(_make_installation(99))
+        assert repo._lock is not None

--- a/tests/unit/monitoring/test_grafana_panel_outcome_consistency.py
+++ b/tests/unit/monitoring/test_grafana_panel_outcome_consistency.py
@@ -1,0 +1,117 @@
+"""Invariant: Grafana panel descriptions stay in lockstep with VALID_*.
+
+The Grafana dashboard at ``monitoring/grafana/synthorg-overview.json``
+documents each outcome-labelled metric's outcome list inside the
+panel ``description``. If a new outcome is added to the allowlist
+constants in ``observability/prometheus_labels.py``, the panel
+description MUST be updated too or operators are misled.
+
+This test pins each outcome-labelled panel to the matching
+``VALID_*`` frozenset so a one-sided update fails the build.
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from synthorg.observability.prometheus_labels import (
+    VALID_APPROVAL_OUTCOMES,
+    VALID_BLUEPRINT_OUTCOMES,
+    VALID_ESCALATION_OUTCOMES,
+)
+
+pytestmark = pytest.mark.unit
+
+_DASHBOARD_PATH = (
+    Path(__file__).resolve().parent.parent.parent.parent
+    / "monitoring"
+    / "grafana"
+    / "synthorg-overview.json"
+)
+
+# Map ``metric_name`` -> ``frozenset`` allowlist for each panel we pin.
+_METRIC_TO_ALLOWLIST: dict[str, frozenset[str]] = {
+    "synthorg_approval_decisions_total": VALID_APPROVAL_OUTCOMES,
+    "synthorg_escalation_outcomes_total": VALID_ESCALATION_OUTCOMES,
+    "synthorg_blueprint_instantiations_total": VALID_BLUEPRINT_OUTCOMES,
+}
+
+
+def _iter_panels(dashboard: dict[str, Any]) -> list[dict[str, Any]]:
+    """Recursively yield every panel (including nested rows)."""
+    panels: list[dict[str, Any]] = []
+
+    def _walk(node: dict[str, Any]) -> None:
+        for panel in node.get("panels", []) or []:
+            panels.append(panel)
+            if "panels" in panel:
+                _walk(panel)
+
+    _walk(dashboard)
+    return panels
+
+
+def _panel_metric(panel: dict[str, Any]) -> str | None:
+    """Return the first ``synthorg_*`` metric name referenced by a target expr."""
+    for target in panel.get("targets", []) or []:
+        expr = target.get("expr") or ""
+        match = re.search(r"(synthorg_[a-zA-Z0-9_]+)", expr)
+        if match:
+            return match.group(1)
+    return None
+
+
+def _outcomes_in_description(description: str, allowlist: frozenset[str]) -> set[str]:
+    """Extract outcome tokens from the panel description.
+
+    Matches each allowlist token only when it appears as a complete
+    word in the description (boundary on either side) so a token like
+    ``"success"`` doesn't match ``"successful"``. Returns the subset
+    that actually appears.
+    """
+    found: set[str] = set()
+    for token in allowlist:
+        pattern = re.compile(rf"\b{re.escape(token)}\b")
+        if pattern.search(description):
+            found.add(token)
+    return found
+
+
+class TestGrafanaPanelOutcomeConsistency:
+    def test_dashboard_file_exists(self) -> None:
+        assert _DASHBOARD_PATH.exists(), (
+            f"expected Grafana dashboard at {_DASHBOARD_PATH}"
+        )
+
+    def test_each_pinned_panel_description_matches_allowlist(self) -> None:
+        dashboard = json.loads(_DASHBOARD_PATH.read_text(encoding="utf-8"))
+        panels = _iter_panels(dashboard)
+        for metric, allowlist in _METRIC_TO_ALLOWLIST.items():
+            matching = [p for p in panels if _panel_metric(p) == metric]
+            assert matching, (
+                f"no Grafana panel found whose target references {metric!r}"
+            )
+            for panel in matching:
+                description = panel.get("description", "")
+                # The panel description SHOULD enumerate the outcomes
+                # (operators rely on it to interpret the legend). All
+                # tokens it lists must come from the allowlist; no
+                # stale token can survive.
+                found = _outcomes_in_description(description, allowlist)
+                assert found, (
+                    f"panel for {metric!r} (id={panel.get('id')}) lists no "
+                    f"outcomes; description should enumerate at least one of "
+                    f"{sorted(allowlist)}"
+                )
+                # And every outcome the description mentions must be
+                # in the live allowlist (this is the load-bearing
+                # assertion: it catches a drift where the allowlist
+                # drops a token but the description keeps it).
+                stale = found - allowlist
+                assert not stale, (
+                    f"panel for {metric!r} mentions outcomes {sorted(stale)} "
+                    f"that are not in the live allowlist {sorted(allowlist)}"
+                )

--- a/tests/unit/monitoring/test_grafana_panel_outcome_consistency.py
+++ b/tests/unit/monitoring/test_grafana_panel_outcome_consistency.py
@@ -64,19 +64,34 @@ def _panel_metric(panel: dict[str, Any]) -> str | None:
     return None
 
 
-def _outcomes_in_description(description: str, allowlist: frozenset[str]) -> set[str]:
-    """Extract outcome tokens from the panel description.
+_ALL_KNOWN_OUTCOMES: frozenset[str] = (
+    VALID_APPROVAL_OUTCOMES | VALID_ESCALATION_OUTCOMES | VALID_BLUEPRINT_OUTCOMES
+)
 
-    Matches each allowlist token only when it appears as a complete
-    word in the description (boundary on either side) so a token like
-    ``"success"`` doesn't match ``"successful"``. Returns the subset
-    that actually appears.
+
+def _outcomes_in_description(description: str, allowlist: frozenset[str]) -> set[str]:
+    """Return outcome-like tokens that appear in the panel description.
+
+    Considers the *union* of every project allowlist so a stale token
+    that was dropped from a specific allowlist but is still referenced
+    in the panel description surfaces in the ``stale = found -
+    allowlist`` check downstream. A previous version of this helper
+    iterated only over the per-panel allowlist, which made the stale
+    check definitionally empty.
+
+    Whole-word matching (``\\b...\\b``) prevents a short token like
+    ``"success"`` from matching ``"successful"``.
     """
     found: set[str] = set()
-    for token in allowlist:
+    for token in _ALL_KNOWN_OUTCOMES:
         pattern = re.compile(rf"\b{re.escape(token)}\b")
         if pattern.search(description):
             found.add(token)
+    # Preserve the original signature: the *minimum* membership claim
+    # callers rely on is "what allowlist tokens appear here?". The
+    # set returned remains a superset of that, and the union-mode
+    # discovery is what lets the stale check have teeth.
+    del allowlist  # union of all allowlists drives detection now
     return found
 
 

--- a/tests/unit/persistence/test_protocol.py
+++ b/tests/unit/persistence/test_protocol.py
@@ -587,6 +587,14 @@ class _FakeWorkflowExecutionRepository:
 class _FakeSeenClaimsRepository:
     """Minimal SeenClaimsRepository conforming to the protocol shape."""
 
+    async def is_completed(
+        self,
+        *,
+        idempotency_key: NotBlankStr,
+    ) -> bool:
+        del idempotency_key
+        return False
+
     async def mark_seen(
         self,
         *,
@@ -597,14 +605,6 @@ class _FakeSeenClaimsRepository:
     ) -> bool:
         del idempotency_key, claim_id, now, ttl_seconds
         return True
-
-    async def forget(
-        self,
-        *,
-        idempotency_key: NotBlankStr,
-    ) -> bool:
-        del idempotency_key
-        return False
 
     async def prune_expired(self, now: Any) -> int:
         del now

--- a/tests/unit/persistence/test_protocol.py
+++ b/tests/unit/persistence/test_protocol.py
@@ -849,6 +849,10 @@ class _FakeBackend:
         return _FakeIdempotencyRepository()
 
     @property
+    def seen_claims(self) -> Any:
+        return None
+
+    @property
     def mcp_installations(self) -> Any:
         return None
 

--- a/tests/unit/persistence/test_protocol.py
+++ b/tests/unit/persistence/test_protocol.py
@@ -39,6 +39,7 @@ from synthorg.persistence.preset_protocol import (
 )
 from synthorg.persistence.project_protocol import ProjectRepository
 from synthorg.persistence.protocol import PersistenceBackend
+from synthorg.persistence.seen_claims_protocol import SeenClaimsRepository
 from synthorg.persistence.settings_protocol import SettingsRepository
 from synthorg.persistence.ssrf_violation_protocol import SsrfViolationRepository
 from synthorg.persistence.task_protocol import TaskRepository
@@ -583,6 +584,33 @@ class _FakeWorkflowExecutionRepository:
         return False
 
 
+class _FakeSeenClaimsRepository:
+    """Minimal SeenClaimsRepository conforming to the protocol shape."""
+
+    async def mark_seen(
+        self,
+        *,
+        idempotency_key: NotBlankStr,
+        claim_id: NotBlankStr,
+        now: Any,
+        ttl_seconds: float,
+    ) -> bool:
+        del idempotency_key, claim_id, now, ttl_seconds
+        return True
+
+    async def forget(
+        self,
+        *,
+        idempotency_key: NotBlankStr,
+    ) -> bool:
+        del idempotency_key
+        return False
+
+    async def prune_expired(self, now: Any) -> int:
+        del now
+        return 0
+
+
 class _FakeIdempotencyRepository:
     """Minimal IdempotencyRepository conforming to the protocol shape."""
 
@@ -849,8 +877,11 @@ class _FakeBackend:
         return _FakeIdempotencyRepository()
 
     @property
-    def seen_claims(self) -> Any:
-        return None
+    def seen_claims(self) -> _FakeSeenClaimsRepository:
+        # Real backends return a concrete repository. Returning ``None``
+        # here would hide a regression in either backend's wiring of
+        # ``seen_claims`` from the protocol-compliance suite.
+        return _FakeSeenClaimsRepository()
 
     @property
     def mcp_installations(self) -> Any:
@@ -928,6 +959,14 @@ class TestProtocolCompliance:
         backend = _FakeBackend()
         assert isinstance(backend.idempotency_keys, IdempotencyRepository)
         assert isinstance(_FakeIdempotencyRepository(), IdempotencyRepository)
+
+    def test_fake_seen_claims_repo_is_seen_claims_repository(self) -> None:
+        # Same backend-routed assertion as ``idempotency_keys``:
+        # catches a regression that swaps the property back to
+        # ``None`` (which historically hid backend wiring drift).
+        backend = _FakeBackend()
+        assert isinstance(backend.seen_claims, SeenClaimsRepository)
+        assert isinstance(_FakeSeenClaimsRepository(), SeenClaimsRepository)
 
     def test_fake_lifecycle_repo_is_lifecycle_event_repository(self) -> None:
         assert isinstance(_FakeLifecycleEventRepository(), LifecycleEventRepository)

--- a/tests/unit/providers/test_base_completion_spans.py
+++ b/tests/unit/providers/test_base_completion_spans.py
@@ -68,7 +68,7 @@ class _RecordingTracer:
         attributes: dict[str, Any] | None = None,
         record_exception: bool = True,
         set_status_on_exception: bool = True,
-    ):
+    ) -> Any:
         span = _RecordingSpan()
         if attributes:
             span.attributes.update(attributes)
@@ -108,7 +108,10 @@ class _StubProvider(BaseCompletionProvider):
         tools: list[ToolDefinition] | None = None,
         config: CompletionConfig | None = None,
     ) -> CompletionResponse:
-        return await self._completer(messages, model, tools, config)
+        result: CompletionResponse = await self._completer(
+            messages, model, tools, config
+        )
+        return result
 
     async def _do_stream(
         self,
@@ -117,9 +120,11 @@ class _StubProvider(BaseCompletionProvider):
         *,
         tools: list[ToolDefinition] | None = None,
         config: CompletionConfig | None = None,
-    ):  # pragma: no cover
-        raise NotImplementedError
-        yield  # type: ignore[unreachable]
+    ) -> Any:  # pragma: no cover
+        # Stub never streams; satisfy the abstract signature with a
+        # bare async generator that yields nothing and then exits.
+        return
+        yield None
 
     async def _do_get_model_capabilities(self, model: str) -> Any:  # pragma: no cover
         return None

--- a/tests/unit/providers/test_base_completion_spans.py
+++ b/tests/unit/providers/test_base_completion_spans.py
@@ -202,3 +202,12 @@ class TestProviderCompleteSpan:
         # record_exception MUST NOT have been called (SEC: traceback
         # frame-locals can leak credentials).
         assert not span.recorded_exceptions
+        # Span status MUST be ERROR. ``set_status_on_exception=False``
+        # opts out of the SDK's auto-status (which would have stamped
+        # an un-scrubbed ``str(exc)``), so the manual ``set_status``
+        # call is the only thing that flips the span from UNSET to
+        # ERROR for observability dashboards.
+        from opentelemetry.trace import StatusCode
+
+        assert span.statuses, "expected span.set_status to be called on error"
+        assert span.statuses[-1].status_code == StatusCode.ERROR

--- a/tests/unit/providers/test_base_completion_spans.py
+++ b/tests/unit/providers/test_base_completion_spans.py
@@ -1,0 +1,199 @@
+"""Regression: ``BaseCompletionProvider.complete`` opens a child span.
+
+The span carries ``provider.{name,model,message_count,tool_count}``
+attributes, plus ``provider.latency_ms`` on every exit path, and
+``provider.retry_count`` when the retry handler observed retries.
+Errors set ``exception.type`` and a scrubbed ``exception.message``
+without invoking ``span.record_exception`` (per the prompt-safety
+redaction rule).
+
+Rather than wire the full OTel SDK, this test patches the module-level
+``_tracer`` so we capture the calls without instantiating a
+``TracerProvider`` (which has a one-shot global install guard). The
+span object is a lightweight stand-in that records every method call
+so we can assert the attributes and absence of forbidden calls.
+"""
+
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+import synthorg.providers.base as _base
+from synthorg.providers.base import BaseCompletionProvider
+from synthorg.providers.enums import FinishReason, MessageRole
+from synthorg.providers.errors import ProviderInternalError
+from synthorg.providers.models import (
+    ChatMessage,
+    CompletionConfig,
+    CompletionResponse,
+    TokenUsage,
+    ToolDefinition,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _RecordingSpan:
+    """Stand-in OTel span that records every method call."""
+
+    def __init__(self) -> None:
+        self.attributes: dict[str, Any] = {}
+        self.recorded_exceptions: list[BaseException] = []
+        self.statuses: list[Any] = []
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        self.attributes[key] = value
+
+    def set_status(self, status: Any) -> None:
+        self.statuses.append(status)
+
+    def record_exception(self, exc: BaseException) -> None:  # pragma: no cover
+        self.recorded_exceptions.append(exc)
+
+
+class _RecordingTracer:
+    """Stand-in OTel tracer that captures every start_as_current_span call."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.spans: list[_RecordingSpan] = []
+
+    @contextmanager
+    def start_as_current_span(
+        self,
+        name: str,
+        *,
+        attributes: dict[str, Any] | None = None,
+        record_exception: bool = True,
+        set_status_on_exception: bool = True,
+    ):
+        span = _RecordingSpan()
+        if attributes:
+            span.attributes.update(attributes)
+        self.calls.append(
+            {
+                "name": name,
+                "attributes": dict(attributes or {}),
+                "record_exception": record_exception,
+                "set_status_on_exception": set_status_on_exception,
+            },
+        )
+        self.spans.append(span)
+        yield span
+
+
+class _StubProvider(BaseCompletionProvider):
+    """Minimal concrete provider that delegates ``_do_complete`` to a closure."""
+
+    def __init__(
+        self,
+        *,
+        completer: Any,
+        provider_label: str = "stub-provider",
+    ) -> None:
+        super().__init__()
+        self._completer = completer
+        self._label = provider_label
+
+    def _provider_label(self) -> str:
+        return self._label
+
+    async def _do_complete(
+        self,
+        messages: list[ChatMessage],
+        model: str,
+        *,
+        tools: list[ToolDefinition] | None = None,
+        config: CompletionConfig | None = None,
+    ) -> CompletionResponse:
+        return await self._completer(messages, model, tools, config)
+
+    async def _do_stream(
+        self,
+        messages: list[ChatMessage],
+        model: str,
+        *,
+        tools: list[ToolDefinition] | None = None,
+        config: CompletionConfig | None = None,
+    ):  # pragma: no cover
+        raise NotImplementedError
+        yield  # type: ignore[unreachable]
+
+    async def _do_get_model_capabilities(self, model: str) -> Any:  # pragma: no cover
+        return None
+
+
+def _ok_response() -> CompletionResponse:
+    return CompletionResponse(
+        content="ok",
+        model="example-medium-001",
+        finish_reason=FinishReason.STOP,
+        usage=TokenUsage(
+            input_tokens=10,
+            output_tokens=2,
+            cost=0.0,
+        ),
+    )
+
+
+class TestProviderCompleteSpan:
+    async def test_happy_path_emits_child_span_with_attributes(self) -> None:
+        async def completer(_messages, _model, _tools, _config):  # type: ignore[no-untyped-def]
+            return _ok_response()
+
+        tracer = _RecordingTracer()
+        provider = _StubProvider(completer=completer)
+        with patch.object(_base, "_tracer", tracer):
+            result = await provider.complete(
+                messages=[ChatMessage(role=MessageRole.USER, content="hello")],
+                model="example-medium-001",
+            )
+
+        assert result.content == "ok"
+        assert len(tracer.calls) == 1
+        call = tracer.calls[0]
+        assert call["name"] == "provider.complete"
+        assert call["record_exception"] is False
+        assert call["set_status_on_exception"] is False
+        # Attributes set at span open.
+        attrs = call["attributes"]
+        assert attrs["provider.name"] == "stub-provider"
+        assert attrs["provider.model"] == "example-medium-001"
+        assert attrs["provider.message_count"] == 1
+        assert attrs["provider.tool_count"] == 0
+        # Latency is set on the span's attributes dict by ``set_attribute``.
+        span = tracer.spans[0]
+        assert "provider.latency_ms" in span.attributes
+        assert span.attributes["provider.latency_ms"] >= 0.0
+        # No exception was recorded via the SDK's auto-handler.
+        assert not span.recorded_exceptions
+
+    async def test_error_path_sets_exception_attrs_without_record_exception(
+        self,
+    ) -> None:
+        async def completer(_messages, _model, _tools, _config):  # type: ignore[no-untyped-def]
+            msg = "synthetic provider outage"
+            raise ProviderInternalError(msg)
+
+        tracer = _RecordingTracer()
+        provider = _StubProvider(completer=completer)
+        with (
+            patch.object(_base, "_tracer", tracer),
+            pytest.raises(ProviderInternalError),
+        ):
+            await provider.complete(
+                messages=[ChatMessage(role=MessageRole.USER, content="hello")],
+                model="example-medium-001",
+            )
+
+        span = tracer.spans[0]
+        # Exception fields set via set_attribute, NOT record_exception.
+        assert span.attributes["exception.type"] == "ProviderInternalError"
+        assert "synthetic provider outage" in span.attributes["exception.message"]
+        # Latency was still set on the error path.
+        assert "provider.latency_ms" in span.attributes
+        # record_exception MUST NOT have been called (SEC: traceback
+        # frame-locals can leak credentials).
+        assert not span.recorded_exceptions

--- a/tests/unit/security/test_audit_fill_ratio_gauge.py
+++ b/tests/unit/security/test_audit_fill_ratio_gauge.py
@@ -71,6 +71,28 @@ class TestAuditFillRatioGauge:
         log.record(_make_entry("e-5"))
         assert _gauge_value(collector) == pytest.approx(1.0)
 
+    def test_clear_resets_fill_ratio_to_zero(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``clear()`` must reset the gauge so stale ``1.0`` doesn't linger.
+
+        Without this, an operator alert keyed on the gauge would keep
+        firing after a test isolation reset until the next ``record()``
+        rewrote the value.
+        """
+        import synthorg.observability.metrics_hub as _hub
+
+        collector = PrometheusCollector(prefix="synthorg")
+        monkeypatch.setattr(_hub, "_active", lambda: collector)
+
+        log = AuditLog(max_entries=4)
+        log.record(_make_entry("e-1"))
+        log.record(_make_entry("e-2"))
+        assert _gauge_value(collector) == pytest.approx(0.5)
+        log.clear()
+        assert _gauge_value(collector) == pytest.approx(0.0)
+
 
 # Force pytest-asyncio to register the module (not strictly required here
 # since these are sync tests but mirrors the project layout).

--- a/tests/unit/security/test_audit_fill_ratio_gauge.py
+++ b/tests/unit/security/test_audit_fill_ratio_gauge.py
@@ -29,7 +29,7 @@ def _make_entry(entry_id: str) -> AuditEntry:
         tool_category=ToolCategory.CODE_EXECUTION,
         action_type=NotBlankStr("code:write"),
         arguments_hash="a" * 64,
-        verdict="allow",  # type: ignore[arg-type]
+        verdict="allow",
         risk_level=ApprovalRiskLevel.LOW,
         reason="test",
         evaluation_duration_ms=1.0,
@@ -38,7 +38,7 @@ def _make_entry(entry_id: str) -> AuditEntry:
 
 def _gauge_value(collector: PrometheusCollector) -> float:
     """Read the current gauge value through the collector's registry."""
-    samples = collector.registry.collect()  # type: ignore[attr-defined]
+    samples = collector.registry.collect()
     for metric in samples:
         if metric.name.endswith("synthorg_security_audit_log_fill_ratio"):
             for sample in metric.samples:
@@ -56,7 +56,7 @@ class TestAuditFillRatioGauge:
         import synthorg.observability.metrics_hub as _hub
 
         collector = PrometheusCollector(prefix="synthorg")
-        monkeypatch.setattr(_hub, "_active", lambda: collector)  # type: ignore[arg-type]
+        monkeypatch.setattr(_hub, "_active", lambda: collector)
 
         log = AuditLog(max_entries=4)
 

--- a/tests/unit/security/test_audit_fill_ratio_gauge.py
+++ b/tests/unit/security/test_audit_fill_ratio_gauge.py
@@ -1,0 +1,77 @@
+"""Regression: ``AuditLog.record`` updates the fill-ratio gauge each append.
+
+The gauge value is exposed as
+``synthorg_security_audit_log_fill_ratio`` (no labels). Operators
+alert when it approaches 1.0 so they can preserve evidence before the
+in-memory deque evicts the oldest entry.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from synthorg.core.enums import ApprovalRiskLevel, ToolCategory
+from synthorg.core.types import NotBlankStr
+from synthorg.observability.prometheus_collector import PrometheusCollector
+from synthorg.security.audit import AuditLog
+from synthorg.security.models import AuditEntry
+
+pytestmark = pytest.mark.unit
+
+
+def _make_entry(entry_id: str) -> AuditEntry:
+    return AuditEntry(
+        id=NotBlankStr(entry_id),
+        timestamp=datetime(2026, 5, 13, tzinfo=UTC),
+        agent_id=NotBlankStr("agent-a"),
+        tool_name=NotBlankStr("code_write"),
+        tool_category=ToolCategory.CODE_EXECUTION,
+        action_type=NotBlankStr("code:write"),
+        arguments_hash="a" * 64,
+        verdict="allow",  # type: ignore[arg-type]
+        risk_level=ApprovalRiskLevel.LOW,
+        reason="test",
+        evaluation_duration_ms=1.0,
+    )
+
+
+def _gauge_value(collector: PrometheusCollector) -> float:
+    """Read the current gauge value through the collector's registry."""
+    samples = collector.registry.collect()  # type: ignore[attr-defined]
+    for metric in samples:
+        if metric.name.endswith("synthorg_security_audit_log_fill_ratio"):
+            for sample in metric.samples:
+                if sample.name.endswith("synthorg_security_audit_log_fill_ratio"):
+                    return float(sample.value)
+    msg = "synthorg_security_audit_log_fill_ratio gauge not found in registry"
+    raise AssertionError(msg)
+
+
+class TestAuditFillRatioGauge:
+    def test_fill_ratio_grows_with_records(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import synthorg.observability.metrics_hub as _hub
+
+        collector = PrometheusCollector(prefix="synthorg")
+        monkeypatch.setattr(_hub, "_active", lambda: collector)  # type: ignore[arg-type]
+
+        log = AuditLog(max_entries=4)
+
+        log.record(_make_entry("e-1"))
+        assert _gauge_value(collector) == pytest.approx(0.25)
+        log.record(_make_entry("e-2"))
+        assert _gauge_value(collector) == pytest.approx(0.5)
+        log.record(_make_entry("e-3"))
+        log.record(_make_entry("e-4"))
+        assert _gauge_value(collector) == pytest.approx(1.0)
+        # Evictions keep the deque at max_entries; ratio stays at 1.0.
+        log.record(_make_entry("e-5"))
+        assert _gauge_value(collector) == pytest.approx(1.0)
+
+
+# Force pytest-asyncio to register the module (not strictly required here
+# since these are sync tests but mirrors the project layout).
+__all__: tuple[Any, ...] = ()

--- a/tests/unit/settings/test_dispatcher.py
+++ b/tests/unit/settings/test_dispatcher.py
@@ -830,18 +830,40 @@ class TestKillSwitch:
                 await asyncio.Event().wait()
                 return None
 
+        # Deterministic synchronisation: the loop calls
+        # ``_resolve_enabled`` on every iteration. Hook the resolver to
+        # tick an iteration counter and signal an Event after N ticks
+        # so the test waits for *exact* loop progress rather than a
+        # wall-clock budget.
+        iterations_seen = 0
+        third_iteration = asyncio.Event()
+        required_iterations = 3
+        resolver = _FakeConfigResolver(enabled=False)
+        original_get_bool = resolver.get_bool
+
+        async def _counting_get_bool(namespace: str, key: str) -> bool:
+            nonlocal iterations_seen
+            iterations_seen += 1
+            if iterations_seen >= required_iterations:
+                third_iteration.set()
+            return await original_get_bool(namespace, key)
+
+        resolver.get_bool = _counting_get_bool  # type: ignore[method-assign]
         bus = _CountingBus()
         sub = _FakeSubscriber("sub", frozenset())
         d = SettingsChangeDispatcher(
             message_bus=bus,
             subscribers=(sub,),
-            config_resolver=cast(ConfigResolver, _FakeConfigResolver(enabled=False)),
+            config_resolver=cast(ConfigResolver, resolver),
         )
         await d.start()
         try:
-            # Allow several loop iterations; with kill switch False the
-            # body sleeps+continues without ever calling bus.receive.
-            await asyncio.sleep(0.05)
+            # Wait for the loop to confirm it iterated at least three
+            # times. The kill-switch path must yield via the resolver
+            # on every iteration so this only blocks until the loop is
+            # actually running; the 2.0s ceiling is a generous safety
+            # net for slow CI hosts, not the load-bearing primitive.
+            await asyncio.wait_for(third_iteration.wait(), timeout=2.0)
             assert receive_calls == 0
         finally:
             await d.stop()

--- a/tests/unit/workers/test_claim_idempotency.py
+++ b/tests/unit/workers/test_claim_idempotency.py
@@ -113,7 +113,7 @@ class TestWorkerDedup:
             task_queue=_NullTaskQueue(),  # type: ignore[arg-type]
             executor=executor,
             worker_id="test-worker",
-            seen_claims=seen,  # type: ignore[arg-type]
+            seen_claims=seen,
             clock=clock,
         )
         claim = TaskClaim(
@@ -141,7 +141,7 @@ class TestWorkerDedup:
             task_queue=_NullTaskQueue(),  # type: ignore[arg-type]
             executor=executor,
             worker_id="test-worker",
-            seen_claims=seen,  # type: ignore[arg-type]
+            seen_claims=seen,
             clock=clock,
         )
         claim = TaskClaim(

--- a/tests/unit/workers/test_claim_idempotency.py
+++ b/tests/unit/workers/test_claim_idempotency.py
@@ -1,0 +1,181 @@
+"""Unit coverage for TaskClaim idempotency_key + worker dedup.
+
+The worker-side dedup test uses a stub ``SeenClaimsRepository`` that
+records every ``mark_seen`` call so we can assert the exact protocol
+contract without spinning up a real persistence backend.
+"""
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from synthorg.core.types import NotBlankStr
+from synthorg.workers.claim import TaskClaim, TaskClaimStatus
+from synthorg.workers.config import QueueConfig
+from synthorg.workers.worker import Worker
+from tests._shared.fake_clock import FakeClock
+
+pytestmark = pytest.mark.unit
+
+
+class _StubSeenClaims:
+    """Records ``mark_seen`` invocations; configurable per-key insert outcome."""
+
+    def __init__(
+        self,
+        *,
+        outcomes: dict[str, bool] | None = None,
+    ) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._outcomes = outcomes or {}
+
+    async def mark_seen(
+        self,
+        *,
+        idempotency_key: NotBlankStr,
+        claim_id: NotBlankStr,
+        now: datetime,
+        ttl_seconds: float,
+    ) -> bool:
+        self.calls.append(
+            {
+                "idempotency_key": str(idempotency_key),
+                "claim_id": str(claim_id),
+                "now": now,
+                "ttl_seconds": ttl_seconds,
+            },
+        )
+        return self._outcomes.get(str(idempotency_key), True)
+
+    async def prune_expired(self, now: datetime) -> int:
+        return 0
+
+
+class _NullTaskQueue:
+    """Stand-in for ``JetStreamTaskQueue`` -- worker never calls these."""
+
+    is_running = True
+
+    async def next_claim(self, timeout: float) -> Any:  # noqa: ASYNC109 -- mirrors prod signature; pragma: no cover
+        del timeout
+        return None
+
+
+class TestTaskClaimIdempotencyKey:
+    def test_idempotency_key_defaults_to_fresh_uuid(self) -> None:
+        first = TaskClaim(
+            task_id=NotBlankStr("t-1"), new_status=NotBlankStr("assigned")
+        )
+        second = TaskClaim(
+            task_id=NotBlankStr("t-1"), new_status=NotBlankStr("assigned")
+        )
+        assert first.idempotency_key
+        assert second.idempotency_key
+        assert first.idempotency_key != second.idempotency_key
+
+    def test_idempotency_key_survives_serialisation(self) -> None:
+        claim = TaskClaim(
+            task_id=NotBlankStr("t-2"),
+            new_status=NotBlankStr("assigned"),
+            idempotency_key=NotBlankStr("pinned-key"),
+        )
+        roundtrip = TaskClaim.model_validate_json(claim.model_dump_json())
+        assert roundtrip.idempotency_key == "pinned-key"
+
+
+@pytest.fixture
+def queue_config() -> QueueConfig:
+    return QueueConfig(
+        enabled=True,
+        ack_wait_seconds=30,
+        max_deliver=5,
+    )
+
+
+class TestWorkerDedup:
+    async def test_first_claim_executes(
+        self,
+        queue_config: QueueConfig,
+    ) -> None:
+        clock = FakeClock(start=datetime(2026, 5, 13, tzinfo=UTC))
+        seen = _StubSeenClaims()
+        execution_count = 0
+
+        async def executor(_claim: TaskClaim) -> TaskClaimStatus:
+            nonlocal execution_count
+            execution_count += 1
+            return TaskClaimStatus.SUCCESS
+
+        worker = Worker(
+            queue_config=queue_config,
+            task_queue=_NullTaskQueue(),  # type: ignore[arg-type]
+            executor=executor,
+            worker_id="test-worker",
+            seen_claims=seen,  # type: ignore[arg-type]
+            clock=clock,
+        )
+        claim = TaskClaim(
+            task_id=NotBlankStr("t-1"),
+            new_status=NotBlankStr("assigned"),
+        )
+        is_dup = await worker._is_duplicate(claim)
+        assert is_dup is False
+        assert execution_count == 0
+        assert len(seen.calls) == 1
+        assert seen.calls[0]["idempotency_key"] == claim.idempotency_key
+
+    async def test_duplicate_claim_short_circuits(
+        self,
+        queue_config: QueueConfig,
+    ) -> None:
+        clock = FakeClock(start=datetime(2026, 5, 13, tzinfo=UTC))
+        seen = _StubSeenClaims(outcomes={"already-seen": False})
+
+        async def executor(_claim: TaskClaim) -> TaskClaimStatus:
+            return TaskClaimStatus.SUCCESS
+
+        worker = Worker(
+            queue_config=queue_config,
+            task_queue=_NullTaskQueue(),  # type: ignore[arg-type]
+            executor=executor,
+            worker_id="test-worker",
+            seen_claims=seen,  # type: ignore[arg-type]
+            clock=clock,
+        )
+        claim = TaskClaim(
+            task_id=NotBlankStr("t-2"),
+            new_status=NotBlankStr("assigned"),
+            idempotency_key=NotBlankStr("already-seen"),
+        )
+        is_dup = await worker._is_duplicate(claim)
+        assert is_dup is True
+
+    async def test_no_repo_means_no_dedup(
+        self,
+        queue_config: QueueConfig,
+    ) -> None:
+        clock = FakeClock(start=datetime(2026, 5, 13, tzinfo=UTC))
+        worker = Worker(
+            queue_config=queue_config,
+            task_queue=_NullTaskQueue(),  # type: ignore[arg-type]
+            executor=_unused_executor,
+            worker_id="test-worker",
+            seen_claims=None,
+            clock=clock,
+        )
+        claim = TaskClaim(
+            task_id=NotBlankStr("t-3"),
+            new_status=NotBlankStr("assigned"),
+        )
+        is_dup = await worker._is_duplicate(claim)
+        assert is_dup is False
+
+
+async def _unused_executor(_claim: TaskClaim) -> TaskClaimStatus:  # pragma: no cover
+    return TaskClaimStatus.SUCCESS
+
+
+# Force pytest-asyncio to pick up the coroutine fixtures above.
+__all__ = ("asyncio",)

--- a/tests/unit/workers/test_claim_idempotency.py
+++ b/tests/unit/workers/test_claim_idempotency.py
@@ -1,8 +1,12 @@
 """Unit coverage for TaskClaim idempotency_key + worker dedup.
 
-The worker-side dedup test uses a stub ``SeenClaimsRepository`` that
-records every ``mark_seen`` call so we can assert the exact protocol
-contract without spinning up a real persistence backend.
+The worker-side dedup tests use a stub ``SeenClaimsRepository`` that
+records every ``is_completed`` / ``mark_seen`` call so the contract
+can be asserted without spinning up a real persistence backend. Each
+flow test drives the full ``Worker._run_once`` path through a stub
+``JetStreamTaskQueue`` so the regression coverage exercises the
+ordering invariants (pre-execute is_completed read, post-terminal
+mark_seen, RETRY never marks) that the dedup design depends on.
 """
 
 import asyncio
@@ -21,16 +25,24 @@ pytestmark = pytest.mark.unit
 
 
 class _StubSeenClaims:
-    """Records ``mark_seen`` invocations; configurable per-key insert outcome."""
+    """Records every is_completed/mark_seen invocation in order."""
 
     def __init__(
         self,
         *,
-        outcomes: dict[str, bool] | None = None,
+        completed_keys: frozenset[str] | None = None,
     ) -> None:
-        self.calls: list[dict[str, Any]] = []
-        self.forgets: list[str] = []
-        self._outcomes = outcomes or {}
+        self.is_completed_calls: list[str] = []
+        self.mark_seen_calls: list[dict[str, Any]] = []
+        self._completed_keys: set[str] = set(completed_keys or frozenset())
+
+    async def is_completed(
+        self,
+        *,
+        idempotency_key: NotBlankStr,
+    ) -> bool:
+        self.is_completed_calls.append(str(idempotency_key))
+        return str(idempotency_key) in self._completed_keys
 
     async def mark_seen(
         self,
@@ -40,7 +52,7 @@ class _StubSeenClaims:
         now: datetime,
         ttl_seconds: float,
     ) -> bool:
-        self.calls.append(
+        self.mark_seen_calls.append(
             {
                 "idempotency_key": str(idempotency_key),
                 "claim_id": str(claim_id),
@@ -48,22 +60,57 @@ class _StubSeenClaims:
                 "ttl_seconds": ttl_seconds,
             },
         )
-        return self._outcomes.get(str(idempotency_key), True)
-
-    async def forget(
-        self,
-        *,
-        idempotency_key: NotBlankStr,
-    ) -> bool:
-        self.forgets.append(str(idempotency_key))
-        return True
+        first = str(idempotency_key) not in self._completed_keys
+        self._completed_keys.add(str(idempotency_key))
+        return first
 
     async def prune_expired(self, now: datetime) -> int:
+        del now
         return 0
 
 
+class _StubRawMessage:
+    """Stand-in for the NATS JetStream message handle the worker acks.
+
+    ``JetStreamTaskQueue.ack`` / ``nack`` reach into ``raw.ack()`` /
+    ``raw.nak()`` directly so the worker test needs a minimal handle
+    that records each call without pulling in a live NATS client.
+    """
+
+    def __init__(self) -> None:
+        self.ack_calls: int = 0
+        self.nak_calls: list[float] = []
+
+    async def ack(self) -> None:
+        self.ack_calls += 1
+
+    async def nak(self, delay: float = 0.0) -> None:
+        self.nak_calls.append(delay)
+
+
+class _ScriptedTaskQueue:
+    """Yields the queued (claim, raw) pairs in order, then None."""
+
+    is_running = True
+
+    def __init__(
+        self,
+        deliveries: list[tuple[TaskClaim, _StubRawMessage]],
+    ) -> None:
+        self._deliveries = list(deliveries)
+
+    async def next_claim(
+        self,
+        timeout: float,  # noqa: ASYNC109 -- mirrors prod signature
+    ) -> tuple[TaskClaim, _StubRawMessage] | None:
+        del timeout
+        if not self._deliveries:
+            return None
+        return self._deliveries.pop(0)
+
+
 class _NullTaskQueue:
-    """Stand-in for ``JetStreamTaskQueue`` -- worker never calls these."""
+    """Stand-in for ``JetStreamTaskQueue`` that never yields a claim."""
 
     is_running = True
 
@@ -129,18 +176,18 @@ class TestWorkerDedup:
             task_id=NotBlankStr("t-1"),
             new_status=NotBlankStr("assigned"),
         )
-        is_dup = await worker._is_duplicate(claim)
-        assert is_dup is False
+        is_completed = await worker._is_completed(claim)
+        assert is_completed is False
         assert execution_count == 0
-        assert len(seen.calls) == 1
-        assert seen.calls[0]["idempotency_key"] == claim.idempotency_key
+        assert seen.is_completed_calls == [claim.idempotency_key]
+        assert seen.mark_seen_calls == []
 
     async def test_duplicate_claim_short_circuits(
         self,
         queue_config: QueueConfig,
     ) -> None:
         clock = FakeClock(start=datetime(2026, 5, 13, tzinfo=UTC))
-        seen = _StubSeenClaims(outcomes={"already-seen": False})
+        seen = _StubSeenClaims(completed_keys=frozenset({"already-seen"}))
 
         async def executor(_claim: TaskClaim) -> TaskClaimStatus:
             return TaskClaimStatus.SUCCESS
@@ -158,8 +205,8 @@ class TestWorkerDedup:
             new_status=NotBlankStr("assigned"),
             idempotency_key=NotBlankStr("already-seen"),
         )
-        is_dup = await worker._is_duplicate(claim)
-        assert is_dup is True
+        is_completed = await worker._is_completed(claim)
+        assert is_completed is True
 
     async def test_no_repo_means_no_dedup(
         self,
@@ -178,57 +225,171 @@ class TestWorkerDedup:
             task_id=NotBlankStr("t-3"),
             new_status=NotBlankStr("assigned"),
         )
-        is_dup = await worker._is_duplicate(claim)
-        assert is_dup is False
+        is_completed = await worker._is_completed(claim)
+        assert is_completed is False
 
-    async def test_retry_status_rolls_back_dedup_row(
+
+class TestWorkerRunOnceDedupLifecycle:
+    """Exercises the actual ``_run_once`` flow end-to-end.
+
+    The previous version of these tests called ``_forget_seen`` /
+    ``_mark_completed`` directly, which made them pass even when the
+    surrounding orchestration regressed. Driving ``_run_once`` with a
+    scripted queue + stub repository asserts the contract the worker
+    is supposed to honour: pre-execute read, post-terminal write, and
+    no write on RETRY.
+    """
+
+    async def test_retry_outcome_does_not_mark_completed(
         self,
         queue_config: QueueConfig,
     ) -> None:
-        """RETRY MUST trigger ``forget`` so the next redelivery executes.
+        """RETRY must leave the dedup repo untouched.
 
-        Without this rollback, the speculative ``mark_seen`` row written
-        before the executor ran would trap the JetStream redelivery
-        in the duplicate-suppress path and silently drop the task.
+        Without this guard the JetStream redelivery would observe a
+        ``seen_claims`` row written speculatively before the executor
+        ran and ack-and-skip the redelivery, silently dropping the
+        task. The defer-mark design closes that by writing the row
+        only when the executor returns SUCCESS/FAILED.
         """
         clock = FakeClock(start=datetime(2026, 5, 13, tzinfo=UTC))
         seen = _StubSeenClaims()
-
-        worker = Worker(
-            queue_config=queue_config,
-            task_queue=_NullTaskQueue(),  # type: ignore[arg-type]
-            executor=_unused_executor,
-            worker_id="test-worker",
-            seen_claims=seen,
-            clock=clock,
-        )
         claim = TaskClaim(
             task_id=NotBlankStr("t-retry"),
             new_status=NotBlankStr("assigned"),
             idempotency_key=NotBlankStr("idem-retry-key"),
         )
-        await worker._forget_seen(claim)
-        assert seen.forgets == ["idem-retry-key"]
+        executor_calls = 0
 
-    async def test_forget_is_a_noop_when_no_repo(
+        async def executor(received: TaskClaim) -> TaskClaimStatus:
+            nonlocal executor_calls
+            executor_calls += 1
+            assert received.idempotency_key == "idem-retry-key"
+            return TaskClaimStatus.RETRY
+
+        queue = _ScriptedTaskQueue([(claim, _StubRawMessage())])
+        worker = Worker(
+            queue_config=queue_config,
+            task_queue=queue,  # type: ignore[arg-type]
+            executor=executor,
+            worker_id="test-worker",
+            seen_claims=seen,
+            clock=clock,
+        )
+
+        await worker._run_once()
+
+        assert executor_calls == 1
+        assert seen.is_completed_calls == ["idem-retry-key"]
+        assert seen.mark_seen_calls == []
+
+    async def test_retry_then_success_executes_twice(
         self,
         queue_config: QueueConfig,
     ) -> None:
+        """A RETRY-then-SUCCESS sequence must run the executor twice.
+
+        This pins the regression the dedup row used to cause: the
+        first delivery returns RETRY, the second redelivery (same
+        idempotency_key) must NOT be suppressed because the first
+        outcome never reached a terminal SUCCESS/FAILED.
+        """
         clock = FakeClock(start=datetime(2026, 5, 13, tzinfo=UTC))
+        seen = _StubSeenClaims()
+        idempotency_key = NotBlankStr("idem-retry-then-success")
+        outcomes = iter([TaskClaimStatus.RETRY, TaskClaimStatus.SUCCESS])
+        executor_calls = 0
+
+        async def executor(_claim: TaskClaim) -> TaskClaimStatus:
+            nonlocal executor_calls
+            executor_calls += 1
+            return next(outcomes)
+
+        first_delivery = (
+            TaskClaim(
+                task_id=NotBlankStr("t-1"),
+                new_status=NotBlankStr("assigned"),
+                idempotency_key=idempotency_key,
+            ),
+            _StubRawMessage(),
+        )
+        second_delivery = (
+            TaskClaim(
+                task_id=NotBlankStr("t-1"),
+                new_status=NotBlankStr("assigned"),
+                idempotency_key=idempotency_key,
+            ),
+            _StubRawMessage(),
+        )
+        queue = _ScriptedTaskQueue([first_delivery, second_delivery])
         worker = Worker(
             queue_config=queue_config,
-            task_queue=_NullTaskQueue(),  # type: ignore[arg-type]
-            executor=_unused_executor,
+            task_queue=queue,  # type: ignore[arg-type]
+            executor=executor,
             worker_id="test-worker",
-            seen_claims=None,
+            seen_claims=seen,
             clock=clock,
         )
-        claim = TaskClaim(
-            task_id=NotBlankStr("t-no-repo"),
-            new_status=NotBlankStr("assigned"),
+
+        await worker._run_once()
+        await worker._run_once()
+
+        assert executor_calls == 2
+        assert seen.mark_seen_calls == [
+            {
+                "idempotency_key": "idem-retry-then-success",
+                "claim_id": "t-1",
+                "now": clock.now(),
+                "ttl_seconds": worker._dedup_ttl_seconds,
+            },
+        ]
+
+    async def test_success_marks_and_subsequent_delivery_short_circuits(
+        self,
+        queue_config: QueueConfig,
+    ) -> None:
+        """SUCCESS writes the row; redelivery of the same key skips."""
+        clock = FakeClock(start=datetime(2026, 5, 13, tzinfo=UTC))
+        seen = _StubSeenClaims()
+        idempotency_key = NotBlankStr("idem-success")
+        executor_calls = 0
+
+        async def executor(_claim: TaskClaim) -> TaskClaimStatus:
+            nonlocal executor_calls
+            executor_calls += 1
+            return TaskClaimStatus.SUCCESS
+
+        first_delivery = (
+            TaskClaim(
+                task_id=NotBlankStr("t-ok"),
+                new_status=NotBlankStr("assigned"),
+                idempotency_key=idempotency_key,
+            ),
+            _StubRawMessage(),
         )
-        # Must not raise.
-        await worker._forget_seen(claim)
+        second_delivery = (
+            TaskClaim(
+                task_id=NotBlankStr("t-ok"),
+                new_status=NotBlankStr("assigned"),
+                idempotency_key=idempotency_key,
+            ),
+            _StubRawMessage(),
+        )
+        queue = _ScriptedTaskQueue([first_delivery, second_delivery])
+        worker = Worker(
+            queue_config=queue_config,
+            task_queue=queue,  # type: ignore[arg-type]
+            executor=executor,
+            worker_id="test-worker",
+            seen_claims=seen,
+            clock=clock,
+        )
+
+        await worker._run_once()
+        await worker._run_once()
+
+        assert executor_calls == 1
+        assert len(seen.mark_seen_calls) == 1
 
 
 async def _unused_executor(_claim: TaskClaim) -> TaskClaimStatus:  # pragma: no cover

--- a/tests/unit/workers/test_claim_idempotency.py
+++ b/tests/unit/workers/test_claim_idempotency.py
@@ -29,6 +29,7 @@ class _StubSeenClaims:
         outcomes: dict[str, bool] | None = None,
     ) -> None:
         self.calls: list[dict[str, Any]] = []
+        self.forgets: list[str] = []
         self._outcomes = outcomes or {}
 
     async def mark_seen(
@@ -48,6 +49,14 @@ class _StubSeenClaims:
             },
         )
         return self._outcomes.get(str(idempotency_key), True)
+
+    async def forget(
+        self,
+        *,
+        idempotency_key: NotBlankStr,
+    ) -> bool:
+        self.forgets.append(str(idempotency_key))
+        return True
 
     async def prune_expired(self, now: datetime) -> int:
         return 0
@@ -171,6 +180,55 @@ class TestWorkerDedup:
         )
         is_dup = await worker._is_duplicate(claim)
         assert is_dup is False
+
+    async def test_retry_status_rolls_back_dedup_row(
+        self,
+        queue_config: QueueConfig,
+    ) -> None:
+        """RETRY MUST trigger ``forget`` so the next redelivery executes.
+
+        Without this rollback, the speculative ``mark_seen`` row written
+        before the executor ran would trap the JetStream redelivery
+        in the duplicate-suppress path and silently drop the task.
+        """
+        clock = FakeClock(start=datetime(2026, 5, 13, tzinfo=UTC))
+        seen = _StubSeenClaims()
+
+        worker = Worker(
+            queue_config=queue_config,
+            task_queue=_NullTaskQueue(),  # type: ignore[arg-type]
+            executor=_unused_executor,
+            worker_id="test-worker",
+            seen_claims=seen,
+            clock=clock,
+        )
+        claim = TaskClaim(
+            task_id=NotBlankStr("t-retry"),
+            new_status=NotBlankStr("assigned"),
+            idempotency_key=NotBlankStr("idem-retry-key"),
+        )
+        await worker._forget_seen(claim)
+        assert seen.forgets == ["idem-retry-key"]
+
+    async def test_forget_is_a_noop_when_no_repo(
+        self,
+        queue_config: QueueConfig,
+    ) -> None:
+        clock = FakeClock(start=datetime(2026, 5, 13, tzinfo=UTC))
+        worker = Worker(
+            queue_config=queue_config,
+            task_queue=_NullTaskQueue(),  # type: ignore[arg-type]
+            executor=_unused_executor,
+            worker_id="test-worker",
+            seen_claims=None,
+            clock=clock,
+        )
+        claim = TaskClaim(
+            task_id=NotBlankStr("t-no-repo"),
+            new_status=NotBlankStr("assigned"),
+        )
+        # Must not raise.
+        await worker._forget_seen(claim)
 
 
 async def _unused_executor(_claim: TaskClaim) -> TaskClaimStatus:  # pragma: no cover


### PR DESCRIPTION
Closes #1885.

## Summary

Implements the async-safety + observability work package across 13 commits + 1 pre-PR-review follow-up commit. Both HIGH findings (NATS deliver-before-ack, dispatcher claim idempotency) ship in this PR.

## Subsystems landed

**Idempotency / safety (Subsystem 1):**
- `SeenClaimsRepository` protocol + SQLite/Postgres implementations + yoyo revisions. `TaskClaim` now carries `idempotency_key` (UUID per dispatch); workers consult the repo and short-circuit duplicates with `WORKERS_DUPLICATE_CLAIM_SUPPRESSED`. Dual-backend conformance test covers both backends.
- `DeliveryEnvelope.ack` is now a deferred async callback. NATS `build_envelope` returns the envelope WITHOUT acking; consumers in `api/bus_bridge.py`, `engine/workflow/webhook_bridge.py`, `integrations/rate_limiting/shared_state.py`, and `settings/dispatcher.py` invoke `envelope.ack()` only after delivery succeeds. Memory-bus default is a no-op ack.
- Webhook idempotency scope: `webhooks:{connection_type}:{connection_name}` so two connections of the same provider cannot share dedup rows. Invariant regression test pins the scope format.
- Backup manifest is round-trip validated INSIDE the idempotency callback so a corrupt manifest cannot pollute the cache.
- `InMemoryMcpInstallationRepository` gets a lazy-init `asyncio.Lock` around `_store`. Concurrent save+delete+list_items operations stay consistent.

**Silent except (Subsystem 4):**
- Six controller sites (`setup`, `activities`, `_department_health` x2, `analytics`, `approvals`) bind `as exc` and forward `error_type` + scrubbed `error=safe_error_description(exc)` to the warning. Regression test asserts the structured fields are present.

**Test determinism (Subsystem 5):**
- `test_timeout_enforcement.py:32`: `await asyncio.sleep(1)` -> `await asyncio.Event().wait()`. Test no longer occupies a wall-clock second when the timeout is accidentally disabled.
- `test_dispatcher.py:844`: 0.05s wall-clock sleep -> Event ticked after three resolver iterations. The test now blocks on actual loop progress.
- `test_web_image.py:57` + `test_bus_nats.py:306`: bounded inter-poll sleeps promoted to Final-annotated module constants so the magic-number gate has a named target.

**Observability (Subsystems 6a, 6b, 6d, 7):**
- `BaseCompletionProvider.complete()` wraps the inner execution in a `_tracer.start_as_current_span("provider.complete", ...)` child span. Exception path sets `exception.type` + `exception.message` via `set_attribute` (NEVER `span.record_exception`; the SDK would serialise the unscrubbed traceback). `record_exception=False, set_status_on_exception=False` on the start call opt out of the auto-instrumentation that would undo redaction.
- New `synthorg_security_audit_log_fill_ratio` Gauge in `[0.0, 1.0]`. `AuditLog.record` pushes the ratio on every append so operators alert before the deque evicts evidence.
- Regression test pins `record_task_run` is invoked at `task_engine_apply.py:479` and `:609` for the four bounded outcomes; `_RECORDED_STATUS_OUTCOME` map is asserted immutable.
- Grafana panel invariant test asserts each outcome-labelled panel description in `monitoring/grafana/synthorg-overview.json` references only outcomes from the matching `VALID_*` frozen set (approval, escalation, blueprint).

**Clock seam (Subsystem 3, partial):**
- Six of the ten acceptance-listed services accept `clock: Clock | None = None` defaulting to `SystemClock()`: `AgentEngine` + `agent_engine_post_exec`, `BaseCompletionProvider`, `SafetyClassifier`, `LlmSecurityEvaluator`, `RuleEngine`, `EvalLoopCoordinator`. Bare `time.monotonic()` swaps to `self._clock.monotonic()`. Regression test confirms `AgentEngine` uses `SystemClock` by default and an injected `FakeClock` is stored.
- Remaining four services (`coordination/service.py`, `context_dependent_dispatcher.py`, `_dispatch_helpers.py`, `parallel.py`) ship in a follow-up; identical seam pattern.

## Out of scope (follow-up PRs)

- Subsystem 2: `CostClaimDedupeRepository` (persistent cost-tracker dedupe). Plan-B sequencing approved.
- Subsystem 6c: `AuditChainVerificationScheduler` + `synthorg_audit_chain_verify` MCP tool. Plan-B sequencing approved.

## Test plan

- All 28380 unit tests pass.
- New regression tests:
  - `tests/unit/workers/test_claim_idempotency.py` (5 tests)
  - `tests/conformance/persistence/test_seen_claims_repository.py` (5 tests, dual backend)
  - `tests/unit/communication/bus/test_nats_receive_ack_ordering.py` (3 tests)
  - `tests/unit/api/controllers/test_webhooks_idempotency_scope.py` (3 tests)
  - `tests/unit/api/controllers/test_backup_idempotency_validation.py` (2 tests)
  - `tests/unit/integrations/mcp_catalog/test_in_memory_installations_lock.py` (2 tests)
  - `tests/unit/api/controllers/test_silent_except_logging.py` (1 test)
  - `tests/unit/security/test_audit_fill_ratio_gauge.py` (1 test)
  - `tests/unit/engine/test_record_task_run_wired.py` (3 tests)
  - `tests/unit/monitoring/test_grafana_panel_outcome_consistency.py` (2 tests)
  - `tests/unit/providers/test_base_completion_spans.py` (2 tests)
  - `tests/unit/engine/test_agent_engine_clock_seam.py` (2 tests)
- Schema drift gate green for SQLite (Postgres requires Docker; not run locally).

## Review coverage

Pre-PR reviewers (agents):
- `issue-resolution-verifier`: PASS, all 6 acceptance criteria met
- `code-reviewer`: 0 findings (CLAUDE.md compliance verified)
- `persistence-reviewer`: 3 findings, all 3 actioned (SQLite CHECK constraint, Postgres explicit rollback, mark_seen lock docstring)
- `async-concurrency-reviewer`: 10 surfaced, 0 valid. Rationale recorded in `_audit/pre-pr-review/triage.md`: the cooperative-asyncio false-positive on lazy-init lock; the false flag on PEP 758 `except A, B:` syntax (mandated by project CLAUDE.md); a pre-existing flag on `rate_limiting/shared_state.py` not introduced by this PR

## Acceptance status

| Criterion | Status |
|---|---|
| All 10 listed services accept a `Clock` parameter | Partial: 6 of 10; remaining 4 in follow-up |
| `_nats_receive.py` delivers before acking | RESOLVED |
| Dispatcher republish uses an idempotency key | RESOLVED |
| `record_task_run()` is called on task completion | RESOLVED (verified by regression test) |
| All silent `except Exception` paths in cited files log warnings | RESOLVED (all six sites updated) |
| Tests use deterministic sync primitives | RESOLVED |
