### PR TITLE
fix: dashboard broken flows + provider sync safety

### DIFF
--- a/data/runtime_stats.yaml
+++ b/data/runtime_stats.yaml
@@ -1,16 +1,16 @@
 schema_version: 1
-last_generated_utc: '2026-05-13T10:19:00Z'
-generator_revision: 28ebda1b4
+last_generated_utc: '2026-05-13T12:50:01Z'
+generator_revision: faa85db4c
 stats:
   tests:
-    raw: 29978
-    rounded: 29000
-    display: 29,000+
+    raw: 30006
+    rounded: 30000
+    display: 30,000+
   version:
     raw: v0.8.4-dev.2
     display: v0.8.4-dev.2
   mem0_stars:
-    raw: 55567
+    raw: 55583
     rounded: 55000
     display: 55k+
   providers_curated:

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -826,17 +826,11 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
                 service="a2a_gateway",
             )
 
-    # Wire the client-simulation runtime onto AppState BEFORE the
-    # optional-controllers tuple is built so the predicate check below
-    # sees its presence at controller-list-assembly time. Default to a
-    # fresh ``ClientSimulationState()`` with empty in-memory stores so
-    # the always-registered ``ClientController`` can serve an empty
-    # ``/clients`` list instead of 503ing on every dashboard poll;
-    # callers that need a configured intake / review pipeline pass a
-    # fully-built state via the kwarg. The optional Simulation /
-    # Request controllers still gate on the same predicate so endpoints
-    # that require ``intake_engine`` / ``review_pipeline`` only register
-    # when those fields are actually populated.
+    # Default to a fresh ``ClientSimulationState()`` so the
+    # always-registered ``ClientController`` can serve an empty
+    # ``/clients`` list instead of 503ing on every dashboard poll.
+    # Callers wanting the full intake / review pipeline pass a
+    # configured state via the kwarg.
     if client_simulation_state is None:
         from synthorg.client.simulation_state import (  # noqa: PLC0415
             ClientSimulationState as _ClientSimulationState,

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -826,14 +826,24 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
                 service="a2a_gateway",
             )
 
-    # Wire the optional client-simulation runtime onto AppState BEFORE the
+    # Wire the client-simulation runtime onto AppState BEFORE the
     # optional-controllers tuple is built so the predicate check below
-    # sees its presence at controller-list-assembly time. Production
-    # callers that need the surface pass it as a kwarg; tests that
-    # exercise the simulation/request endpoints do the same instead of
-    # post-construction ``set_client_simulation_state``.
-    if client_simulation_state is not None:
-        app_state.set_client_simulation_state(client_simulation_state)
+    # sees its presence at controller-list-assembly time. Default to a
+    # fresh ``ClientSimulationState()`` with empty in-memory stores so
+    # the always-registered ``ClientController`` can serve an empty
+    # ``/clients`` list instead of 503ing on every dashboard poll;
+    # callers that need a configured intake / review pipeline pass a
+    # fully-built state via the kwarg. The optional Simulation /
+    # Request controllers still gate on the same predicate so endpoints
+    # that require ``intake_engine`` / ``review_pipeline`` only register
+    # when those fields are actually populated.
+    if client_simulation_state is None:
+        from synthorg.client.simulation_state import (  # noqa: PLC0415
+            ClientSimulationState as _ClientSimulationState,
+        )
+
+        client_simulation_state = _ClientSimulationState()
+    app_state.set_client_simulation_state(client_simulation_state)
 
     # Optional controllers gated on their primary collaborator service.
     # Routes for unconfigured subsystems are not registered at all so

--- a/src/synthorg/api/controllers/__init__.py
+++ b/src/synthorg/api/controllers/__init__.py
@@ -168,8 +168,8 @@ BASE_CONTROLLERS: tuple[type[Controller], ...] = (
 # ``app.py`` includes the controller in ``route_handlers`` only when
 # the predicate evaluates truthy at controller-list assembly time.
 OPTIONAL_CONTROLLERS: tuple[tuple[type[Controller], str], ...] = (
-    (SimulationController, "has_client_simulation_state"),
-    (RequestController, "has_client_simulation_state"),
+    (SimulationController, "has_simulation_runtime"),
+    (RequestController, "has_simulation_runtime"),
 )
 
 # Integration subsystem controllers. Registered only when

--- a/src/synthorg/api/controllers/capabilities.py
+++ b/src/synthorg/api/controllers/capabilities.py
@@ -118,8 +118,8 @@ class CapabilitiesController(Controller):
         a2a_wired = getattr(app_state, "_a2a_peer_registry", None) is not None
         return ApiResponse(
             data=CapabilitiesResponse(
-                simulations=app_state.has_client_simulation_state,
-                requests=app_state.has_client_simulation_state,
+                simulations=app_state.has_simulation_runtime,
+                requests=app_state.has_simulation_runtime,
                 ontology=app_state.has_ontology_service,
                 tunnel=app_state.has_tunnel_provider,
                 webhooks=webhooks_wired,

--- a/src/synthorg/api/controllers/providers.py
+++ b/src/synthorg/api/controllers/providers.py
@@ -410,9 +410,11 @@ class ProviderController(Controller):
         # Strip preset_name from external requests -- only
         # create_from_preset may set it (capability flag injection).
         safe_data = data.model_copy(update={"preset_name": None})
+        actor = audit_actor_from_context()
         try:
             config = await app_state.provider_management.create_provider(
                 safe_data,
+                actor=actor,
             )
         except ProviderAlreadyExistsError as exc:
             logger.warning(
@@ -461,9 +463,11 @@ class ProviderController(Controller):
                 validation fails.
         """
         app_state: AppState = state.app_state
+        actor = audit_actor_from_context()
         try:
             config = await app_state.provider_management.create_from_preset(
                 data,
+                actor=actor,
             )
         except ProviderAlreadyExistsError as exc:
             logger.warning(
@@ -510,10 +514,12 @@ class ProviderController(Controller):
             ValidationError: If the update fails validation.
         """
         app_state: AppState = state.app_state
+        actor = audit_actor_from_context()
         try:
             config = await app_state.provider_management.update_provider(
                 name,
                 data,
+                actor=actor,
             )
         except ProviderNotFoundError as exc:
             logger.warning(
@@ -555,8 +561,9 @@ class ProviderController(Controller):
             NotFoundError: If the provider does not exist.
         """
         app_state: AppState = state.app_state
+        actor = audit_actor_from_context()
         try:
-            await app_state.provider_management.delete_provider(name)
+            await app_state.provider_management.delete_provider(name, actor=actor)
         except ProviderNotFoundError as exc:
             logger.warning(
                 API_RESOURCE_NOT_FOUND,
@@ -874,8 +881,13 @@ class ProviderController(Controller):
             model_id: Model identifier (may contain colons).
         """
         app_state: AppState = state.app_state
+        actor = audit_actor_from_context()
         try:
-            await app_state.provider_management.delete_model(name, model_id)
+            await app_state.provider_management.delete_model(
+                name,
+                model_id,
+                actor=actor,
+            )
         except ProviderNotFoundError as exc:
             msg = f"Provider {name!r} not found"
             logger.warning(
@@ -946,11 +958,13 @@ class ProviderController(Controller):
             ValidationError: If the launch parameters are unsupported.
         """
         app_state: AppState = state.app_state
+        actor = audit_actor_from_context()
         try:
             updated = await app_state.provider_management.update_model_config(
                 name,
                 model_id,
                 data.local_params,
+                actor=actor,
             )
         except ProviderNotFoundError as exc:
             msg = f"Provider {name!r} not found"

--- a/src/synthorg/api/lifecycle.py
+++ b/src/synthorg/api/lifecycle.py
@@ -317,6 +317,38 @@ async def _init_persistence(
             )
             raise
 
+    # Re-bind the ConnectionCatalog onto the persistence-backed
+    # repository.  ``auto_wire_integrations`` runs before
+    # ``persistence.connect()``, so the catalog is initially seeded
+    # with an in-memory stub repo.  Without this re-bind, every
+    # ``POST /connections`` would write to a stub that the
+    # ``mcp_installations.connection_name`` foreign key cannot
+    # observe, surfacing as cross-store FK violations on install.
+    # Wrapping in ``hasattr`` keeps the helper backend-agnostic for
+    # tests / backends that have not implemented a ``connections``
+    # accessor; missing accessors fall through quietly because the
+    # in-memory stub is still functional for read-only flows.
+    if app_state.has_connection_catalog and hasattr(persistence, "connections"):
+        try:
+            persistent_connections = persistence.connections
+        except Exception as exc:
+            logger.warning(
+                API_APP_STARTUP,
+                note="Persistence backend exposes no connections repo; "
+                "catalog stays bound to the startup-window stub",
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+        else:
+            await app_state.connection_catalog.rebind_repository(
+                persistent_connections,
+            )
+            logger.info(
+                API_APP_STARTUP,
+                note="Re-bound ConnectionCatalog to persistence-backed repo",
+                backend=type(persistence).__name__,
+            )
+
 
 def _reset_if_tasks_dead(  # noqa: PLR0911
     obj: object,

--- a/src/synthorg/api/lifecycle.py
+++ b/src/synthorg/api/lifecycle.py
@@ -317,41 +317,63 @@ async def _init_persistence(
             )
             raise
 
-    # Re-bind the ConnectionCatalog onto the persistence-backed
-    # repository.  ``auto_wire_integrations`` runs before
-    # ``persistence.connect()``, so the catalog is initially seeded
-    # with an in-memory stub repo; without this re-bind, every
-    # ``POST /connections`` would write to a stub that the
-    # ``mcp_installations.connection_name`` foreign key cannot
-    # observe, surfacing as cross-store FK violations on install.
-    # ``AttributeError`` keeps the helper backend-agnostic for
-    # tests / backends without a ``connections`` accessor (the
-    # in-memory stub stays bound for read-only flows); any other
-    # property-getter failure surfaces via the warning path so the
-    # operator sees the cause instead of an opaque startup crash.
     if app_state.has_connection_catalog:
-        try:
-            persistent_connections = persistence.connections
-        except AttributeError:
-            persistent_connections = None
-        except Exception as exc:
-            persistent_connections = None
-            logger.warning(
-                API_APP_STARTUP,
-                note="Persistence backend connections accessor failed; "
-                "catalog stays bound to the startup-window stub",
-                error_type=type(exc).__name__,
-                error=safe_error_description(exc),
-            )
-        if persistent_connections is not None:
-            await app_state.connection_catalog.rebind_repository(
-                persistent_connections,
-            )
-            logger.info(
-                API_APP_STARTUP,
-                note="Re-bound ConnectionCatalog to persistence-backed repo",
-                backend=type(persistence).__name__,
-            )
+        await _rebind_connection_catalog(persistence, app_state)
+
+
+async def _rebind_connection_catalog(
+    persistence: PersistenceBackend,
+    app_state: AppState,
+) -> None:
+    """Re-bind the ConnectionCatalog onto a persistence-backed repo.
+
+    ``auto_wire_integrations`` runs before ``persistence.connect()``,
+    so the catalog is initially seeded with an in-memory stub; without
+    this re-bind, every ``POST /connections`` would write to a stub
+    that the ``mcp_installations.connection_name`` foreign key cannot
+    observe, surfacing as cross-store FK violations on install.
+
+    ``AttributeError`` keeps the helper backend-agnostic for tests /
+    backends without a ``connections`` accessor (the in-memory stub
+    stays bound for read-only flows); any other property-getter
+    failure surfaces via the warning path so the operator sees the
+    cause instead of an opaque startup crash. A failure inside the
+    catalog's own ``rebind_repository`` is fatal and logged at ERROR
+    before re-raising, so root-cause diagnosis is not blind.
+    """
+    try:
+        persistent_connections = persistence.connections
+    except AttributeError:
+        return
+    except Exception as exc:
+        logger.warning(
+            API_APP_STARTUP,
+            note="Persistence backend connections accessor failed; "
+            "catalog stays bound to the startup-window stub",
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
+        )
+        return
+    try:
+        await app_state.connection_catalog.rebind_repository(
+            persistent_connections,
+        )
+    except MemoryError, RecursionError:
+        raise
+    except Exception as exc:
+        logger.error(
+            API_APP_STARTUP,
+            note="Failed to re-bind ConnectionCatalog to persistence-backed repo",
+            backend=type(persistence).__name__,
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
+        )
+        raise
+    logger.info(
+        API_APP_STARTUP,
+        note="Re-bound ConnectionCatalog to persistence-backed repo",
+        backend=type(persistence).__name__,
+    )
 
 
 def _reset_if_tasks_dead(  # noqa: PLR0911

--- a/src/synthorg/api/lifecycle.py
+++ b/src/synthorg/api/lifecycle.py
@@ -320,26 +320,30 @@ async def _init_persistence(
     # Re-bind the ConnectionCatalog onto the persistence-backed
     # repository.  ``auto_wire_integrations`` runs before
     # ``persistence.connect()``, so the catalog is initially seeded
-    # with an in-memory stub repo.  Without this re-bind, every
+    # with an in-memory stub repo; without this re-bind, every
     # ``POST /connections`` would write to a stub that the
     # ``mcp_installations.connection_name`` foreign key cannot
     # observe, surfacing as cross-store FK violations on install.
-    # Wrapping in ``hasattr`` keeps the helper backend-agnostic for
-    # tests / backends that have not implemented a ``connections``
-    # accessor; missing accessors fall through quietly because the
-    # in-memory stub is still functional for read-only flows.
-    if app_state.has_connection_catalog and hasattr(persistence, "connections"):
+    # ``AttributeError`` keeps the helper backend-agnostic for
+    # tests / backends without a ``connections`` accessor (the
+    # in-memory stub stays bound for read-only flows); any other
+    # property-getter failure surfaces via the warning path so the
+    # operator sees the cause instead of an opaque startup crash.
+    if app_state.has_connection_catalog:
         try:
             persistent_connections = persistence.connections
+        except AttributeError:
+            persistent_connections = None
         except Exception as exc:
+            persistent_connections = None
             logger.warning(
                 API_APP_STARTUP,
-                note="Persistence backend exposes no connections repo; "
+                note="Persistence backend connections accessor failed; "
                 "catalog stays bound to the startup-window stub",
                 error_type=type(exc).__name__,
                 error=safe_error_description(exc),
             )
-        else:
+        if persistent_connections is not None:
             await app_state.connection_catalog.rebind_repository(
                 persistent_connections,
             )

--- a/src/synthorg/api/middleware.py
+++ b/src/synthorg/api/middleware.py
@@ -41,7 +41,28 @@ from synthorg.observability.events.settings import SETTINGS_VALUE_RESOLVED
 
 _UNMATCHED_ROUTE: Final[str] = "__unmatched__"
 
+# Healthcheck routes are polled by supervisors (Docker, k8s) on a
+# fixed-interval schedule and produce thousands of identical
+# ``api.request.started`` / ``api.request.completed`` records per
+# day. They carry no operational signal beyond uptime, drown out
+# real traffic in log queries, and inflate file-sink rotation churn.
+# Suppress the structured request-log pair for these paths; the
+# Prometheus duration metric and OpenTelemetry span still fire so
+# operators retain aggregated latency visibility.
+#
+# Suffix match (not exact match) because the router prefix
+# (``api.api_prefix``, default ``/api/v1``) is operator-configurable
+# and the healthcheck controller paths are defined as ``/healthz``
+# and ``/readyz`` without a leading prefix.
+_HEALTHCHECK_PATH_SUFFIXES: Final[tuple[str, ...]] = ("/healthz", "/readyz")
+
 logger = get_logger(__name__)
+
+
+def _is_healthcheck_path(path: str) -> bool:
+    """Return True for paths whose request-log pair should be skipped."""
+    return path.endswith(_HEALTHCHECK_PATH_SUFFIXES)
+
 
 # ── Security headers ────────────────────────────────────────────
 # Applied to every HTTP response via the before_send hook.
@@ -237,6 +258,13 @@ async def security_headers_hook(message: Message, scope: Scope) -> None:
         headers["Pragma"] = _API_PRAGMA
 
 
+def _log_request_started(method: str, path: str) -> None:
+    """Log request start at INFO, skipping supervisor healthcheck paths."""
+    if _is_healthcheck_path(path):
+        return
+    logger.info(API_REQUEST_STARTED, method=method, path=path)
+
+
 def _log_request_completion(
     method: str,
     path: str,
@@ -244,6 +272,8 @@ def _log_request_completion(
     duration_ms: float,
 ) -> None:
     """Log request completion at the appropriate level."""
+    if _is_healthcheck_path(path):
+        return
     if status_code is None:
         logger.warning(
             API_REQUEST_COMPLETED,
@@ -377,7 +407,7 @@ class RequestLoggingMiddleware:
 
         correlation_id = generate_correlation_id()
         bind_correlation_id(request_id=correlation_id)
-        logger.info(API_REQUEST_STARTED, method=method, path=path)
+        _log_request_started(method, path)
         start = time.perf_counter()
 
         status_code: int | None = None

--- a/src/synthorg/api/state.py
+++ b/src/synthorg/api/state.py
@@ -876,8 +876,35 @@ class AppState(AppStateServicesMixin):
 
     @property
     def has_client_simulation_state(self) -> bool:
-        """Check whether client simulation state is configured."""
+        """Check whether client simulation state is configured.
+
+        Always ``True`` in production: ``create_app`` default-constructs
+        a fresh ``ClientSimulationState`` so the always-registered
+        ``ClientController`` (``GET /clients``, CRUD) can serve an
+        empty profile list rather than 503ing on every dashboard poll.
+        The stricter ``has_simulation_runtime`` predicate gates the
+        controllers that actually need ``intake_engine`` /
+        ``review_pipeline``.
+        """
         return self._client_simulation_state is not None
+
+    @property
+    def has_simulation_runtime(self) -> bool:
+        """Check whether the full simulation runtime is wired.
+
+        Requires both ``intake_engine`` and ``review_pipeline`` on the
+        attached ``ClientSimulationState``; without them the
+        ``Simulation`` and ``Request`` controllers cannot execute
+        end-to-end flows, so the optional-controller predicate keeps
+        their routes off the router and the ``/capabilities`` flag
+        reads ``False`` so the dashboard skips polling them.
+        """
+        if self._client_simulation_state is None:
+            return False
+        return (
+            self._client_simulation_state.intake_engine is not None
+            and self._client_simulation_state.review_pipeline is not None
+        )
 
     @property
     def client_simulation_state(self) -> ClientSimulationState:

--- a/src/synthorg/config/schema.py
+++ b/src/synthorg/config/schema.py
@@ -223,6 +223,26 @@ class AgentConfig(BaseModel):
             "None inherits the company strategy config default."
         ),
     )
+    tier: str | None = Field(
+        default=None,
+        description=(
+            "Resolved model tier from the setup wizard "
+            "(``large`` / ``medium`` / ``small``). Round-trips so the "
+            "company-agents setting survives Pydantic validation when "
+            "the wizard persists tier alongside the model selection."
+        ),
+    )
+    model_requirement: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Structured model requirement dict emitted by the setup "
+            "wizard (tier / priority / min_context / capabilities). "
+            "Stored as a raw dict because the canonical "
+            "``ModelRequirement`` model lives in ``synthorg.templates`` "
+            "and importing it here would create a config -> templates "
+            "cycle; the matcher rehydrates the dict at use sites."
+        ),
+    )
 
 
 class GracefulShutdownConfig(BaseModel):

--- a/src/synthorg/config/schema.py
+++ b/src/synthorg/config/schema.py
@@ -223,7 +223,7 @@ class AgentConfig(BaseModel):
             "None inherits the company strategy config default."
         ),
     )
-    tier: str | None = Field(
+    tier: Literal["large", "medium", "small"] | None = Field(
         default=None,
         description=(
             "Resolved model tier from the setup wizard "

--- a/src/synthorg/integrations/connections/catalog.py
+++ b/src/synthorg/integrations/connections/catalog.py
@@ -92,6 +92,27 @@ class ConnectionCatalog:
         self._name_locks: dict[str, asyncio.Lock] = {}
         self._name_locks_lock = asyncio.Lock()
 
+    async def rebind_repository(self, repository: ConnectionRepository) -> None:
+        """Swap the underlying repository and invalidate the cache.
+
+        Used by the API lifecycle hook to graduate the catalog from the
+        startup-window ``InMemoryConnectionRepository`` stub (installed
+        before ``persistence.connect()`` succeeds) to the real
+        backend-bound repository once persistence is live. Holding
+        ``_cache_lock`` for the swap keeps a concurrent
+        ``_ensure_cache`` from observing a half-swapped state where
+        ``self._repo`` is the new backend but ``self._cache`` still
+        carries entries from the in-memory stub.
+
+        Args:
+            repository: The newly-available persistence-backed
+                ``ConnectionRepository`` to take over from this point on.
+        """
+        async with self._cache_lock:
+            self._repo = repository
+            self._cache = {}
+            self._cache_valid = False
+
     async def _ensure_cache(self) -> None:
         """Populate the cache from persistence if invalid."""
         if self._cache_valid:

--- a/src/synthorg/integrations/connections/catalog.py
+++ b/src/synthorg/integrations/connections/catalog.py
@@ -35,6 +35,7 @@ from synthorg.observability.events.integrations import (
     CONNECTION_UPDATE_FAILED,
     CONNECTION_UPDATED,
     CONNECTION_VALIDATION_FAILED,
+    HEALTH_STATUS_TRANSITIONED,
     OAUTH_TOKEN_EXCHANGE_FAILED,
     OAUTH_TOKEN_EXCHANGED,
     SECRET_DELETE_FAILED,
@@ -98,16 +99,16 @@ class ConnectionCatalog:
         Used by the API lifecycle hook to graduate the catalog from the
         startup-window ``InMemoryConnectionRepository`` stub (installed
         before ``persistence.connect()`` succeeds) to the real
-        backend-bound repository once persistence is live. Holding
-        ``_cache_lock`` for the swap keeps a concurrent
-        ``_ensure_cache`` from observing a half-swapped state where
-        ``self._repo`` is the new backend but ``self._cache`` still
-        carries entries from the in-memory stub.
+        backend-bound repository once persistence is live.
 
         Args:
             repository: The newly-available persistence-backed
                 ``ConnectionRepository`` to take over from this point on.
         """
+        # Hold ``_cache_lock`` for the swap so a concurrent
+        # ``_ensure_cache`` cannot observe a half-swapped state where
+        # ``self._repo`` is already the new backend but ``self._cache``
+        # still carries entries seeded from the in-memory stub.
         async with self._cache_lock:
             self._repo = repository
             self._cache = {}
@@ -556,6 +557,16 @@ class ConnectionCatalog:
             )
             await self._repo.save(updated)
             self._invalidate_cache()
+            # Log the transition only when it actually changed, so a
+            # quiet health prober cycling the same status does not
+            # flood the log stream.
+            if existing.health_status != status:
+                logger.info(
+                    HEALTH_STATUS_TRANSITIONED,
+                    connection_name=name,
+                    previous_status=existing.health_status.value,
+                    new_status=status.value,
+                )
             return updated
 
     async def delete(self, name: str) -> None:

--- a/src/synthorg/persistence/postgres/mcp_installation_repo.py
+++ b/src/synthorg/persistence/postgres/mcp_installation_repo.py
@@ -11,9 +11,10 @@ name -- robust to accidental SELECT re-ordering.
 
 from typing import TYPE_CHECKING, Any
 
+import psycopg
 from psycopg.rows import dict_row
 
-from synthorg.core.persistence_errors import QueryError
+from synthorg.core.persistence_errors import ConstraintViolationError, QueryError
 from synthorg.core.types import NotBlankStr
 from synthorg.integrations.mcp_catalog.installations import McpInstallation
 from synthorg.observability import get_logger, safe_error_description
@@ -58,7 +59,18 @@ class PostgresMcpInstallationRepository:
         self._pool = pool
 
     async def save(self, installation: McpInstallation) -> None:
-        """Upsert an installation row (idempotent on catalog_entry_id)."""
+        """Upsert an installation row (idempotent on catalog_entry_id).
+
+        Raises:
+            ConstraintViolationError: When the upsert violates a
+                database constraint -- in practice the
+                ``mcp_installations_connection_name_fkey`` foreign key
+                on ``connection_name``, raised when the supplied
+                connection has not been persisted. Surfaces the
+                Postgres constraint name so the central exception
+                handler can return a 400 with a structured payload
+                rather than a 500.
+        """
         installed_at = normalize_utc(installation.installed_at)
         try:
             async with self._pool.connection() as conn, conn.cursor() as cur:
@@ -79,6 +91,26 @@ class PostgresMcpInstallationRepository:
                 )
         except MemoryError, RecursionError:
             raise
+        except psycopg.errors.IntegrityError as exc:
+            constraint = (
+                getattr(getattr(exc, "diag", None), "constraint_name", None)
+                or "<unknown>"
+            )
+            logger.warning(
+                MCP_SERVER_INSTALL_FAILED,
+                operation="upsert",
+                catalog_entry_id=installation.catalog_entry_id,
+                connection_name=installation.connection_name,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+                constraint=constraint,
+                backend="postgres",
+            )
+            msg = (
+                f"Constraint violation saving MCP installation "
+                f"{installation.catalog_entry_id!r}"
+            )
+            raise ConstraintViolationError(msg, constraint=constraint) from exc
         except Exception as exc:
             logger.warning(
                 MCP_SERVER_INSTALL_FAILED,

--- a/src/synthorg/persistence/postgres/mcp_installation_repo.py
+++ b/src/synthorg/persistence/postgres/mcp_installation_repo.py
@@ -63,13 +63,11 @@ class PostgresMcpInstallationRepository:
 
         Raises:
             ConstraintViolationError: When the upsert violates a
-                database constraint -- in practice the
-                ``mcp_installations_connection_name_fkey`` foreign key
-                on ``connection_name``, raised when the supplied
-                connection has not been persisted. Surfaces the
-                Postgres constraint name so the central exception
-                handler can return a 400 with a structured payload
-                rather than a 500.
+                database constraint, in practice the foreign key on
+                ``connection_name`` when the supplied connection has
+                not been persisted. Surfaces the constraint identity
+                so the central exception handler can return a
+                structured 4xx envelope.
         """
         installed_at = normalize_utc(installation.installed_at)
         try:

--- a/src/synthorg/persistence/postgres/mcp_installation_repo.py
+++ b/src/synthorg/persistence/postgres/mcp_installation_repo.py
@@ -68,6 +68,10 @@ class PostgresMcpInstallationRepository:
                 not been persisted. Surfaces the constraint identity
                 so the central exception handler can return a
                 structured 4xx envelope.
+            QueryError: For all other ``psycopg`` failures (pool
+                checkout errors, transient connectivity, etc.). Parity
+                with the SQLite backend so callers receive a uniform
+                envelope across backends.
         """
         installed_at = normalize_utc(installation.installed_at)
         try:
@@ -119,7 +123,8 @@ class PostgresMcpInstallationRepository:
                 error=safe_error_description(exc),
                 backend="postgres",
             )
-            raise
+            msg = f"Failed to save mcp installation {installation.catalog_entry_id!r}"
+            raise QueryError(msg) from exc
         logger.info(
             MCP_SERVER_INSTALLED,
             catalog_entry_id=installation.catalog_entry_id,

--- a/src/synthorg/persistence/sqlite/mcp_installation_repo.py
+++ b/src/synthorg/persistence/sqlite/mcp_installation_repo.py
@@ -10,7 +10,7 @@ import sqlite3
 
 import aiosqlite
 
-from synthorg.core.persistence_errors import QueryError
+from synthorg.core.persistence_errors import ConstraintViolationError, QueryError
 from synthorg.core.types import NotBlankStr
 from synthorg.integrations.mcp_catalog.installations import McpInstallation
 from synthorg.observability import get_logger, safe_error_description
@@ -30,6 +30,27 @@ from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
 logger = get_logger(__name__)
 
 
+def _classify_sqlite_constraint(exc: sqlite3.IntegrityError) -> str:
+    """Map a SQLite IntegrityError message to a stable constraint label.
+
+    SQLite (unlike Postgres) does not name constraints in its
+    exception payload; the only identity is the human-readable
+    message text. Match the message prefix and emit a stable token
+    that mirrors the Postgres ``exc.diag.constraint_name`` shape so
+    callers can route both backends through the same handler.
+    """
+    text = str(exc).lower()
+    if "foreign key" in text:
+        return "mcp_installations_connection_name_fkey"
+    if "unique" in text:
+        return "mcp_installations_catalog_entry_id_key"
+    if "not null" in text:
+        return "mcp_installations_not_null"
+    if "check" in text:
+        return "mcp_installations_check"
+    return "<unknown>"
+
+
 class SQLiteMcpInstallationRepository:
     """SQLite implementation of :class:`McpInstallationRepository`."""
 
@@ -43,7 +64,19 @@ class SQLiteMcpInstallationRepository:
         self._write_context = write_context
 
     async def save(self, installation: McpInstallation) -> None:
-        """Upsert an installation row (idempotent on catalog_entry_id)."""
+        """Upsert an installation row (idempotent on catalog_entry_id).
+
+        Raises:
+            ConstraintViolationError: When the upsert violates a
+                database constraint, in practice the foreign key on
+                ``connection_name`` when the supplied connection has
+                not been persisted. Surfaces the constraint identity
+                so the central exception handler can return a
+                structured 4xx envelope. Parity with the Postgres
+                backend, which extracts ``exc.diag.constraint_name``.
+            QueryError: For all other ``sqlite3`` / ``aiosqlite``
+                failures (lock timeouts, disk I/O errors, etc.).
+        """
         installed_at_iso = format_iso_utc(installation.installed_at)
         async with self._write_context():
             try:
@@ -63,6 +96,29 @@ class SQLiteMcpInstallationRepository:
                     ),
                 )
                 await self._db.commit()
+            except sqlite3.IntegrityError as exc:
+                with contextlib.suppress(sqlite3.Error, aiosqlite.Error):
+                    await self._db.rollback()
+                # SQLite does not expose constraint names; the error
+                # message text is the only identity available.
+                # Surface the literal "FOREIGN KEY constraint failed"
+                # so callers can route the same way as Postgres'
+                # named foreign-key constraint.
+                constraint = _classify_sqlite_constraint(exc)
+                logger.warning(
+                    PERSISTENCE_MCP_INSTALLATION_SAVE_FAILED,
+                    catalog_entry_id=installation.catalog_entry_id,
+                    connection_name=installation.connection_name,
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
+                    constraint=constraint,
+                    backend="sqlite",
+                )
+                msg = (
+                    f"Constraint violation saving MCP installation "
+                    f"{installation.catalog_entry_id!r}"
+                )
+                raise ConstraintViolationError(msg, constraint=constraint) from exc
             except (sqlite3.Error, aiosqlite.Error) as exc:
                 with contextlib.suppress(sqlite3.Error, aiosqlite.Error):
                     await self._db.rollback()

--- a/src/synthorg/providers/discovery.py
+++ b/src/synthorg/providers/discovery.py
@@ -215,7 +215,15 @@ async def discover_models(
     Returns:
         Tuple of discovered model configs, or empty tuple on failure.
     """
-    if preset_name == "ollama":
+    # ``ollama`` (local) and ``ollama-cloud`` (hosted) both speak the
+    # native Ollama listing protocol (``GET /api/tags``); the hosted
+    # variant is just a different base URL with the same payload
+    # shape. Routing the cloud preset through ``_discover_standard_api``
+    # used to fetch ``GET {base}/models``, which Ollama does not
+    # expose -- the 404 was being treated as an empty model list and,
+    # paired with the dialog's ``replace_existing=true`` default,
+    # silently wiped every persisted model on the very first sync.
+    if preset_name in {"ollama", "ollama-cloud"}:
         return await _discover_ollama(
             base_url,
             headers=headers,

--- a/src/synthorg/providers/discovery.py
+++ b/src/synthorg/providers/discovery.py
@@ -217,12 +217,11 @@ async def discover_models(
     """
     # ``ollama`` (local) and ``ollama-cloud`` (hosted) both speak the
     # native Ollama listing protocol (``GET /api/tags``); the hosted
-    # variant is just a different base URL with the same payload
-    # shape. Routing the cloud preset through ``_discover_standard_api``
-    # used to fetch ``GET {base}/models``, which Ollama does not
-    # expose -- the 404 was being treated as an empty model list and,
-    # paired with the dialog's ``replace_existing=true`` default,
-    # silently wiped every persisted model on the very first sync.
+    # variant only differs by base URL with the same payload shape.
+    # ``_discover_standard_api`` calls ``GET {base}/models``, which
+    # Ollama does not expose; routing the cloud preset there would
+    # treat the 404 as an empty model list, and an empty list paired
+    # with ``replace_existing=true`` deletes every persisted model.
     if preset_name in {"ollama", "ollama-cloud"}:
         return await _discover_ollama(
             base_url,

--- a/src/synthorg/providers/management/_capabilities_mixin.py
+++ b/src/synthorg/providers/management/_capabilities_mixin.py
@@ -52,6 +52,44 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _reject_destructive_empty_discovery(
+    *,
+    name: str,
+    request: SyncModelsRequest,
+    discovered: tuple[ProviderModelConfig, ...],
+    pre_discover: ProviderConfig,
+) -> None:
+    """Refuse a replace-mode sync that would wipe every persisted model.
+
+    An empty discovery paired with ``replace_existing=True`` used to
+    silently delete every model when discovery hit a 404 / timeout /
+    wrong URL. The safe fallback is ``replace_existing=False`` (append-
+    only); it adds nothing when discovery is empty, so the operator
+    can run it freely while debugging the discovery endpoint.
+    """
+    if not request.replace_existing or discovered:
+        return
+    existing_count = len(pre_discover.models)
+    if not existing_count:
+        return
+    msg = (
+        f"Sync would delete all {existing_count} persisted "
+        f"model(s) for provider {name!r} because discovery "
+        f"returned no models; refusing destructive replace. "
+        f"Re-check the provider URL or retry with "
+        f"``replace_existing=false``."
+    )
+    logger.warning(
+        PROVIDER_VALIDATION_FAILED,
+        provider=name,
+        error=msg,
+        discovered_count=0,
+        existing_count=existing_count,
+        replace_existing=True,
+    )
+    raise ProviderValidationError(msg)
+
+
 # Narrows the mixin's self-type to the 3 attrs + 3 methods consumed;
 # host: ProviderManagementService (composed via MRO in service.py).
 class _ServiceProtocol(Protocol):
@@ -213,6 +251,13 @@ class ProviderCapabilitiesMixin:
         discovered = await self.discover_models_for_provider(
             name,
             preset_hint=request.preset_hint,
+        )
+
+        _reject_destructive_empty_discovery(
+            name=name,
+            request=request,
+            discovered=discovered,
+            pre_discover=pre_discover,
         )
 
         async with self._lock:

--- a/src/synthorg/providers/management/_capabilities_mixin.py
+++ b/src/synthorg/providers/management/_capabilities_mixin.py
@@ -61,11 +61,12 @@ def _reject_destructive_empty_discovery(
 ) -> None:
     """Refuse a replace-mode sync that would wipe every persisted model.
 
-    An empty discovery paired with ``replace_existing=True`` used to
-    silently delete every model when discovery hit a 404 / timeout /
-    wrong URL. The safe fallback is ``replace_existing=False`` (append-
-    only); it adds nothing when discovery is empty, so the operator
-    can run it freely while debugging the discovery endpoint.
+    Invariant: when ``replace_existing=True`` and discovery returns
+    no models while persisted models exist, refuse the sync so a
+    transient 404 / timeout / wrong-URL outcome cannot delete every
+    persisted model. ``replace_existing=False`` (append-only) is the
+    safe path for operators to retry while debugging the discovery
+    endpoint, since it adds nothing when discovery is empty.
     """
     if not request.replace_existing or discovered:
         return

--- a/src/synthorg/providers/management/_capabilities_mixin.py
+++ b/src/synthorg/providers/management/_capabilities_mixin.py
@@ -254,13 +254,6 @@ class ProviderCapabilitiesMixin:
             preset_hint=request.preset_hint,
         )
 
-        _reject_destructive_empty_discovery(
-            name=name,
-            request=request,
-            discovered=discovered,
-            pre_discover=pre_discover,
-        )
-
         async with self._lock:
             providers = await self._config_resolver.get_provider_configs()
             current = providers.get(name)
@@ -270,6 +263,20 @@ class ProviderCapabilitiesMixin:
                 msg = f"Provider {name!r} not found"
                 logger.warning(PROVIDER_NOT_FOUND, provider=name, error=msg)
                 raise ProviderNotFoundError(msg)
+
+            # Re-check the destructive-empty guard against the
+            # post-lock snapshot; a concurrent ``add_model()`` that
+            # lands between the pre-lock ``pre_discover`` read and
+            # ``self._lock`` acquisition can flip the persisted set
+            # from empty (guard returns early) to non-empty (guard
+            # MUST refuse the wipe). Using ``current`` closes that
+            # window.
+            _reject_destructive_empty_discovery(
+                name=name,
+                request=request,
+                discovered=discovered,
+                pre_discover=current,
+            )
 
             # If the discovery target was swapped under us (different
             # base_url / auth_type / preset) we must NOT persist the

--- a/src/synthorg/providers/management/service.py
+++ b/src/synthorg/providers/management/service.py
@@ -10,7 +10,7 @@ import time
 from typing import TYPE_CHECKING
 
 from synthorg.budget.call_category import LLMCallCategory
-from synthorg.config.schema import ProviderConfig, ProviderModelConfig  # noqa: TC001
+from synthorg.config.schema import ProviderConfig, ProviderModelConfig
 from synthorg.core.types import NotBlankStr
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.provider import (
@@ -92,12 +92,17 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 # Provider fields that carry credential / secret material.  Their
-# values must never appear in audit-row payloads -- the audit table is
-# read by anyone with operator role and is exported on data backups,
-# so a leaked api_key here defeats the secret-backend isolation
-# entirely.  Diffs against these fields collapse to a sentinel that
-# preserves the "this field changed" signal without exposing either
-# the prior or the new value.
+# values must never appear in audit-row payloads: the audit table is
+# operator-readable and is included in data backups.  Diffs against
+# these fields collapse to a sentinel that preserves the
+# "this field changed" signal without exposing either value.
+#
+# This list must stay synchronised with every credential-bearing
+# field on ``ProviderConfig``.  Adding a new credential field without
+# extending this set leaks it on the next ``update_provider`` audit
+# entry.  ``_assert_sensitive_fields_complete`` runs at import time
+# to fail fast when ``ProviderConfig`` grows a credential field that
+# is not whitelisted here.
 _SENSITIVE_PROVIDER_FIELDS: frozenset[str] = frozenset(
     {
         "api_key",
@@ -106,6 +111,34 @@ _SENSITIVE_PROVIDER_FIELDS: frozenset[str] = frozenset(
         "custom_header_value",
     },
 )
+
+
+def _assert_sensitive_fields_complete() -> None:
+    """Fail-fast guard against silent credential leakage in audit diffs.
+
+    A new ``ProviderConfig`` field whose name encodes a credential
+    (matches ``*_key`` / ``*_token`` / ``*_secret`` / contains
+    ``password``) must be added to ``_SENSITIVE_PROVIDER_FIELDS``.
+    Catching the omission here, at import time, prevents the field
+    from ever reaching an audit row in production.
+    """
+    credential_suffixes = ("_key", "_token", "_secret", "_password")
+    suspected = {
+        name
+        for name in ProviderConfig.model_fields
+        if name.endswith(credential_suffixes) or "password" in name.lower()
+    }
+    leaks = suspected - _SENSITIVE_PROVIDER_FIELDS
+    if leaks:
+        msg = (
+            "ProviderConfig fields look credential-bearing but are not "
+            f"redacted in audit diffs: {sorted(leaks)!r}. Add them to "
+            "synthorg.providers.management.service._SENSITIVE_PROVIDER_FIELDS."
+        )
+        raise RuntimeError(msg)
+
+
+_assert_sensitive_fields_complete()
 
 
 def _diff_provider_update(

--- a/src/synthorg/providers/management/service.py
+++ b/src/synthorg/providers/management/service.py
@@ -91,6 +91,54 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+# Provider fields that carry credential / secret material.  Their
+# values must never appear in audit-row payloads -- the audit table is
+# read by anyone with operator role and is exported on data backups,
+# so a leaked api_key here defeats the secret-backend isolation
+# entirely.  Diffs against these fields collapse to a sentinel that
+# preserves the "this field changed" signal without exposing either
+# the prior or the new value.
+_SENSITIVE_PROVIDER_FIELDS: frozenset[str] = frozenset(
+    {
+        "api_key",
+        "subscription_token",
+        "oauth_client_secret",
+        "custom_header_value",
+    },
+)
+
+
+def _diff_provider_update(
+    existing: ProviderConfig,
+    updated: ProviderConfig,
+) -> dict[str, object]:
+    """Build an audit payload listing only fields whose value changed.
+
+    The EDIT form on the frontend re-sends every field on every submit,
+    so ``request.model_dump(exclude_unset=True)`` would mark every
+    field as "changed" even when the user only touched ``base_url``.
+    Comparing the persisted ``existing`` config against the post-merge
+    ``updated`` config produces the operator-meaningful diff: each
+    changed field gets an ``{"old": ..., "new": ...}`` entry, sensitive
+    fields collapse to ``"<redacted>"`` sentinels, and the legacy
+    ``fields_changed`` list is kept for downstream audit-log
+    consumers that already filter on it.
+    """
+    before = existing.model_dump(mode="json")
+    after = updated.model_dump(mode="json")
+    changes: dict[str, dict[str, object]] = {}
+    for key in sorted(set(before) | set(after)):
+        if before.get(key) == after.get(key):
+            continue
+        if key in _SENSITIVE_PROVIDER_FIELDS:
+            changes[key] = {"old": "<redacted>", "new": "<redacted>"}
+        else:
+            changes[key] = {"old": before.get(key), "new": after.get(key)}
+    return {
+        "fields_changed": list(changes.keys()),
+        "diff": changes,
+    }
+
 
 def _safe_task_id_segment(value: str) -> str:
     """Strip control / whitespace / colon characters from a task-id segment.
@@ -267,11 +315,7 @@ class ProviderManagementService(ProviderCapabilitiesMixin):
                 provider_name=name,
                 event_type="provider_updated",
                 actor=actor,
-                payload={
-                    "fields_changed": sorted(
-                        request.model_dump(exclude_unset=True).keys(),
-                    ),
-                },
+                payload=_diff_provider_update(existing, updated),
             )
             return updated
 

--- a/src/synthorg/providers/presets.py
+++ b/src/synthorg/providers/presets.py
@@ -395,21 +395,18 @@ _COHERE = CloudPreset(
 _OLLAMA_CLOUD = CloudPreset(
     name="ollama-cloud",
     display_name="Ollama Cloud",
-    description=(
-        "Hosted Ollama models (managed inference). Supply the API base URL"
-        " from your ollama.com account."
-    ),
+    description="Hosted Ollama models (managed inference) at ollama.com.",
     driver="litellm",
     litellm_provider="ollama",
     auth_type=AuthType.API_KEY,
     supported_auth_types=(AuthType.API_KEY,),
-    # No default base URL on purpose: the canonical hosted endpoint can
-    # change as the service evolves, and we should not bake an unverified
-    # marketing URL into the form.  Users supply the URL from their
-    # ollama.com account; once a stable canonical endpoint is documented
-    # we can ship a safe default and flip ``requires_base_url`` back.
-    default_base_url=None,
-    requires_base_url=True,
+    # ollama.com is the canonical hosted Ollama endpoint that LiteLLM's
+    # ``ollama`` provider targets when a base URL is supplied. Users
+    # with a private deployment may override the field; the default
+    # matches the public service so the form is submit-ready after
+    # entering an API key alone.
+    default_base_url="https://ollama.com",
+    requires_base_url=False,
     default_models=(),
 )
 

--- a/tests/conformance/persistence/test_mcp_installations_repository.py
+++ b/tests/conformance/persistence/test_mcp_installations_repository.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from synthorg.core.persistence_errors import QueryError
+from synthorg.core.persistence_errors import ConstraintViolationError, QueryError
 from synthorg.core.types import NotBlankStr
 from synthorg.integrations.mcp_catalog.installations import McpInstallation
 from synthorg.persistence.protocol import PersistenceBackend
@@ -165,3 +165,26 @@ class TestMcpInstallationRepository:
             NotBlankStr("never_existed"),
         )
         assert deleted is False
+
+    async def test_save_raises_constraint_violation_on_unknown_connection(
+        self, backend: PersistenceBackend
+    ) -> None:
+        """Both backends surface FK violations as ConstraintViolationError.
+
+        Pre-parity, Postgres translated the psycopg ``IntegrityError``
+        but SQLite returned a generic ``QueryError``; callers had to
+        branch on backend type to render the right 4xx vs 5xx
+        response. Both must now raise the same shape so the central
+        exception handler can route uniformly.
+        """
+        rogue = _installation(
+            "catalog_fk_violation",
+            connection_name="never_registered_connection",
+        )
+        with pytest.raises(ConstraintViolationError) as exc_info:
+            await backend.mcp_installations.save(rogue)
+        # The constraint identity is the FK on connection_name; both
+        # backends must surface a non-empty identifier so the handler
+        # can include it in the structured error payload.
+        assert exc_info.value.constraint
+        assert exc_info.value.constraint != "<unknown>"

--- a/tests/unit/api/controllers/test_providers.py
+++ b/tests/unit/api/controllers/test_providers.py
@@ -555,7 +555,9 @@ async def _bound_audit_actor() -> AsyncIterator[None]:
     Production traffic goes through ``AuthContextMiddleware`` which
     populates the same ContextVar; these direct-handler tests bypass
     the middleware stack, so the fixture has to bind the user
-    explicitly.
+    explicitly. Inherits the default function scope so the
+    ``ContextVar`` reset happens between every test, even when
+    xdist groups them onto one worker.
     """
     from synthorg.api.auth.context import authenticated_user_scope
     from synthorg.core.auth.models import AuthenticatedUser, AuthMethod

--- a/tests/unit/api/controllers/test_providers.py
+++ b/tests/unit/api/controllers/test_providers.py
@@ -1,6 +1,7 @@
 """Tests for provider controller."""
 
 import json
+from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -545,7 +546,33 @@ class TestProbeLocalEndpoint:
             assert resp.status_code == 429
 
 
+@pytest.fixture
+async def _bound_audit_actor() -> AsyncIterator[None]:
+    """Bind a synthetic authenticated user so ``audit_actor_from_context``
+    resolves to a real ``ProviderAuditActor`` instead of raising
+    ``AuthContextMissingError`` during direct controller-handler calls.
+
+    Production traffic goes through ``AuthContextMiddleware`` which
+    populates the same ContextVar; these direct-handler tests bypass
+    the middleware stack, so the fixture has to bind the user
+    explicitly.
+    """
+    from synthorg.api.auth.context import authenticated_user_scope
+    from synthorg.core.auth.models import AuthenticatedUser, AuthMethod
+    from synthorg.core.auth.roles import HumanRole
+
+    user = AuthenticatedUser(
+        user_id="test-user-id",
+        username="test-user",
+        role=HumanRole.CEO,
+        auth_method=AuthMethod.JWT,
+    )
+    async with authenticated_user_scope(user):
+        yield
+
+
 @pytest.mark.unit
+@pytest.mark.usefixtures("_bound_audit_actor")
 class TestProviderControllerErrorSanitization:
     """Validation / conflict error paths must surface sanitized text.
 

--- a/tests/unit/api/test_middleware.py
+++ b/tests/unit/api/test_middleware.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import pytest
+import structlog
 from litestar import Litestar, get, post
 from litestar.enums import ScopeType
 from litestar.exceptions import ValidationException
@@ -596,7 +597,6 @@ class TestHealthcheckLogSuppression:
     )
     def test_healthcheck_paths_emit_no_request_log_pair(self, path: str) -> None:
         """No ``api.request.started`` / ``api.request.completed`` for probes."""
-        import structlog as _structlog
 
         @get(path)
         async def handler() -> dict[str, str]:
@@ -607,7 +607,7 @@ class TestHealthcheckLogSuppression:
             middleware=[RequestLoggingMiddleware],
             exception_handlers=dict(EXCEPTION_HANDLERS),  # type: ignore[arg-type]
         )
-        with _structlog.testing.capture_logs() as logs, TestClient(app) as client:
+        with structlog.testing.capture_logs() as logs, TestClient(app) as client:
             resp = client.get(path)
             assert resp.status_code == 200
 
@@ -621,7 +621,6 @@ class TestHealthcheckLogSuppression:
 
     def test_non_healthcheck_path_still_logs(self) -> None:
         """Regular routes continue to emit the started/completed pair."""
-        import structlog as _structlog
 
         @get("/some/business/endpoint")
         async def handler() -> dict[str, str]:
@@ -632,10 +631,16 @@ class TestHealthcheckLogSuppression:
             middleware=[RequestLoggingMiddleware],
             exception_handlers=dict(EXCEPTION_HANDLERS),  # type: ignore[arg-type]
         )
-        with _structlog.testing.capture_logs() as logs, TestClient(app) as client:
+        with structlog.testing.capture_logs() as logs, TestClient(app) as client:
             resp = client.get("/some/business/endpoint")
             assert resp.status_code == 200
 
         events = [entry.get("event") for entry in logs]
-        assert "api.request.started" in events
-        assert "api.request.completed" in events
+        # Exactly one of each, started before completed; bare presence
+        # checks miss the ordering invariant and would also accept a
+        # duplicate pair from accidental middleware re-entry.
+        assert events.count("api.request.started") == 1
+        assert events.count("api.request.completed") == 1
+        assert events.index("api.request.started") < events.index(
+            "api.request.completed",
+        )

--- a/tests/unit/api/test_middleware.py
+++ b/tests/unit/api/test_middleware.py
@@ -577,3 +577,65 @@ class TestLogRequestCompletion:
         info_logs = [entry for entry in logs if entry.get("log_level") == "info"]
         assert len(info_logs) >= 1
         assert info_logs[0]["status_code"] == 201
+
+
+class TestHealthcheckLogSuppression:
+    """Healthcheck paths must not emit api.request.* log records.
+
+    Supervisors (Docker healthcheck, k8s probes) hammer ``/readyz``
+    and ``/healthz`` on a fixed interval, producing thousands of
+    duplicate entries per day. The middleware suppresses the
+    structured request-log pair for those paths while keeping the
+    Prometheus metric and OpenTelemetry span so operators still see
+    aggregated latency.
+    """
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/healthz", "/readyz", "/api/v1/healthz", "/api/v1/readyz"],
+    )
+    def test_healthcheck_paths_emit_no_request_log_pair(self, path: str) -> None:
+        """No ``api.request.started`` / ``api.request.completed`` for probes."""
+        import structlog as _structlog
+
+        @get(path)
+        async def handler() -> dict[str, str]:
+            return {"status": "ok"}
+
+        app = Litestar(
+            route_handlers=[handler],
+            middleware=[RequestLoggingMiddleware],
+            exception_handlers=dict(EXCEPTION_HANDLERS),  # type: ignore[arg-type]
+        )
+        with _structlog.testing.capture_logs() as logs, TestClient(app) as client:
+            resp = client.get(path)
+            assert resp.status_code == 200
+
+        events = [entry.get("event") for entry in logs]
+        assert "api.request.started" not in events, (
+            f"healthcheck path {path} emitted api.request.started"
+        )
+        assert "api.request.completed" not in events, (
+            f"healthcheck path {path} emitted api.request.completed"
+        )
+
+    def test_non_healthcheck_path_still_logs(self) -> None:
+        """Regular routes continue to emit the started/completed pair."""
+        import structlog as _structlog
+
+        @get("/some/business/endpoint")
+        async def handler() -> dict[str, str]:
+            return {"ok": "true"}
+
+        app = Litestar(
+            route_handlers=[handler],
+            middleware=[RequestLoggingMiddleware],
+            exception_handlers=dict(EXCEPTION_HANDLERS),  # type: ignore[arg-type]
+        )
+        with _structlog.testing.capture_logs() as logs, TestClient(app) as client:
+            resp = client.get("/some/business/endpoint")
+            assert resp.status_code == 200
+
+        events = [entry.get("event") for entry in logs]
+        assert "api.request.started" in events
+        assert "api.request.completed" in events

--- a/tests/unit/api/test_state.py
+++ b/tests/unit/api/test_state.py
@@ -571,3 +571,58 @@ class TestAppStateApiBridgeConfig:
         state.swap_api_bridge_config(snapshot)
         state.swap_api_bridge_config(snapshot)
         assert state.api_bridge_config is snapshot
+
+
+@pytest.mark.unit
+class TestAppStateSimulationRuntime:
+    """Tests for has_client_simulation_state vs has_simulation_runtime.
+
+    The two predicates intentionally differ: the broad one is always
+    true in production (so ``/clients`` serves an empty list rather
+    than 503ing on the dashboard's first poll), and the strict one
+    gates the optional Simulation / Request controllers that need a
+    real ``intake_engine`` + ``review_pipeline``.
+    """
+
+    def _state_with_simulation(
+        self,
+        *,
+        intake_engine: object | None = None,
+        review_pipeline: object | None = None,
+    ) -> AppState:
+        from synthorg.client.simulation_state import ClientSimulationState
+
+        sim = ClientSimulationState(
+            intake_engine=intake_engine,  # type: ignore[arg-type]
+            review_pipeline=review_pipeline,  # type: ignore[arg-type]
+        )
+        state = _make_state()
+        state.set_client_simulation_state(sim)
+        return state
+
+    def test_has_simulation_runtime_false_when_no_state(self) -> None:
+        state = _make_state()
+        assert state.has_client_simulation_state is False
+        assert state.has_simulation_runtime is False
+
+    def test_has_simulation_runtime_false_when_only_state_present(self) -> None:
+        state = self._state_with_simulation()
+        assert state.has_client_simulation_state is True
+        assert state.has_simulation_runtime is False
+
+    def test_has_simulation_runtime_false_when_only_intake_engine(self) -> None:
+        sentinel = object()
+        state = self._state_with_simulation(intake_engine=sentinel)
+        assert state.has_simulation_runtime is False
+
+    def test_has_simulation_runtime_false_when_only_review_pipeline(self) -> None:
+        sentinel = object()
+        state = self._state_with_simulation(review_pipeline=sentinel)
+        assert state.has_simulation_runtime is False
+
+    def test_has_simulation_runtime_true_when_both_present(self) -> None:
+        state = self._state_with_simulation(
+            intake_engine=object(),
+            review_pipeline=object(),
+        )
+        assert state.has_simulation_runtime is True

--- a/tests/unit/config/test_schema.py
+++ b/tests/unit/config/test_schema.py
@@ -283,6 +283,62 @@ class TestAgentConfig:
         assert isinstance(a, AgentConfig)
         assert a.name
 
+    def test_tier_roundtrips_through_pydantic(self) -> None:
+        """``tier`` survives serialise/deserialise.
+
+        Setup wizard persists ``tier`` alongside the model selection;
+        without round-trip support every read would drop the field
+        and the company-agents setting would surface as
+        ``no agents visible`` across the dashboard.
+        """
+        a = AgentConfig(
+            name="Alice",
+            role="dev",
+            department="eng",
+            tier="medium",
+        )
+        rebuilt = AgentConfig.model_validate(a.model_dump(mode="json"))
+        assert rebuilt.tier == "medium"
+
+    def test_tier_rejects_unknown_value(self) -> None:
+        """``tier`` is constrained to large / medium / small.
+
+        Typos like ``"med"`` or ``"big"`` were silently accepted as
+        ``str`` and broke the wizard's tier-to-model matcher at use
+        time; the Literal narrows the contract so the failure
+        happens at config-load.
+        """
+        with pytest.raises(ValidationError):
+            AgentConfig(
+                name="Alice",
+                role="dev",
+                department="eng",
+                tier="extra-large",  # type: ignore[arg-type]
+            )
+
+    def test_model_requirement_roundtrips_as_raw_dict(self) -> None:
+        """``model_requirement`` survives serialise/deserialise.
+
+        Stored as a raw dict because the canonical
+        ``ModelRequirement`` model lives in ``synthorg.templates``
+        and importing it here would create a config -> templates
+        cycle.  The matcher rehydrates the dict at use sites.
+        """
+        requirement = {
+            "tier": "medium",
+            "priority": "balanced",
+            "min_context": 32_000,
+            "capabilities": ["text", "tool_use"],
+        }
+        a = AgentConfig(
+            name="Alice",
+            role="dev",
+            department="eng",
+            model_requirement=requirement,
+        )
+        rebuilt = AgentConfig.model_validate(a.model_dump(mode="json"))
+        assert rebuilt.model_requirement == requirement
+
 
 # ── RootConfig ───────────────────────────────────────────────────
 

--- a/tests/unit/integrations/test_connection_catalog_rebind.py
+++ b/tests/unit/integrations/test_connection_catalog_rebind.py
@@ -1,0 +1,105 @@
+"""Tests for ConnectionCatalog.rebind_repository.
+
+The catalog is built with an in-memory stub before persistence is
+live; once ``persistence.connect()`` succeeds the API lifecycle hook
+calls ``rebind_repository`` to swap the stub for the backend-bound
+repo. Tests verify the swap is atomic, idempotent, and invalidates
+the cache so subsequent reads observe the new backend.
+"""
+
+from typing import Any
+
+import pytest
+
+from synthorg.integrations.connections.catalog import ConnectionCatalog
+
+pytestmark = pytest.mark.unit
+
+
+class _StubRepo:
+    """Minimal ``ConnectionRepository`` stub recording its identity."""
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+        self.list_all_calls = 0
+
+    async def list_all(self) -> tuple[Any, ...]:
+        self.list_all_calls += 1
+        return ()
+
+    async def save(self, _connection: Any) -> Any:  # pragma: no cover
+        raise NotImplementedError
+
+    async def get(self, _name: str) -> Any:  # pragma: no cover
+        raise NotImplementedError
+
+    async def delete(self, _name: str) -> bool:  # pragma: no cover
+        raise NotImplementedError
+
+
+class _StubSecretBackend:
+    """No-op secret backend; rebind doesn't touch it."""
+
+    async def store(self, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover
+        raise NotImplementedError
+
+    async def fetch(self, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover
+        raise NotImplementedError
+
+    async def delete(self, *args: Any, **kwargs: Any) -> bool:  # pragma: no cover
+        raise NotImplementedError
+
+
+def _make_catalog(initial_label: str) -> tuple[ConnectionCatalog, _StubRepo]:
+    initial = _StubRepo(initial_label)
+    catalog = ConnectionCatalog(
+        repository=initial,  # type: ignore[arg-type]
+        secret_backend=_StubSecretBackend(),  # type: ignore[arg-type]
+    )
+    return catalog, initial
+
+
+class TestRebindRepository:
+    async def test_swaps_repo_reference(self) -> None:
+        catalog, _initial = _make_catalog("stub")
+        replacement = _StubRepo("persistent")
+        await catalog.rebind_repository(replacement)  # type: ignore[arg-type]
+        # ``_repo`` is typed as ConnectionRepository so a ``StubRepo``
+        # identity check is non-overlapping under strict mypy; tag the
+        # field as Any locally for the assertion only.
+        assert catalog._repo is replacement  # type: ignore[comparison-overlap]
+
+    async def test_invalidates_cache(self) -> None:
+        catalog, initial = _make_catalog("stub")
+        # Force the cache to populate from the initial (stub) repo.
+        await catalog._ensure_cache()
+        # ``getattr`` defeats mypy's literal-narrowing so the
+        # post-rebind invalidation read below is reachable; the field
+        # really is mutated, mypy just can't observe it through the
+        # rebind call.
+        assert getattr(catalog, "_cache_valid") is True  # noqa: B009
+        assert initial.list_all_calls == 1
+
+        replacement = _StubRepo("persistent")
+        await catalog.rebind_repository(replacement)  # type: ignore[arg-type]
+        # Cache must be reset, otherwise subsequent reads would observe
+        # connections that only exist in the stub.
+        assert getattr(catalog, "_cache_valid") is False  # noqa: B009
+        assert len(catalog._cache) == 0
+
+    async def test_subsequent_read_uses_new_repo(self) -> None:
+        catalog, initial = _make_catalog("stub")
+        replacement = _StubRepo("persistent")
+        await catalog.rebind_repository(replacement)  # type: ignore[arg-type]
+        # Trigger a cache populate; should hit replacement, not initial.
+        await catalog._ensure_cache()
+        assert initial.list_all_calls == 0
+        assert replacement.list_all_calls == 1
+
+    async def test_double_rebind_is_safe(self) -> None:
+        catalog, _initial = _make_catalog("stub")
+        first = _StubRepo("first_replacement")
+        second = _StubRepo("second_replacement")
+        await catalog.rebind_repository(first)  # type: ignore[arg-type]
+        await catalog.rebind_repository(second)  # type: ignore[arg-type]
+        assert catalog._repo is second  # type: ignore[comparison-overlap]

--- a/tests/unit/providers/management/test_destructive_sync_guard.py
+++ b/tests/unit/providers/management/test_destructive_sync_guard.py
@@ -1,0 +1,92 @@
+"""Tests for the destructive-empty-discovery guard.
+
+The provider sync flow used to silently wipe every persisted model
+when discovery returned an empty set (404 / wrong URL / network
+blip) paired with ``replace_existing=True``.  The guard now refuses
+the destructive path; this file covers the three branches.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from synthorg.config.schema import ProviderConfig, ProviderModelConfig
+from synthorg.core.resilience_config import RateLimiterConfig, RetryConfig
+from synthorg.providers.enums import AuthType
+from synthorg.providers.errors import ProviderValidationError
+from synthorg.providers.management._capabilities_mixin import (
+    _reject_destructive_empty_discovery,
+)
+from synthorg.providers.management.capability_dtos import SyncModelsRequest
+
+pytestmark = pytest.mark.unit
+
+
+_ALIAS_CYCLE = ("small", "medium", "large")
+
+
+def _config_with_models(count: int) -> ProviderConfig:
+    return ProviderConfig(
+        driver="litellm",
+        auth_type=AuthType.API_KEY,
+        api_key="test-key",
+        base_url="http://example/api",
+        models=tuple(
+            # Alias must be unique across the model tuple; cycle
+            # through the standard small/medium/large rotation so
+            # any model count up to 3 is valid. Tests that need >3
+            # only use ``count=29`` for the "wipe-protection" path,
+            # which the loop handles by repeating None aliases.
+            ProviderModelConfig(
+                id=f"test-model-{i:03d}",
+                alias=_ALIAS_CYCLE[i] if i < len(_ALIAS_CYCLE) else None,
+            )
+            for i in range(count)
+        ),
+        retry=RetryConfig(max_retries=0),
+        rate_limiter=RateLimiterConfig(),
+        tos_accepted_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+
+class TestRejectDestructiveEmptyDiscovery:
+    def test_raises_when_replace_and_empty_and_models_exist(self) -> None:
+        with pytest.raises(ProviderValidationError, match="refusing destructive"):
+            _reject_destructive_empty_discovery(
+                name="ollama-cloud",
+                request=SyncModelsRequest(replace_existing=True),
+                discovered=(),
+                pre_discover=_config_with_models(29),
+            )
+
+    def test_allows_when_replace_false_even_with_empty_discovery(self) -> None:
+        # Append-only mode is safe even if discovery returns nothing:
+        # it adds zero models and removes zero, so the persisted list
+        # is preserved verbatim.
+        _reject_destructive_empty_discovery(
+            name="ollama-cloud",
+            request=SyncModelsRequest(replace_existing=False),
+            discovered=(),
+            pre_discover=_config_with_models(29),
+        )
+
+    def test_allows_when_no_existing_models_to_lose(self) -> None:
+        # Replace-mode with empty discovery against a provider that
+        # never had models is a no-op, not a wipe; let it through.
+        _reject_destructive_empty_discovery(
+            name="ollama-cloud",
+            request=SyncModelsRequest(replace_existing=True),
+            discovered=(),
+            pre_discover=_config_with_models(0),
+        )
+
+    def test_allows_when_discovery_returned_models(self) -> None:
+        # The "would wipe" condition only triggers on empty discovery.
+        # A non-empty discovery in replace-mode is the happy path.
+        discovered = (ProviderModelConfig(id="test-model-001", alias="medium"),)
+        _reject_destructive_empty_discovery(
+            name="ollama-cloud",
+            request=SyncModelsRequest(replace_existing=True),
+            discovered=discovered,
+            pre_discover=_config_with_models(29),
+        )

--- a/tests/unit/providers/management/test_destructive_sync_guard.py
+++ b/tests/unit/providers/management/test_destructive_sync_guard.py
@@ -53,7 +53,7 @@ class TestRejectDestructiveEmptyDiscovery:
     def test_raises_when_replace_and_empty_and_models_exist(self) -> None:
         with pytest.raises(ProviderValidationError, match="refusing destructive"):
             _reject_destructive_empty_discovery(
-                name="ollama-cloud",
+                name="test-provider",
                 request=SyncModelsRequest(replace_existing=True),
                 discovered=(),
                 pre_discover=_config_with_models(29),
@@ -64,7 +64,7 @@ class TestRejectDestructiveEmptyDiscovery:
         # it adds zero models and removes zero, so the persisted list
         # is preserved verbatim.
         _reject_destructive_empty_discovery(
-            name="ollama-cloud",
+            name="test-provider",
             request=SyncModelsRequest(replace_existing=False),
             discovered=(),
             pre_discover=_config_with_models(29),
@@ -74,7 +74,7 @@ class TestRejectDestructiveEmptyDiscovery:
         # Replace-mode with empty discovery against a provider that
         # never had models is a no-op, not a wipe; let it through.
         _reject_destructive_empty_discovery(
-            name="ollama-cloud",
+            name="test-provider",
             request=SyncModelsRequest(replace_existing=True),
             discovered=(),
             pre_discover=_config_with_models(0),
@@ -85,7 +85,7 @@ class TestRejectDestructiveEmptyDiscovery:
         # A non-empty discovery in replace-mode is the happy path.
         discovered = (ProviderModelConfig(id="test-model-001", alias="medium"),)
         _reject_destructive_empty_discovery(
-            name="ollama-cloud",
+            name="test-provider",
             request=SyncModelsRequest(replace_existing=True),
             discovered=discovered,
             pre_discover=_config_with_models(29),

--- a/tests/unit/providers/management/test_helpers.py
+++ b/tests/unit/providers/management/test_helpers.py
@@ -330,3 +330,81 @@ class TestModelsFromLitellm:
         assert small.cost_per_1k_input == round(0.000003 * 1000, 6)
         assert small.cost_per_1k_output == round(0.000015 * 1000, 6)
         assert small.max_context == 128_000
+
+
+@pytest.mark.unit
+class TestDiffProviderUpdate:
+    """Tests for the structured field-diff audit payload.
+
+    The EDIT form on the frontend re-sends every field on every
+    submit, so ``request.model_dump(exclude_unset=True)`` would mark
+    every field as "changed" even when the user only touched
+    ``base_url``.  Comparing the persisted ``existing`` config
+    against the post-merge ``updated`` config produces the
+    operator-meaningful diff; sensitive fields must collapse to
+    ``"<redacted>"`` so credentials never reach the audit table.
+    """
+
+    def test_only_changed_fields_appear(self) -> None:
+        from synthorg.providers.management.service import _diff_provider_update
+
+        before = _make_config(base_url="http://old.example/api")
+        after = before.model_copy(update={"base_url": "http://new.example/api"})
+
+        diff = _diff_provider_update(before, after)
+
+        assert diff["fields_changed"] == ["base_url"]
+        inner = diff["diff"]
+        assert isinstance(inner, dict)
+        assert inner == {
+            "base_url": {
+                "old": "http://old.example/api",
+                "new": "http://new.example/api",
+            },
+        }
+
+    def test_sensitive_fields_collapse_to_redacted_sentinel(self) -> None:
+        from synthorg.providers.management.service import _diff_provider_update
+
+        before = _make_config(api_key="old-secret-do-not-leak")
+        after = before.model_copy(update={"api_key": "new-secret-do-not-leak"})
+
+        diff = _diff_provider_update(before, after)
+        assert diff["fields_changed"] == ["api_key"]
+        inner = diff["diff"]
+        assert isinstance(inner, dict)
+        # Neither the prior nor the new credential may appear; both
+        # collapse to the redacted sentinel while keeping the
+        # ``this-field-changed`` signal so the audit row is still
+        # informative.
+        assert inner == {
+            "api_key": {"old": "<redacted>", "new": "<redacted>"},
+        }
+        rendered = repr(inner)
+        assert "old-secret-do-not-leak" not in rendered
+        assert "new-secret-do-not-leak" not in rendered
+
+    def test_sensitive_fields_complete_against_provider_config(self) -> None:
+        """No credential-bearing field on ProviderConfig is left unredacted.
+
+        Backstops the import-time
+        ``_assert_sensitive_fields_complete`` guard: if a future
+        rename or new field slips past the heuristic, this test
+        flags it via the explicit name list rather than a startup
+        crash.
+        """
+        from synthorg.providers.management.service import (
+            _SENSITIVE_PROVIDER_FIELDS,
+        )
+
+        credential_suffixes = ("_key", "_token", "_secret", "_password")
+        suspected = {
+            name
+            for name in ProviderConfig.model_fields
+            if name.endswith(credential_suffixes) or "password" in name.lower()
+        }
+        leaks = suspected - _SENSITIVE_PROVIDER_FIELDS
+        assert leaks == set(), (
+            f"ProviderConfig field(s) look credential-bearing but are "
+            f"missing from _SENSITIVE_PROVIDER_FIELDS: {sorted(leaks)!r}"
+        )

--- a/tests/unit/providers/test_capability_mutations.py
+++ b/tests/unit/providers/test_capability_mutations.py
@@ -513,6 +513,41 @@ class TestSyncModels:
                 actor=actor,
             )
 
+    async def test_sync_rejects_when_models_added_between_pre_discover_and_lock(
+        self,
+        service: ProviderManagementService,
+        actor: ProviderAuditActor,
+    ) -> None:
+        """Race: pre-lock snapshot empty, post-lock snapshot non-empty.
+
+        If a concurrent ``add_model()`` lands between the pre-discover
+        read and lock acquisition, ``replace_existing=True`` with an
+        empty discovery would wipe the freshly-added models unless the
+        guard re-checks against the post-lock snapshot.
+        """
+        empty = _make_provider_config(models=())
+        # Concurrent ``add_model()`` populated the persisted set
+        # between the pre-discover read and lock acquisition.
+        populated = empty.model_copy(
+            update={"models": (ProviderModelConfig(id="race-m1", alias="m1"),)},
+        )
+        service._config_resolver.get_provider_configs = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[
+                {"cloud-test": empty},  # get_provider() pre-discover
+                {"cloud-test": populated},  # post-lock snapshot
+            ],
+        )
+        # Discovery returns empty (the destructive trigger).
+        service.discover_models_for_provider = AsyncMock(  # type: ignore[method-assign]
+            return_value=(),
+        )
+        with pytest.raises(ProviderValidationError, match="refusing destructive"):
+            await service.sync_models(
+                "cloud-test",
+                SyncModelsRequest(replace_existing=True),
+                actor=actor,
+            )
+
 
 @pytest.mark.unit
 class TestSubscriptionRotationToSGuard:

--- a/tests/unit/providers/test_discovery.py
+++ b/tests/unit/providers/test_discovery.py
@@ -190,6 +190,32 @@ class TestDiscoverOllama:
         assert result[0].id == "test-model-001"
         assert result[1].id == "test-model-002"
 
+    async def test_ollama_cloud_routes_through_api_tags(self) -> None:
+        """``ollama-cloud`` must hit ``/api/tags`` (not ``/models``).
+
+        Pre-fix, the cloud variant fell through to ``_discover_standard_api``
+        which fetched ``GET {base}/models``; Ollama returns 404 there,
+        the response was treated as an empty model list, and
+        ``replace_existing=True`` then deleted every persisted model
+        on the first sync click.
+        """
+        response = _mock_response({"models": [{"name": "cloud-model-001"}]})
+        with patch("synthorg.providers.discovery.httpx.AsyncClient") as mock_cls:
+            client = _mock_client(response)
+            mock_cls.return_value = client
+
+            result = await discover_models(
+                "http://localhost:11434",
+                "ollama-cloud",
+            )
+
+            client.get.assert_called_once_with(
+                "http://127.0.0.1:11434/api/tags",
+                headers={"Host": "localhost"},
+            )
+        assert len(result) == 1
+        assert result[0].id == "cloud-model-001"
+
 
 @pytest.mark.usefixtures("_bypass_ssrf")
 class TestDiscoverStandardApi:

--- a/tests/unit/providers/test_presets.py
+++ b/tests/unit/providers/test_presets.py
@@ -171,19 +171,19 @@ class TestProviderPresets:
         assert preset is not None
         assert preset.requires_base_url is True
 
-    def test_ollama_cloud_requires_user_supplied_base_url(self) -> None:
-        """Ollama Cloud has no default base URL; the user must supply it.
+    def test_ollama_cloud_prefills_canonical_base_url(self) -> None:
+        """Ollama Cloud prefills the canonical hosted endpoint.
 
-        The canonical hosted endpoint is unverified -- we deliberately
-        do not bake an unverified marketing URL into the form.  When a
-        stable endpoint is documented we can ship a safe default and
-        flip ``requires_base_url`` back to ``False``.
+        ``ollama.com`` is the canonical host LiteLLM's ``ollama``
+        provider targets when a base URL is supplied; the field is
+        optional so users with a private deployment can override but
+        the form is submit-ready after entering an API key alone.
         """
         preset = get_preset("ollama-cloud")
         assert preset is not None
         assert isinstance(preset, CloudPreset)
-        assert preset.requires_base_url is True
-        assert preset.default_base_url is None
+        assert preset.requires_base_url is False
+        assert preset.default_base_url == "https://ollama.com"
 
     @pytest.mark.parametrize("name", ["ollama", "lm-studio", "vllm"])
     def test_local_preset_requires_base_url(self, name: str) -> None:

--- a/web/src/api/types/agents.ts
+++ b/web/src/api/types/agents.ts
@@ -7,12 +7,22 @@ import type {
   SeniorityLevel,
 } from './enums'
 
+export type AgentTier = 'large' | 'medium' | 'small'
+
+export type StrategicOutputMode =
+  | 'mission_first'
+  | 'evidence_first'
+  | 'option_first'
+
 /**
  * Agent configuration as returned by the /agents API endpoints.
  *
  * Matches the backend AgentConfig Pydantic model (config/schema.py).
- * Runtime fields (id, status, hiring_date) are optional -- they exist
+ * Runtime fields (id, status, hiring_date) are optional; they exist
  * on AgentIdentity but may not be present in config-level responses.
+ * Wizard round-trip fields (personality_preset, strategic_output_mode,
+ * tier, model_requirement) are optional and null when the agent was
+ * not built through the setup wizard.
  */
 export interface AgentConfig {
   id?: string
@@ -22,12 +32,16 @@ export interface AgentConfig {
   level: SeniorityLevel
   status?: AgentStatus
   personality: Record<string, unknown>
+  personality_preset?: string | null
+  strategic_output_mode?: StrategicOutputMode | null
   model: Record<string, unknown>
   memory: Record<string, unknown>
   tools: Record<string, unknown>
   authority: Record<string, unknown>
   autonomy_level: AutonomyLevel | null
   hiring_date?: string
+  tier?: AgentTier | null
+  model_requirement?: Record<string, unknown> | null
 }
 
 export type TrendDirection = 'improving' | 'stable' | 'declining' | 'insufficient_data'

--- a/web/src/pages/ProviderDetailPage.tsx
+++ b/web/src/pages/ProviderDetailPage.tsx
@@ -56,6 +56,10 @@ export default function ProviderDetailPage() {
   const discoveringModels = useProvidersStore((s) => s.discoveringModels)
   const deletingModel = useProvidersStore((s) => s.deletingModel)
 
+  const handleDeleteModelOpenChange = useCallback((open: boolean) => {
+    if (!open) setDeleteModelId(null)
+  }, [])
+
   // Walk the parent provider list (filtered + sorted) so prev/next on
   // this detail page steps through the same providers the operator
   // saw on ProvidersPage. ``ProviderWithName.name`` is the URL key.
@@ -227,7 +231,7 @@ export default function ProviderDetailPage() {
       {/* Delete model confirmation */}
       <ConfirmDialog
         open={deleteModelId !== null}
-        onOpenChange={(open) => { if (!open) setDeleteModelId(null) }}
+        onOpenChange={handleDeleteModelOpenChange}
         title="Delete Model"
         description={`Are you sure you want to delete "${deleteModelId ?? ''}" from this provider? This will remove the model from the local instance.`}
         variant="destructive"

--- a/web/src/pages/ProviderDetailPage.tsx
+++ b/web/src/pages/ProviderDetailPage.tsx
@@ -6,7 +6,6 @@ import { useProvidersStore } from '@/stores/providers'
 import { DetailNavBar } from '@/components/ui/detail-nav-bar'
 import { ErrorBoundary } from '@/components/ui/error-boundary'
 import { ErrorBanner } from '@/components/ui/error-banner'
-import { EmptyState } from '@/components/ui/empty-state'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { ROUTES } from '@/router/routes'
 import {
@@ -27,7 +26,6 @@ import { CredentialsRotateDialog } from './providers/CredentialsRotateDialog'
 import { AddManualModelDialog } from './providers/AddManualModelDialog'
 import { SyncModelsConfirmDialog } from './providers/SyncModelsConfirmDialog'
 import { Button } from '@/components/ui/button'
-import { Server } from 'lucide-react'
 import type { ProviderModelResponse } from '@/api/types/providers'
 
 export default function ProviderDetailPage() {
@@ -39,7 +37,6 @@ export default function ProviderDetailPage() {
     provider,
     models,
     health,
-    loading,
     error,
     testConnectionResult,
     testingConnection,
@@ -76,12 +73,12 @@ export default function ProviderDetailPage() {
   })
   const { goPrev, goNext } = useDetailNavigationCallbacks(nav)
 
-  // Loading state
-  if (loading && !provider) {
-    return <ProviderDetailSkeleton />
-  }
-
-  // Error state
+  // Error state: a definitive negative answer from the backend always
+  // sets ``detailError`` (the store rewrites a missing-provider 404
+  // into ``'Provider not found'``), so the error banner is the right
+  // surface for both "could not load" and "this provider does not
+  // exist". Checked before the skeleton so a stale ``selectedProvider``
+  // from a prior detail view does not mask a fresh error.
   if (error && !provider) {
     return (
       <div className="flex flex-col gap-section-gap">
@@ -94,15 +91,14 @@ export default function ProviderDetailPage() {
     )
   }
 
+  // Loading / pre-fetch state: the page mounts with
+  // ``detailLoading=false`` because the polling effect runs after the
+  // first render -- showing the skeleton whenever no provider is
+  // resolved yet (regardless of ``loading``) eliminates the
+  // "Provider not found" flash that used to appear for the few
+  // hundred ms before the polled fetch landed.
   if (!provider) {
-    return (
-      <EmptyState
-        icon={Server}
-        title="Provider not found"
-        description="The provider you are looking for does not exist or has been removed."
-        action={{ label: 'Back to Providers', onClick: () => navigate(ROUTES.PROVIDERS) }}
-      />
-    )
+    return <ProviderDetailSkeleton />
   }
 
   return (

--- a/web/src/pages/org/build-org-tree.ts
+++ b/web/src/pages/org/build-org-tree.ts
@@ -247,7 +247,7 @@ export function buildOrgTree(
     if (!configuredDeptNames.has(deptName)) {
       syntheticDepts.push({
         name: deptName,
-        display_name: deptName,
+        display_name: humanizeDepartmentName(deptName),
         teams: [],
       })
     }

--- a/web/src/pages/org/build-org-tree.ts
+++ b/web/src/pages/org/build-org-tree.ts
@@ -6,6 +6,30 @@ import type { CompanyConfig, Department } from '@/api/types/org'
 import type { AgentRuntimeStatus } from '@/lib/utils'
 import { resolveRuntimeStatus } from './status-mapping'
 
+/**
+ * Render a department's identifier in human-readable form.
+ *
+ * The backend stores department names as ``snake_case`` machine keys
+ * (e.g. ``quality_assurance``). Without humanisation the org chart's
+ * ``uppercase tracking-wide`` text styling on
+ * ``DepartmentGroupNode`` renders the underscore verbatim
+ * (``QUALITY_ASSURANCE``), which looks like a leaked enum value.
+ * Replacing ``_`` with a space restores word boundaries
+ * (``Quality Assurance`` -> ``QUALITY ASSURANCE``) so the upstream
+ * CSS transform produces a real heading.
+ */
+export function humanizeDepartmentName(raw: string): string {
+  if (!raw) return raw
+  return raw
+    .split('_')
+    .map((seg) => {
+      if (!seg) return seg
+      const first = seg.charAt(0).toUpperCase()
+      return first + seg.slice(1)
+    })
+    .join(' ')
+}
+
 // ── Node data interfaces ────────────────────────────────────
 
 export interface OwnerNodeData {
@@ -261,7 +285,7 @@ export function buildOrgTree(
     }))
     return {
       departmentName: dept.name,
-      displayName: dept.display_name ?? dept.name,
+      displayName: dept.display_name ?? humanizeDepartmentName(dept.name),
       agentCount: deptMembers.length,
       activeCount,
       budgetPercent,

--- a/web/src/pages/org/build-org-tree.ts
+++ b/web/src/pages/org/build-org-tree.ts
@@ -546,13 +546,13 @@ function findHighestSeniority(agents: readonly AgentConfig[]): AgentConfig | nul
 }
 
 function findCeo(agents: readonly AgentConfig[]): AgentConfig | null {
-  const execCSuite = agents.filter(
+  const [execCeo] = agents.filter(
     (a) => a.department === 'executive' && a.level === 'c_suite',
   )
-  if (execCSuite.length > 0) return execCSuite[0]!
+  if (execCeo) return execCeo
 
-  const cSuite = agents.filter((a) => a.level === 'c_suite')
-  if (cSuite.length > 0) return cSuite[0]!
+  const [anyCSuite] = agents.filter((a) => a.level === 'c_suite')
+  if (anyCSuite) return anyCSuite
 
   return findHighestSeniority(agents)
 }

--- a/web/src/pages/providers/SyncModelsConfirmDialog.tsx
+++ b/web/src/pages/providers/SyncModelsConfirmDialog.tsx
@@ -14,10 +14,11 @@ interface SyncModelsConfirmDialogProps {
 }
 
 /**
- * Confirmation modal for the bulk model sync flow.  Defaults to
- * ``replace_existing=true``; the operator can opt into append-only
- * merge via a toggle.  After a successful sync, the result banner
- * shows the diff (added / removed / updated) until dismissed.
+ * Confirmation modal for the bulk model sync flow. Defaults to
+ * ``replace_existing=false`` (non-destructive append-only merge);
+ * the operator can opt into the destructive replace mode via a
+ * toggle. After a successful sync, the result banner shows the
+ * diff (added / removed / updated) until dismissed.
  */
 export function SyncModelsConfirmDialog({
   providerName,

--- a/web/src/pages/providers/SyncModelsConfirmDialog.tsx
+++ b/web/src/pages/providers/SyncModelsConfirmDialog.tsx
@@ -27,7 +27,13 @@ export function SyncModelsConfirmDialog({
 }: SyncModelsConfirmDialogProps) {
   const syncProviderModels = useProvidersStore((s) => s.syncProviderModels)
 
-  const [replaceExisting, setReplaceExisting] = useState(true)
+  // Default to the non-destructive append-only mode. The destructive
+  // ``replace_existing=true`` path can delete every persisted model
+  // if discovery returns an empty set (wrong URL / network blip /
+  // provider outage); the backend now refuses that case explicitly,
+  // but the safe default for the click path is still merge-not-replace
+  // so a single mis-clicked button cannot lose data.
+  const [replaceExisting, setReplaceExisting] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [result, setResult] = useState<SyncModelsResponse | null>(null)
 
@@ -42,7 +48,7 @@ export function SyncModelsConfirmDialog({
   }, [open])
 
   const reset = (): void => {
-    setReplaceExisting(true)
+    setReplaceExisting(false)
     setSubmitting(false)
     setResult(null)
   }

--- a/web/src/stores/budget.ts
+++ b/web/src/stores/budget.ts
@@ -81,7 +81,7 @@ export const useBudgetStore = create<BudgetState>()((set, get) => ({
           getOverviewMetrics(),
           getBudgetConfig(),
           getForecast(),
-          listCostRecords({ limit: 500 }),
+          listCostRecords({ limit: 200 }),
           getTrends('30d', 'spend'),
           listActivities({ limit: 30 }),
         ])

--- a/web/src/stores/budget.ts
+++ b/web/src/stores/budget.ts
@@ -5,6 +5,7 @@ import { listActivities } from '@/api/endpoints/activities'
 import { listAgents } from '@/api/endpoints/agents'
 import { wsEventToActivityItem } from '@/utils/dashboard'
 import { getErrorMessage } from '@/utils/errors'
+import { sanitizeForLog } from '@/utils/logging'
 import { createLogger } from '@/lib/logger'
 import { aggregateWeekly, type AggregationPeriod } from '@/utils/budget'
 import type {
@@ -106,18 +107,23 @@ export const useBudgetStore = create<BudgetState>()((set, get) => ({
       const activitiesData =
         activitiesR.status === 'fulfilled' ? activitiesR.value.data : []
 
-      // Log non-critical failures so degradation is debuggable
+      // Log non-critical failures so degradation is debuggable.
+      // Each rejection reason is sanitised explicitly to match the
+      // store-wide pattern in approvals.ts / agents.ts / company.ts;
+      // the logger sanitizes separate args automatically but the
+      // explicit wrap is the project convention and avoids drifting
+      // when this store later switches to structured payloads.
       if (forecastR.status === 'rejected') {
-        log.warn('Failed to fetch forecast:', forecastR.reason)
+        log.warn('Failed to fetch forecast:', sanitizeForLog(forecastR.reason))
       }
       if (recordsR.status === 'rejected') {
-        log.warn('Failed to fetch cost records:', recordsR.reason)
+        log.warn('Failed to fetch cost records:', sanitizeForLog(recordsR.reason))
       }
       if (trendsR.status === 'rejected') {
-        log.warn('Failed to fetch trends:', trendsR.reason)
+        log.warn('Failed to fetch trends:', sanitizeForLog(trendsR.reason))
       }
       if (activitiesR.status === 'rejected') {
-        log.warn('Failed to fetch activities:', activitiesR.reason)
+        log.warn('Failed to fetch activities:', sanitizeForLog(activitiesR.reason))
       }
 
       // Agent metadata fetch (separate from main data -- failures degrade display names to raw IDs but don't block rendering)
@@ -134,7 +140,10 @@ export const useBudgetStore = create<BudgetState>()((set, get) => ({
           }
         }
       } catch (err) {
-        log.warn('Failed to fetch agent list for name/dept mapping:', err)
+        log.warn(
+          'Failed to fetch agent list for name/dept mapping:',
+          sanitizeForLog(err),
+        )
       }
 
       set({
@@ -161,7 +170,7 @@ export const useBudgetStore = create<BudgetState>()((set, get) => ({
       const overview = await getOverviewMetrics()
       set({ overview })
     } catch (err) {
-      log.warn('Failed to refresh overview (polling):', err)
+      log.warn('Failed to refresh overview (polling):', sanitizeForLog(err))
     }
   },
 
@@ -183,7 +192,7 @@ export const useBudgetStore = create<BudgetState>()((set, get) => ({
     } catch (err) {
       // Clear stale data from previous period so chart doesn't mislead
       set({ trends: null })
-      log.warn('Failed to fetch trends:', err)
+      log.warn('Failed to fetch trends:', sanitizeForLog(err))
     }
   },
 
@@ -208,7 +217,11 @@ export const useBudgetStore = create<BudgetState>()((set, get) => ({
         get().fetchOverview()
       }
     } catch (err) {
-      log.error('Failed to process WS event:', { type: event.event_type, channel: event.channel }, err)
+      log.error('Failed to process WS event:', {
+        type: event.event_type,
+        channel: event.channel,
+        error: sanitizeForLog(err),
+      })
     }
   },
 }))

--- a/web/src/stores/budget.ts
+++ b/web/src/stores/budget.ts
@@ -6,6 +6,7 @@ import { listAgents } from '@/api/endpoints/agents'
 import { wsEventToActivityItem } from '@/utils/dashboard'
 import { getErrorMessage } from '@/utils/errors'
 import { sanitizeForLog } from '@/utils/logging'
+import { sanitizeWsString } from '@/stores/notifications'
 import { createLogger } from '@/lib/logger'
 import { aggregateWeekly, type AggregationPeriod } from '@/utils/budget'
 import type {
@@ -218,8 +219,8 @@ export const useBudgetStore = create<BudgetState>()((set, get) => ({
       }
     } catch (err) {
       log.error('Failed to process WS event:', {
-        type: event.event_type,
-        channel: event.channel,
+        type: sanitizeWsString(event.event_type),
+        channel: sanitizeWsString(event.channel),
         error: sanitizeForLog(err),
       })
     }


### PR DESCRIPTION
## Summary

Triggered by a live `/analyse-logs` session that showed 17k requests over 22h, of which only ~1.7k were not healthcheck noise, and four UI flows (`/clients`, `/budget/records`, `/integrations/mcp/catalog/install`, `/integrations/tunnel/start`) were uniformly failing while ~1190 `settings.fetch.failed` warnings/2h silently substituted default agents on every read. Plus a second dashboard session that surfaced four bugs in the provider mutation flow — a single click on **Sync models** had been deleting 29 persisted models.

Three commits land on this branch:

1. **`fix(dashboard): unblock click-through flows hammered by 6 distinct bugs`** — the original observability + flow fixes (middleware healthcheck filter, `AgentConfig` schema additions, `IntegrityError` → `ConstraintViolationError` translation, `ConnectionCatalog.rebind_repository`, default-construct `ClientSimulationState`, `has_simulation_runtime` predicate split, `ProviderDetailPage` skeleton, etc.).
2. **`fix(providers): stop sync from deleting models, fix audit attribution`** — `ollama-cloud` now routes through `_discover_ollama`; service refuses `replace_existing=True` when discovery returned an empty set; dialog default is now non-destructive; six controller methods now thread `audit_actor_from_context()`; `update_provider` audit emits a structured diff with sensitive fields redacted.
3. **`fix: address pre-PR review findings on dashboard / provider bug fixes`** — the polish landed below.

## Pre-PR review

Reviewed by **21 agents** (16 standard + 5 mini-pass) through `/pre-pr-review`. **19 valid findings** raised, **15 fixed in code** (4 dropped during implementation when closer inspection showed the agent had misread; documented in `_audit/pre-pr-review/triage.md`).

| # | Severity | Finding |
|---|----------|---------|
| 1 | MAJOR | Backend parity: SQLite `mcp_installation_repo` now translates `IntegrityError` → `ConstraintViolationError`, matching Postgres. `_classify_sqlite_constraint` helper maps message text to a stable token (SQLite has no named constraints). |
| 2 | MAJOR | `web/src/api/types/agents.ts AgentConfig` gains `tier`, `model_requirement`, `personality_preset`, `strategic_output_mode` (last two were pre-existing drift). |
| 4 | MAJOR | `SyncModelsConfirmDialog` docstring now matches the runtime default (`replace_existing=false`). |
| 5 | MAJOR | `_SENSITIVE_PROVIDER_FIELDS` comment simplified from catastrophising to factual operator-readability rationale. |
| 7 | MEDIUM | `AgentConfig.tier` narrowed from `str` to `Literal["large","medium","small"]`. |
| 8 | MEDIUM | `ConnectionCatalog.update_health` now emits `HEALTH_STATUS_TRANSITIONED` at INFO when the status actually changes. |
| 9 | MEDIUM | `rebind_repository` docstring + inline concurrency comment split. |
| 10 | MEDIUM | `_assert_sensitive_fields_complete()` import-time guard against unredacted credential fields on `ProviderConfig`. |
| 11 | MEDIUM | `app.py` default-construct comment trimmed. |
| 12 | MEDIUM | `build-org-tree.ts findCeo` uses destructuring + truthy check instead of `[0]!`. |
| 13 | MEDIUM | `budget.ts` error args now wrapped in `sanitizeForLog()` explicitly. |
| 15 | MEDIUM | Postgres `save()` `Raises:` docstring dropped HTTP-status implementation detail. |
| 18 | MINOR | Inline arrow at `ConfirmDialog onOpenChange` extracted via `useCallback`. |
| 16 / 17 | MINOR | `test_middleware` count + ordering assertions; module-level `structlog` import. |
| 14 | MEDIUM | **+22 tests** for new behaviour (see below). |

### Findings rejected as agent error

| # | Source | Claim | Why rejected |
|---|---|---|---|
| R1 | 5 agents | `except A, B:` is "Python 2 syntax" | CLAUDE.md mandates PEP 758 form; pytest passed 29935 tests, so it parses cleanly. Confirmed: `python -c "..."` works on 3.14.4. |
| R2 | code-reviewer | "Healthcheck filter drops spans / Prometheus metric" | Verified at `middleware.py:433-471`: spans + metrics fire for ALL requests. |
| R3 | code-reviewer | "Default `ClientSimulationState()` leaks test state" | Instance-scoped, no shared module-level state. |
| R4 | async-concurrency-reviewer | "rebind race condition" | Rebind runs before traffic accepted; race-conditions mini-pass independently confirmed safe. |
| R5 | test-quality-reviewer | "`TestHealthcheckLogSuppression` missing `@pytest.mark.unit`" | Module-level `pytestmark = pytest.mark.unit` at line 25 already covers it. |
| R6 | mini-pass-missing-event-constants | "`_try_stop event` parameter dead" | Verified: shutdown callers pass `API_APP_SHUTDOWN`, not `API_APP_STARTUP`. The parameter is doing real work. |

## Tests added (22 new, covering finding #14)

- `TestAppStateSimulationRuntime` (5) — `has_simulation_runtime` predicate's four branches + `has_client_simulation_state` always-true contract.
- `TestRebindRepository` (4) — repo swap, cache invalidation, subsequent-read backend selection, double-rebind safety.
- ollama-cloud routing (1) — confirms `/api/tags` (not `/models`).
- `TestDiffProviderUpdate` (3) — changed-only output, redaction sentinels, `ProviderConfig` vs sensitive-list cross-check.
- `test_destructive_sync_guard` (4) — all four branches of `_reject_destructive_empty_discovery`.
- AgentConfig (3) — `tier` round-trip, `tier` Literal rejection, `model_requirement` round-trip.
- conformance `test_save_raises_constraint_violation_on_unknown_connection` (2; SQLite + Postgres parameterised) — locks `ConstraintViolationError` parity across both backends.

## Test plan

```bash
uv run python -m pytest tests/ -n 8            # 29957 passed, 49 skipped
uv run mypy src/ tests/                        # Success: no issues found in 3713 source files
uv run ruff check src/ tests/                  # All checks passed!
npm --prefix web run lint                      # max-warnings 0, clean
npm --prefix web run type-check                # clean
npm --prefix web run test                      # 251 files, 3075 tests passed
```

## Review coverage

Agents run (21 total, 0 failed):
- standard: docs-consistency, code-reviewer, python-reviewer, security-reviewer, frontend-reviewer, design-token-audit, api-contract-drift, persistence-reviewer, async-concurrency-reviewer, type-design-analyzer, conventions-enforcer, logging-audit, resilience-audit, comment-quality-rot, silent-failure-hunter, comment-analyzer, pr-test-analyzer, test-quality-reviewer
- mini-pass: missing-logger, missing-event-constants, missing-state-transition-log, race-conditions

Triage at `_audit/pre-pr-review/triage.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)