### PR TITLE
fix: correct invalid git for-each-ref syntax in post-merge-cleanup skill

### DIFF
--- a/.claude/skills/post-merge-cleanup/SKILL.md
+++ b/.claude/skills/post-merge-cleanup/SKILL.md
@@ -19,7 +19,7 @@ Run this after squash-merging a PR to clean up the local repo.
    First check which branches are gone using the plumbing command:
 
    ```bash
-   git for-each-ref --format='%(refname:short) %(upstream:track,gone)' refs/heads | grep '\[gone\]$'
+   git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads | grep '\[gone\]$'
    ```
 
    If no gone branches exist, skip this step. Otherwise, delete each one individually:


### PR DESCRIPTION
## Summary

- The `post-merge-cleanup` skill's "gone branch" detection used `%(upstream:track,gone)` in `git for-each-ref --format`, which is **invalid git format syntax** (there is no `gone` atom modifier). It fails on every git version with `fatal: unrecognized %(upstream) argument: track,gone`, so step 3 (delete local branches whose remote is gone) never worked.
- Replaced with plain `%(upstream:track)`, which already emits `[gone]` for branches whose upstream was deleted. The downstream `grep '\[gone\]$'` and the rest of the skill are unaffected.

```diff
- git for-each-ref --format='%(refname:short) %(upstream:track,gone)' refs/heads | grep '\[gone\]$'
+ git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads | grep '\[gone\]$'
```

## Test plan

- Verified `git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads` runs without error on git 2.54 (the `,gone` form errors out).
- `git grep` confirms no other tracked file carries the broken syntax (no OpenCode mirror to keep in parity).

## Review coverage

Docs-only change to a single `.claude/` skill file. Pre-PR pipeline auto-skipped the agent roster (no substantive code, no `.py`/`.go`/`.tsx`, no diagram fences); automated checks had nothing to run (no Python/web/Go changes). Parity check performed manually.