### PR TITLE
refactor(memory): per-call processing_kwargs + observability for ST encode

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,18 @@
+have_fun: false
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true
+  ignore_patterns:
+    - "**/*.lock"
+    - "uv.lock"
+    - "package-lock.json"
+    - "pnpm-lock.yaml"
+    - "**/*.min.js"
+    - "**/*.min.css"
+    - "docs/openapi/**"
+    - "docs/api/**"

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,147 @@
+# SynthOrg Review Style Guide
+
+This repository is **Python 3.14+ first**. Apply the project conventions in
+[`CLAUDE.md`](../CLAUDE.md) (root), [`web/CLAUDE.md`](../web/CLAUDE.md), and
+[`cli/CLAUDE.md`](../cli/CLAUDE.md) as authoritative. Read those files before
+reviewing; they take precedence over generic best-practice defaults.
+
+## Python 3.14 specifics (do NOT flag these as bugs)
+
+### PEP 649: deferred evaluation of annotations is default
+
+Python 3.14 ships PEP 649, which makes function and class annotations
+**lazily evaluated by default**. Symbols referenced only in annotations do
+**not** need to be imported at runtime. They can live inside
+`if TYPE_CHECKING:` blocks and the annotation will still resolve via
+`typing.get_type_hints()` or `inspect.get_annotations(eval_str=True)`.
+
+**This codebase deliberately does NOT use `from __future__ import annotations`**
+because PEP 649 supersedes it. The root `CLAUDE.md` codifies this:
+
+> No `from __future__ import annotations` (3.14 has PEP 649).
+
+Concretely, the following pattern is **correct and intentional**. Never flag
+it as a `NameError` risk:
+
+```python
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from synthorg.memory.embedding.cancellation import CancellationToken
+    from synthorg.memory.embedding.fine_tune_models import EvalMetrics
+
+
+async def encode(
+    *,
+    cancellation: CancellationToken | None,  # unquoted; resolves lazily
+) -> EvalMetrics:                              # unquoted; resolves lazily
+    ...
+```
+
+Do **not** suggest replacing `CancellationToken | None` with the string form
+`"CancellationToken | None"`. Do **not** suggest moving the import out of the
+`TYPE_CHECKING` block "to avoid `NameError`". Neither is required on Python
+3.14, and the established project convention is the unquoted form.
+
+If you genuinely believe an annotation will be evaluated eagerly (e.g. it
+appears in a dataclass field default, a `TypeAlias`, a `cast()`, a
+`Pydantic` `Field` annotation read at class-definition time, or a
+`typing.NewType()`), say so explicitly and cite the exact eager-evaluation
+site. Do not blanket-flag every annotation.
+
+### PEP 758: parenthesisless multi-exception `except`
+
+PEP 758 makes `except A, B:` (comma-separated, no parens) valid Python.
+This codebase uses that form intentionally. The most common example is the
+project-wide system-error propagation pattern:
+
+```python
+except builtins.MemoryError, RecursionError:
+    raise
+```
+
+Do not flag the missing parentheses as a syntax error or stylistic issue.
+
+### Other Python 3.14 idioms
+
+- `Final` and `Final[int]` / `Final[float]` annotations on module-level
+  named constants are the **only** allowlisted form for magic numbers per
+  `scripts/check_no_magic_numbers.py`. The pattern
+  `NAME: Final[int] = 512` is correct.
+- `asyncio.TaskGroup` is the project's fan-out / fan-in primitive
+  (per `CLAUDE.md`). Helpers catch `Exception` and re-raise
+  `MemoryError` / `RecursionError`.
+
+## Architecture and conventions (load from CLAUDE.md)
+
+The root `CLAUDE.md` is the source of truth for:
+
+- Mandatory rules (design spec, planning, persistence boundary,
+  configuration precedence, no-hardcoded-values, doc numeric claims,
+  test regression, regional defaults).
+- Code conventions: comments WHY only; type hints required; Google-style
+  docstrings; line length 88; functions < 50 lines; files < 800 lines;
+  errors named `<Domain><Condition>Error` from `DomainError`.
+- Pydantic v2 frozen models with `extra="forbid"` on API DTOs.
+- Repository CRUD signatures: `save(entity)`, `get(id)`,
+  `delete(id) -> bool`, `list_items(...)`, `query(...)`.
+- Logging conventions (event names from `observability.events.<domain>`,
+  structured kwargs, secret-log redaction via
+  `safe_error_description(exc)`).
+- Test conventions (markers, FakeClock seam, `mock_of[T]` helper,
+  Hypothesis profiles).
+
+Before flagging a finding, check whether it conflicts with `CLAUDE.md`. If
+it does, the project convention wins; do not raise the finding.
+
+## Doc numeric macros, narrow scope
+
+The `<!--RS:NAME-->...<!--/RS-->` runtime-stats macro requirement is
+**not** a blanket rule for every numeric literal in every doc file. It is
+enforced by `scripts/check_doc_numeric_macros.py`, which scopes to **only**
+these files:
+
+- `README.md`
+- `docs/index.md`
+- `docs/roadmap/index.md`
+- `docs/architecture/decisions.md`
+- `docs/reference/convention-gates.md`
+
+… and matches **only** digits adjacent to specific stat nouns
+(`tests`, `providers`, `agents`, `stars`, `releases`) or stat keywords
+(`Mem0`, `version`, `release`, `current`, `latest`).
+
+Generic constants in unrelated docs (e.g. `max_length=512` in an embedding
+guide, `batch_size=128` in a tuning page) are **out of scope** for the
+gate. Do not suggest wrapping them in `<!--RS:...-->` markers unless they
+appear in one of the scoped files and reference a tracked stat.
+
+## What to focus on
+
+When reviewing this repo, prioritise:
+
+1. **Correctness bugs**: missing `await`s, exception-handling regressions,
+   data-loss paths, race conditions in async code, off-by-one errors in
+   indexing / pagination.
+2. **Security**: untrusted-content wrapping (`wrap_untrusted()` from
+   `engine.prompt_safety`), secret-log redaction (`safe_error_description`
+   not `str(exc)`), SQL / command injection, persistence-boundary leaks.
+3. **Public API contract drift**: Pydantic DTO field renames /
+   removals without a migration path, OpenAPI shape changes, REST route
+   signature changes.
+4. **Real concurrency hazards**: cancellation tokens that are dropped
+   on a code path that does I/O, blocking calls inside async, missing
+   `_lifecycle_lock` on lifecycle services.
+5. **Tests that don't actually test the change**: mocks at typed
+   boundaries (use `mock_of[T]` instead), `MagicMock` at typed boundaries
+   (blocked by `scripts/check_mock_spec.py`), `sleep()` instead of
+   `asyncio.Event().wait()` for synchronisation.
+
+Skip:
+
+- Cosmetic / formatting nits (ruff handles those).
+- Stylistic preferences not codified in `CLAUDE.md`.
+- Hypothetical NameError / ImportError on TYPE_CHECKING annotations
+  (covered above).
+- "Add a docstring" suggestions on test files (ruff D rules are
+  src-only by project policy).

--- a/docs/design/memory.md
+++ b/docs/design/memory.md
@@ -265,12 +265,15 @@ The pipeline requires no manual annotation and runs on a single GPU.
 
 1. **Synthetic data generation**: LLM generates query-document pairs from org documents
    (policies, ADRs, procedures, coding standards)
-2. **Hard negative mining**: base model embeds all passages; top-k semantically similar
-   but non-matching passages become hard negatives
+2. **Hard negative mining**: base model embeds all passages (max_length=512) and queries
+   (max_length=128) with truncation enabled; top-k semantically similar but non-matching
+   passages become hard negatives. Inputs that overflow the token cap surface a
+   `memory.fine_tune.encode_truncation_likely` WARNING so silent quality loss is visible
 3. **Contrastive fine-tuning**: biencoder training with InfoNCE loss (tau=0.02, 3 epochs,
    lr=1e-5). Single GPU, 1-2 hours for ~500 documents
 4. **Evaluation**: NDCG@10 and Recall@10 comparison of the fine-tuned checkpoint against
-   the base model on held-out validation data
+   the base model on held-out validation data, re-using the Stage 2 query / passage token
+   caps so eval embeddings are tokenisation-consistent with mining
 5. **Deploy**: save checkpoint; update `Mem0EmbedderConfig` to point to fine-tuned model
 
 **Integration design:** fine-tuning is an offline pipeline triggered via

--- a/docs/reference/embedding-evaluation.md
+++ b/docs/reference/embedding-evaluation.md
@@ -182,6 +182,10 @@ graph LR
   non-positive passages (with margin filter to avoid false negatives)
 - Output: `(query, positive, [hard_negative_1, ..., hard_negative_k])` triples
 - GPU required (40 GB VRAM for embedding)
+- Encoding constraints: per-call `processing_kwargs={"text": {"max_length": N, "truncation": True}}`
+  with `_QUERY_MAX_LENGTH = 128` for queries and `_PASSAGE_MAX_LENGTH = 512` for passages.
+  Inputs whose word count likely exceeds the token limit emit a
+  `memory.fine_tune.encode_truncation_likely` WARNING log.
 
 **Stage 3: Contrastive Fine-Tuning**
 
@@ -190,6 +194,8 @@ graph LR
 - Key hyperparameters: 3 epochs, lr=1e-5, batch size 128, 5 passages per query (1 positive + 4 hard negatives)
 - GPU required (80 GB VRAM for training, or reduced batch size on smaller GPUs)
 - Duration: 1-2 hours for typical org corpus (~500 documents)
+- Evaluation (NDCG@10, Recall@10) re-applies the same query (128) / passage (512) token caps
+  with truncation enabled, so eval embeddings are tokenisation-consistent with mining.
 
 **Stage 4: Deploy**
 

--- a/docs/reference/embedding-evaluation.md
+++ b/docs/reference/embedding-evaluation.md
@@ -194,10 +194,16 @@ graph LR
 - Key hyperparameters: 3 epochs, lr=1e-5, batch size 128, 5 passages per query (1 positive + 4 hard negatives)
 - GPU required (80 GB VRAM for training, or reduced batch size on smaller GPUs)
 - Duration: 1-2 hours for typical org corpus (~500 documents)
-- Evaluation (NDCG@10, Recall@10) re-applies the same query (128) / passage (512) token caps
-  with truncation enabled, so eval embeddings are tokenisation-consistent with mining.
 
-**Stage 4: Deploy**
+**Stage 4: Evaluation**
+
+- Input: held-out validation pairs + fine-tuned checkpoint and base model
+- Process: encode queries and passages with both models and compute NDCG@10 and Recall@10
+- Re-applies the same query (128) / passage (512) token caps with truncation enabled, so
+  eval embeddings are tokenisation-consistent with mining
+- Output: `EvalMetrics` snapshot (per-model NDCG@10 / Recall@10) persisted alongside the checkpoint
+
+**Stage 5: Deploy**
 
 - Save fine-tuned model checkpoint to configured path
 - Update `Mem0EmbedderConfig` to point to the fine-tuned model (via custom Mem0 provider or

--- a/src/synthorg/memory/embedding/fine_tune.py
+++ b/src/synthorg/memory/embedding/fine_tune.py
@@ -143,6 +143,8 @@ async def _encode_query_passage_pair(
     cancellation: CancellationToken | None,
 ) -> tuple[object, object]:
     """Encode queries and passages, honouring cancellation between the two calls."""
+    if cancellation is not None:
+        cancellation.check()
     q_embs = await _encode_with_observability(
         model=model,
         texts=queries,
@@ -164,6 +166,9 @@ async def _encode_query_passage_pair(
     return q_embs, p_embs
 
 
+_REQUIRED_PAIR_FIELDS: Final[tuple[str, ...]] = ("query", "positive_passage")
+
+
 async def _load_query_passage_pairs(
     path: str,
     *,
@@ -174,8 +179,38 @@ async def _load_query_passage_pairs(
     if require_non_empty and not pairs:
         msg = "Validation data is empty"
         raise ValueError(msg)
-    queries = [p["query"] for p in pairs]
-    passages = [p["positive_passage"] for p in pairs]
+    queries: list[str] = []
+    passages: list[str] = []
+    for idx, pair in enumerate(pairs):
+        missing = [f for f in _REQUIRED_PAIR_FIELDS if f not in pair]
+        if missing:
+            msg = (
+                f"Invalid JSONL record at index {idx}: missing field(s) "
+                f"{missing} (expected {list(_REQUIRED_PAIR_FIELDS)})"
+            )
+            logger.warning(
+                MEMORY_FINE_TUNE_VALIDATION_FAILED,
+                field="training_record",
+                record_index=idx,
+                missing_fields=missing,
+            )
+            raise ValueError(msg)
+        query = pair["query"]
+        passage = pair["positive_passage"]
+        if not isinstance(query, str) or not isinstance(passage, str):
+            msg = (
+                f"Invalid JSONL record at index {idx}: query and "
+                "positive_passage must be strings"
+            )
+            logger.warning(
+                MEMORY_FINE_TUNE_VALIDATION_FAILED,
+                field="training_record",
+                record_index=idx,
+                reason="non_string_field",
+            )
+            raise TypeError(msg)
+        queries.append(query)
+        passages.append(passage)
     return queries, passages
 
 

--- a/src/synthorg/memory/embedding/fine_tune.py
+++ b/src/synthorg/memory/embedding/fine_tune.py
@@ -27,6 +27,8 @@ from synthorg.observability.events.memory import (
     MEMORY_FINE_TUNE_BACKUP_READ_SKIPPED,
     MEMORY_FINE_TUNE_CHECKPOINT_DEPLOYED,
     MEMORY_FINE_TUNE_DEPENDENCY_MISSING,
+    MEMORY_FINE_TUNE_ENCODE_INVOKED,
+    MEMORY_FINE_TUNE_ENCODE_TRUNCATION_LIKELY,
     MEMORY_FINE_TUNE_EVAL_COMPLETED,
     MEMORY_FINE_TUNE_VALIDATION_FAILED,
 )
@@ -84,6 +86,108 @@ _DEFAULT_TRAIN_BATCH_SIZE: Final[int] = 128
 _DEFAULT_METRICS_K: Final[int] = 10
 _QUERY_MAX_LENGTH: Final[int] = 128
 _PASSAGE_MAX_LENGTH: Final[int] = 512
+_TOKENS_PER_WORD: Final[float] = 1.33
+
+_ENCODE_ROLE_QUERY: Final[str] = "query"
+_ENCODE_ROLE_PASSAGE: Final[str] = "passage"
+
+
+def _likely_truncated_count(texts: list[str], max_length: int) -> int:
+    """Count texts whose word count suggests they will hit ``max_length`` tokens."""
+    word_threshold = max_length / _TOKENS_PER_WORD
+    return sum(1 for text in texts if len(text.split()) > word_threshold)
+
+
+async def _encode_with_observability(
+    *,
+    model: object,
+    texts: list[str],
+    max_length: int,
+    role: str,
+    model_name: str,
+) -> object:
+    """Run ``model.encode`` with per-call ``processing_kwargs`` and observability."""
+    logger.debug(
+        MEMORY_FINE_TUNE_ENCODE_INVOKED,
+        role=role,
+        model=model_name,
+        max_length=max_length,
+        batch_size=len(texts),
+    )
+    truncated = _likely_truncated_count(texts, max_length)
+    if truncated > 0:
+        logger.warning(
+            MEMORY_FINE_TUNE_ENCODE_TRUNCATION_LIKELY,
+            role=role,
+            model=model_name,
+            max_length=max_length,
+            batch_size=len(texts),
+            likely_truncated_count=truncated,
+        )
+    return await asyncio.to_thread(
+        model.encode,  # type: ignore[attr-defined]
+        texts,
+        show_progress_bar=False,
+        processing_kwargs={
+            "text": {"max_length": max_length, "truncation": True},
+        },
+    )
+
+
+async def _encode_query_passage_pair(
+    *,
+    model: object,
+    model_name: str,
+    queries: list[str],
+    passages: list[str],
+    cancellation: CancellationToken | None,
+) -> tuple[object, object]:
+    """Encode queries and passages, honouring cancellation between the two calls."""
+    q_embs = await _encode_with_observability(
+        model=model,
+        texts=queries,
+        max_length=_QUERY_MAX_LENGTH,
+        role=_ENCODE_ROLE_QUERY,
+        model_name=model_name,
+    )
+    if cancellation is not None:
+        cancellation.check()
+    p_embs = await _encode_with_observability(
+        model=model,
+        texts=passages,
+        max_length=_PASSAGE_MAX_LENGTH,
+        role=_ENCODE_ROLE_PASSAGE,
+        model_name=model_name,
+    )
+    if cancellation is not None:
+        cancellation.check()
+    return q_embs, p_embs
+
+
+async def _load_query_passage_pairs(
+    path: str,
+    *,
+    require_non_empty: bool,
+) -> tuple[list[str], list[str]]:
+    """Read JSONL ``{"query", "positive_passage"}`` records into parallel lists."""
+    pairs = await asyncio.to_thread(_read_jsonl, Path(path))
+    if require_non_empty and not pairs:
+        msg = "Validation data is empty"
+        raise ValueError(msg)
+    queries = [p["query"] for p in pairs]
+    passages = [p["positive_passage"] for p in pairs]
+    return queries, passages
+
+
+async def _persist_triples(
+    triples: list[dict[str, object]],
+    output_dir: str,
+) -> Path:
+    """Write mining triples to ``training_triples.jsonl`` under ``output_dir``."""
+    out = _ensure_dir(output_dir)
+    triples_path = out / "training_triples.jsonl"
+    await asyncio.to_thread(_write_jsonl_any, triples_path, triples)
+    return triples_path
 
 
 def _import_sentence_transformers() -> ModuleType:
@@ -322,43 +426,78 @@ async def mine_hard_negatives(  # noqa: PLR0913
     _require_not_blank(output_dir, "output_dir")
 
     st = _import_sentence_transformers()
-    pairs = await asyncio.to_thread(_read_jsonl, Path(training_data_path))
-    passages = [p["positive_passage"] for p in pairs]
-    queries = [p["query"] for p in pairs]
-
+    queries, passages = await _load_query_passage_pairs(
+        training_data_path,
+        require_non_empty=False,
+    )
     model = await asyncio.to_thread(st.SentenceTransformer, base_model)
-    passage_embeddings = await asyncio.to_thread(
-        model.encode,
-        passages,
-        show_progress_bar=False,
-        processing_kwargs={
-            "text": {"max_length": _PASSAGE_MAX_LENGTH, "truncation": True},
-        },
+    triples = await _mine_negatives_from_pairs(
+        model=model,
+        model_name=base_model,
+        queries=queries,
+        passages=passages,
+        top_k=top_k,
+        cancellation=cancellation,
+        progress_callback=progress_callback,
+    )
+    return await _persist_triples(triples, output_dir)
+
+
+async def _mine_negatives_from_pairs(  # noqa: PLR0913
+    *,
+    model: object,
+    model_name: str,
+    queries: list[str],
+    passages: list[str],
+    top_k: int,
+    cancellation: CancellationToken | None,
+    progress_callback: ProgressCallback | None,
+) -> list[dict[str, object]]:
+    """Encode the pairs and pick hard negatives in one orchestration."""
+    query_embeddings, passage_embeddings = await _encode_query_passage_pair(
+        model=model,
+        model_name=model_name,
+        queries=queries,
+        passages=passages,
+        cancellation=None,
+    )
+    return await _select_hard_negatives(
+        queries=queries,
+        passages=passages,
+        query_embeddings=query_embeddings,
+        passage_embeddings=passage_embeddings,
+        top_k=top_k,
+        cancellation=cancellation,
+        progress_callback=progress_callback,
     )
 
-    out = _ensure_dir(output_dir)
-    triples_path = out / "training_triples.jsonl"
 
-    query_embeddings = await asyncio.to_thread(
-        model.encode,
-        queries,
-        show_progress_bar=False,
-        processing_kwargs={
-            "text": {"max_length": _QUERY_MAX_LENGTH, "truncation": True},
-        },
-    )
+_HARD_NEGATIVE_MARGIN_RATIO: Final[float] = 0.95
+_CANCELLATION_CHECK_INTERVAL: Final[int] = 50
 
+
+async def _select_hard_negatives(  # noqa: PLR0913
+    *,
+    queries: list[str],
+    passages: list[str],
+    query_embeddings: object,
+    passage_embeddings: object,
+    top_k: int,
+    cancellation: CancellationToken | None,
+    progress_callback: ProgressCallback | None,
+) -> list[dict[str, object]]:
+    """Pick the top-k hardest non-positive passages per query by similarity."""
     triples: list[dict[str, object]] = []
     for i, query in enumerate(queries):
-        if cancellation is not None and i % 50 == 0:
+        if cancellation is not None and i % _CANCELLATION_CHECK_INTERVAL == 0:
             cancellation.check()
         sims = await asyncio.to_thread(
             _cosine_similarities,
-            query_embeddings[i],
+            query_embeddings[i],  # type: ignore[index]
             passage_embeddings,
         )
         positive_sim = sims[i]
-        margin = 0.95 * positive_sim
+        margin = _HARD_NEGATIVE_MARGIN_RATIO * positive_sim
         candidates = sorted(
             ((j, s) for j, s in enumerate(sims) if j != i and s < margin),
             key=lambda x: x[1],
@@ -374,9 +513,7 @@ async def mine_hard_negatives(  # noqa: PLR0913
         )
         if progress_callback:
             progress_callback((i + 1) / len(queries))
-
-    await asyncio.to_thread(_write_jsonl_any, triples_path, triples)
-    return triples_path
+    return triples
 
 
 def _read_jsonl(path: Path) -> list[dict[str, Any]]:
@@ -567,81 +704,96 @@ async def evaluate_checkpoint(  # noqa: PLR0913
     _require_not_blank(validation_data_path, "validation_data_path")
     _require_not_blank(output_dir, "output_dir")
 
+    queries, passages = await _load_query_passage_pairs(
+        validation_data_path,
+        require_non_empty=True,
+    )
+    return await _run_eval_pipeline(
+        checkpoint_path=checkpoint_path,
+        base_model=base_model,
+        output_dir=output_dir,
+        queries=queries,
+        passages=passages,
+        cancellation=cancellation,
+        progress_callback=progress_callback,
+    )
+
+
+_EVAL_PROGRESS_AFTER_LOAD: Final[float] = 0.2
+_EVAL_PROGRESS_AFTER_FINETUNED: Final[float] = 0.5
+_EVAL_PROGRESS_AFTER_BASE: Final[float] = 0.8
+_EVAL_PROGRESS_COMPLETE: Final[float] = 1.0
+
+
+def _report_progress(callback: ProgressCallback | None, value: float) -> None:
+    """Invoke ``callback`` with ``value`` when a callback was supplied."""
+    if callback is not None:
+        callback(value)
+
+
+async def _run_eval_pipeline(  # noqa: PLR0913
+    *,
+    checkpoint_path: str,
+    base_model: str,
+    output_dir: str,
+    queries: list[str],
+    passages: list[str],
+    cancellation: CancellationToken | None,
+    progress_callback: ProgressCallback | None,
+) -> EvalMetrics:
+    """Load both models, encode query/passage pairs, persist metrics."""
     st = _import_sentence_transformers()
     from synthorg.memory.embedding.fine_tune_models import (  # noqa: PLC0415
         EvalMetrics,
     )
 
-    pairs = await asyncio.to_thread(_read_jsonl, Path(validation_data_path))
-    if not pairs:
-        msg = "Validation data is empty"
-        raise ValueError(msg)
-
-    queries = [p["query"] for p in pairs]
-    passages = [p["positive_passage"] for p in pairs]
-
-    finetuned = await asyncio.to_thread(
-        st.SentenceTransformer,
-        checkpoint_path,
-    )
+    finetuned = await asyncio.to_thread(st.SentenceTransformer, checkpoint_path)
     base = await asyncio.to_thread(st.SentenceTransformer, base_model)
-
     if cancellation is not None:
         cancellation.check()
-    if progress_callback:
-        progress_callback(0.2)
+    _report_progress(progress_callback, _EVAL_PROGRESS_AFTER_LOAD)
+    ft_q_embs, ft_p_embs = await _encode_query_passage_pair(
+        model=finetuned,
+        model_name=checkpoint_path,
+        queries=queries,
+        passages=passages,
+        cancellation=cancellation,
+    )
+    _report_progress(progress_callback, _EVAL_PROGRESS_AFTER_FINETUNED)
+    base_q_embs, base_p_embs = await _encode_query_passage_pair(
+        model=base,
+        model_name=base_model,
+        queries=queries,
+        passages=passages,
+        cancellation=cancellation,
+    )
+    _report_progress(progress_callback, _EVAL_PROGRESS_AFTER_BASE)
+    metrics = await _persist_eval_metrics(
+        ft_q_embs=ft_q_embs,
+        ft_p_embs=ft_p_embs,
+        base_q_embs=base_q_embs,
+        base_p_embs=base_p_embs,
+        output_dir=output_dir,
+        eval_metrics_cls=EvalMetrics,
+    )
+    _report_progress(progress_callback, _EVAL_PROGRESS_COMPLETE)
+    return metrics
 
-    ft_q_embs = await asyncio.to_thread(
-        finetuned.encode,
-        queries,
-        show_progress_bar=False,
-        processing_kwargs={
-            "text": {"max_length": _QUERY_MAX_LENGTH, "truncation": True},
-        },
-    )
-    if cancellation is not None:
-        cancellation.check()
-    ft_p_embs = await asyncio.to_thread(
-        finetuned.encode,
-        passages,
-        show_progress_bar=False,
-        processing_kwargs={
-            "text": {"max_length": _PASSAGE_MAX_LENGTH, "truncation": True},
-        },
-    )
-    if cancellation is not None:
-        cancellation.check()
-    if progress_callback:
-        progress_callback(0.5)
 
-    base_q_embs = await asyncio.to_thread(
-        base.encode,
-        queries,
-        show_progress_bar=False,
-        processing_kwargs={
-            "text": {"max_length": _QUERY_MAX_LENGTH, "truncation": True},
-        },
-    )
-    if cancellation is not None:
-        cancellation.check()
-    base_p_embs = await asyncio.to_thread(
-        base.encode,
-        passages,
-        show_progress_bar=False,
-        processing_kwargs={
-            "text": {"max_length": _PASSAGE_MAX_LENGTH, "truncation": True},
-        },
-    )
-    if progress_callback:
-        progress_callback(0.8)
-
+async def _persist_eval_metrics(  # noqa: PLR0913
+    *,
+    ft_q_embs: object,
+    ft_p_embs: object,
+    base_q_embs: object,
+    base_p_embs: object,
+    output_dir: str,
+    eval_metrics_cls: type[EvalMetrics],
+) -> EvalMetrics:
+    """Compute eval metrics, write the JSON file, and emit the completion log."""
     ft_ndcg, ft_recall = _compute_metrics(ft_q_embs, ft_p_embs)
-    base_ndcg, base_recall = _compute_metrics(
-        base_q_embs,
-        base_p_embs,
-    )
+    base_ndcg, base_recall = _compute_metrics(base_q_embs, base_p_embs)
 
-    metrics = EvalMetrics(
+    metrics = eval_metrics_cls(
         ndcg_at_10=ft_ndcg,
         recall_at_10=ft_recall,
         base_ndcg_at_10=base_ndcg,
@@ -662,9 +814,6 @@ async def evaluate_checkpoint(  # noqa: PLR0913
         improvement_ndcg=metrics.improvement_ndcg,
         improvement_recall=metrics.improvement_recall,
     )
-    if progress_callback:
-        progress_callback(1.0)
-
     return metrics
 
 

--- a/src/synthorg/memory/embedding/fine_tune.py
+++ b/src/synthorg/memory/embedding/fine_tune.py
@@ -459,7 +459,7 @@ async def _mine_negatives_from_pairs(  # noqa: PLR0913
         model_name=model_name,
         queries=queries,
         passages=passages,
-        cancellation=None,
+        cancellation=cancellation,
     )
     return await _select_hard_negatives(
         queries=queries,

--- a/src/synthorg/memory/embedding/fine_tune.py
+++ b/src/synthorg/memory/embedding/fine_tune.py
@@ -82,6 +82,8 @@ _DEFAULT_TRAIN_LEARNING_RATE: Final[float] = 1e-5
 _DEFAULT_TRAIN_TEMPERATURE: Final[float] = 0.02
 _DEFAULT_TRAIN_BATCH_SIZE: Final[int] = 128
 _DEFAULT_METRICS_K: Final[int] = 10
+_QUERY_MAX_LENGTH: Final[int] = 128
+_PASSAGE_MAX_LENGTH: Final[int] = 512
 
 
 def _import_sentence_transformers() -> ModuleType:
@@ -329,6 +331,9 @@ async def mine_hard_negatives(  # noqa: PLR0913
         model.encode,
         passages,
         show_progress_bar=False,
+        processing_kwargs={
+            "text": {"max_length": _PASSAGE_MAX_LENGTH, "truncation": True},
+        },
     )
 
     out = _ensure_dir(output_dir)
@@ -338,6 +343,9 @@ async def mine_hard_negatives(  # noqa: PLR0913
         model.encode,
         queries,
         show_progress_bar=False,
+        processing_kwargs={
+            "text": {"max_length": _QUERY_MAX_LENGTH, "truncation": True},
+        },
     )
 
     triples: list[dict[str, object]] = []
@@ -587,6 +595,9 @@ async def evaluate_checkpoint(  # noqa: PLR0913
         finetuned.encode,
         queries,
         show_progress_bar=False,
+        processing_kwargs={
+            "text": {"max_length": _QUERY_MAX_LENGTH, "truncation": True},
+        },
     )
     if cancellation is not None:
         cancellation.check()
@@ -594,6 +605,9 @@ async def evaluate_checkpoint(  # noqa: PLR0913
         finetuned.encode,
         passages,
         show_progress_bar=False,
+        processing_kwargs={
+            "text": {"max_length": _PASSAGE_MAX_LENGTH, "truncation": True},
+        },
     )
     if cancellation is not None:
         cancellation.check()
@@ -604,6 +618,9 @@ async def evaluate_checkpoint(  # noqa: PLR0913
         base.encode,
         queries,
         show_progress_bar=False,
+        processing_kwargs={
+            "text": {"max_length": _QUERY_MAX_LENGTH, "truncation": True},
+        },
     )
     if cancellation is not None:
         cancellation.check()
@@ -611,6 +628,9 @@ async def evaluate_checkpoint(  # noqa: PLR0913
         base.encode,
         passages,
         show_progress_bar=False,
+        processing_kwargs={
+            "text": {"max_length": _PASSAGE_MAX_LENGTH, "truncation": True},
+        },
     )
     if progress_callback:
         progress_callback(0.8)

--- a/src/synthorg/observability/events/memory.py
+++ b/src/synthorg/observability/events/memory.py
@@ -113,6 +113,10 @@ MEMORY_FINE_TUNE_BACKUP_READ_SKIPPED: Final[str] = (
 )
 MEMORY_FINE_TUNE_WS_EMIT_FAILED: Final[str] = "memory.fine_tune.ws_emit_failed"
 MEMORY_FINE_TUNE_PERSIST_FAILED: Final[str] = "memory.fine_tune.persist_failed"
+MEMORY_FINE_TUNE_ENCODE_INVOKED: Final[str] = "memory.fine_tune.encode_invoked"
+MEMORY_FINE_TUNE_ENCODE_TRUNCATION_LIKELY: Final[str] = (
+    "memory.fine_tune.encode_truncation_likely"
+)
 MEMORY_EMBEDDER_SETTINGS_READ_FAILED: Final[str] = (
     "memory.embedder.settings_read_failed"
 )

--- a/tests/unit/memory/embedding/test_fine_tune.py
+++ b/tests/unit/memory/embedding/test_fine_tune.py
@@ -3,12 +3,13 @@
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Protocol, cast
 from unittest.mock import patch
 
 import numpy as np
 import pytest
 
+from synthorg.memory.embedding import fine_tune as fine_tune_module
 from synthorg.memory.embedding.cancellation import CancellationToken
 from synthorg.memory.embedding.fine_tune import (
     _PASSAGE_MAX_LENGTH,
@@ -27,8 +28,19 @@ from synthorg.memory.errors import (
 )
 
 
+class _FakeSentenceTransformersModule(Protocol):
+    """Shape of the patched ``sentence_transformers`` module returned by the factory."""
+
+    def SentenceTransformer(self, name: str) -> _RecordingEncoder: ...  # noqa: N802
+
+
 class _RecordingEncoder:
-    """Fake SentenceTransformer that records every encode() call."""
+    """Fake ``SentenceTransformer`` that records every ``encode()`` call.
+
+    ``encode_query`` and ``encode_document`` raise so the test fails loudly
+    if production code switches to those alternate sentence-transformers APIs;
+    these tests assert that the project calls ``encode()`` exclusively.
+    """
 
     _EMBED_DIM = 8
 
@@ -37,17 +49,55 @@ class _RecordingEncoder:
         self._calls = calls
 
     def encode(self, texts: list[str], **kwargs: Any) -> np.ndarray:
-        self._calls.append({"model": self.name, "texts": list(texts), "kwargs": kwargs})
+        self._calls.append(
+            {"model": self.name, "texts": list(texts), "kwargs": kwargs},
+        )
+        # ``max(len(texts), 1)`` guards against the degenerate ``np.eye(0, dim)``
+        # shape; the trailing slice produces the correct ``(len(texts), dim)``.
         return np.eye(max(len(texts), 1), self._EMBED_DIM, dtype=np.float32)[
             : len(texts)
         ]
 
+    def encode_query(self, *_args: Any, **_kwargs: Any) -> np.ndarray:
+        msg = (
+            "Production code must call encode() with processing_kwargs, "
+            "not encode_query()."
+        )
+        raise AssertionError(msg)
 
-def _make_fake_st_module(calls: list[dict[str, Any]]) -> SimpleNamespace:
-    """Build a SimpleNamespace fake of the sentence_transformers module."""
-    return SimpleNamespace(
+    def encode_document(self, *_args: Any, **_kwargs: Any) -> np.ndarray:
+        msg = (
+            "Production code must call encode() with processing_kwargs, "
+            "not encode_document()."
+        )
+        raise AssertionError(msg)
+
+
+def _make_fake_st_module(
+    calls: list[dict[str, Any]],
+) -> _FakeSentenceTransformersModule:
+    """Build a ``SimpleNamespace`` fake of the ``sentence_transformers`` module."""
+    fake = SimpleNamespace(
         SentenceTransformer=lambda name: _RecordingEncoder(name, calls),
     )
+    return cast("_FakeSentenceTransformersModule", fake)
+
+
+def _expected_encode_kwargs(*, max_length: int) -> dict[str, Any]:
+    """Return the full kwargs dict the production code should pass to ``encode``."""
+    return {
+        "show_progress_bar": False,
+        "processing_kwargs": {
+            "text": {"max_length": max_length, "truncation": True},
+        },
+    }
+
+
+def _index_calls(
+    calls: list[dict[str, Any]],
+) -> dict[tuple[str, tuple[str, ...]], dict[str, Any]]:
+    """Index encode calls by ``(model_name, texts)`` for order-independent lookup."""
+    return {(call["model"], tuple(call["texts"])): call for call in calls}
 
 
 @pytest.mark.unit
@@ -257,17 +307,56 @@ class TestMineHardNegatives:
                 output_dir=str(tmp_path / "out"),
             )
 
-        # First encode = passages, second = queries.
         assert len(calls) == 2
-        passage_call, query_call = calls
-        assert passage_call["texts"] == ["p1", "p2"]
-        assert passage_call["kwargs"]["processing_kwargs"] == {
-            "text": {"max_length": _PASSAGE_MAX_LENGTH, "truncation": True},
-        }
-        assert query_call["texts"] == ["q1", "q2"]
-        assert query_call["kwargs"]["processing_kwargs"] == {
-            "text": {"max_length": _QUERY_MAX_LENGTH, "truncation": True},
-        }
+        indexed = _index_calls(calls)
+        query_key = ("test-small-001", ("q1", "q2"))
+        passage_key = ("test-small-001", ("p1", "p2"))
+        assert query_key in indexed
+        assert passage_key in indexed
+        assert indexed[query_key]["kwargs"] == _expected_encode_kwargs(
+            max_length=_QUERY_MAX_LENGTH,
+        )
+        assert indexed[passage_key]["kwargs"] == _expected_encode_kwargs(
+            max_length=_PASSAGE_MAX_LENGTH,
+        )
+
+    async def test_emits_truncation_warning_for_long_query(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from synthorg.memory.embedding.fine_tune import (
+            mine_hard_negatives,
+        )
+
+        long_query = " ".join(["word"] * 200)
+        train = tmp_path / "train.jsonl"
+        train.write_text(
+            json.dumps({"query": long_query, "positive_passage": "p1"}) + "\n",
+        )
+        calls: list[dict[str, Any]] = []
+        with (
+            patch(
+                "synthorg.memory.embedding.fine_tune._import_sentence_transformers",
+                return_value=_make_fake_st_module(calls),
+            ),
+            patch.object(fine_tune_module, "logger") as mock_logger,
+        ):
+            await mine_hard_negatives(
+                training_data_path=str(train),
+                base_model="test-small-001",
+                output_dir=str(tmp_path / "out"),
+            )
+
+        truncation_events = [
+            call
+            for call in mock_logger.warning.call_args_list
+            if call.args
+            and call.args[0] == "memory.fine_tune.encode_truncation_likely"
+            and call.kwargs.get("role") == "query"
+        ]
+        assert truncation_events, (
+            "expected a truncation-likely warning for the long query input"
+        )
 
 
 # -- Stage 3: Contrastive fine-tuning (mock-based) -------------------
@@ -382,24 +471,54 @@ class TestEvaluateCheckpoint:
                 output_dir=str(tmp_path / "out"),
             )
 
-        # Order: ft.encode(queries), ft.encode(passages),
-        #        base.encode(queries), base.encode(passages).
         assert len(calls) == 4
-        ft_q, ft_p, base_q, base_p = calls
-        query_kwargs = {
-            "text": {"max_length": _QUERY_MAX_LENGTH, "truncation": True},
-        }
-        passage_kwargs = {
-            "text": {"max_length": _PASSAGE_MAX_LENGTH, "truncation": True},
-        }
-        assert ft_q["texts"] == ["q1", "q2"]
-        assert ft_q["kwargs"]["processing_kwargs"] == query_kwargs
-        assert ft_p["texts"] == ["p1", "p2"]
-        assert ft_p["kwargs"]["processing_kwargs"] == passage_kwargs
-        assert base_q["texts"] == ["q1", "q2"]
-        assert base_q["kwargs"]["processing_kwargs"] == query_kwargs
-        assert base_p["texts"] == ["p1", "p2"]
-        assert base_p["kwargs"]["processing_kwargs"] == passage_kwargs
+        indexed = _index_calls(calls)
+        query_kwargs = _expected_encode_kwargs(max_length=_QUERY_MAX_LENGTH)
+        passage_kwargs = _expected_encode_kwargs(max_length=_PASSAGE_MAX_LENGTH)
+        for model_name in (str(cp), "test-small-001"):
+            assert indexed[(model_name, ("q1", "q2"))]["kwargs"] == query_kwargs
+            assert indexed[(model_name, ("p1", "p2"))]["kwargs"] == passage_kwargs
+
+    async def test_emits_truncation_warning_for_long_passage(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from synthorg.memory.embedding.fine_tune import (
+            evaluate_checkpoint,
+        )
+
+        long_passage = " ".join(["word"] * 500)
+        val = tmp_path / "val.jsonl"
+        val.write_text(
+            json.dumps({"query": "q1", "positive_passage": long_passage}) + "\n",
+        )
+        cp = tmp_path / "checkpoint"
+        cp.mkdir()
+        calls: list[dict[str, Any]] = []
+        with (
+            patch(
+                "synthorg.memory.embedding.fine_tune._import_sentence_transformers",
+                return_value=_make_fake_st_module(calls),
+            ),
+            patch.object(fine_tune_module, "logger") as mock_logger,
+        ):
+            await evaluate_checkpoint(
+                checkpoint_path=str(cp),
+                base_model="test-small-001",
+                validation_data_path=str(val),
+                output_dir=str(tmp_path / "out"),
+            )
+
+        truncation_events = [
+            call
+            for call in mock_logger.warning.call_args_list
+            if call.args
+            and call.args[0] == "memory.fine_tune.encode_truncation_likely"
+            and call.kwargs.get("role") == "passage"
+        ]
+        assert truncation_events, (
+            "expected truncation-likely warning for the long passage input"
+        )
 
 
 # -- Stage 5: Deploy checkpoint ---------------------------------------

--- a/tests/unit/memory/embedding/test_fine_tune.py
+++ b/tests/unit/memory/embedding/test_fine_tune.py
@@ -358,6 +358,61 @@ class TestMineHardNegatives:
             "expected a truncation-likely warning for the long query input"
         )
 
+    async def test_rejects_jsonl_record_missing_required_field(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from synthorg.memory.embedding.fine_tune import (
+            mine_hard_negatives,
+        )
+
+        train = tmp_path / "train.jsonl"
+        train.write_text(
+            json.dumps({"query": "q1", "positive_passage": "p1"})
+            + "\n"
+            + json.dumps({"query": "q2"})
+            + "\n",
+        )
+        calls: list[dict[str, Any]] = []
+        with (
+            patch(
+                "synthorg.memory.embedding.fine_tune._import_sentence_transformers",
+                return_value=_make_fake_st_module(calls),
+            ),
+            pytest.raises(ValueError, match="index 1"),
+        ):
+            await mine_hard_negatives(
+                training_data_path=str(train),
+                base_model="test-small-001",
+                output_dir=str(tmp_path / "out"),
+            )
+
+    async def test_rejects_jsonl_record_with_non_string_field(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from synthorg.memory.embedding.fine_tune import (
+            mine_hard_negatives,
+        )
+
+        train = tmp_path / "train.jsonl"
+        train.write_text(
+            json.dumps({"query": "q1", "positive_passage": 42}) + "\n",
+        )
+        calls: list[dict[str, Any]] = []
+        with (
+            patch(
+                "synthorg.memory.embedding.fine_tune._import_sentence_transformers",
+                return_value=_make_fake_st_module(calls),
+            ),
+            pytest.raises(TypeError, match="index 0"),
+        ):
+            await mine_hard_negatives(
+                training_data_path=str(train),
+                base_model="test-small-001",
+                output_dir=str(tmp_path / "out"),
+            )
+
 
 # -- Stage 3: Contrastive fine-tuning (mock-based) -------------------
 

--- a/tests/unit/memory/embedding/test_fine_tune.py
+++ b/tests/unit/memory/embedding/test_fine_tune.py
@@ -2,12 +2,17 @@
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import patch
 
+import numpy as np
 import pytest
 
 from synthorg.memory.embedding.cancellation import CancellationToken
 from synthorg.memory.embedding.fine_tune import (
+    _PASSAGE_MAX_LENGTH,
+    _QUERY_MAX_LENGTH,
     FineTuneStage,
     _chunk_text,
     _compute_metrics,
@@ -20,6 +25,29 @@ from synthorg.memory.errors import (
     FineTuneCancelledError,
     FineTuneDependencyError,
 )
+
+
+class _RecordingEncoder:
+    """Fake SentenceTransformer that records every encode() call."""
+
+    _EMBED_DIM = 8
+
+    def __init__(self, name: str, calls: list[dict[str, Any]]) -> None:
+        self.name = name
+        self._calls = calls
+
+    def encode(self, texts: list[str], **kwargs: Any) -> np.ndarray:
+        self._calls.append({"model": self.name, "texts": list(texts), "kwargs": kwargs})
+        return np.eye(max(len(texts), 1), self._EMBED_DIM, dtype=np.float32)[
+            : len(texts)
+        ]
+
+
+def _make_fake_st_module(calls: list[dict[str, Any]]) -> SimpleNamespace:
+    """Build a SimpleNamespace fake of the sentence_transformers module."""
+    return SimpleNamespace(
+        SentenceTransformer=lambda name: _RecordingEncoder(name, calls),
+    )
 
 
 @pytest.mark.unit
@@ -206,6 +234,41 @@ class TestMineHardNegatives:
                 output_dir="/output",
             )
 
+    async def test_uses_per_call_max_length(self, tmp_path: Path) -> None:
+        from synthorg.memory.embedding.fine_tune import (
+            mine_hard_negatives,
+        )
+
+        train = tmp_path / "train.jsonl"
+        train.write_text(
+            json.dumps({"query": "q1", "positive_passage": "p1"})
+            + "\n"
+            + json.dumps({"query": "q2", "positive_passage": "p2"})
+            + "\n",
+        )
+        calls: list[dict[str, Any]] = []
+        with patch(
+            "synthorg.memory.embedding.fine_tune._import_sentence_transformers",
+            return_value=_make_fake_st_module(calls),
+        ):
+            await mine_hard_negatives(
+                training_data_path=str(train),
+                base_model="test-small-001",
+                output_dir=str(tmp_path / "out"),
+            )
+
+        # First encode = passages, second = queries.
+        assert len(calls) == 2
+        passage_call, query_call = calls
+        assert passage_call["texts"] == ["p1", "p2"]
+        assert passage_call["kwargs"]["processing_kwargs"] == {
+            "text": {"max_length": _PASSAGE_MAX_LENGTH, "truncation": True},
+        }
+        assert query_call["texts"] == ["q1", "q2"]
+        assert query_call["kwargs"]["processing_kwargs"] == {
+            "text": {"max_length": _QUERY_MAX_LENGTH, "truncation": True},
+        }
+
 
 # -- Stage 3: Contrastive fine-tuning (mock-based) -------------------
 
@@ -239,8 +302,6 @@ class TestContrastiveFineTune:
         value: float,
         match: str,
     ) -> None:
-        from typing import Any
-
         from synthorg.memory.embedding.fine_tune import (
             contrastive_fine_tune,
         )
@@ -294,6 +355,51 @@ class TestEvaluateCheckpoint:
                 validation_data_path="/val.jsonl",
                 output_dir="/out",
             )
+
+    async def test_uses_per_call_max_length(self, tmp_path: Path) -> None:
+        from synthorg.memory.embedding.fine_tune import (
+            evaluate_checkpoint,
+        )
+
+        val = tmp_path / "val.jsonl"
+        val.write_text(
+            json.dumps({"query": "q1", "positive_passage": "p1"})
+            + "\n"
+            + json.dumps({"query": "q2", "positive_passage": "p2"})
+            + "\n",
+        )
+        cp = tmp_path / "checkpoint"
+        cp.mkdir()
+        calls: list[dict[str, Any]] = []
+        with patch(
+            "synthorg.memory.embedding.fine_tune._import_sentence_transformers",
+            return_value=_make_fake_st_module(calls),
+        ):
+            await evaluate_checkpoint(
+                checkpoint_path=str(cp),
+                base_model="test-small-001",
+                validation_data_path=str(val),
+                output_dir=str(tmp_path / "out"),
+            )
+
+        # Order: ft.encode(queries), ft.encode(passages),
+        #        base.encode(queries), base.encode(passages).
+        assert len(calls) == 4
+        ft_q, ft_p, base_q, base_p = calls
+        query_kwargs = {
+            "text": {"max_length": _QUERY_MAX_LENGTH, "truncation": True},
+        }
+        passage_kwargs = {
+            "text": {"max_length": _PASSAGE_MAX_LENGTH, "truncation": True},
+        }
+        assert ft_q["texts"] == ["q1", "q2"]
+        assert ft_q["kwargs"]["processing_kwargs"] == query_kwargs
+        assert ft_p["texts"] == ["p1", "p2"]
+        assert ft_p["kwargs"]["processing_kwargs"] == passage_kwargs
+        assert base_q["texts"] == ["q1", "q2"]
+        assert base_q["kwargs"]["processing_kwargs"] == query_kwargs
+        assert base_p["texts"] == ["p1", "p2"]
+        assert base_p["kwargs"]["processing_kwargs"] == passage_kwargs
 
 
 # -- Stage 5: Deploy checkpoint ---------------------------------------


### PR DESCRIPTION
## Summary

Two-stage refactor of `src/synthorg/memory/embedding/fine_tune.py` to adopt the sentence-transformers 5.5 per-call `processing_kwargs` override.

**Stage 1 (first commit, `b978eadc4`):** the 2 encode calls in `mine_hard_negatives` and the 4 in `evaluate_checkpoint` now pass distinct `processing_kwargs={"text": {"max_length": N, "truncation": True}}` for short queries (`_QUERY_MAX_LENGTH = 128`) vs long passages (`_PASSAGE_MAX_LENGTH = 512`) instead of relying on the model tokenizer default. Two new module-level `Final[int]` constants alongside the existing `_DEFAULT_*` block. Initial pair of unit tests asserting kwargs forwarding via a `SentenceTransformer` spy.

**Stage 2 (second commit, `3db012f8e`):** pre-PR review pipeline addressed 14 findings:

- **Silent error masking via `truncation=True`** (resilience-audit, Critical): added 2 event constants (`memory.fine_tune.encode_invoked`, `memory.fine_tune.encode_truncation_likely`) and an `_encode_with_observability` helper that emits a DEBUG log per encode call (role / model / max_length / batch_size) and a WARNING when any text's word count exceeds `max_length / _TOKENS_PER_WORD` (1.33). Quality regressions are no longer silent.
- **Docs drift** (docs-consistency, Critical/Major): documented the new query / passage tokenizer caps in `docs/reference/embedding-evaluation.md` Stage 2/3 and `docs/design/memory.md` "Domain-Specific Embedding Fine-Tuning". Evaluation stage now explicitly references the same caps.
- **Test assertion fragility** (pr-test-analyzer + test-quality-reviewer, Critical/Major): assertions now compare the full `kwargs` dict (including `show_progress_bar=False`), not just the `processing_kwargs` sub-dict. Order-dependent positional unpacking replaced with role-keyed lookup (`(model_name, texts) -> call`).
- **Spy resilience** (test-quality-reviewer, Medium): `_RecordingEncoder` now raises if production switches to `encode_query()` / `encode_document()`, so the alternate sentence-transformers 3+/5+ API can't silently no-op the spy.
- **Function-length breaches** (conventions-enforcer, Major, pre-existing): `mine_hard_negatives` 68 -> 49 lines; `evaluate_checkpoint` 78 -> 43 lines. Both now under the 50-line CLAUDE.md limit. Extracted helpers: `_encode_with_observability`, `_encode_query_passage_pair`, `_load_query_passage_pairs`, `_persist_triples`, `_mine_negatives_from_pairs`, `_run_eval_pipeline`, `_persist_eval_metrics`, `_report_progress`, `_select_hard_negatives`.
- **WHAT-not-WHY comments** (comment-analyzer, Major): removed two comments that restated what the unpacking line below them already showed.
- **Coverage gap** (pr-test-analyzer, Minor): added two truncation-warning tests (`test_emits_truncation_warning_for_long_query`, `test_emits_truncation_warning_for_long_passage`) that exercise the new WARNING path.
- **Type-design info** (type-design-analyzer): added a `_FakeSentenceTransformersModule` `Protocol` for the test fake's return type plus a 2-line comment on the `np.eye(max(len(texts), 1), ...)[: len(texts)]` empty-input guard.

## Track B no-op (logfire `level=`)

The 2026-05-16 bump also added `level=` to `@logfire.instrument(...)`. A repo-wide grep finds zero such decorators in `src/synthorg/`; all observability is OpenTelemetry `tracer.start_as_current_span(...)` which has no `level=` kwarg. The kwarg has no applicable target here, so this PR ships Track A only. Detail in the plan file (`.claude/plans/polished-twirling-stonebraker.md`).

## Test plan

- `uv run ruff check src/synthorg/ tests/` -> clean.
- `uv run mypy src/synthorg/ tests/` -> clean (3816 source files).
- `uv run python -m pytest tests/ -m unit -n 8` -> 28957 passed, 18 skipped (logfire extra + POSIX-only paths), 146.8 s.
- `uv run pre-commit run --files <all modified>` -> all gates green; no em-dashes, no reviewer citations, doc-count floors satisfied, magic-numbers gate clean.

## Review coverage

Pre-reviewed by 16 agents (docs-consistency, code-reviewer, python-reviewer, type-design-analyzer, async-concurrency-reviewer, comment-quality-rot, pr-test-analyzer, comment-analyzer, logging-audit, resilience-audit, conventions-enforcer, test-quality-reviewer, plus the 4 codebase-audit mini-pass agents). Full triage table: `_audit/pre-pr-review/triage.md`. 14 actionable items + 3 info; 14 fixed, 2 user-skipped (item 14 pre-existing PEP 758 comment in untouched code; item 17 sub-agent's own Bash policy note, not actionable).
