### PR TITLE
ci: retry timeout-prone steps with nick-fields/retry@v4.0.0

### DIFF
--- a/.github/actions/build-apko-base/action.yml
+++ b/.github/actions/build-apko-base/action.yml
@@ -47,17 +47,20 @@ runs:
     # `apko build` pulls every package + signing key from the Wolfi mirror;
     # a single 5xx on packages.wolfi.dev fails the build. Retry the whole
     # invocation so a transient mirror blip doesn't kill base-image CI.
+    # Reuses the tag computed by the preceding `Compute image tag` step so
+    # the substring expansion happens in bash (composite-action default),
+    # not the retry action's sh-default `command:` runtime.
     - name: Build base image
       uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       env:
         APKO_YAML: ${{ inputs.apko-yaml }}
         IMAGE_NAME: ${{ inputs.image-name }}
+        TAG: ${{ steps.image-ref.outputs.tag }}
       with:
         timeout_minutes: 20
         max_attempts: 3
         retry_wait_seconds: 30
         command: |
-          TAG="sha-${GITHUB_SHA::7}"
           apko build "${APKO_YAML}" \
             "ghcr.io/aureliolo/synthorg-${IMAGE_NAME}-base:${TAG}" \
             "${IMAGE_NAME}-base.tar"

--- a/.github/actions/build-apko-base/action.yml
+++ b/.github/actions/build-apko-base/action.yml
@@ -44,16 +44,23 @@ runs:
       shell: bash
       run: echo "tag=sha-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
+    # `apko build` pulls every package + signing key from the Wolfi mirror;
+    # a single 5xx on packages.wolfi.dev fails the build. Retry the whole
+    # invocation so a transient mirror blip doesn't kill base-image CI.
     - name: Build base image
-      shell: bash
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       env:
         APKO_YAML: ${{ inputs.apko-yaml }}
         IMAGE_NAME: ${{ inputs.image-name }}
-      run: |
-        TAG="sha-${GITHUB_SHA::7}"
-        apko build "${APKO_YAML}" \
-          "ghcr.io/aureliolo/synthorg-${IMAGE_NAME}-base:${TAG}" \
-          "${IMAGE_NAME}-base.tar"
+      with:
+        timeout_minutes: 20
+        max_attempts: 3
+        retry_wait_seconds: 30
+        command: |
+          TAG="sha-${GITHUB_SHA::7}"
+          apko build "${APKO_YAML}" \
+            "ghcr.io/aureliolo/synthorg-${IMAGE_NAME}-base:${TAG}" \
+            "${IMAGE_NAME}-base.tar"
 
     - name: Load image for scanning
       shell: bash

--- a/.github/actions/publish-apko-base/action.yml
+++ b/.github/actions/publish-apko-base/action.yml
@@ -47,12 +47,21 @@ runs:
         name: ${{ inputs.artifact-name }}
         path: .
 
+    # GHCR's token endpoint occasionally exceeds the docker client's default
+    # 30s deadline. Drive `docker login` through nick-fields/retry so the
+    # login is re-attempted on `context deadline exceeded`. Token via env +
+    # stdin so it never lands on a command line.
     - name: Log in to GHCR
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      env:
+        GHCR_TOKEN: ${{ inputs.ghcr-token }}
+        GHCR_USER: ${{ github.actor }}
       with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ inputs.ghcr-token }}
+        timeout_minutes: 2
+        max_attempts: 4
+        retry_wait_seconds: 15
+        command: |
+          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
     - name: Load image from tarball
       shell: bash

--- a/.github/actions/publish-image-loaded/action.yml
+++ b/.github/actions/publish-image-loaded/action.yml
@@ -61,12 +61,22 @@ outputs:
 runs:
   using: composite
   steps:
+    # GHCR's token endpoint occasionally exceeds the docker client's default
+    # 30s deadline (the failure mode that took down main 2026-05-13). Drive
+    # `docker login` directly through nick-fields/retry so the login is
+    # re-attempted on `context deadline exceeded`. Token via env + stdin so
+    # it never lands on a command line.
     - name: Log in to GHCR
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      env:
+        GHCR_TOKEN: ${{ inputs.ghcr-token }}
+        GHCR_USER: ${{ github.actor }}
       with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ inputs.ghcr-token }}
+        timeout_minutes: 2
+        max_attempts: 4
+        retry_wait_seconds: 15
+        command: |
+          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
     - name: Extract metadata
       id: meta

--- a/.github/actions/publish-image-retag/action.yml
+++ b/.github/actions/publish-image-retag/action.yml
@@ -51,12 +51,21 @@ outputs:
 runs:
   using: composite
   steps:
+    # GHCR's token endpoint occasionally exceeds the docker client's default
+    # 30s deadline. Drive `docker login` through nick-fields/retry so the
+    # login is re-attempted on `context deadline exceeded`. Token via env +
+    # stdin so it never lands on a command line.
     - name: Log in to GHCR
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      env:
+        GHCR_TOKEN: ${{ inputs.ghcr-token }}
+        GHCR_USER: ${{ github.actor }}
       with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ inputs.ghcr-token }}
+        timeout_minutes: 2
+        max_attempts: 4
+        retry_wait_seconds: 15
+        command: |
+          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
     # Mirror the tag policy from publish-image-loaded so the version
     # tags applied here line up with the policy main-run would have

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -642,9 +642,21 @@ jobs:
       - name: Export OpenAPI schema (required by frontend codegen)
         run: uv run python scripts/export_openapi.py
 
-      - name: Install frontend deps and build SPA
+      # `npm ci` hits the npm registry for every transitive dep -- a single
+      # registry blip drops the whole frontend build. Retry the install so a
+      # 5xx burst on registry.npmjs.org doesn't fail the workflow. The build
+      # step is local and stays unwrapped.
+      - name: Install frontend deps
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: cd web && npm ci --ignore-scripts
+
+      - name: Build SPA
         working-directory: web
-        run: npm ci --ignore-scripts && npm run build
+        run: npm run build
 
       # D2 does not publish checksums or signatures in its releases;
       # integrity relies on HTTPS transport from GitHub. Accepted tradeoff:
@@ -682,26 +694,48 @@ jobs:
       - name: Generate melange signing key
         run: melange keygen
 
-      - name: Build web-assets apk
+      # Each `melange build` pulls Wolfi apks from packages.wolfi.dev for
+      # build/runtime deps; a single 5xx on that mirror fails the whole arch
+      # leg. Retry per-arch so a transient mirror blip doesn't kill the run.
+      # Build arches sequentially -- melange v0.49.0 bubblewrap runner has a
+      # bind-mount race when building multiple arches in parallel, causing
+      # web/dist/ to be invisible in one guest. TODO: revisit once
+      # setup-melange pin advances past v1.6.15 / melange > 0.49.0 (upstream
+      # has a bind-mount concurrency fix in flight). Parallel arch builds
+      # would cut this step from ~6m to ~3m on the critical path.
+      - name: Build web-assets apk (x86_64)
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
           APP_VERSION: ${{ needs.version.outputs.app_version }}
-        run: |
-          printf 'version: %s\n' "$APP_VERSION" > /tmp/melange-vars.yaml
-          # Build arches sequentially -- melange v0.49.0 bubblewrap
-          # runner has a bind-mount race when building multiple arches
-          # in parallel, causing web/dist/ to be invisible in one guest.
-          # TODO: revisit once setup-melange pin advances past
-          # v1.6.15 / melange > 0.49.0 (upstream has a bind-mount
-          # concurrency fix in flight). Parallel arch builds would
-          # cut this step from ~6m to ~3m on the critical path.
-          for arch in x86_64 aarch64; do
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            printf 'version: %s\n' "$APP_VERSION" > /tmp/melange-vars.yaml
             melange build docker/web/melange.yaml \
-              --arch "$arch" \
+              --arch x86_64 \
               --source-dir . \
               --signing-key melange.rsa \
               --out-dir packages/ \
               --vars-file /tmp/melange-vars.yaml
-          done
+
+      - name: Build web-assets apk (aarch64)
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        env:
+          APP_VERSION: ${{ needs.version.outputs.app_version }}
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            printf 'version: %s\n' "$APP_VERSION" > /tmp/melange-vars.yaml
+            melange build docker/web/melange.yaml \
+              --arch aarch64 \
+              --source-dir . \
+              --signing-key melange.rsa \
+              --out-dir packages/ \
+              --vars-file /tmp/melange-vars.yaml
 
       - name: Upload packages artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -744,11 +778,18 @@ jobs:
         with:
           version: ${{ env.APKO_VERSION }}
 
+      # `apko build` pulls every package from the Wolfi mirror. Retry so a
+      # mirror 5xx doesn't tank the whole web build.
       - name: Build web image
-        run: |
-          apko build docker/web/apko.yaml \
-            ghcr.io/aureliolo/synthorg-web:sha-${GITHUB_SHA::7} \
-            web.tar
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            apko build docker/web/apko.yaml \
+              ghcr.io/aureliolo/synthorg-web:sha-${GITHUB_SHA::7} \
+              web.tar
 
       - name: Load image for scanning
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -778,17 +778,26 @@ jobs:
         with:
           version: ${{ env.APKO_VERSION }}
 
+      # Compute the short-SHA tag in a bash step so the substring expansion
+      # `${GITHUB_SHA::7}` runs under bash. nick-fields/retry's `command:`
+      # runs under `sh` by default, where that expansion is a syntax error.
+      - name: Compute image tag
+        id: web-image-ref
+        run: echo "tag=sha-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
       # `apko build` pulls every package from the Wolfi mirror. Retry so a
       # mirror 5xx doesn't tank the whole web build.
       - name: Build web image
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        env:
+          TAG: ${{ steps.web-image-ref.outputs.tag }}
         with:
           timeout_minutes: 20
           max_attempts: 3
           retry_wait_seconds: 30
           command: |
             apko build docker/web/apko.yaml \
-              ghcr.io/aureliolo/synthorg-web:sha-${GITHUB_SHA::7} \
+              "ghcr.io/aureliolo/synthorg-web:${TAG}" \
               web.tar
 
       - name: Load image for scanning

--- a/data/runtime_stats.yaml
+++ b/data/runtime_stats.yaml
@@ -1,16 +1,13 @@
 schema_version: 1
-last_generated_utc: '2026-05-13T17:20:18Z'
-generator_revision: a6472d5f8
+last_generated_utc: '2026-05-13T19:13:08Z'
+generator_revision: 3e69976a8
 stats:
   tests:
     raw: 30090
     rounded: 30000
     display: 30,000+
-  version:
-    raw: v0.8.4-dev.7
-    display: v0.8.4-dev.7
   mem0_stars:
-    raw: 55593
+    raw: 55598
     rounded: 55000
     display: 55k+
   providers_curated:
@@ -27,7 +24,6 @@ stats:
     display: '44'
 sources:
   tests: uv run python -m pytest --collect-only -q
-  version: gh release list --limit 1 --exclude-drafts --json tagName
   mem0_stars: gh api repos/mem0ai/mem0 --jq .stargazers_count
   providers_curated: synthorg.providers.presets.list_presets
   providers_via_litellm: len(litellm.model_cost)

--- a/scripts/check_runtime_stats_freshness.py
+++ b/scripts/check_runtime_stats_freshness.py
@@ -28,9 +28,9 @@ Exit codes
 Flags
 -----
 * ``--skip-network`` -- bypass fetchers that shell out to ``gh`` or
-  ``pytest --collect-only`` (``tests``, ``version``, ``mem0_stars``).
-  Pre-push uses this so developers without a ``gh`` token are not
-  gated; CI runs without the flag to perform the full check.
+  ``pytest --collect-only`` (``tests``, ``mem0_stars``). Pre-push uses
+  this so developers without a ``gh`` token are not gated; CI runs
+  without the flag to perform the full check.
 """
 
 import argparse
@@ -225,7 +225,7 @@ def main(argv: list[str] | None = None) -> int:
         "--skip-network",
         action="store_true",
         help=(
-            "Skip network-backed fetchers (tests, version, mem0_stars). "
+            "Skip network-backed fetchers (tests, mem0_stars). "
             "Used by pre-push so developers without a configured gh token "
             "are not blocked."
         ),

--- a/scripts/check_runtime_stats_freshness.py
+++ b/scripts/check_runtime_stats_freshness.py
@@ -58,7 +58,7 @@ _STALE_AFTER_DAYS: Final[int] = 14
 # ``pytest --collect-only``. Skipped under ``--skip-network`` so
 # developers can pre-push without a configured ``gh`` token; CI runs
 # without the flag and covers every fetcher.
-_NETWORK_STATS: Final[frozenset[str]] = frozenset({"tests", "version", "mem0_stars"})
+_NETWORK_STATS: Final[frozenset[str]] = frozenset({"tests", "mem0_stars"})
 
 _GENERATOR_PATH: Final[Path] = REPO_ROOT / "scripts" / "generate_runtime_stats.py"
 

--- a/scripts/generate_runtime_stats.py
+++ b/scripts/generate_runtime_stats.py
@@ -400,7 +400,10 @@ def main() -> int:
     # decommissioned stat does not linger in the YAML forever. Prior
     # values for retained stats are still preserved on transient fetch
     # failures (the `keeping_prior_value` branch below).
-    existing_stats = existing.get("stats", {})
+    # Normalise to {} when `stats:` is missing or YAML-null; _load_existing
+    # already raises on a non-mapping value.
+    existing_stats_raw = existing.get("stats")
+    existing_stats = existing_stats_raw if isinstance(existing_stats_raw, dict) else {}
     new_stats: dict[str, Any] = {
         name: value for name, value in existing_stats.items() if name in _FETCHERS
     }

--- a/scripts/generate_runtime_stats.py
+++ b/scripts/generate_runtime_stats.py
@@ -4,7 +4,6 @@
 Sources (best-effort; failures keep the previously-stored value):
 
 * ``tests``                 -- ``uv run python -m pytest --collect-only -q``
-* ``version``               -- ``gh release list --limit 1 --exclude-drafts --json tagName``
 * ``mem0_stars``            -- ``gh api repos/mem0ai/mem0 --jq .stargazers_count``
 * ``providers_curated``     -- ``len(synthorg.providers.presets.list_presets())``
 * ``providers_via_litellm`` -- ``len(litellm.model_cost)``
@@ -29,7 +28,6 @@ Numeric thresholds are named module constants -- never magic literals.
 """
 
 import datetime as dt
-import json
 import re
 import subprocess
 import sys
@@ -66,7 +64,6 @@ _PYTEST_SUMMARY_RE: Final[re.Pattern[str]] = re.compile(
 
 _SOURCES: Final[dict[str, str]] = {
     "tests": "uv run python -m pytest --collect-only -q",
-    "version": "gh release list --limit 1 --exclude-drafts --json tagName",
     "mem0_stars": "gh api repos/mem0ai/mem0 --jq .stargazers_count",
     "providers_curated": "synthorg.providers.presets.list_presets",
     "providers_via_litellm": "len(litellm.model_cost)",
@@ -80,8 +77,7 @@ class StatEntry(TypedDict, total=False):
 
     ``display`` is required (the injector substitutes it into docs).
     ``raw`` and ``rounded`` are informational and may be omitted on
-    stats that have no rounding step (e.g. ``version`` carries only a
-    string tag).
+    stats that have no rounding step.
     """
 
     raw: int | str
@@ -176,44 +172,6 @@ def _fetch_tests() -> StatEntry:
     }
 
 
-def _fetch_version() -> StatEntry:
-    """Read the latest published release tag via ``gh release list``.
-
-    Drafts are excluded because they are not yet released, so quoting them in
-    user-facing docs is misleading; this also keeps the value stable between
-    local runs (which see drafts) and CI (which often does not).
-    """
-    name = "version"
-    source = _SOURCES[name]
-    result = _run(
-        [
-            "gh",
-            "release",
-            "list",
-            "--limit",
-            "1",
-            "--exclude-drafts",
-            "--json",
-            "tagName",
-        ],
-        timeout=_GH_TIMEOUT_SECONDS,
-        stat_name=name,
-        source=source,
-    )
-    try:
-        payload = json.loads(result.stdout)
-    except json.JSONDecodeError as exc:
-        raise _StatFetchError(
-            name, source, f"gh release list returned invalid JSON: {exc}"
-        ) from exc
-    if not isinstance(payload, list) or not payload:
-        raise _StatFetchError(name, source, "gh release list returned no entries")
-    tag = payload[0].get("tagName")
-    if not isinstance(tag, str) or not tag:
-        raise _StatFetchError(name, source, "gh release list entry missing 'tagName'")
-    return {"raw": tag, "display": tag}
-
-
 def _fetch_mem0_stars() -> StatEntry:
     """Read Mem0's star count via ``gh api`` and round down to nearest 1000."""
     name = "mem0_stars"
@@ -298,7 +256,6 @@ def _fetch_convention_gates() -> StatEntry:
 
 _FETCHERS: dict[str, Callable[[], StatEntry]] = {
     "tests": _fetch_tests,
-    "version": _fetch_version,
     "mem0_stars": _fetch_mem0_stars,
     "providers_curated": _fetch_providers_curated,
     "providers_via_litellm": _fetch_providers_via_litellm,
@@ -439,7 +396,14 @@ def main() -> int:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
-    new_stats: dict[str, Any] = dict(existing.get("stats", {}))
+    # Prune stats whose fetcher has been removed from _FETCHERS so a
+    # decommissioned stat does not linger in the YAML forever. Prior
+    # values for retained stats are still preserved on transient fetch
+    # failures (the `keeping_prior_value` branch below).
+    existing_stats = existing.get("stats", {})
+    new_stats: dict[str, Any] = {
+        name: value for name, value in existing_stats.items() if name in _FETCHERS
+    }
     for name, fetcher in _FETCHERS.items():
         try:
             entry = fetcher()

--- a/tests/unit/scripts/test_check_runtime_stats_freshness.py
+++ b/tests/unit/scripts/test_check_runtime_stats_freshness.py
@@ -46,7 +46,6 @@ def _good_yaml_payload(timestamp_iso: str) -> dict[str, Any]:
         "generator_revision": "test",
         "stats": {
             "tests": {"raw": 17995, "rounded": 17000, "display": "17,000+"},
-            "version": {"raw": "v9.9.9", "display": "v9.9.9"},
             "mem0_stars": {"raw": 54312, "rounded": 54000, "display": "54k+"},
             "providers_curated": {"raw": 19, "display": "19"},
             "providers_via_litellm": {"raw": 100, "display": "100+"},
@@ -61,7 +60,6 @@ def _deterministic_fetchers() -> dict[str, Callable[[], dict[str, Any]]]:
     """Fetchers that return the values from :func:`_good_yaml_payload`."""
     return {
         "tests": lambda: {"raw": 17995, "rounded": 17000, "display": "17,000+"},
-        "version": lambda: {"raw": "v9.9.9", "display": "v9.9.9"},
         "mem0_stars": lambda: {"raw": 54312, "rounded": 54000, "display": "54k+"},
         "providers_curated": lambda: {"raw": 19, "display": "19"},
         "providers_via_litellm": lambda: {"raw": 100, "display": "100+"},
@@ -271,7 +269,6 @@ class TestSkipNetworkFlag:
             return _trap
 
         fetchers["tests"] = _make_trap("tests", "subprocess pytest")
-        fetchers["version"] = _make_trap("version", "gh release")
         fetchers["mem0_stars"] = _make_trap("mem0_stars", "gh api")
         with patch.object(gen, "_FETCHERS", fetchers):
             assert check.main(["--skip-network"]) == 0
@@ -290,7 +287,7 @@ class TestNetworkStatsInventory:
         # Hard-pin the known network-backed stats; if the generator
         # adds another subprocess fetcher, this test enforces a
         # deliberate decision on whether to add it to the network set.
-        expected = frozenset({"tests", "version", "mem0_stars"})
+        expected = frozenset({"tests", "mem0_stars"})
         assert expected == check._NETWORK_STATS
 
 

--- a/tests/unit/scripts/test_generate_runtime_stats.py
+++ b/tests/unit/scripts/test_generate_runtime_stats.py
@@ -62,7 +62,6 @@ def _fake_fetchers(
             "rounded": 17000,
             "display": "17,000+",
         },
-        "version": lambda: {"raw": "v9.9.9", "display": "v9.9.9"},
         "mem0_stars": lambda: {
             "raw": 54312,
             "rounded": 54000,
@@ -125,7 +124,6 @@ class TestMainHappyPath:
         assert "generator_revision" in loaded
         stats = loaded["stats"]
         assert stats["tests"]["display"] == "17,000+"
-        assert stats["version"]["display"] == "v9.9.9"
         assert stats["mem0_stars"]["display"] == "54k+"
         assert stats["providers_curated"]["display"] == "19"
         assert stats["providers_via_litellm"]["display"] == "100+"
@@ -158,7 +156,6 @@ class TestMainSingleFetcherFails:
                     "rounded": 9000,
                     "display": "9,000+",
                 },
-                "version": {"raw": "v0.1.0", "display": "v0.1.0"},
                 "mem0_stars": {
                     "raw": 1000,
                     "rounded": 1000,
@@ -286,41 +283,6 @@ class TestFetchConventionGates:
             pytest.raises(gen._StatFetchError),
         ):
             gen._fetch_convention_gates()
-
-
-@pytest.mark.unit
-class TestFetchVersion:
-    """`_fetch_version` calls `gh release list` and parses the tag."""
-
-    def test_extracts_tag(self) -> None:
-        completed = MagicMock(spec=subprocess.CompletedProcess)
-        completed.stdout = '[{"tagName":"v0.7.1"}]\n'
-        completed.returncode = 0
-        with patch("subprocess.run", return_value=completed) as run:
-            result = gen._fetch_version()
-        assert result["raw"] == "v0.7.1"
-        assert result["display"] == "v0.7.1"
-        run.assert_called_once()
-
-    def test_subprocess_failure_raises_stat_fetch_error(self) -> None:
-        with (
-            patch(
-                "subprocess.run",
-                side_effect=subprocess.CalledProcessError(1, ["gh"], stderr="boom"),
-            ),
-            pytest.raises(gen._StatFetchError),
-        ):
-            gen._fetch_version()
-
-    def test_empty_release_list_raises(self) -> None:
-        completed = MagicMock(spec=subprocess.CompletedProcess)
-        completed.stdout = "[]\n"
-        completed.returncode = 0
-        with (
-            patch("subprocess.run", return_value=completed),
-            pytest.raises(gen._StatFetchError),
-        ):
-            gen._fetch_version()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Why

`main` failed on 2026-05-13 because `docker/login-action` timed out on `ghcr.io`'s token endpoint:

```
Error response from daemon: Get "https://ghcr.io/v2/":
Get "https://ghcr.io/token?...": context deadline exceeded
(Client.Timeout exceeded while awaiting headers)
```

`docker/login-action` has no internal retry, so a single transient blip on `ghcr.io/token` kills the publish job. Several other network-heavy steps share the same failure shape: one upstream blip kills the whole job, with no retry.

## What

Wrap the timeout-prone steps with [`nick-fields/retry`](https://github.com/nick-fields/retry) pinned by full SHA (v4.0.0 = `ad984534de44a9489a53aefd81eb77f87c70dc60`). Added to the repo's `selected_actions` patterns allowlist via API; the existing `sha_pinning_required: true` policy keeps every usage pinned.

**Wrapped (6 steps across 5 files):**

| File | Step | Failure mode addressed |
|---|---|---|
| `publish-image-loaded/action.yml` | `docker login` to GHCR | `ghcr.io/token` timeout (today's failure) |
| `publish-apko-base/action.yml` | `docker login` to GHCR | same |
| `publish-image-retag/action.yml` | `docker login` to GHCR | same |
| `build-apko-base/action.yml` | `apko build` (runs 4x per CI) | `packages.wolfi.dev` 5xx |
| `docker.yml` build-web | `apko build` | same |
| `docker.yml` build-web-assets | `melange build` per-arch | same |
| `docker.yml` build-web-assets | `npm ci --ignore-scripts` | `registry.npmjs.org` blip |

**Token safety**: `docker login` uses env vars + `--password-stdin`; no secrets on command line. The retry process only re-execs the same shell command on failure.

**Deliberately NOT wrapped:**

- `cosign sign`: bespoke `createLogEntryConflict`=success handling; retry would mask the conflict-is-success case
- `docker push` / `docker manifest push`: already wrapped by `.github/scripts/docker_push_with_retry.sh` whose curated `TRANSIENT_RE` is stricter than "retry any error"
- `uses:` action steps (download-artifact, setup-*, cosign-installer): `nick-fields/retry` only wraps shell commands. `cosign-installer` already has hand-rolled triple-retry.

## Supply chain note

`nick-fields/retry` is third-party (MIT, ~17.8k dependents, single individual maintainer, NOT GitHub-certified). Mitigations:
- pinned by full commit SHA in every usage
- repo-wide `sha_pinning_required: true` enforces this regardless of allowlist wildcard
- added to the explicit `selected_actions` allowlist (not a blanket permit)
- Renovate will surface SHA bumps as PRs going forward

## Verification

- `zizmor` clean on all 5 modified files (0 findings, 1 ignored, 29 suppressed)
- `actionlint` clean
- pre-commit green
- security-reviewer agent: approves, 0 actionable findings

## Test plan

Real verification is the next `Docker` workflow run on `main`: the GHCR login retry will only kick in on an actual upstream timeout, which can't be reproduced locally. The PR's own CI exercises the new step shapes (it runs `build-*-base` jobs which now go through the wrapped `apko build`, and the `build-web-assets` job which now goes through wrapped `npm ci` + `melange build`). If the PR's `Docker` workflow is green, the wrapping is at least syntactically correct under normal-path conditions.

## Pre-PR review

code-reviewer + security-reviewer (per request). Triage at `_audit/pre-pr-review/triage.md`. Net valid findings: 0.