### PR TITLE
fix(providers): read supports_native_streaming from litellm model info

### DIFF
--- a/src/synthorg/providers/drivers/litellm_driver.py
+++ b/src/synthorg/providers/drivers/litellm_driver.py
@@ -340,7 +340,8 @@ class LiteLLMDriver(BaseCompletionProvider):
         max_output = int(
             info.get("max_output_tokens", 0) or info.get("max_tokens", 0) or fallback,
         )
-        supports_streaming = bool(info.get("supports_streaming", True))
+        streaming_raw = info.get("supports_native_streaming")
+        supports_streaming = True if streaming_raw is None else bool(streaming_raw)
         supports_tools = bool(
             info.get("supports_function_calling", False),
         )

--- a/tests/unit/providers/drivers/test_litellm_driver.py
+++ b/tests/unit/providers/drivers/test_litellm_driver.py
@@ -726,12 +726,31 @@ class TestGetModelCapabilities:
         assert caps.model_id == "test-model-001"
         assert caps.max_output_tokens == 4096
 
-    async def test_streaming_capability_from_model_info(self) -> None:
-        """supports_streaming reads from model info, not hard-coded."""
+    @pytest.mark.parametrize(
+        (
+            "supports_native_streaming",
+            "supports_function_calling",
+            "expected_streaming",
+            "expected_streaming_tool_calls",
+        ),
+        [
+            pytest.param(False, True, False, False, id="streaming_false"),
+            pytest.param(True, False, True, False, id="tools_false"),
+            pytest.param(None, True, True, True, id="streaming_none_defaults_true"),
+        ],
+    )
+    async def test_streaming_capabilities(
+        self,
+        supports_native_streaming: bool | None,
+        supports_function_calling: bool,
+        expected_streaming: bool,
+        expected_streaming_tool_calls: bool,
+    ) -> None:
+        """supports_streaming follows model_info; None is treated as unknown."""
         driver = _make_driver()
         model_info = {
-            "supports_native_streaming": False,
-            "supports_function_calling": True,
+            "supports_native_streaming": supports_native_streaming,
+            "supports_function_calling": supports_function_calling,
         }
 
         with patch(
@@ -740,42 +759,8 @@ class TestGetModelCapabilities:
         ):
             caps = await driver.get_model_capabilities("medium")
 
-        assert caps.supports_streaming is False
-        assert caps.supports_streaming_tool_calls is False
-
-    async def test_streaming_tool_calls_requires_both(self) -> None:
-        """supports_streaming_tool_calls needs streaming AND tools."""
-        driver = _make_driver()
-        model_info = {
-            "supports_native_streaming": True,
-            "supports_function_calling": False,
-        }
-
-        with patch(
-            _PATCH_MODEL_INFO,
-            return_value=model_info,
-        ):
-            caps = await driver.get_model_capabilities("medium")
-
-        assert caps.supports_streaming is True
-        assert caps.supports_streaming_tool_calls is False
-
-    async def test_streaming_defaults_true_when_litellm_returns_none(self) -> None:
-        """None means unknown (LiteLLM's own convention); default to True."""
-        driver = _make_driver()
-        model_info = {
-            "supports_native_streaming": None,
-            "supports_function_calling": True,
-        }
-
-        with patch(
-            _PATCH_MODEL_INFO,
-            return_value=model_info,
-        ):
-            caps = await driver.get_model_capabilities("medium")
-
-        assert caps.supports_streaming is True
-        assert caps.supports_streaming_tool_calls is True
+        assert caps.supports_streaming is expected_streaming
+        assert caps.supports_streaming_tool_calls is expected_streaming_tool_calls
 
     async def test_max_output_capped_at_context(self) -> None:
         config = make_provider_config(

--- a/tests/unit/providers/drivers/test_litellm_driver.py
+++ b/tests/unit/providers/drivers/test_litellm_driver.py
@@ -730,7 +730,7 @@ class TestGetModelCapabilities:
         """supports_streaming reads from model info, not hard-coded."""
         driver = _make_driver()
         model_info = {
-            "supports_streaming": False,
+            "supports_native_streaming": False,
             "supports_function_calling": True,
         }
 
@@ -747,7 +747,7 @@ class TestGetModelCapabilities:
         """supports_streaming_tool_calls needs streaming AND tools."""
         driver = _make_driver()
         model_info = {
-            "supports_streaming": True,
+            "supports_native_streaming": True,
             "supports_function_calling": False,
         }
 
@@ -759,6 +759,23 @@ class TestGetModelCapabilities:
 
         assert caps.supports_streaming is True
         assert caps.supports_streaming_tool_calls is False
+
+    async def test_streaming_defaults_true_when_litellm_returns_none(self) -> None:
+        """None means unknown (LiteLLM's own convention); default to True."""
+        driver = _make_driver()
+        model_info = {
+            "supports_native_streaming": None,
+            "supports_function_calling": True,
+        }
+
+        with patch(
+            _PATCH_MODEL_INFO,
+            return_value=model_info,
+        ):
+            caps = await driver.get_model_capabilities("medium")
+
+        assert caps.supports_streaming is True
+        assert caps.supports_streaming_tool_calls is True
 
     async def test_max_output_capped_at_context(self) -> None:
         config = make_provider_config(


### PR DESCRIPTION
## Summary

While verifying LiteLLM 1.84.0 compatibility (follow-up to PR #1929), discovered that `LiteLLMDriver._build_capabilities` was reading the phantom key `supports_streaming` from `litellm.get_model_info()` results. LiteLLM exposes that capability under `supports_native_streaming` instead, and has done so for at least 1.83.14 as well, so this is a pre-existing latent bug surfaced (not caused) by the version bump.

The fallback `True` masked the issue: every model silently reported `supports_streaming=True` regardless of what LiteLLM actually said. After this fix, the driver honors LiteLLM's real answer; for models where LiteLLM reports `None` (the unknown case, common for flagship models like `gpt-4o-mini`), we still default to `True` to match LiteLLM's own `litellm.supports_native_streaming()` helper convention.

## Changes

- `src/synthorg/providers/drivers/litellm_driver.py`: read `supports_native_streaming`; treat `None` as unknown (defaults to `True`).
- `tests/unit/providers/drivers/test_litellm_driver.py`: rename two existing mock-dict keys to the real LiteLLM key; collapse three near-identical streaming-capability tests into one `@pytest.mark.parametrize`-d test with three cases (`streaming_false`, `tools_false`, `streaming_none_defaults_true`).

## Test plan

- `uv run python -m pytest tests/unit/providers/drivers/test_litellm_driver.py -n0` (49 passed in 0.5s).
- `uv run python -m pytest tests/ -m unit -k "litellm or provider or cost or capability or rate_limit"` (2266 passed in 47s).
- `uv run python -m pytest tests/ -m integration -k "litellm or provider or cost"` (113 passed, 1 SQLite-only skip in 88s).
- `uv run ruff check src/ tests/` and `uv run ruff format --check src/ tests/` clean.
- `uv run mypy src/ tests/` clean (3816 source files, strict).
- `scripts/check_currency_aggregation_invariant.py` and `scripts/check_provider_complete_chokepoint.py` both exit 0.

The full `pytest -n 8` run reported 3 worker-crash failures + 8 errors caused by the known Windows + Python 3.14 + testcontainers ProactorEventLoop teardown race documented in `CLAUDE.md`. These are pre-existing on `origin/main` and unrelated to this change; all crashed tests pass when run serially (`-n0`).

## Review coverage

Pre-reviewed by 7 agents (`code-reviewer`, `python-reviewer`, `docs-consistency`, `comment-quality-rot`, `conventions-enforcer`, `test-quality-reviewer`, plus `logging-audit` + `resilience-audit` + 4 mini-pass agents bundled). One Medium-severity SUGGESTION addressed (parametrize refactor of streaming tests). No Critical or Major findings.

## Context

No linked issue. This branch is a follow-up verification to PR #1929 (LiteLLM 1.83.14 -> 1.84.0 bump, merged green). Every v1.84.0 breaking change in the upstream release notes is either scoped to the LiteLLM proxy server (which we do not run) or affects an SDK surface we do not consume; the only real issue surfaced by the verification sweep is the phantom-key bug fixed here.