### PR TITLE
perf(ci): mypy --num-workers=4 + enable ruff TID255

### DIFF
--- a/.claude/agents/python-reviewer.md
+++ b/.claude/agents/python-reviewer.md
@@ -11,7 +11,7 @@ You are a senior Python code reviewer ensuring high standards of Pythonic code a
 
 When invoked:
 1. Run `git diff -- '*.py'` to see recent Python file changes
-2. Run static analysis if available: `uv run ruff check src/ tests/`, `uv run mypy src/ tests/` (strict mode is configured in `pyproject.toml`, no flag needed)
+2. Run static analysis if available: `uv run ruff check src/ tests/`, `uv run mypy --num-workers=4 src/ tests/` (strict mode is configured in `pyproject.toml`, no flag needed)
 3. Focus on modified `.py` files
 4. Begin review immediately
 

--- a/.claude/agents/python-reviewer.md
+++ b/.claude/agents/python-reviewer.md
@@ -154,7 +154,7 @@ Do NOT flag the unparenthesized form as a syntax error. Do flag the parenthesize
 ```bash
 uv run ruff check src/ tests/
 uv run ruff format --check src/ tests/
-uv run mypy src/ tests/
+uv run mypy --num-workers=4 src/ tests/
 uv run python -m pytest tests/ -m unit -n 8
 uv run pre-commit run --all-files
 ```

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -345,7 +345,7 @@ Conditional gates by file type touched:
   ```bash
   uv run ruff check src/ tests/ --fix
   uv run ruff format src/ tests/
-  uv run mypy src/ tests/
+  uv run mypy --num-workers=4 src/ tests/
   uv run python -m pytest tests/ -m unit -n 8
   ```
 

--- a/.claude/skills/pre-pr-review/SKILL.md
+++ b/.claude/skills/pre-pr-review/SKILL.md
@@ -168,7 +168,7 @@ Run these sequentially, fixing as we go:
 4. **Type-check:**
 
    ```bash
-   uv run mypy src/ tests/
+   uv run mypy --num-workers=4 src/ tests/
    ```
 
 5. **Test:**
@@ -897,7 +897,7 @@ Run automated checks again (same conditional gating as Phase 2):
 
 1. `uv run ruff check src/ tests/`
 2. `uv run ruff format src/ tests/`
-3. `uv run mypy src/ tests/`
+3. `uv run mypy --num-workers=4 src/ tests/`
 4. `uv run python -m pytest tests/ -n 8`
 
 **Web dashboard checks (steps 5-7):** Run only if `web_src` or `web_test` files were changed or modified during Phase 7.
@@ -919,7 +919,7 @@ git add -A
 1. Launch `code-simplifier` on all modified files
 2. If it suggests improvements, apply them
 3. Re-run verification (same conditional gating as Phase 8):
-   - If `src_py` or `test_py` changed: `uv run ruff check src/ tests/` + `uv run ruff format src/ tests/` + `uv run mypy src/ tests/` + `uv run python -m pytest tests/ -n 8`
+   - If `src_py` or `test_py` changed: `uv run ruff check src/ tests/` + `uv run ruff format src/ tests/` + `uv run mypy --num-workers=4 src/ tests/` + `uv run python -m pytest tests/ -n 8`
    - If `web_src` or `web_test` changed: `npm --prefix web run lint` + `npm --prefix web run type-check` + `npm --prefix web run test`
 
 ## Phase 10: Commit + Push + Create PR

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -72,7 +72,7 @@ Run these before pushing:
 ```bash
 uv run ruff check src/ tests/              # lint
 uv run ruff format --check src/ tests/     # format check
-uv run mypy src/                           # type check
+uv run mypy --num-workers=4 src/ tests/    # type check
 ```
 
 Auto-fix lint and formatting issues:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
       - uses: ./.github/actions/setup-python-uv
 
       - name: mypy
-        run: uv run mypy src/ tests/
+        run: uv run mypy --num-workers=4 src/ tests/
 
   # ── Python: OpenAPI Liveness ──
   openapi-liveness:

--- a/.opencode/agents/python-reviewer.md
+++ b/.opencode/agents/python-reviewer.md
@@ -153,7 +153,7 @@ Do NOT flag the unparenthesized form as a syntax error. Do flag the parenthesize
 ```bash
 uv run ruff check src/ tests/
 uv run ruff format --check src/ tests/
-uv run mypy src/ tests/
+uv run mypy --num-workers=4 src/ tests/
 uv run python -m pytest tests/ -m unit -n 8
 uv run pre-commit run --all-files
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ uv sync --group docs                                # docs toolchain (zensical +
 bash scripts/install_cli_tools.sh                   # one-time per-machine: golangci-lint only (CI installs separately; install d2 via docs/getting_started.md)
 uv run ruff check src/ tests/ --fix                 # lint + auto-fix
 uv run ruff format src/ tests/                      # format
-uv run mypy src/ tests/                             # strict type-check
+uv run mypy --num-workers=4 src/ tests/             # strict type-check
 uv run python -m pytest tests/ -m unit                                              # -n 8 --dist=loadfile via pyproject addopts
 uv run python -m pytest tests/ -m integration
 uv run python -m pytest tests/ -m e2e

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -106,7 +106,7 @@ uv run ruff check src/ tests/
 uv run ruff format --check src/ tests/
 
 # Type check
-uv run mypy src/ tests/
+uv run mypy --num-workers=4 src/ tests/
 
 # Tests with coverage
 uv run python -m pytest tests/ -n 8 --cov=synthorg --cov-fail-under=80

--- a/docs/guides/adding-a-provider.md
+++ b/docs/guides/adding-a-provider.md
@@ -165,7 +165,7 @@ The featured/soft tier invariants are already tested generically: `test_featured
 
 ```bash
 uv run python -m pytest tests/unit/providers/test_presets.py -m unit -n 8 -v
-uv run mypy src/synthorg/providers/presets.py tests/unit/providers/test_presets.py
+uv run mypy --num-workers=4 src/synthorg/providers/presets.py tests/unit/providers/test_presets.py
 uv run ruff check src/ tests/ --fix
 uv run ruff format src/ tests/
 npm --prefix web run lint

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -92,7 +92,7 @@ Run these before pushing to ensure CI will pass:
 ```bash
 uv run ruff check src/ tests/              # lint
 uv run ruff format --check src/ tests/     # format check
-uv run mypy src/ tests/                    # type check (strict)
+uv run mypy --num-workers=4 src/ tests/    # type check (strict)
 ```
 
 Auto-fix issues:

--- a/docs/reference/conventions.md
+++ b/docs/reference/conventions.md
@@ -770,6 +770,27 @@ ordering purposes, even though they wrap a third-party logger
 under the hood. The package facade is the convention boundary; what
 it wraps is an implementation detail.
 
+## 31. Ruff lint preview rules
+
+The project opts into individual ruff preview rules via three coupled
+keys in `[tool.ruff.lint]`:
+
+* `preview = true` enables ruff's preview-rule machinery.
+* `explicit-preview-rules = true` restricts activation to preview rules
+  that are explicitly listed in `select` / `extend-select`. Without
+  this flag, `preview = true` activates every preview rule and would
+  surface hundreds of unintended violations across the codebase.
+* `extend-select` lists each preview rule the project opts into.
+
+Active preview opt-ins:
+
+* `TID255` (`lazy-import-immediately-resolved`): pre-emptive gate for
+  PEP 690 lazy imports. Currently inert on Python 3.14 (no `lazy`
+  syntax in the language yet); becomes meaningful when 3.15 lands.
+
+When adding a new preview rule, list it in `extend-select` and keep
+the `explicit-preview-rules = true` flag; never remove that flag.
+
 ## See also
 
 * [persistence-boundary.md](persistence-boundary.md): repository /

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,8 @@ line-length = 88
 src = ["src", "tests"]
 
 [tool.ruff.lint]
+preview = true
+explicit-preview-rules = true  # only opt-in to preview rules listed in extend-select
 select = [
     "F",      # pyflakes
     "E", "W", # pycodestyle
@@ -243,6 +245,9 @@ ignore = [
     # for triage without the leak. Enforced by
     # scripts/check_logger_exception_str_exc.py instead.
     "TRY400",
+]
+extend-select = [
+    "TID255",  # lazy-import-immediately-resolved; pre-emptive gate for PEP 690 lazy imports
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,8 +190,12 @@ line-length = 88
 src = ["src", "tests"]
 
 [tool.ruff.lint]
+# preview + explicit-preview-rules: required to activate TID255 (added via
+# extend-select below). Removing explicit-preview-rules would enable every
+# ruff preview rule at once, not just TID255, surfacing hundreds of
+# unintended violations across the codebase. Keep both flags together.
 preview = true
-explicit-preview-rules = true  # only opt-in to preview rules listed in extend-select
+explicit-preview-rules = true
 select = [
     "F",      # pyflakes
     "E", "W", # pycodestyle

--- a/scripts/run_affected_mypy.py
+++ b/scripts/run_affected_mypy.py
@@ -164,7 +164,7 @@ def _affected_mypy_paths(changed: list[str]) -> tuple[list[str], bool]:
 
 def _run_mypy(paths: list[str]) -> int:
     """Run mypy with the given paths."""
-    cmd = [sys.executable, "-m", "mypy", *paths]
+    cmd = [sys.executable, "-m", "mypy", "--num-workers=4", *paths]
     result = subprocess.run(cmd, cwd=_REPO_ROOT, check=False)
     return result.returncode
 

--- a/src/synthorg/api/controllers/memory.py
+++ b/src/synthorg/api/controllers/memory.py
@@ -887,7 +887,7 @@ def _check_fine_tune_sidecar_health() -> bool:
     import urllib.request  # noqa: PLC0415
 
     try:
-        req = urllib.request.Request(_FINE_TUNE_SIDECAR_HEALTH_URL)  # noqa: S310
+        req = urllib.request.Request(_FINE_TUNE_SIDECAR_HEALTH_URL)
         with urllib.request.urlopen(  # noqa: S310
             req,
             timeout=_FINE_TUNE_SIDECAR_HEALTH_TIMEOUT_S,

--- a/src/synthorg/budget/coordination_metrics.py
+++ b/src/synthorg/budget/coordination_metrics.py
@@ -281,7 +281,7 @@ class StragglerGap(BaseModel):
 # Module-level (not class-level) so the ``alert`` computed_field does
 # not pay a Pydantic field-table lookup per instance -- a class-level
 # float annotation is otherwise picked up by Pydantic's model-fields
-# inspection and adds measurable overhead (~26µs per call observed on
+# inspection and adds measurable overhead (~26μs per call observed on
 # the CodSpeed benchmark).
 _DEFAULT_TOKEN_SPEEDUP_ALERT_RATIO: Final[float] = 2.0
 

--- a/tests/unit/api/controllers/test_memory_admin.py
+++ b/tests/unit/api/controllers/test_memory_admin.py
@@ -265,6 +265,116 @@ class TestRecommendBatchSize:
                 del proxy.warning
 
 
+class _FakeHttpResponse:
+    """Minimal stand-in for the context-manager returned by ``urlopen``.
+
+    Only ``status`` is read by ``_check_fine_tune_sidecar_health``; the
+    helper wraps the call in ``with urllib.request.urlopen(...) as resp:``
+    so the fake must also be a context manager. Spec'd as a concrete
+    class so the mock-spec ratchet stays at zero.
+    """
+
+    def __init__(self, status: int) -> None:
+        self.status = status
+
+    def __enter__(self) -> _FakeHttpResponse:
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        return None
+
+
+@pytest.mark.unit
+class TestCheckFineTuneSidecarHealth:
+    """Cover the urllib-based fine-tune sidecar health probe.
+
+    The probe is wrapped in a broad try/except so callers fall back to
+    the in-process import path on any failure (DNS miss, refused
+    connection, non-2xx response, timeout, unexpected). These tests pin
+    the four branches: 2xx -> True, non-2xx -> False, expected exceptions
+    -> False, unexpected exception -> False.
+    """
+
+    def test_returns_true_on_2xx_response(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A 200 OK response flips the probe to ``True``."""
+        import urllib.request
+
+        from synthorg.api.controllers.memory import _check_fine_tune_sidecar_health
+
+        def fake_urlopen(*_args: object, **_kwargs: object) -> _FakeHttpResponse:
+            return _FakeHttpResponse(status=200)
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        assert _check_fine_tune_sidecar_health() is True
+
+    def test_returns_false_on_5xx_response(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A 503 Service Unavailable response stays at ``False``."""
+        import urllib.request
+
+        from synthorg.api.controllers.memory import _check_fine_tune_sidecar_health
+
+        def fake_urlopen(*_args: object, **_kwargs: object) -> _FakeHttpResponse:
+            return _FakeHttpResponse(status=503)
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        assert _check_fine_tune_sidecar_health() is False
+
+    def test_returns_false_on_urlerror(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Network errors are swallowed; the probe returns ``False``."""
+        import urllib.error
+        import urllib.request
+
+        from synthorg.api.controllers.memory import _check_fine_tune_sidecar_health
+
+        def raise_url_error(*_args: object, **_kwargs: object) -> object:
+            msg = "connection refused"
+            raise urllib.error.URLError(msg)
+
+        monkeypatch.setattr(urllib.request, "urlopen", raise_url_error)
+        assert _check_fine_tune_sidecar_health() is False
+
+    def test_returns_false_on_timeout(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A request that times out returns ``False`` rather than raising."""
+        import urllib.request
+
+        from synthorg.api.controllers.memory import _check_fine_tune_sidecar_health
+
+        def raise_timeout(*_args: object, **_kwargs: object) -> object:
+            msg = "probe timed out"
+            raise TimeoutError(msg)
+
+        monkeypatch.setattr(urllib.request, "urlopen", raise_timeout)
+        assert _check_fine_tune_sidecar_health() is False
+
+    def test_returns_false_on_unexpected_exception(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Any other exception lands in the catch-all, returning ``False``."""
+        import urllib.request
+
+        from synthorg.api.controllers.memory import _check_fine_tune_sidecar_health
+
+        def raise_runtime(*_args: object, **_kwargs: object) -> object:
+            msg = "unexpected probe failure"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(urllib.request, "urlopen", raise_runtime)
+        assert _check_fine_tune_sidecar_health() is False
+
+
 @pytest.mark.unit
 class TestDeleteMemoryEntryEndpoint:
     """Direct-method coverage for ``MemoryAdminController.delete_memory_entry``."""

--- a/tests/unit/api/controllers/test_memory_admin.py
+++ b/tests/unit/api/controllers/test_memory_admin.py
@@ -374,6 +374,43 @@ class TestCheckFineTuneSidecarHealth:
         monkeypatch.setattr(urllib.request, "urlopen", raise_runtime)
         assert _check_fine_tune_sidecar_health() is False
 
+    def test_reraises_memory_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``MemoryError`` is re-raised, never swallowed by the catch-all.
+
+        The helper has an explicit ``except MemoryError, RecursionError:
+        raise`` clause before the broad ``except Exception``; a system
+        error must propagate so the process is not left limping.
+        """
+        import urllib.request
+
+        from synthorg.api.controllers.memory import _check_fine_tune_sidecar_health
+
+        def raise_memory_error(*_args: object, **_kwargs: object) -> object:
+            raise MemoryError
+
+        monkeypatch.setattr(urllib.request, "urlopen", raise_memory_error)
+        with pytest.raises(MemoryError):
+            _check_fine_tune_sidecar_health()
+
+    def test_reraises_recursion_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``RecursionError`` propagates rather than being swallowed."""
+        import urllib.request
+
+        from synthorg.api.controllers.memory import _check_fine_tune_sidecar_health
+
+        def raise_recursion_error(*_args: object, **_kwargs: object) -> object:
+            raise RecursionError
+
+        monkeypatch.setattr(urllib.request, "urlopen", raise_recursion_error)
+        with pytest.raises(RecursionError):
+            _check_fine_tune_sidecar_health()
+
 
 @pytest.mark.unit
 class TestDeleteMemoryEntryEndpoint:


### PR DESCRIPTION
## Summary

Two cheap CI / perf wins:

1. **mypy 2.x parallel checking**: pass `--num-workers=4` everywhere mypy runs (CI workflow, `scripts/run_affected_mypy.py`, every doc / skill / agent that documents the local command).
2. **Ruff preview TID255** (`lazy-import-immediately-resolved`): activated now via `extend-select` + `preview = true` + `explicit-preview-rules = true`. Pre-emptive gate for PEP 690 lazy imports; currently inert on Python 3.14 (zero hits).

Preview-mode behaviour of stable rules unmasked two pre-existing findings, both fixed inline in this PR:

- `src/synthorg/api/controllers/memory.py:890`: drop unused `# noqa: S310` on `urllib.request.Request(...)`. S310 fires on `urlopen` / `urlretrieve`, not on `Request()` construction. The `noqa` on the next-line `urlopen` call is retained.
- `src/synthorg/budget/coordination_metrics.py:284`: replace ambiguous `µ` (U+00B5 MICRO SIGN) with `μ` (U+03BC GREEK SMALL LETTER MU) in a benchmark-overhead comment.

## Wall-clock measurement (local A/B)

Full-tree mypy run on this machine, both modes return `Success: no issues found in 3816 source files`:

| Cache state | `--num-workers=1` | `--num-workers=4` | Speedup |
|---|---|---|---|
| Warm | 56.7s | 3.5s | 16.2x |
| Cold (`.mypy_cache` removed) | 69.1s | 28.2s | 2.45x |

Both modes are correct (same error count, same diagnostic set). The warm-cache 16x ratio reflects parallel cache validation; the cold-cache 2.45x reflects real type-check work being parallelised. CI runs land somewhere between these two extremes depending on cache restore.

GitHub-hosted `ubuntu-latest` is 4 vCPU / 16 GB RAM since the 2024 upgrade, so 4 workers maps cleanly to available cores.

## Why `explicit-preview-rules = true` is load-bearing

`preview = true` alone would activate every ruff preview rule, surfacing hundreds of unintended violations. `explicit-preview-rules = true` confines activation to rules listed in `extend-select`, which is `["TID255"]`. A `pyproject.toml` comment makes this constraint explicit so the flag is not removed in a future cleanup.

## Pre-PR review coverage

Reviewed locally with 7 agents (`docs-consistency`, `python-reviewer`, `code-reviewer`, `security-reviewer`, `tool-parity-checker`, `comment-quality-rot`, `infra-reviewer`). 5 valid findings; all addressed in commit `195d21f10`:

1. **Worker-count justification**: kept `--num-workers=4`, added wall-clock A/B above.
2. **Docs drift**: aligned 9 follower docs / agent / skill files with the canonical CLAUDE.md command (`docs/getting_started.md`, `docs/guides/contributing.md`, `docs/guides/adding-a-provider.md`, `.github/CONTRIBUTING.md`, `.claude/agents/python-reviewer.md`, `.opencode/agents/python-reviewer.md`, `.claude/skills/pre-pr-review/SKILL.md` (×3), `.claude/skills/babysit-pr/SKILL.md`).
3. **Timing data** included above.
4. **Load-bearing comment** added above `preview = true` in `pyproject.toml`.
5. **`docs/reference/conventions.md`** gained a §31 "Ruff lint preview rules" section documenting the gate.

3 code-reviewer findings dismissed as false positives after cross-checking with security-reviewer (S310 placement is correct), infra-reviewer (ubuntu-latest is 4 vCPU not 2), and a direct file read (CLAUDE.md comment column is preserved).

## Test plan

- `uv run ruff check src/ tests/`: clean (TID255 active, zero hits).
- `uv run mypy --num-workers=4 src/ tests/`: 0 errors across 3816 source files.
- Full unit suite (30533 tests): 30533 passed / 50 skipped / 1 ERROR on `tests/unit/persistence/sqlite/test_training_plan_repo.py::test_save_and_get`. The flake is unrelated to this PR (no persistence files touched); the test passes in isolation.
- `uv run pre-commit run`: clean on all touched files.
