### PR TITLE
fix: make coordination metrics live (#1959)

### DIFF
--- a/docs/design/budget.md
+++ b/docs/design/budget.md
@@ -330,6 +330,13 @@ etc.).
           - coordination_failure
     ```
 
+    The `Ae` baseline is a sliding window of recent single-agent (SAS)
+    runs. Its size is the `budget.baseline_window_size` setting
+    (default 50), sourced from the `SYNTHORG_BUDGET_BASELINE_WINDOW_SIZE`
+    environment variable at API start. It is read-only post-init: the
+    window is sized once when the baseline store is constructed, so a
+    change requires a restart.
+
 ???+ note "Full Analytics Layer Configuration"
 
     Expanded per-call metadata for comprehensive financial and operational reporting:

--- a/docs/design/budget.md
+++ b/docs/design/budget.md
@@ -321,7 +321,6 @@ etc.).
         - straggler_gap                    # computed from per-agent turn times
         - token_speedup_ratio              # computed from token usage + speedup
         - message_overhead                 # computed from pairwise message counts
-      baseline_window: 50                  # number of SAS runs to establish baseline for Ae
       error_taxonomy:
         enabled: false                     # opt-in -- enable for targeted diagnosis
         categories:

--- a/docs/reference/configuration-precedence.md
+++ b/docs/reference/configuration-precedence.md
@@ -128,6 +128,8 @@ domain-specific startup event (e.g. `API_APP_STARTUP`,
 | `communication.nats_url` | `SYNTHORG_NATS_URL` | Read once by the bus driver at startup. |
 | `workers.count` | `SYNTHORG_WORKERS` | Read at worker-process boot AND by the worker pool builder. |
 | `observability.log_directory` | `SYNTHORG_LOG_DIR` | Path-traversal validated at the boot site. |
+| `budget.coordination_metrics_max_entries` | `SYNTHORG_BUDGET_COORDINATION_METRICS_MAX_ENTRIES` | Sizes the coordination-metrics ring buffer at boot. |
+| `budget.baseline_window_size` | `SYNTHORG_BUDGET_BASELINE_WINDOW_SIZE` | Sizes the single-agent baseline window at `BaselineStore` construction. |
 
 ### Category 3 examples (env only; no registry entry)
 

--- a/scripts/_ghost_wiring_manifest.txt
+++ b/scripts/_ghost_wiring_manifest.txt
@@ -29,8 +29,8 @@ ENFORCED ApprovalGate #1957 -- one gate wired at boot in lifecycle_builder, inje
 ENFORCED TrustService #1957 -- built at boot (non-DISABLED strategy), injected into AgentEngine; narrows tool permissions at the invoker seam
 ENFORCED build_mcp_self_consumer #1957 -- called in runtime_builder; agent invokes SynthOrg's own MCP tools trust-scoped with actor fail-closed
 ENFORCED build_autonomy_change_strategy #1957 -- built at boot in app_builders, attached to AppState; autonomy controller routes through it
-PENDING BaselineStore #1959 -- construct at boot (window from budget.baseline_window_size)
-PENDING CoordinationMetricsCollector #1959 -- construct at boot, thread into execution
+ENFORCED BaselineStore #1959 -- construct at boot (window from budget.baseline_window_size)
+ENFORCED CoordinationMetricsCollector #1959 -- construct at boot, thread into execution
 ENFORCED IntakeEngine #1961 -- wired at boot via client/runtime_builder.build_client_simulation_runtime
 ENFORCED create_lifecycle_strategy #1965 -- constructed at boot in workers/runtime_builder._build_tool_registry and injected into the Docker sandbox backend
 ENFORCED build_distributed_backend_services #1966 -- called in api/auto_wire._register_distributed_dispatcher behind queue.enabled; builds the dead-letter consumer + dedup pruner + heartbeat subscriber bundle

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -131,8 +131,8 @@ from synthorg.settings.errors import (
 from synthorg.settings.mirrors import (
     parse_bool,
     parse_float,
-    parse_int,
     parse_str_tuple_json,
+    resolve_init_int,
 )
 from synthorg.tools.invocation_tracker import ToolInvocationTracker  # noqa: TC001
 
@@ -192,11 +192,10 @@ def _resolve_api_str_tuple(key: str) -> tuple[str, ...]:
 def _resolve_api_int(key: str) -> int:
     """Resolve an integer-typed api.* setting at boot.
 
-    Uses ``parse_int`` so a non-integer env value falls through to the
-    registered default rather than raising at app construction time.
+    Non-integer env values fall through to the registered default rather
+    than raising at app construction time.
     """
-    resolved = resolve_init_value(SettingNamespace.API, key, parse=parse_int)
-    return int(resolved.value)
+    return resolve_init_int(SettingNamespace.API, key)
 
 
 def _resolve_api_str(key: str) -> str:
@@ -213,8 +212,7 @@ def _resolve_budget_int(key: str) -> int:
     registered default via the bootstrap resolver (a runtime change
     requires a restart -- the consumer is a fixed-length ring buffer).
     """
-    resolved = resolve_init_value(SettingNamespace.BUDGET, key, parse=parse_int)
-    return int(resolved.value)
+    return resolve_init_int(SettingNamespace.BUDGET, key)
 
 
 def _build_default_approval_timeout_scheduler(

--- a/src/synthorg/budget/coordination_collector.py
+++ b/src/synthorg/budget/coordination_collector.py
@@ -9,7 +9,7 @@ Individual metric failures are logged and skipped without blocking
 remaining metric collection.
 """
 
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, NamedTuple, Protocol, runtime_checkable
 
 from synthorg.budget.coordination_config import (
     CoordinationMetricName,
@@ -64,6 +64,31 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 _MIN_TEAM_SIZE: int = 2
+
+
+class CollectionInputs(NamedTuple):
+    """Inputs for a single :meth:`CoordinationMetricsCollector.collect`.
+
+    Bundles the post-execution context so the entry point takes one
+    typed argument instead of eight keyword parameters.
+
+    Attributes:
+        execution_result: Completed execution result.
+        agent_id: Executing agent identifier.
+        task_id: Task identifier.
+        team_size: Number of agents (1 for single-agent runs).
+        agent_durations: Per-agent ``(agent_id, seconds)`` pairs.
+        agent_outputs: Agent outputs for redundancy (multi-agent).
+        is_multi_agent: Whether this is a multi-agent execution.
+    """
+
+    execution_result: ExecutionResult
+    agent_id: str
+    task_id: str
+    team_size: int = 1
+    agent_durations: tuple[tuple[str, float], ...] | None = None
+    agent_outputs: tuple[str, ...] | None = None
+    is_multi_agent: bool = False
 
 
 def _extract_run_stats(
@@ -169,33 +194,17 @@ class CoordinationMetricsCollector:
         """Return True if the metric is in config.collect."""
         return metric in self._config.collect
 
-    async def collect(  # noqa: PLR0913
-        self,
-        *,
-        execution_result: ExecutionResult,
-        agent_id: str,
-        task_id: str,
-        team_size: int = 1,
-        agent_durations: tuple[tuple[str, float], ...] | None = None,
-        agent_outputs: tuple[str, ...] | None = None,
-        is_multi_agent: bool = False,
-    ) -> CoordinationMetrics:
+    async def collect(self, inputs: CollectionInputs) -> CoordinationMetrics:
         """Collect all enabled coordination metrics post-execution.
 
-        Single-agent runs (``is_multi_agent=False``) only record baseline
-        data and return an empty ``CoordinationMetrics``; multi-agent runs
-        compute all enabled metrics against the accumulated baseline.
-        Individual metric failures are logged and skipped without
-        blocking the rest.
+        Single-agent runs (``inputs.is_multi_agent=False``) only record
+        baseline data and return an empty ``CoordinationMetrics``;
+        multi-agent runs compute all enabled metrics against the
+        accumulated baseline. Individual metric failures are logged and
+        skipped without blocking the rest.
 
         Args:
-            execution_result: Completed execution result.
-            agent_id: Executing agent identifier.
-            task_id: Task identifier.
-            team_size: Number of agents (1 for single-agent runs).
-            agent_durations: Per-agent ``(agent_id, seconds)`` pairs.
-            agent_outputs: Agent outputs for redundancy (multi-agent).
-            is_multi_agent: Whether this is a multi-agent execution.
+            inputs: Post-execution collection context.
 
         Returns:
             Container of all collected metrics (None for skipped ones).
@@ -205,25 +214,25 @@ class CoordinationMetricsCollector:
 
         logger.debug(
             COORD_METRICS_COLLECTION_STARTED,
-            agent_id=agent_id,
-            task_id=task_id,
-            is_multi_agent=is_multi_agent,
-            team_size=team_size,
+            agent_id=inputs.agent_id,
+            task_id=inputs.task_id,
+            is_multi_agent=inputs.is_multi_agent,
+            team_size=inputs.team_size,
         )
 
         turns, error_rate, total_tokens = _extract_run_stats(
-            execution_result,
+            inputs.execution_result,
         )
 
         # Single-agent runs: record baseline (if store available), return early.
-        if not is_multi_agent:
+        if not inputs.is_multi_agent:
             self._record_baseline(
-                agent_id,
-                task_id,
+                inputs.agent_id,
+                inputs.task_id,
                 turns,
                 error_rate,
                 total_tokens,
-                execution_result,
+                inputs.execution_result,
             )
             return CoordinationMetrics()
 
@@ -232,11 +241,11 @@ class CoordinationMetricsCollector:
             turns=turns,
             error_rate=error_rate,
             total_tokens=total_tokens,
-            agent_id=agent_id,
-            task_id=task_id,
-            team_size=team_size,
-            agent_durations=agent_durations,
-            agent_outputs=agent_outputs,
+            agent_id=inputs.agent_id,
+            task_id=inputs.task_id,
+            team_size=inputs.team_size,
+            agent_durations=inputs.agent_durations,
+            agent_outputs=inputs.agent_outputs,
         )
 
     @staticmethod

--- a/src/synthorg/budget/coordination_collector.py
+++ b/src/synthorg/budget/coordination_collector.py
@@ -182,23 +182,19 @@ class CoordinationMetricsCollector:
     ) -> CoordinationMetrics:
         """Collect all enabled coordination metrics post-execution.
 
-        For single-agent runs (``is_multi_agent=False``), records
-        baseline data and returns an empty ``CoordinationMetrics``.
-        For multi-agent runs, computes all enabled metrics using the
-        accumulated baseline data.
-
-        All individual metric failures are logged and skipped without
-        blocking the remaining metrics.
+        Single-agent runs (``is_multi_agent=False``) only record baseline
+        data and return an empty ``CoordinationMetrics``; multi-agent runs
+        compute all enabled metrics against the accumulated baseline.
+        Individual metric failures are logged and skipped without
+        blocking the rest.
 
         Args:
             execution_result: Completed execution result.
             agent_id: Executing agent identifier.
             task_id: Task identifier.
             team_size: Number of agents (1 for single-agent runs).
-            agent_durations: Per-agent completion times as
-                ``(agent_id, seconds)`` pairs.
-            agent_outputs: Agent output strings for redundancy
-                computation (multi-agent only).
+            agent_durations: Per-agent ``(agent_id, seconds)`` pairs.
+            agent_outputs: Agent outputs for redundancy (multi-agent).
             is_multi_agent: Whether this is a multi-agent execution.
 
         Returns:
@@ -243,6 +239,21 @@ class CoordinationMetricsCollector:
             agent_outputs=agent_outputs,
         )
 
+    @staticmethod
+    def _log_single_agent_completed(agent_id: str, task_id: str) -> None:
+        """Emit the single-agent collection-completed debug event.
+
+        Single-agent runs never compute metrics (they only feed the
+        baseline), so ``metrics_computed`` is always 0.
+        """
+        logger.debug(
+            COORD_METRICS_COLLECTION_COMPLETED,
+            agent_id=agent_id,
+            task_id=task_id,
+            is_multi_agent=False,
+            metrics_computed=0,
+        )
+
     def _record_baseline(  # noqa: PLR0913
         self,
         agent_id: str,
@@ -253,24 +264,8 @@ class CoordinationMetricsCollector:
         execution_result: ExecutionResult,
     ) -> None:
         """Record single-agent baseline data when store is available."""
-        if self._baseline_store is None:
-            logger.debug(
-                COORD_METRICS_COLLECTION_COMPLETED,
-                agent_id=agent_id,
-                task_id=task_id,
-                is_multi_agent=False,
-                metrics_computed=0,
-            )
-            return
-
-        if turns == 0:
-            logger.debug(
-                COORD_METRICS_COLLECTION_COMPLETED,
-                agent_id=agent_id,
-                task_id=task_id,
-                is_multi_agent=False,
-                metrics_computed=0,
-            )
+        if self._baseline_store is None or turns == 0:
+            self._log_single_agent_completed(agent_id, task_id)
             return
 
         from synthorg.budget.baseline_store import BaselineRecord  # noqa: PLC0415
@@ -279,13 +274,7 @@ class CoordinationMetricsCollector:
             sum(t.latency_ms or 0.0 for t in execution_result.turns) / 1000.0
         )
         if duration_seconds <= 0:
-            logger.debug(
-                COORD_METRICS_COLLECTION_COMPLETED,
-                agent_id=agent_id,
-                task_id=task_id,
-                is_multi_agent=False,
-                metrics_computed=0,
-            )
+            self._log_single_agent_completed(agent_id, task_id)
             return
 
         baseline = BaselineRecord(
@@ -297,13 +286,7 @@ class CoordinationMetricsCollector:
             duration_seconds=duration_seconds,
         )
         self._baseline_store.record(baseline)
-        logger.debug(
-            COORD_METRICS_COLLECTION_COMPLETED,
-            agent_id=agent_id,
-            task_id=task_id,
-            is_multi_agent=False,
-            metrics_computed=0,
-        )
+        self._log_single_agent_completed(agent_id, task_id)
 
     async def _collect_multi_agent(  # noqa: PLR0913
         self,
@@ -318,6 +301,41 @@ class CoordinationMetricsCollector:
         agent_outputs: tuple[str, ...] | None,
     ) -> CoordinationMetrics:
         """Compute all enabled metrics for a multi-agent execution."""
+        metrics = await self._compute_all_metrics(
+            turns=turns,
+            error_rate=error_rate,
+            total_tokens=total_tokens,
+            team_size=team_size,
+            agent_durations=agent_durations,
+            agent_outputs=agent_outputs,
+        )
+        logger.info(
+            COORD_METRICS_COLLECTION_COMPLETED,
+            agent_id=agent_id,
+            task_id=task_id,
+            is_multi_agent=True,
+            metrics_computed=self._count_computed(metrics),
+        )
+        await self._fire_alerts(metrics, agent_id=agent_id, task_id=task_id)
+        self._record_metrics(task_id, team_size, metrics)
+        return metrics
+
+    async def _compute_all_metrics(  # noqa: PLR0913
+        self,
+        *,
+        turns: int,
+        error_rate: float,
+        total_tokens: int,
+        team_size: int,
+        agent_durations: tuple[tuple[str, float], ...] | None,
+        agent_outputs: tuple[str, ...] | None,
+    ) -> CoordinationMetrics:
+        """Run every enabled metric collector in order, assemble the result.
+
+        The collectors are awaited in a fixed sequence (``message_overhead``
+        consumes the already-computed ``message_density``); the order is
+        load-bearing and must not be reshuffled.
+        """
         efficiency = await self._try_collect_efficiency(turns, error_rate)
         overhead = await self._try_collect_overhead(turns)
         error_amplification = await self._try_collect_error_amplification(
@@ -335,8 +353,7 @@ class CoordinationMetricsCollector:
             team_size,
             message_density,
         )
-
-        metrics = CoordinationMetrics(
+        return CoordinationMetrics(
             efficiency=efficiency,
             overhead=overhead,
             error_amplification=error_amplification,
@@ -348,32 +365,24 @@ class CoordinationMetricsCollector:
             message_overhead=message_overhead,
         )
 
-        computed_count = sum(
+    @staticmethod
+    def _count_computed(metrics: CoordinationMetrics) -> int:
+        """Number of metrics that were actually computed (non-``None``)."""
+        return sum(
             1
             for m in (
-                efficiency,
-                overhead,
-                error_amplification,
-                message_density,
-                redundancy_rate,
-                amdahl_ceiling,
-                straggler_gap,
-                token_speedup,
-                message_overhead,
+                metrics.efficiency,
+                metrics.overhead,
+                metrics.error_amplification,
+                metrics.message_density,
+                metrics.redundancy_rate,
+                metrics.amdahl_ceiling,
+                metrics.straggler_gap,
+                metrics.token_speedup_ratio,
+                metrics.message_overhead,
             )
             if m is not None
         )
-        logger.info(
-            COORD_METRICS_COLLECTION_COMPLETED,
-            agent_id=agent_id,
-            task_id=task_id,
-            is_multi_agent=True,
-            metrics_computed=computed_count,
-        )
-
-        await self._fire_alerts(metrics, agent_id=agent_id, task_id=task_id)
-        self._record_metrics(task_id, team_size, metrics)
-        return metrics
 
     def _record_metrics(
         self,
@@ -712,26 +721,51 @@ class CoordinationMetricsCollector:
 
         When ``notification_dispatcher`` is ``None``, no alerts are fired.
         """
-        if self._notification_dispatcher is None:
+        dispatcher = self._notification_dispatcher
+        if dispatcher is None:
             return
-
         overhead = metrics.overhead
         if overhead is None:
             return
-
-        thresholds: OrchestrationAlertThresholds = self._config.orchestration_alerts
         # O% is in percent; thresholds are fractions -> convert O% to fraction
-        overhead_fraction = overhead.value_percent / 100.0
-
-        if overhead_fraction >= thresholds.critical:
-            severity = "critical"
-        elif overhead_fraction >= thresholds.warn:
-            severity = "warning"
-        elif overhead_fraction >= thresholds.info:
-            severity = "info"
-        else:
+        severity = self._classify_overhead_severity(
+            overhead.value_percent / 100.0,
+        )
+        if severity is None:
             return
+        await self._dispatch_overhead_alert(
+            dispatcher,
+            severity=severity,
+            overhead=overhead,
+            agent_id=agent_id,
+            task_id=task_id,
+        )
 
+    def _classify_overhead_severity(self, overhead_fraction: float) -> str | None:
+        """Map an overhead fraction to an alert severity.
+
+        Returns ``None`` when the overhead is below the info threshold
+        (no alert is fired in that case).
+        """
+        thresholds: OrchestrationAlertThresholds = self._config.orchestration_alerts
+        if overhead_fraction >= thresholds.critical:
+            return "critical"
+        if overhead_fraction >= thresholds.warn:
+            return "warning"
+        if overhead_fraction >= thresholds.info:
+            return "info"
+        return None
+
+    async def _dispatch_overhead_alert(
+        self,
+        dispatcher: NotificationDispatcher,
+        *,
+        severity: str,
+        overhead: CoordinationOverhead,
+        agent_id: str,
+        task_id: str,
+    ) -> None:
+        """Build and dispatch the overhead notification; never fatal."""
         from synthorg.notifications.models import (  # noqa: PLC0415
             Notification,
             NotificationCategory,
@@ -745,7 +779,7 @@ class CoordinationMetricsCollector:
             f"agent={agent_id}, task={task_id}"
         )
         try:
-            await self._notification_dispatcher.dispatch(
+            await dispatcher.dispatch(
                 Notification(
                     category=NotificationCategory.BUDGET,
                     severity=NotificationSeverity(severity),

--- a/src/synthorg/budget/coordination_collector.py
+++ b/src/synthorg/budget/coordination_collector.py
@@ -37,6 +37,8 @@ from synthorg.budget.coordination_metrics import (
     compute_straggler_gap,
     compute_token_speedup_ratio,
 )
+from synthorg.budget.coordination_store import CoordinationMetricsRecord
+from synthorg.core.clock import Clock, SystemClock
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.coordination_metrics import (
     COORD_METRICS_ALERT_FIRED,
@@ -53,6 +55,7 @@ from synthorg.providers.enums import FinishReason
 
 if TYPE_CHECKING:
     from synthorg.budget.baseline_store import BaselineStore
+    from synthorg.budget.coordination_store import CoordinationMetricsStore
     from synthorg.budget.tracker import CostTracker
     from synthorg.communication.bus_protocol import MessageBus
     from synthorg.engine.loop_protocol import ExecutionResult
@@ -133,6 +136,12 @@ class CoordinationMetricsCollector:
         baseline_store: Optional store for single-agent baselines.
             When ``None``, efficiency, overhead, and error_amplification
             are skipped (no comparison data).
+        metrics_store: Optional store the computed multi-agent metrics
+            are recorded into. When ``None``, metrics are returned but
+            not persisted (the ``/coordination/metrics`` API stays
+            empty).
+        clock: Clock seam for the record timestamp. Defaults to
+            ``SystemClock``; tests inject ``FakeClock``.
     """
 
     def __init__(  # noqa: PLR0913
@@ -144,6 +153,8 @@ class CoordinationMetricsCollector:
         notification_dispatcher: NotificationDispatcher | None = None,
         similarity_computer: SimilarityComputer | None = None,
         baseline_store: BaselineStore | None = None,
+        metrics_store: CoordinationMetricsStore | None = None,
+        clock: Clock | None = None,
     ) -> None:
         self._config = config
         self._cost_tracker = cost_tracker
@@ -151,6 +162,8 @@ class CoordinationMetricsCollector:
         self._notification_dispatcher = notification_dispatcher
         self._similarity_computer = similarity_computer
         self._baseline_store = baseline_store
+        self._metrics_store = metrics_store
+        self._clock: Clock = clock or SystemClock()
 
     def _is_enabled(self, metric: CoordinationMetricName) -> bool:
         """Return True if the metric is in config.collect."""
@@ -359,7 +372,42 @@ class CoordinationMetricsCollector:
         )
 
         await self._fire_alerts(metrics, agent_id=agent_id, task_id=task_id)
+        self._record_metrics(task_id, team_size, metrics)
         return metrics
+
+    def _record_metrics(
+        self,
+        task_id: str,
+        team_size: int,
+        metrics: CoordinationMetrics,
+    ) -> None:
+        """Persist multi-agent metrics into the store when one is wired.
+
+        Multi-agent coordination is a system-level run with no single
+        lead agent, so ``agent_id`` is ``None``.  Never fatal: a store
+        write failure must not fail an already-completed run.
+        """
+        if self._metrics_store is None:
+            return
+        try:
+            record = CoordinationMetricsRecord(
+                task_id=task_id,
+                agent_id=None,
+                computed_at=self._clock.now(),
+                team_size=team_size,
+                metrics=metrics,
+            )
+            self._metrics_store.record(record)
+        except MemoryError, RecursionError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                COORD_METRICS_COLLECTION_FAILED,
+                metric="record_persist",
+                task_id=task_id,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
 
     # Private collection helpers
 

--- a/src/synthorg/budget/coordination_config.py
+++ b/src/synthorg/budget/coordination_config.py
@@ -257,8 +257,6 @@ class CoordinationMetricsConfig(BaseModel):
     Attributes:
         enabled: Whether coordination metrics are collected.
         collect: Which metrics to collect.
-        baseline_window: Number of recent records for baseline
-            computation.
         error_taxonomy: Error taxonomy tracking configuration.
         orchestration_alerts: Orchestration overhead alert thresholds.
     """
@@ -272,11 +270,6 @@ class CoordinationMetricsConfig(BaseModel):
     collect: tuple[CoordinationMetricName, ...] = Field(
         default=tuple(CoordinationMetricName),
         description="Which metrics to collect (must be unique)",
-    )
-    baseline_window: int = Field(
-        default=50,
-        gt=0,
-        description="Number of recent records for baseline computation",
     )
     error_taxonomy: ErrorTaxonomyConfig = Field(
         default_factory=ErrorTaxonomyConfig,

--- a/src/synthorg/engine/agent_engine_post_exec.py
+++ b/src/synthorg/engine/agent_engine_post_exec.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 from typing import TYPE_CHECKING, Any, Final
 
+from synthorg.budget.coordination_collector import CollectionInputs
 from synthorg.engine.checkpoint.resume import (
     cleanup_checkpoint_artifacts,
     make_loop_with_callback,
@@ -290,10 +291,12 @@ class AgentEnginePostExecMixin:
             return
         try:
             await self._coordination_metrics_collector.collect(
-                execution_result=execution_result,
-                agent_id=agent_id,
-                task_id=task_id,
-                is_multi_agent=False,
+                CollectionInputs(
+                    execution_result=execution_result,
+                    agent_id=agent_id,
+                    task_id=task_id,
+                    is_multi_agent=False,
+                ),
             )
         except MemoryError, RecursionError:
             raise

--- a/src/synthorg/engine/coordination/factory.py
+++ b/src/synthorg/engine/coordination/factory.py
@@ -24,6 +24,9 @@ from synthorg.observability.events.decomposition import (
 )
 
 if TYPE_CHECKING:
+    from synthorg.budget.coordination_collector import (
+        CoordinationMetricsCollector,
+    )
     from synthorg.config.schema import TaskAssignmentConfig
     from synthorg.core.enums import CoordinationTopology
     from synthorg.core.task import Task
@@ -169,6 +172,7 @@ def build_coordinator(  # noqa: PLR0913
     shutdown_manager: ShutdownManager | None = None,
     performance_tracker: PerformanceTracker | None = None,
     routing_scorer_config: RoutingScorerConfig | None = None,
+    coordination_metrics_collector: CoordinationMetricsCollector | None = None,
 ) -> MultiAgentCoordinator:
     """Build a fully wired :class:`MultiAgentCoordinator`.
 
@@ -208,6 +212,10 @@ def build_coordinator(  # noqa: PLR0913
             falls back to scorer defaults that mirror the historical
             hardcoded values; ``task_assignment_config.min_score`` is
             still honoured as a min-score override in that case.
+        coordination_metrics_collector: Shared collector the coordinator
+            invokes post-completion to compute and record the
+            multi-agent metrics. ``None`` disables collection (the
+            ``/coordination/metrics`` API stays empty).
 
     Returns:
         A fully constructed ``MultiAgentCoordinator``.
@@ -245,6 +253,7 @@ def build_coordinator(  # noqa: PLR0913
         task_engine=task_engine,
         performance_tracker=performance_tracker,
         default_topology_provider=_topology_provider,
+        coordination_metrics_collector=coordination_metrics_collector,
     )
 
     logger.debug(

--- a/src/synthorg/engine/coordination/service.py
+++ b/src/synthorg/engine/coordination/service.py
@@ -551,12 +551,19 @@ class MultiAgentCoordinator:
         aggregate = results[0].execution_result.model_copy(
             update={"turns": aggregate_turns},
         )
+        # Sum durations per agent so StragglerGap reflects each actor's
+        # total time across waves rather than a single subtask slice.
+        durations_by_agent: dict[str, float] = {}
+        for r in results:
+            durations_by_agent[r.agent_id] = (
+                durations_by_agent.get(r.agent_id, 0.0) + r.duration_seconds
+            )
         return CollectionInputs(
             execution_result=aggregate,
             agent_id=_COORDINATOR_ACTOR,
             task_id=task_id,
-            team_size=len({r.agent_id for r in results}),
-            agent_durations=tuple((r.agent_id, r.duration_seconds) for r in results),
+            team_size=len(durations_by_agent),
+            agent_durations=tuple(durations_by_agent.items()),
             agent_outputs=tuple(
                 r.completion_summary for r in results if r.completion_summary
             ),

--- a/src/synthorg/engine/coordination/service.py
+++ b/src/synthorg/engine/coordination/service.py
@@ -5,10 +5,11 @@ update parent. Rollup + parent lifecycle walk live in
 :mod:`synthorg.engine.coordination.parent_rollup`.
 """
 
+import asyncio
 from collections.abc import (
     Callable,  # noqa: TC003 -- runtime-read by typing.get_type_hints()
 )
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from synthorg.budget.currency import assert_currencies_match
 from synthorg.core.clock import Clock, SystemClock
@@ -50,6 +51,7 @@ if TYPE_CHECKING:
         DecompositionResult,
     )
     from synthorg.engine.decomposition.service import DecompositionService
+    from synthorg.engine.loop_protocol import ExecutionResult
     from synthorg.engine.middleware.coordination_protocol import (
         CoordinationMiddlewareChain,
     )
@@ -60,6 +62,13 @@ if TYPE_CHECKING:
     from synthorg.engine.workspace.service import WorkspaceIsolationService
     from synthorg.hr.performance.tracker import PerformanceTracker
 
+    _MetricsCollectCall = tuple[
+        ExecutionResult,
+        tuple[tuple[str, float], ...],
+        tuple[str, ...],
+        int,
+    ]
+
 logger = get_logger(__name__)
 
 # Logging actor for the multi-agent (system-level) metrics collection.
@@ -67,6 +76,14 @@ logger = get_logger(__name__)
 # (no single lead in a coordinated run); this label only tags the
 # collector's observability events / overhead alerts.
 _COORDINATOR_ACTOR: str = "coordinator"
+
+# Upper bound on the post-completion metrics-collection hook. The
+# collector awaits the message bus and similarity computer; a degraded
+# dependency must not wedge an already-completed coordination run.
+# Like ``budget/enforcer._DEFAULT_TIMEOUT_SEC`` this bounds a
+# never-fatal drain, not operator-tunable policy, so it stays a typed
+# constant rather than a registered setting.
+_METRICS_COLLECT_TIMEOUT_SECONDS: Final[float] = 30.0
 
 
 class MultiAgentCoordinator:
@@ -442,6 +459,7 @@ class MultiAgentCoordinator:
             logger.warning(
                 COORDINATION_CLEANUP_FAILED,
                 parent_task_id=task.id,
+                error_type=type(attr_exc).__name__,
                 error=safe_error_description(attr_exc),
                 context="post_completion_attribution_build",
             )
@@ -457,6 +475,7 @@ class MultiAgentCoordinator:
                 logger.warning(
                     COORDINATION_CLEANUP_FAILED,
                     parent_task_id=task.id,
+                    error_type=type(tracker_exc).__name__,
                     error=safe_error_description(tracker_exc),
                     context="post_completion_tracker_write",
                 )
@@ -482,15 +501,54 @@ class MultiAgentCoordinator:
         Never fatal: a collector failure must not fail an already
         completed coordination run (mirrors the ``_performance_tracker``
         guard above). Skipped when no collector is wired or no sub-agent
-        produced a result. The aggregate ``ExecutionResult`` carries the
-        team-wide turn records (``model_copy`` off a real sub-agent
-        result, swapping only ``turns`` -- the collector reads nothing
-        else off it) so ``turns_mas`` is the total reasoning turns
-        across the system.
+        produced a result. ``asyncio.wait_for`` bounds the hook so a
+        degraded message bus or similarity computer cannot wedge a
+        completed run; a timeout surfaces as ``TimeoutError`` in the
+        guard below (logged via ``error_type``).
         """
         collector = self._coordination_metrics_collector
         if collector is None:
             return
+        call = self._build_metrics_collect_call(dispatch_result)
+        if call is None:
+            return
+        aggregate, agent_durations, agent_outputs, team_size = call
+        try:
+            await asyncio.wait_for(
+                collector.collect(
+                    execution_result=aggregate,
+                    agent_id=_COORDINATOR_ACTOR,
+                    task_id=task_id,
+                    team_size=team_size,
+                    agent_durations=agent_durations,
+                    agent_outputs=agent_outputs,
+                    is_multi_agent=True,
+                ),
+                timeout=_METRICS_COLLECT_TIMEOUT_SECONDS,
+            )
+        except MemoryError, RecursionError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                COORDINATION_CLEANUP_FAILED,
+                parent_task_id=task_id,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+                context="post_completion_coordination_metrics",
+            )
+
+    def _build_metrics_collect_call(
+        self,
+        dispatch_result: DispatchResult,
+    ) -> _MetricsCollectCall | None:
+        """Aggregate sub-agent results into the collector's arguments.
+
+        Returns ``None`` when no sub-agent produced a result. The
+        aggregate ``ExecutionResult`` carries the team-wide turn records
+        (``model_copy`` off a real sub-agent result, swapping only
+        ``turns`` -- the collector reads nothing else off it) so
+        ``turns_mas`` is the total reasoning turns across the system.
+        """
         results = [
             outcome.result
             for wave in dispatch_result.waves
@@ -499,7 +557,7 @@ class MultiAgentCoordinator:
             if outcome.result is not None
         ]
         if not results:
-            return
+            return None
         aggregate_turns = tuple(
             turn for r in results for turn in r.execution_result.turns
         )
@@ -511,25 +569,7 @@ class MultiAgentCoordinator:
             r.completion_summary for r in results if r.completion_summary
         )
         team_size = len({r.agent_id for r in results})
-        try:
-            await collector.collect(
-                execution_result=aggregate,
-                agent_id=_COORDINATOR_ACTOR,
-                task_id=task_id,
-                team_size=team_size,
-                agent_durations=agent_durations,
-                agent_outputs=agent_outputs,
-                is_multi_agent=True,
-            )
-        except MemoryError, RecursionError:
-            raise
-        except Exception as exc:
-            logger.warning(
-                COORDINATION_CLEANUP_FAILED,
-                parent_task_id=task_id,
-                error=safe_error_description(exc),
-                context="post_completion_coordination_metrics",
-            )
+        return aggregate, agent_durations, agent_outputs, team_size
 
     async def _phase_decompose(
         self,

--- a/src/synthorg/engine/coordination/service.py
+++ b/src/synthorg/engine/coordination/service.py
@@ -41,6 +41,9 @@ from synthorg.observability.events.coordination import (
 )
 
 if TYPE_CHECKING:
+    from synthorg.budget.coordination_collector import (
+        CoordinationMetricsCollector,
+    )
     from synthorg.engine.coordination.dispatcher_types import DispatchResult
     from synthorg.engine.coordination.models import CoordinationContext
     from synthorg.engine.decomposition.models import (
@@ -58,6 +61,12 @@ if TYPE_CHECKING:
     from synthorg.hr.performance.tracker import PerformanceTracker
 
 logger = get_logger(__name__)
+
+# Logging actor for the multi-agent (system-level) metrics collection.
+# The recorded ``CoordinationMetricsRecord`` carries ``agent_id=None``
+# (no single lead in a coordinated run); this label only tags the
+# collector's observability events / overhead alerts.
+_COORDINATOR_ACTOR: str = "coordinator"
 
 
 class MultiAgentCoordinator:
@@ -98,11 +107,16 @@ class MultiAgentCoordinator:
             rebuilding the coordinator. Falls back to
             ``CoordinationTopology.SAS`` (the historical default)
             when ``None`` is supplied.
+        coordination_metrics_collector: Optional collector invoked
+            post-completion to compute and record the multi-agent
+            coordination metrics. ``None`` disables collection (never
+            fatal: a collector failure cannot fail a completed run).
     """
 
     __slots__ = (
         "_clock",
         "_coordination_chain",
+        "_coordination_metrics_collector",
         "_decomposition_service",
         "_default_topology_provider",
         "_parallel_executor",
@@ -124,8 +138,10 @@ class MultiAgentCoordinator:
         coordination_chain: CoordinationMiddlewareChain | None = None,
         default_topology_provider: Callable[[], CoordinationTopology] | None = None,
         clock: Clock | None = None,
+        coordination_metrics_collector: CoordinationMetricsCollector | None = None,
     ) -> None:
         self._clock: Clock = clock if clock is not None else SystemClock()
+        self._coordination_metrics_collector = coordination_metrics_collector
         self._decomposition_service = decomposition_service
         self._routing_service = routing_service
         self._parallel_executor = parallel_executor
@@ -445,10 +461,75 @@ class MultiAgentCoordinator:
                     context="post_completion_tracker_write",
                 )
 
+        await self._collect_coordination_metrics(
+            task_id=task.id,
+            dispatch_result=dispatch_result,
+        )
+
         return CoordinationResultWithAttribution(
             result=result,
             agent_contributions=contributions,
         )
+
+    async def _collect_coordination_metrics(
+        self,
+        *,
+        task_id: str,
+        dispatch_result: DispatchResult,
+    ) -> None:
+        """Compute and record the multi-agent coordination metrics.
+
+        Never fatal: a collector failure must not fail an already
+        completed coordination run (mirrors the ``_performance_tracker``
+        guard above). Skipped when no collector is wired or no sub-agent
+        produced a result. The aggregate ``ExecutionResult`` carries the
+        team-wide turn records (``model_copy`` off a real sub-agent
+        result, swapping only ``turns`` -- the collector reads nothing
+        else off it) so ``turns_mas`` is the total reasoning turns
+        across the system.
+        """
+        collector = self._coordination_metrics_collector
+        if collector is None:
+            return
+        results = [
+            outcome.result
+            for wave in dispatch_result.waves
+            if wave.execution_result is not None
+            for outcome in wave.execution_result.outcomes
+            if outcome.result is not None
+        ]
+        if not results:
+            return
+        aggregate_turns = tuple(
+            turn for r in results for turn in r.execution_result.turns
+        )
+        aggregate = results[0].execution_result.model_copy(
+            update={"turns": aggregate_turns},
+        )
+        agent_durations = tuple((r.agent_id, r.duration_seconds) for r in results)
+        agent_outputs = tuple(
+            r.completion_summary for r in results if r.completion_summary
+        )
+        team_size = len({r.agent_id for r in results})
+        try:
+            await collector.collect(
+                execution_result=aggregate,
+                agent_id=_COORDINATOR_ACTOR,
+                task_id=task_id,
+                team_size=team_size,
+                agent_durations=agent_durations,
+                agent_outputs=agent_outputs,
+                is_multi_agent=True,
+            )
+        except MemoryError, RecursionError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                COORDINATION_CLEANUP_FAILED,
+                parent_task_id=task_id,
+                error=safe_error_description(exc),
+                context="post_completion_coordination_metrics",
+            )
 
     async def _phase_decompose(
         self,

--- a/src/synthorg/engine/coordination/service.py
+++ b/src/synthorg/engine/coordination/service.py
@@ -536,15 +536,19 @@ class MultiAgentCoordinator:
         Multi-agent coordination has no single lead, so ``agent_id`` is
         the system-level ``_COORDINATOR_ACTOR`` label.
         """
-        results = [
-            outcome.result
+        outcomes = [
+            outcome
             for wave in dispatch_result.waves
             if wave.execution_result is not None
             for outcome in wave.execution_result.outcomes
-            if outcome.result is not None
         ]
+        results = [outcome.result for outcome in outcomes if outcome.result is not None]
         if not results:
             return None
+        # Count every dispatched participant, including ones whose
+        # subtask failed (no result), so team-level metrics are not
+        # skewed low by partial failures.
+        participating_agents = {outcome.agent_id for outcome in outcomes}
         aggregate_turns = tuple(
             turn for r in results for turn in r.execution_result.turns
         )
@@ -562,7 +566,7 @@ class MultiAgentCoordinator:
             execution_result=aggregate,
             agent_id=_COORDINATOR_ACTOR,
             task_id=task_id,
-            team_size=len(durations_by_agent),
+            team_size=len(participating_agents),
             agent_durations=tuple(durations_by_agent.items()),
             agent_outputs=tuple(
                 r.completion_summary for r in results if r.completion_summary

--- a/src/synthorg/engine/coordination/service.py
+++ b/src/synthorg/engine/coordination/service.py
@@ -11,6 +11,7 @@ from collections.abc import (
 )
 from typing import TYPE_CHECKING, Final
 
+from synthorg.budget.coordination_collector import CollectionInputs
 from synthorg.budget.currency import assert_currencies_match
 from synthorg.core.clock import Clock, SystemClock
 from synthorg.core.enums import CoordinationTopology
@@ -51,7 +52,6 @@ if TYPE_CHECKING:
         DecompositionResult,
     )
     from synthorg.engine.decomposition.service import DecompositionService
-    from synthorg.engine.loop_protocol import ExecutionResult
     from synthorg.engine.middleware.coordination_protocol import (
         CoordinationMiddlewareChain,
     )
@@ -61,13 +61,6 @@ if TYPE_CHECKING:
     from synthorg.engine.task_engine import TaskEngine
     from synthorg.engine.workspace.service import WorkspaceIsolationService
     from synthorg.hr.performance.tracker import PerformanceTracker
-
-    _MetricsCollectCall = tuple[
-        ExecutionResult,
-        tuple[tuple[str, float], ...],
-        tuple[str, ...],
-        int,
-    ]
 
 logger = get_logger(__name__)
 
@@ -509,21 +502,12 @@ class MultiAgentCoordinator:
         collector = self._coordination_metrics_collector
         if collector is None:
             return
-        call = self._build_metrics_collect_call(dispatch_result)
-        if call is None:
+        inputs = self._build_collection_inputs(task_id, dispatch_result)
+        if inputs is None:
             return
-        aggregate, agent_durations, agent_outputs, team_size = call
         try:
             await asyncio.wait_for(
-                collector.collect(
-                    execution_result=aggregate,
-                    agent_id=_COORDINATOR_ACTOR,
-                    task_id=task_id,
-                    team_size=team_size,
-                    agent_durations=agent_durations,
-                    agent_outputs=agent_outputs,
-                    is_multi_agent=True,
-                ),
+                collector.collect(inputs),
                 timeout=_METRICS_COLLECT_TIMEOUT_SECONDS,
             )
         except MemoryError, RecursionError:
@@ -537,17 +521,20 @@ class MultiAgentCoordinator:
                 context="post_completion_coordination_metrics",
             )
 
-    def _build_metrics_collect_call(
+    def _build_collection_inputs(
         self,
+        task_id: str,
         dispatch_result: DispatchResult,
-    ) -> _MetricsCollectCall | None:
-        """Aggregate sub-agent results into the collector's arguments.
+    ) -> CollectionInputs | None:
+        """Aggregate sub-agent results into the collector inputs.
 
         Returns ``None`` when no sub-agent produced a result. The
         aggregate ``ExecutionResult`` carries the team-wide turn records
         (``model_copy`` off a real sub-agent result, swapping only
         ``turns`` -- the collector reads nothing else off it) so
         ``turns_mas`` is the total reasoning turns across the system.
+        Multi-agent coordination has no single lead, so ``agent_id`` is
+        the system-level ``_COORDINATOR_ACTOR`` label.
         """
         results = [
             outcome.result
@@ -564,12 +551,17 @@ class MultiAgentCoordinator:
         aggregate = results[0].execution_result.model_copy(
             update={"turns": aggregate_turns},
         )
-        agent_durations = tuple((r.agent_id, r.duration_seconds) for r in results)
-        agent_outputs = tuple(
-            r.completion_summary for r in results if r.completion_summary
+        return CollectionInputs(
+            execution_result=aggregate,
+            agent_id=_COORDINATOR_ACTOR,
+            task_id=task_id,
+            team_size=len({r.agent_id for r in results}),
+            agent_durations=tuple((r.agent_id, r.duration_seconds) for r in results),
+            agent_outputs=tuple(
+                r.completion_summary for r in results if r.completion_summary
+            ),
+            is_multi_agent=True,
         )
-        team_size = len({r.agent_id for r in results})
-        return aggregate, agent_durations, agent_outputs, team_size
 
     async def _phase_decompose(
         self,

--- a/src/synthorg/settings/definitions/budget.py
+++ b/src/synthorg/settings/definitions/budget.py
@@ -170,3 +170,29 @@ _r.register(
         max_value=1_000_000,
     )
 )
+
+_r.register(
+    SettingDefinition(
+        namespace=SettingNamespace.BUDGET,
+        key="baseline_window_size",
+        type=SettingType.INTEGER,
+        default="50",
+        description=(
+            "Sliding-window size for single-agent baseline records used"
+            " to derive the multi-agent coordination baselines (Ec, O%,"
+            " Ae). Sizes a fixed-length deque at BaselineStore"
+            " construction; sourced from the"
+            " SYNTHORG_BUDGET_BASELINE_WINDOW_SIZE env var > default at"
+            " API-process start. Read-only post-init: resizing the"
+            " window at runtime would discard accumulated baselines, so"
+            " a change requires a restart."
+        ),
+        group="Coordination",
+        level=SettingLevel.ADVANCED,
+        restart_required=True,
+        read_only_post_init=True,
+        env_var_override="SYNTHORG_BUDGET_BASELINE_WINDOW_SIZE",
+        min_value=1,
+        max_value=1_000_000,
+    )
+)

--- a/src/synthorg/settings/mirrors.py
+++ b/src/synthorg/settings/mirrors.py
@@ -55,6 +55,22 @@ def parse_int(raw: str) -> int | None:
         return None
 
 
+def resolve_init_int(namespace: SettingNamespace, key: str) -> int:
+    """Resolve an integer-typed setting at app construction time.
+
+    Cat-2 boot knob: the consumer is built before the
+    ``SettingsService`` connects, so the value is sourced env >
+    registered default via the bootstrap resolver (a runtime change
+    requires a restart). ``parse_int`` makes a non-integer env value
+    fall through to the registered default rather than raising at
+    construction time. This is the single sanctioned int-resolver so
+    boot sites do not each re-implement ``resolve_init_value`` +
+    ``parse_int`` + ``int(...)``.
+    """
+    resolved = resolve_init_value(namespace, key, parse=parse_int)
+    return int(resolved.value)
+
+
 def parse_float(raw: str) -> float | None:
     """Parse a float env token."""
     try:

--- a/src/synthorg/workers/runtime_builder.py
+++ b/src/synthorg/workers/runtime_builder.py
@@ -26,6 +26,8 @@ restart.
 import asyncio
 from typing import TYPE_CHECKING, NamedTuple
 
+from synthorg.budget.baseline_store import BaselineStore
+from synthorg.budget.coordination_collector import CoordinationMetricsCollector
 from synthorg.engine.agent_engine import AgentEngine
 from synthorg.engine.coordination.factory import build_coordinator
 from synthorg.engine.mcp_self_consumer import build_mcp_self_consumer
@@ -36,6 +38,9 @@ from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.api import API_APP_STARTUP
 from synthorg.security.action_types import ActionTypeRegistry
 from synthorg.security.autonomy.resolver import AutonomyResolver
+from synthorg.settings.bootstrap_resolver import resolve_init_value
+from synthorg.settings.enums import SettingNamespace
+from synthorg.settings.mirrors import parse_int
 from synthorg.tools.factory import build_default_tools_from_config
 from synthorg.tools.registry import ToolRegistry
 from synthorg.tools.sandbox.factory import build_sandbox_backends
@@ -64,6 +69,55 @@ _GIT_TIMEOUT_NS: str = "tools"
 _GIT_TIMEOUT_KEY: str = "git_command_timeout_seconds"
 _DECOMPOSITION_NS: str = "coordination"
 _DECOMPOSITION_KEY: str = "decomposition_model"
+_BASELINE_WINDOW_KEY: str = "baseline_window_size"
+
+
+def _resolve_baseline_window_size() -> int:
+    """Resolve ``budget.baseline_window_size`` at boot.
+
+    Cat-2 boot knob (``read_only_post_init``): the ``BaselineStore``
+    sliding window is sized once at construction, so the value is
+    sourced env > registered default via the bootstrap resolver (a
+    runtime change requires a restart). Mirrors ``app._resolve_budget_int``
+    for ``coordination_metrics_max_entries``.
+    """
+    resolved = resolve_init_value(
+        SettingNamespace.BUDGET,
+        _BASELINE_WINDOW_KEY,
+        parse=parse_int,
+    )
+    return int(resolved.value)
+
+
+def _construct_coordination_collector(
+    app_state: AppState,
+) -> CoordinationMetricsCollector | None:
+    """Build the shared coordination-metrics collector, or ``None``.
+
+    Requires a live ``CostTracker`` (the collector's only non-optional
+    dependency). Without one - the empty/degraded path - no collector
+    is built and the metrics pipeline stays a no-op, mirroring the
+    ``_construct_agent_engine`` optional-dependency guards. The single
+    instance returned is threaded into both the single-agent
+    ``AgentEngine`` and the multi-agent coordinator so one
+    ``BaselineStore`` accumulates the single-agent baselines the
+    multi-agent metrics compare against.
+    """
+    if not app_state.has_cost_tracker:
+        return None
+    baseline_store = BaselineStore(window_size=_resolve_baseline_window_size())
+    return CoordinationMetricsCollector(
+        config=app_state.config.coordination_metrics,
+        cost_tracker=app_state.cost_tracker,
+        message_bus=(app_state.message_bus if app_state.has_message_bus else None),
+        baseline_store=baseline_store,
+        metrics_store=(
+            app_state.coordination_metrics_store
+            if app_state.has_coordination_metrics_store
+            else None
+        ),
+        clock=app_state.clock,
+    )
 
 
 class RuntimeServices(NamedTuple):
@@ -172,14 +226,19 @@ def _construct_agent_engine(
     provider: CompletionProvider,
     registry: ProviderRegistry,
     tool_registry: ToolRegistry,
+    coordination_metrics_collector: CoordinationMetricsCollector | None,
 ) -> AgentEngine:
     """Assemble the boot ``AgentEngine`` from live application state.
 
     A single instance is shared by the worker execution service and the
     coordinator's parallel executor so both consumers observe the same
-    interrupt store, event stream hub, and clock seam.
+    interrupt store, event stream hub, and clock seam. The same
+    ``coordination_metrics_collector`` is shared too, so single-agent
+    runs accumulate the baselines the multi-agent metrics compare
+    against.
     """
     return AgentEngine(
+        coordination_metrics_collector=coordination_metrics_collector,
         provider=provider,
         provider_registry=registry,
         tool_registry=tool_registry,
@@ -283,6 +342,7 @@ async def _build_runtime_coordinator(
     app_state: AppState,
     engine: AgentEngine,
     provider: CompletionProvider,
+    coordination_metrics_collector: CoordinationMetricsCollector | None,
 ) -> MultiAgentCoordinator:
     """Build the multi-agent coordinator sharing the boot engine.
 
@@ -319,6 +379,7 @@ async def _build_runtime_coordinator(
         workspace_config=workspace_config,
         performance_tracker=performance_tracker,
         routing_scorer_config=routing_scorer_config,
+        coordination_metrics_collector=coordination_metrics_collector,
     )
     logger.info(
         API_APP_STARTUP,
@@ -364,11 +425,13 @@ async def build_runtime_services(
         app_state,
         workspace_root,
     )
+    coordination_metrics_collector = _construct_coordination_collector(app_state)
     engine = _construct_agent_engine(
         app_state,
         provider,
         registry,
         tool_registry,
+        coordination_metrics_collector,
     )
     autonomy_resolver = AutonomyResolver(
         registry=ActionTypeRegistry(),
@@ -378,6 +441,7 @@ async def build_runtime_services(
         app_state,
         engine,
         provider,
+        coordination_metrics_collector,
     )
     logger.info(
         API_APP_STARTUP,

--- a/src/synthorg/workers/runtime_builder.py
+++ b/src/synthorg/workers/runtime_builder.py
@@ -38,9 +38,8 @@ from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.api import API_APP_STARTUP
 from synthorg.security.action_types import ActionTypeRegistry
 from synthorg.security.autonomy.resolver import AutonomyResolver
-from synthorg.settings.bootstrap_resolver import resolve_init_value
 from synthorg.settings.enums import SettingNamespace
-from synthorg.settings.mirrors import parse_int
+from synthorg.settings.mirrors import resolve_init_int
 from synthorg.tools.factory import build_default_tools_from_config
 from synthorg.tools.registry import ToolRegistry
 from synthorg.tools.sandbox.factory import build_sandbox_backends
@@ -78,15 +77,9 @@ def _resolve_baseline_window_size() -> int:
     Cat-2 boot knob (``read_only_post_init``): the ``BaselineStore``
     sliding window is sized once at construction, so the value is
     sourced env > registered default via the bootstrap resolver (a
-    runtime change requires a restart). Mirrors ``app._resolve_budget_int``
-    for ``coordination_metrics_max_entries``.
+    runtime change requires a restart).
     """
-    resolved = resolve_init_value(
-        SettingNamespace.BUDGET,
-        _BASELINE_WINDOW_KEY,
-        parse=parse_int,
-    )
-    return int(resolved.value)
+    return resolve_init_int(SettingNamespace.BUDGET, _BASELINE_WINDOW_KEY)
 
 
 def _construct_coordination_collector(

--- a/tests/e2e/test_coordinator_online_seam.py
+++ b/tests/e2e/test_coordinator_online_seam.py
@@ -26,6 +26,10 @@ import pytest
 
 from synthorg.api.approval_store import ApprovalStore
 from synthorg.api.state import AppState
+from synthorg.budget.coordination_config import CoordinationMetricsConfig
+from synthorg.budget.coordination_metrics import CoordinationMetrics
+from synthorg.budget.coordination_store import CoordinationMetricsStore
+from synthorg.budget.tracker import CostTracker
 from synthorg.config.schema import RootConfig
 from synthorg.core.agent import AgentIdentity, ModelConfig, SkillSet
 from synthorg.core.clock import SystemClock
@@ -286,3 +290,109 @@ async def test_coordinator_runs_decomposable_task_end_to_end(
     assert update_parent.success, update_parent.error
     assert result.total_duration_seconds >= 0.0
     assert isinstance(attributed.agent_contributions, tuple)
+
+
+async def test_coordinator_records_coordination_metrics_end_to_end(
+    persistence: FakePersistenceBackend,
+    task_engine: TaskEngine,
+    tmp_path: Path,
+) -> None:
+    """A real multi-agent run lands a record the read API would return.
+
+    Closes the #1951/#1954 ghost: with the collector wired at boot
+    (cost_tracker present) and ``coordination_metrics.enabled``, the
+    coordinator's post-completion hook writes a
+    ``CoordinationMetricsRecord`` into the boot-wired
+    ``CoordinationMetricsStore``. ``store.query(...)`` is exactly what
+    the ``GET /coordination/metrics`` controller returns, so a non-empty
+    query proves the endpoint now serves real data.
+    """
+    provider = ScriptedDriver(
+        "test-provider",
+        strategy=_DecompositionAwareStrategy(),
+    )
+    registry = ProviderRegistry({"test-provider": provider})
+    agent_registry = AgentRegistryService()
+    alice = _make_agent("alice", _RESEARCH_SKILL)
+    bob = _make_agent("bob", _ANALYSIS_SKILL)
+    await agent_registry.register(alice)
+    await agent_registry.register(bob)
+
+    root_config = RootConfig(
+        company_name="coordinator-metrics-test",
+        coordination_metrics=CoordinationMetricsConfig(enabled=True),
+    )
+    settings_service = SettingsService(
+        repository=persistence.settings,
+        registry=get_registry(),
+    )
+    config_resolver = ConfigResolver(
+        settings_service=settings_service,
+        config=root_config,
+    )
+    metrics_store = CoordinationMetricsStore()
+    app_state = mock_of[AppState](
+        has_active_provider=True,
+        provider_registry=registry,
+        config=root_config,
+        config_resolver=config_resolver,
+        task_engine=task_engine,
+        agent_registry=agent_registry,
+        approval_store=ApprovalStore(),
+        clock=SystemClock(),
+        event_stream_hub=None,
+        interrupt_store=None,
+        agent_workspace_root=tmp_path,
+        has_cost_tracker=True,
+        cost_tracker=CostTracker(),
+        has_message_bus=False,
+        has_coordination_metrics_store=True,
+        coordination_metrics_store=metrics_store,
+        has_audit_log=False,
+        has_memory_backend=False,
+        has_performance_tracker=False,
+    )
+
+    runtime = await build_runtime_services(
+        app_state,
+        workspace_root=tmp_path,
+    )
+    coordinator = runtime.coordinator
+    assert isinstance(coordinator, MultiAgentCoordinator)
+
+    created = await task_engine.create_task(
+        CreateTaskData(
+            title="Financial analysis",
+            description="Decompose into research and analysis.",
+            type=TaskType.DEVELOPMENT,
+            project="proj-coord-metrics",
+            created_by="operator",
+            priority=Priority.MEDIUM,
+        ),
+        requested_by="operator",
+    )
+
+    context = CoordinationContext(
+        task=created,
+        available_agents=(alice, bob),
+        decomposition_context=DecompositionContext(max_subtasks=4),
+        config=CoordinationConfig(
+            enable_workspace_isolation=False,
+            fail_fast=False,
+        ),
+    )
+
+    attributed = await coordinator.coordinate(context)
+    assert attributed.result.parent_task_id == created.id
+
+    # Exactly the call the GET /coordination/metrics controller makes.
+    records, total = metrics_store.query(limit=10)
+    assert total >= 1
+    assert metrics_store.count() >= 1
+    record = records[0]
+    assert record.task_id == created.id
+    # Multi-agent coordination is a system-level run: no single lead.
+    assert record.agent_id is None
+    assert record.team_size == 2
+    assert record.computed_at is not None
+    assert isinstance(record.metrics, CoordinationMetrics)

--- a/tests/e2e/test_coordinator_online_seam.py
+++ b/tests/e2e/test_coordinator_online_seam.py
@@ -299,13 +299,14 @@ async def test_coordinator_records_coordination_metrics_end_to_end(
 ) -> None:
     """A real multi-agent run lands a record the read API would return.
 
-    Closes the #1951/#1954 ghost: with the collector wired at boot
-    (cost_tracker present) and ``coordination_metrics.enabled``, the
-    coordinator's post-completion hook writes a
-    ``CoordinationMetricsRecord`` into the boot-wired
-    ``CoordinationMetricsStore``. ``store.query(...)`` is exactly what
-    the ``GET /coordination/metrics`` controller returns, so a non-empty
-    query proves the endpoint now serves real data.
+    With ``cost_tracker`` present and ``coordination_metrics.enabled``,
+    ``build_runtime_services`` constructs the collector and the
+    coordinator's post-completion hook persists a
+    ``CoordinationMetricsRecord`` into the ``CoordinationMetricsStore``.
+    ``store.query(...)`` is exactly the call the
+    ``GET /coordination/metrics`` controller makes, so a non-empty query
+    proves the endpoint serves real, persisted coordination metrics
+    rather than an empty list.
     """
     provider = ScriptedDriver(
         "test-provider",

--- a/tests/e2e/test_coordinator_online_seam.py
+++ b/tests/e2e/test_coordinator_online_seam.py
@@ -32,7 +32,6 @@ from synthorg.budget.coordination_store import CoordinationMetricsStore
 from synthorg.budget.tracker import CostTracker
 from synthorg.config.schema import RootConfig
 from synthorg.core.agent import AgentIdentity, ModelConfig, SkillSet
-from synthorg.core.clock import SystemClock
 from synthorg.core.enums import (
     AgentStatus,
     Priority,
@@ -62,7 +61,7 @@ from synthorg.settings.registry import get_registry
 from synthorg.settings.resolver import ConfigResolver
 from synthorg.settings.service import SettingsService
 from synthorg.workers.runtime_builder import build_runtime_services
-from tests._shared import mock_of
+from tests._shared import FakeClock, mock_of
 from tests.unit.api.fakes import FakePersistenceBackend
 
 pytestmark = pytest.mark.e2e
@@ -203,7 +202,7 @@ async def test_coordinator_runs_decomposable_task_end_to_end(
         task_engine=task_engine,
         agent_registry=agent_registry,
         approval_store=ApprovalStore(),
-        clock=SystemClock(),
+        clock=FakeClock(),
         event_stream_hub=None,
         interrupt_store=None,
         agent_workspace_root=tmp_path,
@@ -340,7 +339,7 @@ async def test_coordinator_records_coordination_metrics_end_to_end(
         task_engine=task_engine,
         agent_registry=agent_registry,
         approval_store=ApprovalStore(),
-        clock=SystemClock(),
+        clock=FakeClock(),
         event_stream_hub=None,
         interrupt_store=None,
         agent_workspace_root=tmp_path,

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -690,6 +690,20 @@ def test_client(  # noqa: C901, PLR0912, PLR0913, PLR0915
         fake_persistence._connected = True
         if app_state._settings_service is not None:
             app_state._settings_service._cache.clear()
+        # ``create_app``'s ``_install_runtime_services`` startup hook is
+        # once-only (a ``_runtime_services_installed`` closure flag), but
+        # the session-scoped shared app re-runs lifespan startup every
+        # test. The hook therefore wires the coordinator / worker-exec
+        # seams only during the FIRST test's startup; the snapshot in
+        # step 5 then restores them to ``None`` for every later test.
+        # Left alone, the first test per xdist worker would observe a
+        # wired coordinator while all others observe ``None``, making any
+        # coordinator-dependent assertion order-dependent. Force the
+        # no-runtime-services baseline post-startup so every test sees
+        # the same state (the worker-exec property lazily re-defaults);
+        # tests that need a coordinator inject one via their own client.
+        app_state._coordinator = None
+        app_state._worker_execution_service = None
         _seed_test_users(fake_persistence, auth_service)
         _promote_first_owner(fake_persistence)
         client.headers.update(make_auth_headers("ceo"))

--- a/tests/unit/api/controllers/test_coordination.py
+++ b/tests/unit/api/controllers/test_coordination.py
@@ -370,20 +370,9 @@ class TestCoordinationControllerNoCoordinator:
         self,
         test_client: TestClient[Any],
         fake_persistence: FakePersistenceBackend,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """503 when coordinator is not configured (uses shared client).
-
-        The shared session app's startup hook wires a coordinator
-        whenever a provider is present, and the per-test reset does not
-        clear that seam, so the no-coordinator precondition must be
-        forced here rather than assumed. ``monkeypatch`` restores the
-        seam after the test so the shared app is unaffected.
-        """
+        """503 when coordinator is not configured (uses shared client)."""
         from tests.unit.api.conftest import make_task
-
-        app_state = test_client.app.state.app_state
-        monkeypatch.setattr(app_state, "_coordinator", None)
 
         task = make_task()
         fake_persistence.tasks._tasks[task.id] = task

--- a/tests/unit/api/controllers/test_coordination.py
+++ b/tests/unit/api/controllers/test_coordination.py
@@ -370,9 +370,20 @@ class TestCoordinationControllerNoCoordinator:
         self,
         test_client: TestClient[Any],
         fake_persistence: FakePersistenceBackend,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """503 when coordinator is not configured (uses shared client)."""
+        """503 when coordinator is not configured (uses shared client).
+
+        The shared session app's startup hook wires a coordinator
+        whenever a provider is present, and the per-test reset does not
+        clear that seam, so the no-coordinator precondition must be
+        forced here rather than assumed. ``monkeypatch`` restores the
+        seam after the test so the shared app is unaffected.
+        """
         from tests.unit.api.conftest import make_task
+
+        app_state = test_client.app.state.app_state
+        monkeypatch.setattr(app_state, "_coordinator", None)
 
         task = make_task()
         fake_persistence.tasks._tasks[task.id] = task

--- a/tests/unit/api/test_app_bootstrap_resolvers.py
+++ b/tests/unit/api/test_app_bootstrap_resolvers.py
@@ -170,3 +170,38 @@ class TestResolveBudgetInt:
         assert (
             _resolve_budget_int("coordination_metrics_max_entries") == expected_default
         )
+
+
+@pytest.mark.unit
+class TestResolveBaselineWindowSize:
+    """Cat-2 boot resolution for ``budget.baseline_window_size``.
+
+    The ``BaselineStore`` sliding window is sized before the
+    ``SettingsService`` connects, so the value is env > registered
+    default via the bootstrap resolver.
+    """
+
+    _ENV = "SYNTHORG_BUDGET_BASELINE_WINDOW_SIZE"
+
+    def test_env_set_to_valid_int(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(self._ENV, "120")
+        assert _resolve_budget_int("baseline_window_size") == 120
+
+    def test_env_unset_returns_registered_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv(self._ENV, raising=False)
+        assert _resolve_budget_int("baseline_window_size") == 50
+
+    def test_invalid_int_falls_through_to_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv(self._ENV, raising=False)
+        expected_default = _resolve_budget_int("baseline_window_size")
+        monkeypatch.setenv(self._ENV, "not-a-number")
+        assert _resolve_budget_int("baseline_window_size") == expected_default

--- a/tests/unit/budget/test_coordination_collector.py
+++ b/tests/unit/budget/test_coordination_collector.py
@@ -15,8 +15,10 @@ from synthorg.budget.coordination_config import (
     OrchestrationAlertThresholds,
 )
 from synthorg.budget.coordination_metrics import CoordinationMetrics
+from synthorg.budget.coordination_store import CoordinationMetricsStore
 from synthorg.communication.bus_protocol import MessageBus
 from synthorg.providers.enums import FinishReason
+from tests._shared import FakeClock
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -771,3 +773,111 @@ class TestMetricIsolation:
             team_size=1,
         )
         assert isinstance(result, CoordinationMetrics)
+
+
+# ---------------------------------------------------------------------------
+# CoordinationMetricsStore write (collector owns the store)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestStoreWrite:
+    """The collector writes a CoordinationMetricsRecord for multi-agent runs."""
+
+    async def test_multi_agent_writes_one_record(self) -> None:
+        metrics_store = CoordinationMetricsStore()
+        clock = FakeClock()
+        collector = CoordinationMetricsCollector(
+            config=_config(),
+            cost_tracker=_cost_tracker(),
+            baseline_store=_baseline_store(),
+            metrics_store=metrics_store,
+            clock=clock,
+        )
+        result = await collector.collect(
+            execution_result=_execution_result(_turn(), _turn(), _turn()),
+            agent_id="lead-agent",
+            task_id="task-42",
+            team_size=3,
+            is_multi_agent=True,
+        )
+        assert metrics_store.count() == 1
+        records, total = metrics_store.query(limit=10)
+        assert total == 1
+        record = records[0]
+        assert record.task_id == "task-42"
+        # Multi-agent is a system-level run: no single lead agent.
+        assert record.agent_id is None
+        assert record.team_size == 3
+        assert record.computed_at == clock.now()
+        assert record.metrics is result
+
+    async def test_single_agent_writes_no_record(self) -> None:
+        metrics_store = CoordinationMetricsStore()
+        collector = CoordinationMetricsCollector(
+            config=_config(),
+            cost_tracker=_cost_tracker(),
+            baseline_store=_baseline_store(pre_populated=False),
+            metrics_store=metrics_store,
+            clock=FakeClock(),
+        )
+        await collector.collect(
+            execution_result=_execution_result(_turn(), _turn()),
+            agent_id="agent-1",
+            task_id="task-1",
+            is_multi_agent=False,
+        )
+        assert metrics_store.count() == 0
+
+    async def test_no_store_does_not_raise(self) -> None:
+        collector = CoordinationMetricsCollector(
+            config=_config(),
+            cost_tracker=_cost_tracker(),
+            baseline_store=_baseline_store(),
+            metrics_store=None,
+        )
+        result = await collector.collect(
+            execution_result=_execution_result(_turn(), _turn()),
+            agent_id="lead-agent",
+            task_id="task-1",
+            team_size=2,
+            is_multi_agent=True,
+        )
+        assert isinstance(result, CoordinationMetrics)
+
+    async def test_disabled_collector_writes_no_record(self) -> None:
+        metrics_store = CoordinationMetricsStore()
+        collector = CoordinationMetricsCollector(
+            config=_config(enabled=False),
+            cost_tracker=_cost_tracker(),
+            baseline_store=_baseline_store(),
+            metrics_store=metrics_store,
+            clock=FakeClock(),
+        )
+        await collector.collect(
+            execution_result=_execution_result(_turn(), _turn()),
+            agent_id="lead-agent",
+            task_id="task-1",
+            team_size=2,
+            is_multi_agent=True,
+        )
+        assert metrics_store.count() == 0
+
+    async def test_record_written_even_when_all_metrics_skipped(self) -> None:
+        """A multi-agent run still records the (possibly sparse) metrics."""
+        metrics_store = CoordinationMetricsStore()
+        collector = CoordinationMetricsCollector(
+            config=_config(),
+            cost_tracker=_cost_tracker(),
+            baseline_store=_baseline_store(pre_populated=False),
+            metrics_store=metrics_store,
+            clock=FakeClock(),
+        )
+        await collector.collect(
+            execution_result=_execution_result(_turn()),
+            agent_id="lead-agent",
+            task_id="task-1",
+            team_size=1,
+            is_multi_agent=True,
+        )
+        assert metrics_store.count() == 1

--- a/tests/unit/budget/test_coordination_collector.py
+++ b/tests/unit/budget/test_coordination_collector.py
@@ -6,6 +6,7 @@ import pytest
 
 from synthorg.budget.baseline_store import BaselineRecord, BaselineStore
 from synthorg.budget.coordination_collector import (
+    CollectionInputs,
     CoordinationMetricsCollector,
     SimilarityComputer,
 )
@@ -17,6 +18,7 @@ from synthorg.budget.coordination_config import (
 from synthorg.budget.coordination_metrics import CoordinationMetrics
 from synthorg.budget.coordination_store import CoordinationMetricsStore
 from synthorg.communication.bus_protocol import MessageBus
+from synthorg.engine.loop_protocol import ExecutionResult
 from synthorg.providers.enums import FinishReason
 from tests._shared import FakeClock
 
@@ -60,6 +62,31 @@ def _execution_result(*turns: MagicMock) -> MagicMock:
     result = MagicMock()
     result.turns = turns
     return result
+
+
+async def _collect(  # noqa: PLR0913
+    collector: CoordinationMetricsCollector,
+    *,
+    execution_result: ExecutionResult,
+    agent_id: str,
+    task_id: str,
+    team_size: int = 1,
+    agent_durations: tuple[tuple[str, float], ...] | None = None,
+    agent_outputs: tuple[str, ...] | None = None,
+    is_multi_agent: bool = False,
+) -> CoordinationMetrics:
+    """Invoke ``collect`` with the kwargs bundled into ``CollectionInputs``."""
+    return await collector.collect(
+        CollectionInputs(
+            execution_result=execution_result,
+            agent_id=agent_id,
+            task_id=task_id,
+            team_size=team_size,
+            agent_durations=agent_durations,
+            agent_outputs=agent_outputs,
+            is_multi_agent=is_multi_agent,
+        ),
+    )
 
 
 def _cost_tracker() -> MagicMock:
@@ -135,7 +162,8 @@ class TestDisabledCollection:
             config=_config(enabled=False),
             cost_tracker=_cost_tracker(),
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="agent-1",
             task_id="task-1",
@@ -155,7 +183,8 @@ class TestDisabledCollection:
             cost_tracker=_cost_tracker(),
             baseline_store=store,
         )
-        await collector.collect(
+        await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="agent-1",
             task_id="task-1",
@@ -180,7 +209,8 @@ class TestSingleAgentRun:
             cost_tracker=_cost_tracker(),
             baseline_store=store,
         )
-        await collector.collect(
+        await _collect(
+            collector,
             execution_result=_execution_result(_turn(), _turn()),
             agent_id="agent-1",
             task_id="task-1",
@@ -196,7 +226,8 @@ class TestSingleAgentRun:
             cost_tracker=_cost_tracker(),
             baseline_store=store,
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="agent-1",
             task_id="task-1",
@@ -213,7 +244,8 @@ class TestSingleAgentRun:
             cost_tracker=_cost_tracker(),
             baseline_store=None,
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="agent-1",
             task_id="task-1",
@@ -234,7 +266,8 @@ class TestSingleAgentRun:
             _turn(FinishReason.ERROR),
             _turn(FinishReason.CONTENT_FILTER),
         )
-        await collector.collect(
+        await _collect(
+            collector,
             execution_result=_execution_result(*turns),
             agent_id="agent-1",
             task_id="task-1",
@@ -259,7 +292,8 @@ class TestMissingDependencies:
             cost_tracker=_cost_tracker(),
             baseline_store=None,
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="a",
             task_id="t",
@@ -273,7 +307,8 @@ class TestMissingDependencies:
             cost_tracker=_cost_tracker(),
             baseline_store=None,
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="a",
             task_id="t",
@@ -288,7 +323,8 @@ class TestMissingDependencies:
             cost_tracker=_cost_tracker(),
             baseline_store=store,
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="a",
             task_id="t",
@@ -302,7 +338,8 @@ class TestMissingDependencies:
             cost_tracker=_cost_tracker(),
             message_bus=None,
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="a",
             task_id="t",
@@ -316,7 +353,8 @@ class TestMissingDependencies:
             cost_tracker=_cost_tracker(),
             similarity_computer=None,
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="a",
             task_id="t",
@@ -332,7 +370,8 @@ class TestMissingDependencies:
             cost_tracker=_cost_tracker(),
             similarity_computer=_mock_similarity_computer(),
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="a",
             task_id="t",
@@ -346,7 +385,8 @@ class TestMissingDependencies:
             config=_config(),
             cost_tracker=_cost_tracker(),
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="a",
             task_id="t",
@@ -360,7 +400,8 @@ class TestMissingDependencies:
             config=_config(),
             cost_tracker=_cost_tracker(),
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="a",
             task_id="t",
@@ -376,7 +417,8 @@ class TestMissingDependencies:
             cost_tracker=_cost_tracker(),
             message_bus=None,
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="a",
             task_id="t",
@@ -401,7 +443,8 @@ class TestSelectiveCollection:
             cost_tracker=_cost_tracker(),
             baseline_store=store,
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn(), _turn(), _turn()),
             agent_id="a",
             task_id="t",
@@ -433,7 +476,8 @@ class TestMetricComputation:
             baseline_store=store,
         )
         t1, t2, t3, t4, t5 = (_turn() for _ in range(5))
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(t1, t2, t3, t4, t5),
             agent_id="a",
             task_id="t",
@@ -451,7 +495,8 @@ class TestMetricComputation:
             baseline_store=store,
         )
         turns = tuple(_turn() for _ in range(8))
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(*turns),
             agent_id="a",
             task_id="t",
@@ -468,7 +513,8 @@ class TestMetricComputation:
             baseline_store=store,
         )
         # 1 error turn out of 2 -> error_rate_mas = 0.5
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(
                 _turn(FinishReason.STOP), _turn(FinishReason.ERROR)
             ),
@@ -486,7 +532,8 @@ class TestMetricComputation:
             cost_tracker=_cost_tracker(),
             baseline_store=store,
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn(FinishReason.ERROR)),
             agent_id="a",
             task_id="t",
@@ -504,7 +551,8 @@ class TestMetricComputation:
         )
         # 5 turns, 10 messages -> c = 10/5 = 2.0
         turns = tuple(_turn() for _ in range(5))
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(*turns),
             agent_id="a",
             task_id="t",
@@ -520,7 +568,8 @@ class TestMetricComputation:
             cost_tracker=_cost_tracker(),
             similarity_computer=computer,
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="a",
             task_id="t",
@@ -536,7 +585,8 @@ class TestMetricComputation:
             config=_config(),
             cost_tracker=_cost_tracker(),
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="a",
             task_id="t",
@@ -553,7 +603,8 @@ class TestMetricComputation:
             cost_tracker=_cost_tracker(),
         )
         durations = (("agent-1", 10.0), ("agent-2", 20.0))
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="a",
             task_id="t",
@@ -576,7 +627,8 @@ class TestMetricComputation:
             cost_tracker=_cost_tracker(),
             message_bus=bus,
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="a",
             task_id="t",
@@ -613,7 +665,8 @@ class TestAlertDispatching:
             notification_dispatcher=dispatcher,
         )
         turns = tuple(_turn() for _ in range(12))
-        await collector.collect(
+        await _collect(
+            collector,
             execution_result=_execution_result(*turns),
             agent_id="a",
             task_id="t",
@@ -632,7 +685,8 @@ class TestAlertDispatching:
             notification_dispatcher=dispatcher,
         )
         turns = tuple(_turn() for _ in range(10))
-        await collector.collect(
+        await _collect(
+            collector,
             execution_result=_execution_result(*turns),
             agent_id="a",
             task_id="t",
@@ -651,7 +705,8 @@ class TestAlertDispatching:
         )
         turns = tuple(_turn() for _ in range(12))
         # Should not raise
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(*turns),
             agent_id="a",
             task_id="t",
@@ -675,7 +730,8 @@ class TestAlertDispatching:
             notification_dispatcher=dispatcher,
         )
         turns = tuple(_turn() for _ in range(12))  # 12 turns, SAS=2 -> O%=500%
-        await collector.collect(
+        await _collect(
+            collector,
             execution_result=_execution_result(*turns),
             agent_id="a",
             task_id="t",
@@ -714,7 +770,8 @@ class TestMetricIsolation:
             similarity_computer=computer,
         )
         turns = tuple(_turn() for _ in range(6))
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(*turns),
             agent_id="a",
             task_id="t",
@@ -743,7 +800,8 @@ class TestMetricIsolation:
             baseline_store=store,
             message_bus=bus,
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn(), _turn(), _turn()),
             agent_id="a",
             task_id="t",
@@ -765,7 +823,8 @@ class TestMetricIsolation:
             cost_tracker=_cost_tracker(),
             baseline_store=store,
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="a",
             task_id="t",
@@ -794,7 +853,8 @@ class TestStoreWrite:
             metrics_store=metrics_store,
             clock=clock,
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn(), _turn(), _turn()),
             agent_id="lead-agent",
             task_id="task-42",
@@ -821,7 +881,8 @@ class TestStoreWrite:
             metrics_store=metrics_store,
             clock=FakeClock(),
         )
-        await collector.collect(
+        await _collect(
+            collector,
             execution_result=_execution_result(_turn(), _turn()),
             agent_id="agent-1",
             task_id="task-1",
@@ -836,7 +897,8 @@ class TestStoreWrite:
             baseline_store=_baseline_store(),
             metrics_store=None,
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn(), _turn()),
             agent_id="lead-agent",
             task_id="task-1",
@@ -854,7 +916,8 @@ class TestStoreWrite:
             metrics_store=metrics_store,
             clock=FakeClock(),
         )
-        await collector.collect(
+        await _collect(
+            collector,
             execution_result=_execution_result(_turn(), _turn()),
             agent_id="lead-agent",
             task_id="task-1",
@@ -873,7 +936,8 @@ class TestStoreWrite:
             metrics_store=metrics_store,
             clock=FakeClock(),
         )
-        await collector.collect(
+        await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="lead-agent",
             task_id="task-1",

--- a/tests/unit/budget/test_coordination_collector.py
+++ b/tests/unit/budget/test_coordination_collector.py
@@ -1,6 +1,8 @@
 """Tests for CoordinationMetricsCollector runtime collection pipeline."""
 
+from datetime import date
 from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
 
 import pytest
 
@@ -18,7 +20,13 @@ from synthorg.budget.coordination_config import (
 from synthorg.budget.coordination_metrics import CoordinationMetrics
 from synthorg.budget.coordination_store import CoordinationMetricsStore
 from synthorg.communication.bus_protocol import MessageBus
-from synthorg.engine.loop_protocol import ExecutionResult, TurnRecord
+from synthorg.core.agent import AgentIdentity, ModelConfig
+from synthorg.engine.context import AgentContext
+from synthorg.engine.loop_protocol import (
+    ExecutionResult,
+    TerminationReason,
+    TurnRecord,
+)
 from synthorg.providers.enums import FinishReason
 from tests._shared import FakeClock
 
@@ -63,12 +71,24 @@ def _turn(
 def _execution_result(*turns: TurnRecord) -> ExecutionResult:
     """Build a real ExecutionResult carrying the given turns.
 
-    ``model_construct`` skips validation so the heavyweight
-    ``context`` / ``termination_reason`` fields the collector never
-    reads are not required, while still yielding a genuine typed
-    ``ExecutionResult`` rather than a bare mock at the boundary.
+    A genuine ``ExecutionResult`` (real ``AgentContext`` + real
+    ``TurnRecord``s) at the ``_collect`` boundary instead of a bare
+    mock; the collector reads only ``turns`` but the full typed
+    instance keeps the contract honest.
     """
-    return ExecutionResult.model_construct(turns=tuple(turns))
+    identity = AgentIdentity(
+        id=uuid4(),
+        name="Test Agent",
+        role="Developer",
+        department="Engineering",
+        model=ModelConfig(provider="test-provider", model_id="test-large-001"),
+        hiring_date=date(2026, 1, 1),
+    )
+    return ExecutionResult(
+        context=AgentContext.from_identity(identity),
+        termination_reason=TerminationReason.COMPLETED,
+        turns=tuple(turns),
+    )
 
 
 async def _collect(  # noqa: PLR0913

--- a/tests/unit/budget/test_coordination_collector.py
+++ b/tests/unit/budget/test_coordination_collector.py
@@ -1,6 +1,5 @@
 """Tests for CoordinationMetricsCollector runtime collection pipeline."""
 
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -19,9 +18,9 @@ from synthorg.budget.coordination_config import (
 from synthorg.budget.coordination_metrics import CoordinationMetrics
 from synthorg.budget.coordination_store import CoordinationMetricsStore
 from synthorg.communication.bus_protocol import MessageBus
-from synthorg.engine.loop_protocol import ExecutionResult
+from synthorg.engine.loop_protocol import ExecutionResult, TurnRecord
 from synthorg.providers.enums import FinishReason
-from tests._shared import FakeClock, mock_of
+from tests._shared import FakeClock
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -49,18 +48,27 @@ def _turn(
     input_tokens: int = 100,
     output_tokens: int = 50,
     latency_ms: float | None = 50.0,
-) -> SimpleNamespace:
-    """Build a minimal TurnRecord attribute-bag."""
-    return SimpleNamespace(
+) -> TurnRecord:
+    """Build a minimal real TurnRecord."""
+    return TurnRecord(
+        turn_number=1,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cost=0.0,
         finish_reason=finish_reason,
-        total_tokens=input_tokens + output_tokens,
         latency_ms=latency_ms,
     )
 
 
-def _execution_result(*turns: SimpleNamespace) -> ExecutionResult:
-    """Build a minimal typed ExecutionResult double."""
-    return mock_of[ExecutionResult](turns=turns)
+def _execution_result(*turns: TurnRecord) -> ExecutionResult:
+    """Build a real ExecutionResult carrying the given turns.
+
+    ``model_construct`` skips validation so the heavyweight
+    ``context`` / ``termination_reason`` fields the collector never
+    reads are not required, while still yielding a genuine typed
+    ``ExecutionResult`` rather than a bare mock at the boundary.
+    """
+    return ExecutionResult.model_construct(turns=tuple(turns))
 
 
 async def _collect(  # noqa: PLR0913

--- a/tests/unit/budget/test_coordination_collector.py
+++ b/tests/unit/budget/test_coordination_collector.py
@@ -1,5 +1,6 @@
 """Tests for CoordinationMetricsCollector runtime collection pipeline."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -20,7 +21,7 @@ from synthorg.budget.coordination_store import CoordinationMetricsStore
 from synthorg.communication.bus_protocol import MessageBus
 from synthorg.engine.loop_protocol import ExecutionResult
 from synthorg.providers.enums import FinishReason
-from tests._shared import FakeClock
+from tests._shared import FakeClock, mock_of
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -48,20 +49,18 @@ def _turn(
     input_tokens: int = 100,
     output_tokens: int = 50,
     latency_ms: float | None = 50.0,
-) -> MagicMock:
-    """Build a minimal mock TurnRecord."""
-    turn = MagicMock()
-    turn.finish_reason = finish_reason
-    turn.total_tokens = input_tokens + output_tokens
-    turn.latency_ms = latency_ms
-    return turn
+) -> SimpleNamespace:
+    """Build a minimal TurnRecord attribute-bag."""
+    return SimpleNamespace(
+        finish_reason=finish_reason,
+        total_tokens=input_tokens + output_tokens,
+        latency_ms=latency_ms,
+    )
 
 
-def _execution_result(*turns: MagicMock) -> MagicMock:
-    """Build a minimal mock ExecutionResult."""
-    result = MagicMock()
-    result.turns = turns
-    return result
+def _execution_result(*turns: SimpleNamespace) -> ExecutionResult:
+    """Build a minimal typed ExecutionResult double."""
+    return mock_of[ExecutionResult](turns=turns)
 
 
 async def _collect(  # noqa: PLR0913

--- a/tests/unit/budget/test_coordination_collector_properties.py
+++ b/tests/unit/budget/test_coordination_collector_properties.py
@@ -7,10 +7,14 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from synthorg.budget.baseline_store import BaselineRecord, BaselineStore
-from synthorg.budget.coordination_collector import CoordinationMetricsCollector
+from synthorg.budget.coordination_collector import (
+    CollectionInputs,
+    CoordinationMetricsCollector,
+)
 from synthorg.budget.coordination_config import CoordinationMetricsConfig
 from synthorg.budget.coordination_metrics import CoordinationMetrics
 from synthorg.budget.tracker import CostTracker
+from synthorg.engine.loop_protocol import ExecutionResult
 from synthorg.providers.enums import FinishReason
 
 # ---------------------------------------------------------------------------
@@ -34,6 +38,31 @@ def _execution_result(*turns: MagicMock) -> MagicMock:
     result = MagicMock()
     result.turns = turns
     return result
+
+
+async def _collect(  # noqa: PLR0913
+    collector: CoordinationMetricsCollector,
+    *,
+    execution_result: ExecutionResult,
+    agent_id: str,
+    task_id: str,
+    team_size: int = 1,
+    agent_durations: tuple[tuple[str, float], ...] | None = None,
+    agent_outputs: tuple[str, ...] | None = None,
+    is_multi_agent: bool = False,
+) -> CoordinationMetrics:
+    """Invoke ``collect`` with the kwargs bundled into ``CollectionInputs``."""
+    return await collector.collect(
+        CollectionInputs(
+            execution_result=execution_result,
+            agent_id=agent_id,
+            task_id=task_id,
+            team_size=team_size,
+            agent_durations=agent_durations,
+            agent_outputs=agent_outputs,
+            is_multi_agent=is_multi_agent,
+        ),
+    )
 
 
 def _baseline_store_with_record(turns: float = 5.0) -> BaselineStore:
@@ -69,7 +98,8 @@ class TestCoordinationCollectorProperties:
             config=_cfg(),
             cost_tracker=MagicMock(spec=CostTracker),
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="agent-1",
             task_id="task-1",
@@ -84,7 +114,8 @@ class TestCoordinationCollectorProperties:
             config=_cfg(enabled=False),
             cost_tracker=MagicMock(spec=CostTracker),
         )
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(_turn()),
             agent_id="agent-1",
             task_id="task-1",
@@ -112,7 +143,8 @@ class TestCoordinationCollectorProperties:
             baseline_store=store,
         )
         for i in range(n_calls):
-            await collector.collect(
+            await _collect(
+                collector,
                 execution_result=_execution_result(_turn()),
                 agent_id=f"agent-{i}",
                 task_id="task-1",
@@ -135,7 +167,8 @@ class TestCoordinationCollectorProperties:
             baseline_store=store,
         )
         turns = tuple(_turn() for _ in range(turns_mas))
-        result = await collector.collect(
+        result = await _collect(
+            collector,
             execution_result=_execution_result(*turns),
             agent_id="a",
             task_id="t",

--- a/tests/unit/budget/test_coordination_config.py
+++ b/tests/unit/budget/test_coordination_config.py
@@ -1,5 +1,7 @@
 """Tests for coordination metrics configuration models."""
 
+from unittest.mock import AsyncMock
+
 import pytest
 from pydantic import ValidationError
 
@@ -13,6 +15,12 @@ from synthorg.budget.coordination_config import (
     ErrorTaxonomyConfig,
     OrchestrationAlertThresholds,
 )
+from synthorg.persistence.settings_protocol import SettingsRepository
+from synthorg.settings import definitions as _settings_definitions  # noqa: F401
+from synthorg.settings.enums import SettingType
+from synthorg.settings.errors import SettingReadOnlyError
+from synthorg.settings.registry import get_registry
+from synthorg.settings.service import SettingsService
 
 
 @pytest.mark.unit
@@ -314,3 +322,39 @@ class TestCoordinationMetricsConfig:
         config = CoordinationMetricsConfig()
         with pytest.raises(ValidationError):
             config.enabled = True  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestBaselineWindowSizeSetting:
+    """The ``> 0`` baseline-window invariant is enforced at the
+    settings layer.
+
+    The single-agent baseline window is no longer a Pydantic
+    ``CoordinationMetricsConfig`` field with ``gt=0``; it is the
+    registered ``budget.baseline_window_size`` setting. These tests
+    guard that the positive-window invariant survived the move: the
+    registered definition still carries the ``[1, 1_000_000]`` bound
+    and, being read-only post-init, the value cannot be mutated to an
+    out-of-range one at runtime.
+    """
+
+    def test_registered_definition_bounds(self) -> None:
+        defn = get_registry().get("budget", "baseline_window_size")
+        assert defn is not None
+        assert defn.type is SettingType.INTEGER
+        assert defn.default == "50"
+        # The bound that the deleted ``gt=0`` field validator enforced.
+        assert defn.min_value == 1
+        assert defn.max_value == 1_000_000
+        assert defn.read_only_post_init is True
+        assert defn.restart_required is True
+        assert defn.env_var_override == "SYNTHORG_BUDGET_BASELINE_WINDOW_SIZE"
+
+    async def test_read_only_post_init_rejects_runtime_mutation(self) -> None:
+        repo = AsyncMock(spec=SettingsRepository)
+        repo.get.return_value = None
+        repo.get_namespace.return_value = ()
+        repo.list_items.return_value = ()
+        service = SettingsService(repository=repo, registry=get_registry())
+        with pytest.raises(SettingReadOnlyError):
+            await service.set("budget", "baseline_window_size", "0")

--- a/tests/unit/budget/test_coordination_config.py
+++ b/tests/unit/budget/test_coordination_config.py
@@ -296,7 +296,6 @@ class TestCoordinationMetricsConfig:
         config = CoordinationMetricsConfig()
         assert config.enabled is False
         assert len(config.collect) == 9
-        assert config.baseline_window == 50
         assert config.error_taxonomy.enabled is False
         assert config.orchestration_alerts.info == 0.30
 
@@ -310,18 +309,6 @@ class TestCoordinationMetricsConfig:
         )
         assert config.enabled is True
         assert len(config.collect) == 2
-
-    def test_custom_baseline_window(self) -> None:
-        config = CoordinationMetricsConfig(baseline_window=100)
-        assert config.baseline_window == 100
-
-    def test_zero_baseline_window_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            CoordinationMetricsConfig(baseline_window=0)
-
-    def test_negative_baseline_window_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            CoordinationMetricsConfig(baseline_window=-1)
 
     def test_frozen(self) -> None:
         config = CoordinationMetricsConfig()

--- a/tests/unit/budget/test_coordination_config.py
+++ b/tests/unit/budget/test_coordination_config.py
@@ -21,6 +21,7 @@ from synthorg.settings.enums import SettingType
 from synthorg.settings.errors import SettingReadOnlyError
 from synthorg.settings.registry import get_registry
 from synthorg.settings.service import SettingsService
+from tests._shared import mock_of
 
 
 @pytest.mark.unit
@@ -351,10 +352,11 @@ class TestBaselineWindowSizeSetting:
         assert defn.env_var_override == "SYNTHORG_BUDGET_BASELINE_WINDOW_SIZE"
 
     async def test_read_only_post_init_rejects_runtime_mutation(self) -> None:
-        repo = AsyncMock(spec=SettingsRepository)
-        repo.get.return_value = None
-        repo.get_namespace.return_value = ()
-        repo.list_items.return_value = ()
+        repo = mock_of[SettingsRepository](
+            get=AsyncMock(return_value=None),
+            get_namespace=AsyncMock(return_value=()),
+            list_items=AsyncMock(return_value=()),
+        )
         service = SettingsService(repository=repo, registry=get_registry())
         with pytest.raises(SettingReadOnlyError):
-            await service.set("budget", "baseline_window_size", "0")
+            await service.set("budget", "baseline_window_size", "51")

--- a/tests/unit/engine/test_coordination_service.py
+++ b/tests/unit/engine/test_coordination_service.py
@@ -1,5 +1,6 @@
 """Tests for MultiAgentCoordinator service."""
 
+import asyncio
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
@@ -1120,3 +1121,37 @@ class TestCoordinationMetricsCollection:
         assert inputs.agent_durations is not None
         assert len(inputs.agent_durations) == 1
         assert inputs.agent_durations[0][0] == agent_id_b
+
+    @pytest.mark.unit
+    async def test_collector_timeout_is_never_fatal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A collector exceeding the bounded wait must not fail the run."""
+        monkeypatch.setattr(
+            "synthorg.engine.coordination.service._METRICS_COLLECT_TIMEOUT_SECONDS",
+            0.01,
+        )
+        decomp, routing, exec_results, ctx = self._two_agent_setup()
+
+        async def _hang(_inputs: object) -> CoordinationMetrics:
+            # Never completes; the bounded asyncio.wait_for must cancel
+            # it and surface TimeoutError into the non-fatal guard.
+            await asyncio.Event().wait()
+            return CoordinationMetrics()
+
+        collector = mock_of[CoordinationMetricsCollector](
+            collect=AsyncMock(side_effect=_hang),
+        )
+        coordinator = _make_coordinator(
+            decomp_result=decomp,
+            routing_result=routing,
+            exec_results=exec_results,
+            collector=collector,
+        )
+
+        attributed = await coordinator.coordinate(ctx)
+
+        # The coordination run itself succeeded; the collector timeout
+        # is swallowed by the bounded-cleanup guard.
+        assert attributed.is_success
+        collector.collect.assert_awaited_once()

--- a/tests/unit/engine/test_coordination_service.py
+++ b/tests/unit/engine/test_coordination_service.py
@@ -9,6 +9,8 @@ import pytest
 if TYPE_CHECKING:
     from synthorg.engine.decomposition.models import DecompositionResult
 
+from synthorg.budget.coordination_collector import CoordinationMetricsCollector
+from synthorg.budget.coordination_metrics import CoordinationMetrics
 from synthorg.core.enums import (
     CoordinationTopology,
     TaskStatus,
@@ -37,7 +39,7 @@ from synthorg.engine.workspace.models import (
     Workspace,
     WorkspaceGroupResult,
 )
-from tests._shared import FakeClock
+from tests._shared import FakeClock, mock_of
 from tests.unit.engine.conftest import (
     build_run_result,
     make_assignment_agent,
@@ -61,6 +63,7 @@ def _make_coordinator(  # noqa: PLR0913
     decompose_error: Exception | None = None,
     route_error: Exception | None = None,
     clock: FakeClock | None = None,
+    collector: CoordinationMetricsCollector | None = None,
 ) -> MultiAgentCoordinator:
     """Build a MultiAgentCoordinator with mocked dependencies."""
     decomp_service = AsyncMock(spec=DecompositionService)
@@ -91,6 +94,7 @@ def _make_coordinator(  # noqa: PLR0913
         workspace_service=workspace_service,
         task_engine=task_engine,
         clock=clock,
+        coordination_metrics_collector=collector,
     )
 
 
@@ -931,3 +935,96 @@ class TestMultiAgentCoordinator:
 
         assert exc_info.value.phase == "dispatch"
         assert len(exc_info.value.partial_phases) >= 3
+
+
+class TestCoordinationMetricsCollection:
+    """The coordinator computes + records multi-agent metrics post-run."""
+
+    @staticmethod
+    def _two_agent_setup() -> tuple[
+        DecompositionResult,
+        RoutingResult,
+        list[ParallelExecutionResult],
+        CoordinationContext,
+    ]:
+        sub_a = make_subtask("sub-a")
+        sub_b = make_subtask("sub-b")
+        decomp = make_decomposition((sub_a, sub_b))
+        routing = make_routing([("sub-a", "alice"), ("sub-b", "bob")])
+        agent_id_a = str(routing.decisions[0].selected_candidate.agent_identity.id)
+        agent_id_b = str(routing.decisions[1].selected_candidate.agent_identity.id)
+        exec_results = [
+            make_exec_result(
+                "wave-0",
+                [("sub-a", agent_id_a), ("sub-b", agent_id_b)],
+            ),
+        ]
+        ctx = CoordinationContext(
+            task=make_assignment_task(id="parent-1"),
+            available_agents=(
+                make_assignment_agent("alice"),
+                make_assignment_agent("bob"),
+            ),
+        )
+        return decomp, routing, exec_results, ctx
+
+    @pytest.mark.unit
+    async def test_multi_agent_collect_invoked(self) -> None:
+        decomp, routing, exec_results, ctx = self._two_agent_setup()
+        collector = mock_of[CoordinationMetricsCollector](
+            collect=AsyncMock(return_value=CoordinationMetrics()),
+        )
+        coordinator = _make_coordinator(
+            decomp_result=decomp,
+            routing_result=routing,
+            exec_results=exec_results,
+            collector=collector,
+        )
+
+        attributed = await coordinator.coordinate(ctx)
+
+        assert attributed.is_success
+        collector.collect.assert_awaited_once()
+        kwargs = collector.collect.await_args.kwargs
+        assert kwargs["is_multi_agent"] is True
+        assert kwargs["task_id"] == "parent-1"
+        assert kwargs["team_size"] == 2
+        assert len(kwargs["agent_durations"]) == 2
+        assert all(
+            isinstance(d, tuple) and len(d) == 2 for d in kwargs["agent_durations"]
+        )
+        assert isinstance(kwargs["agent_outputs"], tuple)
+        # The aggregate carries the team-wide turn records.
+        assert hasattr(kwargs["execution_result"], "turns")
+
+    @pytest.mark.unit
+    async def test_collector_failure_is_never_fatal(self) -> None:
+        decomp, routing, exec_results, ctx = self._two_agent_setup()
+        collector = mock_of[CoordinationMetricsCollector](
+            collect=AsyncMock(side_effect=RuntimeError("collector boom")),
+        )
+        coordinator = _make_coordinator(
+            decomp_result=decomp,
+            routing_result=routing,
+            exec_results=exec_results,
+            collector=collector,
+        )
+
+        attributed = await coordinator.coordinate(ctx)
+
+        assert attributed.is_success
+        collector.collect.assert_awaited_once()
+
+    @pytest.mark.unit
+    async def test_no_collector_completes_cleanly(self) -> None:
+        decomp, routing, exec_results, ctx = self._two_agent_setup()
+        coordinator = _make_coordinator(
+            decomp_result=decomp,
+            routing_result=routing,
+            exec_results=exec_results,
+            collector=None,
+        )
+
+        attributed = await coordinator.coordinate(ctx)
+
+        assert attributed.is_success

--- a/tests/unit/engine/test_coordination_service.py
+++ b/tests/unit/engine/test_coordination_service.py
@@ -1073,3 +1073,50 @@ class TestCoordinationMetricsCollection:
         # build_run_result sets duration_seconds=0.5 per subtask; the two
         # subtasks for the same agent must sum rather than appear twice.
         assert entry_duration == pytest.approx(1.0)
+
+    @pytest.mark.unit
+    async def test_team_size_counts_failed_participants(self) -> None:
+        """A participant whose subtask failed still counts in team_size."""
+        sub_a = make_subtask("sub-a")
+        sub_b = make_subtask("sub-b", dependencies=("sub-a",))
+        decomp = make_decomposition(
+            (sub_a, sub_b),
+            structure=TaskStructure.SEQUENTIAL,
+        )
+        routing = make_routing([("sub-a", "alice"), ("sub-b", "bob")])
+        agent_id_a = str(routing.decisions[0].selected_candidate.agent_identity.id)
+        agent_id_b = str(routing.decisions[1].selected_candidate.agent_identity.id)
+        exec_results = [
+            make_exec_result("wave-0", [("sub-a", agent_id_a)], all_succeed=False),
+            make_exec_result("wave-1", [("sub-b", agent_id_b)], all_succeed=True),
+        ]
+        ctx = CoordinationContext(
+            task=make_assignment_task(id="parent-1"),
+            available_agents=(
+                make_assignment_agent("alice"),
+                make_assignment_agent("bob"),
+            ),
+            config=CoordinationConfig(fail_fast=False),
+        )
+        collector = mock_of[CoordinationMetricsCollector](
+            collect=AsyncMock(return_value=CoordinationMetrics()),
+        )
+        coordinator = _make_coordinator(
+            decomp_result=decomp,
+            routing_result=routing,
+            exec_results=exec_results,
+            collector=collector,
+        )
+
+        await coordinator.coordinate(ctx)
+
+        collector.collect.assert_awaited_once()
+        inputs = collector.collect.await_args.args[0]
+        assert isinstance(inputs, CollectionInputs)
+        # Both agents were dispatched; alice's subtask failed (no result)
+        # but still counts toward team_size.
+        assert inputs.team_size == 2
+        # agent_durations only carries agents that produced a result.
+        assert inputs.agent_durations is not None
+        assert len(inputs.agent_durations) == 1
+        assert inputs.agent_durations[0][0] == agent_id_b

--- a/tests/unit/engine/test_coordination_service.py
+++ b/tests/unit/engine/test_coordination_service.py
@@ -9,7 +9,10 @@ import pytest
 if TYPE_CHECKING:
     from synthorg.engine.decomposition.models import DecompositionResult
 
-from synthorg.budget.coordination_collector import CoordinationMetricsCollector
+from synthorg.budget.coordination_collector import (
+    CollectionInputs,
+    CoordinationMetricsCollector,
+)
 from synthorg.budget.coordination_metrics import CoordinationMetrics
 from synthorg.core.enums import (
     CoordinationTopology,
@@ -985,17 +988,17 @@ class TestCoordinationMetricsCollection:
 
         assert attributed.is_success
         collector.collect.assert_awaited_once()
-        kwargs = collector.collect.await_args.kwargs
-        assert kwargs["is_multi_agent"] is True
-        assert kwargs["task_id"] == "parent-1"
-        assert kwargs["team_size"] == 2
-        assert len(kwargs["agent_durations"]) == 2
-        assert all(
-            isinstance(d, tuple) and len(d) == 2 for d in kwargs["agent_durations"]
-        )
-        assert isinstance(kwargs["agent_outputs"], tuple)
+        inputs = collector.collect.await_args.args[0]
+        assert isinstance(inputs, CollectionInputs)
+        assert inputs.is_multi_agent is True
+        assert inputs.task_id == "parent-1"
+        assert inputs.team_size == 2
+        assert inputs.agent_durations is not None
+        assert len(inputs.agent_durations) == 2
+        assert all(isinstance(d, tuple) and len(d) == 2 for d in inputs.agent_durations)
+        assert isinstance(inputs.agent_outputs, tuple)
         # The aggregate carries the team-wide turn records.
-        assert hasattr(kwargs["execution_result"], "turns")
+        assert hasattr(inputs.execution_result, "turns")
 
     @pytest.mark.unit
     async def test_collector_failure_is_never_fatal(self) -> None:

--- a/tests/unit/engine/test_coordination_service.py
+++ b/tests/unit/engine/test_coordination_service.py
@@ -1031,3 +1031,45 @@ class TestCoordinationMetricsCollection:
         attributed = await coordinator.coordinate(ctx)
 
         assert attributed.is_success
+
+    @pytest.mark.unit
+    async def test_durations_aggregated_per_agent(self) -> None:
+        """One agent across two subtasks yields a single summed entry."""
+        sub_a = make_subtask("sub-a")
+        sub_b = make_subtask("sub-b")
+        decomp = make_decomposition((sub_a, sub_b))
+        routing = make_routing([("sub-a", "alice"), ("sub-b", "alice")])
+        agent_id = str(routing.decisions[0].selected_candidate.agent_identity.id)
+        exec_results = [
+            make_exec_result(
+                "wave-0",
+                [("sub-a", agent_id), ("sub-b", agent_id)],
+            ),
+        ]
+        ctx = CoordinationContext(
+            task=make_assignment_task(id="parent-1"),
+            available_agents=(make_assignment_agent("alice"),),
+        )
+        collector = mock_of[CoordinationMetricsCollector](
+            collect=AsyncMock(return_value=CoordinationMetrics()),
+        )
+        coordinator = _make_coordinator(
+            decomp_result=decomp,
+            routing_result=routing,
+            exec_results=exec_results,
+            collector=collector,
+        )
+
+        attributed = await coordinator.coordinate(ctx)
+
+        assert attributed.is_success
+        inputs = collector.collect.await_args.args[0]
+        assert isinstance(inputs, CollectionInputs)
+        assert inputs.team_size == 1
+        assert inputs.agent_durations is not None
+        assert len(inputs.agent_durations) == 1
+        entry_agent_id, entry_duration = inputs.agent_durations[0]
+        assert entry_agent_id == agent_id
+        # build_run_result sets duration_seconds=0.5 per subtask; the two
+        # subtasks for the same agent must sum rather than appear twice.
+        assert entry_duration == pytest.approx(1.0)

--- a/tests/unit/workers/test_runtime_builder.py
+++ b/tests/unit/workers/test_runtime_builder.py
@@ -7,6 +7,9 @@ from unittest.mock import AsyncMock
 import pytest
 
 from synthorg.api.state import AppState
+from synthorg.budget.coordination_collector import CoordinationMetricsCollector
+from synthorg.budget.coordination_store import CoordinationMetricsStore
+from synthorg.budget.tracker import CostTracker
 from synthorg.config.provider_schema import ProviderConfig
 from synthorg.config.schema import RootConfig
 from synthorg.engine.coordination.service import MultiAgentCoordinator
@@ -33,11 +36,16 @@ def _provider_app_state(
     workspace: Path,
     *,
     bridge_config_error: Exception | None = None,
+    cost_tracker: CostTracker | None = None,
+    coordination_metrics_store: CoordinationMetricsStore | None = None,
 ) -> AppState:
     """Build a mocked AppState for the provider-present path.
 
     ``bridge_config_error`` makes ``get_engine_bridge_config`` raise, to
     exercise the fail-open routing-scorer-config resolve branch.
+    ``cost_tracker`` (and the paired ``coordination_metrics_store``)
+    drive the coordination-metrics collector wiring: absent, the
+    collector is not constructed (mirrors the empty/degraded path).
     """
     if bridge_config_error is None:
         bridge_mock = AsyncMock(return_value=EngineBridgeConfig())
@@ -63,7 +71,11 @@ def _provider_app_state(
             event_stream_hub=None,
             interrupt_store=None,
             agent_workspace_root=workspace,
-            has_cost_tracker=False,
+            has_cost_tracker=cost_tracker is not None,
+            cost_tracker=cost_tracker,
+            has_message_bus=False,
+            has_coordination_metrics_store=coordination_metrics_store is not None,
+            coordination_metrics_store=coordination_metrics_store,
             has_audit_log=False,
             has_memory_backend=False,
             has_performance_tracker=False,
@@ -224,3 +236,73 @@ class TestProviderPresentSwitch:
         )
         assert isinstance(result.coordinator, MultiAgentCoordinator)
         assert deep.is_dir()
+
+
+class TestCoordinationMetricsWiring:
+    """The coordination-metrics collector is built and shared at boot."""
+
+    @staticmethod
+    def _registry() -> ProviderRegistry:
+        return ProviderRegistry.from_config(
+            {"test-provider": ProviderConfig(driver="scripted")}
+        )
+
+    async def test_no_collector_without_cost_tracker(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        app_state = _provider_app_state(self._registry(), tmp_path)
+        result = await build_runtime_services(app_state, workspace_root=tmp_path)
+
+        worker = result.worker_execution_service
+        coordinator = result.coordinator
+        assert isinstance(worker, AgentEngineExecutionService)
+        assert coordinator is not None
+        assert worker._engine._coordination_metrics_collector is None
+        assert coordinator._coordination_metrics_collector is None
+
+    async def test_collector_built_and_shared_when_cost_tracker_present(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store = CoordinationMetricsStore()
+        app_state = _provider_app_state(
+            self._registry(),
+            tmp_path,
+            cost_tracker=mock_of[CostTracker](),
+            coordination_metrics_store=store,
+        )
+        result = await build_runtime_services(app_state, workspace_root=tmp_path)
+
+        worker = result.worker_execution_service
+        coordinator = result.coordinator
+        assert isinstance(worker, AgentEngineExecutionService)
+        assert coordinator is not None
+        collector = worker._engine._coordination_metrics_collector
+        assert isinstance(collector, CoordinationMetricsCollector)
+        # Same single instance threaded into the single-agent engine AND
+        # the multi-agent coordinator (no divergent collectors).
+        assert coordinator._coordination_metrics_collector is collector
+        assert collector._metrics_store is store
+
+    async def test_baseline_window_size_from_setting(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("SYNTHORG_BUDGET_BASELINE_WINDOW_SIZE", "7")
+        app_state = _provider_app_state(
+            self._registry(),
+            tmp_path,
+            cost_tracker=mock_of[CostTracker](),
+            coordination_metrics_store=CoordinationMetricsStore(),
+        )
+        result = await build_runtime_services(app_state, workspace_root=tmp_path)
+
+        worker = result.worker_execution_service
+        assert isinstance(worker, AgentEngineExecutionService)
+        collector = worker._engine._coordination_metrics_collector
+        assert isinstance(collector, CoordinationMetricsCollector)
+        baseline_store = collector._baseline_store
+        assert baseline_store is not None
+        assert baseline_store._window_size == 7


### PR DESCRIPTION
Closes #1959

(#1959 itself Closes #1951 — the correctly-scoped replacement under EPIC #1955.)

## Summary

Wires the previously-ghost coordination-metrics subsystem so it is reachable in a running deployment, plus the pre-PR review fixes layered on top.

Commits (squash-merged via this PR body):
- `fix: make coordination metrics live` — construct `BaselineStore` + `CoordinationMetricsCollector` at boot in `workers/runtime_builder`, thread the single shared collector into both the single-agent `AgentEngine` and the multi-agent coordinator, write `CoordinationMetricsRecord` into the `CoordinationMetricsStore` (closes the #1954 ghost so `GET /coordination/metrics` serves real data), register `budget.baseline_window_size`, and flip both `BaselineStore` + `CoordinationMetricsCollector` manifest lines `PENDING` → `ENFORCED`.
- `fix: harden coordination-metrics wiring (pre-PR review round)` — V1 add `error_type` to the three post-completion exception handlers (SEC-1); V2 extract a shared `resolve_init_int` so `runtime_builder` and `app` stop duplicating the bootstrap-int resolver; V3 document the Ae baseline window in `docs/design/budget.md`; V5 split `_collect_coordination_metrics` under the line limit; V6 add a SettingDefinition-bound enforcement test; V7 document the Cat-2 budget settings; V8 bound the post-completion collector hook with `asyncio.wait_for`; refactor the four long `coordination_collector` functions.
- `refactor: bundle collect() args into CollectionInputs (P1)` — collapse `collect()`'s 8 kwargs into a single `CollectionInputs` payload; updated all production + test call sites.
- `test: make coordinator-not-configured 503 test order-independent` and `test: fix shared-app runtime-services isolation leak (once-only install)` — see Pre-PR review note below.

## Test plan

- `ruff check` + `ruff format` clean; `mypy --strict` clean across all changed modules.
- All affected unit suites pass, including `--count=2` isolation runs of the previously-flaky tests (`test_503_when_coordinator_not_configured`, `test_no_active_agents`, `test_get_autonomy`) and all 7 isolation-gate victim files (156 passed).
- Multi-agent metrics validated end-to-end under the coordinator simulation harness (`tests/e2e/test_coordinator_online_seam.py`): a real `coordinate()` run records a `CoordinationMetricsRecord` retrievable via the exact `metrics_store.query(...)` call the `GET /coordination/metrics` controller makes.
- Full pre-push gate green (mypy-affected, pytest-affected `--count=2` isolation, all convention gates, ghost-wiring gate).

## Review coverage

Pre-reviewed by 11 agents (issue-resolution-verifier, code-reviewer, python-reviewer, conventions-enforcer, async-concurrency-reviewer, silent-failure-hunter, test-quality-reviewer, docs-consistency, comment-quality-rot, mini-pass-ghost-wiring, mini-pass-unwired-settings). 8 valid findings + P1 implemented; 6 findings refuted with empirical evidence (ruff/mypy/tests + the documented PEP 758 `except A, B:` convention + the `BaselineStore` single-loop-asyncio model).

## Notes for the reviewer

- **`_resolve_api_int` adjacency**: V2's shared `resolve_init_int` extraction also delegates `app._resolve_api_int` (the API-namespace sibling of the same duplicated resolve+parse+int pattern), in addition to the budget resolver the finding named. No behaviour change; covered by the existing `test_app_bootstrap_resolvers` suite. Called out so the API-namespace resolver edit in a coordination-metrics PR is not a surprise.
- **Pre-PR review surfaced a pre-existing test-infra bug** unrelated to coordination metrics: `api/app.py:_install_runtime_services` is once-only (a `_runtime_services_installed` closure), but the session-scoped shared test app is reused across all tests per xdist worker, so the coordinator/worker-exec seams were wired only during the *first* test's lifespan startup and snapshot-restored to `None` for every later test — making any coordinator-dependent assertion order-dependent (flaky `[1-2]/[2-2]` under the `--count=2` isolation gate). It was latent on `main` (narrow per-commit affected sets never co-exercised the coordinator-sensitive `tests/unit/api` tree under `--count=2`); this PR's `app.py` edit pulls that tree into the affected selection and surfaced it. Root-caused at code level and fixed deterministically in `tests/unit/api/conftest.py` (force the runtime-service seams to the no-runtime-services baseline post-startup every test); A/B-verified against clean `origin/main`.

Branch rebased onto `origin/main`.