### PR TITLE
refactor(ci): drop aquasecurity/trivy-action, use direct trivy binary

### DIFF
--- a/.github/.zizmor.yml
+++ b/.github/.zizmor.yml
@@ -10,9 +10,3 @@ rules:
       # access to commit signatures). Mitigated: checkout uses ref: main
       # (not PR head), no untrusted input in run: steps.
       - cla.yml
-
-  template-injection:
-    ignore:
-      # steps.scan-ref.outputs.ref is set by echo in the same job (not
-      # user-controllable). zizmor flags it at Low confidence.
-      - docker.yml

--- a/.github/actions/build-apko-base/action.yml
+++ b/.github/actions/build-apko-base/action.yml
@@ -100,7 +100,8 @@ runs:
         curl -sfL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
         curl -sfL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt" -o /tmp/trivy_checksums.txt
         (cd /tmp && grep "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy_checksums.txt | sha256sum -c -)
-        tar -xzf "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -C /usr/local/bin trivy
+        tar -xzf "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -C /tmp trivy
+        sudo install -m 0755 /tmp/trivy /usr/local/bin/trivy
 
     - name: Trivy scan
       shell: bash

--- a/.github/actions/build-apko-base/action.yml
+++ b/.github/actions/build-apko-base/action.yml
@@ -120,19 +120,14 @@ runs:
 
     - name: Trivy SARIF scan
       if: always()
-      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-      with: # zizmor: ignore[template-injection]
-        image-ref: ghcr.io/aureliolo/synthorg-${{ inputs.image-name }}-base:${{ steps.image-ref.outputs.tag }}
-        format: sarif
-        output: trivy-${{ inputs.image-name }}-base.sarif
-        exit-code: "0"
-        severity: CRITICAL,HIGH
-        # Pin trivy version as a literal so zizmor's `unpinned-tools`
-        # audit recognises the pin. Keep in sync with TRIVY_VERSION env
-        # vars used by the curl-install steps in this composite.
-        # renovate: datasource=github-releases depName=aquasecurity/trivy
-        version: v0.70.0
-        trivyignores: .github/.trivyignore.yaml
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+        IMAGE_TAG: ${{ steps.image-ref.outputs.tag }}
+      run: |
+        IMAGE_REF="ghcr.io/aureliolo/synthorg-${IMAGE_NAME}-base:${IMAGE_TAG}"
+        trivy image "${IMAGE_REF}" --format sarif --output "trivy-${IMAGE_NAME}-base.sarif" \
+          --exit-code 0 --severity CRITICAL,HIGH --ignorefile .github/.trivyignore.yaml
 
     - name: Upload SARIF to GitHub Security
       if: always()

--- a/.github/actions/build-scan-image/action.yml
+++ b/.github/actions/build-scan-image/action.yml
@@ -319,7 +319,8 @@ runs:
         curl -sfL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
         curl -sfL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt" -o /tmp/trivy_checksums.txt
         (cd /tmp && grep "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy_checksums.txt | sha256sum -c -)
-        tar -xzf "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -C /usr/local/bin trivy
+        tar -xzf "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -C /tmp trivy
+        sudo install -m 0755 /tmp/trivy /usr/local/bin/trivy
 
     # Trivy JSON + SARIF + CIS benchmark per arch. JSON feeds
     # evaluate-scan.sh (fails on CRITICAL, warns on HIGH). SARIF goes to

--- a/.github/actions/build-scan-image/action.yml
+++ b/.github/actions/build-scan-image/action.yml
@@ -89,6 +89,9 @@ inputs:
       enable.
     required: false
     default: "false"
+  trivy-version:
+    description: "Trivy version, WITHOUT a leading `v` (e.g. `0.70.0`). The release download URL adds the `v` prefix; the tarball filename does not."
+    required: true
 
 outputs:
   ref_amd64:
@@ -308,20 +311,27 @@ runs:
         DISPLAY_NAME: ${{ inputs.display-name }}
       run: scripts/report-image-size.sh "$SCAN_REF" "$DISPLAY_NAME (arm64)"
 
+    - name: Install Trivy
+      shell: bash
+      env:
+        TRIVY_VERSION: ${{ inputs.trivy-version }}
+      run: |
+        curl -sfL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+        curl -sfL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt" -o /tmp/trivy_checksums.txt
+        (cd /tmp && grep "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy_checksums.txt | sha256sum -c -)
+        tar -xzf "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -C /usr/local/bin trivy
+
     # Trivy JSON + SARIF + CIS benchmark per arch. JSON feeds
     # evaluate-scan.sh (fails on CRITICAL, warns on HIGH). SARIF goes to
     # GitHub Security for both arches with distinct categories.
     - name: Trivy scan (amd64)
-      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-      with:
-        image-ref: ${{ steps.scan-ref.outputs.ref_amd64 }}
-        format: json
-        output: trivy-${{ inputs.image-name }}-amd64.json
-        exit-code: "0"
-        severity: CRITICAL,HIGH
-        trivyignores: .github/.trivyignore.yaml
-        # renovate: datasource=github-releases depName=aquasecurity/trivy
-        version: v0.70.0
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+        SCAN_REF: ${{ steps.scan-ref.outputs.ref_amd64 }}
+      run: |
+        trivy image "${SCAN_REF}" --format json --output "trivy-${IMAGE_NAME}-amd64.json" \
+          --exit-code 0 --severity CRITICAL,HIGH --ignorefile .github/.trivyignore.yaml
 
     - name: Evaluate Trivy results (amd64)
       shell: bash
@@ -332,16 +342,13 @@ runs:
 
     - name: Trivy scan (arm64)
       if: github.event_name != 'pull_request' && inputs.enable-arm64 == 'true'
-      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-      with:
-        image-ref: ${{ steps.scan-ref.outputs.ref_arm64 }}
-        format: json
-        output: trivy-${{ inputs.image-name }}-arm64.json
-        exit-code: "0"
-        severity: CRITICAL,HIGH
-        trivyignores: .github/.trivyignore.yaml
-        # renovate: datasource=github-releases depName=aquasecurity/trivy
-        version: v0.70.0
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+        SCAN_REF: ${{ steps.scan-ref.outputs.ref_arm64 }}
+      run: |
+        trivy image "${SCAN_REF}" --format json --output "trivy-${IMAGE_NAME}-arm64.json" \
+          --exit-code 0 --severity CRITICAL,HIGH --ignorefile .github/.trivyignore.yaml
 
     - name: Evaluate Trivy results (arm64)
       if: github.event_name != 'pull_request' && inputs.enable-arm64 == 'true'
@@ -362,16 +369,13 @@ runs:
 
     - name: Trivy SARIF scan (amd64)
       if: always()
-      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-      with:
-        image-ref: ${{ steps.scan-ref.outputs.ref_amd64 }}
-        format: sarif
-        output: trivy-${{ inputs.image-name }}-amd64.sarif
-        exit-code: "0"
-        severity: CRITICAL,HIGH
-        trivyignores: .github/.trivyignore.yaml
-        # renovate: datasource=github-releases depName=aquasecurity/trivy
-        version: v0.70.0
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+        SCAN_REF: ${{ steps.scan-ref.outputs.ref_amd64 }}
+      run: |
+        trivy image "${SCAN_REF}" --format sarif --output "trivy-${IMAGE_NAME}-amd64.sarif" \
+          --exit-code 0 --severity CRITICAL,HIGH --ignorefile .github/.trivyignore.yaml
 
     - name: Upload SARIF amd64 to GitHub Security
       if: always()
@@ -382,16 +386,13 @@ runs:
 
     - name: Trivy SARIF scan (arm64)
       if: always() && github.event_name != 'pull_request' && inputs.enable-arm64 == 'true'
-      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-      with:
-        image-ref: ${{ steps.scan-ref.outputs.ref_arm64 }}
-        format: sarif
-        output: trivy-${{ inputs.image-name }}-arm64.sarif
-        exit-code: "0"
-        severity: CRITICAL,HIGH
-        trivyignores: .github/.trivyignore.yaml
-        # renovate: datasource=github-releases depName=aquasecurity/trivy
-        version: v0.70.0
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+        SCAN_REF: ${{ steps.scan-ref.outputs.ref_arm64 }}
+      run: |
+        trivy image "${SCAN_REF}" --format sarif --output "trivy-${IMAGE_NAME}-arm64.sarif" \
+          --exit-code 0 --severity CRITICAL,HIGH --ignorefile .github/.trivyignore.yaml
 
     - name: Upload SARIF arm64 to GitHub Security
       if: always() && github.event_name != 'pull_request' && inputs.enable-arm64 == 'true'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -816,8 +816,6 @@ jobs:
         run: scripts/report-image-size.sh "${SCAN_REF}" "Web"
 
       - name: Install Trivy
-        env:
-          TRIVY_VERSION: ${{ env.TRIVY_VERSION }}
         run: |
           curl -sfL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
           curl -sfL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt" -o /tmp/trivy_checksums.txt

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -532,6 +532,7 @@ jobs:
           base-image-digest: ${{ needs.build-backend-base-publish.outputs.digest }}
           base-image-artifact-name: ${{ needs.build-backend-base.outputs.artifact-name }}
           base-image-tarball-name: ${{ needs.build-backend-base.outputs.tarball-name }}
+          trivy-version: ${{ env.TRIVY_VERSION }}
           # ``LOGFIRE_PROJECT_TOKEN`` is the GHA repo secret; the
           # Dockerfile's ``embed_logfire_token.py`` step writes it
           # into ``_embedded_token.py`` before ``uv sync`` packages
@@ -810,35 +811,36 @@ jobs:
         run: echo "ref=ghcr.io/aureliolo/synthorg-web:sha-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Report image size
-        run: scripts/report-image-size.sh "${{ steps.scan-ref.outputs.ref }}" "Web"
+        env:
+          SCAN_REF: ${{ steps.scan-ref.outputs.ref }}
+        run: scripts/report-image-size.sh "${SCAN_REF}" "Web"
+
+      - name: Install Trivy
+        env:
+          TRIVY_VERSION: ${{ env.TRIVY_VERSION }}
+        run: |
+          curl -sfL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+          curl -sfL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt" -o /tmp/trivy_checksums.txt
+          (cd /tmp && grep "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy_checksums.txt | sha256sum -c -)
+          tar -xzf "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -C /usr/local/bin trivy
 
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: ${{ steps.scan-ref.outputs.ref }}
-          format: json
-          output: trivy-web.json
-          exit-code: "0"
-          severity: CRITICAL,HIGH
-          trivyignores: .github/.trivyignore.yaml
-          # renovate: datasource=github-releases depName=aquasecurity/trivy
-          version: v0.70.0
+        env:
+          SCAN_REF: ${{ steps.scan-ref.outputs.ref }}
+        run: |
+          trivy image "${SCAN_REF}" --format json --output trivy-web.json \
+            --exit-code 0 --severity CRITICAL,HIGH --ignorefile .github/.trivyignore.yaml
 
       - name: Evaluate Trivy results
         run: scripts/evaluate-scan.sh --verbose trivy-web.json "Web"
 
       - name: Trivy SARIF scan (web)
         if: always()
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: ${{ steps.scan-ref.outputs.ref }}
-          format: sarif
-          output: trivy-web.sarif
-          exit-code: "0"
-          severity: CRITICAL,HIGH
-          trivyignores: .github/.trivyignore.yaml
-          # renovate: datasource=github-releases depName=aquasecurity/trivy
-          version: v0.70.0
+        env:
+          SCAN_REF: ${{ steps.scan-ref.outputs.ref }}
+        run: |
+          trivy image "${SCAN_REF}" --format sarif --output trivy-web.sarif \
+            --exit-code 0 --severity CRITICAL,HIGH --ignorefile .github/.trivyignore.yaml
 
       - name: Upload SARIF to GitHub Security (web)
         if: always()
@@ -948,6 +950,7 @@ jobs:
           base-image-digest: ${{ needs.build-sandbox-base-publish.outputs.digest }}
           base-image-artifact-name: ${{ needs.build-sandbox-base.outputs.artifact-name }}
           base-image-tarball-name: ${{ needs.build-sandbox-base.outputs.tarball-name }}
+          trivy-version: ${{ env.TRIVY_VERSION }}
 
   build-sandbox-publish:
     name: Publish Sandbox
@@ -1010,6 +1013,7 @@ jobs:
           base-image-digest: ${{ needs.build-sidecar-base-publish.outputs.digest }}
           base-image-artifact-name: ${{ needs.build-sidecar-base.outputs.artifact-name }}
           base-image-tarball-name: ${{ needs.build-sidecar-base.outputs.tarball-name }}
+          trivy-version: ${{ env.TRIVY_VERSION }}
 
   build-sidecar-publish:
     name: Publish Sidecar
@@ -1096,6 +1100,7 @@ jobs:
           enable-arm64: "false"
           cache-scope: fine-tune-${{ matrix.variant }}
           free-disk-space: "true"
+          trivy-version: ${{ env.TRIVY_VERSION }}
 
   build-fine-tune-publish:
     name: Publish Fine-Tune

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -820,7 +820,8 @@ jobs:
           curl -sfL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
           curl -sfL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt" -o /tmp/trivy_checksums.txt
           (cd /tmp && grep "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy_checksums.txt | sha256sum -c -)
-          tar -xzf "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -C /usr/local/bin trivy
+          tar -xzf "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -C /tmp trivy
+          sudo install -m 0755 /tmp/trivy /usr/local/bin/trivy
 
       - name: Trivy scan
         env:


### PR DESCRIPTION
## Summary

Drops the `aquasecurity/trivy-action@v0.36.0` wrapper from all 7 callsites and replaces each with direct `trivy image` shell invocations. The trivy binary is curl-installed + sha256-verified, with `TRIVY_VERSION` (`.github/workflows/docker.yml:47`) as the single source of truth.

### Why

- **Drops dual-pinning maintenance**: every `trivy-action` callsite carried a literal `version: v0.70.0` plus a Renovate marker, in addition to the curl-installed copy tracked by the `TRIVY_VERSION` env. Renovate had to keep both in sync.
- **Removes zizmor template-injection ignores**: 1 inline `# zizmor: ignore[template-injection]` block (on the trivy-action `with:` in `build-apko-base`) AND 1 workflow-level ignore (`template-injection: ignore: docker.yml` in `.zizmor.yml`) gone. The new `run:` steps consume their refs via `env:` blocks, which zizmor doesn't flag.
- **Smaller supply-chain surface**: one less external action dependency. The curl + sha256 install is the same trust root as the action's bootstrap path.

### Callsites replaced (7)

| File | Step | Format |
|---|---|---|
| `.github/actions/build-apko-base/action.yml` | Trivy SARIF scan | SARIF |
| `.github/actions/build-scan-image/action.yml` | Trivy scan (amd64) | JSON |
| `.github/actions/build-scan-image/action.yml` | Trivy scan (arm64) | JSON |
| `.github/actions/build-scan-image/action.yml` | Trivy SARIF scan (amd64) | SARIF |
| `.github/actions/build-scan-image/action.yml` | Trivy SARIF scan (arm64) | SARIF |
| `.github/workflows/docker.yml` | Trivy scan (web) | JSON |
| `.github/workflows/docker.yml` | Trivy SARIF scan (web) | SARIF |

### Plumbing

- New `trivy-version` input on `.github/actions/build-scan-image/action.yml` (required, no default). Composites don't inherit workflow `env:`, so the version is threaded through. Four callers updated in `docker.yml`: `build-backend`, `build-sandbox`, `build-sidecar`, `build-fine-tune` matrix.
- New `Install Trivy` step (curl + sha256 + tar; identical shape to the existing one at `build-apko-base/action.yml:95-103`) added to `build-scan-image` and to `docker.yml` `build-web`. `build-apko-base` already had one.
- Behaviour preserved byte-for-byte: same output paths, same `--severity CRITICAL,HIGH`, same `--exit-code 0`, same `--ignorefile .github/.trivyignore.yaml`, same SARIF categories on the downstream `codeql-action/upload-sarif` steps. The JSON scans still feed `scripts/evaluate-scan.sh` (CRITICAL = fail, HIGH = warn).

### Adjacent fix

- `.github/workflows/docker.yml` `Report image size` (build-web): switched `${{ steps.scan-ref.outputs.ref }}` from inline interpolation to an `env:` block. This is a pre-existing template-injection finding that the now-removed workflow-level `.zizmor.yml` ignore had been masking; the env-block pattern matches the new trivy steps. Without this fix the workflow-level ignore would have to be restored.

## Test plan

- `uv run pre-commit run actionlint --all-files`  passes
- `uv run pre-commit run zizmor --all-files`  passes with **fewer ignores than before** (-1 inline, -1 workflow-level)
- `grep -r "trivy-action" .github/`  empty
- `grep -r "version: v0.70.0" .github/`  empty
- Live CI: every job under `.github/workflows/docker.yml` (backend / sandbox / sidecar / fine-tune / web bases + apps + retag) must complete Trivy JSON, SARIF upload, and `evaluate-scan.sh` steps successfully on this PR. The PR run is the only way to validate end-to-end since the workflow only fires on `pull_request: branches: [main]` and `push: branches: [main]`.

## Review coverage

Pre-reviewed locally by 3 agents:
- `docs-consistency`: zero drift; no doc names `aquasecurity/trivy-action` or describes the dual-pin pattern.
- `comment-quality-rot`: no reviewer citations, no issue back-refs, no migration framing in any new comment.
- `infra-reviewer`: template-injection wrap verified across all surviving `${{ ... }}` interpolations; supply-chain sha256 check is `set -e`-safe; action SHA pins preserved; composite `trivy-version` input passed by all 4 callers; no permission broadening; no `--no-verify`; no secret echoing.

One MINOR finding (`infra-reviewer`) was addressed in commit `f276952e`: dropped a redundant `env: TRIVY_VERSION: ${{ env.TRIVY_VERSION }}` block on the `Install Trivy` step in `build-web` (workflow-level env was already visible).

## Out of scope

- Refactoring the three Install Trivy blocks (now in `build-apko-base`, `build-scan-image`, `docker.yml` build-web) into a shared `setup-trivy` composite. Three 5-line copies are acceptable.
- The `# zizmor: ignore[github-app]` blocks on `owner:` lines (tracked separately by #1937).
- The other inline `# zizmor: ignore[template-injection]` blocks on `actions/upload-artifact` and `github/codeql-action/upload-sarif` (not on trivy-action `with:`).
