### PR TITLE
fix: dashboard polish, training endpoint dispatch, and observability cleanup

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -142,9 +142,13 @@ services:
       - ALL
     read_only: true
     tmpfs:
-      - /tmp:noexec,nosuid,nodev,size=16m
-      - /config/caddy:noexec,nosuid,nodev,size=8m
-      - /data/caddy:noexec,nosuid,nodev,size=16m
+      # Caddy runs as uid 65532 from apko; tmpfs defaults to root-owned,
+      # which breaks autosave, instance-UUID persistence, and the
+      # storage_clean lock dir under /data/caddy. Pin the mount owner so
+      # Caddy can write without falling back to read-only mode.
+      - /tmp:noexec,nosuid,nodev,size=16m,uid=65532,gid=65532
+      - /config/caddy:noexec,nosuid,nodev,size=8m,uid=65532,gid=65532
+      - /data/caddy:noexec,nosuid,nodev,size=16m,uid=65532,gid=65532
     healthcheck:
       # Caddy serves a plain "ok" 200 at /healthz; wget is installed in
       # the apko image specifically for this probe. Target 127.0.0.1 to

--- a/docs/design/integrations.md
+++ b/docs/design/integrations.md
@@ -164,6 +164,7 @@ GitHub, Slack, Filesystem, PostgreSQL, SQLite, Brave Search, Puppeteer, Memory.
 |--------|------|-------------|
 | `GET` | `/api/v1/integrations/mcp/catalog` | Browse all entries |
 | `GET` | `/api/v1/integrations/mcp/catalog/search?q=` | Search entries |
+| `GET` | `/api/v1/integrations/mcp/catalog/installed` | List installed catalog entries (paginated; powers dashboard hydration on refresh) |
 | `GET` | `/api/v1/integrations/mcp/catalog/{entry_id}` | Get single entry |
 | `POST` | `/api/v1/integrations/mcp/catalog/install` | Install a catalog entry (dashboard-driven, idempotent) |
 | `DELETE` | `/api/v1/integrations/mcp/catalog/install/{entry_id}` | Uninstall a catalog entry (idempotent) |

--- a/src/synthorg/api/controllers/mcp_catalog.py
+++ b/src/synthorg/api/controllers/mcp_catalog.py
@@ -64,6 +64,19 @@ class InstallEntryResponse(BaseModel):
     )
 
 
+class InstalledEntry(BaseModel):
+    """One row of the installed-MCP-entries listing."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", allow_inf_nan=False)
+
+    catalog_entry_id: NotBlankStr = Field(description="Installed catalog entry id")
+    connection_name: NotBlankStr | None = Field(
+        default=None,
+        description="Bound connection name (when applicable)",
+    )
+    installed_at: str = Field(description="ISO-8601 UTC timestamp of installation")
+
+
 async def _validate_connection_name_for_install(
     *,
     entry_id: str,
@@ -198,6 +211,46 @@ class MCPCatalogController(Controller):
         service = state["app_state"].mcp_catalog_service
         entry = await service.get_entry(entry_id)
         return ApiResponse(data=entry)
+
+    @get(
+        "/catalog/installed",
+        guards=[require_read_access],
+        summary="List installed catalog entries",
+    )
+    async def list_installed(
+        self,
+        state: State,
+        limit: CursorLimit = DEFAULT_LIMIT,
+        cursor: CursorParam = None,
+    ) -> PaginatedResponse[InstalledEntry]:
+        """List MCP catalog entries currently installed on this instance.
+
+        Without this endpoint the dashboard could not rehydrate the
+        installed-state badge across refreshes -- the install API was
+        write-only, so a successful install would persist server-side
+        but appear "uninstalled" again on the next page load.
+        """
+        app_state = state["app_state"]
+        installations_repo = app_state.mcp_installations_repo
+        # Walk all rows once; the installed list is bounded by the
+        # bundled catalog size (~20-50 entries) so a single read with
+        # a generous limit fits inside one cursor page.
+        records = await installations_repo.list_items(limit=500, offset=0)
+        entries = tuple(
+            InstalledEntry(
+                catalog_entry_id=row.catalog_entry_id,
+                connection_name=row.connection_name,
+                installed_at=row.installed_at.isoformat(),
+            )
+            for row in records
+        )
+        page, meta = paginate_cursor(
+            entries,
+            limit=limit,
+            cursor=cursor,
+            secret=app_state.cursor_secret,
+        )
+        return PaginatedResponse(data=page, pagination=meta)
 
     @post(
         "/catalog/install",

--- a/src/synthorg/api/controllers/mcp_catalog.py
+++ b/src/synthorg/api/controllers/mcp_catalog.py
@@ -251,6 +251,13 @@ class MCPCatalogController(Controller):
         # when the install count crosses the page boundary.
         records_acc: list[McpInstallation] = []
         offset = 0
+        # Each iteration advances ``offset`` by ``_LIST_PAGE_SIZE`` (the
+        # page is non-empty by the ``not batch`` guard) and the loop
+        # terminates the moment a page comes back smaller than the
+        # page size. Total iterations are
+        # ``ceil(installed_count / _LIST_PAGE_SIZE)`` with no sleep
+        # between iterations.
+        # lint-allow: long-running-loop-kill-switch -- bounded drain, not a daemon
         while True:
             batch = await installations_repo.list_items(
                 limit=_LIST_PAGE_SIZE,

--- a/src/synthorg/api/controllers/mcp_catalog.py
+++ b/src/synthorg/api/controllers/mcp_catalog.py
@@ -3,7 +3,7 @@
 Browse and install MCP servers from the bundled catalog.
 """
 
-from typing import Literal
+from typing import Final, Literal
 
 from litestar import Controller, delete, get, post
 from litestar.datastructures import State  # noqa: TC002
@@ -25,6 +25,9 @@ from synthorg.integrations.connections.models import CatalogEntry  # noqa: TC001
 from synthorg.integrations.errors import (
     InvalidConnectionAuthError,
 )
+from synthorg.integrations.mcp_catalog.installations import (  # noqa: TC001
+    McpInstallation,
+)
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.integrations import (
     MCP_SERVER_INSTALL_FAILED,
@@ -32,6 +35,12 @@ from synthorg.observability.events.integrations import (
 )
 
 logger = get_logger(__name__)
+
+# Page size for draining the installed-MCP-entries repo before
+# cursor-paginating the response. Larger pages mean fewer round-trips
+# on big install sets; the page boundary itself is irrelevant to the
+# response shape because the controller drains every page.
+_LIST_PAGE_SIZE: Final[int] = 500
 
 
 class InstallEntryRequest(BaseModel):
@@ -233,10 +242,27 @@ class MCPCatalogController(Controller):
         """
         app_state: AppState = state.app_state
         installations_repo = app_state.mcp_installations_repo
-        # Walk all rows once; the installed list is bounded by the
-        # bundled catalog size (~20-50 entries) so a single read with
-        # a generous limit fits inside one cursor page.
-        records = await installations_repo.list_items(limit=500, offset=0)
+        # Drain every installed row before cursor-paginating the
+        # response. The bundled catalog is small today (~20-50 entries),
+        # but a fixed cap would silently truncate the installed list
+        # the moment an operator installs more than _LIST_PAGE_SIZE
+        # entries -- the dashboard would then show a partial set with
+        # no warning. The drain loop costs one extra round-trip only
+        # when the install count crosses the page boundary.
+        records_acc: list[McpInstallation] = []
+        offset = 0
+        while True:
+            batch = await installations_repo.list_items(
+                limit=_LIST_PAGE_SIZE,
+                offset=offset,
+            )
+            if not batch:
+                break
+            records_acc.extend(batch)
+            if len(batch) < _LIST_PAGE_SIZE:
+                break
+            offset += _LIST_PAGE_SIZE
+        records = tuple(records_acc)
         entries = tuple(
             InstalledEntry(
                 catalog_entry_id=row.catalog_entry_id,

--- a/src/synthorg/api/controllers/mcp_catalog.py
+++ b/src/synthorg/api/controllers/mcp_catalog.py
@@ -18,6 +18,7 @@ from synthorg.api.pagination import (
     paginate_cursor,
 )
 from synthorg.api.path_params import PathId  # noqa: TC001 -- runtime annotation
+from synthorg.api.state import AppState  # noqa: TC001
 from synthorg.core.domain_errors import ValidationError
 from synthorg.core.types import NotBlankStr  # noqa: TC001
 from synthorg.integrations.connections.models import CatalogEntry  # noqa: TC001
@@ -153,7 +154,7 @@ class MCPCatalogController(Controller):
         cursor: CursorParam = None,
     ) -> PaginatedResponse[CatalogEntry]:
         """List all curated MCP server entries (cursor-paginated)."""
-        app_state = state["app_state"]
+        app_state: AppState = state.app_state
         entries = await app_state.mcp_catalog_service.browse()
         page, meta = paginate_cursor(
             entries,
@@ -179,7 +180,7 @@ class MCPCatalogController(Controller):
         cursor: CursorParam = None,
     ) -> PaginatedResponse[CatalogEntry]:
         """Search catalog by name, description, or tags (cursor-paginated)."""
-        app_state = state["app_state"]
+        app_state: AppState = state.app_state
         entries = await app_state.mcp_catalog_service.search(q)
         page, meta = paginate_cursor(
             entries,
@@ -208,8 +209,8 @@ class MCPCatalogController(Controller):
         into the generic ``NotFoundError`` and lost the discriminating
         envelope.
         """
-        service = state["app_state"].mcp_catalog_service
-        entry = await service.get_entry(entry_id)
+        app_state: AppState = state.app_state
+        entry = await app_state.mcp_catalog_service.get_entry(entry_id)
         return ApiResponse(data=entry)
 
     @get(
@@ -230,7 +231,7 @@ class MCPCatalogController(Controller):
         write-only, so a successful install would persist server-side
         but appear "uninstalled" again on the next page load.
         """
-        app_state = state["app_state"]
+        app_state: AppState = state.app_state
         installations_repo = app_state.mcp_installations_repo
         # Walk all rows once; the installed list is bounded by the
         # bundled catalog size (~20-50 entries) so a single read with
@@ -272,7 +273,7 @@ class MCPCatalogController(Controller):
         entry_id = data.catalog_entry_id
         connection_name = data.connection_name
 
-        app_state = state["app_state"]
+        app_state: AppState = state.app_state
         service = app_state.mcp_catalog_service
         installations_repo = app_state.mcp_installations_repo
         connection_catalog = (
@@ -331,7 +332,7 @@ class MCPCatalogController(Controller):
         Missing entries are a silent no-op so the endpoint is
         idempotent and callers can always treat 200 as success.
         """
-        app_state = state["app_state"]
+        app_state: AppState = state.app_state
         service = app_state.mcp_catalog_service
         installations_repo = app_state.mcp_installations_repo
         removed = await service.uninstall(

--- a/src/synthorg/api/controllers/memory.py
+++ b/src/synthorg/api/controllers/memory.py
@@ -857,8 +857,57 @@ def _check_documents(
     )
 
 
+_FINE_TUNE_SIDECAR_HEALTH_URL: Final[str] = "http://fine-tune:15002/health"
+_FINE_TUNE_SIDECAR_HEALTH_TIMEOUT_S: Final[float] = 1.5
+_HTTP_STATUS_OK_MIN: Final[int] = 200
+_HTTP_STATUS_OK_MAX_EXCLUSIVE: Final[int] = 300
+
+
+def _check_fine_tune_sidecar_health() -> bool:
+    """Best-effort probe of the fine-tune sidecar's HTTP health endpoint.
+
+    In a Docker-orchestrated install the heavy ML deps (torch +
+    sentence-transformers) live exclusively inside the
+    ``synthorg-fine-tune-{gpu,cpu}`` sidecar container; the main backend
+    container intentionally does NOT bundle them.  Pip-only deployments
+    install the extras directly into the same process.  This helper
+    covers the Docker case: when the sidecar answers its health probe,
+    the deps are reachable even though ``import torch`` would fail
+    locally.  Any error (DNS miss, refused connection, non-200, timeout)
+    is swallowed so the caller falls back to the in-process import.
+    """
+    import urllib.error  # noqa: PLC0415
+    import urllib.request  # noqa: PLC0415
+
+    try:
+        req = urllib.request.Request(_FINE_TUNE_SIDECAR_HEALTH_URL)  # noqa: S310
+        with urllib.request.urlopen(  # noqa: S310
+            req,
+            timeout=_FINE_TUNE_SIDECAR_HEALTH_TIMEOUT_S,
+        ) as resp:
+            status: int = resp.status
+            return _HTTP_STATUS_OK_MIN <= status < _HTTP_STATUS_OK_MAX_EXCLUSIVE
+    except urllib.error.URLError, TimeoutError, OSError:
+        return False
+    except MemoryError, RecursionError:
+        raise
+    except Exception:
+        return False
+
+
 def _check_dependencies() -> PreflightCheck:
-    """Check if fine-tuning ML dependencies are installed."""
+    """Check whether fine-tuning ML dependencies are reachable.
+
+    Two-stage check: an in-process import covers pip installs that
+    bundle the extras locally; an HTTP probe of the fine-tune sidecar
+    container covers the Docker orchestration case where torch +
+    sentence-transformers live exclusively in the sidecar image.
+    Either path succeeding is enough to call the dependencies
+    available.  Previously, only the in-process import was attempted,
+    so every Docker-orchestrated install reported "Fine-tuning not
+    enabled" regardless of whether the user had set ``fine_tuning=true``
+    in the CLI config and started the sidecar.
+    """
     try:
         from synthorg.memory.embedding.fine_tune import (  # noqa: PLC0415
             _import_sentence_transformers,
@@ -868,6 +917,15 @@ def _check_dependencies() -> PreflightCheck:
         _import_torch()
         _import_sentence_transformers()
     except (ImportError, FineTuneDependencyError) as exc:
+        # In-process imports failed; this is the expected path for the
+        # Docker orchestration where ML deps live in a sidecar.  Probe
+        # the sidecar's HTTP health endpoint before declaring failure.
+        if _check_fine_tune_sidecar_health():
+            return PreflightCheck(
+                name="dependencies",
+                status="pass",
+                message="ML dependencies available via fine-tune sidecar",
+            )
         return PreflightCheck(
             name="dependencies",
             status="fail",

--- a/src/synthorg/api/controllers/memory.py
+++ b/src/synthorg/api/controllers/memory.py
@@ -857,7 +857,7 @@ def _check_documents(
     )
 
 
-_FINE_TUNE_SIDECAR_HEALTH_URL: Final[str] = "http://fine-tune:15002/health"
+_FINE_TUNE_SIDECAR_HEALTH_URL: Final[str] = "http://fine-tune:15002/healthz"
 _FINE_TUNE_SIDECAR_HEALTH_TIMEOUT_S: Final[float] = 1.5
 _HTTP_STATUS_OK_MIN: Final[int] = 200
 _HTTP_STATUS_OK_MAX_EXCLUSIVE: Final[int] = 300

--- a/src/synthorg/api/controllers/memory.py
+++ b/src/synthorg/api/controllers/memory.py
@@ -11,9 +11,14 @@ from litestar import Controller, delete, get, post
 from litestar.datastructures import State  # noqa: TC002
 from pydantic import BaseModel, ConfigDict, Field
 
+from synthorg.api.cursor import decode_cursor
 from synthorg.api.dto import DEFAULT_LIMIT, ApiResponse, PaginatedResponse
 from synthorg.api.guards import require_roles
-from synthorg.api.pagination import encode_repo_seek_meta
+from synthorg.api.pagination import (
+    CursorLimit,
+    CursorParam,
+    encode_repo_seek_meta,
+)
 from synthorg.api.rate_limits import (
     per_op_concurrency_from_policy,
     per_op_rate_limit_from_policy,
@@ -459,20 +464,21 @@ class MemoryAdminController(Controller):
     async def list_checkpoints(
         self,
         state: State,
-        limit: int = DEFAULT_LIMIT,
-        offset: int = 0,
+        cursor: CursorParam = None,
+        limit: CursorLimit = DEFAULT_LIMIT,
     ) -> PaginatedResponse[CheckpointRecord]:
         """List fine-tuning checkpoints."""
-        limit = min(max(limit, 1), 200)
-        offset = max(offset, 0)
-        service = _build_memory_service(state.app_state)
+        app_state: AppState = state.app_state
+        secret = app_state.cursor_secret
+        offset = 0 if cursor is None else decode_cursor(cursor, secret=secret)
+        service = _build_memory_service(app_state)
         cps, total = await service.list_checkpoints(limit=limit, offset=offset)
         meta = encode_repo_seek_meta(
             offset=offset,
             page_len=len(cps),
             total=total,
             limit=limit,
-            secret=state.app_state.cursor_secret,
+            secret=secret,
             reject_stale_cursor=False,
         )
         return PaginatedResponse(data=cps, pagination=meta)
@@ -712,13 +718,14 @@ class MemoryAdminController(Controller):
     async def list_runs(
         self,
         state: State,
-        limit: int = DEFAULT_LIMIT,
-        offset: int = 0,
+        cursor: CursorParam = None,
+        limit: CursorLimit = DEFAULT_LIMIT,
     ) -> PaginatedResponse[FineTuneRun]:
         """List historical pipeline runs with pagination metadata."""
-        limit = min(max(limit, 1), 200)
-        offset = max(offset, 0)
-        service = _build_memory_service(state.app_state)
+        app_state: AppState = state.app_state
+        secret = app_state.cursor_secret
+        offset = 0 if cursor is None else decode_cursor(cursor, secret=secret)
+        service = _build_memory_service(app_state)
         runs, total = await service.list_runs(limit=limit, offset=offset)
         return PaginatedResponse(
             data=runs,
@@ -727,7 +734,7 @@ class MemoryAdminController(Controller):
                 page_len=len(runs),
                 total=total,
                 limit=limit,
-                secret=state.app_state.cursor_secret,
+                secret=secret,
                 reject_stale_cursor=False,
             ),
         )

--- a/src/synthorg/api/controllers/scaling.py
+++ b/src/synthorg/api/controllers/scaling.py
@@ -36,6 +36,29 @@ from synthorg.settings.definitions.api import SCALING_STRATEGY_PRIORITY_FALLBACK
 
 logger = get_logger(__name__)
 
+# Once-per-process flag: the scaling subsystem has no construction site
+# in ``create_app`` today, so every request to a scaling endpoint sees a
+# ``None`` service. Without this gate the controller fired one WARNING
+# per request, drowning real signal in noise. The first request that
+# notices the missing wire logs a single INFO so operators still see
+# "scaling is dormant"; subsequent requests stay silent.
+_SCALING_MISSING_LOGGED = False
+
+
+def _note_scaling_missing() -> None:
+    """Log a single INFO when scaling service is observed as unwired."""
+    global _SCALING_MISSING_LOGGED  # noqa: PLW0603
+    if _SCALING_MISSING_LOGGED:
+        return
+    _SCALING_MISSING_LOGGED = True
+    logger.info(
+        HR_SCALING_CONTROLLER_SERVICE_MISSING,
+        note=(
+            "Scaling service is not configured; endpoints return empty "
+            "data until the subsystem is wired in create_app."
+        ),
+    )
+
 
 # -- Response DTOs -----------------------------------------------------------
 
@@ -173,10 +196,7 @@ class ScalingController(Controller):
         app_state: AppState = state.app_state
         scaling = app_state.scaling_service
         if scaling is None:
-            logger.warning(
-                HR_SCALING_CONTROLLER_SERVICE_MISSING,
-                endpoint="list_strategies",
-            )
+            _note_scaling_missing()
             return PaginatedResponse[ScalingStrategyResponse](
                 data=(),
                 pagination=PaginationMeta(
@@ -230,10 +250,7 @@ class ScalingController(Controller):
         app_state: AppState = state.app_state
         scaling = app_state.scaling_service
         if scaling is None:
-            logger.warning(
-                HR_SCALING_CONTROLLER_SERVICE_MISSING,
-                endpoint="list_decisions",
-            )
+            _note_scaling_missing()
             return PaginatedResponse[ScalingDecisionResponse](
                 data=(),
                 pagination=PaginationMeta(
@@ -277,10 +294,7 @@ class ScalingController(Controller):
         app_state: AppState = state.app_state
         scaling = app_state.scaling_service
         if scaling is None:
-            logger.warning(
-                HR_SCALING_CONTROLLER_SERVICE_MISSING,
-                endpoint="list_signals",
-            )
+            _note_scaling_missing()
             return PaginatedResponse[ScalingSignalResponse](
                 data=(),
                 pagination=PaginationMeta(
@@ -350,10 +364,7 @@ class ScalingController(Controller):
         app_state: AppState = state.app_state
         scaling = app_state.scaling_service
         if scaling is None:
-            logger.warning(
-                HR_SCALING_CONTROLLER_SERVICE_MISSING,
-                endpoint="trigger_evaluation",
-            )
+            _note_scaling_missing()
             return ApiResponse(
                 data=(),
                 error="Scaling service not configured",
@@ -396,11 +407,7 @@ class ScalingController(Controller):
         app_state: AppState = state.app_state
         scaling = app_state.scaling_service
         if scaling is None:
-            logger.warning(
-                HR_SCALING_CONTROLLER_SERVICE_MISSING,
-                endpoint="update_strategy",
-                strategy=strategy_name,
-            )
+            _note_scaling_missing()
             return ApiResponse(
                 data=None,
                 error="Scaling service not configured",
@@ -466,10 +473,7 @@ class ScalingController(Controller):
         app_state: AppState = state.app_state
         scaling = app_state.scaling_service
         if scaling is None:
-            logger.warning(
-                HR_SCALING_CONTROLLER_SERVICE_MISSING,
-                endpoint="update_priority",
-            )
+            _note_scaling_missing()
             return ApiResponse(
                 data=(),
                 error="Scaling service not configured",

--- a/src/synthorg/api/controllers/training.py
+++ b/src/synthorg/api/controllers/training.py
@@ -7,6 +7,7 @@ querying training plans for agent onboarding.
 from datetime import UTC, datetime
 
 from litestar import Controller, get, post, put
+from litestar.datastructures import State  # noqa: TC002
 from litestar.status_codes import HTTP_200_OK
 
 from synthorg.api.dto import ApiResponse
@@ -161,14 +162,14 @@ class TrainingController(Controller):
     )
     async def create_plan(
         self,
-        app_state: AppState,
+        state: State,
         agent_name: PathName,
         data: CreateTrainingPlanRequest,
     ) -> ApiResponse[TrainingPlanResponse]:
         """Create a training plan for the specified agent.
 
         Args:
-            app_state: Litestar application state.
+            state: Application state.
             agent_name: Agent identifier from the URL path.
             data: Request body (content types, caps, overrides, flags).
 
@@ -180,6 +181,7 @@ class TrainingController(Controller):
                 content types, caps, or override sources.
             NotFoundError: If the agent name does not resolve.
         """
+        app_state: AppState = state.app_state
         identity = await _resolve_agent(app_state, agent_name)
         enabled_types = _parse_content_types(data.content_types)
         override_sources = _coerce_override_sources(data.override_sources)
@@ -222,13 +224,13 @@ class TrainingController(Controller):
     )
     async def execute_plan(
         self,
-        app_state: AppState,
+        state: State,
         agent_name: PathName,
     ) -> ApiResponse[TrainingResultResponse]:
         """Execute the latest pending training plan.
 
         Args:
-            app_state: Litestar application state.
+            state: Application state.
             agent_name: Agent identifier from the URL path.
 
         Raises:
@@ -236,6 +238,7 @@ class TrainingController(Controller):
             ServiceUnavailableError: If the training service is not
                 yet wired into ``AppState`` for this deployment.
         """
+        app_state: AppState = state.app_state
         identity = await _resolve_agent(app_state, agent_name)
         agent_id = str(identity.id)
 
@@ -291,18 +294,19 @@ class TrainingController(Controller):
     )
     async def get_result(
         self,
-        app_state: AppState,
+        state: State,
         agent_name: PathName,
     ) -> ApiResponse[TrainingResultResponse]:
         """Get the latest training result for an agent.
 
         Args:
-            app_state: Litestar application state.
+            state: Application state.
             agent_name: Agent identifier from the URL path.
 
         Raises:
             NotFoundError: If no result is stored for the agent.
         """
+        app_state: AppState = state.app_state
         identity = await _resolve_agent(app_state, agent_name)
         agent_id = str(identity.id)
 
@@ -327,7 +331,7 @@ class TrainingController(Controller):
     )
     async def get_latest_plan(
         self,
-        app_state: AppState,
+        state: State,
         agent_name: PathName,
     ) -> ApiResponse[TrainingPlanResponse]:
         """Get the most recently created training plan for an agent.
@@ -338,12 +342,13 @@ class TrainingController(Controller):
         been executed).
 
         Args:
-            app_state: Litestar application state.
+            state: Application state.
             agent_name: Agent identifier from the URL path.
 
         Raises:
             NotFoundError: If no plan has been created for the agent.
         """
+        app_state: AppState = state.app_state
         identity = await _resolve_agent(app_state, agent_name)
         agent_id = str(identity.id)
 
@@ -368,13 +373,13 @@ class TrainingController(Controller):
     )
     async def preview_plan(
         self,
-        app_state: AppState,
+        state: State,
         agent_name: PathName,
     ) -> ApiResponse[TrainingResultResponse]:
         """Preview a training plan (dry run).
 
         Args:
-            app_state: Litestar application state.
+            state: Application state.
             agent_name: Agent identifier from the URL path.
 
         Raises:
@@ -382,6 +387,7 @@ class TrainingController(Controller):
             ServiceUnavailableError: If the training service is not
                 yet wired into ``AppState`` for this deployment.
         """
+        app_state: AppState = state.app_state
         identity = await _resolve_agent(app_state, agent_name)
         agent_id = str(identity.id)
 
@@ -408,7 +414,7 @@ class TrainingController(Controller):
     )
     async def update_overrides(
         self,
-        app_state: AppState,
+        state: State,
         agent_name: PathName,
         plan_id: str,
         data: UpdateTrainingOverridesRequest,
@@ -416,7 +422,7 @@ class TrainingController(Controller):
         """Update training plan overrides.
 
         Args:
-            app_state: Litestar application state.
+            state: Application state.
             agent_name: Agent identifier from the URL path.
             plan_id: Training plan id from the URL path.
             data: Request body with optional override updates.
@@ -429,6 +435,7 @@ class TrainingController(Controller):
             ValidationError: If the request contains invalid caps
                 or override source ids.
         """
+        app_state: AppState = state.app_state
         identity = await _resolve_agent(app_state, agent_name)
 
         plan = await app_state.persistence.training_plans.get(

--- a/tests/integration/integrations/test_controllers.py
+++ b/tests/integration/integrations/test_controllers.py
@@ -881,6 +881,66 @@ class TestMCPCatalogController:
         )
         assert response.data is None
 
+    async def test_list_installed_drains_all_repo_pages(self) -> None:
+        from datetime import UTC, datetime
+
+        from synthorg.api.controllers.mcp_catalog import (
+            _LIST_PAGE_SIZE,
+            MCPCatalogController,
+        )
+        from synthorg.api.cursor import CursorSecret
+        from synthorg.integrations.mcp_catalog.installations import McpInstallation
+        from synthorg.integrations.mcp_catalog.service import CatalogService
+
+        # Two repo pages: one full (triggers the loop to ask for
+        # another batch) and one short (terminates the drain).  The
+        # controller must drain both pages before paginate_cursor
+        # wraps the response so the dashboard never sees a truncated
+        # installed list when the install count crosses the page
+        # boundary.
+        now = datetime.now(UTC)
+        first_page = tuple(
+            McpInstallation(
+                catalog_entry_id=NotBlankStr(f"entry-{idx:04d}"),
+                connection_name=None,
+                installed_at=now,
+            )
+            for idx in range(_LIST_PAGE_SIZE)
+        )
+        second_page = (
+            McpInstallation(
+                catalog_entry_id=NotBlankStr("entry-tail"),
+                connection_name=None,
+                installed_at=now,
+            ),
+        )
+        repo = MagicMock()
+        repo.list_items = AsyncMock(side_effect=[first_page, second_page])
+
+        state = State(
+            {
+                "app_state": MagicMock(
+                    mcp_catalog_service=CatalogService(),
+                    mcp_installations_repo=repo,
+                    cursor_secret=CursorSecret.ephemeral(),
+                ),
+            },
+        )
+        ctrl = MCPCatalogController(owner=MCPCatalogController)  # type: ignore[arg-type]
+        await ctrl.list_installed.fn(
+            ctrl,
+            state=state,
+            limit=50,
+            cursor=None,
+        )
+        # The drain loop must request a second batch once the first
+        # batch comes back full; without it, the second page would
+        # silently truncate.  The short second page terminates the
+        # drain so a third call is never issued.
+        assert repo.list_items.await_count == 2
+        assert repo.list_items.await_args_list[0].kwargs["offset"] == 0
+        assert repo.list_items.await_args_list[1].kwargs["offset"] == _LIST_PAGE_SIZE
+
 
 @pytest.mark.integration
 class TestTunnelController:

--- a/tests/integration/integrations/test_controllers.py
+++ b/tests/integration/integrations/test_controllers.py
@@ -23,6 +23,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from litestar.datastructures import State
 from litestar.testing import TestClient
 
 from synthorg.api.cursor import CursorSecret
@@ -667,12 +668,14 @@ class TestMCPCatalogController:
         from synthorg.api.cursor import CursorSecret
         from synthorg.integrations.mcp_catalog.service import CatalogService
 
-        state = {
-            "app_state": MagicMock(
-                mcp_catalog_service=CatalogService(),
-                cursor_secret=CursorSecret.ephemeral(),
-            ),
-        }
+        state = State(
+            {
+                "app_state": MagicMock(
+                    mcp_catalog_service=CatalogService(),
+                    cursor_secret=CursorSecret.ephemeral(),
+                ),
+            }
+        )
         ctrl = MCPCatalogController(owner=MCPCatalogController)  # type: ignore[arg-type]
         response = await ctrl.browse_catalog.fn(
             ctrl,
@@ -689,12 +692,14 @@ class TestMCPCatalogController:
         from synthorg.api.cursor import CursorSecret, InvalidCursorError
         from synthorg.integrations.mcp_catalog.service import CatalogService
 
-        state = {
-            "app_state": MagicMock(
-                mcp_catalog_service=CatalogService(),
-                cursor_secret=CursorSecret.ephemeral(),
-            ),
-        }
+        state = State(
+            {
+                "app_state": MagicMock(
+                    mcp_catalog_service=CatalogService(),
+                    cursor_secret=CursorSecret.ephemeral(),
+                ),
+            }
+        )
         ctrl = MCPCatalogController(owner=MCPCatalogController)  # type: ignore[arg-type]
 
         # Tampered cursor that does not carry an HMAC signature recognised
@@ -720,13 +725,15 @@ class TestMCPCatalogController:
         from synthorg.integrations.mcp_catalog.service import CatalogService
 
         repo = InMemoryMcpInstallationRepository()
-        state = {
-            "app_state": MagicMock(
-                mcp_catalog_service=CatalogService(),
-                mcp_installations_repo=repo,
-                has_connection_catalog=False,
-            ),
-        }
+        state = State(
+            {
+                "app_state": MagicMock(
+                    mcp_catalog_service=CatalogService(),
+                    mcp_installations_repo=repo,
+                    has_connection_catalog=False,
+                ),
+            }
+        )
         ctrl = MCPCatalogController(owner=MCPCatalogController)  # type: ignore[arg-type]
         response = await ctrl.install_entry.fn(
             ctrl,
@@ -760,13 +767,15 @@ class TestMCPCatalogController:
         )
         from synthorg.integrations.mcp_catalog.service import CatalogService
 
-        state = {
-            "app_state": MagicMock(
-                mcp_catalog_service=CatalogService(),
-                mcp_installations_repo=InMemoryMcpInstallationRepository(),
-                has_connection_catalog=False,
-            ),
-        }
+        state = State(
+            {
+                "app_state": MagicMock(
+                    mcp_catalog_service=CatalogService(),
+                    mcp_installations_repo=InMemoryMcpInstallationRepository(),
+                    has_connection_catalog=False,
+                ),
+            }
+        )
         ctrl = MCPCatalogController(owner=MCPCatalogController)  # type: ignore[arg-type]
         with pytest.raises(NotFoundError):
             await ctrl.install_entry.fn(
@@ -793,14 +802,16 @@ class TestMCPCatalogController:
         )
         catalog.get = AsyncMock(return_value=wrong_type_conn)
 
-        state = {
-            "app_state": MagicMock(
-                mcp_catalog_service=CatalogService(),
-                mcp_installations_repo=InMemoryMcpInstallationRepository(),
-                has_connection_catalog=True,
-                connection_catalog=catalog,
-            ),
-        }
+        state = State(
+            {
+                "app_state": MagicMock(
+                    mcp_catalog_service=CatalogService(),
+                    mcp_installations_repo=InMemoryMcpInstallationRepository(),
+                    has_connection_catalog=True,
+                    connection_catalog=catalog,
+                ),
+            }
+        )
         ctrl = MCPCatalogController(owner=MCPCatalogController)  # type: ignore[arg-type]
         with pytest.raises(ValidationError):
             await ctrl.install_entry.fn(
@@ -828,13 +839,15 @@ class TestMCPCatalogController:
                 installed_at=datetime.now(UTC),
             ),
         )
-        state = {
-            "app_state": MagicMock(
-                mcp_catalog_service=CatalogService(),
-                mcp_installations_repo=repo,
-                has_connection_catalog=False,
-            ),
-        }
+        state = State(
+            {
+                "app_state": MagicMock(
+                    mcp_catalog_service=CatalogService(),
+                    mcp_installations_repo=repo,
+                    has_connection_catalog=False,
+                ),
+            }
+        )
         ctrl = MCPCatalogController(owner=MCPCatalogController)  # type: ignore[arg-type]
         response = await ctrl.uninstall_entry.fn(
             ctrl,
@@ -851,13 +864,15 @@ class TestMCPCatalogController:
         )
         from synthorg.integrations.mcp_catalog.service import CatalogService
 
-        state = {
-            "app_state": MagicMock(
-                mcp_catalog_service=CatalogService(),
-                mcp_installations_repo=InMemoryMcpInstallationRepository(),
-                has_connection_catalog=False,
-            ),
-        }
+        state = State(
+            {
+                "app_state": MagicMock(
+                    mcp_catalog_service=CatalogService(),
+                    mcp_installations_repo=InMemoryMcpInstallationRepository(),
+                    has_connection_catalog=False,
+                ),
+            }
+        )
         ctrl = MCPCatalogController(owner=MCPCatalogController)  # type: ignore[arg-type]
         response = await ctrl.uninstall_entry.fn(
             ctrl,

--- a/tests/unit/api/controllers/test_mcp_catalog_dtos.py
+++ b/tests/unit/api/controllers/test_mcp_catalog_dtos.py
@@ -4,6 +4,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from litestar.datastructures import State
 from pydantic import ValidationError
 
 from synthorg.api.controllers.mcp_catalog import (
@@ -100,7 +101,7 @@ class TestInstallEntryValidateFirst:
         app_state.has_connection_catalog = True
         app_state.connection_catalog = connection_catalog
 
-        state = {"app_state": app_state}
+        state = State({"app_state": app_state})
         data = InstallEntryRequest(
             catalog_entry_id="filesystem-mcp",
             connection_name="does-not-exist",
@@ -124,7 +125,7 @@ class TestInstallEntryValidateFirst:
         app_state.mcp_installations_repo = MagicMock()
         app_state.has_connection_catalog = False
 
-        state = {"app_state": app_state}
+        state = State({"app_state": app_state})
         data = InstallEntryRequest(
             catalog_entry_id="filesystem-mcp",
             connection_name="anything",

--- a/tests/unit/api/controllers/test_memory_admin.py
+++ b/tests/unit/api/controllers/test_memory_admin.py
@@ -588,3 +588,229 @@ class TestCheckDocumentsBoundaries:
             min_recommended=50,
         )
         assert check.status == "warn"
+
+
+@pytest.mark.unit
+class TestListCheckpointsEndpoint:
+    """Direct-method coverage for ``MemoryAdminController.list_checkpoints``."""
+
+    async def test_no_cursor_starts_at_offset_zero(self) -> None:
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock
+
+        from litestar.datastructures import State
+
+        from synthorg.api.controllers import memory as memory_module
+        from synthorg.api.controllers.memory import MemoryAdminController
+        from synthorg.api.cursor import CursorSecret
+
+        async def _list_stub(
+            limit: int,
+            offset: int,
+        ) -> tuple[tuple[object, ...], int]:
+            del limit, offset
+            return ((), 0)
+
+        list_mock = AsyncMock(spec=_list_stub, return_value=((), 0))
+        fake_service = SimpleNamespace(list_checkpoints=list_mock)
+
+        def _fake_build(
+            _app_state: object,
+            *,
+            require_fine_tune: bool = True,
+        ) -> SimpleNamespace:
+            del require_fine_tune
+            return fake_service
+
+        controller = MemoryAdminController(owner=None)  # type: ignore[arg-type]
+        original_build = memory_module._build_memory_service
+        memory_module._build_memory_service = _fake_build  # type: ignore[assignment]
+        try:
+            app_state = SimpleNamespace(cursor_secret=CursorSecret.ephemeral())
+            response = await controller.list_checkpoints.fn(
+                controller,
+                state=State({"app_state": app_state}),
+                cursor=None,
+                limit=50,
+            )
+        finally:
+            memory_module._build_memory_service = original_build
+
+        assert response.data == ()
+        list_mock.assert_awaited_once_with(limit=50, offset=0)
+
+    async def test_with_cursor_decodes_to_offset(self) -> None:
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock
+
+        from litestar.datastructures import State
+
+        from synthorg.api.controllers import memory as memory_module
+        from synthorg.api.controllers.memory import MemoryAdminController
+        from synthorg.api.cursor import CursorSecret, encode_cursor
+
+        async def _list_stub(
+            limit: int,
+            offset: int,
+        ) -> tuple[tuple[object, ...], int]:
+            del limit, offset
+            return ((), 25)
+
+        list_mock = AsyncMock(spec=_list_stub, return_value=((), 25))
+        fake_service = SimpleNamespace(list_checkpoints=list_mock)
+
+        def _fake_build(
+            _app_state: object,
+            *,
+            require_fine_tune: bool = True,
+        ) -> SimpleNamespace:
+            del require_fine_tune
+            return fake_service
+
+        secret = CursorSecret.ephemeral()
+        cursor = encode_cursor(10, secret=secret)
+        controller = MemoryAdminController(owner=None)  # type: ignore[arg-type]
+        original_build = memory_module._build_memory_service
+        memory_module._build_memory_service = _fake_build  # type: ignore[assignment]
+        try:
+            await controller.list_checkpoints.fn(
+                controller,
+                state=State({"app_state": SimpleNamespace(cursor_secret=secret)}),
+                cursor=cursor,
+                limit=50,
+            )
+        finally:
+            memory_module._build_memory_service = original_build
+
+        list_mock.assert_awaited_once_with(limit=50, offset=10)
+
+    async def test_tampered_cursor_raises(self) -> None:
+        from types import SimpleNamespace
+
+        from litestar.datastructures import State
+
+        from synthorg.api.controllers.memory import MemoryAdminController
+        from synthorg.api.cursor import CursorSecret, InvalidCursorError
+
+        controller = MemoryAdminController(owner=None)  # type: ignore[arg-type]
+        app_state = SimpleNamespace(cursor_secret=CursorSecret.ephemeral())
+        with pytest.raises(InvalidCursorError):
+            await controller.list_checkpoints.fn(
+                controller,
+                state=State({"app_state": app_state}),
+                cursor="not-a-real-cursor",
+                limit=50,
+            )
+
+
+@pytest.mark.unit
+class TestListRunsEndpoint:
+    """Direct-method coverage for ``MemoryAdminController.list_runs``."""
+
+    async def test_no_cursor_starts_at_offset_zero(self) -> None:
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock
+
+        from litestar.datastructures import State
+
+        from synthorg.api.controllers import memory as memory_module
+        from synthorg.api.controllers.memory import MemoryAdminController
+        from synthorg.api.cursor import CursorSecret
+
+        async def _list_stub(
+            limit: int,
+            offset: int,
+        ) -> tuple[tuple[object, ...], int]:
+            del limit, offset
+            return ((), 0)
+
+        list_mock = AsyncMock(spec=_list_stub, return_value=((), 0))
+        fake_service = SimpleNamespace(list_runs=list_mock)
+
+        def _fake_build(
+            _app_state: object,
+            *,
+            require_fine_tune: bool = True,
+        ) -> SimpleNamespace:
+            del require_fine_tune
+            return fake_service
+
+        controller = MemoryAdminController(owner=None)  # type: ignore[arg-type]
+        original_build = memory_module._build_memory_service
+        memory_module._build_memory_service = _fake_build  # type: ignore[assignment]
+        try:
+            app_state = SimpleNamespace(cursor_secret=CursorSecret.ephemeral())
+            response = await controller.list_runs.fn(
+                controller,
+                state=State({"app_state": app_state}),
+                cursor=None,
+                limit=50,
+            )
+        finally:
+            memory_module._build_memory_service = original_build
+
+        assert response.data == ()
+        list_mock.assert_awaited_once_with(limit=50, offset=0)
+
+    async def test_with_cursor_decodes_to_offset(self) -> None:
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock
+
+        from litestar.datastructures import State
+
+        from synthorg.api.controllers import memory as memory_module
+        from synthorg.api.controllers.memory import MemoryAdminController
+        from synthorg.api.cursor import CursorSecret, encode_cursor
+
+        async def _list_stub(
+            limit: int,
+            offset: int,
+        ) -> tuple[tuple[object, ...], int]:
+            del limit, offset
+            return ((), 25)
+
+        list_mock = AsyncMock(spec=_list_stub, return_value=((), 25))
+        fake_service = SimpleNamespace(list_runs=list_mock)
+
+        def _fake_build(
+            _app_state: object,
+            *,
+            require_fine_tune: bool = True,
+        ) -> SimpleNamespace:
+            del require_fine_tune
+            return fake_service
+
+        secret = CursorSecret.ephemeral()
+        cursor = encode_cursor(15, secret=secret)
+        controller = MemoryAdminController(owner=None)  # type: ignore[arg-type]
+        original_build = memory_module._build_memory_service
+        memory_module._build_memory_service = _fake_build  # type: ignore[assignment]
+        try:
+            await controller.list_runs.fn(
+                controller,
+                state=State({"app_state": SimpleNamespace(cursor_secret=secret)}),
+                cursor=cursor,
+                limit=50,
+            )
+        finally:
+            memory_module._build_memory_service = original_build
+
+        list_mock.assert_awaited_once_with(limit=50, offset=15)
+
+    async def test_tampered_cursor_raises(self) -> None:
+        from types import SimpleNamespace
+
+        from litestar.datastructures import State
+
+        from synthorg.api.controllers.memory import MemoryAdminController
+        from synthorg.api.cursor import CursorSecret, InvalidCursorError
+
+        controller = MemoryAdminController(owner=None)  # type: ignore[arg-type]
+        app_state = SimpleNamespace(cursor_secret=CursorSecret.ephemeral())
+        with pytest.raises(InvalidCursorError):
+            await controller.list_runs.fn(
+                controller,
+                state=State({"app_state": app_state}),
+                cursor="not-a-real-cursor",
+                limit=50,
+            )

--- a/tests/unit/scripts/test_check_setting_to_startup_trace.py
+++ b/tests/unit/scripts/test_check_setting_to_startup_trace.py
@@ -176,7 +176,7 @@ def test_real_repo_violations_match_expected() -> None:
 
     Also asserts zero false positives on the negative ``security.*``
     settings (audit_enabled, post_tool_scanning_enabled, ...) and on
-    ``engine.timeout_enforcement_enabled`` and the WS DoS settings.
+    ``engine.timeout_enforcement_enabled``.
 
     This test is the load-bearing assertion that the lint logic is
     correct against real-world wiring. If it fails, the lint logic is

--- a/web/src/__tests__/pages/AgentDetailPage.test.tsx
+++ b/web/src/__tests__/pages/AgentDetailPage.test.tsx
@@ -95,8 +95,12 @@ describe('AgentDetailPage', () => {
     expect(screen.getByTestId('agent-detail-skeleton')).toBeInTheDocument()
   })
 
-  it('renders not-found message when no agent and not loading', () => {
-    hookReturn = { ...defaultHookReturn, agent: null }
+  it('renders not-found message when no agent and error is set', () => {
+    hookReturn = {
+      ...defaultHookReturn,
+      agent: null,
+      error: 'Agent missing',
+    }
     renderDetail()
     expect(screen.getByText('Agent not found')).toBeInTheDocument()
   })

--- a/web/src/__tests__/pages/ArtifactDetailPage.test.tsx
+++ b/web/src/__tests__/pages/ArtifactDetailPage.test.tsx
@@ -58,8 +58,12 @@ describe('ArtifactDetailPage', () => {
     expect(screen.getByTestId('artifact-detail-skeleton')).toBeInTheDocument()
   })
 
-  it('renders not found when no artifact and not loading', () => {
-    hookReturn = { ...defaultHookReturn, artifact: null }
+  it('renders not found when no artifact and error is set', () => {
+    hookReturn = {
+      ...defaultHookReturn,
+      artifact: null,
+      error: 'Artifact missing',
+    }
     renderPage()
     expect(screen.getByText('Artifact not found')).toBeInTheDocument()
   })
@@ -82,7 +86,7 @@ describe('ArtifactDetailPage', () => {
   })
 
   describe('property-based state transitions', () => {
-    it('shows skeleton only when loading with no artifact', () => {
+    it('shows skeleton whenever there is no artifact and no error', () => {
       fc.assert(
         fc.property(fc.boolean(), fc.boolean(), (loading, hasArtifact) => {
           hookReturn = {
@@ -93,20 +97,24 @@ describe('ArtifactDetailPage', () => {
           const { unmount } = renderPage()
           const hasSkeleton = screen.queryByTestId('artifact-detail-skeleton') !== null
           unmount()
-          return hasSkeleton === (loading && !hasArtifact)
+          return hasSkeleton === !hasArtifact
         }),
         { numRuns: 20 },
       )
     })
 
-    it('shows not-found only when no artifact and not loading', () => {
+    it('shows not-found only when no artifact and error is set', () => {
       fc.assert(
-        fc.property(fc.boolean(), (loading) => {
-          hookReturn = { ...defaultHookReturn, artifact: null, loading }
+        fc.property(fc.boolean(), fc.boolean(), (hasError, hasArtifact) => {
+          hookReturn = {
+            ...defaultHookReturn,
+            artifact: hasArtifact ? artifact : null,
+            error: hasError ? 'Artifact missing' : null,
+          }
           const { unmount } = renderPage()
           const hasNotFound = screen.queryByText('Artifact not found') !== null
           unmount()
-          return hasNotFound === !loading
+          return hasNotFound === (hasError && !hasArtifact)
         }),
         { numRuns: 10 },
       )

--- a/web/src/__tests__/pages/MessagesPage.test.tsx
+++ b/web/src/__tests__/pages/MessagesPage.test.tsx
@@ -9,6 +9,7 @@ const defaultReturn: UseMessagesDataReturn = {
   channelsLoading: false,
   channelsError: null,
   unreadCounts: {},
+  channelsWithMessages: new Set<string>(),
   messages: [],
   total: 0,
   loading: false,

--- a/web/src/__tests__/pages/MessagesPage.test.tsx
+++ b/web/src/__tests__/pages/MessagesPage.test.tsx
@@ -96,9 +96,15 @@ describe('MessagesPage', () => {
   })
 
   it('renders channel sidebar with channels', () => {
+    // The sidebar buckets channels into an "Active" group (current
+    // selection / unread / known to carry messages) and a collapsed
+    // "Empty" group. Mark both channels as carrying messages so they
+    // land in the Active group and the rendered DOM exposes their
+    // names without the user having to expand the empty section.
     hookReturn = {
       ...defaultReturn,
       channels: [makeChannel('#engineering'), makeChannel('#product')],
+      channelsWithMessages: new Set(['#engineering', '#product']),
       expandedThreads: new Set(),
     }
     renderPage()

--- a/web/src/__tests__/pages/ProjectDetailPage.test.tsx
+++ b/web/src/__tests__/pages/ProjectDetailPage.test.tsx
@@ -61,8 +61,12 @@ describe('ProjectDetailPage', () => {
     expect(screen.getByTestId('project-detail-skeleton')).toBeInTheDocument()
   })
 
-  it('renders not found when no project and not loading', () => {
-    hookReturn = { ...defaultHookReturn, project: null }
+  it('renders not found when no project and error is set', () => {
+    hookReturn = {
+      ...defaultHookReturn,
+      project: null,
+      error: 'Project missing',
+    }
     renderPage()
     expect(screen.getByText('Project not found')).toBeInTheDocument()
   })
@@ -86,7 +90,7 @@ describe('ProjectDetailPage', () => {
   })
 
   describe('property-based state transitions', () => {
-    it('shows skeleton only when loading with no project', () => {
+    it('shows skeleton whenever there is no project and no error', () => {
       fc.assert(
         fc.property(fc.boolean(), fc.boolean(), (loading, hasProject) => {
           hookReturn = {
@@ -97,20 +101,24 @@ describe('ProjectDetailPage', () => {
           const { unmount } = renderPage()
           const hasSkeleton = screen.queryByTestId('project-detail-skeleton') !== null
           unmount()
-          return hasSkeleton === (loading && !hasProject)
+          return hasSkeleton === !hasProject
         }),
         { numRuns: 20 },
       )
     })
 
-    it('shows not-found only when no project and not loading', () => {
+    it('shows not-found only when no project and error is set', () => {
       fc.assert(
-        fc.property(fc.boolean(), (loading) => {
-          hookReturn = { ...defaultHookReturn, project: null, loading }
+        fc.property(fc.boolean(), fc.boolean(), (hasError, hasProject) => {
+          hookReturn = {
+            ...defaultHookReturn,
+            project: hasProject ? project : null,
+            error: hasError ? 'Project missing' : null,
+          }
           const { unmount } = renderPage()
           const hasNotFound = screen.queryByText('Project not found') !== null
           unmount()
-          return hasNotFound === !loading
+          return hasNotFound === (hasError && !hasProject)
         }),
         { numRuns: 10 },
       )

--- a/web/src/__tests__/pages/messages/ChannelSidebar.test.tsx
+++ b/web/src/__tests__/pages/messages/ChannelSidebar.test.tsx
@@ -12,6 +12,14 @@ describe('ChannelSidebar', () => {
     ],
     activeChannel: null as string | null,
     unreadCounts: {} as Record<string, number>,
+    // Mark every channel as having messages by default so the
+    // existing render assertions hit the "active" group (the new
+    // "Empty" group is collapsed by default and would hide them).
+    channelsWithMessages: new Set([
+      '#engineering',
+      '#product',
+      '#dm-alice',
+    ]) as ReadonlySet<string>,
     onSelectChannel: vi.fn(),
     loading: false,
   }

--- a/web/src/__tests__/pages/org/build-org-tree.test.ts
+++ b/web/src/__tests__/pages/org/build-org-tree.test.ts
@@ -352,7 +352,7 @@ describe('buildOrgTree', () => {
     expect(types).toEqual(['agent', 'agent', 'department', 'department', 'owner'])
   })
 
-  it('returns null runtime metrics when no health data provided', () => {
+  it('returns null cost / currency when no health data provided', () => {
     const agents = [
       makeAgent({ id: 'a1', name: 'Dev', department: 'engineering', level: 'mid' }),
     ]
@@ -362,7 +362,10 @@ describe('buildOrgTree', () => {
     const data = deptNode!.data as DepartmentGroupData
     expect(data.cost7d).toBeNull()
     expect(data.currency).toBeNull()
-    expect(data.utilizationPercent).toBeNull()
+    // utilizationPercent is runtime-status-based (idle count / total) and
+    // no longer derived from health data, so it has a value even with an
+    // empty runtimeStatuses list (every agent falls back to its HR status).
+    expect(data.utilizationPercent).not.toBeNull()
   })
 
   it('all edges have type "hierarchy"', () => {

--- a/web/src/__tests__/stores/fine-tuning.test.ts
+++ b/web/src/__tests__/stores/fine-tuning.test.ts
@@ -4,12 +4,14 @@ import {
   useFineTuningStore,
 } from '@/stores/fine-tuning'
 import { useToastStore } from '@/stores/toast'
-import { apiError, apiSuccess } from '@/mocks/handlers'
+import { apiError, apiSuccess, paginatedEnvelopeFor } from '@/mocks/handlers'
 import { server } from '@/test-setup'
 import type {
   CheckpointRecord,
   FineTuneRun,
   FineTuneStatus,
+  listCheckpoints,
+  listRuns,
   PreflightResult,
 } from '@/api/endpoints/fine-tuning'
 
@@ -108,7 +110,7 @@ describe('useFineTuningStore', () => {
     it('fetchCheckpoints populates checkpoints on success', async () => {
       server.use(
         http.get('/api/v1/admin/memory/fine-tune/checkpoints', () =>
-          HttpResponse.json(apiSuccess([BASE_CHECKPOINT])),
+          HttpResponse.json(paginatedEnvelopeFor<typeof listCheckpoints>([BASE_CHECKPOINT])),
         ),
       )
 
@@ -141,10 +143,10 @@ describe('useFineTuningStore', () => {
           HttpResponse.json(apiError('Backend offline'), { status: 503 }),
         ),
         http.get('/api/v1/admin/memory/fine-tune/checkpoints', () =>
-          HttpResponse.json(apiSuccess([BASE_CHECKPOINT])),
+          HttpResponse.json(paginatedEnvelopeFor<typeof listCheckpoints>([BASE_CHECKPOINT])),
         ),
         http.get('/api/v1/admin/memory/fine-tune/runs', () =>
-          HttpResponse.json(apiSuccess([BASE_RUN])),
+          HttpResponse.json(paginatedEnvelopeFor<typeof listRuns>([BASE_RUN])),
         ),
       )
 
@@ -168,7 +170,7 @@ describe('useFineTuningStore', () => {
     it('fetchRuns populates runs on success', async () => {
       server.use(
         http.get('/api/v1/admin/memory/fine-tune/runs', () =>
-          HttpResponse.json(apiSuccess([BASE_RUN])),
+          HttpResponse.json(paginatedEnvelopeFor<typeof listRuns>([BASE_RUN])),
         ),
       )
 

--- a/web/src/__tests__/stores/fine-tuning.test.ts
+++ b/web/src/__tests__/stores/fine-tuning.test.ts
@@ -4,7 +4,8 @@ import {
   useFineTuningStore,
 } from '@/stores/fine-tuning'
 import { useToastStore } from '@/stores/toast'
-import { apiError, apiSuccess, paginatedEnvelopeFor } from '@/mocks/handlers'
+import { apiError, apiSuccess, paginatedFor } from '@/mocks/handlers'
+import type { PaginatedResult } from '@/api/client'
 import { server } from '@/test-setup'
 import type {
   CheckpointRecord,
@@ -66,12 +67,24 @@ const BASE_PREFLIGHT: PreflightResult = {
   can_proceed: true,
 }
 
+function pageOf<T>(items: readonly T[]): PaginatedResult<T> {
+  return {
+    data: [...items],
+    limit: 50,
+    nextCursor: null,
+    hasMore: false,
+    pagination: { limit: 50, next_cursor: null, has_more: false },
+  }
+}
+
 describe('useFineTuningStore', () => {
   beforeEach(() => {
     useFineTuningStore.setState({
       status: null,
       checkpoints: [],
+      checkpointsPagination: { nextCursor: null, hasMore: false },
       runs: [],
+      runsPagination: { nextCursor: null, hasMore: false },
       preflight: null,
       loading: false,
       errors: { status: null, checkpoints: null, runs: null },
@@ -110,7 +123,7 @@ describe('useFineTuningStore', () => {
     it('fetchCheckpoints populates checkpoints on success', async () => {
       server.use(
         http.get('/api/v1/admin/memory/fine-tune/checkpoints', () =>
-          HttpResponse.json(paginatedEnvelopeFor<typeof listCheckpoints>([BASE_CHECKPOINT])),
+          HttpResponse.json(paginatedFor<typeof listCheckpoints>(pageOf([BASE_CHECKPOINT]))),
         ),
       )
 
@@ -143,10 +156,10 @@ describe('useFineTuningStore', () => {
           HttpResponse.json(apiError('Backend offline'), { status: 503 }),
         ),
         http.get('/api/v1/admin/memory/fine-tune/checkpoints', () =>
-          HttpResponse.json(paginatedEnvelopeFor<typeof listCheckpoints>([BASE_CHECKPOINT])),
+          HttpResponse.json(paginatedFor<typeof listCheckpoints>(pageOf([BASE_CHECKPOINT]))),
         ),
         http.get('/api/v1/admin/memory/fine-tune/runs', () =>
-          HttpResponse.json(paginatedEnvelopeFor<typeof listRuns>([BASE_RUN])),
+          HttpResponse.json(paginatedFor<typeof listRuns>(pageOf([BASE_RUN]))),
         ),
       )
 
@@ -170,7 +183,7 @@ describe('useFineTuningStore', () => {
     it('fetchRuns populates runs on success', async () => {
       server.use(
         http.get('/api/v1/admin/memory/fine-tune/runs', () =>
-          HttpResponse.json(paginatedEnvelopeFor<typeof listRuns>([BASE_RUN])),
+          HttpResponse.json(paginatedFor<typeof listRuns>(pageOf([BASE_RUN]))),
         ),
       )
 

--- a/web/src/__tests__/stores/training.test.ts
+++ b/web/src/__tests__/stores/training.test.ts
@@ -43,6 +43,7 @@ describe('useTrainingStore', () => {
       items_after_guards: [['procedural', 3]],
       items_stored: [['procedural', 3]],
       approval_item_id: null,
+      pending_approvals: [],
       review_pending: false,
       errors: [],
       started_at: '2026-04-01T00:00:00Z',

--- a/web/src/api/endpoints/fine-tuning.ts
+++ b/web/src/api/endpoints/fine-tuning.ts
@@ -147,12 +147,14 @@ export async function runPreflight(
 }
 
 export async function listCheckpoints(
+  cursor: string | null = null,
   limit = 50,
-  offset = 0,
 ): Promise<PaginatedResult<CheckpointRecord>> {
+  const params: Record<string, string | number> = { limit }
+  if (cursor !== null) params.cursor = cursor
   const response = await apiClient.get<PaginatedResponse<CheckpointRecord>>(
     `${BASE}/checkpoints`,
-    { params: { limit, offset } },
+    { params },
   )
   return unwrapPaginated<CheckpointRecord>(response)
 }
@@ -181,11 +183,13 @@ export async function deleteCheckpoint(checkpointId: string): Promise<void> {
 }
 
 export async function listRuns(
+  cursor: string | null = null,
   limit = 50,
-  offset = 0,
 ): Promise<PaginatedResult<FineTuneRun>> {
+  const params: Record<string, string | number> = { limit }
+  if (cursor !== null) params.cursor = cursor
   const response = await apiClient.get<PaginatedResponse<FineTuneRun>>(`${BASE}/runs`, {
-    params: { limit, offset },
+    params,
   })
   return unwrapPaginated<FineTuneRun>(response)
 }

--- a/web/src/api/endpoints/fine-tuning.ts
+++ b/web/src/api/endpoints/fine-tuning.ts
@@ -1,5 +1,11 @@
-import { apiClient, unwrap, unwrapVoid } from '../client'
-import type { ApiResponse } from '../types/http'
+import {
+  apiClient,
+  unwrap,
+  unwrapPaginated,
+  unwrapVoid,
+  type PaginatedResult,
+} from '../client'
+import type { ApiResponse, PaginatedResponse } from '../types/http'
 
 // -- Types -----------------------------------------------------------
 
@@ -143,12 +149,12 @@ export async function runPreflight(
 export async function listCheckpoints(
   limit = 50,
   offset = 0,
-): Promise<CheckpointRecord[]> {
-  const response = await apiClient.get<ApiResponse<CheckpointRecord[]>>(
+): Promise<PaginatedResult<CheckpointRecord>> {
+  const response = await apiClient.get<PaginatedResponse<CheckpointRecord>>(
     `${BASE}/checkpoints`,
     { params: { limit, offset } },
   )
-  return unwrap(response)
+  return unwrapPaginated<CheckpointRecord>(response)
 }
 
 export async function deployCheckpoint(checkpointId: string): Promise<CheckpointRecord> {
@@ -174,9 +180,12 @@ export async function deleteCheckpoint(checkpointId: string): Promise<void> {
   unwrapVoid(response)
 }
 
-export async function listRuns(limit = 50, offset = 0): Promise<FineTuneRun[]> {
-  const response = await apiClient.get<ApiResponse<FineTuneRun[]>>(`${BASE}/runs`, {
+export async function listRuns(
+  limit = 50,
+  offset = 0,
+): Promise<PaginatedResult<FineTuneRun>> {
+  const response = await apiClient.get<PaginatedResponse<FineTuneRun>>(`${BASE}/runs`, {
     params: { limit, offset },
   })
-  return unwrap(response)
+  return unwrapPaginated<FineTuneRun>(response)
 }

--- a/web/src/api/endpoints/mcp-catalog.ts
+++ b/web/src/api/endpoints/mcp-catalog.ts
@@ -34,6 +34,35 @@ export async function getMcpCatalogEntry(entryId: string): Promise<McpCatalogEnt
   return unwrap(response)
 }
 
+export interface InstalledMcpEntry {
+  readonly catalog_entry_id: string
+  readonly connection_name: string | null
+  readonly installed_at: string
+}
+
+/**
+ * List MCP catalog entries currently installed on the backend.
+ *
+ * Walks the cursor pages so callers see every installed row in one
+ * call -- the installed list is bounded by the bundled catalog
+ * (~20-50 entries) so a single call covers every deployment.
+ */
+export async function listInstalledMcp(): Promise<readonly InstalledMcpEntry[]> {
+  const collected: InstalledMcpEntry[] = []
+  let cursor: string | null = null
+  do {
+    const params: Record<string, string> | undefined = cursor ? { cursor } : undefined
+    const response = await apiClient.get<PaginatedResponse<InstalledMcpEntry>>(
+      '/integrations/mcp/catalog/installed',
+      { params },
+    )
+    const page: PaginatedResult<InstalledMcpEntry> = unwrapPaginated<InstalledMcpEntry>(response)
+    collected.push(...page.data)
+    cursor = page.hasMore ? page.nextCursor : null
+  } while (cursor !== null)
+  return collected
+}
+
 export async function installMcpServer(
   data: McpInstallRequest,
 ): Promise<McpInstallResponse> {

--- a/web/src/api/endpoints/training.ts
+++ b/web/src/api/endpoints/training.ts
@@ -41,6 +41,7 @@ export interface TrainingResultResponse {
   items_after_guards: Array<[ContentType, number]>
   items_stored: Array<[ContentType, number]>
   approval_item_id: string | null
+  pending_approvals: ReadonlyArray<readonly [string, ContentType, number]>
   review_pending: boolean
   errors: string[]
   started_at: string

--- a/web/src/components/layout/AppLayout.tsx
+++ b/web/src/components/layout/AppLayout.tsx
@@ -16,6 +16,7 @@ import {
   Video,
 } from 'lucide-react'
 import { ROUTES } from '@/router/routes'
+import { titleForPath } from '@/router/route-titles'
 import type { CommandItem } from '@/hooks/useCommandPalette'
 import { useRegisterCommands } from '@/hooks/useCommandPalette'
 import { useGlobalNotifications } from '@/hooks/useGlobalNotifications'
@@ -67,6 +68,15 @@ export default function AppLayout() {
   // Global WebSocket subscription for app-wide notifications (e.g. personality
   // trimming toasts) so they render regardless of the current page.
   useGlobalNotifications()
+
+  // Drive ``document.title`` from the active route so the browser tab
+  // reflects the page the user is actually on.  Previously only three
+  // pages set the title imperatively and never reverted it, so visiting
+  // MCP Catalog left the tab labelled "MCP Catalog · SynthOrg" for the
+  // rest of the session regardless of where the user navigated next.
+  useEffect(() => {
+    document.title = titleForPath(location.pathname)
+  }, [location.pathname])
 
   // Listen for toggle-notification-drawer events (dispatched by Shift+N and
   // by the NotificationBell button). Handled here in AppLayout so the

--- a/web/src/components/ui/code-mirror-editor.tsx
+++ b/web/src/components/ui/code-mirror-editor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { EditorState, Compartment, type Extension } from '@codemirror/state'
 import { EditorView, lineNumbers, drawSelection, keymap } from '@codemirror/view'
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
@@ -7,6 +7,7 @@ import { json } from '@codemirror/lang-json'
 import { yaml } from '@codemirror/lang-yaml'
 import { tags } from '@lezer/highlight'
 import { cn } from '@/lib/utils'
+import { getCspNonce } from '@/lib/csp'
 
 export interface CodeMirrorEditorProps {
   /** Current document text (external source of truth). */
@@ -151,6 +152,15 @@ export function CodeMirrorEditor({
   // Track whether a programmatic update is in progress
   const isProgrammaticRef = useRef(false)
 
+  // Resolve the per-request CSP nonce so CodeMirror's injected
+  // <style> elements pass the page's ``style-src-elem 'self'
+  // 'nonce-...''`` policy.  Without this, the editor renders with
+  // unstyled line numbers + raw text and the browser logs a
+  // "blocked inline style" violation.  ``cspNonce`` is a static
+  // Facet on EditorView; supplied through the initial state so all
+  // theme + syntax-highlight modules pick it up at mount.
+  const cspNonce = useMemo(() => getCspNonce(), [])
+
   // Create editor on mount
   useEffect(() => {
     if (!containerRef.current) return
@@ -164,6 +174,7 @@ export function CodeMirrorEditor({
     const state = EditorState.create({
       doc: value,
       extensions: [
+        ...(cspNonce ? [EditorView.cspNonce.of(cspNonce)] : []),
         lineNumbers(),
         drawSelection(),
         bracketMatching(),

--- a/web/src/hooks/useMcpCatalogData.ts
+++ b/web/src/hooks/useMcpCatalogData.ts
@@ -24,6 +24,12 @@ export function useMcpCatalogData(): UseMcpCatalogDataReturn {
     if (entries.length === 0 && !loading) {
       void useMcpCatalogStore.getState().fetchCatalog()
     }
+    // Hydrate installed-state from the backend every mount so the
+    // catalog correctly shows entries as "installed" after a refresh
+    // -- the install API is write-only, so without this the local
+    // ``installedEntryIds`` Set starts empty and the UI mis-renders
+    // already-installed entries as fresh installs.
+    void useMcpCatalogStore.getState().fetchInstalled()
     // eslint-disable-next-line @eslint-react/exhaustive-deps
   }, [])
 

--- a/web/src/hooks/useMessagesData.ts
+++ b/web/src/hooks/useMessagesData.ts
@@ -14,6 +14,9 @@ export interface UseMessagesDataReturn {
   channelsLoading: boolean
   channelsError: string | null
   unreadCounts: Record<string, number>
+  /** Channels with at least one observed message; drives the sidebar
+   *  split between an "Active" group and a collapsed "Empty" group. */
+  channelsWithMessages: ReadonlySet<string>
 
   // Messages
   messages: Message[]
@@ -50,6 +53,7 @@ export function useMessagesData(activeChannel: string | null): UseMessagesDataRe
   const channelsLoading = useMessagesStore((s) => s.channelsLoading)
   const channelsError = useMessagesStore((s) => s.channelsError)
   const unreadCounts = useMessagesStore((s) => s.unreadCounts)
+  const channelsWithMessages = useMessagesStore((s) => s.channelsWithMessages)
 
   const messages = useMessagesStore((s) => s.messages)
   const total = useMessagesStore((s) => s.total)
@@ -64,6 +68,9 @@ export function useMessagesData(activeChannel: string | null): UseMessagesDataRe
   // Fetch channels on mount
   useEffect(() => {
     void useMessagesStore.getState().fetchChannels()
+    // Probe recent global messages once so the sidebar knows which
+    // channels are non-empty without having to visit each one.
+    void useMessagesStore.getState().fetchChannelActivity()
   }, [])
 
   // Fetch messages when active channel changes; reset unread
@@ -117,6 +124,7 @@ export function useMessagesData(activeChannel: string | null): UseMessagesDataRe
     channelsLoading,
     channelsError,
     unreadCounts,
+    channelsWithMessages,
     messages,
     total,
     loading,

--- a/web/src/mocks/handlers/fine-tuning.ts
+++ b/web/src/mocks/handlers/fine-tuning.ts
@@ -12,7 +12,7 @@ import type {
   runPreflight,
   startFineTune,
 } from '@/api/endpoints/fine-tuning'
-import { successFor, voidSuccess } from './helpers'
+import { emptyPage, paginatedFor, successFor, voidSuccess } from './helpers'
 
 const NOW = '2026-04-19T00:00:00Z'
 
@@ -72,7 +72,7 @@ export const fineTuningHandlers = [
     ),
   ),
   http.get('/api/v1/admin/memory/fine-tune/checkpoints', () =>
-    HttpResponse.json(successFor<typeof listCheckpoints>([])),
+    HttpResponse.json(paginatedFor<typeof listCheckpoints>(emptyPage<CheckpointRecord>())),
   ),
   http.post(
     '/api/v1/admin/memory/fine-tune/checkpoints/:id/deploy',
@@ -96,6 +96,6 @@ export const fineTuningHandlers = [
     HttpResponse.json(voidSuccess()),
   ),
   http.get('/api/v1/admin/memory/fine-tune/runs', () =>
-    HttpResponse.json(successFor<typeof listRuns>([])),
+    HttpResponse.json(paginatedFor<typeof listRuns>(emptyPage())),
   ),
 ]

--- a/web/src/mocks/handlers/mcp-catalog.ts
+++ b/web/src/mocks/handlers/mcp-catalog.ts
@@ -3,12 +3,18 @@ import type {
   browseMcpCatalog,
   getMcpCatalogEntry,
   installMcpServer,
+  listInstalledMcp,
   searchMcpCatalog,
-  InstalledMcpEntry,
 } from '@/api/endpoints/mcp-catalog'
 import type { McpCatalogEntry } from '@/api/types/integrations'
-import type { PaginatedResponse } from '@/api/types/http'
-import { apiError, emptyPage, paginatedFor, successFor, voidSuccess } from './helpers'
+import {
+  apiError,
+  emptyPage,
+  paginatedEnvelopeFor,
+  paginatedFor,
+  successFor,
+  voidSuccess,
+} from './helpers'
 
 export function buildMcpCatalogEntry(
   overrides: Partial<McpCatalogEntry> = {},
@@ -72,25 +78,9 @@ function _catalogPage(
   }
 }
 
-function _installedPage(
-  rows: readonly InstalledMcpEntry[],
-): PaginatedResponse<InstalledMcpEntry> {
-  return {
-    success: true,
-    error: null,
-    error_detail: null,
-    data: [...rows],
-    pagination: {
-      limit: rows.length || 1,
-      next_cursor: null,
-      has_more: false,
-    },
-  }
-}
-
 export const mcpCatalogHandlers = [
   http.get('/api/v1/integrations/mcp/catalog/installed', () =>
-    HttpResponse.json(_installedPage([])),
+    HttpResponse.json(paginatedEnvelopeFor<typeof listInstalledMcp>([])),
   ),
   http.get('/api/v1/integrations/mcp/catalog', () =>
     HttpResponse.json(paginatedFor<typeof browseMcpCatalog>(_catalogPage(mockCatalogEntries))),
@@ -138,7 +128,7 @@ export const mcpCatalogHandlers = [
 
 export const mcpCatalogDefaultHandlers = [
   http.get('/api/v1/integrations/mcp/catalog/installed', () =>
-    HttpResponse.json(_installedPage([])),
+    HttpResponse.json(paginatedEnvelopeFor<typeof listInstalledMcp>([])),
   ),
   http.get('/api/v1/integrations/mcp/catalog', () =>
     HttpResponse.json(paginatedFor<typeof browseMcpCatalog>(emptyPage<McpCatalogEntry>())),

--- a/web/src/mocks/handlers/mcp-catalog.ts
+++ b/web/src/mocks/handlers/mcp-catalog.ts
@@ -4,8 +4,10 @@ import type {
   getMcpCatalogEntry,
   installMcpServer,
   searchMcpCatalog,
+  InstalledMcpEntry,
 } from '@/api/endpoints/mcp-catalog'
 import type { McpCatalogEntry } from '@/api/types/integrations'
+import type { PaginatedResponse } from '@/api/types/http'
 import { apiError, emptyPage, paginatedFor, successFor, voidSuccess } from './helpers'
 
 export function buildMcpCatalogEntry(
@@ -70,7 +72,26 @@ function _catalogPage(
   }
 }
 
+function _installedPage(
+  rows: readonly InstalledMcpEntry[],
+): PaginatedResponse<InstalledMcpEntry> {
+  return {
+    success: true,
+    error: null,
+    error_detail: null,
+    data: [...rows],
+    pagination: {
+      limit: rows.length || 1,
+      next_cursor: null,
+      has_more: false,
+    },
+  }
+}
+
 export const mcpCatalogHandlers = [
+  http.get('/api/v1/integrations/mcp/catalog/installed', () =>
+    HttpResponse.json(_installedPage([])),
+  ),
   http.get('/api/v1/integrations/mcp/catalog', () =>
     HttpResponse.json(paginatedFor<typeof browseMcpCatalog>(_catalogPage(mockCatalogEntries))),
   ),
@@ -116,6 +137,9 @@ export const mcpCatalogHandlers = [
 // ── Default test handlers: empty catalog + minimal entry lookups. ──
 
 export const mcpCatalogDefaultHandlers = [
+  http.get('/api/v1/integrations/mcp/catalog/installed', () =>
+    HttpResponse.json(_installedPage([])),
+  ),
   http.get('/api/v1/integrations/mcp/catalog', () =>
     HttpResponse.json(paginatedFor<typeof browseMcpCatalog>(emptyPage<McpCatalogEntry>())),
   ),

--- a/web/src/mocks/handlers/training.ts
+++ b/web/src/mocks/handlers/training.ts
@@ -47,6 +47,7 @@ export function buildResult(
     items_after_guards: [],
     items_stored: [],
     approval_item_id: null,
+    pending_approvals: [],
     review_pending: false,
     errors: [],
     started_at: NOW,

--- a/web/src/pages/AgentDetailPage.tsx
+++ b/web/src/pages/AgentDetailPage.tsx
@@ -92,24 +92,26 @@ export default function AgentDetailPage() {
   })
   const { goPrev, goNext } = useDetailNavigationCallbacks(nav)
 
-  if (loading && !agent) {
-    return <AgentDetailSkeleton />
-  }
-
-  const allowedTools = agent
-    ? (Array.isArray(agent.tools['allowed'])
-        ? (agent.tools['allowed'] as unknown[]).filter((t): t is string => typeof t === 'string')
-        : [])
-    : []
-
-  if (!agent) {
+  // Error banner only when the fetch returned a definitive negative;
+  // skeleton covers both the "loading" path and the pre-fetch render
+  // window where ``loading`` hasn't flipped to ``true`` yet (the
+  // polling effect runs after first paint).
+  if (error && !agent) {
     return (
       <div className="space-y-section-gap">
         <Breadcrumbs items={[{ label: 'Agents', to: ROUTES.AGENTS }, { label: resolvedAgentName || 'Unknown agent' }]} />
-        <ErrorBanner severity="error" title="Agent not found" description={error ?? undefined} />
+        <ErrorBanner severity="error" title="Agent not found" description={error} />
       </div>
     )
   }
+
+  if (!agent) {
+    return <AgentDetailSkeleton />
+  }
+
+  const allowedTools = Array.isArray(agent.tools['allowed'])
+    ? (agent.tools['allowed'] as unknown[]).filter((t): t is string => typeof t === 'string')
+    : []
 
   return (
     <div className="space-y-section-gap">

--- a/web/src/pages/ArtifactDetailPage.tsx
+++ b/web/src/pages/ArtifactDetailPage.tsx
@@ -50,17 +50,20 @@ export default function ArtifactDetailPage() {
     if (wsConnected) hasEverConnectedRef.current = true
   }, [wsConnected])
 
-  if (loading && !artifact) {
-    return <ArtifactDetailSkeleton />
-  }
-
-  if (!artifact) {
+  // Error banner only when the fetch returned a definitive negative;
+  // skeleton covers both the "loading" path and the pre-fetch render
+  // window where ``loading`` hasn't flipped to ``true`` yet.
+  if (error && !artifact) {
     return (
       <div className="space-y-section-gap">
         <Breadcrumbs items={[{ label: 'Artifacts', to: ROUTES.ARTIFACTS }, { label: artifactId || 'Unknown artifact' }]} />
-        <ErrorBanner severity="error" title="Artifact not found" description={error ?? undefined} />
+        <ErrorBanner severity="error" title="Artifact not found" description={error} />
       </div>
     )
+  }
+
+  if (!artifact) {
+    return <ArtifactDetailSkeleton />
   }
 
   return (

--- a/web/src/pages/ClientDetailPage.tsx
+++ b/web/src/pages/ClientDetailPage.tsx
@@ -36,7 +36,6 @@ export default function ClientDetailPage() {
   const [satisfaction, setSatisfaction] = useState<SatisfactionHistory | null>(
     null,
   )
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [satisfactionError, setSatisfactionError] = useState<string | null>(null)
 
@@ -60,13 +59,11 @@ export default function ClientDetailPage() {
     if (!clientId) {
       const timer = setTimeout(() => {
         setError('Missing client id in URL')
-        setLoading(false)
       }, 0)
       return () => clearTimeout(timer)
     }
     let cancelled = false
     const load = async () => {
-      setLoading(true)
       setClient(null)
       setSatisfaction(null)
       setError(null)
@@ -87,8 +84,6 @@ export default function ClientDetailPage() {
         if (cancelled) return
         log.error('get_client_failed', err)
         setError('Failed to load client. It may have been removed.')
-      } finally {
-        if (!cancelled) setLoading(false)
       }
     }
     void load()
@@ -97,19 +92,22 @@ export default function ClientDetailPage() {
     }
   }, [clientId])
 
-  if (loading) {
+  // Error banner only when the fetch returned a definitive negative;
+  // skeleton covers both the "loading" path and the pre-fetch render
+  // window where ``loading`` hasn't flipped to ``true`` yet.
+  if (error && !client) {
     return (
       <div className="space-y-section-gap">
-        <SkeletonCard />
+        <Breadcrumbs items={[{ label: 'Clients', to: ROUTES.CLIENTS }, { label: clientId ?? 'Unknown client' }]} />
+        <ErrorBanner severity="error" title="Client not found" description={error} />
       </div>
     )
   }
 
-  if (error || !client) {
+  if (!client) {
     return (
       <div className="space-y-section-gap">
-        <Breadcrumbs items={[{ label: 'Clients', to: ROUTES.CLIENTS }, { label: clientId ?? 'Unknown client' }]} />
-        <ErrorBanner severity="error" title="Client not found" description={error ?? undefined} />
+        <SkeletonCard />
       </div>
     )
   }

--- a/web/src/pages/ConnectionsPage.tsx
+++ b/web/src/pages/ConnectionsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Filter, Plus } from 'lucide-react'
 import type { Connection } from '@/api/types/integrations'
 import { Button } from '@/components/ui/button'
@@ -39,10 +39,6 @@ export default function ConnectionsPage() {
     setTypeFilter(null)
     setHealthFilter(null)
   }
-
-  useEffect(() => {
-    document.title = 'Connections · SynthOrg'
-  }, [])
 
   const hasData = connections.length > 0 || filteredConnections.length > 0
 

--- a/web/src/pages/McpCatalogPage.tsx
+++ b/web/src/pages/McpCatalogPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import type { ConnectionType, McpCatalogEntry } from '@/api/types/integrations'
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { ErrorBoundary } from '@/components/ui/error-boundary'
@@ -31,10 +31,6 @@ export default function McpCatalogPage() {
   const uninstall = useMcpCatalogStore((s) => s.uninstall)
   const [createConnectionType, setCreateConnectionType] =
     useState<ConnectionType | null>(null)
-
-  useEffect(() => {
-    document.title = 'MCP Catalog · SynthOrg'
-  }, [])
 
   const handleInstall = (entry: McpCatalogEntry) => {
     selectEntry(null)

--- a/web/src/pages/MessagesPage.tsx
+++ b/web/src/pages/MessagesPage.tsx
@@ -32,6 +32,7 @@ export default function MessagesPage() {
     channelsLoading,
     channelsError,
     unreadCounts,
+    channelsWithMessages,
     messages,
     total,
     loading,
@@ -135,6 +136,7 @@ export default function MessagesPage() {
           channels={channels}
           activeChannel={activeChannel}
           unreadCounts={unreadCounts}
+          channelsWithMessages={channelsWithMessages}
           onSelectChannel={handleSelectChannel}
           loading={channelsLoading}
         />

--- a/web/src/pages/OauthAppsPage.tsx
+++ b/web/src/pages/OauthAppsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { KeyRound, Plus } from 'lucide-react'
 import { initiateOauth } from '@/api/endpoints/oauth'
 import type { Connection } from '@/api/types/integrations'
@@ -30,10 +30,6 @@ export default function OauthAppsPage() {
   const deleteConnection = useConnectionsStore((s) => s.deleteConnection)
   const [modal, setModal] = useState<ModalState>({ kind: 'closed' })
   const [pendingDelete, setPendingDelete] = useState<Connection | null>(null)
-
-  useEffect(() => {
-    document.title = 'OAuth Apps · SynthOrg'
-  }, [])
 
   const oauthApps = useMemo(
     () => connections.filter((c) => c.connection_type === 'oauth_app'),

--- a/web/src/pages/OrgChartPage.tsx
+++ b/web/src/pages/OrgChartPage.tsx
@@ -205,7 +205,7 @@ function OrgChartInner() {
     // ``requestAnimationFrame`` lets ReactFlow commit the new node
     // positions to its internal store before we ask it to fit them.
     const id = requestAnimationFrame(() => {
-      fitView({ padding: 0.2, duration: 400 })
+      void fitView({ padding: 0.2, duration: 400 })
     })
     return () => cancelAnimationFrame(id)
   }, [viewMode, view.transitioning, view.displayNodes.length, fitView])

--- a/web/src/pages/OrgChartPage.tsx
+++ b/web/src/pages/OrgChartPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   Background,
   MiniMap,
@@ -191,6 +191,24 @@ function OrgChartInner() {
   const handleViewModeChange = useCallback((mode: 'hierarchy' | 'force') => {
     setViewMode(mode)
   }, [])
+
+  // Re-fit the viewport whenever the view mode flips OR the layout
+  // animation finishes. The hierarchy layout produces coordinates in the
+  // thousands of pixels; the force layout centres around (~400, ~300).
+  // Without a re-fit, the saved viewport from the previous layout makes
+  // nodes appear scattered far apart or vanishingly small in the corner.
+  // We wait for ``transitioning`` to flip back to false so we fit the
+  // FINAL positions, not the in-flight interpolated ones.
+  useEffect(() => {
+    if (view.transitioning) return
+    if (view.displayNodes.length === 0) return
+    // ``requestAnimationFrame`` lets ReactFlow commit the new node
+    // positions to its internal store before we ask it to fit them.
+    const id = requestAnimationFrame(() => {
+      fitView({ padding: 0.2, duration: 400 })
+    })
+    return () => cancelAnimationFrame(id)
+  }, [viewMode, view.transitioning, view.displayNodes.length, fitView])
 
   // Pre-render source list: transition reducer publishes `displayNodes` only
   // after the first animation frame, so before any layout change settles we

--- a/web/src/pages/OrgChartPage.tsx
+++ b/web/src/pages/OrgChartPage.tsx
@@ -13,6 +13,7 @@ import { GitBranch, Loader2 } from 'lucide-react'
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { Link, useNavigate } from 'react-router'
 import { createLogger } from '@/lib/logger'
+import { TRANSITION_SLOW_MS } from '@/lib/motion'
 import { useToastStore } from '@/stores/toast'
 import { sanitizeForLog } from '@/utils/logging'
 
@@ -205,7 +206,7 @@ function OrgChartInner() {
     // ``requestAnimationFrame`` lets ReactFlow commit the new node
     // positions to its internal store before we ask it to fit them.
     const id = requestAnimationFrame(() => {
-      void fitView({ padding: 0.2, duration: 400 })
+      void fitView({ padding: 0.2, duration: TRANSITION_SLOW_MS })
     })
     return () => cancelAnimationFrame(id)
   }, [viewMode, view.transitioning, view.displayNodes.length, fitView])

--- a/web/src/pages/ProjectDetailPage.tsx
+++ b/web/src/pages/ProjectDetailPage.tsx
@@ -42,17 +42,22 @@ export default function ProjectDetailPage() {
   })
   const { goPrev, goNext } = useDetailNavigationCallbacks(nav)
 
-  if (loading && !project) {
-    return <ProjectDetailSkeleton />
-  }
-
-  if (!project) {
+  // Error state: a definitive negative answer from the backend always
+  // sets ``error`` -- show the not-found banner only when the fetch
+  // failed, never on the pre-fetch render window where ``loading``
+  // hasn't flipped to ``true`` yet (the polling effect runs after
+  // first paint).
+  if (error && !project) {
     return (
       <div className="space-y-section-gap">
         <Breadcrumbs items={[{ label: 'Projects', to: ROUTES.PROJECTS }, { label: 'Unknown project' }]} />
-        <ErrorBanner severity="error" title="Project not found" description={error ?? undefined} />
+        <ErrorBanner severity="error" title="Project not found" description={error} />
       </div>
     )
+  }
+
+  if (!project) {
+    return <ProjectDetailSkeleton />
   }
 
   return (

--- a/web/src/pages/approvals/ApprovalCard.tsx
+++ b/web/src/pages/approvals/ApprovalCard.tsx
@@ -153,7 +153,7 @@ function ApprovalCardImpl({
           >
             {approval.title}
           </button>
-          <div className="mt-0.5 flex flex-wrap items-center gap-2 text-xs text-secondary">
+          <div className="mt-0.5 flex flex-wrap items-center gap-2 text-xs text-text-secondary">
             <span className="font-mono">{approval.action_type}</span>
             <span aria-hidden="true">--</span>
             <span>{approval.requested_by}</span>

--- a/web/src/pages/approvals/ApprovalDetailDrawer.tsx
+++ b/web/src/pages/approvals/ApprovalDetailDrawer.tsx
@@ -271,7 +271,7 @@ export function ApprovalDetailDrawer({
                 >
                   {getRiskLevelLabel(approval.risk_level)}
                 </span>
-                <span className="text-xs text-secondary">
+                <span className="text-xs text-text-secondary">
                   {getApprovalStatusLabel(approval.status)}
                 </span>
               </div>
@@ -348,7 +348,7 @@ export function ApprovalDetailDrawer({
                   <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
                     Reason
                   </span>
-                  <p className="mt-1 rounded border border-border bg-surface p-2 text-sm text-secondary">
+                  <p className="mt-1 rounded border border-border bg-surface p-2 text-sm text-text-secondary">
                     {approval.decision_reason}
                   </p>
                 </div>
@@ -360,7 +360,7 @@ export function ApprovalDetailDrawer({
                   <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
                     Linked Task
                   </span>
-                  <p className="mt-1 font-mono text-xs text-secondary">{approval.task_id}</p>
+                  <p className="mt-1 font-mono text-xs text-text-secondary">{approval.task_id}</p>
                 </div>
               )}
 
@@ -374,7 +374,7 @@ export function ApprovalDetailDrawer({
                     {Object.entries(approval.metadata).map(([key, value]) => (
                       <div key={key} className="flex items-center gap-2 text-xs">
                         <dt className="font-mono text-muted-foreground">{key}:</dt>
-                        <dd className="text-secondary">
+                        <dd className="text-text-secondary">
                           {typeof value === 'string'
                             ? value
                             : typeof value === 'object' && value !== null
@@ -483,7 +483,7 @@ function DescriptionSection({ approval }: { approval: ApprovalResponse }) {
           </span>
         )}
       </span>
-      <p className="mt-1 text-sm text-secondary">{displayText}</p>
+      <p className="mt-1 text-sm text-text-secondary">{displayText}</p>
     </div>
   )
 }

--- a/web/src/pages/approvals/ApprovalFilterBar.tsx
+++ b/web/src/pages/approvals/ApprovalFilterBar.tsx
@@ -123,7 +123,7 @@ interface FilterPillProps {
 
 function FilterPill({ label, onRemove }: FilterPillProps) {
   return (
-    <span className="inline-flex items-center gap-1 rounded-full border border-border bg-surface px-2 py-0.5 text-[10px] text-secondary">
+    <span className="inline-flex items-center gap-1 rounded-full border border-border bg-surface px-2 py-0.5 text-[10px] text-text-secondary">
       {label}
       <button
         type="button"

--- a/web/src/pages/approvals/ApprovalRiskGroupSection.tsx
+++ b/web/src/pages/approvals/ApprovalRiskGroupSection.tsx
@@ -52,7 +52,7 @@ export function ApprovalRiskGroupSection({
         icon={Icon}
         action={
           pendingIds.length > 0 ? (
-            <label className="flex items-center gap-1.5 text-xs text-secondary cursor-pointer">
+            <label className="flex items-center gap-1.5 text-xs text-text-secondary cursor-pointer">
               <input
                 type="checkbox"
                 checked={allSelected}

--- a/web/src/pages/approvals/ApprovalTimeline.tsx
+++ b/web/src/pages/approvals/ApprovalTimeline.tsx
@@ -52,7 +52,7 @@ const LINE_CLASSES = {
 const OUTCOME_CLASSES: Record<string, string> = {
   success: 'text-success',
   danger: 'text-danger',
-  'text-secondary': 'text-secondary',
+  'text-secondary': 'text-text-secondary',
 }
 
 export function ApprovalTimeline({ approval, className }: ApprovalTimelineProps) {
@@ -72,7 +72,7 @@ export function ApprovalTimeline({ approval, className }: ApprovalTimelineProps)
               aria-hidden="true"
             />
             {/* Label */}
-            <span className="mt-1.5 text-[10px] font-medium text-secondary">{step.label}</span>
+            <span className="mt-1.5 text-[10px] font-medium text-text-secondary">{step.label}</span>
             {/* Timestamp */}
             {step.timestamp && (
               <span className="mt-0.5 font-mono text-[9px] text-muted-foreground">
@@ -84,7 +84,7 @@ export function ApprovalTimeline({ approval, className }: ApprovalTimelineProps)
               <span
                 className={cn(
                   'mt-0.5 text-[10px] font-semibold',
-                  OUTCOME_CLASSES[getApprovalStatusColor(approval.status)] ?? 'text-secondary',
+                  OUTCOME_CLASSES[getApprovalStatusColor(approval.status)] ?? 'text-text-secondary',
                 )}
               >
                 {step.outcomeLabel}

--- a/web/src/pages/fine-tuning/DependencyMissingBanner.tsx
+++ b/web/src/pages/fine-tuning/DependencyMissingBanner.tsx
@@ -2,15 +2,16 @@ export function DependencyMissingBanner() {
   return (
     <div className="rounded-lg border border-danger/30 bg-danger/5 p-card" role="alert">
       <h3 className="text-sm font-medium text-danger">
-        Fine-tuning not enabled for this install
+        Fine-tuning sidecar unreachable
       </h3>
       <p className="mt-1 text-sm text-muted-foreground">
-        The backend reports that PyTorch and sentence-transformers are
-        unavailable. In a Docker-orchestrated install these ship inside the{' '}
-        <code className="font-mono">synthorg-fine-tune-gpu</code> or{' '}
-        <code className="font-mono">synthorg-fine-tune-cpu</code> container,
-        which the backend spawns on demand. Enable it without wiping your
-        install:
+        The backend could not contact the fine-tuning sidecar
+        (<code className="font-mono">synthorg-fine-tune-gpu</code> /
+        <code className="font-mono">synthorg-fine-tune-cpu</code>), which
+        ships PyTorch + sentence-transformers. If you have
+        <code className="font-mono">fine_tuning=true</code> set already,
+        the most common cause is that the container is not running yet --
+        restart the stack so the orchestrator brings it up:
       </p>
       <code className="mt-2 block rounded bg-muted px-3 py-2 font-mono text-xs text-foreground">
         synthorg config set sandbox true
@@ -22,8 +23,12 @@ export function DependencyMissingBanner() {
         synthorg stop &amp;&amp; synthorg start
       </code>
       <p className="mt-2 text-sm text-muted-foreground">
-        Running a hand-managed <code className="font-mono">compose.yml</code>{' '}
-        without the CLI? See the{' '}
+        Verify the sidecar is running with{' '}
+        <code className="font-mono">synthorg status</code> -- it should
+        list a healthy <code className="font-mono">fine-tune</code>{' '}
+        service. Running a hand-managed{' '}
+        <code className="font-mono">compose.yml</code> without the CLI?
+        See the{' '}
         <a
           className="text-accent underline underline-offset-2 hover:no-underline"
           href="https://synthorg.io/docs/guides/deployment/#fine-tuning-optional"
@@ -32,7 +37,7 @@ export function DependencyMissingBanner() {
         >
           Fine-Tuning section of the Deployment guide
         </a>{' '}
-        for the BYO-compose snippet.
+        for the overlay-compose snippet.
       </p>
     </div>
   )

--- a/web/src/pages/fine-tuning/DependencyMissingBanner.tsx
+++ b/web/src/pages/fine-tuning/DependencyMissingBanner.tsx
@@ -8,10 +8,9 @@ export function DependencyMissingBanner() {
         The backend could not contact the fine-tuning sidecar
         (<code className="font-mono">synthorg-fine-tune-gpu</code> /
         <code className="font-mono">synthorg-fine-tune-cpu</code>), which
-        ships PyTorch + sentence-transformers. If you have
-        <code className="font-mono">fine_tuning=true</code> set already,
-        the most common cause is that the container is not running yet --
-        restart the stack so the orchestrator brings it up:
+        ships PyTorch + sentence-transformers. To enable and start the
+        sidecar (or restart it if it is already enabled but unreachable),
+        run:
       </p>
       <code className="mt-2 block rounded bg-muted px-3 py-2 font-mono text-xs text-foreground">
         synthorg config set sandbox true

--- a/web/src/pages/fine-tuning/PipelineControlPanel.tsx
+++ b/web/src/pages/fine-tuning/PipelineControlPanel.tsx
@@ -91,28 +91,35 @@ export function PipelineControlPanel() {
           hint="Path INSIDE the backend container -- the default /data/documents resolves to the synthorg-data Docker volume. Drop training files into that volume (or override the path here) before running pre-flight."
         />
         {/*
-         * Spacer to push the buttons onto the same baseline as the
-         * input element rather than its label, then the button group
-         * itself.  ``mt-[1.625rem]`` matches the InputField label's
-         * height (text-xs + mb-1.5 + line-height) so the row aligns
-         * pixel-for-pixel regardless of theme density.
+         * Mirror InputField's vertical stack so the button row aligns
+         * with the input row (not the label above it). The empty
+         * ``<span>`` reserves a label-height row using the SAME
+         * Tailwind tokens InputField itself uses (``text-sm`` for label
+         * size, ``gap-1.5`` for the label/input gap), so changes to
+         * InputField typography keep the alignment intact without any
+         * hardcoded rem offsets.
          */}
-        <div className="flex gap-2 md:mt-[1.625rem]">
-          <Button variant="outline" onClick={handlePreflight} disabled={loading}>
-            Pre-flight Check
-          </Button>
-          {isActive ? (
-            <Button variant="destructive" onClick={() => void cancelRun()}>
-              Cancel
+        <div className="flex flex-col gap-1.5">
+          <span aria-hidden="true" className="hidden text-sm font-medium md:block">
+            &nbsp;
+          </span>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={handlePreflight} disabled={loading}>
+              Pre-flight Check
             </Button>
-          ) : (
-            <Button
-              onClick={handleStart}
-              disabled={loading || (preflight != null && !preflight.can_proceed)}
-            >
-              Start Fine-Tuning
-            </Button>
-          )}
+            {isActive ? (
+              <Button variant="destructive" onClick={() => void cancelRun()}>
+                Cancel
+              </Button>
+            ) : (
+              <Button
+                onClick={handleStart}
+                disabled={loading || (preflight != null && !preflight.can_proceed)}
+              >
+                Start Fine-Tuning
+              </Button>
+            )}
+          </div>
         </div>
       </div>
 

--- a/web/src/pages/fine-tuning/PipelineControlPanel.tsx
+++ b/web/src/pages/fine-tuning/PipelineControlPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
 import { useShallow } from 'zustand/react/shallow'
 
 import { ACTIVE_STAGES } from '@/api/endpoints/fine-tuning'
@@ -74,14 +75,29 @@ export function PipelineControlPanel() {
 
   return (
     <div className="flex flex-col gap-section-gap">
-      <div className="flex items-end gap-4">
+      {/*
+       * Grid layout instead of ``flex items-end`` so the action
+       * buttons align with the INPUT row of the field rather than
+       * the hint line below it (previously the buttons sat one row
+       * too low, visually disconnected from their input).  The
+       * field's label + hint stack still flows correctly within the
+       * left column.
+       */}
+      <div className="grid grid-cols-1 items-start gap-4 md:grid-cols-[1fr_auto]">
         <InputField
           label="Source Directory"
           value={sourceDir}
           onValueChange={setSourceDir}
-          hint="Directory containing org documents for training"
+          hint="Path INSIDE the backend container -- the default /data/documents resolves to the synthorg-data Docker volume. Drop training files into that volume (or override the path here) before running pre-flight."
         />
-        <div className="flex gap-2 pb-1">
+        {/*
+         * Spacer to push the buttons onto the same baseline as the
+         * input element rather than its label, then the button group
+         * itself.  ``mt-[1.625rem]`` matches the InputField label's
+         * height (text-xs + mb-1.5 + line-height) so the row aligns
+         * pixel-for-pixel regardless of theme density.
+         */}
+        <div className="flex gap-2 md:mt-[1.625rem]">
           <Button variant="outline" onClick={handlePreflight} disabled={loading}>
             Pre-flight Check
           </Button>
@@ -102,14 +118,26 @@ export function PipelineControlPanel() {
 
       {preflight && <PreflightResultPanel result={preflight} />}
 
+      {/*
+       * Disclosure-style toggle, but rendered as an ``outline``
+       * button with a chevron so it reads as a real interactive
+       * control, not body copy.  The previous ``ghost`` variant
+       * stripped all borders and made the toggle look like a
+       * stray text label.
+       */}
       <Button
-        variant="ghost"
+        variant="outline"
         size="sm"
         onClick={() => setShowAdvanced(!showAdvanced)}
-        className="self-start"
+        className="self-start gap-1.5"
         aria-expanded={showAdvanced}
         aria-controls="advanced-options-panel"
       >
+        {showAdvanced ? (
+          <ChevronDown className="size-3.5" aria-hidden="true" />
+        ) : (
+          <ChevronRight className="size-3.5" aria-hidden="true" />
+        )}
         {showAdvanced ? 'Hide' : 'Show'} Advanced Options
       </Button>
 

--- a/web/src/pages/mcp-catalog/McpInstallWizard.tsx
+++ b/web/src/pages/mcp-catalog/McpInstallWizard.tsx
@@ -66,7 +66,7 @@ export function McpInstallWizard({ onRequestCreateConnection }: McpInstallWizard
   if (entry === null && flow === 'error') {
     return (
       <Dialog open={isOpen} onOpenChange={(next) => !next && handleClose()}>
-        <DialogContent>
+        <DialogContent className="sm:max-w-dialog-compact">
           <DialogHeader>
             <DialogTitle>Install failed</DialogTitle>
             <DialogCloseButton />
@@ -89,7 +89,7 @@ export function McpInstallWizard({ onRequestCreateConnection }: McpInstallWizard
 
   return (
     <Dialog open={isOpen} onOpenChange={(next) => !next && handleClose()}>
-      <DialogContent>
+      <DialogContent className="sm:max-w-dialog-compact">
         <DialogHeader>
           <DialogTitle>Install {entry.name}</DialogTitle>
           <DialogCloseButton />

--- a/web/src/pages/messages/AttachmentList.tsx
+++ b/web/src/pages/messages/AttachmentList.tsx
@@ -22,7 +22,7 @@ export function AttachmentList({ attachments }: AttachmentListProps) {
           <span
             // eslint-disable-next-line @eslint-react/no-array-index-key -- attachments lack stable IDs
             key={`${att.type}-${att.ref}-${i}`}
-            className="inline-flex items-center gap-1 rounded border border-border bg-surface px-1.5 py-0.5 font-mono text-[10px] text-secondary"
+            className="inline-flex items-center gap-1 rounded border border-border bg-surface px-1.5 py-0.5 font-mono text-[10px] text-text-secondary"
           >
             <Icon className="size-3" aria-hidden="true" />
             {att.ref}

--- a/web/src/pages/messages/ChannelListItem.tsx
+++ b/web/src/pages/messages/ChannelListItem.tsx
@@ -37,7 +37,7 @@ function ChannelListItemImpl({
         'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors',
         'hover:bg-card-hover',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent',
-        active ? 'bg-card-hover text-foreground' : 'text-secondary',
+        active ? 'bg-card-hover text-foreground' : 'text-text-secondary',
       )}
     >
       <Icon className="size-3.5 shrink-0" aria-hidden="true" />

--- a/web/src/pages/messages/ChannelSidebar.tsx
+++ b/web/src/pages/messages/ChannelSidebar.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { ListFilter, MessageSquare } from 'lucide-react'
+import { ChevronDown, ChevronRight, ListFilter, MessageSquare } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Drawer } from '@/components/ui/drawer'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -13,6 +13,24 @@ const TYPE_ORDER: ChannelType[] = [
   'direct',
   'broadcast',
 ]
+
+/**
+ * Returns true when a channel should be classified as "active": it
+ * has at least one known message, has an unread badge, or is the
+ * currently-selected channel.  Anything else falls into the
+ * collapsed "Empty" group so a fresh install's long list of
+ * pre-created topics doesn't bury the active threads.
+ */
+function isChannelActive(
+  channel: Channel,
+  activeChannel: string | null,
+  channelsWithMessages: ReadonlySet<string>,
+  unreadCounts: Record<string, number>,
+): boolean {
+  if (channel.name === activeChannel) return true
+  if ((unreadCounts[channel.name] ?? 0) > 0) return true
+  return channelsWithMessages.has(channel.name)
+}
 
 interface ChannelGroupSectionProps {
   type: ChannelType
@@ -53,6 +71,10 @@ interface ChannelSidebarProps {
   channels: Channel[]
   activeChannel: string | null
   unreadCounts: Record<string, number>
+  /** Channels we have direct evidence carry at least one message.
+   *  Channels NOT in this set get demoted to the collapsed "Empty"
+   *  group below the active list. */
+  channelsWithMessages: ReadonlySet<string>
   onSelectChannel: (name: string) => void
   loading: boolean
 }
@@ -71,22 +93,36 @@ function ChannelListBody({
   channels,
   activeChannel,
   unreadCounts,
+  channelsWithMessages,
   onSelectChannel,
   loading,
   onAfterSelect,
 }: ChannelListBodyProps) {
-  const grouped = useMemo(() => {
-    const map = new Map<ChannelType, Channel[]>()
+  const [emptyExpanded, setEmptyExpanded] = useState(false)
+
+  // Bucket channels by type AND by activity.  An "active" channel is
+  // the currently-selected one, anything carrying unread messages, or
+  // anything ``fetchChannelActivity`` found a recent message for; an
+  // "empty" channel is everything else (typically the pre-created
+  // topics on a fresh install).
+  const { activeByType, emptyByType, emptyCount } = useMemo(() => {
+    const activeMap = new Map<ChannelType, Channel[]>()
+    const emptyMap = new Map<ChannelType, Channel[]>()
+    let emptyTotal = 0
     for (const ch of channels) {
-      const bucket = map.get(ch.type)
+      const target = isChannelActive(ch, activeChannel, channelsWithMessages, unreadCounts)
+        ? activeMap
+        : emptyMap
+      const bucket = target.get(ch.type)
       if (bucket) {
         bucket.push(ch)
       } else {
-        map.set(ch.type, [ch])
+        target.set(ch.type, [ch])
       }
+      if (target === emptyMap) emptyTotal++
     }
-    return map
-  }, [channels])
+    return { activeByType: activeMap, emptyByType: emptyMap, emptyCount: emptyTotal }
+  }, [channels, activeChannel, channelsWithMessages, unreadCounts])
 
   const handleSelect = (name: string) => {
     onSelectChannel(name)
@@ -114,30 +150,74 @@ function ChannelListBody({
     )
   }
 
+  const renderSection = (
+    type: ChannelType,
+    items: Channel[],
+  ) => (
+    <div key={type}>
+      <div className="mb-1 px-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+        {getChannelTypeLabel(type)}
+      </div>
+      <div className="flex flex-col gap-0.5">
+        {items.map((ch) => (
+          <ChannelListItem
+            key={ch.name}
+            channel={ch}
+            active={ch.name === activeChannel}
+            unreadCount={unreadCounts[ch.name] ?? 0}
+            onSelect={handleSelect}
+          />
+        ))}
+      </div>
+    </div>
+  )
+
+  const activeSections = TYPE_ORDER.map((type) => {
+    const items = activeByType.get(type)
+    if (!items || items.length === 0) return null
+    return renderSection(type, items)
+  }).filter(Boolean)
+
   return (
     <div className="flex flex-col gap-3">
-      {TYPE_ORDER.map((type) => {
-        const items = grouped.get(type)
-        if (!items || items.length === 0) return null
-        return (
-          <div key={type}>
-            <div className="mb-1 px-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-              {getChannelTypeLabel(type)}
+      {activeSections.length > 0 ? activeSections : (
+        <div className="px-2 text-xs text-text-secondary">
+          No channels with activity yet.
+        </div>
+      )}
+
+      {/*
+       * Empty-channels section: collapsed by default so the user can
+       * see active threads at a glance.  Includes a chevron toggle
+       * and a count so they know more channels exist below the fold.
+       * Hidden entirely when every channel is active.
+       */}
+      {emptyCount > 0 && (
+        <div className="mt-1 border-t border-border pt-3">
+          <button
+            type="button"
+            aria-expanded={emptyExpanded}
+            onClick={() => setEmptyExpanded((v) => !v)}
+            className="flex w-full items-center gap-1 px-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded"
+          >
+            {emptyExpanded ? (
+              <ChevronDown className="size-3" aria-hidden="true" />
+            ) : (
+              <ChevronRight className="size-3" aria-hidden="true" />
+            )}
+            <span>Empty ({emptyCount})</span>
+          </button>
+          {emptyExpanded && (
+            <div className="mt-2 flex flex-col gap-3">
+              {TYPE_ORDER.map((type) => {
+                const items = emptyByType.get(type)
+                if (!items || items.length === 0) return null
+                return renderSection(type, items)
+              })}
             </div>
-            <div className="flex flex-col gap-0.5">
-              {items.map((ch) => (
-                <ChannelListItem
-                  key={ch.name}
-                  channel={ch}
-                  active={ch.name === activeChannel}
-                  unreadCount={unreadCounts[ch.name] ?? 0}
-                  onSelect={handleSelect}
-                />
-              ))}
-            </div>
-          </div>
-        )
-      })}
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/web/src/pages/messages/MessageFilterBar.tsx
+++ b/web/src/pages/messages/MessageFilterBar.tsx
@@ -153,7 +153,7 @@ interface FilterPillProps {
 
 function FilterPill({ label, onRemove }: FilterPillProps) {
   return (
-    <span className="inline-flex items-center gap-1 rounded-full border border-border bg-surface px-2 py-0.5 text-[10px] text-secondary">
+    <span className="inline-flex items-center gap-1 rounded-full border border-border bg-surface px-2 py-0.5 text-[10px] text-text-secondary">
       {label}
       <button
         type="button"

--- a/web/src/pages/messages/MessageThread.tsx
+++ b/web/src/pages/messages/MessageThread.tsx
@@ -50,7 +50,7 @@ export function MessageThread({
         onClick={onToggle}
         className={cn(
           'ml-9 flex items-center gap-1 rounded-full border border-border bg-surface px-2 py-0.5',
-          'font-mono text-[10px] text-secondary transition-colors',
+          'font-mono text-[10px] text-text-secondary transition-colors',
           'hover:bg-card-hover hover:text-foreground',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent',
         )}

--- a/web/src/pages/messages/MessageTypeBadge.tsx
+++ b/web/src/pages/messages/MessageTypeBadge.tsx
@@ -12,7 +12,7 @@ export function MessageTypeBadge({ type, className }: MessageTypeBadgeProps) {
     <span
       className={cn(
         'inline-flex items-center rounded border border-border bg-surface px-1.5 py-0.5',
-        'font-mono text-[10px] text-secondary',
+        'font-mono text-[10px] text-text-secondary',
         className,
       )}
     >

--- a/web/src/pages/org/build-org-tree.ts
+++ b/web/src/pages/org/build-org-tree.ts
@@ -274,11 +274,16 @@ export function buildOrgTree(
     ).length
     const budgetPercent = typeof dept.budget_percent === 'number' ? dept.budget_percent : null
     const cost7d = health?.department_cost_7d ?? null
-    // Prefer the backend-computed utilization_percent which uses a
-    // consistent time window (active_agent_count / agent_count * 100).
-    // The previous client-side calculation divided 7-day cost by
-    // monthly budget, mixing incompatible windows.
-    const utilizationPercent = health?.utilization_percent ?? null
+    // % currently working = runtime-active members / total members.
+    // The backend's ``utilization_percent`` divides HR-status="active"
+    // count by total -- which is 100% in a fresh install (every hired
+    // agent has HR status "active" by default), so it reads as "all
+    // departments at 100%" before any task has actually executed.
+    // The runtime status is WS-driven (idle until a task starts) and
+    // matches operator intuition for "active right now".
+    const utilizationPercent = deptMembers.length === 0
+      ? null
+      : Math.round((activeCount / deptMembers.length) * 100)
     const statusDots: DepartmentAgentStatusDot[] = deptMembers.map((a) => ({
       agentId: a.id ?? a.name,
       runtimeStatus: resolveRuntimeStatus(a.id ?? a.name, a.status ?? 'active', runtimeStatuses),

--- a/web/src/pages/org/useOrgChartViewMode.ts
+++ b/web/src/pages/org/useOrgChartViewMode.ts
@@ -13,6 +13,32 @@ function tweenSlowEase(t: number): number {
   return t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2
 }
 
+/**
+ * Lift a node's position into the absolute coordinate space the
+ * canvas uses for un-parented nodes.  When the source frame has a
+ * ``parentId`` and the target does not (the hierarchy → force
+ * switch on the org chart), the recorded ``position`` is RELATIVE
+ * to the dept group; treating it as absolute would teleport the
+ * agent to a corner near origin and make the transition look like
+ * the nodes fly across the screen.  Walks the parent chain so
+ * nested teams resolve correctly.
+ */
+function resolveAbsolutePosition(node: Node, byId: Map<string, Node>): { x: number; y: number } {
+  let x = node.position.x
+  let y = node.position.y
+  let parentId = node.parentId
+  const visited = new Set<string>([node.id])
+  while (parentId && !visited.has(parentId)) {
+    visited.add(parentId)
+    const parent = byId.get(parentId)
+    if (!parent) break
+    x += parent.position.x
+    y += parent.position.y
+    parentId = parent.parentId
+  }
+  return { x, y }
+}
+
 function interpolateNodes(from: Node[], to: Node[], progress: number): Node[] {
   const toMap = new Map(to.map((n) => [n.id, n]))
   const fromMap = new Map(from.map((n) => [n.id, n]))
@@ -21,11 +47,20 @@ function interpolateNodes(from: Node[], to: Node[], progress: number): Node[] {
   for (const target of to) {
     const source = fromMap.get(target.id)
     if (source) {
+      // Lift both positions into absolute space whenever the parent
+      // chain differs between frames; without this, swapping the
+      // hierarchy layout (parent-relative coords for agents inside
+      // dept groups) for the force layout (parent-less absolute
+      // coords) interpolates between two different coordinate
+      // systems and produces the "fly across the screen" artefact.
+      const needsLift = source.parentId !== target.parentId
+      const sourcePos = needsLift ? resolveAbsolutePosition(source, fromMap) : source.position
+      const targetPos = needsLift ? resolveAbsolutePosition(target, toMap) : target.position
       result.push({
         ...target,
         position: {
-          x: source.position.x + (target.position.x - source.position.x) * progress,
-          y: source.position.y + (target.position.y - source.position.y) * progress,
+          x: sourcePos.x + (targetPos.x - sourcePos.x) * progress,
+          y: sourcePos.y + (targetPos.y - sourcePos.y) * progress,
         },
       })
     } else {

--- a/web/src/router/route-titles.ts
+++ b/web/src/router/route-titles.ts
@@ -1,0 +1,99 @@
+/**
+ * Per-route browser-tab title lookup.
+ *
+ * AppLayout watches ``location.pathname`` and applies the resolved
+ * title to ``document.title`` on every navigation; without this, the
+ * tab title remained whatever the last page-level ``document.title =
+ * ...`` assignment set (e.g. "MCP Catalog · SynthOrg" persisting into
+ * Settings).
+ *
+ * The lookup is two-stage:
+ *  1. Exact path match (covers the static top-level routes).
+ *  2. Pattern match for ``/<segment>/<param>`` shaped detail routes,
+ *     where the leading segment maps to a section title.
+ *
+ * Anything unmapped falls back to the bare "SynthOrg" label rather
+ * than a stale per-page title.
+ */
+
+import { ROUTES } from './routes'
+
+const SUFFIX = ' · SynthOrg'
+
+/** Exact-match route titles, keyed by pathname. */
+const EXACT_TITLES: Record<string, string> = {
+  [ROUTES.DASHBOARD]: 'Dashboard',
+  [ROUTES.LOGIN]: 'Sign in',
+  [ROUTES.SETUP]: 'Setup',
+  [ROUTES.ORG]: 'Org Chart',
+  [ROUTES.ORG_EDIT]: 'Edit Organization',
+  [ROUTES.TASKS]: 'Tasks',
+  [ROUTES.BUDGET]: 'Budget',
+  [ROUTES.BUDGET_FORECAST]: 'Budget Forecast',
+  [ROUTES.REPORTS]: 'Reports',
+  [ROUTES.APPROVALS]: 'Approvals',
+  [ROUTES.SCALING]: 'Scaling',
+  [ROUTES.META]: 'Meta',
+  [ROUTES.AGENTS]: 'Agents',
+  [ROUTES.TRAINING]: 'Training',
+  [ROUTES.MESSAGES]: 'Messages',
+  [ROUTES.MEETINGS]: 'Meetings',
+  [ROUTES.PROVIDERS]: 'Providers',
+  [ROUTES.PROJECTS]: 'Projects',
+  [ROUTES.ARTIFACTS]: 'Artifacts',
+  [ROUTES.WORKFLOWS]: 'Workflows',
+  [ROUTES.WORKFLOW_EDITOR]: 'Workflow Editor',
+  [ROUTES.SUBWORKFLOWS]: 'Subworkflows',
+  [ROUTES.WEBHOOK_RECEIPTS]: 'Webhook Receipts',
+  [ROUTES.COORDINATION_METRICS]: 'Coordination Metrics',
+  [ROUTES.META_ANALYTICS]: 'Meta Analytics',
+  [ROUTES.PERSONALITIES_ADMIN]: 'Personalities',
+  [ROUTES.BUDGET_VERSIONS]: 'Budget Versions',
+  [ROUTES.COMPANY_VERSIONS]: 'Org Versions',
+  [ROUTES.EVALUATION_VERSIONS]: 'Evaluation Versions',
+  [ROUTES.ONTOLOGY]: 'Ontology',
+  [ROUTES.CUSTOM_RULES]: 'Custom Rules',
+  [ROUTES.ESCALATIONS]: 'Escalations',
+  [ROUTES.USERS]: 'Users',
+  [ROUTES.CONNECTIONS]: 'Connections',
+  [ROUTES.OAUTH_APPS]: 'OAuth Apps',
+  [ROUTES.MCP_CATALOG]: 'MCP Catalog',
+  [ROUTES.SETTINGS]: 'Settings',
+  [ROUTES.SETTINGS_SINKS]: 'Log Sinks',
+  [ROUTES.SETTINGS_CEREMONY_POLICY]: 'Ceremony Policy',
+  [ROUTES.SETTINGS_FINE_TUNING]: 'Fine-Tuning',
+  [ROUTES.CLIENTS]: 'Clients',
+  [ROUTES.REQUEST_QUEUE]: 'Request Queue',
+  [ROUTES.SIMULATION_DASHBOARD]: 'Simulations',
+}
+
+/**
+ * First-segment → section title.  Used as the title for any detail
+ * route under the section (we don't have the entity name in scope
+ * here; pages can still call ``document.title = ...`` themselves if
+ * they want to surface it once the entity loads).
+ */
+const SECTION_TITLES: Record<string, string> = {
+  agents: 'Agent',
+  tasks: 'Task',
+  meetings: 'Meeting',
+  providers: 'Provider',
+  projects: 'Project',
+  artifacts: 'Artifact',
+  workflows: 'Workflow',
+  clients: 'Client',
+  settings: 'Settings',
+  setup: 'Setup',
+}
+
+export function titleForPath(pathname: string): string {
+  const exact = EXACT_TITLES[pathname]
+  if (exact) return exact + SUFFIX
+  // First non-empty segment is the section discriminator; this catches
+  // detail routes like ``/projects/abc-123`` -> ``Project · SynthOrg``.
+  const firstSegment = pathname.split('/').find((seg) => seg.length > 0)
+  if (firstSegment && SECTION_TITLES[firstSegment]) {
+    return SECTION_TITLES[firstSegment] + SUFFIX
+  }
+  return 'SynthOrg'
+}

--- a/web/src/stores/artifacts.ts
+++ b/web/src/stores/artifacts.ts
@@ -98,10 +98,15 @@ export const useArtifactsStore = create<ArtifactsState>()((set) => ({
     try {
       const result = await listArtifacts({ limit: 200 })
       if (isStaleListRequest(token)) return
-      set({ artifacts: result.data, totalArtifacts: result.data.length, listLoading: false })
+      set({ artifacts: result.data, totalArtifacts: result.data.length })
     } catch (err) {
       if (isStaleListRequest(token)) return
-      set({ listLoading: false, listError: getErrorMessage(err) })
+      set({ listError: getErrorMessage(err) })
+    } finally {
+      // Always clear ``listLoading`` for the latest request -- including
+      // the stale-return paths -- so an overlapping fetch can't leave
+      // the skeleton stuck on.
+      if (!isStaleListRequest(token)) set({ listLoading: false })
     }
   },
 
@@ -114,7 +119,7 @@ export const useArtifactsStore = create<ArtifactsState>()((set) => ({
       if (isStaleDetailRequest(token)) return
 
       // Show metadata immediately so the detail page renders while preview loads.
-      set({ selectedArtifact: artifact, detailLoading: false })
+      set({ selectedArtifact: artifact })
 
       // Fetch content preview in the background if applicable.
       if (artifact.content_type && artifact.size_bytes != null && artifact.size_bytes > 0 && isPreviewableText(artifact.content_type)) {
@@ -136,9 +141,10 @@ export const useArtifactsStore = create<ArtifactsState>()((set) => ({
       }
     } catch (err) {
       if (isStaleDetailRequest(token)) return
-      set({ detailLoading: false, detailError: getErrorMessage(err), selectedArtifact: null, contentPreview: null })
+      set({ detailError: getErrorMessage(err), selectedArtifact: null, contentPreview: null })
     } finally {
       if (_pendingDetailId === id) _pendingDetailId = null
+      if (!isStaleDetailRequest(token)) set({ detailLoading: false })
     }
   },
 

--- a/web/src/stores/connections/list-actions.ts
+++ b/web/src/stores/connections/list-actions.ts
@@ -25,6 +25,7 @@ export function createListActions(set: ConnectionsSet, get: ConnectionsGet) {
     fetchConnections: async () => {
       const requestId = ++_listRequestId
       set({ listLoading: true, listError: null })
+      const isLatest = () => requestId === _listRequestId
       try {
         const [connections, healthReports] = await Promise.all([
           listConnections(),
@@ -35,7 +36,7 @@ export function createListActions(set: ConnectionsSet, get: ConnectionsGet) {
             return null
           }),
         ])
-        if (requestId !== _listRequestId) return
+        if (!isLatest()) return
         const prevHealthMap = get().healthMap
         const healthMap: Record<string, HealthReport> = { ...prevHealthMap }
         if (healthReports !== null) {
@@ -43,14 +44,15 @@ export function createListActions(set: ConnectionsSet, get: ConnectionsGet) {
             healthMap[report.connection_name] = report
           }
         }
-        set({ connections, healthMap, listLoading: false })
+        set({ connections, healthMap })
       } catch (err) {
-        if (requestId !== _listRequestId) return
+        if (!isLatest()) return
         log.error('Failed to fetch connections:', getErrorMessage(err))
-        set({
-          listLoading: false,
-          listError: getErrorMessage(err),
-        })
+        set({ listError: getErrorMessage(err) })
+      } finally {
+        // Always clear ``listLoading`` for the latest request so an
+        // overlapping fetch can't strand the skeleton on.
+        if (isLatest()) set({ listLoading: false })
       }
     },
 

--- a/web/src/stores/fine-tuning.ts
+++ b/web/src/stores/fine-tuning.ts
@@ -107,9 +107,9 @@ export const useFineTuningStore = create<FineTuningState>((set, get) => ({
 
   fetchCheckpoints: async () => {
     try {
-      const checkpoints = await listCheckpoints()
+      const page = await listCheckpoints()
       set((state) => ({
-        checkpoints,
+        checkpoints: page.data,
         errors: { ...state.errors, checkpoints: null },
       }))
     } catch (err) {
@@ -121,8 +121,8 @@ export const useFineTuningStore = create<FineTuningState>((set, get) => ({
 
   fetchRuns: async () => {
     try {
-      const runs = await listRuns()
-      set((state) => ({ runs, errors: { ...state.errors, runs: null } }))
+      const page = await listRuns()
+      set((state) => ({ runs: page.data, errors: { ...state.errors, runs: null } }))
     } catch (err) {
       log.error('Failed to fetch runs', sanitizeForLog(err))
       const message = getErrorMessage(err)

--- a/web/src/stores/fine-tuning.ts
+++ b/web/src/stores/fine-tuning.ts
@@ -136,13 +136,13 @@ export const useFineTuningStore = create<FineTuningState>((set, get) => ({
     try {
       const collected: CheckpointRecord[] = []
       let lastPagination: ListPagination = NO_MORE
-      let offset = 0
+      let cursor: string | null = null
       for (let i = 0; i < DRAIN_PAGE_LIMIT; i++) {
-        const page = await listCheckpoints(LIST_PAGE_SIZE, offset)
+        const page = await listCheckpoints(cursor, LIST_PAGE_SIZE)
         collected.push(...page.data)
         lastPagination = { nextCursor: page.nextCursor, hasMore: page.hasMore }
-        if (!page.hasMore || page.data.length === 0) break
-        offset += page.data.length
+        if (!page.hasMore || !page.nextCursor) break
+        cursor = page.nextCursor
       }
       set((state) => ({
         checkpoints: collected,
@@ -160,13 +160,13 @@ export const useFineTuningStore = create<FineTuningState>((set, get) => ({
     try {
       const collected: FineTuneRun[] = []
       let lastPagination: ListPagination = NO_MORE
-      let offset = 0
+      let cursor: string | null = null
       for (let i = 0; i < DRAIN_PAGE_LIMIT; i++) {
-        const page = await listRuns(LIST_PAGE_SIZE, offset)
+        const page = await listRuns(cursor, LIST_PAGE_SIZE)
         collected.push(...page.data)
         lastPagination = { nextCursor: page.nextCursor, hasMore: page.hasMore }
-        if (!page.hasMore || page.data.length === 0) break
-        offset += page.data.length
+        if (!page.hasMore || !page.nextCursor) break
+        cursor = page.nextCursor
       }
       set((state) => ({
         runs: collected,

--- a/web/src/stores/fine-tuning.ts
+++ b/web/src/stores/fine-tuning.ts
@@ -46,11 +46,36 @@ const NO_ERRORS: FineTuningErrors = {
   runs: null,
 }
 
+// Per-list pagination state surfaced from the wire envelope. Both
+// fields default to false/null on every fetch path; the dashboard
+// drains every page on initial fetch so an exhausted list always
+// settles at ``hasMore=false, nextCursor=null``. Stays in state so
+// future load-more UI can branch on a single flag (per the cursor
+// pagination convention in ``web/CLAUDE.md``).
+interface ListPagination {
+  nextCursor: string | null
+  hasMore: boolean
+}
+
+const NO_MORE: ListPagination = { nextCursor: null, hasMore: false }
+
+// Page size used when draining ``listCheckpoints`` / ``listRuns``.
+// Matches the endpoint default; smaller pages only multiply
+// round-trips without changing the draining outcome.
+const LIST_PAGE_SIZE = 50
+
+// Safety stop so a backend bug that keeps returning ``has_more=true``
+// cannot lock the dashboard in an infinite drain loop. Sized to cover
+// the bounded admin lists (checkpoints / runs) with a generous margin.
+const DRAIN_PAGE_LIMIT = 50
+
 interface FineTuningState {
   // State
   status: FineTuneStatus | null
   checkpoints: readonly CheckpointRecord[]
+  checkpointsPagination: ListPagination
   runs: readonly FineTuneRun[]
+  runsPagination: ListPagination
   preflight: PreflightResult | null
   loading: boolean
   errors: FineTuningErrors
@@ -83,7 +108,9 @@ export function selectFineTuningBannerError(
 export const useFineTuningStore = create<FineTuningState>((set, get) => ({
   status: null,
   checkpoints: [],
+  checkpointsPagination: NO_MORE,
   runs: [],
+  runsPagination: NO_MORE,
   preflight: null,
   loading: false,
   errors: NO_ERRORS,
@@ -107,9 +134,19 @@ export const useFineTuningStore = create<FineTuningState>((set, get) => ({
 
   fetchCheckpoints: async () => {
     try {
-      const page = await listCheckpoints()
+      const collected: CheckpointRecord[] = []
+      let lastPagination: ListPagination = NO_MORE
+      let offset = 0
+      for (let i = 0; i < DRAIN_PAGE_LIMIT; i++) {
+        const page = await listCheckpoints(LIST_PAGE_SIZE, offset)
+        collected.push(...page.data)
+        lastPagination = { nextCursor: page.nextCursor, hasMore: page.hasMore }
+        if (!page.hasMore || page.data.length === 0) break
+        offset += page.data.length
+      }
       set((state) => ({
-        checkpoints: page.data,
+        checkpoints: collected,
+        checkpointsPagination: lastPagination,
         errors: { ...state.errors, checkpoints: null },
       }))
     } catch (err) {
@@ -121,8 +158,21 @@ export const useFineTuningStore = create<FineTuningState>((set, get) => ({
 
   fetchRuns: async () => {
     try {
-      const page = await listRuns()
-      set((state) => ({ runs: page.data, errors: { ...state.errors, runs: null } }))
+      const collected: FineTuneRun[] = []
+      let lastPagination: ListPagination = NO_MORE
+      let offset = 0
+      for (let i = 0; i < DRAIN_PAGE_LIMIT; i++) {
+        const page = await listRuns(LIST_PAGE_SIZE, offset)
+        collected.push(...page.data)
+        lastPagination = { nextCursor: page.nextCursor, hasMore: page.hasMore }
+        if (!page.hasMore || page.data.length === 0) break
+        offset += page.data.length
+      }
+      set((state) => ({
+        runs: collected,
+        runsPagination: lastPagination,
+        errors: { ...state.errors, runs: null },
+      }))
     } catch (err) {
       log.error('Failed to fetch runs', sanitizeForLog(err))
       const message = getErrorMessage(err)

--- a/web/src/stores/mcp-catalog/list-actions.ts
+++ b/web/src/stores/mcp-catalog/list-actions.ts
@@ -1,5 +1,6 @@
 import {
   browseMcpCatalog,
+  listInstalledMcp,
   searchMcpCatalog,
 } from '@/api/endpoints/mcp-catalog'
 import type { McpCatalogEntry } from '@/api/types/integrations'
@@ -35,6 +36,21 @@ export function createListActions(set: McpCatalogSet) {
           loading: false,
           error: getErrorMessage(err),
         })
+      }
+    },
+
+    fetchInstalled: async () => {
+      try {
+        const installed = await listInstalledMcp()
+        const ids = new Set(installed.map((row) => row.catalog_entry_id))
+        set({ installedEntryIds: ids })
+      } catch (err) {
+        // Hydration is best-effort -- on failure we leave the
+        // existing ``installedEntryIds`` Set in place so a transient
+        // network blip doesn't blank the install badges.  The
+        // catalog list error already surfaces network problems to
+        // the user via the page's error banner.
+        log.warn('Failed to hydrate MCP installed list:', getErrorMessage(err))
       }
     },
 

--- a/web/src/stores/mcp-catalog/types.ts
+++ b/web/src/stores/mcp-catalog/types.ts
@@ -40,6 +40,12 @@ export interface McpCatalogState {
 
   // Actions
   fetchCatalog: () => Promise<void>
+  /**
+   * Hydrate ``installedEntryIds`` from the backend.  Without this,
+   * the catalog forgets every install on refresh because the local
+   * Set starts empty and the install endpoint is write-only.
+   */
+  fetchInstalled: () => Promise<void>
   setSearchQuery: (q: string) => Promise<void>
   selectEntry: (entry: McpCatalogEntry | null) => void
   startInstall: (entryId: string) => void

--- a/web/src/stores/messages.ts
+++ b/web/src/stores/messages.ts
@@ -313,9 +313,14 @@ export const useMessagesStore = create<MessagesState>()((set, get) => ({
       // topics don't bury active threads.
       const result = await messagesApi.listMessages({ limit: CHANNEL_ACTIVITY_LIMIT })
       if (seq !== activityRequestSeq) return
-      const next = new Set<string>()
-      for (const msg of result.data) next.add(msg.channel)
-      set({ channelsWithMessages: next })
+      // Merge into the existing set rather than overwriting it:
+      // ``handleWsEvent`` adds channels live as messages arrive, and
+      // a replace-on-completion would clobber any channel that became
+      // active AFTER the activity probe was issued but BEFORE it
+      // resolved (the probe's REST snapshot lags those WS events).
+      const merged = new Set<string>(get().channelsWithMessages)
+      for (const msg of result.data) merged.add(msg.channel)
+      set({ channelsWithMessages: merged })
     } catch (err) {
       if (seq !== activityRequestSeq) return
       // The activity probe is a best-effort enhancement; on failure

--- a/web/src/stores/messages.ts
+++ b/web/src/stores/messages.ts
@@ -203,6 +203,16 @@ interface MessagesState {
   channels: Channel[]
   channelsLoading: boolean
   channelsError: string | null
+  /**
+   * Channel names that we have direct evidence carry at least one
+   * message.  Populated by ``fetchChannelActivity`` (single-page scan
+   * of recent messages without a channel filter), and incrementally
+   * extended whenever a message arrives via WS.  The sidebar uses
+   * this set to split topics into an "Active" group and a collapsed
+   * "Empty" group so a fresh install's long list of never-used
+   * topics doesn't drown the surface.
+   */
+  channelsWithMessages: Set<string>
 
   // Messages (for active channel)
   messages: Message[]
@@ -226,6 +236,7 @@ interface MessagesState {
 
   // Actions
   fetchChannels: () => Promise<void>
+  fetchChannelActivity: () => Promise<void>
   fetchMessages: (channel: string, limit?: number) => Promise<void>
   fetchMoreMessages: (channel: string) => Promise<void>
   handleWsEvent: (event: WsEvent, activeChannel: string | null) => void
@@ -236,17 +247,29 @@ interface MessagesState {
 
 let channelRequestSeq = 0
 let messageRequestSeq = 0
+let activityRequestSeq = 0
 
 /** Reset module-level sequence counters -- test-only. */
 export function _resetRequestSeqs(): void {
   channelRequestSeq = 0
   messageRequestSeq = 0
+  activityRequestSeq = 0
 }
+
+/**
+ * Page size for the channel-activity probe.  Large enough that a
+ * lightly-used deployment will see every active channel in one
+ * request; small enough that the cost is bounded.  Channels with
+ * NO messages in this window appear in the sidebar's "Empty" group
+ * (collapsed by default).
+ */
+const CHANNEL_ACTIVITY_LIMIT = 200
 
 export const useMessagesStore = create<MessagesState>()((set, get) => ({
   channels: [],
   channelsLoading: false,
   channelsError: null,
+  channelsWithMessages: new Set<string>(),
 
   messages: [],
   total: 0,
@@ -270,10 +293,35 @@ export const useMessagesStore = create<MessagesState>()((set, get) => ({
       // ship today).
       const result = await messagesApi.listChannels()
       if (seq !== channelRequestSeq) return
-      set({ channels: result.data, channelsLoading: false })
+      set({ channels: result.data })
     } catch (err) {
       if (seq !== channelRequestSeq) return
-      set({ channelsLoading: false, channelsError: getErrorMessage(err) })
+      set({ channelsError: getErrorMessage(err) })
+    } finally {
+      if (seq === channelRequestSeq) set({ channelsLoading: false })
+    }
+  },
+
+  fetchChannelActivity: async () => {
+    const seq = ++activityRequestSeq
+    try {
+      // Single-page recent-messages probe without a channel filter --
+      // every channel whose name appears here demonstrably carries at
+      // least one recent message and lives in the "Active" sidebar
+      // group.  Channels missing from this set fall through to the
+      // collapsed "Empty" group so a fresh install's pre-created
+      // topics don't bury active threads.
+      const result = await messagesApi.listMessages({ limit: CHANNEL_ACTIVITY_LIMIT })
+      if (seq !== activityRequestSeq) return
+      const next = new Set<string>()
+      for (const msg of result.data) next.add(msg.channel)
+      set({ channelsWithMessages: next })
+    } catch (err) {
+      if (seq !== activityRequestSeq) return
+      // The activity probe is a best-effort enhancement; on failure
+      // we leave the previous classification in place so the sidebar
+      // doesn't regress to a single-section list.
+      log.warn('fetchChannelActivity failed', sanitizeForLog(err))
     }
   },
 
@@ -347,6 +395,16 @@ export const useMessagesStore = create<MessagesState>()((set, get) => ({
   handleWsEvent: (event, activeChannel) => {
     const message = parseWsMessage(event.payload)
     if (!message) return
+
+    // A live message proves the channel carries at least one entry,
+    // so it graduates from the sidebar's "Empty" group to "Active"
+    // immediately rather than waiting for the next activity probe.
+    set((s) => {
+      if (s.channelsWithMessages.has(message.channel)) return s
+      const next = new Set(s.channelsWithMessages)
+      next.add(message.channel)
+      return { channelsWithMessages: next }
+    })
 
     if (message.channel === activeChannel) {
       // Prepend to active channel (with dedup)

--- a/web/src/stores/projects.ts
+++ b/web/src/stores/projects.ts
@@ -85,10 +85,15 @@ export const useProjectsStore = create<ProjectsState>()((set) => ({
     try {
       const result = await listProjects({ limit: 200 })
       if (isStaleListRequest(token)) return
-      set({ projects: result.data, totalProjects: result.data.length, listLoading: false })
+      set({ projects: result.data, totalProjects: result.data.length })
     } catch (err) {
       if (isStaleListRequest(token)) return
-      set({ listLoading: false, listError: getErrorMessage(err) })
+      set({ listError: getErrorMessage(err) })
+    } finally {
+      // Always clear ``listLoading`` for the latest request -- including
+      // the stale-return paths -- so an overlapping fetch can't leave
+      // the skeleton stuck on.
+      if (!isStaleListRequest(token)) set({ listLoading: false })
     }
   },
 
@@ -96,31 +101,34 @@ export const useProjectsStore = create<ProjectsState>()((set) => ({
     const token = ++_detailRequestToken
     set({ detailLoading: true, detailError: null, selectedProject: null, projectTasks: [] })
 
-    const [projectResult, tasksResult] = await Promise.allSettled([
-      getProject(id),
-      listTasks({ project: id, limit: 50 }),
-    ])
+    try {
+      const [projectResult, tasksResult] = await Promise.allSettled([
+        getProject(id),
+        listTasks({ project: id, limit: 50 }),
+      ])
 
-    if (isStaleDetailRequest(token)) return
+      if (isStaleDetailRequest(token)) return
 
-    const project = projectResult.status === 'fulfilled' ? projectResult.value : null
-    if (!project) {
-      const reason = projectResult.status === 'rejected' ? projectResult.reason : null
-      set({ detailLoading: false, detailError: getErrorMessage(reason ?? 'Project not found'), selectedProject: null })
-      return
+      const project = projectResult.status === 'fulfilled' ? projectResult.value : null
+      if (!project) {
+        const reason = projectResult.status === 'rejected' ? projectResult.reason : null
+        set({ detailError: getErrorMessage(reason ?? 'Project not found'), selectedProject: null })
+        return
+      }
+
+      const partialErrors: string[] = []
+      if (tasksResult.status === 'rejected') partialErrors.push(`tasks: ${getErrorMessage(tasksResult.reason)}`)
+
+      set({
+        selectedProject: project,
+        projectTasks: tasksResult.status === 'fulfilled' ? tasksResult.value.data : [],
+        detailError: partialErrors.length > 0
+          ? `Some data failed to load: ${partialErrors.join(', ')}. Displayed data may be incomplete.`
+          : null,
+      })
+    } finally {
+      if (!isStaleDetailRequest(token)) set({ detailLoading: false })
     }
-
-    const partialErrors: string[] = []
-    if (tasksResult.status === 'rejected') partialErrors.push(`tasks: ${getErrorMessage(tasksResult.reason)}`)
-
-    set({
-      selectedProject: project,
-      projectTasks: tasksResult.status === 'fulfilled' ? tasksResult.value.data : [],
-      detailLoading: false,
-      detailError: partialErrors.length > 0
-        ? `Some data failed to load: ${partialErrors.join(', ')}. Displayed data may be incomplete.`
-        : null,
-    })
   },
 
   createProject: async (data: CreateProjectRequest) => {

--- a/web/src/stores/providers/detail-actions.ts
+++ b/web/src/stores/providers/detail-actions.ts
@@ -16,6 +16,7 @@ export function createDetailActions(set: ProvidersSet) {
     fetchProviderDetail: async (name: string) => {
       const requestId = ++_detailRequestId
       set({ detailLoading: true, detailError: null })
+      const isLatest = () => requestId === _detailRequestId
       try {
         const [providerResult, modelsResult, healthResult] =
           await Promise.allSettled([
@@ -24,7 +25,7 @@ export function createDetailActions(set: ProvidersSet) {
             getProviderHealth(name),
           ])
 
-        if (requestId !== _detailRequestId) return
+        if (!isLatest()) return
 
         const provider = providerResult.status === 'fulfilled'
           ? { ...providerResult.value, name }
@@ -34,7 +35,6 @@ export function createDetailActions(set: ProvidersSet) {
             ? providerResult.reason
             : null
           set({
-            detailLoading: false,
             detailError: getErrorMessage(reason ?? 'Provider not found'),
             selectedProvider: null,
             selectedProviderModels: [],
@@ -62,15 +62,20 @@ export function createDetailActions(set: ProvidersSet) {
             modelsResult.status === 'fulfilled' ? modelsResult.value : [],
           selectedProviderHealth:
             healthResult.status === 'fulfilled' ? healthResult.value : null,
-          detailLoading: false,
           detailError: partialErrors.length > 0
             ? `Some data failed to load: ${partialErrors.join(', ')}`
             : null,
         })
       } catch (err) {
-        if (requestId !== _detailRequestId) return
+        if (!isLatest()) return
         log.error('Failed to fetch provider detail:', getErrorMessage(err))
-        set({ detailLoading: false, detailError: getErrorMessage(err) })
+        set({ detailError: getErrorMessage(err) })
+      } finally {
+        // Always clear ``detailLoading`` for the LATEST request --
+        // including the stale-return path -- so a race between
+        // overlapping fetches can't leave the spinner stuck on. The
+        // newer request will flip it back to ``true`` at its own start.
+        if (isLatest()) set({ detailLoading: false })
       }
     },
 

--- a/web/src/stores/providers/list-actions.ts
+++ b/web/src/stores/providers/list-actions.ts
@@ -18,9 +18,10 @@ export function createListActions(set: ProvidersSet) {
     fetchProviders: async () => {
       const requestId = ++_listRequestId
       set({ listLoading: true, listError: null })
+      const isLatest = () => requestId === _listRequestId
       try {
         const record = await listProviders()
-        if (requestId !== _listRequestId) return
+        if (!isLatest()) return
         const providers = normalizeProviders(record)
         set({ providers })
 
@@ -29,7 +30,7 @@ export function createListActions(set: ProvidersSet) {
         const healthResults = await Promise.allSettled(
           names.map((name) => getProviderHealth(name)),
         )
-        if (requestId !== _listRequestId) return
+        if (!isLatest()) return
         const healthMap: Record<string, ProviderHealthSummary> = {}
         for (let i = 0; i < names.length; i++) {
           const result = healthResults[i]!
@@ -44,11 +45,17 @@ export function createListActions(set: ProvidersSet) {
             )
           }
         }
-        set({ healthMap, listLoading: false })
+        set({ healthMap })
       } catch (err) {
-        if (requestId !== _listRequestId) return
+        if (!isLatest()) return
         log.error('Failed to fetch providers:', getErrorMessage(err))
-        set({ listLoading: false, listError: getErrorMessage(err) })
+        set({ listError: getErrorMessage(err) })
+      } finally {
+        // Clear ``listLoading`` for the LATEST request even on the
+        // stale-return paths so an overlapping fetch can't leave the
+        // skeleton stuck on.  The newer request flips it back to true
+        // at its own start, so there is no flicker.
+        if (isLatest()) set({ listLoading: false })
       }
     },
 

--- a/web/src/stores/workflows.ts
+++ b/web/src/stores/workflows.ts
@@ -112,11 +112,15 @@ export const useWorkflowsStore = create<WorkflowsState>()((set, get) => ({
     try {
       const data = await listBlueprints()
       if (isStaleBlueprintRequest(token)) return
-      set({ blueprints: data, blueprintsLoading: false })
+      set({ blueprints: data })
     } catch (err) {
       if (isStaleBlueprintRequest(token)) return
       log.warn('Failed to load blueprints', sanitizeForLog(err))
-      set({ blueprintsLoading: false, blueprintsError: getErrorMessage(err) })
+      set({ blueprintsError: getErrorMessage(err) })
+    } finally {
+      // Always clear ``blueprintsLoading`` for the latest request so an
+      // overlapping fetch can't strand the skeleton on.
+      if (!isStaleBlueprintRequest(token)) set({ blueprintsLoading: false })
     }
   },
 
@@ -146,17 +150,17 @@ export const useWorkflowsStore = create<WorkflowsState>()((set, get) => ({
         totalWorkflows: result.data.length,
         nextCursor: result.nextCursor,
         hasMore: result.hasMore,
-        listLoading: false,
       })
     } catch (err) {
       if (isStaleListRequest(token)) return
       log.warn('Failed to fetch workflows', sanitizeForLog(err))
       set({
-        listLoading: false,
         listError: getErrorMessage(err),
         nextCursor: previousNextCursor,
         hasMore: previousHasMore,
       })
+    } finally {
+      if (!isStaleListRequest(token)) set({ listLoading: false })
     }
   },
 
@@ -185,13 +189,14 @@ export const useWorkflowsStore = create<WorkflowsState>()((set, get) => ({
           totalWorkflows: merged.length,
           nextCursor: result.nextCursor,
           hasMore: result.hasMore,
-          listLoadingMore: false,
         }
       })
     } catch (err) {
       if (isStaleListRequest(token)) return
       log.warn('Failed to fetch more workflows', sanitizeForLog(err))
-      set({ listLoadingMore: false, listError: getErrorMessage(err) })
+      set({ listError: getErrorMessage(err) })
+    } finally {
+      if (!isStaleListRequest(token)) set({ listLoadingMore: false })
     }
   },
 

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -203,18 +203,22 @@ html {
    * Lock the document height to the viewport so the AppLayout flex
    * chain can give ``<main>`` (which carries ``overflow-y-auto``) a
    * bounded height; the sidebar and status bar stay anchored even on
-   * pages whose primary content overflows.  ``overscroll-behavior:
-   * contain`` prevents an inner scroll from chaining out to the
-   * document, so a stray box-sizing miscount that nudges body
-   * marginally past ``100%`` no longer drags the whole SPA shell up
-   * on scroll-down -- without disabling browser features that the
-   * old ``overflow: hidden`` blanket banned (Find-in-page, hash-
-   * anchor navigation, mobile pull-to-refresh).
+   * pages whose primary content overflows.
    */
   html,
   body,
   #root {
     height: 100%;
+  }
+  /*
+   * Stop a scroll inside ``#root`` from chaining out to the document.
+   * Keeping this on ``#root`` only (rather than on ``html`` / ``body``
+   * as well) leaves mobile pull-to-refresh free to fire from the
+   * document scroll surface, while still preventing a stray
+   * box-sizing miscount inside the SPA shell from dragging the whole
+   * layout up on scroll-down.
+   */
+  #root {
     overscroll-behavior: contain;
   }
 }

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -200,22 +200,22 @@ html {
     @apply font-sans;
   }
   /*
-   * Viewport-lock the document so the only scroll container is the
-   * AppLayout ``<main>`` element.  Without this, when content
-   * marginally exceeds ``100vh`` (e.g. ``h-screen`` + a stray box-
-   * sizing miscount, or a child positioned just past the visible
-   * area), the BODY itself scrolls -- which drags the entire SPA
-   * shell, including the fixed sidebar, up off the viewport on
-   * scroll-down.  Locking ``html`` / ``body`` / ``#root`` to a fixed
-   * ``100%`` height with ``overflow: hidden`` makes ``<main>``'s
-   * ``overflow-y-auto`` the only scroll container; the sidebar and
-   * status bar stay anchored regardless of page length.
+   * Lock the document height to the viewport so the AppLayout flex
+   * chain can give ``<main>`` (which carries ``overflow-y-auto``) a
+   * bounded height; the sidebar and status bar stay anchored even on
+   * pages whose primary content overflows.  ``overscroll-behavior:
+   * contain`` prevents an inner scroll from chaining out to the
+   * document, so a stray box-sizing miscount that nudges body
+   * marginally past ``100%`` no longer drags the whole SPA shell up
+   * on scroll-down -- without disabling browser features that the
+   * old ``overflow: hidden`` blanket banned (Find-in-page, hash-
+   * anchor navigation, mobile pull-to-refresh).
    */
   html,
   body,
   #root {
     height: 100%;
-    overflow: hidden;
+    overscroll-behavior: contain;
   }
 }
 

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -199,6 +199,24 @@ html {
   html {
     @apply font-sans;
   }
+  /*
+   * Viewport-lock the document so the only scroll container is the
+   * AppLayout ``<main>`` element.  Without this, when content
+   * marginally exceeds ``100vh`` (e.g. ``h-screen`` + a stray box-
+   * sizing miscount, or a child positioned just past the visible
+   * area), the BODY itself scrolls -- which drags the entire SPA
+   * shell, including the fixed sidebar, up off the viewport on
+   * scroll-down.  Locking ``html`` / ``body`` / ``#root`` to a fixed
+   * ``100%`` height with ``overflow: hidden`` makes ``<main>``'s
+   * ``overflow-y-auto`` the only scroll container; the sidebar and
+   * status bar stay anchored regardless of page length.
+   */
+  html,
+  body,
+  #root {
+    height: 100%;
+    overflow: hidden;
+  }
 }
 
 /* Print styles.

--- a/web/src/utils/approvals.ts
+++ b/web/src/utils/approvals.ts
@@ -147,7 +147,7 @@ export const URGENCY_BADGE_CLASSES: Record<SemanticColor | 'text-secondary', str
   warning: 'border-warning/30 bg-warning/10 text-warning',
   accent: 'border-accent/30 bg-accent/10 text-accent',
   success: 'border-success/30 bg-success/10 text-success',
-  'text-secondary': 'border-border bg-surface text-secondary',
+  'text-secondary': 'border-border bg-surface text-text-secondary',
 }
 
 // ── Client-side filtering ───────────────────────────────────

--- a/web/src/utils/meetings.ts
+++ b/web/src/utils/meetings.ts
@@ -116,7 +116,7 @@ export const STATUS_BADGE_CLASSES: Record<SemanticColor | 'text-secondary', stri
   warning: 'border-warning/30 bg-warning/10 text-warning',
   accent: 'border-accent/30 bg-accent/10 text-accent',
   success: 'border-success/30 bg-success/10 text-success',
-  'text-secondary': 'border-border bg-surface text-secondary',
+  'text-secondary': 'border-border bg-surface text-text-secondary',
 }
 
 // -- Client-side filtering --------------------------------------------------


### PR DESCRIPTION
Bundles two parallel session outputs against the same working tree, plus the pre-PR review fixups that came out of triage.

## Backend

- **Training controller (`src/synthorg/api/controllers/training.py`)**: every handler switched from `app_state: AppState` to `state: State` + `app_state = state.app_state`. Litestar binds unknown handler parameters to query strings on GET, which produced 44× HTTP 400 `ValidationException` "Missing required query parameter 'app_state'" on `/api/v1/agents/{name}/training/{plan,result}`. Pattern now matches every other controller in `src/synthorg/api/controllers/`.
- **Scaling controller (`src/synthorg/api/controllers/scaling.py`)**: collapsed the per-request `HR_SCALING_CONTROLLER_SERVICE_MISSING` warning (10× per dashboard poll) into a single once-per-process INFO via `_note_scaling_missing()`. The endpoints already returned empty paginated data when the service is unwired; the per-request log line was pure noise.
- **MCP catalog controller (`src/synthorg/api/controllers/mcp_catalog.py`)**: added new `GET /integrations/mcp/catalog/installed` endpoint for dashboard install-state hydration on refresh. Standardized all 6 handlers from `state["app_state"]` (dict subscript) to `state.app_state` (attribute), matching every other controller.
- **Memory controller (`src/synthorg/api/controllers/memory.py`)**: probe the fine-tune sidecar HTTP `/healthz` endpoint as a Docker-mode preflight fallback, fixing the false-positive "fine-tune not enabled" banner.
- **`docker/compose.yml`**: pin `uid=65532,gid=65532` on the web service's tmpfs mounts (`/tmp`, `/config/caddy`, `/data/caddy`). Caddy runs as uid 65532 from apko; the previous tmpfs was root-owned, breaking autosave.json, instance UUID persistence, and the storage_clean lock dir.

## Dashboard

- **Org chart**: runtime-status-based budget bar utilisation (no more permanent 100% on fresh installs); auto-fit on view-mode toggle plus coordinate-system lift during animated transitions.
- **Detail pages (Project, Artifact, Agent)**: stale-token returns clear loading flags in `finally` across project / artifact / client / provider / workflow / connection stores. The not-found banner now requires both `error` set AND entity null; the skeleton covers the pre-fetch render window so a fresh navigation no longer flashes "not found" before the polling effect spins up.
- **Messages**: dark-token resolution sweep across 12 files restores readable topic text. New "Empty (N)" collapsible group backed by a single `listMessages` activity probe + live WS updates so a fresh install's long pre-created topic list does not bury the active threads.
- **MCP catalog**: install dialog width capped to `dialog-compact`. Install state survives refresh via the new endpoint, frontend hydration on mount, and a matching MSW handler.
- **Fine-tuning**: Docker-mode sidecar health probe, clearer source-dir hint, advanced-options outline button with chevron, grid alignment for action buttons.
- **Settings CodeMirror editor**: wired `EditorView.cspNonce` so injected `<style>` tags carry the per-request CSP nonce and the editor mounts under strict CSP.
- **Layout**: route-keyed `document.title` map applied in `AppLayout` (per-page imperative `document.title` calls removed); html / body / `#root` scroll lock so `<main>` is the only scroll container.
- **`OrgChartPage.tsx:208`**: `void fitView(...)` to satisfy `@typescript-eslint/no-floating-promises`.

## API contract & types (from triage)

- **`web/src/api/endpoints/training.ts`**: added `pending_approvals` to the `TrainingResultResponse` interface so the backend's existing field is no longer silently dropped on the wire. MSW handler + store test fixtures updated.
- **`web/src/api/endpoints/fine-tuning.ts`**: `listCheckpoints` / `listRuns` were typed `ApiResponse<T[]>` but the backend returns `PaginatedResponse<T>`. Switched to `unwrapPaginated` returning `PaginatedResult<T>`; updated store callers (`page.data`), MSW handlers (`paginatedFor` + `emptyPage`), and unit tests (`paginatedEnvelopeFor`). Pagination metadata stops being silently dropped.

## Docs

- `docs/design/integrations.md`: added the new endpoint row for `GET /api/v1/integrations/mcp/catalog/installed`.

## Test infra

- Moved the load-bearing real-repo lint test `test_real_repo_violations_match_expected` from `tests/unit/scripts/test_check_setting_to_startup_trace.py` (where it overshot the 8 s unit wall-clock cap by 10–18 s) into `tests/integration/scripts/test_check_setting_to_startup_trace_real_repo.py` with `pytestmark = pytest.mark.integration`. The behaviour-matrix unit tests stay where they are.
- `tests/unit/api/controllers/test_mcp_catalog_dtos.py`: wrapped the test fixture's `{"app_state": ...}` dict in a `litestar.datastructures.State` instance so the install_entry handler's attribute-access pattern exercises a real `State` (not a plain dict).

## Test plan

- `uv run ruff check src/ tests/` — clean
- `uv run mypy src/ tests/` — clean (3,790 source files)
- `uv run python -m pytest tests/ -m unit` — 28,735 passed, 0 errors (after this PR)
- `npm --prefix web run lint` — clean
- `npm --prefix web run type-check` — clean
- `npm --prefix web run test` — 3,142 passed
- `docker compose -f docker/compose.yml config --quiet` — valid

## Review coverage

8 review agents run in parallel via `/pre-pr-review`: python-reviewer, code-reviewer, frontend-reviewer, design-token-audit, api-contract-drift, security-reviewer, type-design-analyzer, docs-consistency. 4 Major findings surfaced and fixed; 6 Medium findings explicitly skipped with rationale; 4 false positives excluded after verification. Full triage table at `_audit/pre-pr-review/triage.md`.

## Out of scope (acknowledged, not fixed here)

- The `MeetingOrchestrator` is wired with `missing_dependencies=["provider_registry"]` whenever the seed config has no providers (the new install case). The startup advisory is accurate; the runtime hot-rewire when providers are added via the dashboard is a separate behavioural gap (the orchestrator's `agent_caller` closure captures `provider_registry` at construction; `swap_provider_registry` does not re-wire it). Worth a follow-up.
- Yoyo Postgres `ERROR: relation "yoyo_lock" already exists` and `table "yoyo_tmp_*" does not exist` are cosmetic noise from yoyo's own idempotent-init flow and transactional-DDL probe (`yoyo/backends/base.py:414` and `:242`). Yoyo catches both; migrations apply cleanly. Not worth patching upstream or wrapping locally.