### PR TITLE
refactor: Phase 7 follow-up — complete RootConfig mirror coverage (closes #1907)

### DIFF
--- a/docs/reference/configuration-precedence.md
+++ b/docs/reference/configuration-precedence.md
@@ -285,6 +285,30 @@ class MyConfig(BaseModel):
         return apply_settings_mirrors(data, cls._MIRROR_FIELDS)
 ```
 
+### Available parsers
+
+`synthorg.settings.mirrors` ships the parser callbacks below. A
+`MirrorField` with `parse=None` applies identity parsing (the raw env
+string reaches the field, and the Pydantic field type does any
+coercion). A parser returning `None` signals invalid input; the
+registered default is then applied.
+
+| Parser | Signature | Use for |
+|---|---|---|
+| `parse_bool` | `(str) -> bool \| None` | Boolean tokens (`true`/`false`/`1`/`0`/`yes`/`no`). |
+| `parse_int` | `(str) -> int \| None` | Integer settings. |
+| `parse_float` | `(str) -> float \| None` | Float settings. |
+| `parse_str_tuple_json` | `(str) -> tuple[str, ...] \| None` | JSON list-of-strings into a tuple. |
+| `parse_json_int_pair_dict` | `(str) -> dict[str, list[int]] \| None` | JSON `{op: [int, int]}` (e.g. `PerOpRateLimitConfig.overrides`). Top-level shape only; the owning config's `mode="before"` validator promotes inner lists to tuples and rejects negatives. |
+| `parse_json_int_dict` | `(str) -> dict[str, int] \| None` | JSON `{op: int}` (e.g. `PerOpConcurrencyConfig.overrides`). Top-level shape only; the owning validator rejects non-int / negative values. |
+
+The two JSON-dict parsers deliberately validate only the top-level
+JSON structure. Per-entry semantics (non-blank keys, tuple arity,
+non-negativity) belong to the owning config's `mode="before"`
+validator so operator-facing error context fires before Pydantic
+coercion. See "Validator declaration order" in
+[conventions.md](conventions.md).
+
 ### Sentinel-preserving mode: `only_if_env_set=True`
 
 When the Pydantic field's `None` default carries semantic meaning the

--- a/docs/reference/configuration-precedence.md
+++ b/docs/reference/configuration-precedence.md
@@ -231,6 +231,24 @@ With YAML eliminated from the precedence chain, the Pydantic-tier
 default would otherwise drift from the env-tier override resolved by
 `SettingsService`.
 
+### Settings-only registered keys (no Pydantic mirror)
+
+Some registered settings are consumed exclusively through
+`SettingsService` (or `ConfigResolver`) and have no corresponding
+field on any Pydantic config class. They participate in the standard
+precedence chain (DB > env > default) without needing a mirror
+declaration. Examples in the `company` namespace:
+
+- `company.name_locales`: consumed in
+  `src/synthorg/api/controllers/setup/company_helpers.py` via
+  `SettingsService.get_entry`.
+- `company.description`: registered for `/settings` UI discoverability;
+  no current code consumer.
+
+These keys are NOT fields on `RootConfig`; treating them as
+settings-only avoids the dual-surface drift that the mirror pattern
+exists to fix.
+
 `synthorg.settings.mirrors.apply_settings_mirrors` is the sanctioned
 fix. Each Pydantic class with mirror fields declares them via a
 `MirrorField` tuple and attaches a `model_validator(mode="before")`

--- a/docs/reference/conventions.md
+++ b/docs/reference/conventions.md
@@ -84,6 +84,23 @@ All `mode="before"` validators in the codebase return new dicts; the
 immutability tests under `tests/unit/{api,tools}/...` lock in the
 pattern.
 
+### Validator declaration order (`mode="before"`)
+
+Pydantic v2 runs multiple `mode="before"` validators on a class in
+**reverse declaration order**: the validator declared LAST in source
+runs FIRST. When a class pairs a settings-mirror validator
+(`_apply_mirrors`, populating a field from the env via
+`apply_settings_mirrors`) with a shape validator that must inspect the
+populated value, declare the shape validator BEFORE `_apply_mirrors`
+in source so it runs AFTER the mirror has populated the field.
+
+Reference: `PerOpRateLimitConfig._validate_override_tuples` and
+`PerOpConcurrencyConfig._validate_override_values` in
+`src/synthorg/config/rate_limits.py` are declared before
+`_apply_mirrors` precisely so the env-populated `overrides` dict is
+shape-checked. Getting the order wrong means the shape validator runs
+against an empty default and never sees the env override.
+
 ## 5. Event constant module imports
 
 Every observability event is defined as a `Final[str]` constant under

--- a/src/synthorg/a2a/well_known.py
+++ b/src/synthorg/a2a/well_known.py
@@ -242,15 +242,17 @@ class WellKnownAgentCardController(Controller):
         ttl = app_state.config.a2a.agent_card_cache_ttl_seconds
 
         base_url = strip_trailing_slash(str(request.base_url))
-        # Resolve company_name before the cache read and key on it so a
-        # runtime write to ``company.company_name`` (DB-tier override
-        # per the configuration-precedence contract) takes effect
-        # immediately instead of being hidden until TTL expiry. Stale
-        # entries for prior names age out by TTL. Agent-list staleness
-        # remains TTL-bounded by design.
+        # Resolve company_name before the cache read and use it as the
+        # read-side fingerprint so a runtime write to
+        # ``company.company_name`` (DB-tier override per the
+        # configuration-precedence contract) invalidates the cached
+        # card immediately instead of being hidden until TTL expiry.
+        # The key stays stable per host so a rename overwrites the same
+        # entry rather than orphaning a never-reused one. Agent-list
+        # staleness remains TTL-bounded by design.
         company_name = await _resolve_company_name(app_state)
-        cache_key = f"__company__:{base_url}:{company_name}"
-        cached = await _get_cached_card(cache_key, ttl)
+        cache_key = f"__company__:{base_url}"
+        cached = await _get_cached_card(cache_key, ttl, fingerprint=company_name)
         if cached is not None:
             logger.debug(A2A_AGENT_CARD_CACHE_HIT, cache_key=cache_key)
             return _card_response(cached, ttl)
@@ -275,7 +277,12 @@ class WellKnownAgentCardController(Controller):
             )
             return _service_unavailable_response()
 
-        await _put_cached_card(cache_key, card_data, ttl)
+        await _put_cached_card(
+            cache_key,
+            card_data,
+            ttl,
+            fingerprint=company_name,
+        )
         logger.info(
             A2A_AGENT_CARD_SERVED,
             card_type="company",

--- a/src/synthorg/a2a/well_known.py
+++ b/src/synthorg/a2a/well_known.py
@@ -160,27 +160,22 @@ def _service_unavailable_response() -> Response[dict[str, Any]]:
 async def _assemble_company_card(
     app_state: Any,
     base_url: str,
-) -> tuple[dict[str, Any], str, int]:
-    """Build the company card payload + staleness fingerprint.
+    company_name: str,
+) -> tuple[dict[str, Any], int]:
+    """Build the company card payload for an already-resolved name.
 
-    Returns ``(card_data, fingerprint, agent_count)``. Raises on any
-    failure; the caller maps that to a 503.
+    Returns ``(card_data, agent_count)``. Raises on any failure; the
+    caller maps that to a 503.
     """
     builder: AgentCardBuilder = app_state.a2a_card_builder
     registry = app_state.agent_registry
     identities = await registry.list_active()
-    company_name = await _resolve_company_name(app_state)
     card = builder.build_company_card(
         identities=identities,
         base_url=f"{base_url}/api/v1/a2a",
         company_name=company_name,
     )
-    card_data = card.model_dump()
-    # Fingerprint: sorted identity IDs for staleness detection.
-    fingerprint = hashlib.sha256(
-        ",".join(sorted(str(i.id) for i in identities)).encode(),
-    ).hexdigest()[:16]
-    return card_data, fingerprint, len(identities)
+    return card.model_dump(), len(identities)
 
 
 async def _resolve_agent_for_card(app_state: Any, agent_id: str) -> Any | None:
@@ -247,9 +242,14 @@ class WellKnownAgentCardController(Controller):
         ttl = app_state.config.a2a.agent_card_cache_ttl_seconds
 
         base_url = strip_trailing_slash(str(request.base_url))
-        cache_key = f"__company__:{base_url}"
-        # Fingerprint not checked on read for company card (requires
-        # listing all agents); TTL-based expiry is the primary guard.
+        # Resolve company_name before the cache read and key on it so a
+        # runtime write to ``company.company_name`` (DB-tier override
+        # per the configuration-precedence contract) takes effect
+        # immediately instead of being hidden until TTL expiry. Stale
+        # entries for prior names age out by TTL. Agent-list staleness
+        # remains TTL-bounded by design.
+        company_name = await _resolve_company_name(app_state)
+        cache_key = f"__company__:{base_url}:{company_name}"
         cached = await _get_cached_card(cache_key, ttl)
         if cached is not None:
             logger.debug(A2A_AGENT_CARD_CACHE_HIT, cache_key=cache_key)
@@ -258,9 +258,10 @@ class WellKnownAgentCardController(Controller):
         logger.debug(A2A_AGENT_CARD_CACHE_MISS, cache_key=cache_key)
 
         try:
-            card_data, fingerprint, agent_count = await _assemble_company_card(
+            card_data, agent_count = await _assemble_company_card(
                 app_state,
                 base_url,
+                company_name,
             )
         except MemoryError, RecursionError:
             raise
@@ -274,12 +275,7 @@ class WellKnownAgentCardController(Controller):
             )
             return _service_unavailable_response()
 
-        await _put_cached_card(
-            cache_key,
-            card_data,
-            ttl,
-            fingerprint=fingerprint,
-        )
+        await _put_cached_card(cache_key, card_data, ttl)
         logger.info(
             A2A_AGENT_CARD_SERVED,
             card_type="company",

--- a/src/synthorg/a2a/well_known.py
+++ b/src/synthorg/a2a/well_known.py
@@ -183,34 +183,44 @@ async def _assemble_company_card(
     return card_data, fingerprint, len(identities)
 
 
-async def _resolve_and_build_agent_card(
-    app_state: Any,
-    agent_id: str,
-    host_base: str,
-) -> tuple[dict[str, Any], str] | None:
-    """Resolve an agent and build its card payload + fingerprint.
+async def _resolve_agent_for_card(app_state: Any, agent_id: str) -> Any | None:
+    """Resolve an agent identity by id, then by name.
 
-    Returns ``(card_data, fingerprint)``, or ``None`` when no agent
-    matches ``agent_id`` (caller maps that to 404). Raises on any other
+    Returns the identity, or ``None`` when no agent matches
+    ``agent_id`` (caller maps that to 404). Raises on registry
     failure; the caller maps that to a 503.
     """
     registry = app_state.agent_registry
     identity = await registry.get(agent_id)
     if identity is None:
         identity = await registry.get_by_name(agent_id)
-    if identity is None:
-        return None
+    return identity
+
+
+def _agent_fingerprint(identity: Any) -> str:
+    """Compute the staleness fingerprint for an agent identity.
+
+    Derived from name + role + skills so a rename, role change, or
+    skill edit invalidates a cached card before TTL expiry instead
+    of serving a stale document.
+    """
+    return hashlib.sha256(
+        f"{identity.name}:{identity.role}:{identity.skills}".encode(),
+    ).hexdigest()[:16]
+
+
+def _build_agent_card_payload(
+    app_state: Any,
+    identity: Any,
+    host_base: str,
+) -> dict[str, Any]:
+    """Build the card payload for an already-resolved identity."""
     builder: AgentCardBuilder = app_state.a2a_card_builder
     card = builder.build(
         identity=identity,
         base_url=f"{host_base}/api/v1/a2a",
     )
-    card_data = card.model_dump()
-    # Fingerprint: identity name + role + skills for staleness.
-    fingerprint = hashlib.sha256(
-        f"{identity.name}:{identity.role}:{identity.skills}".encode(),
-    ).hexdigest()[:16]
-    return card_data, fingerprint
+    return card.model_dump()
 
 
 class WellKnownAgentCardController(Controller):
@@ -254,11 +264,13 @@ class WellKnownAgentCardController(Controller):
             )
         except MemoryError, RecursionError:
             raise
-        except Exception:
-            logger.exception(
+        except Exception as exc:
+            logger.error(
                 A2A_AGENT_CARD_SERVED,
                 card_type="company",
-                error="Failed to build company agent card",
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+                reason="company_agent_card_build_failed",
             )
             return _service_unavailable_response()
 
@@ -296,7 +308,32 @@ class WellKnownAgentCardController(Controller):
 
         host_base = strip_trailing_slash(str(request.base_url))
         cache_key = f"{agent_id}:{host_base}"
-        cached = await _get_cached_card(cache_key, ttl)
+
+        try:
+            identity = await _resolve_agent_for_card(app_state, agent_id)
+        except MemoryError, RecursionError:
+            raise
+        except Exception as exc:
+            logger.error(
+                A2A_AGENT_CARD_SERVED,
+                card_type="agent",
+                agent_id=agent_id,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+                reason="agent_identity_resolution_failed",
+            )
+            return _service_unavailable_response()
+
+        if identity is None:
+            msg = f"Agent '{agent_id}' not found"
+            raise NotFoundError(msg)
+
+        # Resolve identity before the cache read so the current
+        # fingerprint gates the lookup: a rename, role change, or
+        # skill edit invalidates the cached card immediately instead
+        # of being served stale until TTL expiry.
+        fingerprint = _agent_fingerprint(identity)
+        cached = await _get_cached_card(cache_key, ttl, fingerprint=fingerprint)
         if cached is not None:
             logger.debug(A2A_AGENT_CARD_CACHE_HIT, cache_key=cache_key)
             return _card_response(cached, ttl)
@@ -304,27 +341,20 @@ class WellKnownAgentCardController(Controller):
         logger.debug(A2A_AGENT_CARD_CACHE_MISS, cache_key=cache_key)
 
         try:
-            built = await _resolve_and_build_agent_card(
-                app_state,
-                agent_id,
-                host_base,
-            )
+            card_data = _build_agent_card_payload(app_state, identity, host_base)
         except MemoryError, RecursionError:
             raise
-        except Exception:
-            logger.exception(
+        except Exception as exc:
+            logger.error(
                 A2A_AGENT_CARD_SERVED,
                 card_type="agent",
                 agent_id=agent_id,
-                error="Failed to build agent card",
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+                reason="agent_card_build_failed",
             )
             return _service_unavailable_response()
 
-        if built is None:
-            msg = f"Agent '{agent_id}' not found"
-            raise NotFoundError(msg)
-
-        card_data, fingerprint = built
         await _put_cached_card(cache_key, card_data, ttl, fingerprint=fingerprint)
         logger.info(A2A_AGENT_CARD_SERVED, card_type="agent", agent_id=agent_id)
         return _card_response(card_data, ttl)

--- a/src/synthorg/a2a/well_known.py
+++ b/src/synthorg/a2a/well_known.py
@@ -139,6 +139,80 @@ async def _resolve_company_name(app_state: Any) -> str:
     return str(resolved)
 
 
+def _card_response(card_data: dict[str, Any], ttl: int) -> Response[dict[str, Any]]:
+    """Build the success JSON response with the public cache header."""
+    return Response(
+        content=card_data,
+        media_type="application/json",
+        headers={"Cache-Control": f"public, max-age={ttl}"},
+    )
+
+
+def _service_unavailable_response() -> Response[dict[str, Any]]:
+    """Build the 503 response served when card assembly fails."""
+    return Response(
+        content={"error": "Service temporarily unavailable"},
+        media_type="application/json",
+        status_code=503,
+    )
+
+
+async def _assemble_company_card(
+    app_state: Any,
+    base_url: str,
+) -> tuple[dict[str, Any], str, int]:
+    """Build the company card payload + staleness fingerprint.
+
+    Returns ``(card_data, fingerprint, agent_count)``. Raises on any
+    failure; the caller maps that to a 503.
+    """
+    builder: AgentCardBuilder = app_state.a2a_card_builder
+    registry = app_state.agent_registry
+    identities = await registry.list_active()
+    company_name = await _resolve_company_name(app_state)
+    card = builder.build_company_card(
+        identities=identities,
+        base_url=f"{base_url}/api/v1/a2a",
+        company_name=company_name,
+    )
+    card_data = card.model_dump()
+    # Fingerprint: sorted identity IDs for staleness detection.
+    fingerprint = hashlib.sha256(
+        ",".join(sorted(str(i.id) for i in identities)).encode(),
+    ).hexdigest()[:16]
+    return card_data, fingerprint, len(identities)
+
+
+async def _resolve_and_build_agent_card(
+    app_state: Any,
+    agent_id: str,
+    host_base: str,
+) -> tuple[dict[str, Any], str] | None:
+    """Resolve an agent and build its card payload + fingerprint.
+
+    Returns ``(card_data, fingerprint)``, or ``None`` when no agent
+    matches ``agent_id`` (caller maps that to 404). Raises on any other
+    failure; the caller maps that to a 503.
+    """
+    registry = app_state.agent_registry
+    identity = await registry.get(agent_id)
+    if identity is None:
+        identity = await registry.get_by_name(agent_id)
+    if identity is None:
+        return None
+    builder: AgentCardBuilder = app_state.a2a_card_builder
+    card = builder.build(
+        identity=identity,
+        base_url=f"{host_base}/api/v1/a2a",
+    )
+    card_data = card.model_dump()
+    # Fingerprint: identity name + role + skills for staleness.
+    fingerprint = hashlib.sha256(
+        f"{identity.name}:{identity.role}:{identity.skills}".encode(),
+    ).hexdigest()[:16]
+    return card_data, fingerprint
+
+
 class WellKnownAgentCardController(Controller):
     """Serves A2A Agent Cards at well-known URIs."""
 
@@ -160,57 +234,23 @@ class WellKnownAgentCardController(Controller):
     ) -> Response[dict[str, Any]]:
         """Serve the company-level Agent Card."""
         app_state = state["app_state"]
-        a2a_config = app_state.config.a2a
-        ttl = a2a_config.agent_card_cache_ttl_seconds
+        ttl = app_state.config.a2a.agent_card_cache_ttl_seconds
 
-        host_base = strip_trailing_slash(str(request.base_url))
-        company_cache_key = f"__company__:{host_base}"
+        base_url = strip_trailing_slash(str(request.base_url))
+        cache_key = f"__company__:{base_url}"
         # Fingerprint not checked on read for company card (requires
         # listing all agents); TTL-based expiry is the primary guard.
-        cached = await _get_cached_card(company_cache_key, ttl)
+        cached = await _get_cached_card(cache_key, ttl)
         if cached is not None:
-            logger.debug(
-                A2A_AGENT_CARD_CACHE_HIT,
-                cache_key=company_cache_key,
-            )
-            return Response(
-                content=cached,
-                media_type="application/json",
-                headers={
-                    "Cache-Control": f"public, max-age={ttl}",
-                },
-            )
+            logger.debug(A2A_AGENT_CARD_CACHE_HIT, cache_key=cache_key)
+            return _card_response(cached, ttl)
 
-        logger.debug(
-            A2A_AGENT_CARD_CACHE_MISS,
-            cache_key=company_cache_key,
-        )
-
-        builder: AgentCardBuilder = app_state.a2a_card_builder
-        registry = app_state.agent_registry
+        logger.debug(A2A_AGENT_CARD_CACHE_MISS, cache_key=cache_key)
 
         try:
-            identities = await registry.list_active()
-            base_url = strip_trailing_slash(str(request.base_url))
-            company_name = await _resolve_company_name(app_state)
-            card = builder.build_company_card(
-                identities=identities,
-                base_url=f"{base_url}/api/v1/a2a",
-                company_name=company_name,
-            )
-            card_data = card.model_dump()
-            # Fingerprint: sorted identity IDs for staleness detection.
-            id_fp = hashlib.sha256(
-                ",".join(
-                    sorted(str(i.id) for i in identities),
-                ).encode(),
-            ).hexdigest()[:16]
-            cache_key = f"__company__:{base_url}"
-            await _put_cached_card(
-                cache_key,
-                card_data,
-                ttl,
-                fingerprint=id_fp,
+            card_data, fingerprint, agent_count = await _assemble_company_card(
+                app_state,
+                base_url,
             )
         except MemoryError, RecursionError:
             raise
@@ -220,24 +260,20 @@ class WellKnownAgentCardController(Controller):
                 card_type="company",
                 error="Failed to build company agent card",
             )
-            return Response(
-                content={"error": "Service temporarily unavailable"},
-                media_type="application/json",
-                status_code=503,
-            )
+            return _service_unavailable_response()
 
+        await _put_cached_card(
+            cache_key,
+            card_data,
+            ttl,
+            fingerprint=fingerprint,
+        )
         logger.info(
             A2A_AGENT_CARD_SERVED,
             card_type="company",
-            agent_count=len(identities),
+            agent_count=agent_count,
         )
-        return Response(
-            content=card_data,
-            media_type="application/json",
-            headers={
-                "Cache-Control": f"public, max-age={ttl}",
-            },
-        )
+        return _card_response(card_data, ttl)
 
     @get(
         "/agents/{agent_id:str}/agent-card.json",
@@ -256,36 +292,23 @@ class WellKnownAgentCardController(Controller):
         from synthorg.core.domain_errors import NotFoundError  # noqa: PLC0415
 
         app_state = state["app_state"]
-        a2a_config = app_state.config.a2a
-        ttl = a2a_config.agent_card_cache_ttl_seconds
+        ttl = app_state.config.a2a.agent_card_cache_ttl_seconds
 
         host_base = strip_trailing_slash(str(request.base_url))
-        agent_cache_key = f"{agent_id}:{host_base}"
-        cached = await _get_cached_card(agent_cache_key, ttl)
+        cache_key = f"{agent_id}:{host_base}"
+        cached = await _get_cached_card(cache_key, ttl)
         if cached is not None:
-            logger.debug(
-                A2A_AGENT_CARD_CACHE_HIT,
-                cache_key=agent_cache_key,
-            )
-            return Response(
-                content=cached,
-                media_type="application/json",
-                headers={
-                    "Cache-Control": f"public, max-age={ttl}",
-                },
-            )
+            logger.debug(A2A_AGENT_CARD_CACHE_HIT, cache_key=cache_key)
+            return _card_response(cached, ttl)
 
-        logger.debug(
-            A2A_AGENT_CARD_CACHE_MISS,
-            cache_key=agent_cache_key,
-        )
-
-        registry = app_state.agent_registry
+        logger.debug(A2A_AGENT_CARD_CACHE_MISS, cache_key=cache_key)
 
         try:
-            identity = await registry.get(agent_id)
-            if identity is None:
-                identity = await registry.get_by_name(agent_id)
+            built = await _resolve_and_build_agent_card(
+                app_state,
+                agent_id,
+                host_base,
+            )
         except MemoryError, RecursionError:
             raise
         except Exception:
@@ -295,57 +318,13 @@ class WellKnownAgentCardController(Controller):
                 agent_id=agent_id,
                 error="Failed to build agent card",
             )
-            return Response(
-                content={"error": "Service temporarily unavailable"},
-                media_type="application/json",
-                status_code=503,
-            )
+            return _service_unavailable_response()
 
-        if identity is None:
+        if built is None:
             msg = f"Agent '{agent_id}' not found"
             raise NotFoundError(msg)
 
-        try:
-            builder: AgentCardBuilder = app_state.a2a_card_builder
-            card = builder.build(
-                identity=identity,
-                base_url=f"{host_base}/api/v1/a2a",
-            )
-            card_data = card.model_dump()
-            # Fingerprint: identity name + role + skills for staleness.
-            agent_fp = hashlib.sha256(
-                f"{identity.name}:{identity.role}:{identity.skills}".encode(),
-            ).hexdigest()[:16]
-            await _put_cached_card(
-                agent_cache_key,
-                card_data,
-                ttl,
-                fingerprint=agent_fp,
-            )
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
-            logger.exception(
-                A2A_AGENT_CARD_SERVED,
-                card_type="agent",
-                agent_id=agent_id,
-                error="Failed to build agent card",
-            )
-            return Response(
-                content={"error": "Service temporarily unavailable"},
-                media_type="application/json",
-                status_code=503,
-            )
-
-        logger.info(
-            A2A_AGENT_CARD_SERVED,
-            card_type="agent",
-            agent_id=agent_id,
-        )
-        return Response(
-            content=card_data,
-            media_type="application/json",
-            headers={
-                "Cache-Control": f"public, max-age={ttl}",
-            },
-        )
+        card_data, fingerprint = built
+        await _put_cached_card(cache_key, card_data, ttl, fingerprint=fingerprint)
+        logger.info(A2A_AGENT_CARD_SERVED, card_type="agent", agent_id=agent_id)
+        return _card_response(card_data, ttl)

--- a/src/synthorg/a2a/well_known.py
+++ b/src/synthorg/a2a/well_known.py
@@ -20,12 +20,13 @@ from litestar.response import Response
 from synthorg.a2a.agent_card import AgentCardBuilder  # noqa: TC001
 from synthorg.core.clock import Clock, SystemClock
 from synthorg.core.normalization import strip_trailing_slash
-from synthorg.observability import get_logger
+from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.a2a import (
     A2A_AGENT_CARD_CACHE_HIT,
     A2A_AGENT_CARD_CACHE_MISS,
     A2A_AGENT_CARD_SERVED,
 )
+from synthorg.settings.errors import SettingNotFoundError
 
 logger = get_logger(__name__)
 
@@ -105,6 +106,39 @@ async def _put_cached_card(
         )
 
 
+async def _resolve_company_name(app_state: Any) -> str:
+    """Read ``company.company_name`` through ``ConfigResolver`` with fallback.
+
+    A ``/settings/company/company_name`` runtime write only reaches this
+    endpoint when the resolver is consulted per request; capturing the
+    value at boot-time would freeze it on the running process. The
+    fallback to ``app_state.config.company_name`` keeps ``.well-known``
+    serving on a settings-backend outage instead of 500'ing.
+
+    ``SettingNotFoundError`` is a quiet fallback because it is a normal
+    initial state on fresh installs before setup has registered the
+    key. The broader ``Exception`` catch logs WARNING with safe error
+    description; ``MemoryError`` and ``RecursionError`` propagate per
+    the surrounding controller's convention.
+    """
+    try:
+        resolved = await app_state.config_resolver.get_str("company", "company_name")
+    except MemoryError, RecursionError:
+        raise
+    except SettingNotFoundError:
+        return str(app_state.config.company_name)
+    except Exception as exc:
+        logger.warning(
+            A2A_AGENT_CARD_SERVED,
+            card_type="company",
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
+            reason="company_name_resolver_failed_using_snapshot_fallback",
+        )
+        return str(app_state.config.company_name)
+    return str(resolved)
+
+
 class WellKnownAgentCardController(Controller):
     """Serves A2A Agent Cards at well-known URIs."""
 
@@ -158,10 +192,11 @@ class WellKnownAgentCardController(Controller):
         try:
             identities = await registry.list_active()
             base_url = strip_trailing_slash(str(request.base_url))
+            company_name = await _resolve_company_name(app_state)
             card = builder.build_company_card(
                 identities=identities,
                 base_url=f"{base_url}/api/v1/a2a",
-                company_name=str(app_state.config.company_name),
+                company_name=company_name,
             )
             card_data = card.model_dump()
             # Fingerprint: sorted identity IDs for staleness detection.

--- a/src/synthorg/config/rate_limits.py
+++ b/src/synthorg/config/rate_limits.py
@@ -19,6 +19,8 @@ from synthorg.settings.mirrors import (
     MirrorField,
     apply_settings_mirrors,
     parse_bool,
+    parse_json_int_dict,
+    parse_json_int_pair_dict,
 )
 
 logger = get_logger(__name__)
@@ -78,16 +80,17 @@ class PerOpRateLimitConfig(BaseModel):
             key="per_op_rate_limit_enabled",
             parse=parse_bool,
         ),
+        MirrorField(
+            field="overrides",
+            namespace=SettingNamespace.API,
+            key="per_op_rate_limit_overrides",
+            parse=parse_json_int_pair_dict,
+        ),
     )
 
     enabled: bool = True
     backend: Literal["memory"] = "memory"
     overrides: dict[NotBlankStr, tuple[int, int]] = Field(default_factory=dict)
-
-    @model_validator(mode="before")
-    @classmethod
-    def _apply_mirrors(cls, data: Any) -> Any:
-        return apply_settings_mirrors(data, cls._MIRROR_FIELDS)
 
     @model_validator(mode="before")
     @classmethod
@@ -101,6 +104,11 @@ class PerOpRateLimitConfig(BaseModel):
         and our log line would never fire.  Zero is allowed and means
         "disable this operation" -- the guard short-circuits when
         either component is ``0``.
+
+        Declared BEFORE ``_apply_mirrors`` in source order. Pydantic v2
+        runs ``mode="before"`` validators in REVERSE declaration order,
+        so this runs LAST -- after the mirror has populated ``overrides``
+        from env -- which is what we want.
         """
         if not isinstance(data, dict):
             return data
@@ -149,6 +157,11 @@ class PerOpRateLimitConfig(BaseModel):
                 _warn_and_raise(msg, operation=operation, override=str(pair))
         return data
 
+    @model_validator(mode="before")
+    @classmethod
+    def _apply_mirrors(cls, data: Any) -> Any:
+        return apply_settings_mirrors(data, cls._MIRROR_FIELDS)
+
 
 class PerOpConcurrencyConfig(BaseModel):
     """Configuration for the per-operation inflight limiter.
@@ -175,6 +188,12 @@ class PerOpConcurrencyConfig(BaseModel):
             key="per_op_concurrency_enabled",
             parse=parse_bool,
         ),
+        MirrorField(
+            field="overrides",
+            namespace=SettingNamespace.API,
+            key="per_op_concurrency_overrides",
+            parse=parse_json_int_dict,
+        ),
     )
 
     enabled: bool = True
@@ -188,11 +207,6 @@ class PerOpConcurrencyConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def _apply_mirrors(cls, data: Any) -> Any:
-        return apply_settings_mirrors(data, cls._MIRROR_FIELDS)
-
-    @model_validator(mode="before")
-    @classmethod
     def _validate_override_values(cls, data: Any) -> Any:
         """Reject malformed-shape and negative override values.
 
@@ -202,6 +216,11 @@ class PerOpConcurrencyConfig(BaseModel):
         already have rejected mis-shaped inputs with a generic
         ``ValidationError`` and our log line would never fire.  Zero
         is allowed and means "disable this operation".
+
+        Declared BEFORE ``_apply_mirrors`` in source order. Pydantic v2
+        runs ``mode="before"`` validators in REVERSE declaration order,
+        so this runs LAST -- after the mirror has populated ``overrides``
+        from env -- which is what we want.
         """
         if not isinstance(data, dict):
             return data
@@ -225,3 +244,8 @@ class PerOpConcurrencyConfig(BaseModel):
                 )
                 _warn_and_raise(msg, operation=operation, override=str(value))
         return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def _apply_mirrors(cls, data: Any) -> Any:
+        return apply_settings_mirrors(data, cls._MIRROR_FIELDS)

--- a/src/synthorg/engine/evolution/config.py
+++ b/src/synthorg/engine/evolution/config.py
@@ -23,9 +23,11 @@ from synthorg.memory.procedural.propagation.config import (
 from synthorg.memory.procedural.pruning.config import (
     PruningConfig,
 )
+from synthorg.settings.enums import SettingNamespace
 from synthorg.settings.mirrors import (
     MirrorField,
     apply_settings_mirrors,
+    parse_bool,
 )
 
 
@@ -242,15 +244,16 @@ class EvolutionConfig(BaseModel):
 
     model_config = ConfigDict(frozen=True, allow_inf_nan=False, extra="forbid")
 
-    # ``enabled`` intentionally omits the mirror: the registered
-    # ``engine.evolution_enabled`` default is False (kill-switch
-    # default) while the Pydantic field default is True (runtime-
-    # mutable feature flag).  Service consumers read the registered
-    # value via ConfigResolver at runtime; the Pydantic field is the
-    # internal-default the evolution service initialises with.
-    _MIRROR_FIELDS: ClassVar[tuple[MirrorField, ...]] = ()
+    _MIRROR_FIELDS: ClassVar[tuple[MirrorField, ...]] = (
+        MirrorField(
+            field="enabled",
+            namespace=SettingNamespace.ENGINE,
+            key="evolution_enabled",
+            parse=parse_bool,
+        ),
+    )
 
-    enabled: bool = True
+    enabled: bool = False
     triggers: TriggerConfig = Field(default_factory=TriggerConfig)
     proposer: ProposerConfig = Field(default_factory=ProposerConfig)
     adapters: AdapterConfig = Field(default_factory=AdapterConfig)

--- a/src/synthorg/settings/mirrors.py
+++ b/src/synthorg/settings/mirrors.py
@@ -76,6 +76,43 @@ def parse_str_tuple_json(raw: str) -> tuple[str, ...] | None:
     return tuple(parsed)
 
 
+def parse_json_int_pair_dict(raw: str) -> dict[str, list[int]] | None:
+    """Parse a JSON ``{op_name: [int, int]}`` env token.
+
+    Returns the raw ``dict[str, list[int]]`` produced by ``json.loads``;
+    the owning Pydantic config's ``mode="before"`` validator promotes
+    inner lists to tuples and rejects malformed values, so this parser
+    only enforces top-level JSON shape (object with string keys).
+    """
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    if not all(isinstance(k, str) for k in parsed):
+        return None
+    return parsed
+
+
+def parse_json_int_dict(raw: str) -> dict[str, int] | None:
+    """Parse a JSON ``{op_name: int}`` env token.
+
+    Returns the raw ``dict[str, int]`` from ``json.loads``. The owning
+    Pydantic validator rejects non-int and negative values, so this
+    parser only enforces top-level JSON shape (object with string keys).
+    """
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    if not all(isinstance(k, str) for k in parsed):
+        return None
+    return parsed
+
+
 @dataclass(frozen=True)
 class MirrorField:
     """Declaration of one settings-mirror Pydantic field.

--- a/tests/unit/a2a/test_well_known.py
+++ b/tests/unit/a2a/test_well_known.py
@@ -164,3 +164,14 @@ class TestResolveCompanyName:
         app_state = SimpleNamespace(config_resolver=resolver, config=config)
         with pytest.raises(MemoryError):
             await _resolve_company_name(app_state)
+
+    @pytest.mark.unit
+    async def test_recursion_error_propagates(self) -> None:
+        """``RecursionError`` is re-raised, not swallowed by the fallback."""
+        resolver = _make_resolver_stub(
+            get_str_side_effect=RecursionError("too deep"),
+        )
+        config = SimpleNamespace(company_name="Snapshot Co")
+        app_state = SimpleNamespace(config_resolver=resolver, config=config)
+        with pytest.raises(RecursionError):
+            await _resolve_company_name(app_state)

--- a/tests/unit/a2a/test_well_known.py
+++ b/tests/unit/a2a/test_well_known.py
@@ -1,15 +1,25 @@
 """Tests for well-known Agent Card cache helpers."""
 
+from collections.abc import Iterator
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from synthorg.a2a import well_known
+from synthorg.a2a.agent_card import AgentCardBuilder
 from synthorg.a2a.well_known import (
+    WellKnownAgentCardController,
+    _agent_fingerprint,
+    _assemble_company_card,
+    _build_agent_card_payload,
     _get_cached_card,
     _put_cached_card,
+    _resolve_agent_for_card,
     _resolve_company_name,
 )
+from synthorg.core.domain_errors import NotFoundError
+from synthorg.hr.registry import AgentRegistryService
 from synthorg.settings.errors import SettingNotFoundError
 from synthorg.settings.resolver import ConfigResolver
 
@@ -175,3 +185,334 @@ class TestResolveCompanyName:
         app_state = SimpleNamespace(config_resolver=resolver, config=config)
         with pytest.raises(RecursionError):
             await _resolve_company_name(app_state)
+
+
+@pytest.fixture(autouse=True)
+def _clear_card_cache() -> Iterator[None]:
+    """Reset the module-level card cache around every test in this module."""
+    well_known._card_cache.clear()
+    yield
+    well_known._card_cache.clear()
+
+
+def _make_identity(
+    *,
+    agent_id: str = "agent-1",
+    name: str = "Ada",
+    role: str = "engineer",
+    skills: tuple[str, ...] = ("python",),
+    department: str = "RnD",
+) -> SimpleNamespace:
+    """Build an attribute-bag agent identity for card tests."""
+    return SimpleNamespace(
+        id=agent_id,
+        name=name,
+        role=role,
+        skills=skills,
+        department=department,
+    )
+
+
+def _make_app_state(
+    *,
+    registry: AsyncMock,
+    builder: Mock,
+    ttl: int = 60,
+    company_name: str = "Snapshot Co",
+    resolver: AsyncMock | None = None,
+) -> SimpleNamespace:
+    """Assemble the ``app_state`` attribute-bag the controller reads."""
+    config = SimpleNamespace(
+        a2a=SimpleNamespace(agent_card_cache_ttl_seconds=ttl),
+        company_name=company_name,
+    )
+    return SimpleNamespace(
+        agent_registry=registry,
+        a2a_card_builder=builder,
+        config=config,
+        config_resolver=resolver,
+    )
+
+
+def _make_request(base_url: str = "http://test.example/") -> SimpleNamespace:
+    """Minimal request stand-in exposing ``base_url``."""
+    return SimpleNamespace(base_url=base_url)
+
+
+def _state(app_state: SimpleNamespace) -> dict[str, object]:
+    """Litestar ``State`` is a mapping; the handler only does ``state[...]``."""
+    return {"app_state": app_state}
+
+
+def _controller() -> WellKnownAgentCardController:
+    """Construct the controller without mounting it on a real Router."""
+    return WellKnownAgentCardController(
+        owner=WellKnownAgentCardController,  # type: ignore[arg-type]
+    )
+
+
+class TestAgentCardHelpers:
+    """Resolve / fingerprint / build split for the per-agent path."""
+
+    @pytest.mark.unit
+    async def test_resolve_prefers_id_then_name(self) -> None:
+        """``get`` wins; ``get_by_name`` is the fallback."""
+        identity = _make_identity()
+        registry = AsyncMock(spec=AgentRegistryService)
+        registry.get.return_value = identity
+        app_state = SimpleNamespace(agent_registry=registry)
+        assert await _resolve_agent_for_card(app_state, "agent-1") is identity
+        registry.get_by_name.assert_not_awaited()
+
+    @pytest.mark.unit
+    async def test_resolve_falls_back_to_name(self) -> None:
+        """A miss on ``get`` retries via ``get_by_name``."""
+        identity = _make_identity()
+        registry = AsyncMock(spec=AgentRegistryService)
+        registry.get.return_value = None
+        registry.get_by_name.return_value = identity
+        app_state = SimpleNamespace(agent_registry=registry)
+        assert await _resolve_agent_for_card(app_state, "Ada") is identity
+
+    @pytest.mark.unit
+    async def test_resolve_returns_none_when_unknown(self) -> None:
+        """Both lookups missing yields ``None`` (caller maps to 404)."""
+        registry = AsyncMock(spec=AgentRegistryService)
+        registry.get.return_value = None
+        registry.get_by_name.return_value = None
+        app_state = SimpleNamespace(agent_registry=registry)
+        assert await _resolve_agent_for_card(app_state, "ghost") is None
+
+    @pytest.mark.unit
+    def test_fingerprint_changes_with_identity(self) -> None:
+        """Name/role/skill edits each change the fingerprint."""
+        base = _agent_fingerprint(_make_identity())
+        assert base == _agent_fingerprint(_make_identity())
+        assert _agent_fingerprint(_make_identity(name="Grace")) != base
+        assert _agent_fingerprint(_make_identity(role="lead")) != base
+        assert _agent_fingerprint(_make_identity(skills=("go",))) != base
+
+    @pytest.mark.unit
+    def test_build_payload_uses_builder(self) -> None:
+        """The payload is the builder's card ``model_dump``."""
+        identity = _make_identity()
+        builder = Mock(spec=AgentCardBuilder)
+        builder.build.return_value = SimpleNamespace(
+            model_dump=lambda: {"name": "Ada"},
+        )
+        payload = _build_agent_card_payload(
+            SimpleNamespace(a2a_card_builder=builder),
+            identity,
+            "http://test.example",
+        )
+        assert payload == {"name": "Ada"}
+        builder.build.assert_called_once_with(
+            identity=identity,
+            base_url="http://test.example/api/v1/a2a",
+        )
+
+
+class TestCompanyAgentCardEndpoint:
+    """`company_agent_card` cache / build / failure behaviour."""
+
+    @pytest.mark.unit
+    async def test_miss_then_hit(self) -> None:
+        """First call assembles + caches; second call serves the cache."""
+        registry = AsyncMock(spec=AgentRegistryService)
+        registry.list_active.return_value = (_make_identity(),)
+        builder = Mock(spec=AgentCardBuilder)
+        builder.build_company_card.return_value = SimpleNamespace(
+            model_dump=lambda: {"name": "Snapshot Co"},
+        )
+        resolver = AsyncMock(spec=ConfigResolver)
+        resolver.get_str.return_value = "Snapshot Co"
+        app_state = _make_app_state(
+            registry=registry, builder=builder, resolver=resolver
+        )
+        controller = _controller()
+
+        first = await controller.company_agent_card.fn(
+            controller, _state(app_state), _make_request()
+        )
+        assert first.content == {"name": "Snapshot Co"}
+
+        second = await controller.company_agent_card.fn(
+            controller, _state(app_state), _make_request()
+        )
+        assert second.content == {"name": "Snapshot Co"}
+        builder.build_company_card.assert_called_once()
+
+    @pytest.mark.unit
+    async def test_assemble_failure_returns_503_sanitized(self) -> None:
+        """A build failure logs sanitized error fields and returns 503."""
+        registry = AsyncMock(spec=AgentRegistryService)
+        registry.list_active.side_effect = RuntimeError("db down")
+        builder = Mock(spec=AgentCardBuilder)
+        app_state = _make_app_state(registry=registry, builder=builder)
+        controller = _controller()
+
+        with patch.object(well_known, "logger") as mock_logger:
+            response = await controller.company_agent_card.fn(
+                controller, _state(app_state), _make_request()
+            )
+
+        assert response.status_code == 503
+        mock_logger.exception.assert_not_called()
+        mock_logger.error.assert_called_once()
+        kwargs = mock_logger.error.call_args.kwargs
+        assert kwargs["error_type"] == "RuntimeError"
+        assert kwargs["error"] == "RuntimeError: db down"
+        assert "exc_info" not in kwargs
+
+
+class TestAgentCardEndpoint:
+    """`agent_card` resolve-first / fingerprint / failure behaviour."""
+
+    @pytest.mark.unit
+    async def test_unknown_agent_raises_not_found(self) -> None:
+        """No matching identity surfaces as a 404."""
+        registry = AsyncMock(spec=AgentRegistryService)
+        registry.get.return_value = None
+        registry.get_by_name.return_value = None
+        builder = Mock(spec=AgentCardBuilder)
+        app_state = _make_app_state(registry=registry, builder=builder)
+        controller = _controller()
+        with pytest.raises(NotFoundError):
+            await controller.agent_card.fn(
+                controller, _state(app_state), _make_request(), "ghost"
+            )
+
+    @pytest.mark.unit
+    async def test_resolution_failure_returns_503_sanitized(self) -> None:
+        """A registry outage logs sanitized fields and returns 503."""
+        registry = AsyncMock(spec=AgentRegistryService)
+        registry.get.side_effect = RuntimeError("registry boom")
+        builder = Mock(spec=AgentCardBuilder)
+        app_state = _make_app_state(registry=registry, builder=builder)
+        controller = _controller()
+
+        with patch.object(well_known, "logger") as mock_logger:
+            response = await controller.agent_card.fn(
+                controller, _state(app_state), _make_request(), "agent-1"
+            )
+
+        assert response.status_code == 503
+        mock_logger.exception.assert_not_called()
+        kwargs = mock_logger.error.call_args.kwargs
+        assert kwargs["error_type"] == "RuntimeError"
+        assert kwargs["error"] == "RuntimeError: registry boom"
+        assert "exc_info" not in kwargs
+
+    @pytest.mark.unit
+    async def test_fresh_build_then_fingerprint_hit(self) -> None:
+        """A second call with an unchanged identity skips the builder."""
+        identity = _make_identity()
+        registry = AsyncMock(spec=AgentRegistryService)
+        registry.get.return_value = identity
+        builder = Mock(spec=AgentCardBuilder)
+        builder.build.return_value = SimpleNamespace(
+            model_dump=lambda: {"name": "Ada"},
+        )
+        app_state = _make_app_state(registry=registry, builder=builder)
+        controller = _controller()
+
+        first = await controller.agent_card.fn(
+            controller, _state(app_state), _make_request(), "agent-1"
+        )
+        assert first.content == {"name": "Ada"}
+
+        second = await controller.agent_card.fn(
+            controller, _state(app_state), _make_request(), "agent-1"
+        )
+        assert second.content == {"name": "Ada"}
+        builder.build.assert_called_once()
+
+    @pytest.mark.unit
+    async def test_identity_change_invalidates_cached_card(self) -> None:
+        """A rename changes the fingerprint, forcing a rebuild."""
+        registry = AsyncMock(spec=AgentRegistryService)
+        registry.get.return_value = _make_identity(name="Ada")
+        builder = Mock(spec=AgentCardBuilder)
+        builder.build.side_effect = [
+            SimpleNamespace(model_dump=lambda: {"name": "Ada"}),
+            SimpleNamespace(model_dump=lambda: {"name": "Grace"}),
+        ]
+        app_state = _make_app_state(registry=registry, builder=builder)
+        controller = _controller()
+
+        first = await controller.agent_card.fn(
+            controller, _state(app_state), _make_request(), "agent-1"
+        )
+        assert first.content == {"name": "Ada"}
+
+        registry.get.return_value = _make_identity(name="Grace")
+        second = await controller.agent_card.fn(
+            controller, _state(app_state), _make_request(), "agent-1"
+        )
+        assert second.content == {"name": "Grace"}
+        assert builder.build.call_count == 2
+
+    @pytest.mark.unit
+    async def test_build_failure_returns_503_sanitized(self) -> None:
+        """A card-build failure after resolution returns a sanitized 503."""
+        registry = AsyncMock(spec=AgentRegistryService)
+        registry.get.return_value = _make_identity()
+        builder = Mock(spec=AgentCardBuilder)
+        builder.build.side_effect = RuntimeError("build boom")
+        app_state = _make_app_state(registry=registry, builder=builder)
+        controller = _controller()
+
+        with patch.object(well_known, "logger") as mock_logger:
+            response = await controller.agent_card.fn(
+                controller, _state(app_state), _make_request(), "agent-1"
+            )
+
+        assert response.status_code == 503
+        mock_logger.exception.assert_not_called()
+        kwargs = mock_logger.error.call_args.kwargs
+        assert kwargs["error_type"] == "RuntimeError"
+        assert kwargs["error"] == "RuntimeError: build boom"
+        assert "exc_info" not in kwargs
+
+    @pytest.mark.unit
+    async def test_memory_error_propagates_from_resolution(self) -> None:
+        """``MemoryError`` is never swallowed into a 503."""
+        registry = AsyncMock(spec=AgentRegistryService)
+        registry.get.side_effect = MemoryError("oom")
+        builder = Mock(spec=AgentCardBuilder)
+        app_state = _make_app_state(registry=registry, builder=builder)
+        controller = _controller()
+        with pytest.raises(MemoryError):
+            await controller.agent_card.fn(
+                controller, _state(app_state), _make_request(), "agent-1"
+            )
+
+
+class TestAssembleCompanyCard:
+    """`_assemble_company_card` payload + fingerprint."""
+
+    @pytest.mark.unit
+    async def test_returns_payload_fingerprint_and_count(self) -> None:
+        """Fingerprint is derived from the sorted identity ids."""
+        registry = AsyncMock(spec=AgentRegistryService)
+        registry.list_active.return_value = (
+            _make_identity(agent_id="b"),
+            _make_identity(agent_id="a"),
+        )
+        builder = Mock(spec=AgentCardBuilder)
+        builder.build_company_card.return_value = SimpleNamespace(
+            model_dump=lambda: {"name": "Snapshot Co"},
+        )
+        resolver = AsyncMock(spec=ConfigResolver)
+        resolver.get_str.return_value = "Snapshot Co"
+        app_state = _make_app_state(
+            registry=registry, builder=builder, resolver=resolver
+        )
+
+        card_data, fingerprint, count = await _assemble_company_card(
+            app_state, "http://test.example"
+        )
+        assert card_data == {"name": "Snapshot Co"}
+        assert count == 2
+        assert len(fingerprint) == 16
+        builder.build_company_card.assert_called_once()

--- a/tests/unit/a2a/test_well_known.py
+++ b/tests/unit/a2a/test_well_known.py
@@ -1,11 +1,17 @@
 """Tests for well-known Agent Card cache helpers."""
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
 import pytest
 
 from synthorg.a2a.well_known import (
     _get_cached_card,
     _put_cached_card,
+    _resolve_company_name,
 )
+from synthorg.settings.errors import SettingNotFoundError
+from synthorg.settings.resolver import ConfigResolver
 
 
 class TestCacheHelpers:
@@ -101,3 +107,60 @@ class TestCacheHelpers:
         # No fingerprint on get: always returns if within TTL
         result = await _get_cached_card("key-1", ttl=60)
         assert result == {"name": "test"}
+
+
+def _make_resolver_stub(*, get_str_side_effect: object = None) -> AsyncMock:
+    """Return an ``AsyncMock(spec=ConfigResolver)`` with ``get_str`` configured.
+
+    ``get_str_side_effect`` can be a plain return value or an exception
+    instance. When it is an Exception, it is wired as ``side_effect``;
+    otherwise it is the ``return_value``.
+    """
+    resolver = AsyncMock(spec=ConfigResolver)
+    if isinstance(get_str_side_effect, BaseException):
+        resolver.get_str.side_effect = get_str_side_effect
+    else:
+        resolver.get_str.return_value = get_str_side_effect
+    return resolver
+
+
+class TestResolveCompanyName:
+    """`_resolve_company_name` reads through ConfigResolver with snapshot fallback."""
+
+    @pytest.mark.unit
+    async def test_resolver_value_used_on_happy_path(self) -> None:
+        """Resolver value beats the boot snapshot when present."""
+        resolver = _make_resolver_stub(get_str_side_effect="Resolved Co")
+        config = SimpleNamespace(company_name="Snapshot Co")
+        app_state = SimpleNamespace(config_resolver=resolver, config=config)
+        assert await _resolve_company_name(app_state) == "Resolved Co"
+        resolver.get_str.assert_awaited_once_with("company", "company_name")
+
+    @pytest.mark.unit
+    async def test_setting_not_found_falls_back_to_snapshot(self) -> None:
+        """A missing registered key falls back to the boot snapshot quietly."""
+        resolver = _make_resolver_stub(
+            get_str_side_effect=SettingNotFoundError("missing"),
+        )
+        config = SimpleNamespace(company_name="Snapshot Co")
+        app_state = SimpleNamespace(config_resolver=resolver, config=config)
+        assert await _resolve_company_name(app_state) == "Snapshot Co"
+
+    @pytest.mark.unit
+    async def test_unexpected_resolver_failure_falls_back_to_snapshot(self) -> None:
+        """A persistence-backend outage logs and falls back to the snapshot."""
+        resolver = _make_resolver_stub(
+            get_str_side_effect=ConnectionError("db down"),
+        )
+        config = SimpleNamespace(company_name="Snapshot Co")
+        app_state = SimpleNamespace(config_resolver=resolver, config=config)
+        assert await _resolve_company_name(app_state) == "Snapshot Co"
+
+    @pytest.mark.unit
+    async def test_memory_error_propagates(self) -> None:
+        """``MemoryError`` is re-raised, not swallowed by the fallback."""
+        resolver = _make_resolver_stub(get_str_side_effect=MemoryError("oom"))
+        config = SimpleNamespace(company_name="Snapshot Co")
+        app_state = SimpleNamespace(config_resolver=resolver, config=config)
+        with pytest.raises(MemoryError):
+            await _resolve_company_name(app_state)

--- a/tests/unit/a2a/test_well_known.py
+++ b/tests/unit/a2a/test_well_known.py
@@ -364,6 +364,35 @@ class TestCompanyAgentCardEndpoint:
         assert kwargs["error"] == "RuntimeError: db down"
         assert "exc_info" not in kwargs
 
+    @pytest.mark.unit
+    async def test_company_name_change_invalidates_cache(self) -> None:
+        """A runtime company_name write is served immediately, not at TTL."""
+        registry = AsyncMock(spec=AgentRegistryService)
+        registry.list_active.return_value = (_make_identity(),)
+        builder = Mock(spec=AgentCardBuilder)
+        builder.build_company_card.side_effect = [
+            SimpleNamespace(model_dump=lambda: {"name": "Old Co"}),
+            SimpleNamespace(model_dump=lambda: {"name": "New Co"}),
+        ]
+        resolver = AsyncMock(spec=ConfigResolver)
+        resolver.get_str.return_value = "Old Co"
+        app_state = _make_app_state(
+            registry=registry, builder=builder, resolver=resolver
+        )
+        controller = _controller()
+
+        first = await controller.company_agent_card.fn(
+            controller, _state(app_state), _make_request()
+        )
+        assert first.content == {"name": "Old Co"}
+
+        resolver.get_str.return_value = "New Co"
+        second = await controller.company_agent_card.fn(
+            controller, _state(app_state), _make_request()
+        )
+        assert second.content == {"name": "New Co"}
+        assert builder.build_company_card.call_count == 2
+
 
 class TestAgentCardEndpoint:
     """`agent_card` resolve-first / fingerprint / failure behaviour."""
@@ -489,11 +518,11 @@ class TestAgentCardEndpoint:
 
 
 class TestAssembleCompanyCard:
-    """`_assemble_company_card` payload + fingerprint."""
+    """`_assemble_company_card` payload + agent count."""
 
     @pytest.mark.unit
-    async def test_returns_payload_fingerprint_and_count(self) -> None:
-        """Fingerprint is derived from the sorted identity ids."""
+    async def test_returns_payload_and_count_for_resolved_name(self) -> None:
+        """The pre-resolved name is forwarded to the builder verbatim."""
         registry = AsyncMock(spec=AgentRegistryService)
         registry.list_active.return_value = (
             _make_identity(agent_id="b"),
@@ -501,18 +530,17 @@ class TestAssembleCompanyCard:
         )
         builder = Mock(spec=AgentCardBuilder)
         builder.build_company_card.return_value = SimpleNamespace(
-            model_dump=lambda: {"name": "Snapshot Co"},
+            model_dump=lambda: {"name": "Resolved Co"},
         )
-        resolver = AsyncMock(spec=ConfigResolver)
-        resolver.get_str.return_value = "Snapshot Co"
-        app_state = _make_app_state(
-            registry=registry, builder=builder, resolver=resolver
-        )
+        app_state = _make_app_state(registry=registry, builder=builder)
 
-        card_data, fingerprint, count = await _assemble_company_card(
-            app_state, "http://test.example"
+        card_data, count = await _assemble_company_card(
+            app_state, "http://test.example", "Resolved Co"
         )
-        assert card_data == {"name": "Snapshot Co"}
+        assert card_data == {"name": "Resolved Co"}
         assert count == 2
-        assert len(fingerprint) == 16
-        builder.build_company_card.assert_called_once()
+        builder.build_company_card.assert_called_once_with(
+            identities=registry.list_active.return_value,
+            base_url="http://test.example/api/v1/a2a",
+            company_name="Resolved Co",
+        )

--- a/tests/unit/a2a/test_well_known.py
+++ b/tests/unit/a2a/test_well_known.py
@@ -392,6 +392,12 @@ class TestCompanyAgentCardEndpoint:
         )
         assert second.content == {"name": "New Co"}
         assert builder.build_company_card.call_count == 2
+        # The rename must overwrite the same host-scoped key, not
+        # orphan a never-reused entry: exactly one company entry.
+        company_keys = [
+            k for k in well_known._card_cache if k.startswith("__company__:")
+        ]
+        assert len(company_keys) == 1
 
 
 class TestAgentCardEndpoint:

--- a/tests/unit/api/test_config.py
+++ b/tests/unit/api/test_config.py
@@ -10,6 +10,10 @@ from synthorg.api.config import (
     RateLimitTimeUnit,
     ServerConfig,
 )
+from synthorg.config.rate_limits import (
+    PerOpConcurrencyConfig,
+    PerOpRateLimitConfig,
+)
 
 
 @pytest.mark.unit
@@ -163,3 +167,107 @@ class TestRateLimitConfigMirrors:
         )
         rl = RateLimitConfig()
         assert "/api/v1/healthz" in rl.exclude_paths
+
+
+@pytest.mark.unit
+class TestPerOpOverridesMirror:
+    """Coverage for the per-operation overrides mirror integration.
+
+    The JSON-typed env vars ``SYNTHORG_API_PER_OP_RATE_LIMIT_OVERRIDES``
+    and ``SYNTHORG_API_PER_OP_CONCURRENCY_OVERRIDES`` populate the
+    Pydantic ``overrides`` dict on construction, then the existing
+    ``mode='before'`` shape validators run on the populated dict.
+    """
+
+    def test_rate_limit_overrides_env_populates_dict(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(
+            "SYNTHORG_API_PER_OP_RATE_LIMIT_OVERRIDES",
+            '{"memory.fine_tune":[2,3600]}',
+        )
+        cfg = PerOpRateLimitConfig()
+        assert cfg.overrides == {"memory.fine_tune": (2, 3600)}
+
+    def test_rate_limit_overrides_empty_env_keeps_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("SYNTHORG_API_PER_OP_RATE_LIMIT_OVERRIDES", raising=False)
+        cfg = PerOpRateLimitConfig()
+        assert cfg.overrides == {}
+
+    def test_rate_limit_overrides_invalid_env_falls_through_to_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(
+            "SYNTHORG_API_PER_OP_RATE_LIMIT_OVERRIDES",
+            "{not valid json",
+        )
+        cfg = PerOpRateLimitConfig()
+        assert cfg.overrides == {}
+
+    def test_rate_limit_overrides_caller_kwarg_wins_over_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(
+            "SYNTHORG_API_PER_OP_RATE_LIMIT_OVERRIDES",
+            '{"memory.fine_tune":[2,3600]}',
+        )
+        cfg = PerOpRateLimitConfig(overrides={"meetings.invite": (5, 60)})
+        assert cfg.overrides == {"meetings.invite": (5, 60)}
+
+    def test_rate_limit_overrides_env_with_negative_value_rejected(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(
+            "SYNTHORG_API_PER_OP_RATE_LIMIT_OVERRIDES",
+            '{"memory.fine_tune":[-1,3600]}',
+        )
+        with pytest.raises(ValidationError, match="non-negative"):
+            PerOpRateLimitConfig()
+
+    def test_concurrency_overrides_env_populates_dict(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(
+            "SYNTHORG_API_PER_OP_CONCURRENCY_OVERRIDES",
+            '{"memory.fine_tune":1}',
+        )
+        cfg = PerOpConcurrencyConfig()
+        assert cfg.overrides == {"memory.fine_tune": 1}
+
+    def test_concurrency_overrides_empty_env_keeps_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("SYNTHORG_API_PER_OP_CONCURRENCY_OVERRIDES", raising=False)
+        cfg = PerOpConcurrencyConfig()
+        assert cfg.overrides == {}
+
+    def test_concurrency_overrides_invalid_env_falls_through_to_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(
+            "SYNTHORG_API_PER_OP_CONCURRENCY_OVERRIDES",
+            "{not valid json",
+        )
+        cfg = PerOpConcurrencyConfig()
+        assert cfg.overrides == {}
+
+    def test_concurrency_overrides_env_with_negative_value_rejected(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(
+            "SYNTHORG_API_PER_OP_CONCURRENCY_OVERRIDES",
+            '{"memory.fine_tune":-1}',
+        )
+        with pytest.raises(ValidationError, match="non-negative"):
+            PerOpConcurrencyConfig()

--- a/tests/unit/engine/evolution/test_config.py
+++ b/tests/unit/engine/evolution/test_config.py
@@ -17,7 +17,9 @@ class TestEvolutionConfigDefaults:
     @pytest.mark.unit
     def test_defaults(self) -> None:
         config = EvolutionConfig()
-        assert config.enabled is True
+        # ``enabled`` defaults to False (kill-switch convention; matches
+        # the registered ``engine.evolution_enabled`` default).
+        assert config.enabled is False
         assert config.triggers.types == ("batched", "inflection")
         assert config.proposer.type == "composite"
         assert config.adapters.identity is False
@@ -33,7 +35,28 @@ class TestEvolutionConfigDefaults:
     def test_frozen(self) -> None:
         config = EvolutionConfig()
         with pytest.raises(ValueError, match="frozen"):
-            config.enabled = False  # type: ignore[misc]
+            config.enabled = True  # type: ignore[misc]
+
+    @pytest.mark.unit
+    def test_env_override_enables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SYNTHORG_ENGINE_EVOLUTION_ENABLED=true flips the mirror to True."""
+        monkeypatch.setenv("SYNTHORG_ENGINE_EVOLUTION_ENABLED", "true")
+        config = EvolutionConfig()
+        assert config.enabled is True
+
+    @pytest.mark.unit
+    def test_env_override_explicit_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SYNTHORG_ENGINE_EVOLUTION_ENABLED=false keeps the kill-switch off."""
+        monkeypatch.setenv("SYNTHORG_ENGINE_EVOLUTION_ENABLED", "false")
+        config = EvolutionConfig()
+        assert config.enabled is False
+
+    @pytest.mark.unit
+    def test_caller_kwarg_wins_over_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An explicit ``enabled=True`` kwarg beats the env override."""
+        monkeypatch.setenv("SYNTHORG_ENGINE_EVOLUTION_ENABLED", "false")
+        config = EvolutionConfig(enabled=True)
+        assert config.enabled is True
 
 
 class TestTriggerConfig:

--- a/tests/unit/engine/evolution/test_service.py
+++ b/tests/unit/engine/evolution/test_service.py
@@ -111,8 +111,10 @@ def _make_service(
 
     guard.evaluate = AsyncMock(side_effect=_make_guard_decision)
 
-    adapter = AsyncMock()
+    adapter = AsyncMock(spec=AdaptationAdapter)
     adapter.name = "test_adapter"
+    # ``axis`` is a protocol @property; PropertyMock makes the spec'd
+    # attribute return the concrete enum instead of a child mock.
     type(adapter).axis = PropertyMock(
         return_value=AdaptationAxis.PROMPT_TEMPLATE,
     )
@@ -218,7 +220,7 @@ class TestEvolutionServiceEvolve:
             side_effect=[(snap_v1,), (snap_v2,)],
         )
 
-        adapter = AsyncMock()
+        adapter = AsyncMock(spec=AdaptationAdapter)
         adapter.apply = AsyncMock()
         type(adapter).axis = PropertyMock(
             return_value=AdaptationAxis.IDENTITY,

--- a/tests/unit/engine/evolution/test_service.py
+++ b/tests/unit/engine/evolution/test_service.py
@@ -84,7 +84,11 @@ def _make_service(
 ) -> EvolutionService:
     """Build an EvolutionService with mocked dependencies."""
     if config is None:
-        config = EvolutionConfig()
+        # Tests in this module exercise the full pipeline by default;
+        # the kill-switch ``enabled`` defaults to False on a fresh
+        # install, so opt in explicitly here. Tests that want the
+        # disabled-no-op path pass ``EvolutionConfig(enabled=False)``.
+        config = EvolutionConfig(enabled=True)
 
     store = identity_store or AsyncMock()
     if identity_store is None:
@@ -187,6 +191,7 @@ class TestEvolutionServiceEvolve:
 
         proposal = _make_proposal(axis=AdaptationAxis.IDENTITY)
         config = EvolutionConfig(
+            enabled=True,
             adapters=AdapterConfig(identity=True),
         )
         identity = _make_identity()

--- a/tests/unit/settings/test_mirror_coverage.py
+++ b/tests/unit/settings/test_mirror_coverage.py
@@ -56,8 +56,12 @@ def _discover_mirror_classes() -> list[tuple[type[BaseModel], MirrorField]]:
     for module_info in pkgutil.walk_packages(synthorg.__path__, prefix="synthorg."):
         try:
             module = importlib.import_module(module_info.name)
-        except ImportError:
-            continue
+        except ImportError as exc:
+            msg = (
+                f"Failed to import {module_info.name!r} while discovering "
+                "_MIRROR_FIELDS; skipping it would silently reduce coverage."
+            )
+            raise AssertionError(msg) from exc
         for _, cls in inspect.getmembers(module, inspect.isclass):
             if cls.__module__ != module_info.name:
                 continue

--- a/tests/unit/settings/test_mirror_coverage.py
+++ b/tests/unit/settings/test_mirror_coverage.py
@@ -190,7 +190,7 @@ def _pick_distinct_float(default: float, lo: float, hi: float) -> float:
     for delta in (0.5, 0.25, 0.1, 0.01):
         for cand in (default + delta, default - delta):
             if cand != default and lo <= cand <= hi:
-                return round(cand, 6)
+                return cand
     if lo > float("-inf") and lo != default:
         return lo
     if hi < float("inf") and hi != default:

--- a/tests/unit/settings/test_mirror_coverage.py
+++ b/tests/unit/settings/test_mirror_coverage.py
@@ -1,0 +1,483 @@
+"""Regression coverage for `_MIRROR_FIELDS` and bridge-default alignment.
+
+Two parametrised gates live in this module:
+
+1. `test_mirror_field_propagates_env_override` walks every
+   `_MIRROR_FIELDS` declaration in `synthorg.*`, sets the corresponding
+   env var, constructs the owning Pydantic config, and asserts the env
+   value reaches the declared field. Discovery is via `pkgutil` +
+   `inspect`, so a new mirror class is auto-covered without touching
+   this file.
+
+2. `test_bridge_config_default_matches_registered_default` walks every
+   bridge-config field assembled by `ConfigResolver.get_*_bridge_config`
+   and asserts the Pydantic-tier `Field(default=...)` matches the
+   registered `SettingDefinition.default` after type coercion. Permanent
+   enforcement gate for the bridge_configs convention: BridgeConfig and
+   the registry must never disagree on a default.
+"""
+
+import importlib
+import inspect
+import json
+import pkgutil
+import re
+from typing import Any, Final
+
+import pytest
+from annotated_types import Ge, Gt, Le, Lt
+from pydantic import BaseModel
+from pydantic.fields import FieldInfo
+
+import synthorg
+from synthorg.settings import bridge_configs as bridge_configs_module
+from synthorg.settings import definitions as _settings_definitions  # noqa: F401
+from synthorg.settings.enums import SettingType
+from synthorg.settings.mirrors import (
+    MirrorField,
+    parse_bool,
+    parse_float,
+    parse_int,
+    parse_str_tuple_json,
+)
+from synthorg.settings.registry import get_registry
+from synthorg.settings.resolver import ConfigResolver
+
+pytestmark = pytest.mark.unit
+
+
+def _discover_mirror_classes() -> list[tuple[type[BaseModel], MirrorField]]:
+    """Walk `synthorg.*` and return every (class, MirrorField) pair.
+
+    Empty `_MIRROR_FIELDS = ()` declarations are skipped: nothing to
+    assert there.
+    """
+    pairs: list[tuple[type[BaseModel], MirrorField]] = []
+    for module_info in pkgutil.walk_packages(synthorg.__path__, prefix="synthorg."):
+        try:
+            module = importlib.import_module(module_info.name)
+        except ImportError:
+            continue
+        for _, cls in inspect.getmembers(module, inspect.isclass):
+            if cls.__module__ != module_info.name:
+                continue
+            mirrors = getattr(cls, "_MIRROR_FIELDS", None)
+            if not isinstance(mirrors, tuple) or not mirrors:
+                continue
+            for mirror in mirrors:
+                if not isinstance(mirror, MirrorField):
+                    continue
+                pairs.append((cls, mirror))
+    return pairs
+
+
+_MIRROR_CASES: Final[list[tuple[type[BaseModel], MirrorField]]] = (
+    _discover_mirror_classes()
+)
+
+
+# Classes whose default construction needs explicit kwargs because the
+# Pydantic model declares non-default required fields. The kwargs MUST
+# NOT touch the mirrored field under test, since the assertion checks
+# that the env override (not the kwarg) drove the value.
+#
+# When a new mirror class is added that cannot be default-constructed,
+# the test fails at construction with a clear error; the fix is to add
+# an entry here with the minimum required non-mirror kwargs.
+_CONSTRUCTION_KWARGS: Final[dict[str, dict[str, Any]]] = {
+    "RootConfig": {"company_name": "TestCo"},
+}
+
+
+# Per-(class, field) overrides for env values when the auto-chooser
+# cannot pick a valid value. Identity-parse mirrors whose Pydantic
+# field carries a length, pattern, or membership constraint that the
+# generic "__mirror_regression__" sentinel violates land here. The
+# value is still distinct from the registered default.
+_ENV_VALUE_OVERRIDES: Final[dict[tuple[str, str], str]] = {
+    ("BudgetConfig", "currency"): "GBP",
+    ("CompanyMemoryConfig", "backend"): "inmemory",
+}
+
+
+def _env_var_name(definition: Any) -> str:
+    """Return the env var name for a registered SettingDefinition."""
+    override = getattr(definition, "env_var_override", None)
+    if override:
+        return str(override)
+    namespace = str(definition.namespace).upper()
+    key = str(definition.key).upper()
+    return f"SYNTHORG_{namespace}_{key}"
+
+
+def _registered_default_parsed(definition: Any) -> Any:
+    """Return the registered default parsed to its semantic type."""
+    raw = definition.default
+    if raw is None:
+        return None
+    setting_type = definition.type
+    if setting_type == SettingType.BOOLEAN:
+        return parse_bool(str(raw))
+    if setting_type == SettingType.INTEGER:
+        return parse_int(str(raw))
+    if setting_type == SettingType.FLOAT:
+        return parse_float(str(raw))
+    if setting_type == SettingType.JSON:
+        return json.loads(str(raw))
+    return str(raw)
+
+
+def _field_numeric_bounds(field_info: FieldInfo) -> tuple[float, float]:
+    """Return the Pydantic ge/gt/le/lt bounds on a numeric field.
+
+    Defaults to a wide range when no constraint is declared.
+    """
+    lo = float("-inf")
+    hi = float("inf")
+    for meta in field_info.metadata:
+        if isinstance(meta, Ge):
+            lo = max(lo, float(meta.ge))  # type: ignore[arg-type]
+        elif isinstance(meta, Gt):
+            bump = 1 if isinstance(meta.gt, int) else 1e-9
+            lo = max(lo, float(meta.gt) + bump)  # type: ignore[arg-type]
+        elif isinstance(meta, Le):
+            hi = min(hi, float(meta.le))  # type: ignore[arg-type]
+        elif isinstance(meta, Lt):
+            bump = 1 if isinstance(meta.lt, int) else 1e-9
+            hi = min(hi, float(meta.lt) - bump)  # type: ignore[arg-type]
+    return lo, hi
+
+
+def _registry_bounds(definition: Any) -> tuple[float, float]:
+    """Return the registered min/max for a numeric setting."""
+    lo = float("-inf") if definition.min_value is None else float(definition.min_value)
+    hi = float("inf") if definition.max_value is None else float(definition.max_value)
+    return lo, hi
+
+
+def _pick_distinct_int(
+    default: int,
+    lo: float,
+    hi: float,
+) -> int:
+    """Pick an int within [lo, hi] that is different from default.
+
+    Tries default+1, default-1, lo, hi, and a midpoint in turn.
+    """
+    candidates: list[int] = []
+    if default + 1 <= hi:
+        candidates.append(default + 1)
+    if default - 1 >= lo:
+        candidates.append(default - 1)
+    if lo > float("-inf"):
+        candidates.append(int(lo))
+    if hi < float("inf"):
+        candidates.append(int(hi))
+    if lo > float("-inf") and hi < float("inf"):
+        candidates.append(int((lo + hi) / 2))
+    for cand in candidates:
+        if cand != default and lo <= cand <= hi:
+            return cand
+    msg = (
+        f"No int candidate distinct from default {default} within bounds"
+        f" [{lo}, {hi}] was found"
+    )
+    raise AssertionError(msg)
+
+
+def _pick_distinct_float(default: float, lo: float, hi: float) -> float:
+    """Pick a float within [lo, hi] that is different from default."""
+    for delta in (0.5, 0.25, 0.1, 0.01):
+        for cand in (default + delta, default - delta):
+            if cand != default and lo <= cand <= hi:
+                return round(cand, 6)
+    if lo > float("-inf") and lo != default:
+        return lo
+    if hi < float("inf") and hi != default:
+        return hi
+    msg = (
+        f"No float candidate distinct from default {default} within bounds"
+        f" [{lo}, {hi}] was found"
+    )
+    raise AssertionError(msg)
+
+
+def _pick_distinct_enum(
+    definition: Any,
+    default_value: Any,
+) -> str:
+    """Pick an enum value distinct from the registered default."""
+    enum_values = getattr(definition, "enum_values", ()) or ()
+    for value in enum_values:
+        if str(value) != str(default_value):
+            return str(value)
+    msg = (
+        f"Registered enum {definition.namespace}/{definition.key} has no"
+        " value distinct from the default; mirror coverage cannot exercise"
+        " the env-override branch."
+    )
+    raise AssertionError(msg)
+
+
+def _choose_env_value(  # noqa: PLR0911 -- one branch per parser type is clearer than table dispatch
+    mirror: MirrorField,
+    definition: Any,
+    cls: type[BaseModel],
+    registered_default_parsed: Any,
+) -> str:
+    """Pick an env value distinct from the registered default.
+
+    Honours both the registered ``min_value/max_value`` AND the Pydantic
+    field's ``ge/gt/le/lt`` constraints so the constructor accepts the
+    value. For enum fields, pulls a distinct value from
+    ``SettingDefinition.enum_values``.
+    """
+    parser = mirror.parse
+    if parser is parse_bool:
+        if registered_default_parsed is True:
+            return "false"
+        return "true"
+    field_info = cls.model_fields[mirror.field]
+    if parser is parse_int:
+        reg_lo, reg_hi = _registry_bounds(definition)
+        pyd_lo, pyd_hi = _field_numeric_bounds(field_info)
+        lo = max(reg_lo, pyd_lo)
+        hi = min(reg_hi, pyd_hi)
+        int_default = (
+            int(registered_default_parsed)
+            if registered_default_parsed is not None
+            else 0
+        )
+        return str(_pick_distinct_int(int_default, lo, hi))
+    if parser is parse_float:
+        reg_lo, reg_hi = _registry_bounds(definition)
+        pyd_lo, pyd_hi = _field_numeric_bounds(field_info)
+        lo = max(reg_lo, pyd_lo)
+        hi = min(reg_hi, pyd_hi)
+        float_default = (
+            float(registered_default_parsed)
+            if registered_default_parsed is not None
+            else 0.0
+        )
+        return str(_pick_distinct_float(float_default, lo, hi))
+    if parser is parse_str_tuple_json:
+        return '["__mirror_alpha__","__mirror_beta__"]'
+    parser_name = getattr(parser, "__name__", "")
+    if parser_name == "parse_json_int_pair_dict":
+        return '{"__mirror_regression__":[7,11]}'
+    if parser_name == "parse_json_int_dict":
+        return '{"__mirror_regression__":7}'
+    if parser is None:
+        # Identity-parse mirror: registered as STRING or ENUM.
+        if definition.type == SettingType.ENUM:
+            return _pick_distinct_enum(definition, registered_default_parsed)
+        return "__mirror_regression__"
+    msg = (
+        f"No env-value chooser for parser {parser_name!r};"
+        " extend _choose_env_value in tests/unit/settings/test_mirror_coverage.py"
+    )
+    raise AssertionError(msg)
+
+
+def _expected_value(mirror: MirrorField, env_value: str) -> Any:
+    """Apply mirror.parse to the env value (identity if no parser)."""
+    if mirror.parse is None:
+        return env_value
+    return mirror.parse(env_value)
+
+
+def _coerce_for_field(field_value: Any, expected: Any) -> Any:
+    """Normalise expected value to match Pydantic's post-validator shape.
+
+    Tuple fields like `csp_docs_external_origins: tuple[NotBlankStr, ...]`
+    receive a list from JSON parsing; Pydantic coerces it to a tuple. The
+    regression assertion compares against the post-construction value, so
+    expected lists are converted to tuples when the field-side value is a
+    tuple.
+    """
+    if isinstance(field_value, tuple) and isinstance(expected, list):
+        return tuple(expected)
+    if isinstance(field_value, dict) and isinstance(expected, dict):
+        # PerOpRateLimitConfig promotes inner list -> tuple in its
+        # mode="before" validator; PerOpConcurrencyConfig leaves int
+        # values alone. Match the per-key shape from the actual field.
+        coerced: dict[Any, Any] = {}
+        for k, v in expected.items():
+            actual_v = field_value.get(k)
+            if isinstance(actual_v, tuple) and isinstance(v, list):
+                coerced[k] = tuple(v)
+            else:
+                coerced[k] = v
+        return coerced
+    return expected
+
+
+@pytest.mark.parametrize(
+    ("cls", "mirror"),
+    _MIRROR_CASES,
+    ids=[f"{cls.__name__}.{m.field}" for cls, m in _MIRROR_CASES],
+)
+def test_mirror_field_propagates_env_override(
+    cls: type[BaseModel],
+    mirror: MirrorField,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every declared mirror surfaces an env override at construction."""
+    registry = get_registry()
+    definition = registry.get(str(mirror.namespace), mirror.key)
+    assert definition is not None, (
+        f"MirrorField on {cls.__name__}.{mirror.field} references"
+        f" unregistered setting {mirror.namespace}/{mirror.key}"
+    )
+
+    registered_default = _registered_default_parsed(definition)
+    override = _ENV_VALUE_OVERRIDES.get((cls.__name__, mirror.field))
+    if override is not None:
+        env_value = override
+    else:
+        env_value = _choose_env_value(mirror, definition, cls, registered_default)
+    env_name = _env_var_name(definition)
+    monkeypatch.setenv(env_name, env_value)
+
+    extra_kwargs = _CONSTRUCTION_KWARGS.get(cls.__name__, {})
+    assert mirror.field not in extra_kwargs, (
+        f"_CONSTRUCTION_KWARGS for {cls.__name__} must not override the"
+        f" mirrored field {mirror.field!r}; the test would shadow the env"
+        " override and silently pass."
+    )
+    instance = cls(**extra_kwargs)
+    actual = getattr(instance, mirror.field)
+    expected_raw = _expected_value(mirror, env_value)
+    expected = _coerce_for_field(actual, expected_raw)
+    assert actual == expected, (
+        f"{cls.__name__}.{mirror.field}: env {env_name}={env_value!r}"
+        f" did not reach the field; got {actual!r} expected {expected!r}"
+    )
+
+
+# ---------------------------------------------------------------------
+# Bridge-default gate (item 4 enforcement)
+# ---------------------------------------------------------------------
+
+
+_BRIDGE_FIELDS_CALL_RE: Final[re.Pattern[str]] = re.compile(
+    r'_resolve_bridge_fields\(\s*"([^"]+)"\s*,\s*\((.*?)\),\s*\)',
+    re.DOTALL,
+)
+_BRIDGE_FIELD_ENTRY_RE: Final[re.Pattern[str]] = re.compile(
+    r'\(\s*"([^"]+)"\s*,\s*"([^"]+)"\s*\)',
+)
+_BRIDGE_BUILDER_RE: Final[re.Pattern[str]] = re.compile(
+    r"return\s+(\w+BridgeConfig)\(",
+)
+# Captures explicit constructor remappings such as
+# ``poll_timeout_seconds=values["dispatcher_poll_timeout_seconds"]``.
+_BRIDGE_CTOR_REMAP_RE: Final[re.Pattern[str]] = re.compile(
+    r'(\w+)\s*=\s*values\[\s*"([^"]+)"\s*\]',
+)
+
+
+def _discover_bridge_entries() -> list[tuple[type[BaseModel], str, str, str, str]]:
+    """Walk ConfigResolver bridge builders and yield (cls, field, ns, key, type).
+
+    Each `get_*_bridge_config` method follows one of two shapes:
+
+    1. Default: pass-through unpack into BridgeConfig(**values), with
+       registered key == BridgeConfig field name.
+
+    2. Remapped: explicit constructor call like
+       ``return XBridgeConfig(short_field=values["namespaced_key"], ...)``
+       used when the registry key is verbose but the dataclass field
+       is short. We detect both shapes.
+    """
+    entries: list[tuple[type[BaseModel], str, str, str, str]] = []
+    for name, method in inspect.getmembers(
+        ConfigResolver, predicate=inspect.isfunction
+    ):
+        if not name.startswith("get_") or not name.endswith("_bridge_config"):
+            continue
+        source = inspect.getsource(method)
+        builder_match = _BRIDGE_BUILDER_RE.search(source)
+        call_match = _BRIDGE_FIELDS_CALL_RE.search(source)
+        if builder_match is None or call_match is None:
+            msg = (
+                f"Could not parse bridge builder {name!r}; the"
+                " `_resolve_bridge_fields` shape changed and the gate"
+                " discovery regex needs updating."
+            )
+            raise AssertionError(msg)
+        cls_name = builder_match.group(1)
+        namespace = call_match.group(1)
+        body = call_match.group(2)
+        cls = getattr(bridge_configs_module, cls_name, None)
+        assert cls is not None, (
+            f"Bridge builder {name!r} returns {cls_name!r} which is not"
+            " importable from synthorg.settings.bridge_configs."
+        )
+        # Build the registered_key -> field_name map. Default is
+        # identity; explicit remappings via ``field=values["key"]``
+        # override.
+        registered_keys: list[tuple[str, str]] = []
+        for field_match in _BRIDGE_FIELD_ENTRY_RE.finditer(body):
+            registered_key = field_match.group(1)
+            scalar_type = field_match.group(2)
+            registered_keys.append((registered_key, scalar_type))
+        remap: dict[str, str] = {}
+        builder_tail = source[builder_match.end() :]
+        for ctor_match in _BRIDGE_CTOR_REMAP_RE.finditer(builder_tail):
+            field_name = ctor_match.group(1)
+            registered_key = ctor_match.group(2)
+            remap[registered_key] = field_name
+        for registered_key, scalar_type in registered_keys:
+            field_name = remap.get(registered_key, registered_key)
+            entries.append((cls, field_name, namespace, registered_key, scalar_type))
+    return entries
+
+
+_BRIDGE_CASES: Final[list[tuple[type[BaseModel], str, str, str, str]]] = (
+    _discover_bridge_entries()
+)
+
+
+def _coerce_registered_for_bridge(definition: Any, pydantic_default: Any) -> Any:
+    """Coerce the registered default to match the Pydantic-tier shape.
+
+    Mirrors the rules used by `_resolve_bridge_fields`: BOOLEAN -> bool,
+    INTEGER -> int, FLOAT -> float, JSON -> parsed; tuple-typed fields
+    receive a JSON list whose entries are wrapped to a tuple.
+    """
+    parsed = _registered_default_parsed(definition)
+    if isinstance(pydantic_default, tuple) and isinstance(parsed, list):
+        return tuple(parsed)
+    return parsed
+
+
+@pytest.mark.parametrize(
+    ("cls", "field_name", "namespace", "registered_key"),
+    [(cls, field, ns, key) for cls, field, ns, key, _ in _BRIDGE_CASES],
+    ids=[f"{cls.__name__}.{field}" for cls, field, _, _, _ in _BRIDGE_CASES],
+)
+def test_bridge_config_default_matches_registered_default(
+    cls: type[BaseModel],
+    field_name: str,
+    namespace: str,
+    registered_key: str,
+) -> None:
+    """Every bridge field's Pydantic default agrees with the registered default."""
+    registry = get_registry()
+    definition = registry.get(namespace, registered_key)
+    assert definition is not None, (
+        f"{cls.__name__}.{field_name} bridges {namespace}/{registered_key}"
+        " but no SettingDefinition is registered."
+    )
+    assert field_name in cls.model_fields, (
+        f"{cls.__name__} has no Pydantic field {field_name!r} but its"
+        f" bridge builder references it."
+    )
+    pydantic_default = cls.model_fields[field_name].default
+    expected = _coerce_registered_for_bridge(definition, pydantic_default)
+    assert pydantic_default == expected, (
+        f"{cls.__name__}.{field_name} Pydantic default {pydantic_default!r}"
+        f" does not match registered default {expected!r} for"
+        f" {namespace}/{registered_key}"
+    )

--- a/tests/unit/settings/test_mirrors.py
+++ b/tests/unit/settings/test_mirrors.py
@@ -15,6 +15,8 @@ from synthorg.settings.mirrors import (
     apply_settings_mirrors,
     parse_bool,
     parse_int,
+    parse_json_int_dict,
+    parse_json_int_pair_dict,
 )
 
 pytestmark = pytest.mark.unit
@@ -98,3 +100,49 @@ def test_non_dict_passthrough() -> None:
     """Non-dict inputs are returned verbatim (Pydantic instance reuse path)."""
     sentinel = object()
     assert apply_settings_mirrors(sentinel, ()) is sentinel
+
+
+class TestParseJsonIntPairDict:
+    """Coverage for ``parse_json_int_pair_dict`` (PerOpRateLimit overrides)."""
+
+    def test_valid_json_returns_dict(self) -> None:
+        result = parse_json_int_pair_dict('{"op.alpha":[2,3600]}')
+        assert result == {"op.alpha": [2, 3600]}
+
+    def test_empty_object(self) -> None:
+        assert parse_json_int_pair_dict("{}") == {}
+
+    def test_invalid_json_returns_none(self) -> None:
+        assert parse_json_int_pair_dict("{not valid json") is None
+
+    def test_top_level_list_returns_none(self) -> None:
+        assert parse_json_int_pair_dict("[1, 2, 3]") is None
+
+    def test_top_level_string_returns_none(self) -> None:
+        assert parse_json_int_pair_dict('"plain"') is None
+
+    def test_non_string_key_returns_none(self) -> None:
+        # JSON object keys are always strings at the syntactic level,
+        # but defensive coverage of the post-decode guard ensures the
+        # contract holds.
+        assert parse_json_int_pair_dict('{"1":[2,3]}') == {"1": [2, 3]}
+
+
+class TestParseJsonIntDict:
+    """Coverage for ``parse_json_int_dict`` (PerOpConcurrency overrides)."""
+
+    def test_valid_json_returns_dict(self) -> None:
+        result = parse_json_int_dict('{"op.alpha":7}')
+        assert result == {"op.alpha": 7}
+
+    def test_empty_object(self) -> None:
+        assert parse_json_int_dict("{}") == {}
+
+    def test_invalid_json_returns_none(self) -> None:
+        assert parse_json_int_dict("{not valid json") is None
+
+    def test_top_level_list_returns_none(self) -> None:
+        assert parse_json_int_dict("[1, 2, 3]") is None
+
+    def test_top_level_int_returns_none(self) -> None:
+        assert parse_json_int_dict("42") is None


### PR DESCRIPTION
Closes #1907.

Follow-up to RFC #1890. Mechanical items 1-5 only; items 6-7 (re-plumb services off Pydantic Config objects; split RootConfig) remain out of scope and should be filed as their own RFCs if pursued.

## Summary

- **Item 1 — PerOp overrides mirror.** Added `parse_json_int_pair_dict` / `parse_json_int_dict` to `settings/mirrors.py` and wired `MirrorField` entries for `PerOpRateLimitConfig.overrides` (`api.per_op_rate_limit_overrides`) and `PerOpConcurrencyConfig.overrides` (`api.per_op_concurrency_overrides`). The shape validators are declared *before* `_apply_mirrors` so Pydantic v2's reverse `mode="before"` declaration order runs the mirror first and the validator on the env-populated dict.
- **Item 2 — EvolutionConfig.enabled default.** Flipped the Pydantic default from `True` to `False` to match the registered `engine.evolution_enabled` default and the kill-switch convention; restored the `MirrorField` declaration dropped in `ea24be37`. Test fixtures that drive the full evolution pipeline now opt in with `enabled=True` explicitly.
- **Item 3 — RootConfig company-field audit.** Of the five fields named in the issue, only three are actual `RootConfig` fields. `agents` / `departments` already route through `ConfigResolver` at every consumer. The single consequential snapshot read (`company_name` in `a2a/well_known.py`) now routes through `ConfigResolver.get_str` with a fail-safe snapshot fallback. `name_locales` / `description` are settings-only (not RootConfig fields); documented as such.
- **Item 4 — bridge_configs.py cross-audit.** Permanent enforcement gate added: `test_bridge_config_default_matches_registered_default` walks every `ConfigResolver.get_*_bridge_config` field and asserts the Pydantic-tier default matches the registered default. A one-off audit found **zero drift** across all 90 bridge fields.
- **Item 5 — Regression test.** `tests/unit/settings/test_mirror_coverage.py` discovers every `_MIRROR_FIELDS` declaration via `pkgutil` + `inspect`, sets the env var to a bounds-respecting distinct value, constructs the owning config, and asserts the env value reaches the field. New mirror classes are auto-covered.

## Test plan

- `uv run ruff check src/ tests/` + `ruff format` clean.
- `uv run mypy src/ tests/` clean (3797 files).
- Full unit suite: 28877 passed, 18 skipped.
- A2A agent-card integration tests pass (well_known.py controller refactor verified behaviour-preserving).
- New: parser unit tests, `TestPerOpOverridesMirror`, `TestResolveCompanyName` (incl. MemoryError + RecursionError propagation), `EvolutionConfig` env-override tests, the two parametrised mirror/bridge gates.

## Review coverage

Pre-reviewed by 16 local agents (code/python/security/async/conventions/logging/resilience/docs/test-quality/type-design/comment-rot/issue-resolution + 3 mini-pass + silent-failure). Triage at `_audit/pre-pr-review/triage.md`: 1 CRITICAL, 4 MAJOR, 1 MEDIUM, 4 LOW, 4 INFO. 8 actionable findings implemented (parser docs, validator-ordering doc, two well_known function-length extractions, AsyncMock spec, RecursionError test, mirror-coverage round() fix). LOW/INFO items 7/8/12-14 deferred per the triage rationale (match existing project convention or out of scope). The "PEP 758 except syntax error" flagged by four agents is a false positive — it is CLAUDE.md-documented and compiles on Python 3.14.

## Out of scope (file as RFCs if pursued)

- Item 6: re-plumb services off Pydantic Config snapshots onto per-call `ConfigResolver` reads.
- Item 7: split `RootConfig` into `CompanyTemplate` + `BootstrapSettings`.