### PR TITLE
docs: honest-hybrid refresh of README, site, and design specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ SynthOrg is a self-contained, self-hostable platform for **synthetic organisatio
 
 It is provider-agnostic (<!--RS:providers_via_litellm-->2700+<!--/RS--> LLMs via [LiteLLM](https://github.com/BerriAI/litellm)), configuration-driven ([Pydantic v2](https://docs.pydantic.dev/) models), and licensed BUSL-1.1 (converts to Apache 2.0 at the Change Date).
 
-> **Project status (read this).** The framework and infrastructure are built and tested (<!--RS:tests-->30,000+<!--/RS--> tests, 80%+ coverage): API, dashboard, CLI, dual-backend persistence, the provider layer, and every subsystem as importable, unit-tested components. The autonomous agent **runtime** that makes the organisation actually execute work is **in active development** and tracked openly on the [roadmap](https://synthorg.io/docs/roadmap/) and the [issue tracker](https://github.com/Aureliolo/synthorg/issues). Today, starting SynthOrg brings up the platform and dashboard; running a company end to end is the work in flight. We would rather you see exactly what is built versus in progress than discover it later.
+> **Project status (read this).** The framework and infrastructure are built and tested (<!--RS:tests-->31,000+<!--/RS--> tests, 80%+ coverage): API, dashboard, CLI, dual-backend persistence, the provider layer, and every subsystem as importable, unit-tested components. The autonomous agent **runtime** that makes the organisation actually execute work is **in active development** and tracked openly on the [roadmap](https://synthorg.io/docs/roadmap/) and the [issue tracker](https://github.com/Aureliolo/synthorg/issues). Today, starting SynthOrg brings up the platform and dashboard; running a company end to end is the work in flight. We would rather you see exactly what is built versus in progress than discover it later.
 
 ## What is available now
 
@@ -38,11 +38,11 @@ A tested platform you can run, inspect, and build on:
 
 These are the capabilities that make SynthOrg an autonomous studio. They are designed and largely written as components, but not yet wired into a running product. Each is tracked in the open:
 
-- **Agent runtime online** ([EPIC #1955](https://github.com/Aureliolo/synthorg/issues/1955)): agents actually executing tasks (LLM + sandboxed tools) under a minimal safety spine. This is the foundational item everything else depends on.
-- **Conversational org interface** ([EPIC #1967](https://github.com/Aureliolo/synthorg/issues/1967)): talk to the company in natural language; it clarifies, proposes, and (later) acts under governance.
-- **Autonomous product studio substrate** ([EPIC #1973](https://github.com/Aureliolo/synthorg/issues/1973)): persistent project workspace with pluggable git, brownfield codebase intake, living documentation, and a deep requirements interview.
-- **Best-in-class operate tier** ([EPIC #1979](https://github.com/Aureliolo/synthorg/issues/1979)): a golden-company benchmark, mission control with run replay, a cost forecast/kill-switch dial, a measurable learning curve, deterministic replay, run narratives, and an adversarial red-team.
-- **Agent capability layer** ([EPIC #1987](https://github.com/Aureliolo/synthorg/issues/1987)): a knowledge and provenance retrieval substrate, research mode, continual improvement, governed external API access, headless-browser and virtual-desktop testing, and more.
+- **Agent runtime online**: agents actually executing tasks (LLM + sandboxed tools) under a minimal safety spine. This is the foundational item everything else depends on.
+- **Conversational org interface**: talk to the company in natural language; it clarifies, proposes, and (later) acts under governance.
+- **Autonomous product studio substrate**: persistent project workspace with pluggable git, brownfield codebase intake, living documentation, and a deep requirements interview.
+- **Best-in-class operate tier**: a golden-company benchmark, mission control with run replay, a cost forecast/kill-switch dial, a measurable learning curve, deterministic replay, run narratives, and an adversarial red-team.
+- **Agent capability layer**: a knowledge and provenance retrieval substrate, research mode, continual improvement, governed external API access, headless-browser and virtual-desktop testing, and more.
 
 Until the runtime lands, multi-agent coordination, coordination metrics, the intake engine, autonomy/trust enforcement on a live run, and the self-improvement loop are designed and unit-tested but not exercised end to end. The design for each lives in the [Design Specification](https://synthorg.io/docs/design/).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <strong>SynthOrg</strong><br>
-  <em>Build AI teams that actually collaborate, with roles, budgets, memory, and governance.</em>
+  <em>An autonomous product studio you operate: describe what to build, a synthetic organisation of AI agents plans and delivers it.</em>
 </p>
 
 <p align="center">
@@ -15,22 +15,36 @@
 
 ---
 
-SynthOrg is a Python framework for building **synthetic organizations**, autonomous AI agents orchestrated as a virtual company. Unlike task-queue or DAG-based agent frameworks, SynthOrg models agents as members of an actual organization with roles, departments, hierarchies, persistent memory, budgets, and structured communication.
+SynthOrg is a self-contained, self-hostable platform for **synthetic organisations**: role-based AI agents modelled as an actual company (roles, departments, hierarchies, persistent memory, budgets, governance, structured communication) rather than a task queue or a DAG of function calls. The goal is an autonomous product studio you operate: you describe a product or service to build, or hand it an existing codebase, and the organisation plans, executes, and delivers it under budgets and your steering.
 
-Define your company in YAML. Agents collaborate through a message bus, follow workflows (Kanban, Agile sprints, or custom), track costs against budgets, and produce real artifacts. The framework is provider-agnostic (<!--RS:providers_via_litellm-->2700+<!--/RS--> LLMs via [LiteLLM](https://github.com/BerriAI/litellm)), configuration-driven ([Pydantic v2](https://docs.pydantic.dev/) models), and designed for the full autonomy spectrum, from human approval on every action to fully autonomous operation.
+It is provider-agnostic (<!--RS:providers_via_litellm-->2700+<!--/RS--> LLMs via [LiteLLM](https://github.com/BerriAI/litellm)), configuration-driven ([Pydantic v2](https://docs.pydantic.dev/) models), and licensed BUSL-1.1 (converts to Apache 2.0 at the Change Date).
 
-> **Early access.** Core subsystems are built and tested (<!--RS:tests-->30,000+<!--/RS--> tests, 80%+ coverage). APIs may change between releases. See the [roadmap](https://synthorg.io/docs/roadmap/) for what's next.
+> **Project status (read this).** The framework and infrastructure are built and tested (<!--RS:tests-->30,000+<!--/RS--> tests, 80%+ coverage): API, dashboard, CLI, dual-backend persistence, the provider layer, and every subsystem as importable, unit-tested components. The autonomous agent **runtime** that makes the organisation actually execute work is **in active development** and tracked openly on the [roadmap](https://synthorg.io/docs/roadmap/) and the [issue tracker](https://github.com/Aureliolo/synthorg/issues). Today, starting SynthOrg brings up the platform and dashboard; running a company end to end is the work in flight. We would rather you see exactly what is built versus in progress than discover it later.
 
-## Why SynthOrg?
+## What is available now
 
-Most agent frameworks give you **functions that call LLMs**. SynthOrg gives you a **company that thinks**.
+A tested platform you can run, inspect, and build on:
 
-- **Roles, not functions.** Agents are CEO, engineer, designer, QA, with personality, goals, seniority, and autonomy levels. 9 company templates and 23 personality presets get you started fast.
-- **Shared organizational memory.** Hybrid retrieval pipeline (dense + BM25 sparse with RRF fusion), tool-based and context injection strategies, procedural memory auto-generation from failures, consolidation, and archival. Agents remember across sessions.
-- **Cost-aware by design.** Per-agent token budgets, automatic model downgrade at task boundaries, spending reports, trend analysis, and CFO-level optimization with anomaly detection.
-- **Trust spectrum.** From locked-down (human approves every tool call) to fully autonomous, with a fail-closed security rule engine, output scanning, progressive trust, and audit logging in between.
-- **Real workflows.** Kanban boards, Agile sprints with velocity tracking, ceremony scheduling (8 strategies), visual workflow editor with starter blueprints and version history with diff/rollback, and workflow execution from graph definitions.
-- **Provider-agnostic.** Any LLM via LiteLLM: Ollama, LM Studio, vLLM, and <!--RS:providers_via_litellm-->2700+<!--/RS--> cloud models. Local model management with pull/delete/configure for Ollama and LM Studio.
+- **REST + WebSocket API** (Litestar) and a **React 19 dashboard** (org chart, task board, agent detail, budget tracking, provider management, workflow editor, ceremony settings, setup wizard) with live WebSocket / SSE updates.
+- **Go CLI** for Docker orchestration: `init`, `start`, `stop`, `status`, `doctor`, `config`, `wipe`, `cleanup`, `worker`, `backup`, with cosign signature and SLSA provenance verification at pull time.
+- **Dual-backend persistence**: SQLite (single-node default) and PostgreSQL (multi-instance), conformance-tested for parity, with in-process yoyo schema migrations and ISO 4217 currency stamping on every cost-bearing row.
+- **Provider layer**: any LLM via LiteLLM with built-in retry and rate-limit handling; local model management for Ollama and LM Studio.
+- **Configuration and templates**: define a company in YAML; importable/shareable agent, department, and company templates with personality presets.
+- **Subsystem libraries, tested as components**: the engine, memory, budget, security, coordination, and intake modules exist as importable, unit-tested code. Note honestly: these are exercised by their test suites, not yet by a running agent (see below).
+- **Operations**: structured logging with redaction and correlation, Prometheus metrics and OTLP, HttpOnly-cookie multi-user sessions with CSRF protection, Chainguard distroless images with Trivy + Grype scanning, cosign signatures, and SLSA L3 provenance.
+- **Distributed dispatch plumbing**: NATS JetStream queue and a worker pool. The dispatch path exists; the task-execute endpoint currently advances task state and does not yet invoke an agent.
+
+## In active development
+
+These are the capabilities that make SynthOrg an autonomous studio. They are designed and largely written as components, but not yet wired into a running product. Each is tracked in the open:
+
+- **Agent runtime online** ([EPIC #1955](https://github.com/Aureliolo/synthorg/issues/1955)): agents actually executing tasks (LLM + sandboxed tools) under a minimal safety spine. This is the foundational item everything else depends on.
+- **Conversational org interface** ([EPIC #1967](https://github.com/Aureliolo/synthorg/issues/1967)): talk to the company in natural language; it clarifies, proposes, and (later) acts under governance.
+- **Autonomous product studio substrate** ([EPIC #1973](https://github.com/Aureliolo/synthorg/issues/1973)): persistent project workspace with pluggable git, brownfield codebase intake, living documentation, and a deep requirements interview.
+- **Best-in-class operate tier** ([EPIC #1979](https://github.com/Aureliolo/synthorg/issues/1979)): a golden-company benchmark, mission control with run replay, a cost forecast/kill-switch dial, a measurable learning curve, deterministic replay, run narratives, and an adversarial red-team.
+- **Agent capability layer** ([EPIC #1987](https://github.com/Aureliolo/synthorg/issues/1987)): a knowledge and provenance retrieval substrate, research mode, continual improvement, governed external API access, headless-browser and virtual-desktop testing, and more.
+
+Until the runtime lands, multi-agent coordination, coordination metrics, the intake engine, autonomy/trust enforcement on a live run, and the self-improvement loop are designed and unit-tested but not exercised end to end. The design for each lives in the [Design Specification](https://synthorg.io/docs/design/).
 
 ## Quick Start
 
@@ -54,9 +68,9 @@ synthorg init --persistence-backend postgres    # auto-provision a Postgres cont
 synthorg start                                  # pull images + start containers
 ```
 
-Open [localhost:3000](http://localhost:3000); the **setup wizard** walks you through LLM providers, company config, agent setup with personality presets, and theme selection. Choose **Guided Setup** for the full experience or **Quick Setup** (provider + company name only, configure the rest later).
+Open [localhost:3000](http://localhost:3000); the **setup wizard** covers LLM providers, company config, agent setup with personality presets, and theme selection. Choose **Guided Setup** for the full experience or **Quick Setup** (provider + company name only). This brings up the platform and dashboard. Configuring a provider stores the company; running it as an autonomous organisation is the runtime work in active development, so skipping provider setup yields an empty company by design.
 
-**Persistence backends:** SQLite (default) for single-node and development, Postgres for multi-instance and production deployments. The CLI orchestrates both. `--persistence-backend postgres` generates a `dhi.io/postgres` DHI service (image tag pinned via `DefaultPostgresImageTag` in `cli/internal/config/state.go`), random credentials, and a named data volume. `synthorg stop` preserves the data volume unless `--volumes` is passed.
+**Persistence backends:** SQLite (default) for single-node and development, Postgres for multi-instance deployments. The CLI orchestrates both. `--persistence-backend postgres` generates a `dhi.io/postgres` DHI service (image tag pinned via `DefaultPostgresImageTag` in `cli/internal/config/state.go`), random credentials, and a named data volume. `synthorg stop` preserves the data volume unless `--volumes` is passed.
 
 ### From source
 
@@ -77,37 +91,11 @@ docker compose -f docker/compose.yml up -d
 curl http://localhost:3001/api/v1/readyz
 ```
 
-## What's Inside
+## Target architecture
 
-**[Agent Orchestration](https://synthorg.io/docs/design/engine/)**: task decomposition, 6 routing strategies, execution loops (ReAct, Plan-and-Execute, Hybrid, auto-selection by complexity), crash recovery with checkpoint resume, multi-agent coordination, and multi-project support with project-scoped teams and isolated budgets.
-
-**[Agent Evolution](https://synthorg.io/docs/design/agents/)**: continuous identity evolution based on performance trends with pluggable triggers (batched, inflection, per-task), proposers (separate-analyzer, self-report, composite), and guards (rollback, review, shadow evaluation).
-
-**[Dynamic Workforce Scaling](https://synthorg.io/docs/design/agents/#dynamic-scaling)**: closed-loop hiring and pruning with pluggable strategies (workload, budget cap, skill gap, performance), safety guards (conflict resolution, cooldowns, rate limits, approval gates), and a dashboard for manual evaluation triggers.
-
-**[Budget & Cost Management](https://synthorg.io/docs/design/budget/)**: per-agent and per-project cost limits with hierarchical cascading, auto-downgrade to cheaper models at task boundaries, spending reports, budget forecasting, and anomaly detection.
-
-**[Security & Trust](https://synthorg.io/docs/security/)**: SecOps agent with fail-closed rule engine, progressive trust (4 strategies), configurable autonomy levels (4 tiers), approval gates, LLM fallback evaluator, and audit logging. Container images are cosign-signed with [SLSA L3](https://slsa.dev) provenance.
-
-**[Memory](https://synthorg.io/docs/design/memory/)**: 5 memory types (episodic, semantic, procedural, working, social) with hybrid retrieval, three injection strategies (context, tool-based, and self-editing memory), query reformulation, procedural memory auto-generation from failures, consolidation, and pluggable backends.
-
-**[Communication](https://synthorg.io/docs/design/communication/)**: message bus, hierarchical delegation with loop prevention, conflict resolution (4 strategies), meeting protocols (round-robin, position papers, structured phases), and A2A federation with external agent systems.
-
-**[Tools & MCP](https://synthorg.io/docs/guides/mcp-tools/)**: built-in tools (file system, git, sandbox, code runner) plus MCP bridge for external tools. SynthOrg's own MCP server exposes 200+ tools across 15 domains (agents, tasks, workflows, approvals, budget, memory, quality, organization, communication, coordination, analytics, integrations, infrastructure, signals, meta), split across `read_tool` / `write_tool` / `admin_tool` capability actions; destructive `admin_tool` calls enforce confirm + reason + actor guardrails with attributed audit trail. Layered sandboxing with subprocess and Docker backends. SSRF prevention with configurable allowlists.
-
-**[Client Simulation](https://synthorg.io/docs/design/client-simulation/)**: synthetic workload generation with AI, human, and hybrid clients. 5 requirement generators (template, LLM, dataset, procedural, hybrid), 4 feedback strategies (binary, scored, criteria-check, adversarial), multi-stage review pipeline, intake engine with lifecycle management, and batch simulation runner with configurable concurrency.
-
-**[Web Dashboard](https://synthorg.io/docs/design/page-structure/)**: React 19 + shadcn/ui dashboard with org chart, task board, agent detail, budget tracking, provider management, workflow editor, ceremony policy settings, and setup wizard. Real-time WebSocket updates.
-
-**[Notifications](https://synthorg.io/docs/design/notifications/)**: pluggable notification sinks (console, ntfy, Slack, email) with severity filtering. Approval gates, budget thresholds, and timeout escalations emit alerts through a fan-out dispatcher.
-
-**[Integrations](https://synthorg.io/docs/design/integrations/)**: typed connection catalog (GitHub, Slack, SMTP, database, generic HTTP, OAuth apps) with pluggable secret backends (Fernet-encrypted SQLite or Postgres, auto-selected to match the persistence backend; env-var fallback; Vault/AWS/Azure stubs). Full OAuth 2.1 (authorization code + PKCE, device flow, client credentials) with proactive token refresh. Webhook receiver with pluggable signature verifiers (GitHub HMAC, Slack signing, generic HMAC) and replay protection. Per-connection health checks with background prober and status smoothing. Tool-side `@with_connection_rate_limit` decorator backed by a bus-coordinated sliding window. Bundled MCP server catalog and local-dev ngrok tunnel.
-
-**[Self-Improvement](https://synthorg.io/docs/design/self-improvement/)**: company-level meta-loop that observes 7 signal domains (performance, budget, coordination, scaling, errors, evolution, telemetry), evaluates 9 built-in rules plus user-defined custom rules (visual rule builder in the dashboard), and produces improvement proposals at 4 altitudes (config tuning, architecture, prompt tuning, code modification). Mandatory human approval, concrete rollback plans, staged rollout with canary selection and A/B testing (Welch's t-test for statistical significance, plus a practical-significance gate requiring a configured practical-improvement threshold on the relative mean improvement over control, not a standardized statistic like Cohen's d, before declaring a win), dispatcher-backed inverse-action rollback, and tiered regression detection (threshold + statistical). Chief of Staff agent with proposal outcome learning (EMA/Bayesian confidence adjustment), proactive org-level inflection alerts between scheduled cycles, and LLM-powered natural language explanations via chat interface. Feature is disabled by default.
-
-**[CLI](https://synthorg.io/get/)**: Go binary with init, start, stop, status, doctor, config, wipe, cleanup commands. Cosign signature and SLSA provenance verification at pull time.
-
-## Architecture
+The diagram below is the designed architecture. Components exist as code; the
+edges into and out of the agent engine are what the runtime work (above)
+brings online.
 
 ```mermaid
 graph TB
@@ -135,27 +123,26 @@ graph TB
 
 ## Compare
 
-SynthOrg vs [44 agent frameworks](https://synthorg.io/compare/) across 14 dimensions: org structure, multi-agent coordination, memory, budget tracking, security, observability, and more. <!-- lint-allow: doc-numeric-macros -- competitor count is sourced from data/competitors.yaml via generate_comparison.py, not runtime_stats -->
-
+SynthOrg vs [other agent frameworks](https://synthorg.io/compare/) across organisation structure, multi-agent coordination, memory, budget tracking, security, and observability. The comparison marks SynthOrg capabilities honestly as available now versus planned, matching the status sections above. <!-- lint-allow: doc-numeric-macros -- competitor count is sourced from data/competitors.yaml via generate_comparison.py, not runtime_stats -->
 
 ## Documentation
 
 | Section | What's there |
 |---------|-------------|
-| [User Guide](https://synthorg.io/docs/user_guide/) | Install, configure, run, customize |
+| [User Guide](https://synthorg.io/docs/user_guide/) | Install, configure, run, customise |
 | [Guides](https://synthorg.io/docs/guides/) | Quickstart, company config, agents, budget, security, MCP tools, deployment, logging, memory |
-| [Design Specification](https://synthorg.io/docs/design/) | Agents, HR lifecycle, org structure, communication, engine, coordination, verification, memory, providers, budget, tools, security, observability, notifications, backup, deployment, brand & UX, strategy |
+| [Design Specification](https://synthorg.io/docs/design/) | The designed behaviour of every subsystem (the source of truth; states current wiring status per area) |
 | [Architecture](https://synthorg.io/docs/architecture/) | System overview, tech stack, decision log |
 | [REST API](https://synthorg.io/docs/rest-api/) | Scalar/OpenAPI reference |
-| [Library Reference](https://synthorg.io/docs/api/) | Auto-generated from docstrings (14 modules) |
-| [Security](https://synthorg.io/docs/security/) | Application security, container hardening, CI/CD security (8 scanners) |
-| [Licensing](https://synthorg.io/docs/licensing/) | BSL 1.1 terms, Additional Use Grant, commercial options |
-| [Roadmap](https://synthorg.io/docs/roadmap/) | Current status, open questions, future vision |
+| [Library Reference](https://synthorg.io/docs/api/) | Auto-generated from docstrings |
+| [Security](https://synthorg.io/docs/security/) | Application security, container hardening, CI/CD security |
+| [Licensing](https://synthorg.io/docs/licensing/) | BUSL 1.1 terms, Additional Use Grant, commercial options |
+| [Roadmap](https://synthorg.io/docs/roadmap/) | Current status, what works today, what is in active development |
 
-> **Contributors:** Start with the [Design Specification](https://synthorg.io/docs/design/) before implementing any feature. See [`DESIGN_SPEC.md`](docs/DESIGN_SPEC.md) for the full design set.
+> **Contributors:** Start with the [Design Specification](https://synthorg.io/docs/design/) before implementing any feature. See [`DESIGN_SPEC.md`](docs/DESIGN_SPEC.md) for the full design set. The design pages describe intended behaviour and mark per-area current wiring status; treat any gap between a spec and `src/` as the work, not the spec.
 >
 > **Forking?** CI runs out of the box for code changes; the release pipeline needs setup (environments, labels, branch protection, a release-bot GitHub App). On your first push, the **CI Preflight** workflow opens a tracking issue listing exactly what is missing; see [Fork Setup](https://synthorg.io/docs/guides/fork-setup/) for the long-form walkthrough.
 
 ## License
 
-[Business Source License 1.1](LICENSE): free production use for non-competing organizations with fewer than 500 employees and contractors. Converts to Apache 2.0 on the change date specified in [LICENSE](LICENSE). See [licensing details](https://synthorg.io/docs/licensing/) for the full rationale and what's permitted.
+[Business Source License 1.1](LICENSE): free production use for non-competing organisations with fewer than 500 employees and contractors. Converts to Apache 2.0 on the change date specified in [LICENSE](LICENSE). See [licensing details](https://synthorg.io/docs/licensing/) for the full rationale and what is permitted.

--- a/data/competitors.yaml
+++ b/data/competitors.yaml
@@ -99,7 +99,7 @@ competitors:
     slug: synthorg
     url: "https://synthorg.io"
     repo: "https://github.com/Aureliolo/synthorg"
-    description: "Framework for building synthetic organizations, autonomous AI agents orchestrated as a virtual company"
+    description: "An autonomous product studio you operate: a self-hostable platform for synthetic organisations of role-based AI agents. Platform, infrastructure, and subsystem libraries are built and tested; the agent runtime that executes the organisation is in active development."
     license: "BUSL-1.1"
     language: "Python"
     category: virtual_org
@@ -107,20 +107,20 @@ competitors:
     self_hosted: "true"
     is_synthorg: true
     features:
-      org_structure: {support: full, note: "Departments, hierarchy, 8 seniority levels, reporting lines, HR"}
-      multi_agent: {support: partial, note: "6 assignment strategies, 4 coordination dispatchers, and conflict resolution shipped; multi-project support and formal coordination models still in progress"}
-      task_delegation: {support: full, note: "DAG decomposition, 6 assignment strategies, delegation chains"}
-      memory: {support: full, note: "Pluggable architecture with 3 backends (Mem0, composite, in-memory); 5 memory types (working, episodic, semantic, procedural, social); hybrid retrieval (dense + BM25 sparse, linear-weighted fusion)"}
-      tool_use: {support: full, note: "MCP protocol, sandbox isolation, invocation tracking; 14 ToolCategory values (file_system, code_execution, version_control, web, database, terminal, design, communication, analytics, deployment, memory, ontology, mcp, other)"}
-      human_in_loop: {support: full, note: "Approval gates, review workflows, 4 autonomy tiers (FULL, SEMI, SUPERVISED, LOCKED), two-stage safety classifier, LLM fallback evaluator"}
-      budget_tracking: {support: full, note: "Per-token, per-agent, hierarchical cascades, CFO optimization, automatic model downgrade, and risk-unit action budgets"}
-      security_model: {support: full, note: "Rule engine + LLM evaluator, progressive trust, audit trail, output scanning, hallucination detection, and self-healing SSRF validation"}
-      observability: {support: full, note: "Structured logging, correlation tracking, log shipping, redaction, Prometheus metrics, OTLP"}
-      web_dashboard: {support: full, note: "React 19 dashboard with org chart, tasks, budgets, workflow editor, setup wizard, WebSocket + SSE resilience"}
-      cli: {support: partial, note: "Go binary for container management and verification; not used for agent orchestration"}
-      production_ready: {support: full, note: "Docker + CI/CD + cosign + SLSA L3 provenance; stable REST API; SQLite + PostgreSQL backends GA"}
-      workflow_types: {support: partial, note: "Sequential, parallel, Kanban, Agile sprints, velocity tracking, and ceremony scheduling shipped; throughput-adaptive and milestone-driven strategies still in progress"}
-      template_system: {support: full, note: "9 company templates, 23 personality presets, locale-aware name generation"}
+      org_structure: {support: planned, note: "Departments, hierarchy, seniority levels, reporting lines, HR are modelled and unit-tested as components; exercised once the agent runtime lands (in active development)"}
+      multi_agent: {support: planned, note: "Assignment strategies, coordination dispatchers, and conflict resolution are written and tested; multi-agent coordination is not wired into a running product yet (the /coordinate path is not active)"}
+      task_delegation: {support: planned, note: "DAG decomposition, assignment strategies, and delegation chains are implemented and tested; they run via the agent runtime, which is in active development"}
+      memory: {support: planned, note: "Pluggable backends and memory types with hybrid retrieval exist as tested code; the memory pipeline runs only inside a live agent, which is in active development"}
+      tool_use: {support: planned, note: "MCP protocol, sandbox isolation, and invocation tracking are implemented; tool execution runs via the agent runtime (in active development)"}
+      human_in_loop: {support: planned, note: "Approval gates, review workflows, and four autonomy tiers are designed and tested; the approval producer and enforcement run with the agent runtime (in active development)"}
+      budget_tracking: {support: planned, note: "Per-token/per-agent budgets, hierarchical cascades, and model downgrade are implemented and tested; enforced on a live run with the agent runtime (in active development)"}
+      security_model: {support: planned, note: "Rule engine + LLM evaluator, progressive trust, audit trail, and output scanning are designed and tested; enforced on a live run with the agent runtime (in active development)"}
+      observability: {support: full, note: "Structured logging, correlation tracking, log shipping, redaction, Prometheus metrics, and OTLP ship and run today"}
+      web_dashboard: {support: full, note: "React 19 dashboard (org chart, tasks, budgets, workflow editor, setup wizard, WebSocket + SSE) ships and runs; populated as the agent runtime comes online"}
+      cli: {support: partial, note: "Go binary for container orchestration and supply-chain verification; deliberately not used for agent orchestration"}
+      production_ready: {support: partial, note: "Infrastructure ships (Docker + CI/CD + cosign + SLSA L3, SQLite + PostgreSQL backends, backup/restore); the product is not runnable end to end until the agent runtime lands"}
+      workflow_types: {support: planned, note: "Sequential, parallel, Kanban, Agile sprints, velocity, and ceremony scheduling are implemented and tested; they execute via the agent runtime (in active development)"}
+      template_system: {support: full, note: "Company templates, personality presets, and locale-aware name generation ship and are usable today without the runtime"}
 
   - name: "CrewAI"
     slug: crewai

--- a/docs/design/agent-execution.md
+++ b/docs/design/agent-execution.md
@@ -5,6 +5,10 @@ description: Agent execution status, execution loops (ReAct, Plan-and-Execute, H
 
 # Agent Execution
 
+!!! warning "Designed behaviour; runtime in active development"
+
+    This page is the source of truth for the **designed** behaviour of this subsystem. The autonomous agent runtime that exercises it end to end is in active development (see the [Roadmap](../roadmap/index.md)); the code described here is built and unit-tested as components but not yet run by a live agent.
+
 This page covers the agent-side execution plane: how a single agent runs a task. The engine dispatches work via the [TaskEngine](engine.md#taskengine-centralized-state-coordination); the agent receives it, enters an execution loop, and iterates through LLM turns and tool calls until completion or handoff. The loop type, prompt profile, stagnation guards, and context-budget policies are all pluggable per agent.
 
 ## Agent Execution Status

--- a/docs/design/agents.md
+++ b/docs/design/agents.md
@@ -5,6 +5,10 @@ description: Agent identity system. Personality dimensions, structured skill mod
 
 # Agents
 
+!!! warning "Designed behaviour; runtime in active development"
+
+    This page is the source of truth for the **designed** behaviour of this subsystem. The autonomous agent runtime that exercises it end to end is in active development (see the [Roadmap](../roadmap/index.md)); the code described here is built and unit-tested as components but not yet run by a live agent.
+
 Every agent is a composition of **immutable config** (identity, personality, skills, model, tool permissions, authority) and **mutable runtime state** (execution status, active task, cost accumulation). This page covers the identity layer. The HR lifecycle (seniority, hiring, firing, performance, evolution) lives on a dedicated [HR & Agent Lifecycle](hr-lifecycle.md) page.
 
 ## Agent Identity Card

--- a/docs/design/budget.md
+++ b/docs/design/budget.md
@@ -5,6 +5,10 @@ description: Hierarchical budgets, cost tracking, CFO agent responsibilities, co
 
 # Budget & Cost Management
 
+!!! warning "Designed behaviour; runtime in active development"
+
+    This page is the source of truth for the **designed** behaviour of this subsystem. Budget enforcement is built and unit-tested as components; it is enforced on a live run by the agent runtime, which is in active development (see the [Roadmap](../roadmap/index.md)).
+
 SynthOrg treats money as a first-class runtime constraint. Every LLM call carries a currency-stamped `CostRecord`, budgets cascade from the company down to individual teams, and three layers of enforcement (pre-flight, in-flight, task-boundary) prevent runaway spending without breaking in-progress work. The agent execution pipeline that drives each layer is documented in [Agent Execution > AgentEngine Orchestrator](agent-execution.md#agentengine-orchestrator).
 
 ---

--- a/docs/design/budget.md
+++ b/docs/design/budget.md
@@ -7,7 +7,7 @@ description: Hierarchical budgets, cost tracking, CFO agent responsibilities, co
 
 !!! warning "Designed behaviour; runtime in active development"
 
-    This page is the source of truth for the **designed** behaviour of this subsystem. Budget enforcement is built and unit-tested as components; it is enforced on a live run by the agent runtime, which is in active development (see the [Roadmap](../roadmap/index.md)).
+    This page is the source of truth for the **designed** behaviour of this subsystem. Budget enforcement is built and unit-tested as components; enforcement on a live run is performed by the agent runtime, which is in active development and not yet wired (see the [Roadmap](../roadmap/index.md)).
 
 SynthOrg treats money as a first-class runtime constraint. Every LLM call carries a currency-stamped `CostRecord`, budgets cascade from the company down to individual teams, and three layers of enforcement (pre-flight, in-flight, task-boundary) prevent runaway spending without breaking in-progress work. The agent execution pipeline that drives each layer is documented in [Agent Execution > AgentEngine Orchestrator](agent-execution.md#agentengine-orchestrator).
 

--- a/docs/design/client-simulation.md
+++ b/docs/design/client-simulation.md
@@ -5,6 +5,10 @@ description: Synthetic client framework for generating task requirements, review
 
 # Client Simulation
 
+!!! warning "Designed behaviour; runtime in active development"
+
+    This page is the source of truth for the **designed** behaviour of this subsystem. The intake engine and simulation runtime are not wired into the shipped product yet; this is in active development (see the [Roadmap](../roadmap/index.md)). The code described here is built and unit-tested as components but not yet run end to end.
+
 The client simulation subsystem generates synthetic workloads that exercise the full
 task lifecycle end-to-end. Simulated clients (AI-driven, human, or hybrid) submit task
 requirements through an intake pipeline and review completed deliverables via a

--- a/docs/design/communication.md
+++ b/docs/design/communication.md
@@ -5,6 +5,10 @@ description: Message bus architecture, communication patterns, standards, messag
 
 # Communication
 
+!!! warning "Designed behaviour; runtime in active development"
+
+    This page is the source of truth for the **designed** behaviour of this subsystem. The autonomous agent runtime that exercises it end to end is in active development (see the [Roadmap](../roadmap/index.md)); the code described here is built and unit-tested as components but not yet run by a live agent.
+
 The communication architecture defines how agents exchange information. This
 page covers transport-level concerns: patterns, standards, the message
 contract, and bus configuration. Federation, orchestration, and the event

--- a/docs/design/coordination.md
+++ b/docs/design/coordination.md
@@ -5,6 +5,10 @@ description: Agent crash recovery, graceful shutdown protocol, concurrent worksp
 
 # Coordination & Resilience
 
+!!! warning "Designed behaviour; runtime in active development"
+
+    This page is the source of truth for the **designed** behaviour of this subsystem. Multi-agent coordination is not wired into a running product yet (the `/coordinate` path is not active); this is in active development (see the [Roadmap](../roadmap/index.md)). The code described here is built and unit-tested as components but not yet run by a live agent.
+
 This page covers system-level features that span multiple agents and protect against failure: crash recovery with checkpoint resume, graceful shutdown strategies, concurrent workspace isolation (Git worktrees / virtual filesystem / per-branch), and multi-agent coordination topology (centralized, decentralized, context-dependent dispatchers).
 
 ## Agent Crash Recovery

--- a/docs/design/distributed-runtime.md
+++ b/docs/design/distributed-runtime.md
@@ -5,6 +5,10 @@ description: Pluggable distributed bus backend design, NATS JetStream first impl
 
 # Distributed Runtime
 
+!!! warning "Designed behaviour; runtime in active development"
+
+    This page is the source of truth for the **designed** behaviour of this subsystem. The dispatch plumbing (NATS JetStream queue and worker pool) exists, but the task-execute endpoint currently advances task state without invoking an agent; end-to-end distributed execution depends on the agent runtime, which is in active development (see the [Roadmap](../roadmap/index.md)).
+
 SynthOrg runs in a single Python process by default. Agents communicate over an in-memory `MessageBus` (per-(channel, subscriber) `asyncio.Queue`) and the `TaskEngine` dispatches work through its own single-writer mutation queue inside that same process. For a laptop running one synthetic org, this is the right answer: lowest latency, no extra containers, nothing to operate.
 
 This page describes the **first distributed backend** that plugs into the existing `MessageBus` protocol without changing it, and the **distributed task queue** that sits on top of that backend. Both are opt-in. The in-memory path stays the default and must remain byte-identical in behavior for users who do not turn on distribution.

--- a/docs/design/engine.md
+++ b/docs/design/engine.md
@@ -5,6 +5,10 @@ description: Task lifecycle, task definition, workflow types (sequential, parall
 
 # Task & Workflow Engine
 
+!!! warning "Designed behaviour; runtime in active development"
+
+    This page is the source of truth for the **designed** behaviour of this subsystem. The autonomous agent runtime that exercises it end to end is in active development (see the [Roadmap](../roadmap/index.md)); the code described here is built and unit-tested as components but not yet run by a live agent.
+
 The task and workflow engine orchestrates how work flows through a synthetic
 organization, from task creation and assignment through to review and
 completion. This page covers the task-engine core: lifecycle, workflows,

--- a/docs/design/hr-lifecycle.md
+++ b/docs/design/hr-lifecycle.md
@@ -5,7 +5,11 @@ description: Seniority and authority levels, role catalog, dynamic roles, hiring
 
 # HR & Agent Lifecycle
 
-This page covers the operational lifecycle of every agent in a synthetic organization, from hiring through performance tracking, promotion, evolution, and offboarding. The HR subsystem is how SynthOrg simulates a workforce: closed-loop hiring when new skills are needed, performance-driven pruning when agents fail to deliver, and pluggable evolution for agents that need to adapt their identity.
+!!! warning "Designed behaviour; runtime in active development"
+
+    This page is the source of truth for the **designed** behaviour of this subsystem. The autonomous agent runtime that exercises it end to end is in active development (see the [Roadmap](../roadmap/index.md)); the code described here is built and unit-tested as components but not yet run by a live agent.
+
+This page covers the operational lifecycle of every agent in a synthetic organisation, from hiring through performance tracking, promotion, evolution, and offboarding. The HR subsystem is how SynthOrg simulates a workforce: closed-loop hiring when new skills are needed, performance-driven pruning when agents fail to deliver, and pluggable evolution for agents that need to adapt their identity.
 
 See [Agents](agents.md) for the identity layer (personality, skills, tool namespaces, identity versioning).
 

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -1,6 +1,6 @@
 ---
 title: Design Overview
-description: Core vision, design principles, and foundational concepts of the SynthOrg framework for building synthetic organizations.
+description: Core vision, design principles, and foundational concepts of SynthOrg, an autonomous product studio for synthetic organisations.
 ---
 
 # Design Overview
@@ -74,11 +74,20 @@ development, business operations, creative work, or any domain.
 - Not a toy/demo: designed for real, production-quality output
 - Not a reasoning parallelizer. Single-agent reasoning is typically more token-efficient on isolated multi-hop questions, and SynthOrg's [auto topology selector](coordination.md#task-decomposability--coordination-topology) defaults to single-agent for such tasks. SynthOrg's value is role-specialized work-stream parallelism, organizational simulation fidelity, and audit-grade decision trails, not reasoning parallelism. See [S1 Multi-Agent Architecture Decision](../research/s1-multi-agent-decision.md) for the full reconciliation.
 
-!!! info "How to read the design specification"
+!!! warning "How to read the design specification (important)"
 
-    Sections describe the full vision. The full design is documented upfront to inform
-    architecture decisions; protocol interfaces are designed even for features that are
-    not yet implemented. For current implementation status, see the
+    These pages describe the **designed** behaviour of SynthOrg and are the
+    source of truth for that design. They are documented upfront to inform
+    architecture; protocol interfaces are designed even where the behaviour
+    is not yet wired. Be specific about current state: the autonomous agent
+    **runtime** that makes the organisation execute work is in active
+    development and not yet wired (`AgentEngine` is not constructed in the
+    shipped path), so subsystems that depend on a running agent
+    (coordination, coordination metrics, intake, approval enforcement,
+    self-improvement, and the agent execution loop itself) are designed and
+    unit-tested as components but not exercised end to end. Treat any gap
+    between a spec and the code as the work, not the spec. For exactly what
+    is available now versus in active development, see the
     [Roadmap](../roadmap/index.md).
 
 ## Configuration Philosophy

--- a/docs/design/memory.md
+++ b/docs/design/memory.md
@@ -5,6 +5,10 @@ description: Agent memory architecture, memory types, memory levels, MemoryBacke
 
 # Memory and Persistence
 
+!!! warning "Designed behaviour; runtime in active development"
+
+    This page is the source of truth for the **designed** behaviour of this subsystem. The memory components exist as tested code, but the memory pipeline runs only inside a live agent, which is in active development (see the [Roadmap](../roadmap/index.md)). Persistence storage (SQLite/Postgres) is shipped and available now.
+
 The SynthOrg framework separates two distinct storage concerns:
 
 - **Agent memory**: what agents know, remember, and learn (working, episodic, semantic, procedural, social)

--- a/docs/design/ontology.md
+++ b/docs/design/ontology.md
@@ -5,6 +5,10 @@ description: Shared entity vocabulary, versioned definitions, drift detection, a
 
 # Semantic Ontology
 
+!!! warning "Designed behaviour; runtime in active development"
+
+    This page is the source of truth for the **designed** behaviour of this subsystem. The autonomous agent runtime that exercises it end to end is in active development (see the [Roadmap](../roadmap/index.md)); the code described here is built and unit-tested as components but not yet run by a live agent.
+
 The ontology subsystem provides a shared, versioned vocabulary of entity
 definitions that agents use to communicate unambiguously. Every core concept
 (Task, Agent, Role, etc.) has a canonical definition registered at startup,

--- a/docs/design/organization.md
+++ b/docs/design/organization.md
@@ -5,6 +5,10 @@ description: Company types, organizational hierarchy, department configuration, 
 
 # Organization & Templates
 
+!!! warning "Designed behaviour; runtime in active development"
+
+    This page is the source of truth for the **designed** behaviour of this subsystem. The template and configuration system is available now; the running-organisation behaviour it configures depends on the agent runtime, which is in active development (see the [Roadmap](../roadmap/index.md)).
+
 ## Company Types
 
 SynthOrg provides pre-built company templates for common organizational patterns:

--- a/docs/design/security.md
+++ b/docs/design/security.md
@@ -5,6 +5,10 @@ description: Approval workflow, autonomy levels, security operations agent, outp
 
 # Security & Approval System
 
+!!! warning "Designed behaviour; runtime in active development"
+
+    This page is the source of truth for the **designed** behaviour of this subsystem. The approval producer and runtime enforcement run with the agent runtime, which is in active development (see the [Roadmap](../roadmap/index.md)); the code described here is built and unit-tested as components but not yet enforced on a live run.
+
 SynthOrg enforces a fail-closed security model: every agent action is evaluated by a rule engine (with an optional LLM fallback) before execution, every output is scanned for leaked secrets, and every credential flows through an isolated **hands** plane that never enters the model context. Four configurable autonomy levels (`full`, `semi`, `supervised`, `locked`) control which actions require human approval, and a pluggable trust system lets agents earn higher tool access over time.
 
 ## Approval Workflow

--- a/docs/design/self-improvement.md
+++ b/docs/design/self-improvement.md
@@ -1,5 +1,9 @@
 # Self-Improving Company
 
+!!! warning "Designed behaviour; runtime in active development"
+
+    This page is the source of truth for the **designed** behaviour of this subsystem. The self-improvement loop runs only when agents run; it is in active development (see the [Roadmap](../roadmap/index.md)). The code described here is built and unit-tested as components but not yet exercised end to end.
+
 The self-improvement meta-loop observes company-wide signals from 7 existing subsystems and produces deployment and product-level improvement proposals through a rule-first hybrid pipeline with mandatory human approval.
 
 Company autonomy ships at `supervised` so most state-mutating agent actions queue for approval before execution; raise to `semi` or `full` via `company.autonomy_level` (or `config.autonomy.level` in the company YAML) once operators trust the organization. Rank order: `full` > `semi` > `supervised` > `locked`.

--- a/docs/design/tools.md
+++ b/docs/design/tools.md
@@ -5,6 +5,10 @@ description: Tool categories, concurrent execution model, layered sandboxing, MC
 
 # Tools & Capabilities
 
+!!! warning "Designed behaviour; runtime in active development"
+
+    This page is the source of truth for the **designed** behaviour of this subsystem. Tool execution runs via the agent runtime, which is in active development (see the [Roadmap](../roadmap/index.md)); the code described here is built and unit-tested as components but not yet run by a live agent.
+
 Agents act on the world through tools. SynthOrg defines a pluggable tool system with 12+ categories (file system, git, web, database, terminal, sandbox, MCP bridge, analytics, communication, design), layered sandboxing (subprocess for low-risk, Docker for high-risk, Kubernetes for future multi-tenant), MCP server integration, and a progressive-disclosure model that limits the surface an agent sees to what its role, seniority, and autonomy tier permit.
 
 ## Tool Categories

--- a/docs/design/verification-quality.md
+++ b/docs/design/verification-quality.md
@@ -5,6 +5,10 @@ description: Verification stage, harness middleware layer, review pipeline, and 
 
 # Verification & Quality
 
+!!! warning "Designed behaviour; runtime in active development"
+
+    This page is the source of truth for the **designed** behaviour of this subsystem. The verification pipeline and intake engine run with the agent runtime, which is in active development (see the [Roadmap](../roadmap/index.md)); the code described here is built and unit-tested as components but not yet run by a live agent.
+
 This page covers the quality-assurance pipeline attached to agent output: the verification stage that runs after an agent completes a task, the harness middleware that wraps every agent invocation, the review pipeline that validates produced artifacts, and the intake engine that ingests new work.
 
 ## Verification Stage

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -5,11 +5,11 @@ description: Practical how-to guides for configuring and operating SynthOrg.
 
 # Guides
 
-Practical guides for configuring, operating, and extending your synthetic organization. Each guide is self-contained with a clear goal. Start with the Quickstart Tutorial if you are new to SynthOrg.
+Practical guides for configuring, operating, and extending your synthetic organisation. Each guide is self-contained with a clear goal. Start with the Quickstart Tutorial if you are new to SynthOrg. Note: the platform and configuration surface are available today; the agent runtime that executes work is in active development (see the [Roadmap](../roadmap/index.md)).
 
 !!! tip "New to SynthOrg?"
 
-    Start with the [Quickstart Tutorial](quickstart.md) to get a synthetic org running in under 5 minutes.
+    Start with the [Quickstart Tutorial](quickstart.md) to stand up the platform and configure a company in about 5 minutes.
 
 ---
 
@@ -19,7 +19,7 @@ Practical guides for configuring, operating, and extending your synthetic organi
 
     ---
 
-    Install the CLI, pick a template, and run your first synthetic org in 5 minutes.
+    Install the CLI, pick a template, and stand up the platform in about 5 minutes.
 
     [:octicons-arrow-right-24: Quickstart](quickstart.md)
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -1,17 +1,26 @@
 ---
 title: Quickstart Tutorial
-description: Get a synthetic organization running in under 5 minutes.
+description: Stand up the SynthOrg platform and configure a company in about 5 minutes.
 ---
 
 # Quickstart Tutorial
 
-This tutorial walks you through installing SynthOrg, choosing a template, and running your first synthetic organization, all in about 5 minutes.
+This tutorial walks you through installing SynthOrg, starting the platform,
+and configuring your first company, in about 5 minutes.
+
+!!! warning "Honest status"
+    The platform, dashboard, CLI, and setup wizard below work today. The
+    autonomous agent runtime that executes work is in active development and
+    not yet wired: a task you submit advances through its lifecycle states,
+    but an agent does not yet execute it. The "designed flow" section makes
+    the distinction explicit. See the [Roadmap](../roadmap/index.md).
 
 ---
 
-## What You Will Build
+## What You Will Configure
 
-You will create a **Solo Builder** organization: a lean two-agent team designed for rapid prototyping.
+You will configure a **Solo Builder** organisation: a lean two-agent team
+designed for rapid prototyping.
 
 ```mermaid
 graph TD
@@ -20,7 +29,10 @@ graph TD
     CEO --> DEV
 ```
 
-The CEO handles strategy and task decomposition while the Full-Stack Developer writes code and builds features. Both operate with full autonomy and event-driven communication, with no approval gates or hierarchy overhead.
+By design, the CEO handles strategy and task decomposition while the
+Full-Stack Developer writes code and builds features. That execution
+behaviour is the runtime work in active development; the steps below set up
+the company that will run it.
 
 ---
 
@@ -109,16 +121,16 @@ On a fresh install, the **setup wizard** appears. Pick **Guided Setup** and step
 Once the wizard completes, the dashboard loads and you will see:
 
 - **Agents**: the CEO and Full-Stack Developer, each with their personality and model assignment
-- **Organization status**: health indicators for your synthetic company
-- **Task board**: currently empty, ready for your first task
+- **Organisation status**: health indicators for the platform
+- **Task board**: empty, ready to accept tasks
 
 ---
 
-## Step 5: Submit Your First Task
+## Step 5: Submit a Task
 
 === "Dashboard"
 
-    Use the task board in the dashboard to create a new task. Give it a title and description, and the engine will route it to the appropriate agent.
+    Use the task board in the dashboard to create a new task. Give it a title and description.
 
 === "API"
 
@@ -134,11 +146,16 @@ Once the wizard completes, the dashboard loads and you will see:
 
     Replace `<your-jwt-token>` with the JWT from your admin session. See the [REST API Reference](../openapi/index.md) for authentication details.
 
+Today the task is created and advances through its lifecycle states. An agent
+does not yet pick it up and execute it: that is the agent runtime, in active
+development ([EPIC #1955](https://github.com/Aureliolo/synthorg/issues/1955)).
+
 ---
 
-## What Happened
+## The Designed Flow (in active development)
 
-When you submitted a task, the SynthOrg engine processed it through a multi-step pipeline:
+This is what submitting a task is **designed** to do once the agent runtime
+is wired. It is not what happens end to end today.
 
 ```mermaid
 sequenceDiagram
@@ -160,10 +177,10 @@ sequenceDiagram
     Engine-->>You: Result available
 ```
 
-1. **Task created**: the engine validates the task and puts it in the queue.
-2. **Task routed**: the routing strategy (default: `role_based`) matches the task to the best-suited agent.
-3. **Agent executes**: the assigned agent uses its configured LLM model in a ReAct loop (Think, Act, Observe).
-4. **Result returned**: the completed task and its artifacts are available in the dashboard and API.
+1. **Task created**: the engine validates the task and queues it. (Works today.)
+2. **Task routed**: a routing strategy matches the task to the best-suited agent. (Designed; in active development.)
+3. **Agent executes**: the assigned agent uses its configured LLM in a ReAct loop. (Designed; in active development.)
+4. **Result returned**: the completed task and its artifacts appear in the dashboard and API. (Designed; in active development.)
 
 ---
 
@@ -181,7 +198,8 @@ Your data persists in the `synthorg-data` Docker volume and will be available ne
 
 ## Next Steps
 
-- [Company Configuration](company-config.md): customize every aspect of your organization via YAML
+- [Company Configuration](company-config.md): customise every aspect of your organisation via YAML
 - [Agent Roles & Hierarchy](agents.md): add more agents, define departments, configure personality
 - [Budget & Cost Control](budget.md): set spending limits and auto-downgrade policies
 - [Deployment (Docker)](deployment.md): production hardening and operations
+- [Roadmap](../roadmap/index.md): what is available now versus in active development

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -147,8 +147,9 @@ Once the wizard completes, the dashboard loads and you will see:
     Replace `<your-jwt-token>` with the JWT from your admin session. See the [REST API Reference](../openapi/index.md) for authentication details.
 
 Today the task is created and advances through its lifecycle states. An agent
-does not yet pick it up and execute it: that is the agent runtime, in active
-development ([EPIC #1955](https://github.com/Aureliolo/synthorg/issues/1955)).
+does not yet pick it up and execute it: that is the agent runtime, which is in
+active development. See the [roadmap](https://synthorg.io/docs/roadmap/) for
+current status.
 
 ---
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -148,8 +148,7 @@ Once the wizard completes, the dashboard loads and you will see:
 
 Today the task is created and advances through its lifecycle states. An agent
 does not yet pick it up and execute it: that is the agent runtime, which is in
-active development. See the [roadmap](https://synthorg.io/docs/roadmap/) for
-current status.
+active development. See the [Roadmap](../roadmap/index.md) for current status.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,12 @@
 # SynthOrg Documentation
 
-**Framework for building synthetic organizations**, autonomous AI agents orchestrated as a virtual company.
+**An autonomous product studio you operate**: a self-hostable platform where a synthetic organisation of role-based AI agents is designed to plan and deliver products under budgets and governance.
 
-SynthOrg lets you define agents with roles, hierarchy, budgets, and tools, then orchestrate them to collaborate on complex tasks as a virtual organization.
+SynthOrg lets you define agents with roles, hierarchy, budgets, and tools as a virtual organisation. The platform, infrastructure, and subsystem libraries are built and tested; the agent runtime that makes the organisation execute work is in active development.
 
-!!! warning "Under Active Development"
+!!! warning "Honest status: the agent runtime is in active development"
 
-    SynthOrg is under active development. Many features described in the design specification
-    are planned but not yet implemented. See the [Roadmap](roadmap/index.md) for current status.
+    The platform, dashboard, CLI, persistence, and subsystem libraries are built and tested. The autonomous agent runtime that runs the organisation end to end is **not yet wired** and is the focus of current work. Design-specification pages describe intended behaviour and mark per-area status; treat any gap between a spec and the code as the work, not the spec. See the [Roadmap](roadmap/index.md) for exactly what is available now versus in active development.
 
 ---
 
@@ -19,7 +18,7 @@ SynthOrg lets you define agents with roles, hierarchy, budgets, and tools, then 
 
     ---
 
-    Pick a template and run your first synthetic org via Docker.
+    Pick a template and stand up the SynthOrg platform via Docker.
 
     [:octicons-arrow-right-24: User Guide](user_guide.md)
 
@@ -45,7 +44,7 @@ SynthOrg lets you define agents with roles, hierarchy, budgets, and tools, then 
 
 ## Design Specification
 
-The design spec covers the full architecture of SynthOrg, from agent identity to budget enforcement:
+The design spec covers the full intended architecture of SynthOrg, from agent identity to budget enforcement. It is the source of truth for designed behaviour; each area marks its current wiring status, since the agent runtime is in active development.
 
 <div class="grid cards" markdown>
 
@@ -109,16 +108,20 @@ The design spec covers the full architecture of SynthOrg, from agent identity to
 
 ---
 
-## Key Features
+## Key capabilities (designed)
 
-- **Agent Orchestration**: define agents with roles, models, and tools. The engine handles task decomposition, routing, and collaboration.
-- **Budget Enforcement**: per-agent cost limits, auto-downgrade to cheaper models, spending reports, and CFO-level cost optimization.
-- **Security & Trust**: SecOps agent, fail-closed rule engine, progressive trust (4 strategies), autonomy levels, and audit logging.
-- **Memory**: per-agent and shared organizational memory with retrieval pipeline, consolidation, and archival.
-- **Communication**: message bus, delegation, conflict resolution (4 strategies), and meeting protocols.
-- **HR Engine**: hiring, firing, onboarding, offboarding, performance tracking, and promotion criteria.
-- **Tool Integration**: built-in tools (file system, git, sandbox, code runner) plus MCP bridge for external tools.
-- **LLM Providers**: provider-agnostic via LiteLLM. Routing strategies, retry/rate-limiting, capability matching.
+These describe the designed system. The provider layer is shipped; the
+others are built and unit-tested as components and run via the agent runtime,
+which is in active development (see the [Roadmap](roadmap/index.md)).
+
+- **Agent Orchestration**: agents with roles, models, and tools; designed task decomposition, routing, and collaboration.
+- **Budget Enforcement**: designed per-agent cost limits, auto-downgrade to cheaper models, spending reports, and CFO-level cost optimisation.
+- **Security & Trust**: designed SecOps agent, fail-closed rule engine, progressive trust, autonomy levels, and audit logging.
+- **Memory**: designed per-agent and shared organisational memory with retrieval pipeline, consolidation, and archival.
+- **Communication**: designed message bus, delegation, conflict resolution, and meeting protocols.
+- **HR Engine**: designed hiring, firing, onboarding, offboarding, performance tracking, and promotion criteria.
+- **Tool Integration**: built-in tools (file system, git, sandbox, code runner) plus an MCP bridge for external tools.
+- **LLM Providers** (available now): provider-agnostic via LiteLLM, with routing strategies, retry/rate-limiting, and capability matching.
 
 ---
 
@@ -138,5 +141,5 @@ The design spec covers the full architecture of SynthOrg, from agent identity to
 ## Links
 
 - [GitHub Repository](https://github.com/Aureliolo/synthorg)
-- [License](https://github.com/Aureliolo/synthorg/blob/main/LICENSE) (BSL 1.1, source available; free production use for non-competing small orgs; converts to Apache 2.0 three years after release) <!-- lint-allow: doc-numeric-macros -- "Apache 2.0" is a license version, not a stat claim -->
-- [Licensing & Usage](licensing.md): what's permitted, why BSL, and how to get a commercial license
+- [License](https://github.com/Aureliolo/synthorg/blob/main/LICENSE) (BUSL 1.1, source available; free production use for non-competing small organisations; converts to Apache 2.0 at the Change Date) <!-- lint-allow: doc-numeric-macros -- "Apache 2.0" is a license version, not a stat claim -->
+- [Licensing & Usage](licensing.md): what is permitted, why BUSL, and how to get a commercial license

--- a/docs/reference/comparison.md
+++ b/docs/reference/comparison.md
@@ -11,7 +11,7 @@ description: >-
 
 How SynthOrg compares to agent orchestration frameworks, platforms, and research projects.
 
-Last updated: 2026-05-01
+Last updated: 2026-05-15
 
 **Legend:**
 ✔ Full support | ~ Partial support | - Not supported | ⏲ Planned
@@ -23,7 +23,7 @@ Last updated: 2026-05-01
 
 | Framework | Category | License | Pricing | Self-Hosted | Org Structure | Multi-Agent | Task Delegation | Human-in-the-Loop |
 |:----------|:---------|:--------|:--------|:-----------:|:---:|:---:|:---:|:---:|
-| [**SynthOrg**](https://synthorg.io) | Virtual Org Simulator | BUSL-1.1 | Depends | ✔ | ✔ | ~ | ✔ | ✔ |
+| [**SynthOrg**](https://synthorg.io) | Virtual Org Simulator | BUSL-1.1 | Depends | ✔ | ⏲ | ⏲ | ⏲ | ⏲ |
 | [CrewAI](https://crewai.com) | Multi-Agent Framework | MIT | Open-core | ~ | ~ | ✔ | ✔ | ✔ |
 | [AutoGen](https://microsoft.github.io/autogen/) | Multi-Agent Framework | MIT | Free | ✔ | - | ✔ | ✔ | ✔ |
 | [LangGraph](https://www.langchain.com/langgraph) | Multi-Agent Framework | MIT | Open-core | ~ | - | ✔ | ✔ | ✔ |
@@ -73,7 +73,7 @@ Last updated: 2026-05-01
 
 | Framework | Category | License | Pricing | Self-Hosted | Memory | Tool Use | Security | Workflows |
 |:----------|:---------|:--------|:--------|:-----------:|:---:|:---:|:---:|:---:|
-| [**SynthOrg**](https://synthorg.io) | Virtual Org Simulator | BUSL-1.1 | Depends | ✔ | ✔ | ✔ | ~ | ~ |
+| [**SynthOrg**](https://synthorg.io) | Virtual Org Simulator | BUSL-1.1 | Depends | ✔ | ⏲ | ⏲ | ⏲ | ⏲ |
 | [CrewAI](https://crewai.com) | Multi-Agent Framework | MIT | Open-core | ~ | ✔ | ✔ | ~ | ~ |
 | [AutoGen](https://microsoft.github.io/autogen/) | Multi-Agent Framework | MIT | Free | ✔ | ✔ | ✔ | ~ | ✔ |
 | [LangGraph](https://www.langchain.com/langgraph) | Multi-Agent Framework | MIT | Open-core | ~ | ✔ | ✔ | - | ✔ |
@@ -123,7 +123,7 @@ Last updated: 2026-05-01
 
 | Framework | Category | License | Pricing | Self-Hosted | Budget / Cost | Observability | Dashboard | CLI |
 |:----------|:---------|:--------|:--------|:-----------:|:---:|:---:|:---:|:---:|
-| [**SynthOrg**](https://synthorg.io) | Virtual Org Simulator | BUSL-1.1 | Depends | ✔ | ~ | ✔ | ✔ | ~ |
+| [**SynthOrg**](https://synthorg.io) | Virtual Org Simulator | BUSL-1.1 | Depends | ✔ | ⏲ | ✔ | ✔ | ~ |
 | [CrewAI](https://crewai.com) | Multi-Agent Framework | MIT | Open-core | ~ | ~ | ~ | ~ | ✔ |
 | [AutoGen](https://microsoft.github.io/autogen/) | Multi-Agent Framework | MIT | Free | ✔ | - | ~ | ~ | - |
 | [LangGraph](https://www.langchain.com/langgraph) | Multi-Agent Framework | MIT | Open-core | ~ | - | ~ | ~ | ✔ |

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -1,57 +1,90 @@
 # Roadmap
 
-## Current Status
+## Current status
 
-SynthOrg is in **active development**. The core subsystems are built, tested (<!--RS:tests-->30,000+<!--/RS--> tests in the latest run, 80%+ coverage), and integrated through a REST + WebSocket API, React 19 dashboard, and Go CLI. See the [releases page](https://github.com/Aureliolo/synthorg/releases) for the latest tagged build.
+SynthOrg is in **active development**. The platform, infrastructure, and
+subsystem libraries are built and tested (<!--RS:tests-->30,000+<!--/RS-->
+tests in the latest run, 80%+ coverage) and integrated through a REST +
+WebSocket API, a React 19 dashboard, and a Go CLI. The autonomous agent
+**runtime** that makes the organisation actually execute work is the focus of
+current development and is tracked openly on the
+[issue tracker](https://github.com/Aureliolo/synthorg/issues). Be specific
+about what this means: starting SynthOrg brings up the platform and
+dashboard; running a company end to end is the work in flight.
 
-What works today:
+## Available now
 
-- **Agent engine** with ReAct, Plan-and-Execute, Hybrid execution loops, crash recovery, task decomposition, and agent identity versioning (list, diff, rollback, append-only history)
-- **Agent evolution** with pluggable triggers (batched, inflection, per-task), proposers (separate-analyzer, self-report, composite), and guards (rollback, review, rate limit, shadow evaluation)
-- **Dynamic workforce scaling** with closed-loop hiring and pruning, safety guards, and approval gates
-- **Budget & cost management** with per-agent limits, auto-downgrade at task boundaries, spending reports, anomaly detection, and hierarchical project cascades
-- **Security** with fail-closed rule engine, 4 autonomy tiers, progressive trust, output scanning, audit logging, two-stage safety classifier, and hallucination detection via cross-provider uncertainty check
-- **Memory** with hybrid retrieval (dense + BM25 sparse with RRF fusion), tool-based injection, procedural memory auto-generation from failures, consolidation (LLM Merge, Search-and-Ask), and MVCC snapshot reads on the shared knowledge store
-- **Communication** with message bus, hierarchical delegation with loop prevention, conflict resolution (4 strategies), meeting protocols, and an A2A gateway for external agent systems
-- **Workflow engine** with Kanban, Agile sprints, ceremony scheduling (8 strategies), visual workflow editor, and workflow execution from graph definitions
-- **Tool ecosystem** with 12+ categories (file system, code execution, version control, web, database, terminal, design, communication, analytics, deployment, memory, MCP servers) and sandbox security (auth proxy, gVisor, Chainguard packages)
-- **Persistence** with SQLite (single-node default) and PostgreSQL (multi-instance, dual-backend conformance-tested) backends, yoyo-managed schema migrations, and ISO 4217 currency stamping on every cost-bearing row
-- **Distributed runtime** with NATS JetStream message bus and distributed task queue for multi-instance deployments
-- **Web dashboard** (React 19 + shadcn/ui) with org chart, task board, agent detail, budget tracking, provider management, workflow editor, ceremony policy settings, setup wizard, and WebSocket / SSE resilience
-- **CLI** (Go) with init, start, stop, doctor, config, wipe, cleanup, worker, backup, completion, and cosign / SLSA verification
-- **Docker deployment** with Chainguard distroless images, Trivy + Grype scanning, cosign signatures, and SLSA L3 provenance
-- **Multi-user access** with HttpOnly cookie sessions, CSRF protection, concurrent session control, JWT auth, and session management
-- **Local model management** for Ollama and LM Studio (browse, pull, delete, configure launch parameters)
-- **Observability** with structured logging, correlation tracking, log shipping, redaction, Prometheus metrics, and OTLP
-- **Notification sinks** with operator alerts via Slack, ntfy, email, and HTTP relay (severity filtering and per-channel routing)
+Shipped and exercised today:
 
-What's not there yet:
+- **API, dashboard, CLI**: REST + WebSocket API, the React 19 dashboard, and
+  the Go CLI for Docker orchestration and supply-chain verification.
+- **Persistence**: SQLite (single-node default) and PostgreSQL
+  (multi-instance), dual-backend conformance-tested, with in-process
+  yoyo-managed migrations and ISO 4217 currency stamping on every
+  cost-bearing row.
+- **Provider layer**: any LLM via LiteLLM with retry and rate-limit handling;
+  local model management for Ollama and LM Studio.
+- **Configuration and templates**: define a company in YAML; importable
+  agent, department, and company templates with personality presets and
+  locale-aware name generation.
+- **Operations**: structured logging with correlation tracking and
+  redaction, log shipping, Prometheus metrics, OTLP.
+- **Multi-user access**: HttpOnly cookie sessions, CSRF protection,
+  concurrent session control, JWT auth.
+- **Supply chain**: Chainguard distroless images, Trivy + Grype scanning,
+  cosign signatures, SLSA L3 provenance.
+- **Distributed dispatch plumbing**: the NATS JetStream queue and worker
+  pool exist; the task-execute endpoint currently advances task state and
+  does not yet invoke an agent.
+- **Subsystem libraries**: the engine, memory, budget, security,
+  coordination, and intake modules exist as importable, unit-tested
+  components. They are exercised by their test suites, not yet by a running
+  agent (see below).
 
-- **End-to-end production runs**: subsystems are integrated but the full autonomous loop (agents receiving work, executing, producing artifacts, iterating) has not been validated as a cohesive product
-- **Runtime configuration surface for agent evolution**: the evolution service is implemented but wired at app init; runtime configuration via REST or UI is not yet exposed
+## In active development
 
-## Planned
+These make SynthOrg an autonomous studio. They are designed and largely
+written as components, but not yet wired into a running product. Each is
+tracked as an epic:
 
-Prioritised by dependency order. All work is tracked on the [GitHub issue tracker](https://github.com/Aureliolo/synthorg/issues).
-
-- Operational guides: runtime settings reference, notifications and event subscriptions, workflow API tutorials, agent lifecycle, memory admin API
-- OpenAPI TypeScript codegen for the web dashboard
-- REST API and dashboard UI for agent evolution configuration and triggering
-- TimescaleDB hypertable support for append-only time-series tables
-- Dynamic company scaling across clusters
-- Multi-project support with project-scoped teams and isolated budgets
-- Plugin system and benchmarking suite
-- A2A protocol compatibility: finalise inter-org communication surface
+- **Agent runtime online**
+  ([EPIC #1955](https://github.com/Aureliolo/synthorg/issues/1955)):
+  agents actually executing tasks (LLM + sandboxed tools) under a minimal
+  safety spine. The foundational item; everything else depends on it. Until
+  it lands, multi-agent coordination, coordination metrics, the intake
+  engine, the approval-queue producer, autonomy/trust enforcement on a live
+  run, and the self-improvement loop are implemented and unit-tested but not
+  exercised end to end.
+- **Conversational org interface**
+  ([EPIC #1967](https://github.com/Aureliolo/synthorg/issues/1967)): talk to
+  the company in natural language; it clarifies, proposes, and later acts
+  under governance.
+- **Autonomous product studio substrate**
+  ([EPIC #1973](https://github.com/Aureliolo/synthorg/issues/1973)):
+  persistent project workspace with pluggable git, brownfield codebase
+  intake, living documentation, and a deep requirements interview.
+- **Best-in-class operate tier**
+  ([EPIC #1979](https://github.com/Aureliolo/synthorg/issues/1979)): a
+  golden-company benchmark, mission control with run replay, a cost
+  forecast/kill-switch dial, a measurable learning curve, deterministic
+  replay, run narratives, and an adversarial red-team.
+- **Agent capability layer**
+  ([EPIC #1987](https://github.com/Aureliolo/synthorg/issues/1987)): a
+  knowledge and provenance retrieval substrate, research mode, continual
+  improvement, governed external API access, headless-browser and
+  virtual-desktop testing, and more.
 
 ## Backlog
 
-Research candidates and longer-term ideas without a scheduled timeframe. See [Future Vision](future-vision.md) for detail.
+Research candidates and longer-term ideas without a scheduled timeframe. See
+[Future Vision](future-vision.md) for detail.
 
-- Advanced memory architecture (GraphRAG, consistency protocols, RL consolidation)
+- Advanced memory architecture (GraphRAG, consistency protocols, RL
+  consolidation)
 - Community template marketplace
 - Kubernetes sandbox backend
 - Shift system for agents
 - Training mode (learn from senior agents)
-- Self-improving company (meta-loop signal aggregation, staged rollout)
+- TimescaleDB hypertable support for append-only time-series tables
 
 See [Open Questions](open-questions.md) for unresolved design decisions.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -3,7 +3,7 @@
 ## Current status
 
 SynthOrg is in **active development**. The platform, infrastructure, and
-subsystem libraries are built and tested (<!--RS:tests-->30,000+<!--/RS-->
+subsystem libraries are built and tested (<!--RS:tests-->31,000+<!--/RS-->
 tests in the latest run, 80%+ coverage) and integrated through a REST +
 WebSocket API, a React 19 dashboard, and a Go CLI. The autonomous agent
 **runtime** that makes the organisation actually execute work is the focus of

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -76,17 +76,17 @@ After the containers are running, open the web dashboard at [http://localhost:30
 1. **Account** (conditional): create the first admin user. This step only appears when no admin account exists yet.
 2. **Template**: choose a company template. Templates are displayed in a searchable grid with category and size filters, grouped into Recommended and Other sections. Each card shows structural metadata (agent count, departments, autonomy level, workflow). Side-by-side comparison is available.
 3. **Providers**: configure LLM providers. Local providers (e.g. Ollama) are auto-detected with a re-scan button; additional providers can be added via the full provider form supporting API key, subscription, and custom configurations. Model discovery runs automatically after adding a provider.
-4. **Company**: name your synthetic organization, set a description, choose a display currency, and select a model tier profile (Economy, Balanced, or Premium).
+4. **Company**: name your synthetic organisation, set a description, choose a display currency, and select a model tier profile (Economy, Balanced, or Premium).
 5. **Agents**: customize agent names, personality presets, and model assignments. Agents are pre-populated from the selected template with models matched to configured providers.
 6. **Theme**: set UI preferences including color palette, typography, layout density, animation level, and sidebar position.
-7. **Complete**: review a summary of your configuration and launch the organization.
+7. **Complete**: review a summary of your configuration and finish setup. This stores the company and brings up the platform; the agent runtime that puts the organisation to work is in active development (see the [Roadmap](roadmap/index.md)).
 
 The backend validates that a company and at least one provider exist before allowing setup to finish. Agents are optional (Quick Setup skips agent configuration). Steps are completed sequentially; a later step only appears done if all prior steps are also complete. Completed steps show a summary and can be revisited via the step indicator. After completing the wizard, the dashboard appears and the setup wizard is not shown again.
 
 To start fresh, use `synthorg wipe` (offers an interactive backup, wipes all data, and optionally restarts with a clean slate to re-open the setup wizard) or delete the `api.setup_complete` setting via the settings API.
 
-!!! info "Active Development"
-    SynthOrg is under active development. The web dashboard is available for monitoring and managing the organization. Templates and some features described here may evolve. Check the [GitHub repository](https://github.com/Aureliolo/synthorg) for current status.
+!!! info "Honest status"
+    The platform, dashboard, CLI, and setup wizard are built and available. The autonomous agent runtime that makes the organisation execute work end to end is in active development and not yet wired, so a configured company does not yet run agents. See the [Roadmap](roadmap/index.md) for exactly what is available now versus in active development.
 
 ## Templates
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -86,7 +86,7 @@ The backend validates that a company and at least one provider exist before allo
 To start fresh, use `synthorg wipe` (offers an interactive backup, wipes all data, and optionally restarts with a clean slate to re-open the setup wizard) or delete the `api.setup_complete` setting via the settings API.
 
 !!! info "Honest status"
-    The platform, dashboard, CLI, and setup wizard are built and available. The autonomous agent runtime that makes the organisation execute work end to end is in active development and not yet wired, so a configured company does not yet run agents. See the [Roadmap](roadmap/index.md) for exactly what is available now versus in active development.
+    The platform, dashboard, CLI, and setup wizard are built and available. The autonomous agent runtime that makes the organisation execute work end-to-end is in active development and not yet wired, so a configured company does not yet run agents. See the [Roadmap](roadmap/index.md) for exactly what is available now versus in active development.
 
 ## Templates
 

--- a/site/src/components/ComparisonFAQ.astro
+++ b/site/src/components/ComparisonFAQ.astro
@@ -2,19 +2,19 @@
 const faqs = [
   {
     question: "Why not just use CrewAI or AutoGen?",
-    answer: "CrewAI and AutoGen are excellent frameworks with strong communities and proven track records. CrewAI excels at role-based agent crews with a clean developer experience. AutoGen is powerful for conversation-driven agent systems (though now in maintenance mode as Microsoft merges it into the Agent Framework). SynthOrg targets a different niche: modeling entire organizations with departments, budgets, HR, and security policies. If your use case is a multi-agent pipeline or crew, CrewAI or AutoGen may be simpler and more mature. If you need organizational structure around your agents, SynthOrg is designed for that.",
+    answer: "CrewAI and AutoGen are excellent frameworks with strong communities and proven track records. CrewAI excels at role-based agent crews with a clean developer experience. AutoGen is powerful for conversation-driven agent systems (though now in maintenance mode as Microsoft merges it into the Agent Framework). SynthOrg targets a different niche: modelling entire organisations with departments, budgets, HR, and security policies. If your use case is a multi-agent pipeline or crew, CrewAI or AutoGen may be simpler and more mature. If you need organisational structure around your agents, SynthOrg is designed for that (with the runtime in active development).",
   },
   {
     question: "How is SynthOrg different from ChatDev or MetaGPT?",
-    answer: "ChatDev and MetaGPT simulate software companies for code generation. SynthOrg is a general-purpose framework for building any kind of synthetic organization, not limited to software development. It also includes production infrastructure (Docker, persistence, backup/restore, observability) that research projects typically lack.",
+    answer: "ChatDev and MetaGPT simulate software companies for code generation. SynthOrg is designed as a general-purpose platform for building any kind of synthetic organisation, not limited to software development, and it ships the production infrastructure (Docker, dual-backend persistence, backup/restore, observability) that research projects typically lack. The organisation runtime itself is in active development.",
   },
   {
     question: "Is SynthOrg production-ready?",
-    answer: "Not yet. SynthOrg is in active pre-alpha development. The framework includes production infrastructure (Docker images with Chainguard distroless base, cosign verification, SLSA provenance, backup/restore, structured logging with redaction), but the API is not yet stable and there are no known production deployments. We rate ourselves as 'partial' on production readiness and will upgrade to 'full' when the API stabilizes and the framework has been battle-tested at scale. We recommend it for experimentation and early adoption.",
+    answer: "Not yet, and we are specific about why. The platform and infrastructure are built and tested (Docker images with Chainguard distroless base, cosign verification, SLSA provenance, backup/restore, structured logging with redaction, dual-backend persistence, API, dashboard, CLI). However, the autonomous agent runtime that makes the organisation actually execute work is in active development; today, starting SynthOrg brings up the platform but does not yet run a company end to end. We rate ourselves 'planned' on the capabilities that depend on the runtime and 'full' only on what verifiably ships. Recommended for evaluation and following along, not production workloads.",
   },
   {
     question: "What about LangGraph for complex workflows?",
-    answer: "LangGraph excels at graph-based agent workflows with checkpointing. SynthOrg includes similar workflow capabilities (DAG execution, parallel tasks, Kanban boards, Agile sprints) but adds organizational structure on top: budget tracking, security policies, role-based delegation, and team coordination that LangGraph leaves to the application layer.",
+    answer: "LangGraph excels at graph-based agent workflows with checkpointing. SynthOrg is designed to include similar workflow capabilities (DAG execution, parallel tasks, Kanban boards, Agile sprints) and to add organisational structure on top: budget tracking, security policies, role-based delegation, and team coordination that LangGraph leaves to the application layer. These are built and unit-tested as components; running them is the runtime work in active development.",
   },
   {
     question: "Does SynthOrg support my LLM provider?",
@@ -22,7 +22,7 @@ const faqs = [
   },
   {
     question: "What about commercial platforms like Bedrock, Vertex, or Agentforce?",
-    answer: "Cloud platforms like Amazon Bedrock Agents, Google Vertex AI Agent Builder, and Salesforce Agentforce offer managed infrastructure, enterprise compliance, and deep ecosystem integration. The trade-off is vendor lock-in and less control. SynthOrg is self-hosted and source-available (BUSL-1.1), giving you full control over your infrastructure, data, and agent behavior, but you manage the ops yourself. If your organization already lives in AWS, GCP, or Salesforce, their native agent platform may be the pragmatic choice.",
+    answer: "Cloud platforms like Amazon Bedrock Agents, Google Vertex AI Agent Builder, and Salesforce Agentforce offer managed infrastructure, enterprise compliance, and deep ecosystem integration. The trade-off is vendor lock-in and less control. SynthOrg is self-hosted and source-available (BUSL-1.1), giving you full control over your infrastructure, data, and agent behaviour, but you manage the ops yourself. If your organization already lives in AWS, GCP, or Salesforce, their native agent platform may be the pragmatic choice.",
   },
   {
     question: "What license is SynthOrg under and what does it mean?",

--- a/site/src/components/ComparisonFAQ.astro
+++ b/site/src/components/ComparisonFAQ.astro
@@ -22,11 +22,11 @@ const faqs = [
   },
   {
     question: "What about commercial platforms like Bedrock, Vertex, or Agentforce?",
-    answer: "Cloud platforms like Amazon Bedrock Agents, Google Vertex AI Agent Builder, and Salesforce Agentforce offer managed infrastructure, enterprise compliance, and deep ecosystem integration. The trade-off is vendor lock-in and less control. SynthOrg is self-hosted and source-available (BUSL-1.1), giving you full control over your infrastructure, data, and agent behaviour, but you manage the ops yourself. If your organization already lives in AWS, GCP, or Salesforce, their native agent platform may be the pragmatic choice.",
+    answer: "Cloud platforms like Amazon Bedrock Agents, Google Vertex AI Agent Builder, and Salesforce Agentforce offer managed infrastructure, enterprise compliance, and deep ecosystem integration. The trade-off is vendor lock-in and less control. SynthOrg is self-hosted and source-available (BUSL-1.1), giving you full control over your infrastructure, data, and agent behaviour, but you manage the ops yourself. If your organisation already lives in AWS, GCP, or Salesforce, their native agent platform may be the pragmatic choice.",
   },
   {
     question: "What license is SynthOrg under and what does it mean?",
-    answer: "SynthOrg uses the Business Source License 1.1 (BUSL-1.1), a source-available license. You can freely use it in production for any purpose that does not compete with SynthOrg as a product. Small organizations building internal tools, automations, or custom agents are free to use it without restriction. Each released version automatically converts to Apache 2.0 three years after its release date (the current version's Change Date is April 2, 2029). Once converted, the code is fully permissive with no additional conditions.",
+    answer: "SynthOrg uses the Business Source License 1.1 (BUSL-1.1), a source-available license. You can freely use it in production for any purpose that does not compete with SynthOrg as a product. Small organisations building internal tools, automations, or custom agents are free to use it without restriction. Each released version automatically converts to Apache 2.0 three years after its release date (the current version's Change Date is April 2, 2029). Once converted, the code is fully permissive with no additional conditions.",
   },
   {
     question: "Is this comparison data accurate?",

--- a/site/src/components/ComparisonHero.astro
+++ b/site/src/components/ComparisonHero.astro
@@ -27,8 +27,9 @@ const { competitorCount } = Astro.props;
 
     <!-- Subtext -->
     <p class="text-lg md:text-xl text-gray-400 max-w-2xl mx-auto mb-8">
-      The definitive comparison of agent orchestration frameworks, platforms, and research projects.
-      Filter, sort, and explore what each framework actually delivers.
+      A comparison of agent orchestration frameworks, platforms, and research projects.
+      SynthOrg's row marks capabilities honestly as available now versus planned,
+      matching its roadmap; explore what each project actually delivers today.
     </p>
 
     <!-- Scroll hint -->

--- a/site/src/components/ExpandableArchitecture.astro
+++ b/site/src/components/ExpandableArchitecture.astro
@@ -48,7 +48,7 @@ const architecture = [
       },
       {
         name: "6 Routing Strategies",
-        description: "Manual, role-based, load-balanced, auction, hierarchical delegation, cost-optimized.",
+        description: "Manual, role-based, load-balanced, auction, hierarchical delegation, cost-optimised.",
         href: "/docs/design/engine/",
       },
       {
@@ -131,12 +131,12 @@ const architecture = [
       },
       {
         name: "Budget Engine",
-        description: "Hierarchical cascades, 3-layer cost controls, CFO optimization, trend analysis with Theil-Sen regression.",
+        description: "Hierarchical cascades, layered cost controls, CFO optimisation, trend analysis with Theil-Sen regression.",
         href: "/docs/design/budget/",
       },
       {
-        name: "Real-Time Dashboard",
-        description: "Org chart, task board, budget gauges, agent detail, activity feeds; all live.",
+        name: "Dashboard",
+        description: "Org chart, task board, budget gauges, agent detail, activity feeds, with live WebSocket updates. Shipped; populated as the agent runtime comes online.",
         href: "/docs/",
       },
     ],

--- a/site/src/components/ExpandableArchitecture.astro
+++ b/site/src/components/ExpandableArchitecture.astro
@@ -131,7 +131,7 @@ const architecture = [
       },
       {
         name: "Budget Engine",
-        description: "Hierarchical cascades, layered cost controls, CFO optimisation, trend analysis with Theil-Sen regression.",
+        description: "Hierarchical cascades, 3-layer cost controls, CFO optimisation, trend analysis with Theil-Sen regression.",
         href: "/docs/design/budget/",
       },
       {

--- a/site/src/components/FeatureShowcase.astro
+++ b/site/src/components/FeatureShowcase.astro
@@ -3,20 +3,20 @@ const heroFeatures = [
   {
     icon: "\u2699",
     title: "Orchestration Engine",
-    headline: "Six routing strategies. Three execution loops. One engine.",
+    headline: "Routing strategies and execution loops, designed as one engine.",
     description:
-      "Agents bid for tasks via auction, get assigned by role, or get load-balanced. The engine decomposes work into DAGs, resolves conflicts, and recovers from crashes automatically.",
+      "Designed for auction, role-based, and load-balanced task routing, DAG decomposition, conflict resolution, and crash recovery. Built and unit-tested as components; running it end to end is the runtime work in active development.",
     differentiator:
-      "Sequential, parallel, Kanban, and Agile sprint workflows built in.",
+      "Sequential, parallel, Kanban, and Agile sprint workflows in the design.",
     href: "/docs/design/engine/",
     color: "violet",
   },
   {
     icon: "\uD83D\uDD12",
     title: "Governance & Security",
-    headline: "Every action classified, audited, and gated.",
+    headline: "Every action classified, audited, and gated, by design.",
     description:
-      "Hybrid SecOps: rule engine fast-path for ~95% of actions in sub-millisecond, plus LLM evaluator for uncertain cases. Four autonomy tiers (full, semi, supervised, locked). 25+ classified action types. Budget enforcement at every layer.",
+      "A designed hybrid SecOps model: a fail-closed rule-engine fast-path plus an LLM evaluator for uncertain cases, four autonomy tiers (full, semi, supervised, locked), and budget enforcement. Implemented and unit-tested; enforced on a live run with the agent runtime.",
     differentiator:
       "Progressive trust: privileges never auto-granted, auto-downgrade on violations.",
     href: "/docs/security/",
@@ -25,22 +25,22 @@ const heroFeatures = [
   {
     icon: "\uD83E\uDDE0",
     title: "Agent Identity",
-    headline: "Agents with personalities, careers, and performance reviews.",
+    headline: "Agents designed with personalities, careers, and reviews.",
     description:
-      "Big Five personality dimensions drive team compatibility. Eight seniority levels from Intern to C-Suite. Three-tier quality scoring. Hiring, promotions, and firing with full memory archival.",
+      "Big Five personality dimensions for team compatibility, seniority levels from Intern to C-Suite, quality scoring, and hiring/promotion/offboarding with memory archival. Modelled and tested as components.",
     differentiator:
-      "Not interchangeable workers; agents have identity and growth.",
+      "Not interchangeable workers; agents are designed with identity and growth.",
     href: "/docs/design/agents/",
     color: "violet",
   },
   {
     icon: "\uD83D\uDDC3",
     title: "Memory & Knowledge",
-    headline: "Five memory types. Knowledge that outlasts any agent.",
+    headline: "Multiple memory types. Knowledge designed to outlast any agent.",
     description:
-      "Working, episodic, semantic, procedural, and social memory. Hybrid prompt and retrieval injection. Memories survive offboarding and transfer to successors automatically.",
+      "Working, episodic, semantic, procedural, and social memory with hybrid prompt and retrieval injection, designed to survive offboarding and transfer to successors. The pipeline runs once a live agent exercises it (in active development).",
     differentiator:
-      "Organizational knowledge persists across the entire agent lifecycle.",
+      "Organisational knowledge designed to persist across the agent lifecycle.",
     href: "/docs/design/memory/",
     color: "teal",
   },

--- a/site/src/components/FeatureShowcase.astro
+++ b/site/src/components/FeatureShowcase.astro
@@ -16,7 +16,7 @@ const heroFeatures = [
     title: "Governance & Security",
     headline: "Every action classified, audited, and gated, by design.",
     description:
-      "A designed hybrid SecOps model: a fail-closed rule-engine fast-path plus an LLM evaluator for uncertain cases, four autonomy tiers (full, semi, supervised, locked), and budget enforcement. Implemented and unit-tested; enforced on a live run with the agent runtime.",
+      "A designed hybrid SecOps model: a fail-closed rule-engine fast-path plus an LLM evaluator for uncertain cases, four autonomy tiers (full, semi, supervised, locked), and budget enforcement. Implemented and unit-tested; enforced on a live run once the agent runtime is live.",
     differentiator:
       "Progressive trust: privileges never auto-granted, auto-downgrade on violations.",
     href: "/docs/security/",

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -32,7 +32,7 @@
     <div>
       <p class="font-semibold mb-3">Legal</p>
       <ul class="space-y-2 text-gray-400">
-        <li><a href="/docs/licensing/" class="hover:text-white transition-colors">License & Usage (BUSL 1.1)</a></li>
+        <li><a href="/docs/licensing/" class="hover:text-white transition-colors">License & Usage (BSL 1.1)</a></li>
         <li><a href="/sitemap-index.xml" class="hover:text-white transition-colors">Sitemap</a></li>
       </ul>
     </div>

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -32,7 +32,7 @@
     <div>
       <p class="font-semibold mb-3">Legal</p>
       <ul class="space-y-2 text-gray-400">
-        <li><a href="/docs/licensing/" class="hover:text-white transition-colors">License & Usage (BSL 1.1)</a></li>
+        <li><a href="/docs/licensing/" class="hover:text-white transition-colors">License & Usage (BUSL 1.1)</a></li>
         <li><a href="/sitemap-index.xml" class="hover:text-white transition-colors">Sitemap</a></li>
       </ul>
     </div>

--- a/site/src/components/ScrollSyncPanel.astro
+++ b/site/src/components/ScrollSyncPanel.astro
@@ -4,9 +4,11 @@
 
 <section id="how-it-works" class="py-16 px-6">
   <div class="max-w-6xl mx-auto">
-    <h2 class="text-3xl md:text-4xl font-bold text-center mb-4">See How It Works</h2>
+    <h2 class="text-3xl md:text-4xl font-bold text-center mb-4">How It Is Designed To Work</h2>
     <p class="text-gray-400 text-center max-w-2xl mx-auto mb-16">
-      Set up a full AI organization in minutes, from a solo builder to a 30+ agent enterprise.
+      Steps 1-2 (pick a template, configure via wizard or REST API) work today.
+      Steps 3-4 illustrate the designed runtime behaviour, agents collaborating
+      and the operations view, which is in active development.
     </p>
 
     <div class="md:grid md:grid-cols-[1fr_auto_1fr] md:gap-8">
@@ -34,7 +36,7 @@
 
 <span class="text-gray-500 text-xs">Or define your own with YAML config.</span></code></pre>
             </div>
-            <p class="mt-4 text-sm text-gray-500 italic">9 built-in templates from 2 to 30+ agents. Fully customizable roles, personalities, budgets, and tools.</p>
+            <p class="mt-4 text-sm text-gray-500 italic">Built-in templates from 2 to 30+ agents. Fully customisable roles, personalities, budgets, and tools.</p>
           </div>
         </div>
 
@@ -85,7 +87,7 @@
 <span class="text-green-400">[DONE]</span>  #12a approved by PM (quality: 94%)
 <span class="text-teal-400">[COMMS]</span>  Meeting: sprint review (round-robin)</code></pre>
             </div>
-            <p class="mt-4 text-sm text-gray-500 italic">DAG-based decomposition. 6 routing strategies. Meetings, delegation, and conflict resolution built in.</p>
+            <p class="mt-4 text-sm text-gray-500 italic">Designed runtime behaviour (in active development): DAG-based decomposition, routing strategies, meetings, delegation, and conflict resolution.</p>
           </div>
         </div>
 
@@ -110,7 +112,7 @@
   UX Designer    quality: 93%  tasks:  8  cost: EUR 2.15
   PM             quality: 91%  tasks:  9  cost: EUR 4.80</code></pre>
             </div>
-            <p class="mt-4 text-sm text-gray-500 italic">Per-token cost tracking. Coordination overhead. Performance scoring. Budget enforcement at every layer.</p>
+            <p class="mt-4 text-sm text-gray-500 italic">Designed operations view (in active development): per-token cost tracking, coordination overhead, performance scoring, budget enforcement.</p>
           </div>
         </div>
       </div>

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -12,7 +12,7 @@ interface Props {
 
 const {
   title,
-  description = "Framework for building synthetic organizations, autonomous AI agents orchestrated as a virtual company",
+  description = "An autonomous product studio you operate: a self-hostable platform for synthetic organisations of role-based AI agents. Platform built and tested; agent runtime in active development.",
   image = "/og-image.png",
   type = "website",
   enableRecaptcha = false,

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -12,7 +12,7 @@ interface Props {
 
 const {
   title,
-  description = "An autonomous product studio you operate: a self-hostable platform for synthetic organisations of role-based AI agents. Platform built and tested; agent runtime in active development.",
+  description = "Autonomous product studio: a self-hostable platform for synthetic organisations of role-based AI agents. Platform shipped; agent runtime in active development.",
   image = "/og-image.png",
   type = "website",
   enableRecaptcha = false,

--- a/site/src/pages/compare.astro
+++ b/site/src/pages/compare.astro
@@ -69,10 +69,11 @@ const description = `Interactive comparison of SynthOrg against ${competitorCoun
             <h3 class="text-xl font-semibold">Virtual Organization</h3>
           </div>
           <p class="text-gray-400 leading-relaxed">
-            The only framework that models a complete organizational structure:
-            departments, reporting chains, 8 seniority levels, hiring/firing,
-            performance tracking, and career progression. Agents are not just tools;
-            they are employees with roles and responsibilities.
+            Designed to model a complete organisational structure: departments,
+            reporting chains, seniority levels, hiring/firing, performance
+            tracking, and career progression. Agents are modelled as employees
+            with roles and responsibilities, not just tools. Built and
+            unit-tested as components; exercised once the agent runtime lands.
           </p>
         </div>
 
@@ -85,9 +86,11 @@ const description = `Interactive comparison of SynthOrg against ${competitorCoun
             <h3 class="text-xl font-semibold">Cost Intelligence</h3>
           </div>
           <p class="text-gray-400 leading-relaxed">
-            Per-agent budget tracking with hierarchical cascades, CFO-level optimization,
-            quota degradation, and trend analysis. No other framework gives you financial
-            controls at the agent level. Know exactly what each agent costs and why.
+            Designed for per-agent budget tracking with hierarchical cascades,
+            CFO-level optimisation, quota degradation, and trend analysis:
+            financial controls at the agent level, so you can see exactly what
+            each agent costs and why. Implemented and tested as components;
+            enforced on a live run with the agent runtime (in development).
           </p>
         </div>
 
@@ -100,10 +103,11 @@ const description = `Interactive comparison of SynthOrg against ${competitorCoun
             <h3 class="text-xl font-semibold">Progressive Security</h3>
           </div>
           <p class="text-gray-400 leading-relaxed">
-            A rule engine combined with LLM-based evaluation, 4 autonomy tiers
-            (full, semi, supervised, locked), progressive trust scoring,
-            comprehensive audit trails, and output scanning. Security is built
-            into the framework from day one, not bolted on after.
+            A designed rule engine combined with LLM-based evaluation, four
+            autonomy tiers (full, semi, supervised, locked), progressive trust
+            scoring, audit trails, and output scanning. Security is designed
+            into the framework from day one, not bolted on; the runtime
+            enforcement activates with the agent runtime (in development).
           </p>
         </div>
 
@@ -133,13 +137,13 @@ const description = `Interactive comparison of SynthOrg against ${competitorCoun
   <section class="py-16 px-6">
     <div class="max-w-3xl mx-auto text-center">
       <h2 class="text-3xl md:text-4xl font-bold mb-6">
-        Ready to build your
+        Ready to set up your
         <span class="text-transparent bg-clip-text bg-gradient-to-r from-violet-400 to-teal-400">
-          synthetic organization?
+          synthetic organisation?
         </span>
       </h2>
       <p class="text-gray-400 mb-8">
-        Get started with SynthOrg in minutes. Define your company in YAML, configure your agents, and watch them work.
+        Stand up the SynthOrg platform in minutes and define your company in YAML. The runtime that puts the agents to work is in active development, in the open.
       </p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center items-center">
         <a href="/get/" class="px-8 py-3 bg-violet-600 hover:bg-violet-500 rounded-lg font-semibold transition-colors">

--- a/site/src/pages/compare.astro
+++ b/site/src/pages/compare.astro
@@ -66,7 +66,7 @@ const description = `Interactive comparison of SynthOrg against ${competitorCoun
             <div class="w-10 h-10 rounded-lg bg-violet-600/20 flex items-center justify-center">
               <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-violet-400"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
             </div>
-            <h3 class="text-xl font-semibold">Virtual Organization</h3>
+            <h3 class="text-xl font-semibold">Virtual Organisation</h3>
           </div>
           <p class="text-gray-400 leading-relaxed">
             Designed to model a complete organisational structure: departments,

--- a/site/src/pages/get/index.astro
+++ b/site/src/pages/get/index.astro
@@ -16,7 +16,7 @@ import Base from "../../layouts/Base.astro";
         </span>
       </h1>
       <p class="text-lg text-gray-400 max-w-xl mx-auto">
-        Install the CLI to set up and manage your synthetic organization in seconds.
+        Install the CLI to set up and run the SynthOrg platform in seconds. (The agent runtime is in active development; see the <a href="/docs/roadmap/" class="text-teal-400 underline decoration-teal-400/40 hover:decoration-teal-400">roadmap</a>.)
       </p>
     </div>
   </section>
@@ -83,7 +83,7 @@ import Base from "../../layouts/Base.astro";
 
       <!-- Post-install (full width below both) -->
       <div class="bg-[#1a1f2e] rounded-xl p-6 border border-violet-500/20">
-        <p class="text-sm text-gray-400 mb-3">Then set up and start your organization:</p>
+        <p class="text-sm text-gray-400 mb-3">Then set up and start the platform:</p>
         <div class="relative bg-[#0d1117] rounded-xl border border-white/10 overflow-hidden">
           <div class="flex items-center justify-between px-4 py-2 bg-[#161b22] border-b border-white/10">
             <div class="flex items-center gap-2">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -8,10 +8,10 @@ import ParticleNetwork from "../components/ParticleNetwork.astro";
 import ScrollSyncPanel from "../components/ScrollSyncPanel.astro";
 import DashboardPreview from "../components/islands/DashboardPreview";
 
-const description = "Framework for building synthetic organizations, autonomous AI agents orchestrated as a virtual company";
+const description = "An autonomous product studio you operate: a self-hostable platform where a synthetic organisation of role-based AI agents is designed to plan and deliver products under budgets and governance. Platform built and tested; the agent runtime is in active development.";
 ---
 
-<Base title="SynthOrg | Build Synthetic Organizations" description={description} enableRecaptcha={true}>
+<Base title="SynthOrg | Autonomous Product Studio" description={description} enableRecaptcha={true}>
   <!-- ============================================================ -->
   <!-- HERO (Dark) -->
   <!-- ============================================================ -->
@@ -21,22 +21,23 @@ const description = "Framework for building synthetic organizations, autonomous 
     <div class="relative z-10 max-w-4xl mx-auto text-center">
       <!-- Eyebrow -->
       <p class="text-sm tracking-widest text-violet-400 mb-6 font-mono">
-        Python 3.14+ &middot; BSL 1.1 &middot; Source Available
+        Python 3.14+ &middot; BUSL 1.1 &middot; Source Available
       </p>
 
       <!-- Headline -->
       <h1 class="text-5xl md:text-7xl font-bold leading-tight mb-6">
-        What if your company had
+        An autonomous product studio
         <span class="text-transparent bg-clip-text bg-gradient-to-r from-violet-400 to-teal-400">
-          infinite, tireless employees?
+          you operate.
         </span>
       </h1>
 
       <!-- Subtext -->
       <p class="text-lg md:text-xl text-gray-400 max-w-2xl mx-auto mb-10">
-        A Python framework for building synthetic organizations, autonomous AI agents
-        with real roles, personalities, budgets, memory, and enterprise-grade governance.
-        Define a company in YAML. Watch it run.
+        Describe a product to build, or hand it an existing codebase: a synthetic
+        organisation of role-based AI agents, with budgets, memory, and governance,
+        is designed to plan and deliver it. The platform is built and tested; the
+        agent runtime that runs the organisation is in active development, in the open.
       </p>
 
       <!-- CTAs -->
@@ -69,9 +70,10 @@ const description = "Framework for building synthetic organizations, autonomous 
   <section class="py-4 px-6 bg-gradient-to-r from-violet-600/10 via-teal-600/10 to-violet-600/10 border-y border-violet-500/20">
     <div class="max-w-4xl mx-auto text-center">
       <p class="text-sm text-gray-300">
-        <span class="font-semibold text-violet-400">Early Access:</span>
-        SynthOrg is under active development. Some features shown are planned but not yet fully implemented.
-        <a href="https://github.com/Aureliolo/synthorg" class="text-teal-400 underline decoration-teal-400/40 hover:decoration-teal-400">Follow on GitHub</a> ·
+        <span class="font-semibold text-violet-400">Honest status:</span>
+        The platform, infrastructure, and subsystem libraries are built and tested. The autonomous agent runtime that makes the organisation execute work end to end is in active development and tracked in the open. Capability sections on this page are marked as available now or in active development.
+        <a href="/docs/roadmap/" class="text-teal-400 underline decoration-teal-400/40 hover:decoration-teal-400">Roadmap</a> ·
+        <a href="https://github.com/Aureliolo/synthorg/issues" class="text-teal-400 underline decoration-teal-400/40 hover:decoration-teal-400">Issue tracker</a> ·
         <a href="#contact" class="text-teal-400 underline decoration-teal-400/40 hover:decoration-teal-400">Get in touch</a>
       </p>
     </div>
@@ -115,7 +117,7 @@ const description = "Framework for building synthetic organizations, autonomous 
     <div class="max-w-6xl mx-auto">
       <h2 class="text-3xl md:text-4xl font-bold text-center mb-4">What Makes SynthOrg Different</h2>
       <p class="text-gray-400 text-center max-w-2xl mx-auto mb-12">
-        Not just agent orchestration -- a complete organizational system with HR, governance, personality-driven teams, and enterprise-grade cost controls.
+        Not just agent orchestration. SynthOrg is designed as a complete organisational system: HR, governance, personality-driven teams, and cost controls, modelled as a real company rather than a chain of function calls.
       </p>
       <FeatureShowcase />
     </div>
@@ -127,7 +129,7 @@ const description = "Framework for building synthetic organizations, autonomous 
   <section class="py-16 px-6">
     <div class="max-w-5xl mx-auto text-center">
       <h2 class="text-3xl md:text-4xl font-bold mb-4">Architecture</h2>
-      <p class="text-gray-400 mb-12">Modular, protocol-driven. Every component is pluggable.</p>
+      <p class="text-gray-400 mb-12">The designed, modular, protocol-driven architecture. Every component is pluggable and built as tested code; the agent runtime that drives it end to end is in active development.</p>
 
       <ExpandableArchitecture />
 
@@ -144,19 +146,21 @@ const description = "Framework for building synthetic organizations, autonomous 
     <div class="max-w-6xl mx-auto">
       <h2 class="text-3xl md:text-4xl font-bold text-center mb-4">Security-First by Design</h2>
       <p class="text-gray-400 text-center max-w-2xl mx-auto mb-16">
-        Autonomous agents need guardrails. SynthOrg embeds security at every layer,
-        from the application runtime to the CI/CD pipeline and container infrastructure.
+        Autonomous agents need guardrails. The CI/CD pipeline and container
+        infrastructure security below is in place today; the application-runtime
+        guardrails are designed and unit-tested, and become active with the agent
+        runtime (in active development).
       </p>
 
       <div class="grid md:grid-cols-3 gap-8">
         <!-- Runtime Security -->
         <a href="/docs/security/#application-security" class="block bg-[#0F1219] rounded-xl p-8 border border-teal-500/20 hover:border-teal-500/40 transition-colors no-underline text-white">
           <div class="w-12 h-12 rounded-lg bg-teal-600/20 flex items-center justify-center text-teal-400 mb-4 text-xl">&#128737;</div>
-          <h3 class="text-xl font-semibold mb-3">Runtime Protection</h3>
-          <p class="text-gray-400 mb-4">Hybrid SecOps: rule engine fast-path handles ~95% of actions in sub-millisecond, with an LLM evaluator for uncertain edge cases. 25+ classified action types, four autonomy tiers (full, semi, supervised, locked).</p>
+          <h3 class="text-xl font-semibold mb-3">Runtime Protection <span class="text-xs font-normal text-violet-400">(in active development)</span></h3>
+          <p class="text-gray-400 mb-4">Designed hybrid SecOps: a fail-closed rule-engine fast-path with an LLM evaluator for uncertain cases, classified action types, and four autonomy tiers (full, semi, supervised, locked). Implemented and unit-tested as components; enforced on a live run once the agent runtime lands.</p>
           <ul class="text-sm text-gray-400 space-y-1">
             <li>Fail-closed rule engine + LLM fallback evaluator</li>
-            <li>4 autonomy tiers with progressive trust</li>
+            <li>Four autonomy tiers with progressive trust</li>
             <li>Output scanning with redaction policies</li>
             <li>Persistent audit trail for every decision</li>
           </ul>
@@ -202,7 +206,12 @@ const description = "Framework for building synthetic organizations, autonomous 
   <!-- ============================================================ -->
   <section class="py-16 px-6">
     <div class="max-w-6xl mx-auto">
-      <h2 class="text-3xl md:text-4xl font-bold text-center mb-16">Use Cases</h2>
+      <h2 class="text-3xl md:text-4xl font-bold text-center mb-4">Use Cases</h2>
+      <p class="text-gray-400 text-center max-w-2xl mx-auto mb-16">
+        The studio is designed for organisations like these. They describe the
+        target shape of a SynthOrg company, not validated end-to-end runs; the
+        agent runtime that executes them is in active development.
+      </p>
 
       <UseCaseCards />
     </div>
@@ -215,7 +224,7 @@ const description = "Framework for building synthetic organizations, autonomous 
     <div class="max-w-5xl mx-auto text-center">
       <h2 class="text-3xl md:text-4xl font-bold mb-4">See the Dashboard</h2>
       <p class="text-gray-400 mb-12 max-w-2xl mx-auto">
-        Monitor agents, tasks, budgets, and communications in real time, all from a single dashboard.
+        The React 19 dashboard for agents, tasks, budgets, and communications, with live WebSocket updates. Shipped today; it becomes a live operations view as the agent runtime comes online.
       </p>
       <DashboardPreview client:visible />
     </div>
@@ -326,8 +335,8 @@ const description = "Framework for building synthetic organizations, autonomous 
   <section class="py-16 px-6 bg-gradient-to-b from-[#0F1219] to-[#1a1025]">
     <div class="max-w-3xl mx-auto text-center">
       <h2 class="text-3xl md:text-5xl font-bold mb-6">
-        Build something that thinks
-        <span class="text-transparent bg-clip-text bg-gradient-to-r from-violet-400 to-teal-400">like a team.</span>
+        Operate a company
+        <span class="text-transparent bg-clip-text bg-gradient-to-r from-violet-400 to-teal-400">that builds.</span>
       </h2>
 
       <a


### PR DESCRIPTION
## Summary

Honest-hybrid refresh of public-facing documentation, marketing site, and design specs so that what the project claims matches what is actually built and what is still in flight.

- **README**: reframed the project around the "autonomous product studio you operate" positioning; added an explicit "Project status (read this)" callout; split "What is available now" (tested, runnable platform) from "In active development" (designed/written but not yet wired into a running product); honest note that subsystem libraries are exercised by their test suites, not yet by a running agent.
- **Marketing site** (`site/`): updated hero, comparison, feature showcase, expandable architecture, scroll-sync panel, and footer copy to the same honest framing.
- **Design specs** (`docs/design/*`): status banner added to each page; index, hr-lifecycle, guides, comparison, roadmap, and user guide updated.
- **`data/competitors.yaml`**: SynthOrg capability statuses corrected so anything only "worked toward" is `PLANNED`, never `FULL`.

## Pre-PR review

Reviewed by 3 agents before first push: **docs-consistency**, **comment-quality-rot**, **diagram-syntax-validator**.

4 findings triaged (`_audit/pre-pr-review/triage.md`), 3 fixed + 1 retained by maintainer decision:

- **Fixed** — `<!--RS:tests-->` fallback `30,000+` was stale vs `data/runtime_stats.yaml` (`display: 31,000+`, raw 31118); updated in `README.md` and `docs/roadmap/index.md`.
- **Fixed** — newly-introduced `([EPIC #N](issue url))` links stripped from the user-facing README "In active development" section (roadmap + issue-tracker links already provide traceability).
- **Fixed** — inline `([EPIC #1955](url))` removed from the quickstart tutorial; replaced with a roadmap link.
- **Retained by decision** — the 5 EPIC links in `docs/roadmap/index.md` are kept: the roadmap is the project's canonical public tracking surface and the appropriate home for that traceability.

Verified clean: `competitors.yaml` correctly marks planned capabilities as `PLANNED` (no overclaiming); the honest-hybrid framing accurately reflects that the agent runtime is not yet wired into the shipped path; no American spellings, em-dashes, or historical-framing violations introduced; all 26 Mermaid/D2 diagrams in changed docs are syntactically valid; all other `<!--RS:NAME-->` markers resolve.

## Test plan

- Docs/site/data only; no code paths changed (no Python/web/Go files).
- `pre-commit run --files <branch diff>` passes locally (em-dash gate, doc-count floors, line endings).
- Numeric claims remain RS-marker-wrapped; build-time injection resolves them from `data/runtime_stats.yaml`.

No linked issue (documentation accuracy pass).
