### PR TITLE
feat: real intake engine online

### DIFF
--- a/docs/design/client-simulation.md
+++ b/docs/design/client-simulation.md
@@ -208,6 +208,32 @@ A selected `agent` strategy that cannot be satisfied (no provider or
 no model) degrades to `direct` with a warning rather than failing
 boot.
 
+### Real work-entry path
+
+`POST /requests/{id}/approve` is the real (non-simulated) work-entry
+path. On approval the request is walked to `APPROVED` and a
+background task runs the `IntakeEntryAdapter`
+(`WorkSource.INTAKE`), which maps the `ClientRequest` onto a
+`WorkItem` and drives the work pipeline spine (intake -> projects ->
+decompose -> solo or team execution). The endpoint returns `202
+Accepted` with the `APPROVED` request; the terminal `TASK_CREATED`
+or `CANCELLED` state lands asynchronously and is observable via `GET
+/requests/{id}` and the request WebSocket channel. Reviewer
+`scoping_notes` from a prior `/scope` call are folded into the work
+item's intent body so the manual scope flow is preserved.
+
+The adapter is built once the work pipeline is online
+(`engine.pipeline.entry.boot.wire_real_intake_entry`, called from
+the boot runtime-services hook and the post-setup provider reinit)
+and attached to the `AppState.intake_entry_adapter` seam. When no
+work pipeline is wired (empty company / no provider) approve returns
+`AgentRuntimeNotConfiguredError` rather than minting a task no agent
+will run. The `simulations.intake_default_project` setting (env >
+registered default, baked in at startup) names the project the
+intake strategy files tasks into and the adapter stamps on the work
+item; that project is created at startup if absent so the pipeline's
+project-existence check and the created task agree.
+
 ---
 
 ## Task Source Tracking

--- a/docs/design/client-simulation.md
+++ b/docs/design/client-simulation.md
@@ -200,9 +200,12 @@ of `InternalReviewStage`) during app construction whenever a
 `ClientSimulationState` so `has_simulation_runtime` is true and the
 `/simulations` + `/requests` controllers register. The strategy is
 selected from the `simulations` settings namespace
-(`intake_strategy` ∈ {`direct`, `agent`}, `intake_model`) via the
-bootstrap resolver (env > registered default); the choice is baked
-in at startup (`read_only_post_init`). The default `direct` strategy
+(`intake_strategy` ∈ {`direct`, `agent`}, `intake_model`,
+`intake_default_project`) via the bootstrap resolver (env >
+registered default); the choices are baked in at startup
+(`read_only_post_init`). `intake_default_project` is the project the
+intake strategy files tasks into and the real work-entry adapter
+stamps on the work item (see [Real work-entry path](#real-work-entry-path)). The default `direct` strategy
 makes no LLM calls, so the runtime comes online for an empty company.
 A selected `agent` strategy that cannot be satisfied (no provider or
 no model) degrades to `direct` with a warning rather than failing
@@ -311,7 +314,8 @@ discriminator rather than silently falling back to a default.
 | `ReportConfig.strategy` | `build_report_strategy()` | `summary` → `SummaryReport`, `detailed` → `DetailedReport`, `json_export` → `JsonExportReport`, `metrics_only` → `MetricsOnlyReport` |
 | `ClientPoolConfig.selection_strategy` | `build_client_pool_strategy()` | `round_robin` → `RoundRobinStrategy`, `weighted_random` → `WeightedRandomStrategy`, `domain_matched` → `DomainMatchedStrategy` |
 | `adapter` arg (intake entry point) | `build_entry_point_strategy(adapter, *, project_id=None)` | `direct` → `DirectAdapter`, `project` → `ProjectAdapter`, `intake` → `IntakeAdapter` |
-| `IntakeConfig.strategy` | `build_intake_strategy(config, *, task_engine, provider=None, cost_tracker=None)` | `direct` → `DirectIntake`, `agent` → `AgentIntake` |
+| `IntakeConfig.strategy` | `build_intake_strategy(config, *, task_engine, default_project, provider=None, cost_tracker=None)` | `direct` → `DirectIntake`, `agent` → `AgentIntake` |
+| `WorkSource` (work-entry adapter) | `build_work_entry_adapter(source, *, work_pipeline, default_project)` | `intake` → `IntakeEntryAdapter` |
 
 The factories follow the project-wide pluggable-subsystems pattern
 (protocol + strategy + factory + config discriminator). No silent

--- a/docs/design/page-structure.md
+++ b/docs/design/page-structure.md
@@ -397,6 +397,11 @@ Sidebar layout (220px expanded, 56px icon rail):
 | `/settings/observability/sinks` | Settings Sinks | Observability sink management (card grid with edit/test) |
 | `/settings/coordination/ceremony-policy` | Ceremony Policy | Strategy selection with resolved-policy source badges, department overrides with inherit/override toggle, per-ceremony overrides, velocity-calculator auto-selection per strategy |
 | `/settings/memory/fine-tuning` | Fine-Tuning | Embedding fine-tuning pipeline management (status, run history, preflight checks, start/cancel) |
+| `/clients` | Client List | Synthetic-client roster with search/filter |
+| `/clients/:clientId` | Client Detail | Per-client profile, request history, satisfaction |
+| `/clients/requests` | Request Queue | Client-request intake lifecycle (submit, scope, approve, reject). Approve returns `202`; the request runs through the work pipeline in the background and reaches its terminal state asynchronously |
+| `/clients/simulations` | Simulation Dashboard | Simulation run list, start, detail, cancel |
+| `/clients/reviews/:taskId` | Review Pipeline | Per-task review-pipeline stage progress and decisions |
 | `/docs/` | Documentation | Static MkDocs HTML served by Caddy (bypasses React Router) |
 | `*` | 404 Not Found | Catch-all |
 

--- a/docs/design/verification-quality.md
+++ b/docs/design/verification-quality.md
@@ -7,7 +7,7 @@ description: Verification stage, harness middleware layer, review pipeline, and 
 
 !!! warning "Designed behaviour; runtime in active development"
 
-    This page is the source of truth for the **designed** behaviour of this subsystem. The verification pipeline and intake engine run with the agent runtime, which is in active development (see the [Roadmap](../roadmap/index.md)); the code described here is built and unit-tested as components but not yet run by a live agent.
+    This page is the source of truth for the **designed** behaviour of this subsystem. The intake engine is online: the real work-entry path (`POST /requests/{id}/approve`) drives an approved request through the pipeline spine so an agent executes it. The verification stage runs with the agent runtime, which is in active development (see the [Roadmap](../roadmap/index.md)); that code is built and unit-tested as components but not yet exercised by a live verification agent.
 
 This page covers the quality-assurance pipeline attached to agent output: the verification stage that runs after an agent completes a task, the harness middleware that wraps every agent invocation, the review pipeline that validates produced artifacts, and the intake engine that ingests new work.
 

--- a/docs/design/verification-quality.md
+++ b/docs/design/verification-quality.md
@@ -132,9 +132,12 @@ Key design decisions:
 ## Intake Engine
 
 The intake engine processes `ClientRequest` submissions through an independent
-state machine (`RequestStatus`) before creating tasks in the task engine. See
-[Client Simulation](client-simulation.md) for the full request lifecycle and
-intake strategy contracts.
+state machine (`RequestStatus`) before creating tasks in the task engine. The
+real work-entry path (`POST /requests/{id}/approve`) approves a request and
+runs it through the `IntakeEntryAdapter` into the work pipeline spine so an
+agent executes it; the terminal state lands asynchronously. See
+[Client Simulation](client-simulation.md) for the full request lifecycle,
+intake strategy contracts, and the real work-entry path.
 
 ---
 

--- a/scripts/_ghost_wiring_manifest.txt
+++ b/scripts/_ghost_wiring_manifest.txt
@@ -32,6 +32,10 @@ ENFORCED build_autonomy_change_strategy #1957 -- built at boot in app_builders, 
 ENFORCED BaselineStore #1959 -- construct at boot (window from budget.baseline_window_size)
 ENFORCED CoordinationMetricsCollector #1959 -- construct at boot, thread into execution
 ENFORCED IntakeEngine #1961 -- wired at boot via client/runtime_builder.build_client_simulation_runtime
+ENFORCED DirectIntake #1962 -- constructed by client.factory.build_intake_strategy; real work-entry path via IntakeEntryAdapter -> work pipeline
+ENFORCED AgentIntake #1962 -- constructed by client.factory._build_agent_intake; LLM triage on the real work-entry path
+ENFORCED IntakeEntryAdapter #1962 -- built at boot by engine.pipeline.entry.boot.wire_real_intake_entry; fed by POST /requests/{id}/approve
+ENFORCED build_work_entry_adapter #1962 -- factory called at boot to construct the source-keyed work-entry adapter
 ENFORCED create_lifecycle_strategy #1965 -- constructed at boot in workers/runtime_builder._build_tool_registry and injected into the Docker sandbox backend
 ENFORCED build_distributed_backend_services #1966 -- called in api/auto_wire._register_distributed_dispatcher behind queue.enabled; builds the dead-letter consumer + dedup pruner + heartbeat subscriber bundle
 ENFORCED DeadLetterConsumer #1966 -- constructed by workers.backend_services.build_distributed_backend_services; drains the dead subject and fails exhausted tasks (no-loss closure)

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -91,6 +91,7 @@ from synthorg.config.schema import RootConfig
 from synthorg.core.clock import SystemClock
 from synthorg.core.error_taxonomy import set_error_docs_base_url
 from synthorg.engine.coordination.service import MultiAgentCoordinator  # noqa: TC001
+from synthorg.engine.pipeline.entry.protocol import WorkEntryAdapter  # noqa: TC001
 from synthorg.engine.pipeline.protocol import WorkPipeline  # noqa: TC001
 from synthorg.engine.review_gate import ReviewGateService
 from synthorg.engine.task_engine import TaskEngine  # noqa: TC001
@@ -255,6 +256,7 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
     task_engine: TaskEngine | None = None,
     coordinator: MultiAgentCoordinator | None = None,
     work_pipeline: WorkPipeline | None = None,
+    intake_entry_adapter: WorkEntryAdapter | None = None,
     agent_registry: AgentRegistryService | None = None,
     meeting_orchestrator: MeetingOrchestrator | None = None,
     meeting_scheduler: MeetingScheduler | None = None,
@@ -291,6 +293,8 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
         coordinator: Multi-agent coordinator.
         work_pipeline: Work pipeline spine (injected double wins over
             the boot-autowired one).
+        intake_entry_adapter: Real work-entry adapter (injected double
+            wins over the boot-autowired one).
         agent_registry: Agent registry service.
         meeting_orchestrator: Meeting orchestrator.
         meeting_scheduler: Meeting scheduler.
@@ -551,6 +555,7 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
         task_engine=task_engine,
         coordinator=coordinator,
         work_pipeline=work_pipeline,
+        intake_entry_adapter=intake_entry_adapter,
         agent_registry=agent_registry,
         meeting_orchestrator=meeting_orchestrator,
         meeting_scheduler=meeting_scheduler,
@@ -1072,6 +1077,14 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
         # one is a logged no-op then.
         if services.work_pipeline is not None:
             app_state.set_work_pipeline_if_absent(services.work_pipeline)
+        # Bring the real client-request work-entry path online: ensure
+        # the configured intake project exists and attach the intake
+        # entry adapter. No-op for an empty company (no pipeline).
+        from synthorg.engine.pipeline.entry.boot import (  # noqa: PLC0415
+            wire_real_intake_entry,
+        )
+
+        await wire_real_intake_entry(app_state)
         _runtime_services_installed = True
 
     startup = [*startup, _install_runtime_services]

--- a/src/synthorg/api/controllers/requests.py
+++ b/src/synthorg/api/controllers/requests.py
@@ -81,17 +81,25 @@ def _publish(
     event_type: WsEventType,
     client_request: ClientRequest,
 ) -> None:
-    """Best-effort publish a request lifecycle event."""
-    publish_ws_event(
-        request,
-        event_type,
-        CHANNEL_REQUESTS,
-        {
-            "request_id": client_request.request_id,
-            "client_id": client_request.client_id,
-            "status": client_request.status.value,
-        },
-    )
+    """Best-effort publish a request lifecycle event.
+
+    ``REQUEST_TASK_CREATED`` additionally carries ``task_id`` so the
+    frontend can navigate straight to the spawned task without a
+    second ``GET /requests/{id}``. ``_reconcile_success`` always stamps
+    ``metadata["task_id"]`` before publishing this event, so the field
+    is contract-required for that event type and contract-absent for
+    every other request lifecycle event.
+    """
+    payload: dict[str, object] = {
+        "request_id": client_request.request_id,
+        "client_id": client_request.client_id,
+        "status": client_request.status.value,
+    }
+    if event_type is WsEventType.REQUEST_TASK_CREATED:
+        task_id = client_request.metadata.get("task_id")
+        if isinstance(task_id, str) and task_id:
+            payload["task_id"] = task_id
+    publish_ws_event(request, event_type, CHANNEL_REQUESTS, payload)
 
 
 def _walk_to_approved(stored: ClientRequest) -> ClientRequest:
@@ -154,6 +162,50 @@ def _spawn_intake_pipeline(
     sim_state.background_tasks.add(task)
 
 
+async def _approved_or_none(
+    app_state: AppState,
+    sim_state: ClientSimulationState,
+    request_id: str,
+) -> ClientRequest | None:
+    """Return the request iff still ``APPROVED``, else ``None``.
+
+    Brief read+gate under the per-request lock. The lock-registry
+    entry is always evicted on early-return paths (vanished request,
+    or status already past ``APPROVED``) so the dict cannot leak an
+    entry per orphaned id; on the success path the entry is kept
+    because the downstream reconcile helpers re-acquire the lock and
+    evict it themselves. ``release_request_lock_if_idle`` sits in
+    ``finally`` so it observes the Lock already released by
+    ``__aexit__`` and an idle refcount (its documented contract).
+    """
+    handed_off = False
+    try:
+        async with app_state.acquire_request_lock(request_id):
+            try:
+                stored = await sim_state.request_store.get(request_id)
+            except KeyError:
+                logger.warning(
+                    CLIENT_REQUEST_INTAKE_PIPELINE_FAILED,
+                    request_id=request_id,
+                    note="request vanished before pipeline start",
+                )
+                return None
+            if stored.status is not RequestStatus.APPROVED:
+                logger.info(
+                    CLIENT_REQUEST_STATUS_TRANSITIONED,
+                    request_id=request_id,
+                    from_status=stored.status.value,
+                    to_status=stored.status.value,
+                    note="pipeline skipped: request no longer APPROVED",
+                )
+                return None
+            handed_off = True
+            return stored
+    finally:
+        if not handed_off:
+            app_state.release_request_lock_if_idle(request_id)
+
+
 async def process_intake_pipeline(
     *,
     app_state: AppState,
@@ -170,27 +222,13 @@ async def process_intake_pipeline(
     status reached meanwhile (a user reject wins over a late pipeline
     success). Adapter / pipeline failures are logged and the request
     is cancelled with the reason; ``MemoryError`` / ``RecursionError``
-    propagate.
+    propagate. The lock-registry entry is evicted on every early
+    return so the dict cannot grow unbounded across vanished or
+    already-terminal requests.
     """
-    async with app_state.acquire_request_lock(request_id):
-        try:
-            approved = await sim_state.request_store.get(request_id)
-        except KeyError:
-            logger.warning(
-                CLIENT_REQUEST_INTAKE_PIPELINE_FAILED,
-                request_id=request_id,
-                note="request vanished before pipeline start",
-            )
-            return
-        if approved.status is not RequestStatus.APPROVED:
-            logger.info(
-                CLIENT_REQUEST_STATUS_TRANSITIONED,
-                request_id=request_id,
-                from_status=approved.status.value,
-                to_status=approved.status.value,
-                note="pipeline skipped: request no longer APPROVED",
-            )
-            return
+    approved = await _approved_or_none(app_state, sim_state, request_id)
+    if approved is None:
+        return
     try:
         result = await app_state.intake_entry_adapter.submit(approved)
     except asyncio.CancelledError:
@@ -199,25 +237,16 @@ async def process_intake_pipeline(
         raise
     except MemoryError, RecursionError:
         raise
-    except WorkIntakeRejectedError as exc:
-        # Intake declining the work is a normal outcome, not a defect.
-        await _safe_finalize(
-            _reconcile_cancel,
-            sim_state,
-            app_state,
-            request_id,
-            operation="reconcile_cancel",
-            reason=safe_error_description(exc),
-            publish=publish,
-        )
-        return
     except Exception as exc:
-        logger.error(
-            CLIENT_REQUEST_INTAKE_PIPELINE_FAILED,
-            request_id=request_id,
-            error_type=type(exc).__name__,
-            error=safe_error_description(exc),
-        )
+        if not isinstance(exc, WorkIntakeRejectedError):
+            # Intake declining the work is a normal outcome, not a
+            # defect; only non-rejection paths warrant ERROR.
+            logger.error(
+                CLIENT_REQUEST_INTAKE_PIPELINE_FAILED,
+                request_id=request_id,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
         await _safe_finalize(
             _reconcile_cancel,
             sim_state,

--- a/src/synthorg/api/controllers/requests.py
+++ b/src/synthorg/api/controllers/requests.py
@@ -1,5 +1,7 @@
 """Client request lifecycle endpoints at /requests."""
 
+import asyncio
+from collections.abc import Callable
 from typing import Annotated, Any, Final
 
 from litestar import Controller, Request, get, post
@@ -19,13 +21,29 @@ from synthorg.client.models import (
     RequestStatus,
     TaskRequirement,
 )
-from synthorg.core.domain_errors import ConflictError, NotFoundError
+from synthorg.client.simulation_state import ClientSimulationState  # noqa: TC001
+from synthorg.core.domain_errors import (
+    AgentRuntimeNotConfiguredError,
+    ConflictError,
+    NotFoundError,
+)
 from synthorg.core.types import NotBlankStr  # noqa: TC001
-from synthorg.observability import get_logger
-from synthorg.observability.events.client import CLIENT_REQUEST_STATUS_TRANSITIONED
+from synthorg.engine.pipeline.errors import WorkIntakeRejectedError
+from synthorg.observability import get_logger, safe_error_description
+from synthorg.observability.background_tasks import log_task_exceptions
+from synthorg.observability.events.client import (
+    CLIENT_REQUEST_INTAKE_PIPELINE_FAILED,
+    CLIENT_REQUEST_STATUS_TRANSITIONED,
+)
 
 logger = get_logger(__name__)
 _DEFAULT_LIMIT: Final[int] = 50
+
+# Best-effort WS publisher bound to the originating request. The
+# background reconciliation runs after the HTTP response is sent, so
+# the closure keeps a reference to the request only to reach the
+# channels plugin; ``publish_ws_event`` is itself best-effort.
+_Publisher = Callable[[WsEventType, ClientRequest], None]
 
 
 class CreateRequestPayload(BaseModel):
@@ -74,6 +92,226 @@ def _publish(
             "status": client_request.status.value,
         },
     )
+
+
+def _walk_to_approved(stored: ClientRequest) -> ClientRequest:
+    """Walk a submitted/scoped request to ``APPROVED``.
+
+    ``SUBMITTED`` traverses ``TRIAGING -> SCOPING -> APPROVED``; an
+    already-``SCOPING`` request (manual scope flow) goes straight to
+    ``APPROVED``. ``with_status`` carries metadata forward, so the
+    refined requirement and ``scoping_notes`` survive into the work
+    item the adapter builds.
+    """
+    walked = stored
+    if walked.status is RequestStatus.SUBMITTED:
+        walked = walked.with_status(RequestStatus.TRIAGING)
+        walked = walked.with_status(RequestStatus.SCOPING)
+    return walked.with_status(RequestStatus.APPROVED)
+
+
+def _spawn_intake_pipeline(
+    *,
+    app_state: AppState,
+    sim_state: ClientSimulationState,
+    request_id: str,
+    publish: _Publisher,
+) -> None:
+    """Spawn + track the background intake-pipeline reconciliation.
+
+    Mirrors the simulations runner's callback ordering: the exception
+    logger is attached before the set-discard so a fast-completing
+    failure still surfaces, and a strong reference is held in
+    ``sim_state.background_tasks`` so the task is not GC'd mid-flight.
+    """
+    task = asyncio.create_task(
+        process_intake_pipeline(
+            app_state=app_state,
+            sim_state=sim_state,
+            request_id=request_id,
+            publish=publish,
+        )
+    )
+    task.add_done_callback(
+        log_task_exceptions(
+            logger,
+            CLIENT_REQUEST_INTAKE_PIPELINE_FAILED,
+            request_id=request_id,
+        ),
+    )
+    task.add_done_callback(sim_state.background_tasks.discard)
+    sim_state.background_tasks.add(task)
+
+
+async def process_intake_pipeline(
+    *,
+    app_state: AppState,
+    sim_state: ClientSimulationState,
+    request_id: str,
+    publish: _Publisher | None = None,
+) -> None:
+    """Drive an approved request through the work pipeline and reconcile.
+
+    Runs the work-entry adapter (pipeline spine) WITHOUT holding the
+    request lock -- agent execution can take minutes and a concurrent
+    reject must still be able to cancel an in-flight approval. The
+    terminal write re-acquires the lock and respects any terminal
+    status reached meanwhile (a user reject wins over a late pipeline
+    success). Adapter / pipeline failures are logged and the request
+    is cancelled with the reason; ``MemoryError`` / ``RecursionError``
+    propagate.
+    """
+    async with app_state.acquire_request_lock(request_id):
+        try:
+            approved = await sim_state.request_store.get(request_id)
+        except KeyError:
+            logger.warning(
+                CLIENT_REQUEST_INTAKE_PIPELINE_FAILED,
+                request_id=request_id,
+                note="request vanished before pipeline start",
+            )
+            return
+        if approved.status is not RequestStatus.APPROVED:
+            logger.info(
+                CLIENT_REQUEST_STATUS_TRANSITIONED,
+                request_id=request_id,
+                from_status=approved.status.value,
+                to_status=approved.status.value,
+                note="pipeline skipped: request no longer APPROVED",
+            )
+            return
+    try:
+        result = await app_state.intake_entry_adapter.submit(approved)
+    except MemoryError, RecursionError:
+        raise
+    except WorkIntakeRejectedError as exc:
+        # Intake declining the work is a normal outcome, not a defect.
+        await _reconcile_cancel(
+            sim_state,
+            app_state,
+            request_id,
+            reason=safe_error_description(exc),
+            publish=publish,
+        )
+        return
+    except Exception as exc:
+        logger.error(
+            CLIENT_REQUEST_INTAKE_PIPELINE_FAILED,
+            request_id=request_id,
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
+        )
+        await _reconcile_cancel(
+            sim_state,
+            app_state,
+            request_id,
+            reason=safe_error_description(exc),
+            publish=publish,
+        )
+        return
+    await _reconcile_success(
+        sim_state,
+        app_state,
+        request_id,
+        task_id=result.task_id,
+        publish=publish,
+    )
+
+
+async def _reconcile_success(
+    sim_state: ClientSimulationState,
+    app_state: AppState,
+    request_id: str,
+    *,
+    task_id: str,
+    publish: _Publisher | None,
+) -> None:
+    """Walk the request to ``TASK_CREATED`` unless already terminal."""
+    async with app_state.acquire_request_lock(request_id):
+        current = await _current_if_approved(sim_state, request_id)
+        if current is None:
+            return
+        metadata = dict(current.metadata)
+        metadata["task_id"] = task_id
+        created = current.with_status(
+            RequestStatus.TASK_CREATED,
+            metadata=metadata,
+        )
+        await sim_state.request_store.save(created)
+        logger.info(
+            CLIENT_REQUEST_STATUS_TRANSITIONED,
+            request_id=created.request_id,
+            client_id=created.client_id,
+            from_status=RequestStatus.APPROVED.value,
+            to_status=created.status.value,
+        )
+        if publish is not None:
+            publish(WsEventType.REQUEST_APPROVED, created)
+    app_state.release_request_lock_if_idle(request_id)
+
+
+async def _reconcile_cancel(
+    sim_state: ClientSimulationState,
+    app_state: AppState,
+    request_id: str,
+    *,
+    reason: str,
+    publish: _Publisher | None,
+) -> None:
+    """Cancel the request with ``reason`` unless already terminal."""
+    async with app_state.acquire_request_lock(request_id):
+        current = await _current_if_approved(sim_state, request_id)
+        if current is None:
+            return
+        metadata = dict(current.metadata)
+        metadata["rejection_reason"] = reason
+        cancelled = current.with_status(
+            RequestStatus.CANCELLED,
+            metadata=metadata,
+        )
+        await sim_state.request_store.save(cancelled)
+        logger.info(
+            CLIENT_REQUEST_STATUS_TRANSITIONED,
+            request_id=cancelled.request_id,
+            client_id=cancelled.client_id,
+            from_status=RequestStatus.APPROVED.value,
+            to_status=cancelled.status.value,
+            reason=reason,
+        )
+        if publish is not None:
+            publish(WsEventType.REQUEST_REJECTED, cancelled)
+    app_state.release_request_lock_if_idle(request_id)
+
+
+async def _current_if_approved(
+    sim_state: ClientSimulationState,
+    request_id: str,
+) -> ClientRequest | None:
+    """Return the stored request iff still ``APPROVED``, else ``None``.
+
+    A ``None`` return means a concurrent reject (or a redelivered
+    reconciliation) already drove the request to a terminal state;
+    the caller must not override it.
+    """
+    try:
+        current = await sim_state.request_store.get(request_id)
+    except KeyError:
+        logger.warning(
+            CLIENT_REQUEST_INTAKE_PIPELINE_FAILED,
+            request_id=request_id,
+            note="request vanished before reconciliation",
+        )
+        return None
+    if current.status is not RequestStatus.APPROVED:
+        logger.info(
+            CLIENT_REQUEST_STATUS_TRANSITIONED,
+            request_id=request_id,
+            from_status=current.status.value,
+            to_status=current.status.value,
+            note="reconciliation skipped: request already terminal",
+        )
+        return None
+    return current
 
 
 class RequestController(Controller):
@@ -255,6 +493,7 @@ class RequestController(Controller):
             require_write_access,
             per_op_rate_limit_from_policy("requests.approve", key="user"),
         ],
+        status_code=202,
     )
     async def approve_request(
         self,
@@ -262,16 +501,23 @@ class RequestController(Controller):
         state: State,
         request_id: str,
     ) -> ApiResponse[ClientRequest]:
-        """Walk a request into the ``TASK_CREATED`` terminal state.
+        """Approve a request and run it through the work pipeline.
 
-        Accepts requests in ``SUBMITTED`` (runs the full intake
-        engine) or ``SCOPING`` (finalizes after a prior manual
-        scope call). Any other status produces a 409.
+        Accepts requests in ``SUBMITTED`` or ``SCOPING`` (manual scope
+        flow), walks them to ``APPROVED``, and spawns a background
+        task that drives the work-entry adapter -> pipeline spine so a
+        real agent executes the work. Returns ``202 Accepted`` with
+        the ``APPROVED`` request; the terminal ``TASK_CREATED`` /
+        ``CANCELLED`` state lands asynchronously (observable via
+        ``GET /requests/{id}`` and the request WS channel).
 
         Raises:
             NotFoundError: If the request is not known.
-            ConflictError: If the request cannot be approved from
-                its current state or no intake engine is configured.
+            ConflictError: If the request cannot be approved from its
+                current state.
+            AgentRuntimeNotConfiguredError: If no work-entry adapter
+                is wired (empty company / no provider): the request
+                stays approvable once a provider is configured.
         """
         app_state: AppState = state.app_state
         sim_state = app_state.client_simulation_state
@@ -290,26 +536,30 @@ class RequestController(Controller):
                     f"status {stored.status.value!r}"
                 )
                 raise ConflictError(msg)
-            if sim_state.intake_engine is None:
-                msg = "Intake engine not configured"
-                raise ConflictError(msg)
-            if stored.status is RequestStatus.SUBMITTED:
-                final, _ = await sim_state.intake_engine.process(stored)
-            else:
-                final, _ = await sim_state.intake_engine.finalize_scoped(stored)
-            await sim_state.request_store.save(final)
+            if not app_state.has_intake_entry_adapter:
+                # Empty company / no provider: the work pipeline (and
+                # thus the entry adapter) is not wired. Reject clearly
+                # rather than minting a task no agent will ever run.
+                raise AgentRuntimeNotConfiguredError
+            approved = _walk_to_approved(stored)
+            await sim_state.request_store.save(approved)
             logger.info(
                 CLIENT_REQUEST_STATUS_TRANSITIONED,
-                request_id=final.request_id,
-                client_id=final.client_id,
+                request_id=approved.request_id,
+                client_id=approved.client_id,
                 from_status=stored.status.value,
-                to_status=final.status.value,
+                to_status=approved.status.value,
             )
-            _publish(request, WsEventType.REQUEST_APPROVED, final)
-        # Approve walks to ``TASK_CREATED`` (terminal) -- drop the lock
-        # so the registry does not accumulate.
-        app_state.release_request_lock_if_idle(request_id)
-        return ApiResponse(data=final)
+            _publish(request, WsEventType.REQUEST_APPROVED, approved)
+            _spawn_intake_pipeline(
+                app_state=app_state,
+                sim_state=sim_state,
+                request_id=request_id,
+                publish=lambda et, cr: _publish(request, et, cr),
+            )
+        # APPROVED is not terminal: the background reconciliation drops
+        # the lock once it reaches TASK_CREATED / CANCELLED.
+        return ApiResponse(data=approved)
 
     @post(
         "/{request_id:str}/reject",

--- a/src/synthorg/api/controllers/requests.py
+++ b/src/synthorg/api/controllers/requests.py
@@ -1,7 +1,7 @@
 """Client request lifecycle endpoints at /requests."""
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import Annotated, Any, Final
 
 from litestar import Controller, Request, get, post
@@ -119,10 +119,21 @@ def _spawn_intake_pipeline(
 ) -> None:
     """Spawn + track the background intake-pipeline reconciliation.
 
-    Mirrors the simulations runner's callback ordering: the exception
-    logger is attached before the set-discard so a fast-completing
-    failure still surfaces, and a strong reference is held in
-    ``sim_state.background_tasks`` so the task is not GC'd mid-flight.
+    A detached task (not a ``TaskGroup``) is correct here: the approve
+    handler returns ``202`` immediately and the pipeline run outlives
+    that scope by design, so there is no parent scope to await it.
+    Lifecycle is tracked the same way the simulations runner tracks
+    its detached runners: a strong reference in
+    ``sim_state.background_tasks`` keeps the task from being GC'd
+    mid-flight, the exception logger is attached before the
+    set-discard so a fast-completing failure still surfaces, and the
+    reference is added synchronously here (no ``await`` between
+    ``create_task`` and ``add``, so a done-callback cannot run before
+    the reference exists). The request lock is intentionally not held
+    across the (minutes-long) pipeline run; the ``_current_if_approved``
+    guard plus the reconcile error handling make a concurrent reject
+    racing a late pipeline result a benign no-op rather than a lost
+    transition.
     """
     task = asyncio.create_task(
         process_intake_pipeline(
@@ -182,14 +193,20 @@ async def process_intake_pipeline(
             return
     try:
         result = await app_state.intake_entry_adapter.submit(approved)
+    except asyncio.CancelledError:
+        # Task cancelled (e.g. app shutdown): let it propagate; do not
+        # convert a cancellation into a CANCELLED request.
+        raise
     except MemoryError, RecursionError:
         raise
     except WorkIntakeRejectedError as exc:
         # Intake declining the work is a normal outcome, not a defect.
-        await _reconcile_cancel(
+        await _safe_finalize(
+            _reconcile_cancel,
             sim_state,
             app_state,
             request_id,
+            operation="reconcile_cancel",
             reason=safe_error_description(exc),
             publish=publish,
         )
@@ -201,21 +218,72 @@ async def process_intake_pipeline(
             error_type=type(exc).__name__,
             error=safe_error_description(exc),
         )
-        await _reconcile_cancel(
+        await _safe_finalize(
+            _reconcile_cancel,
             sim_state,
             app_state,
             request_id,
+            operation="reconcile_cancel",
             reason=safe_error_description(exc),
             publish=publish,
         )
         return
-    await _reconcile_success(
+    await _safe_finalize(
+        _reconcile_success,
         sim_state,
         app_state,
         request_id,
+        operation="reconcile_success",
         task_id=result.task_id,
         publish=publish,
     )
+
+
+async def _safe_finalize(  # noqa: PLR0913 -- keyword-only DI + passthrough
+    finalizer: Callable[..., Awaitable[None]],
+    sim_state: ClientSimulationState,
+    app_state: AppState,
+    request_id: str,
+    *,
+    operation: str,
+    publish: _Publisher | None,
+    **kwargs: Any,
+) -> None:
+    """Run a terminal reconciliation, never leaving the request stuck.
+
+    A reconciliation that raises (store / lock / publish failure) must
+    not leave the request silently in ``APPROVED`` with only a
+    done-callback WARNING. On a ``reconcile_success`` failure we log
+    ERROR and fall back to cancelling the request so it still reaches a
+    terminal state; on a ``reconcile_cancel`` failure we log ERROR (no
+    further fallback is possible) so the operator has an actionable
+    signal keyed by ``request_id``. ``CancelledError`` /
+    ``MemoryError`` / ``RecursionError`` propagate unchanged.
+    """
+    try:
+        await finalizer(sim_state, app_state, request_id, publish=publish, **kwargs)
+    except asyncio.CancelledError:
+        raise
+    except MemoryError, RecursionError:
+        raise
+    except Exception as exc:
+        logger.error(
+            CLIENT_REQUEST_INTAKE_PIPELINE_FAILED,
+            request_id=request_id,
+            operation=operation,
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
+        )
+        if operation == "reconcile_success":
+            await _safe_finalize(
+                _reconcile_cancel,
+                sim_state,
+                app_state,
+                request_id,
+                operation="reconcile_cancel",
+                reason=f"reconciliation failed: {safe_error_description(exc)}",
+                publish=publish,
+            )
 
 
 async def _reconcile_success(
@@ -226,28 +294,35 @@ async def _reconcile_success(
     task_id: str,
     publish: _Publisher | None,
 ) -> None:
-    """Walk the request to ``TASK_CREATED`` unless already terminal."""
-    async with app_state.acquire_request_lock(request_id):
-        current = await _current_if_approved(sim_state, request_id)
-        if current is None:
-            return
-        metadata = dict(current.metadata)
-        metadata["task_id"] = task_id
-        created = current.with_status(
-            RequestStatus.TASK_CREATED,
-            metadata=metadata,
-        )
-        await sim_state.request_store.save(created)
-        logger.info(
-            CLIENT_REQUEST_STATUS_TRANSITIONED,
-            request_id=created.request_id,
-            client_id=created.client_id,
-            from_status=RequestStatus.APPROVED.value,
-            to_status=created.status.value,
-        )
-        if publish is not None:
-            publish(WsEventType.REQUEST_APPROVED, created)
-    app_state.release_request_lock_if_idle(request_id)
+    """Walk the request to ``TASK_CREATED`` unless already terminal.
+
+    ``release_request_lock_if_idle`` runs in ``finally`` so a failure
+    inside the locked section evicts the lock entry rather than leaking
+    it; the failure itself propagates to :func:`_safe_finalize`.
+    """
+    try:
+        async with app_state.acquire_request_lock(request_id):
+            current = await _current_if_approved(sim_state, request_id)
+            if current is None:
+                return
+            metadata = dict(current.metadata)
+            metadata["task_id"] = task_id
+            created = current.with_status(
+                RequestStatus.TASK_CREATED,
+                metadata=metadata,
+            )
+            await sim_state.request_store.save(created)
+            logger.info(
+                CLIENT_REQUEST_STATUS_TRANSITIONED,
+                request_id=created.request_id,
+                client_id=created.client_id,
+                from_status=RequestStatus.APPROVED.value,
+                to_status=created.status.value,
+            )
+            if publish is not None:
+                publish(WsEventType.REQUEST_TASK_CREATED, created)
+    finally:
+        app_state.release_request_lock_if_idle(request_id)
 
 
 async def _reconcile_cancel(
@@ -258,29 +333,35 @@ async def _reconcile_cancel(
     reason: str,
     publish: _Publisher | None,
 ) -> None:
-    """Cancel the request with ``reason`` unless already terminal."""
-    async with app_state.acquire_request_lock(request_id):
-        current = await _current_if_approved(sim_state, request_id)
-        if current is None:
-            return
-        metadata = dict(current.metadata)
-        metadata["rejection_reason"] = reason
-        cancelled = current.with_status(
-            RequestStatus.CANCELLED,
-            metadata=metadata,
-        )
-        await sim_state.request_store.save(cancelled)
-        logger.info(
-            CLIENT_REQUEST_STATUS_TRANSITIONED,
-            request_id=cancelled.request_id,
-            client_id=cancelled.client_id,
-            from_status=RequestStatus.APPROVED.value,
-            to_status=cancelled.status.value,
-            reason=reason,
-        )
-        if publish is not None:
-            publish(WsEventType.REQUEST_REJECTED, cancelled)
-    app_state.release_request_lock_if_idle(request_id)
+    """Cancel the request with ``reason`` unless already terminal.
+
+    ``release_request_lock_if_idle`` runs in ``finally`` (see
+    :func:`_reconcile_success`).
+    """
+    try:
+        async with app_state.acquire_request_lock(request_id):
+            current = await _current_if_approved(sim_state, request_id)
+            if current is None:
+                return
+            metadata = dict(current.metadata)
+            metadata["rejection_reason"] = reason
+            cancelled = current.with_status(
+                RequestStatus.CANCELLED,
+                metadata=metadata,
+            )
+            await sim_state.request_store.save(cancelled)
+            logger.info(
+                CLIENT_REQUEST_STATUS_TRANSITIONED,
+                request_id=cancelled.request_id,
+                client_id=cancelled.client_id,
+                from_status=RequestStatus.APPROVED.value,
+                to_status=cancelled.status.value,
+                reason=reason,
+            )
+            if publish is not None:
+                publish(WsEventType.REQUEST_REJECTED, cancelled)
+    finally:
+        app_state.release_request_lock_if_idle(request_id)
 
 
 async def _current_if_approved(
@@ -296,7 +377,10 @@ async def _current_if_approved(
     try:
         current = await sim_state.request_store.get(request_id)
     except KeyError:
-        logger.warning(
+        # The request disappearing mid-reconciliation is an invariant
+        # break (no normal path deletes an APPROVED request), not a
+        # routine warning: surface it at ERROR keyed by request_id.
+        logger.error(
             CLIENT_REQUEST_INTAKE_PIPELINE_FAILED,
             request_id=request_id,
             note="request vanished before reconciliation",

--- a/src/synthorg/api/controllers/setup/agent_helpers.py
+++ b/src/synthorg/api/controllers/setup/agent_helpers.py
@@ -178,6 +178,11 @@ async def _rebuild_runtime_services(app_state: AppState) -> None:
             app_state.swap_coordinator(services.coordinator)
         if services.work_pipeline is not None:
             app_state.swap_work_pipeline(services.work_pipeline)
+        from synthorg.engine.pipeline.entry.boot import (  # noqa: PLC0415
+            wire_real_intake_entry,
+        )
+
+        await wire_real_intake_entry(app_state, hot_swap=True)
     except MemoryError, RecursionError:
         raise
     except RuntimeServicesBuildError:

--- a/src/synthorg/api/state.py
+++ b/src/synthorg/api/state.py
@@ -63,6 +63,7 @@ from synthorg.core.clock import Clock, SystemClock
 from synthorg.core.domain_errors import ServiceUnavailableError
 from synthorg.engine.approval_gate import ApprovalGate  # noqa: TC001
 from synthorg.engine.coordination.service import MultiAgentCoordinator  # noqa: TC001
+from synthorg.engine.pipeline.entry.protocol import WorkEntryAdapter  # noqa: TC001
 from synthorg.engine.pipeline.protocol import WorkPipeline  # noqa: TC001
 from synthorg.engine.review_gate import ReviewGateService  # noqa: TC001
 from synthorg.engine.task_engine import TaskEngine  # noqa: TC001
@@ -229,6 +230,7 @@ class AppState(AppStateServicesMixin):
         "_fine_tune_orchestrator",
         "_health_prober_service",
         "_idempotency_service",
+        "_intake_entry_adapter",
         "_integration_health_facade_service",
         "_interrupt_store",
         "_lazy_service_lock",
@@ -335,6 +337,7 @@ class AppState(AppStateServicesMixin):
         approval_gate: ApprovalGate | None = None,
         coordinator: MultiAgentCoordinator | None = None,
         work_pipeline: WorkPipeline | None = None,
+        intake_entry_adapter: WorkEntryAdapter | None = None,
         agent_registry: AgentRegistryService | None = None,
         performance_tracker: PerformanceTracker | None = None,
         meeting_orchestrator: MeetingOrchestrator | None = None,
@@ -392,6 +395,7 @@ class AppState(AppStateServicesMixin):
         self._distributed_backend_services: DistributedBackendServices | None = None
         self._coordinator = coordinator
         self._work_pipeline = work_pipeline
+        self._intake_entry_adapter = intake_entry_adapter
         self._agent_registry = agent_registry
         self._performance_tracker = performance_tracker
         self._trust_service = trust_service
@@ -1380,6 +1384,107 @@ class AppState(AppStateServicesMixin):
             logger.info(
                 API_APP_STARTUP,
                 service="work_pipeline",
+                transition=transition,
+            )
+
+    @property
+    def intake_entry_adapter(self) -> WorkEntryAdapter:
+        """Return the intake work-entry adapter or raise 503."""
+        return self._require_service(
+            self._intake_entry_adapter,
+            "intake_entry_adapter",
+        )
+
+    @property
+    def has_intake_entry_adapter(self) -> bool:
+        """Check whether the intake work-entry adapter is configured.
+
+        Unsynchronised by design, identical to
+        :meth:`has_work_pipeline`: a single reference read is atomic
+        under CPython and ``swap_intake_entry_adapter`` only reassigns
+        one already-set adapter for another. The only ``None -> set``
+        flip happens once at boot before HTTP traffic.
+        """
+        return self._intake_entry_adapter is not None
+
+    def set_intake_entry_adapter(
+        self,
+        intake_entry_adapter: WorkEntryAdapter,
+    ) -> None:
+        """Attach the intake work-entry adapter (once-only, boot only).
+
+        Once-only: a second set raises, matching the ``work_pipeline``
+        seam. The boot runtime-services hook uses
+        :meth:`set_intake_entry_adapter_if_absent` so an explicitly
+        injected adapter wins; hot-reload after setup uses
+        :meth:`swap_intake_entry_adapter`.
+        """
+        self._set_once(
+            "_intake_entry_adapter",
+            intake_entry_adapter,
+            "Intake entry adapter",
+        )
+
+    def set_intake_entry_adapter_if_absent(
+        self,
+        intake_entry_adapter: WorkEntryAdapter,
+    ) -> bool:
+        """Attach the intake adapter only if none is configured (atomic).
+
+        The boot runtime-services hook calls this unconditionally once
+        the work pipeline is online so the real ``/requests`` entry
+        path comes up with it. An explicitly injected adapter
+        (constructor ``intake_entry_adapter=``) is already set and
+        wins: this is a logged no-op then. The check-and-set is atomic
+        under ``_lazy_service_lock`` so the boot install cannot race a
+        concurrent ``swap_intake_entry_adapter`` or property read.
+
+        Returns:
+            ``True`` if this call installed the adapter, ``False`` if
+            one was already configured (injected) and kept.
+        """
+        with self._lazy_service_lock:
+            if self._intake_entry_adapter is not None:
+                logger.info(
+                    API_APP_STARTUP,
+                    service="intake_entry_adapter",
+                    transition="skipped_injected",
+                )
+                return False
+            self._intake_entry_adapter = intake_entry_adapter
+            logger.info(
+                API_APP_STARTUP,
+                service="intake_entry_adapter",
+                transition="attached",
+            )
+            return True
+
+    def swap_intake_entry_adapter(
+        self,
+        intake_entry_adapter: WorkEntryAdapter,
+    ) -> None:
+        """Replace the intake work-entry adapter (hot-reload).
+
+        Distinct from :meth:`set_intake_entry_adapter`, which is
+        once-only: this replaces an already-wired adapter so a
+        provider configured against an empty-company start brings the
+        real intake entry path online without a restart
+        (``post_setup_reinit``). Holds ``_lazy_service_lock`` so the
+        write is synchronised against concurrent property reads,
+        mirroring :meth:`swap_work_pipeline`.
+        """
+        with self._lazy_service_lock:
+            previous = self._intake_entry_adapter
+            if previous is intake_entry_adapter:
+                transition = "noop"
+            elif previous is None:
+                transition = "attached"
+            else:
+                transition = "replaced"
+            self._intake_entry_adapter = intake_entry_adapter
+            logger.info(
+                API_APP_STARTUP,
+                service="intake_entry_adapter",
                 transition=transition,
             )
 

--- a/src/synthorg/api/ws_models.py
+++ b/src/synthorg/api/ws_models.py
@@ -121,6 +121,7 @@ class WsEventType(StrEnum):
     REQUEST_SUBMITTED = "request.submitted"
     REQUEST_SCOPED = "request.scoped"
     REQUEST_APPROVED = "request.approved"
+    REQUEST_TASK_CREATED = "request.task_created"
     REQUEST_REJECTED = "request.rejected"
     REQUEST_STATUS_CHANGED = "request.status_changed"
 

--- a/src/synthorg/api/ws_payloads/__init__.py
+++ b/src/synthorg/api/ws_payloads/__init__.py
@@ -58,6 +58,7 @@ from synthorg.api.ws_payloads._domain import (
     WsRequestScopedPayload,
     WsRequestStatusChangedPayload,
     WsRequestSubmittedPayload,
+    WsRequestTaskCreatedPayload,
     WsReviewPipelineCompletedPayload,
     WsReviewStageCompletedPayload,
     WsReviewStageDecidedPayload,
@@ -157,6 +158,7 @@ WsEventPayload = Annotated[
     | WsRequestSubmittedPayload
     | WsRequestScopedPayload
     | WsRequestApprovedPayload
+    | WsRequestTaskCreatedPayload
     | WsRequestRejectedPayload
     | WsRequestStatusChangedPayload
     | WsReviewStageCompletedPayload
@@ -234,6 +236,7 @@ __all__ = [
     "WsRequestScopedPayload",
     "WsRequestStatusChangedPayload",
     "WsRequestSubmittedPayload",
+    "WsRequestTaskCreatedPayload",
     "WsReviewPipelineCompletedPayload",
     "WsReviewStageCompletedPayload",
     "WsReviewStageDecidedPayload",

--- a/src/synthorg/api/ws_payloads/_domain.py
+++ b/src/synthorg/api/ws_payloads/_domain.py
@@ -247,6 +247,21 @@ class WsRequestApprovedPayload(_RequestEventBase):
     event_type: Literal[WsEventType.REQUEST_APPROVED] = WsEventType.REQUEST_APPROVED
 
 
+class WsRequestTaskCreatedPayload(_RequestEventBase):
+    """Payload for ``request.task_created``.
+
+    Emitted by the real work-entry path once the background pipeline
+    drives an approved request to ``TASK_CREATED`` (the task is in
+    the task engine and an agent has been dispatched). Status
+    discriminates the terminal hop inside the same channel that
+    carries the intermediate ``request.approved`` event.
+    """
+
+    event_type: Literal[WsEventType.REQUEST_TASK_CREATED] = (
+        WsEventType.REQUEST_TASK_CREATED
+    )
+
+
 class WsRequestRejectedPayload(_RequestEventBase):
     """Payload for ``request.rejected`` -- not yet emitted by Python."""
 

--- a/src/synthorg/api/ws_payloads/_domain.py
+++ b/src/synthorg/api/ws_payloads/_domain.py
@@ -254,12 +254,15 @@ class WsRequestTaskCreatedPayload(_RequestEventBase):
     drives an approved request to ``TASK_CREATED`` (the task is in
     the task engine and an agent has been dispatched). Status
     discriminates the terminal hop inside the same channel that
-    carries the intermediate ``request.approved`` event.
+    carries the intermediate ``request.approved`` event. ``task_id``
+    carries the spawned task's id so the frontend can link directly
+    to it without a second ``GET /requests/{id}`` round-trip.
     """
 
     event_type: Literal[WsEventType.REQUEST_TASK_CREATED] = (
         WsEventType.REQUEST_TASK_CREATED
     )
+    task_id: NotBlankStr
 
 
 class WsRequestRejectedPayload(_RequestEventBase):

--- a/src/synthorg/client/factory.py
+++ b/src/synthorg/client/factory.py
@@ -406,6 +406,7 @@ def _build_agent_intake(
     task_engine: TaskEngine,
     provider: CompletionProvider | None,
     cost_tracker: CostTracker | None,
+    default_project: NotBlankStr,
 ) -> IntakeStrategy:
     """Build the LLM-triage ``AgentIntake`` (needs provider + model)."""
     from synthorg.engine.intake import AgentIntake  # noqa: PLC0415
@@ -429,6 +430,7 @@ def _build_agent_intake(
         task_engine=task_engine,
         provider=provider,
         model=NotBlankStr(model),
+        project=default_project,
         cost_tracker=cost_tracker,
     )
 
@@ -437,6 +439,7 @@ def build_intake_strategy(
     config: IntakeConfig,
     *,
     task_engine: TaskEngine,
+    default_project: NotBlankStr,
     provider: CompletionProvider | None = None,
     cost_tracker: CostTracker | None = None,
 ) -> IntakeStrategy:
@@ -447,6 +450,10 @@ def build_intake_strategy(
     non-blank ``config.model``). Misconfiguration fails loudly with
     :class:`UnknownStrategyError`; the caller decides whether to
     degrade. ``cost_tracker`` is threaded into ``AgentIntake``.
+    ``default_project`` is the project the strategy files created
+    tasks into; the real work-entry adapter stamps the same value on
+    the ``WorkItem`` so the pipeline's project-existence check and the
+    created task agree.
     """
     # Lazy: synthorg.engine.intake pulls the provider/prompt-safety
     # graph; keep it off the synthorg.client package-import path.
@@ -454,13 +461,14 @@ def build_intake_strategy(
 
     strategy = config.strategy
     if strategy == "direct":
-        return DirectIntake(task_engine=task_engine)
+        return DirectIntake(task_engine=task_engine, project=default_project)
     if strategy == "agent":
         return _build_agent_intake(
             config,
             task_engine=task_engine,
             provider=provider,
             cost_tracker=cost_tracker,
+            default_project=default_project,
         )
     _raise_unknown_strategy(
         label="intake",

--- a/src/synthorg/client/runtime_builder.py
+++ b/src/synthorg/client/runtime_builder.py
@@ -42,6 +42,7 @@ logger = get_logger(__name__)
 
 _INTAKE_STRATEGY_KEY = "intake_strategy"
 _INTAKE_MODEL_KEY = "intake_model"
+_INTAKE_DEFAULT_PROJECT_KEY = "intake_default_project"
 _DEFAULT_STRATEGY = "direct"
 
 
@@ -62,11 +63,15 @@ def _select_provider(app_state: AppState) -> CompletionProvider | None:
     return registry.get(names[0])
 
 
-def _resolve_intake_settings(env: Mapping[str, str]) -> tuple[str, str | None]:
-    """Resolve ``(strategy, model)`` from the ``simulations`` namespace.
+def _resolve_intake_settings(
+    env: Mapping[str, str],
+) -> tuple[str, str | None, str]:
+    """Resolve ``(strategy, model, default_project)`` from settings.
 
     Boot-site read (env > registered default) via the bootstrap
-    resolver; ``ConfigResolver`` is not wired at construction.
+    resolver; ``ConfigResolver`` is not wired at construction. The
+    ``default_project`` resolves through the same chain and has a
+    non-blank registered default, so it is always a usable project id.
     """
     strategy = str(
         resolve_init_value(
@@ -77,13 +82,19 @@ def _resolve_intake_settings(env: Mapping[str, str]) -> tuple[str, str | None]:
         SettingNamespace.SIMULATIONS, _INTAKE_MODEL_KEY, env=env
     ).value
     model = None if raw_model is None else str(raw_model).strip() or None
-    return strategy, model
+    default_project = str(
+        resolve_init_value(
+            SettingNamespace.SIMULATIONS, _INTAKE_DEFAULT_PROJECT_KEY, env=env
+        ).value
+    ).strip()
+    return strategy, model, default_project
 
 
-def _build_intake_with_fallback(
+def _build_intake_with_fallback(  # noqa: PLR0913 -- keyword-only DI
     *,
     requested_strategy: str,
     model: str | None,
+    default_project: str,
     task_engine: TaskEngine,
     provider: CompletionProvider | None,
     cost_tracker: CostTracker | None,
@@ -99,6 +110,7 @@ def _build_intake_with_fallback(
         strategy = build_intake_strategy(
             IntakeConfig(strategy=requested_strategy, model=model),
             task_engine=task_engine,
+            default_project=default_project,
             provider=provider,
             cost_tracker=cost_tracker,
         )
@@ -124,6 +136,7 @@ def _build_intake_with_fallback(
         fallback = build_intake_strategy(
             IntakeConfig(strategy=_DEFAULT_STRATEGY),
             task_engine=task_engine,
+            default_project=default_project,
         )
         return fallback, _DEFAULT_STRATEGY
     else:
@@ -146,12 +159,13 @@ def build_client_simulation_runtime(
     tests.
     """
     task_engine = app_state.task_engine
-    requested_strategy, model = _resolve_intake_settings(env)
+    requested_strategy, model, default_project = _resolve_intake_settings(env)
     provider = _select_provider(app_state)
     cost_tracker = app_state.cost_tracker if app_state.has_cost_tracker else None
     strategy, effective_strategy = _build_intake_with_fallback(
         requested_strategy=requested_strategy,
         model=model,
+        default_project=default_project,
         task_engine=task_engine,
         provider=provider,
         cost_tracker=cost_tracker,
@@ -163,8 +177,10 @@ def build_client_simulation_runtime(
         effective_strategy=effective_strategy,
         has_provider=provider is not None,
         review_stages=list(review_pipeline.stage_names),
+        intake_default_project=default_project,
     )
     return ClientSimulationState(
         intake_engine=IntakeEngine(strategy=strategy),
         review_pipeline=review_pipeline,
+        intake_default_project=default_project,
     )

--- a/src/synthorg/client/simulation_state.py
+++ b/src/synthorg/client/simulation_state.py
@@ -28,6 +28,12 @@ class ClientSimulationState:
         feedback_store: Per-client review history for satisfaction.
         intake_engine: Intake engine used by ``/requests/{id}/approve``.
         review_pipeline: Review pipeline surfaced to ``/reviews/...``.
+        intake_default_project: Project the intake strategy files
+            tasks into and the real work-entry adapter stamps on the
+            work item. Resolved once at boot (env > registered
+            default) so the strategy ``project=`` and the adapter's
+            ``WorkItem.project`` cannot drift; the project is ensured
+            to exist at on-startup.
         background_tasks: Strong references keeping background tasks alive.
     """
 
@@ -37,6 +43,7 @@ class ClientSimulationState:
     feedback_store: FeedbackStore = field(default_factory=FeedbackStore)
     intake_engine: IntakeEngine | None = None
     review_pipeline: ReviewPipeline | None = None
+    intake_default_project: str | None = None
     background_tasks: set[asyncio.Task[None]] = field(
         default_factory=set,
         hash=False,

--- a/src/synthorg/engine/pipeline/entry/__init__.py
+++ b/src/synthorg/engine/pipeline/entry/__init__.py
@@ -1,0 +1,19 @@
+"""Work-entry adapters: thin seams that feed the pipeline spine.
+
+Every real work-entry path (client-request intake here; the task
+board and goal/objective intake in sibling work) maps its own
+domain input onto a :class:`~synthorg.engine.pipeline.models.WorkItem`
+and calls :meth:`WorkPipeline.run`. Adapters own no pipeline logic
+and no source-entity reconciliation; the caller (controller /
+background task) owns lifecycle persistence.
+"""
+
+from synthorg.engine.pipeline.entry.factory import build_work_entry_adapter
+from synthorg.engine.pipeline.entry.intake_adapter import IntakeEntryAdapter
+from synthorg.engine.pipeline.entry.protocol import WorkEntryAdapter
+
+__all__ = [
+    "IntakeEntryAdapter",
+    "WorkEntryAdapter",
+    "build_work_entry_adapter",
+]

--- a/src/synthorg/engine/pipeline/entry/boot.py
+++ b/src/synthorg/engine/pipeline/entry/boot.py
@@ -12,14 +12,16 @@ empty company (no pipeline / no simulation runtime).
 from typing import TYPE_CHECKING
 
 from synthorg.core.enums import ProjectStatus
+from synthorg.core.persistence_errors import DuplicateRecordError
 from synthorg.core.project import Project
 from synthorg.engine.pipeline.entry.factory import build_work_entry_adapter
 from synthorg.engine.pipeline.models import WorkSource
-from synthorg.observability import get_logger
+from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.client import CLIENT_SIMULATION_RUNTIME_WIRED
 
 if TYPE_CHECKING:
     from synthorg.api.state import AppState
+    from synthorg.core.types import NotBlankStr
 
 logger = get_logger(__name__)
 
@@ -66,19 +68,47 @@ async def wire_real_intake_entry(
         app_state.set_intake_entry_adapter_if_absent(adapter)
 
 
-async def _ensure_project(app_state: AppState, project_id: str) -> None:
-    """Create the intake project if it does not already exist."""
+async def _ensure_project(
+    app_state: AppState,
+    project_id: NotBlankStr,
+) -> None:
+    """Create the intake project if it does not already exist.
+
+    The ``get`` fast-path skips a redundant create on the common
+    already-exists case, but ``create`` is still guarded: a concurrent
+    winner (boot racing a provider-reinit ``wire_real_intake_entry``)
+    surfaces as ``DuplicateRecordError``, which is benign here (the
+    project exists, which is the post-condition we want). Any other
+    failure is logged at ERROR with the project id before propagating
+    so a boot abort is actionable rather than an opaque traceback.
+    """
     projects = app_state.persistence.projects
     if await projects.get(project_id) is not None:
         return
-    await projects.create(
-        Project(
-            id=project_id,
-            name=project_id,
-            description="Default project for real client-request intake.",
-            status=ProjectStatus.ACTIVE,
+    try:
+        await projects.create(
+            Project(
+                id=project_id,
+                name=project_id,
+                description="Default project for real client-request intake.",
+                status=ProjectStatus.ACTIVE,
+            )
         )
-    )
+    except DuplicateRecordError:
+        # Lost a benign create race; the project now exists either way.
+        return
+    except MemoryError, RecursionError:
+        raise
+    except Exception as exc:
+        logger.error(
+            CLIENT_SIMULATION_RUNTIME_WIRED,
+            service="intake_entry_adapter",
+            note="failed to create intake project",
+            project=project_id,
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
+        )
+        raise
     logger.info(
         CLIENT_SIMULATION_RUNTIME_WIRED,
         service="intake_entry_adapter",

--- a/src/synthorg/engine/pipeline/entry/boot.py
+++ b/src/synthorg/engine/pipeline/entry/boot.py
@@ -1,0 +1,87 @@
+"""Boot wiring for the real client-request work-entry path.
+
+Once the work pipeline spine is online, the real ``/requests``
+approve path needs (1) the configured intake project to exist so the
+pipeline's project-existence check passes, and (2) an
+:class:`IntakeEntryAdapter` attached to ``AppState``. Both the boot
+hook and the post-setup provider-reinit path call this; ``hot_swap``
+selects the once-only vs replace seam. It is a logged no-op for an
+empty company (no pipeline / no simulation runtime).
+"""
+
+from typing import TYPE_CHECKING
+
+from synthorg.core.enums import ProjectStatus
+from synthorg.core.project import Project
+from synthorg.engine.pipeline.entry.factory import build_work_entry_adapter
+from synthorg.engine.pipeline.models import WorkSource
+from synthorg.observability import get_logger
+from synthorg.observability.events.client import CLIENT_SIMULATION_RUNTIME_WIRED
+
+if TYPE_CHECKING:
+    from synthorg.api.state import AppState
+
+logger = get_logger(__name__)
+
+
+async def wire_real_intake_entry(
+    app_state: AppState,
+    *,
+    hot_swap: bool = False,
+) -> None:
+    """Ensure the intake project exists and attach the entry adapter.
+
+    Args:
+        app_state: Live application state (work pipeline, simulation
+            runtime, persistence).
+        hot_swap: When ``True`` replace an already-wired adapter
+            (provider-reinit path); otherwise install once at boot.
+    """
+    if not app_state.has_work_pipeline or not app_state.has_simulation_runtime:
+        logger.info(
+            CLIENT_SIMULATION_RUNTIME_WIRED,
+            service="intake_entry_adapter",
+            mode="disabled",
+            note="no work pipeline / simulation runtime; real intake offline",
+        )
+        return
+    default_project = app_state.client_simulation_state.intake_default_project
+    if not default_project:
+        logger.warning(
+            CLIENT_SIMULATION_RUNTIME_WIRED,
+            service="intake_entry_adapter",
+            mode="disabled",
+            note="simulation runtime present but intake_default_project unset",
+        )
+        return
+    await _ensure_project(app_state, default_project)
+    adapter = build_work_entry_adapter(
+        WorkSource.INTAKE,
+        work_pipeline=app_state.work_pipeline,
+        default_project=default_project,
+    )
+    if hot_swap:
+        app_state.swap_intake_entry_adapter(adapter)
+    else:
+        app_state.set_intake_entry_adapter_if_absent(adapter)
+
+
+async def _ensure_project(app_state: AppState, project_id: str) -> None:
+    """Create the intake project if it does not already exist."""
+    projects = app_state.persistence.projects
+    if await projects.get(project_id) is not None:
+        return
+    await projects.create(
+        Project(
+            id=project_id,
+            name=project_id,
+            description="Default project for real client-request intake.",
+            status=ProjectStatus.ACTIVE,
+        )
+    )
+    logger.info(
+        CLIENT_SIMULATION_RUNTIME_WIRED,
+        service="intake_entry_adapter",
+        note="created intake project",
+        project=project_id,
+    )

--- a/src/synthorg/engine/pipeline/entry/factory.py
+++ b/src/synthorg/engine/pipeline/entry/factory.py
@@ -1,0 +1,46 @@
+"""Factory for source-keyed work-entry adapters.
+
+Dispatch on :class:`WorkSource`. This child ships the ``INTAKE`` arm;
+sibling work adds ``TASK_BOARD`` / ``OBJECTIVE`` arms here. A source
+with no adapter is a hard error (no silent default), matching the
+project-wide pluggable-subsystems contract.
+"""
+
+from typing import TYPE_CHECKING
+
+from synthorg.client.factory import UnknownStrategyError
+from synthorg.engine.pipeline.entry.intake_adapter import IntakeEntryAdapter
+from synthorg.engine.pipeline.models import WorkSource
+
+if TYPE_CHECKING:
+    from synthorg.core.types import NotBlankStr
+    from synthorg.engine.pipeline.entry.protocol import WorkEntryAdapter
+    from synthorg.engine.pipeline.protocol import WorkPipeline
+
+
+def build_work_entry_adapter(
+    source: WorkSource,
+    *,
+    work_pipeline: WorkPipeline,
+    default_project: NotBlankStr,
+) -> WorkEntryAdapter:
+    """Construct the work-entry adapter for ``source``.
+
+    Args:
+        source: The originating work source discriminator.
+        work_pipeline: The composed pipeline spine to drive.
+        default_project: Project intake work items are filed into.
+
+    Returns:
+        The concrete :class:`WorkEntryAdapter`.
+
+    Raises:
+        UnknownStrategyError: If ``source`` has no wired adapter.
+    """
+    if source is WorkSource.INTAKE:
+        return IntakeEntryAdapter(
+            work_pipeline=work_pipeline,
+            default_project=default_project,
+        )
+    msg = f"no work-entry adapter wired for source {source.value!r}"
+    raise UnknownStrategyError(msg)

--- a/src/synthorg/engine/pipeline/entry/intake_adapter.py
+++ b/src/synthorg/engine/pipeline/entry/intake_adapter.py
@@ -1,0 +1,98 @@
+"""Client-request intake work-entry adapter.
+
+Maps a stored :class:`ClientRequest` onto a ``WorkItem`` with
+``source=INTAKE`` and drives the pipeline spine. Thin by design: it
+holds no request store, no lock, and performs no request-lifecycle
+reconciliation (the controller background task owns that). Manual
+scope flow is preserved by folding any reviewer ``scoping_notes`` from
+the request metadata into the work item's intent body.
+"""
+
+from typing import TYPE_CHECKING
+
+from synthorg.engine.pipeline.models import WorkItem, WorkSource
+from synthorg.observability import get_logger
+from synthorg.observability.events.review_pipeline import INTAKE_REQUEST_RECEIVED
+
+if TYPE_CHECKING:
+    from synthorg.client.models import ClientRequest
+    from synthorg.core.types import NotBlankStr
+    from synthorg.engine.pipeline.models import WorkPipelineResult
+    from synthorg.engine.pipeline.protocol import WorkPipeline
+
+logger = get_logger(__name__)
+
+_ORIGIN_ADAPTER_ID = "intake-entry-adapter"
+_SCOPING_NOTES_KEY = "scoping_notes"
+_SCOPING_NOTES_HEADING = "## Reviewer scoping notes"
+
+
+class IntakeEntryAdapter:
+    """Feeds approved client requests into the pipeline spine."""
+
+    __slots__ = ("_default_project", "_work_pipeline")
+
+    def __init__(
+        self,
+        *,
+        work_pipeline: WorkPipeline,
+        default_project: NotBlankStr,
+    ) -> None:
+        """Initialize the adapter.
+
+        Args:
+            work_pipeline: The composed pipeline spine to drive.
+            default_project: Project every intake work item is filed
+                into (the same value the intake strategy creates the
+                task in and that is ensured to exist at boot).
+        """
+        self._work_pipeline = work_pipeline
+        self._default_project = default_project
+
+    @property
+    def source(self) -> WorkSource:
+        """Provenance stamp for items this adapter produces."""
+        return WorkSource.INTAKE
+
+    async def submit(self, request: ClientRequest) -> WorkPipelineResult:
+        """Map ``request`` onto a work item and drive the spine.
+
+        Args:
+            request: The stored client request to enter.
+
+        Returns:
+            The terminal :class:`WorkPipelineResult`.
+
+        Raises:
+            WorkPipelineError: Propagated unchanged from the spine.
+        """
+        requirement = request.requirement
+        work_item = WorkItem(
+            origin_adapter_id=_ORIGIN_ADAPTER_ID,
+            source=WorkSource.INTAKE,
+            title=requirement.title,
+            raw_intent=self._build_raw_intent(request),
+            project=self._default_project,
+            requested_by=request.client_id,
+            priority=requirement.priority,
+            task_type=requirement.task_type,
+            estimated_complexity=requirement.estimated_complexity,
+            acceptance_criteria=requirement.acceptance_criteria,
+            correlation_id=request.request_id,
+        )
+        logger.info(
+            INTAKE_REQUEST_RECEIVED,
+            request_id=request.request_id,
+            client_id=request.client_id,
+            project=self._default_project,
+        )
+        return await self._work_pipeline.run(work_item)
+
+    @staticmethod
+    def _build_raw_intent(request: ClientRequest) -> str:
+        """Compose the intent body, folding in reviewer scope notes."""
+        body = request.requirement.description
+        notes = request.metadata.get(_SCOPING_NOTES_KEY)
+        if isinstance(notes, str) and notes.strip():
+            return f"{body}\n\n{_SCOPING_NOTES_HEADING}\n\n{notes.strip()}"
+        return body

--- a/src/synthorg/engine/pipeline/entry/protocol.py
+++ b/src/synthorg/engine/pipeline/entry/protocol.py
@@ -1,0 +1,41 @@
+"""Work-entry adapter protocol.
+
+A :class:`WorkEntryAdapter` maps one real work-entry source onto the
+pipeline spine. The intake adapter (this child) takes a stored
+:class:`~synthorg.client.models.ClientRequest`; sibling adapters take
+their own domain inputs. The shared contract is narrow on purpose:
+expose the originating :class:`WorkSource` for provenance and a single
+``submit`` coroutine that returns the terminal pipeline result.
+"""
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from synthorg.client.models import ClientRequest
+    from synthorg.engine.pipeline.models import WorkPipelineResult, WorkSource
+
+
+@runtime_checkable
+class WorkEntryAdapter(Protocol):
+    """Maps a real work-entry source into the pipeline spine."""
+
+    @property
+    def source(self) -> WorkSource:
+        """The :class:`WorkSource` this adapter stamps on work items."""
+        ...
+
+    async def submit(self, request: ClientRequest) -> WorkPipelineResult:
+        """Map ``request`` onto a work item and drive the spine.
+
+        Args:
+            request: The stored client request to enter into the
+                pipeline.
+
+        Returns:
+            The terminal :class:`WorkPipelineResult`.
+
+        Raises:
+            WorkPipelineError: Propagated unchanged from the spine
+                (subclasses carry the precise RFC 9457 status).
+        """
+        ...

--- a/src/synthorg/observability/events/client.py
+++ b/src/synthorg/observability/events/client.py
@@ -7,6 +7,9 @@ CLIENT_REQUEST_TRIAGING: Final[str] = "client.request.triaging"
 CLIENT_REQUEST_SCOPED: Final[str] = "client.request.scoped"
 CLIENT_REQUEST_APPROVED: Final[str] = "client.request.approved"
 CLIENT_REQUEST_REJECTED: Final[str] = "client.request.rejected"
+CLIENT_REQUEST_INTAKE_PIPELINE_FAILED: Final[str] = (
+    "client.request.intake_pipeline_failed"
+)
 CLIENT_REVIEW_STARTED: Final[str] = "client.review.started"
 CLIENT_REVIEW_COMPLETED: Final[str] = "client.review.completed"
 CLIENT_FEEDBACK_RECORDED: Final[str] = "client.feedback.recorded"

--- a/src/synthorg/settings/definitions/simulations.py
+++ b/src/synthorg/settings/definitions/simulations.py
@@ -71,6 +71,26 @@ _r.register(
 _r.register(
     SettingDefinition(
         namespace=SettingNamespace.SIMULATIONS,
+        key="intake_default_project",
+        type=SettingType.STRING,
+        default="client-intake",
+        description=(
+            "Project that the real work-entry path files intake tasks"
+            " into. The same value is wired into the intake strategy"
+            " (DirectIntake / AgentIntake) and the WorkItem the intake"
+            " entry adapter feeds the pipeline, and the project is"
+            " created at boot if absent. Baked in at process startup."
+        ),
+        group="Intake",
+        level=SettingLevel.ADVANCED,
+        read_only_post_init=True,
+        restart_required=True,
+    )
+)
+
+_r.register(
+    SettingDefinition(
+        namespace=SettingNamespace.SIMULATIONS,
         key="review_timeout_seconds",
         type=SettingType.FLOAT,
         default="30.0",

--- a/tests/e2e/test_real_intake_entry_e2e.py
+++ b/tests/e2e/test_real_intake_entry_e2e.py
@@ -1,0 +1,275 @@
+"""Acceptance: a real submitted request executes via the pipeline.
+
+Builds the REAL runtime through the production
+``build_runtime_services`` (the exact code the boot hook runs) with a
+deterministic ``ScriptedDriver`` and a real ``IntakeEngine`` whose
+``DirectIntake`` strategy persists a task via the live ``TaskEngine``.
+The real ``IntakeEntryAdapter`` + the
+``POST /requests/{id}/approve`` background coroutine
+(``process_intake_pipeline``) then drive an approved
+``ClientRequest`` through the spine: intake -> projects -> decompose
+-> solo execution. The request reaches ``TASK_CREATED`` and the task
+reaches a post-execution status (proof an agent actually ran).
+
+Zero real LLM spend: the scripted provider returns a plain STOP
+completion for every agent turn.
+"""
+
+from collections.abc import AsyncGenerator
+from datetime import date
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from synthorg.api.approval_store import ApprovalStore
+from synthorg.api.controllers.requests import process_intake_pipeline
+from synthorg.api.state import AppState
+from synthorg.budget.tracker import CostTracker
+from synthorg.client.models import ClientRequest, RequestStatus, TaskRequirement
+from synthorg.client.simulation_state import ClientSimulationState
+from synthorg.config.schema import RootConfig
+from synthorg.core.agent import AgentIdentity, ModelConfig, SkillSet
+from synthorg.core.enums import (
+    AgentStatus,
+    ProjectStatus,
+    SeniorityLevel,
+    TaskStatus,
+)
+from synthorg.core.project import Project
+from synthorg.core.role import Authority, Skill
+from synthorg.engine.intake.engine import IntakeEngine
+from synthorg.engine.intake.strategies import DirectIntake
+from synthorg.engine.pipeline.entry.intake_adapter import IntakeEntryAdapter
+from synthorg.engine.task_engine import TaskEngine
+from synthorg.hr.registry import AgentRegistryService
+from synthorg.providers.drivers.scripted import ScriptedDriver
+from synthorg.providers.enums import FinishReason
+from synthorg.providers.models import (
+    ChatMessage,
+    CompletionConfig,
+    CompletionResponse,
+    TokenUsage,
+    ToolDefinition,
+)
+from synthorg.providers.registry import ProviderRegistry
+from synthorg.settings.registry import get_registry
+from synthorg.settings.resolver import ConfigResolver
+from synthorg.settings.service import SettingsService
+from synthorg.workers.runtime_builder import build_runtime_services
+from tests._shared import FakeClock, mock_of
+from tests.unit.api.fakes import FakePersistenceBackend
+
+pytestmark = pytest.mark.e2e
+
+_PROJECT = "client-intake"
+_RESEARCH_SKILL = "research"
+
+
+class _StopStrategy:
+    """Every agent turn is a plain STOP completion (no tool calls)."""
+
+    def next_response(
+        self,
+        messages: list[ChatMessage],
+        model: str,
+        tools: list[ToolDefinition] | None,
+        config: CompletionConfig | None,
+    ) -> CompletionResponse:
+        del messages, tools, config
+        return CompletionResponse(
+            content="Work complete.",
+            finish_reason=FinishReason.STOP,
+            usage=TokenUsage(input_tokens=8, output_tokens=4, cost=0.0),
+            model=model,
+        )
+
+
+def _make_agent() -> AgentIdentity:
+    return AgentIdentity(
+        id=uuid4(),
+        name="solo-dev",
+        role="developer",
+        department="engineering",
+        level=SeniorityLevel.MID,
+        skills=SkillSet(primary=(Skill(id=_RESEARCH_SKILL, name=_RESEARCH_SKILL),)),
+        authority=Authority(budget_limit=10.0),
+        model=ModelConfig(provider="test-provider", model_id="test-model-001"),
+        hiring_date=date(2026, 1, 1),
+        status=AgentStatus.ACTIVE,
+    )
+
+
+@pytest.fixture
+async def persistence() -> AsyncGenerator[FakePersistenceBackend]:
+    backend = FakePersistenceBackend()
+    await backend.connect()
+    yield backend
+    await backend.disconnect()
+
+
+@pytest.fixture
+async def task_engine(
+    persistence: FakePersistenceBackend,
+) -> AsyncGenerator[TaskEngine]:
+    engine = TaskEngine(persistence=persistence)
+    await engine.start()
+    yield engine
+    await engine.stop()
+
+
+async def _build_app_state(
+    *,
+    persistence: FakePersistenceBackend,
+    task_engine: TaskEngine,
+    tmp_path: Path,
+    sim_state: ClientSimulationState,
+) -> AppState:
+    """Wire the production runtime + the real intake entry adapter."""
+    await persistence.projects.create(
+        Project(
+            id=_PROJECT,
+            name=_PROJECT,
+            description="real intake e2e",
+            status=ProjectStatus.ACTIVE,
+        )
+    )
+    provider = ScriptedDriver("test-provider", strategy=_StopStrategy())
+    registry = ProviderRegistry({"test-provider": provider})
+    agent_registry = AgentRegistryService()
+    await agent_registry.register(_make_agent())
+
+    root_config = RootConfig(company_name="real-intake-e2e")
+    settings_service = SettingsService(
+        repository=persistence.settings,
+        registry=get_registry(),
+    )
+    await settings_service.set("coordination", "routing_policy", "leaf-threshold")
+    config_resolver = ConfigResolver(
+        settings_service=settings_service,
+        config=root_config,
+    )
+    harness_state = mock_of[AppState](
+        has_active_provider=True,
+        provider_registry=registry,
+        config=root_config,
+        config_resolver=config_resolver,
+        task_engine=task_engine,
+        agent_registry=agent_registry,
+        approval_store=ApprovalStore(),
+        clock=FakeClock(),
+        event_stream_hub=None,
+        interrupt_store=None,
+        agent_workspace_root=tmp_path,
+        persistence=persistence,
+        has_simulation_runtime=True,
+        client_simulation_state=sim_state,
+        has_cost_tracker=True,
+        cost_tracker=CostTracker(),
+        has_message_bus=False,
+        has_coordination_metrics_store=False,
+        coordination_metrics_store=None,
+        has_audit_log=False,
+        has_memory_backend=False,
+        has_performance_tracker=False,
+        has_trust_service=False,
+    )
+    runtime = await build_runtime_services(harness_state, workspace_root=tmp_path)
+    assert runtime.work_pipeline is not None
+    adapter = IntakeEntryAdapter(
+        work_pipeline=runtime.work_pipeline,
+        default_project=_PROJECT,
+    )
+    app_state = AppState(
+        config=root_config,
+        approval_store=ApprovalStore(),
+        intake_entry_adapter=adapter,
+    )
+    app_state.set_client_simulation_state(sim_state)
+    return app_state
+
+
+def _sim_state(task_engine: TaskEngine) -> ClientSimulationState:
+    return ClientSimulationState(
+        intake_engine=IntakeEngine(
+            strategy=DirectIntake(task_engine=task_engine, project=_PROJECT),
+        ),
+        intake_default_project=_PROJECT,
+    )
+
+
+async def test_real_request_executes_through_pipeline(
+    persistence: FakePersistenceBackend,
+    task_engine: TaskEngine,
+    tmp_path: Path,
+) -> None:
+    """An approved request becomes a task an agent actually runs."""
+    sim_state = _sim_state(task_engine)
+    request = ClientRequest(
+        client_id="acme-co",
+        requirement=TaskRequirement(
+            title="Add a status endpoint",
+            description="Return a JSON status body from /status.",
+        ),
+        status=RequestStatus.APPROVED,
+    )
+    await sim_state.request_store.save(request)
+    app_state = await _build_app_state(
+        persistence=persistence,
+        task_engine=task_engine,
+        tmp_path=tmp_path,
+        sim_state=sim_state,
+    )
+
+    await process_intake_pipeline(
+        app_state=app_state,
+        sim_state=sim_state,
+        request_id=request.request_id,
+    )
+
+    final = await sim_state.request_store.get(request.request_id)
+    assert final.status is RequestStatus.TASK_CREATED
+    task_id = final.metadata["task_id"]
+    persisted = await task_engine.get_task(task_id)
+    assert persisted is not None
+    # CREATED would mean no agent ran; the worker execution service
+    # drives it past ASSIGNED through the scripted provider.
+    assert persisted.status is not TaskStatus.CREATED
+    assert persisted.project == _PROJECT
+
+
+async def test_scoped_request_with_notes_executes(
+    persistence: FakePersistenceBackend,
+    task_engine: TaskEngine,
+    tmp_path: Path,
+) -> None:
+    """A manually-scoped request (reviewer notes) still executes."""
+    sim_state = _sim_state(task_engine)
+    request = ClientRequest(
+        client_id="acme-co",
+        requirement=TaskRequirement(
+            title="Refined title",
+            description="Refined description after scoping.",
+        ),
+        status=RequestStatus.APPROVED,
+        metadata={"scoping_notes": "Prioritise the JSON contract."},
+    )
+    await sim_state.request_store.save(request)
+    app_state = await _build_app_state(
+        persistence=persistence,
+        task_engine=task_engine,
+        tmp_path=tmp_path,
+        sim_state=sim_state,
+    )
+
+    await process_intake_pipeline(
+        app_state=app_state,
+        sim_state=sim_state,
+        request_id=request.request_id,
+    )
+
+    final = await sim_state.request_store.get(request.request_id)
+    assert final.status is RequestStatus.TASK_CREATED
+    persisted = await task_engine.get_task(final.metadata["task_id"])
+    assert persisted is not None
+    assert persisted.status is not TaskStatus.CREATED

--- a/tests/integration/api/controllers/test_client_simulation.py
+++ b/tests/integration/api/controllers/test_client_simulation.py
@@ -16,8 +16,17 @@ from synthorg.client.adapters import DirectAdapter
 from synthorg.client.pool import RoundRobinStrategy
 from synthorg.client.simulation_state import ClientSimulationState
 from synthorg.config.schema import RootConfig
+from synthorg.core.enums import TaskStatus
 from synthorg.engine.intake.engine import IntakeEngine
 from synthorg.engine.intake.models import IntakeResult
+from synthorg.engine.pipeline.models import (
+    ExecutionPath,
+    RoutingVerdict,
+    WorkItem,
+    WorkPhaseResult,
+    WorkPipelineResult,
+    WorkSource,
+)
 from synthorg.engine.review.pipeline import ReviewPipeline
 from synthorg.engine.review.stages.internal import InternalReviewStage
 from tests.unit.api.conftest import (
@@ -72,7 +81,58 @@ def _build_sim_state() -> ClientSimulationState:
     return ClientSimulationState(
         intake_engine=IntakeEngine(strategy=_AcceptingStrategy()),
         review_pipeline=ReviewPipeline(stages=(InternalReviewStage(),)),
+        intake_default_project="client-intake",
     )
+
+
+class _StubEntryAdapter:
+    """Work-entry adapter double that returns a fixed pipeline result."""
+
+    @property
+    def source(self) -> WorkSource:
+        return WorkSource.INTAKE
+
+    async def submit(self, request: Any) -> WorkPipelineResult:
+        item = WorkItem(
+            origin_adapter_id="intake-entry-adapter",
+            source=WorkSource.INTAKE,
+            title=request.requirement.title,
+            raw_intent=request.requirement.description,
+            project="client-intake",
+            requested_by=request.client_id,
+            correlation_id=request.request_id,
+        )
+        return WorkPipelineResult(
+            work_item=item,
+            verdict=RoutingVerdict.LEAF,
+            execution_path=ExecutionPath.SOLO,
+            task_id=f"task-{request.request_id[:6]}",
+            final_task_status=TaskStatus.IN_REVIEW,
+            phases=(
+                WorkPhaseResult(phase="intake", success=True, duration_seconds=0.0),
+            ),
+            total_duration_seconds=0.0,
+        )
+
+
+def _build_client_with_adapter(
+    fake_persistence: FakePersistenceBackend,
+    fake_message_bus: FakeMessageBus,
+) -> tuple[TestClient[Any], ClientSimulationState]:
+    config = RootConfig(company_name="test")
+    auth_service = _make_test_auth_service()
+    _seed_test_users(fake_persistence, auth_service)
+    sim_state = _build_sim_state()
+    app = create_app(
+        config=config,
+        persistence=fake_persistence,
+        message_bus=fake_message_bus,
+        cost_tracker=CostTracker(),
+        auth_service=auth_service,
+        client_simulation_state=sim_state,
+        intake_entry_adapter=_StubEntryAdapter(),
+    )
+    return TestClient(app), sim_state
 
 
 def _build_client(
@@ -216,6 +276,60 @@ class TestRequestController:
             listing = client.get("/api/v1/requests")
             assert listing.status_code == 200
             assert len(listing.json()["data"]) == 1
+
+    async def test_approve_without_adapter_returns_409(
+        self,
+        fake_persistence: FakePersistenceBackend,
+        fake_message_bus: FakeMessageBus,
+    ) -> None:
+        """No work-entry adapter wired -> honest runtime-not-configured."""
+        with _build_client(fake_persistence, fake_message_bus) as client:
+            client.headers.update(make_auth_headers("ceo"))
+            client.post(
+                "/api/v1/clients/",
+                json={"client_id": "na", "name": "NA", "persona": "P"},
+            )
+            submit = client.post(
+                "/api/v1/requests/",
+                json={
+                    "client_id": "na",
+                    "requirement": {"title": "T", "description": "D"},
+                },
+            )
+            rid = submit.json()["data"]["request_id"]
+            approve = client.post(f"/api/v1/requests/{rid}/approve")
+            assert approve.status_code == 409
+
+    async def test_approve_accepts_and_spawns_pipeline(
+        self,
+        fake_persistence: FakePersistenceBackend,
+        fake_message_bus: FakeMessageBus,
+    ) -> None:
+        """Approve returns 202 APPROVED and spawns the pipeline task."""
+        client, sim_state = _build_client_with_adapter(
+            fake_persistence,
+            fake_message_bus,
+        )
+        with client:
+            client.headers.update(make_auth_headers("ceo"))
+            client.post(
+                "/api/v1/clients/",
+                json={"client_id": "ok", "name": "OK", "persona": "P"},
+            )
+            submit = client.post(
+                "/api/v1/requests/",
+                json={
+                    "client_id": "ok",
+                    "requirement": {"title": "T", "description": "D"},
+                },
+            )
+            rid = submit.json()["data"]["request_id"]
+            approve = client.post(f"/api/v1/requests/{rid}/approve")
+            assert approve.status_code == 202
+            assert approve.json()["data"]["status"] == "approved"
+            # The reconciliation task was registered synchronously
+            # before the response returned (strong ref held).
+            assert len(sim_state.background_tasks) >= 1
 
     async def test_reject_sets_cancelled(
         self,

--- a/tests/unit/api/controllers/test_requests_intake_pipeline.py
+++ b/tests/unit/api/controllers/test_requests_intake_pipeline.py
@@ -1,0 +1,184 @@
+"""Unit coverage for the real-intake background reconciliation.
+
+``process_intake_pipeline`` runs the injected work-entry adapter and
+reconciles the stored ``ClientRequest`` to its terminal status. It is
+the coroutine the ``POST /requests/{id}/approve`` handler spawns; the
+sync handler contract (202 + APPROVED + task spawned) is covered by
+the integration suite.
+"""
+
+import pytest
+
+from synthorg.api.approval_store import ApprovalStore
+from synthorg.api.controllers.requests import process_intake_pipeline
+from synthorg.api.state import AppState
+from synthorg.client.models import ClientRequest, RequestStatus, TaskRequirement
+from synthorg.client.simulation_state import ClientSimulationState
+from synthorg.config.schema import RootConfig
+from synthorg.core.enums import TaskStatus
+from synthorg.engine.pipeline.errors import (
+    WorkIntakeRejectedError,
+    WorkProjectNotFoundError,
+)
+from synthorg.engine.pipeline.models import (
+    ExecutionPath,
+    RoutingVerdict,
+    WorkItem,
+    WorkPhaseResult,
+    WorkPipelineResult,
+    WorkSource,
+)
+
+pytestmark = pytest.mark.unit
+
+_REQUEST_ID = "req-1"
+
+
+class _StubAdapter:
+    """Work-entry adapter double with a scripted outcome."""
+
+    def __init__(
+        self,
+        *,
+        result: WorkPipelineResult | None = None,
+        error: BaseException | None = None,
+    ) -> None:
+        self._result = result
+        self._error = error
+        self.calls = 0
+
+    @property
+    def source(self) -> WorkSource:
+        return WorkSource.INTAKE
+
+    async def submit(self, request: ClientRequest) -> WorkPipelineResult:
+        del request
+        self.calls += 1
+        if self._error is not None:
+            raise self._error
+        assert self._result is not None
+        return self._result
+
+
+def _work_item() -> WorkItem:
+    return WorkItem(
+        origin_adapter_id="intake-entry-adapter",
+        source=WorkSource.INTAKE,
+        title="t",
+        raw_intent="d",
+        project="client-intake",
+        requested_by="acme",
+        correlation_id=_REQUEST_ID,
+    )
+
+
+def _result(task_id: str) -> WorkPipelineResult:
+    return WorkPipelineResult(
+        work_item=_work_item(),
+        verdict=RoutingVerdict.LEAF,
+        execution_path=ExecutionPath.SOLO,
+        task_id=task_id,
+        final_task_status=TaskStatus.IN_REVIEW,
+        phases=(WorkPhaseResult(phase="intake", success=True, duration_seconds=0.0),),
+        total_duration_seconds=0.1,
+    )
+
+
+def _request(status: RequestStatus = RequestStatus.APPROVED) -> ClientRequest:
+    return ClientRequest(
+        request_id=_REQUEST_ID,
+        client_id="acme",
+        requirement=TaskRequirement(title="t", description="d"),
+        status=status,
+    )
+
+
+async def _state(
+    adapter: _StubAdapter,
+    *,
+    seeded: ClientRequest,
+) -> tuple[AppState, ClientSimulationState]:
+    sim_state = ClientSimulationState(intake_default_project="client-intake")
+    await sim_state.request_store.save(seeded)
+    app_state = AppState(
+        config=RootConfig(company_name="t"),
+        approval_store=ApprovalStore(),
+        intake_entry_adapter=adapter,
+    )
+    app_state.set_client_simulation_state(sim_state)
+    return app_state, sim_state
+
+
+async def test_success_walks_to_task_created() -> None:
+    adapter = _StubAdapter(result=_result("task-9"))
+    app_state, sim_state = await _state(adapter, seeded=_request())
+
+    await process_intake_pipeline(
+        app_state=app_state,
+        sim_state=sim_state,
+        request_id=_REQUEST_ID,
+    )
+
+    final = await sim_state.request_store.get(_REQUEST_ID)
+    assert final.status is RequestStatus.TASK_CREATED
+    assert final.metadata["task_id"] == "task-9"
+    assert adapter.calls == 1
+
+
+async def test_intake_rejection_cancels_request() -> None:
+    adapter = _StubAdapter(error=WorkIntakeRejectedError("not actionable"))
+    app_state, sim_state = await _state(adapter, seeded=_request())
+
+    await process_intake_pipeline(
+        app_state=app_state,
+        sim_state=sim_state,
+        request_id=_REQUEST_ID,
+    )
+
+    final = await sim_state.request_store.get(_REQUEST_ID)
+    assert final.status is RequestStatus.CANCELLED
+    assert "not actionable" in final.metadata["rejection_reason"]
+
+
+async def test_pipeline_error_cancels_request() -> None:
+    adapter = _StubAdapter(error=WorkProjectNotFoundError("missing project"))
+    app_state, sim_state = await _state(adapter, seeded=_request())
+
+    await process_intake_pipeline(
+        app_state=app_state,
+        sim_state=sim_state,
+        request_id=_REQUEST_ID,
+    )
+
+    final = await sim_state.request_store.get(_REQUEST_ID)
+    assert final.status is RequestStatus.CANCELLED
+
+
+async def test_concurrent_terminal_state_is_respected() -> None:
+    adapter = _StubAdapter(result=_result("task-9"))
+    app_state, sim_state = await _state(
+        adapter,
+        seeded=_request(status=RequestStatus.CANCELLED),
+    )
+
+    await process_intake_pipeline(
+        app_state=app_state,
+        sim_state=sim_state,
+        request_id=_REQUEST_ID,
+    )
+
+    final = await sim_state.request_store.get(_REQUEST_ID)
+    assert final.status is RequestStatus.CANCELLED
+    assert adapter.calls == 0
+
+
+async def test_memory_error_is_reraised() -> None:
+    adapter = _StubAdapter(error=MemoryError())
+    app_state, sim_state = await _state(adapter, seeded=_request())
+
+    with pytest.raises(MemoryError):
+        await process_intake_pipeline(
+            app_state=app_state,
+            sim_state=sim_state,
+            request_id=_REQUEST_ID,
+        )

--- a/tests/unit/api/controllers/test_requests_intake_pipeline.py
+++ b/tests/unit/api/controllers/test_requests_intake_pipeline.py
@@ -182,3 +182,40 @@ async def test_memory_error_is_reraised() -> None:
             sim_state=sim_state,
             request_id=_REQUEST_ID,
         )
+
+
+async def test_vanished_request_evicts_lock_registry_entry() -> None:
+    # The early-return paths must drop the per-request lock entry
+    # from ``_request_locks`` so the dict cannot leak an entry per
+    # orphaned id. Without the eviction, a vanished request acquired
+    # under ``acquire_request_lock`` would leave the Lock object
+    # behind even though the refcount drops to zero.
+    adapter = _StubAdapter(result=_result("task-9"))
+    app_state, sim_state = await _state(adapter, seeded=_request())
+    await sim_state.request_store.delete(_REQUEST_ID)
+
+    await process_intake_pipeline(
+        app_state=app_state,
+        sim_state=sim_state,
+        request_id=_REQUEST_ID,
+    )
+
+    assert _REQUEST_ID not in app_state._request_locks
+    assert adapter.calls == 0
+
+
+async def test_non_approved_request_evicts_lock_registry_entry() -> None:
+    adapter = _StubAdapter(result=_result("task-9"))
+    app_state, sim_state = await _state(
+        adapter,
+        seeded=_request(status=RequestStatus.CANCELLED),
+    )
+
+    await process_intake_pipeline(
+        app_state=app_state,
+        sim_state=sim_state,
+        request_id=_REQUEST_ID,
+    )
+
+    assert _REQUEST_ID not in app_state._request_locks
+    assert adapter.calls == 0

--- a/tests/unit/api/test_state.py
+++ b/tests/unit/api/test_state.py
@@ -9,6 +9,7 @@ from synthorg.api.state import AppState
 from synthorg.config.schema import RootConfig
 from synthorg.core.domain_errors import ServiceUnavailableError
 from synthorg.engine.coordination.service import MultiAgentCoordinator
+from synthorg.engine.pipeline.entry.protocol import WorkEntryAdapter
 from synthorg.engine.pipeline.protocol import WorkPipeline
 from synthorg.engine.review_gate import ReviewGateService
 from synthorg.engine.task_engine import TaskEngine
@@ -711,3 +712,51 @@ class TestAppStateSimulationRuntime:
             review_pipeline=object(),
         )
         assert state.has_simulation_runtime is True
+
+
+@pytest.mark.unit
+class TestAppStateIntakeEntryAdapter:
+    """Tests for the intake_entry_adapter seam (mirrors work_pipeline)."""
+
+    def test_raises_when_none(self) -> None:
+        state = _make_state(intake_entry_adapter=None)
+        with pytest.raises(ServiceUnavailableError):
+            _ = state.intake_entry_adapter
+
+    def test_returns_when_set(self) -> None:
+        adapter = mock_of[WorkEntryAdapter]()
+        state = _make_state(intake_entry_adapter=adapter)
+        assert state.intake_entry_adapter is adapter
+
+    def test_has_false_when_none(self) -> None:
+        assert _make_state(intake_entry_adapter=None).has_intake_entry_adapter is False
+
+    def test_has_true_when_set(self) -> None:
+        state = _make_state(intake_entry_adapter=mock_of[WorkEntryAdapter]())
+        assert state.has_intake_entry_adapter is True
+
+    def test_set_is_once_only(self) -> None:
+        first = mock_of[WorkEntryAdapter]()
+        state = _make_state(intake_entry_adapter=first)
+        with pytest.raises(RuntimeError, match="already configured"):
+            state.set_intake_entry_adapter(mock_of[WorkEntryAdapter]())
+
+    def test_set_if_absent_installs_when_none(self) -> None:
+        adapter = mock_of[WorkEntryAdapter]()
+        state = _make_state(intake_entry_adapter=None)
+        assert state.set_intake_entry_adapter_if_absent(adapter) is True
+        assert state.intake_entry_adapter is adapter
+
+    def test_set_if_absent_keeps_injected(self) -> None:
+        injected = mock_of[WorkEntryAdapter]()
+        autowired = mock_of[WorkEntryAdapter]()
+        state = _make_state(intake_entry_adapter=injected)
+        assert state.set_intake_entry_adapter_if_absent(autowired) is False
+        assert state.intake_entry_adapter is injected
+
+    def test_swap_replaces_existing(self) -> None:
+        first = mock_of[WorkEntryAdapter]()
+        second = mock_of[WorkEntryAdapter]()
+        state = _make_state(intake_entry_adapter=first)
+        state.swap_intake_entry_adapter(second)
+        assert state.intake_entry_adapter is second

--- a/tests/unit/client/test_runtime_builder.py
+++ b/tests/unit/client/test_runtime_builder.py
@@ -10,7 +10,10 @@ import structlog
 
 from synthorg.client.config import IntakeConfig
 from synthorg.client.factory import UnknownStrategyError, build_intake_strategy
+from synthorg.client.models import ClientRequest, TaskRequirement
 from synthorg.client.simulation_state import ClientSimulationState
+from synthorg.core.enums import Priority, TaskType
+from synthorg.core.task import Task
 from synthorg.engine.intake.strategies import AgentIntake, DirectIntake
 from synthorg.engine.review.stages.internal import InternalReviewStage
 from synthorg.engine.task_engine import TaskEngine
@@ -21,6 +24,8 @@ from tests._shared import mock_of
 
 pytestmark = pytest.mark.unit
 
+_TEST_PROJECT = "client-intake"
+
 
 class TestBuildIntakeStrategy:
     """Dispatch behaviour of ``build_intake_strategy``."""
@@ -30,8 +35,46 @@ class TestBuildIntakeStrategy:
         strategy = build_intake_strategy(
             IntakeConfig(strategy="direct"),
             task_engine=task_engine,
+            default_project=_TEST_PROJECT,
         )
         assert isinstance(strategy, DirectIntake)
+
+    async def test_direct_strategy_files_into_default_project(self) -> None:
+        task_engine = mock_of[TaskEngine]()
+        task_engine.create_task.return_value = Task(
+            id="t-1",
+            title="t",
+            description="d",
+            type=TaskType.DEVELOPMENT,
+            priority=Priority.MEDIUM,
+            project="ops-intake",
+            created_by="acme",
+        )
+        strategy = build_intake_strategy(
+            IntakeConfig(strategy="direct"),
+            task_engine=task_engine,
+            default_project="ops-intake",
+        )
+        await strategy.process(
+            ClientRequest(
+                client_id="acme",
+                requirement=TaskRequirement(title="t", description="d"),
+            )
+        )
+        created = task_engine.create_task.call_args.args[0]
+        assert created.project == "ops-intake"
+
+    async def test_agent_strategy_files_into_default_project(self) -> None:
+        task_engine = mock_of[TaskEngine]()
+        provider = ScriptedDriver("test-provider")
+        strategy = build_intake_strategy(
+            IntakeConfig(strategy="agent", model="test-model-001"),
+            task_engine=task_engine,
+            provider=provider,
+            default_project="ops-intake",
+        )
+        assert isinstance(strategy, AgentIntake)
+        assert strategy._project == "ops-intake"
 
     def test_agent_strategy(self) -> None:
         task_engine = mock_of[TaskEngine]()
@@ -40,6 +83,7 @@ class TestBuildIntakeStrategy:
             IntakeConfig(strategy="agent", model="test-model-001"),
             task_engine=task_engine,
             provider=provider,
+            default_project=_TEST_PROJECT,
         )
         assert isinstance(strategy, AgentIntake)
 
@@ -49,6 +93,7 @@ class TestBuildIntakeStrategy:
             build_intake_strategy(
                 IntakeConfig(strategy="nonsense"),
                 task_engine=task_engine,
+                default_project=_TEST_PROJECT,
             )
 
     def test_agent_without_provider_raises(self) -> None:
@@ -57,6 +102,7 @@ class TestBuildIntakeStrategy:
             build_intake_strategy(
                 IntakeConfig(strategy="agent", model="test-model-001"),
                 task_engine=task_engine,
+                default_project=_TEST_PROJECT,
             )
 
     def test_agent_without_model_raises(self) -> None:
@@ -67,6 +113,7 @@ class TestBuildIntakeStrategy:
                 IntakeConfig(strategy="agent"),
                 task_engine=task_engine,
                 provider=provider,
+                default_project=_TEST_PROJECT,
             )
 
 
@@ -90,6 +137,25 @@ class TestBuildClientSimulationRuntime:
         assert state.intake_engine is not None
         assert state.review_pipeline is not None
         assert state.review_pipeline.stage_names == ("internal",)
+        assert state.intake_default_project == "client-intake"
+
+    def test_intake_default_project_env_override(self) -> None:
+        from synthorg.api.state import AppState
+        from synthorg.client.runtime_builder import (
+            build_client_simulation_runtime,
+        )
+
+        task_engine = mock_of[TaskEngine]()
+        app_state = mock_of[AppState](
+            task_engine=task_engine,
+            has_task_engine=True,
+            has_active_provider=False,
+        )
+        state = build_client_simulation_runtime(
+            app_state,
+            env={"SYNTHORG_SIMULATIONS_INTAKE_DEFAULT_PROJECT": "ops-intake"},
+        )
+        assert state.intake_default_project == "ops-intake"
 
     def test_agent_selected_without_provider_falls_back_to_direct(self) -> None:
         from synthorg.api.state import AppState

--- a/tests/unit/engine/pipeline/__init__.py
+++ b/tests/unit/engine/pipeline/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the work pipeline package."""

--- a/tests/unit/engine/pipeline/entry/__init__.py
+++ b/tests/unit/engine/pipeline/entry/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the work pipeline entry adapters."""

--- a/tests/unit/engine/pipeline/entry/test_boot.py
+++ b/tests/unit/engine/pipeline/entry/test_boot.py
@@ -1,0 +1,89 @@
+"""Unit coverage for the real-intake boot wiring.
+
+``wire_real_intake_entry`` ensures the configured intake project
+exists and attaches the :class:`IntakeEntryAdapter` to ``AppState``
+once the work pipeline is online. It is a no-op when the pipeline /
+simulation runtime is absent (empty company).
+"""
+
+from typing import Any
+
+import pytest
+
+from synthorg.api.state import AppState
+from synthorg.client.simulation_state import ClientSimulationState
+from synthorg.core.enums import ProjectStatus
+from synthorg.core.project import Project
+from synthorg.engine.pipeline.entry.boot import wire_real_intake_entry
+from synthorg.engine.pipeline.entry.intake_adapter import IntakeEntryAdapter
+from synthorg.engine.pipeline.protocol import WorkPipeline
+from synthorg.persistence.project_protocol import ProjectRepository
+from synthorg.persistence.protocol import PersistenceBackend
+from tests._shared import mock_of
+
+pytestmark = pytest.mark.unit
+
+
+def _app_state(
+    *,
+    has_work_pipeline: bool,
+    has_simulation_runtime: bool = True,
+    project: Project | None = None,
+    default_project: str | None = "client-intake",
+) -> tuple[Any, Any]:
+    projects = mock_of[ProjectRepository]()
+    projects.get.return_value = project
+    sim_state = mock_of[ClientSimulationState](
+        intake_default_project=default_project,
+    )
+    app_state = mock_of[AppState](
+        has_work_pipeline=has_work_pipeline,
+        has_simulation_runtime=has_simulation_runtime,
+        work_pipeline=mock_of[WorkPipeline](),
+        client_simulation_state=sim_state,
+        persistence=mock_of[PersistenceBackend](projects=projects),
+    )
+    return app_state, projects
+
+
+async def test_noop_without_work_pipeline() -> None:
+    app_state, projects = _app_state(has_work_pipeline=False)
+    await wire_real_intake_entry(app_state)
+    projects.get.assert_not_called()
+    app_state.set_intake_entry_adapter_if_absent.assert_not_called()
+
+
+async def test_noop_without_simulation_runtime() -> None:
+    app_state, projects = _app_state(
+        has_work_pipeline=True,
+        has_simulation_runtime=False,
+    )
+    await wire_real_intake_entry(app_state)
+    projects.get.assert_not_called()
+    app_state.set_intake_entry_adapter_if_absent.assert_not_called()
+
+
+async def test_creates_project_when_absent_and_attaches_adapter() -> None:
+    app_state, projects = _app_state(has_work_pipeline=True, project=None)
+    await wire_real_intake_entry(app_state)
+    created = projects.create.call_args.args[0]
+    assert isinstance(created, Project)
+    assert created.id == "client-intake"
+    assert created.status is ProjectStatus.ACTIVE
+    adapter = app_state.set_intake_entry_adapter_if_absent.call_args.args[0]
+    assert isinstance(adapter, IntakeEntryAdapter)
+
+
+async def test_skips_create_when_project_exists() -> None:
+    existing = Project(id="client-intake", name="client-intake")
+    app_state, projects = _app_state(has_work_pipeline=True, project=existing)
+    await wire_real_intake_entry(app_state)
+    projects.create.assert_not_called()
+    app_state.set_intake_entry_adapter_if_absent.assert_called_once()
+
+
+async def test_hot_swap_uses_swap_seam() -> None:
+    app_state, _ = _app_state(has_work_pipeline=True, project=None)
+    await wire_real_intake_entry(app_state, hot_swap=True)
+    app_state.swap_intake_entry_adapter.assert_called_once()
+    app_state.set_intake_entry_adapter_if_absent.assert_not_called()

--- a/tests/unit/engine/pipeline/entry/test_factory.py
+++ b/tests/unit/engine/pipeline/entry/test_factory.py
@@ -1,0 +1,44 @@
+"""Unit coverage for :func:`build_work_entry_adapter`.
+
+Dispatch is on :class:`WorkSource`; a source with no wired adapter is
+a hard ``UnknownStrategyError`` (no silent default).
+"""
+
+import pytest
+
+from synthorg.client.factory import UnknownStrategyError
+from synthorg.engine.pipeline.entry.factory import build_work_entry_adapter
+from synthorg.engine.pipeline.entry.intake_adapter import IntakeEntryAdapter
+from synthorg.engine.pipeline.models import WorkSource
+from synthorg.engine.pipeline.protocol import WorkPipeline
+from tests._shared import mock_of
+
+pytestmark = pytest.mark.unit
+
+
+def test_intake_source_builds_intake_adapter() -> None:
+    adapter = build_work_entry_adapter(
+        WorkSource.INTAKE,
+        work_pipeline=mock_of[WorkPipeline](),
+        default_project="client-intake",
+    )
+    assert isinstance(adapter, IntakeEntryAdapter)
+    assert adapter.source is WorkSource.INTAKE
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        WorkSource.SIMULATION,
+        WorkSource.TASK_BOARD,
+        WorkSource.OBJECTIVE,
+        WorkSource.CONVERSATIONAL,
+    ],
+)
+def test_unwired_source_is_hard_error(source: WorkSource) -> None:
+    with pytest.raises(UnknownStrategyError, match=source.value):
+        build_work_entry_adapter(
+            source,
+            work_pipeline=mock_of[WorkPipeline](),
+            default_project="client-intake",
+        )

--- a/tests/unit/engine/pipeline/entry/test_intake_adapter.py
+++ b/tests/unit/engine/pipeline/entry/test_intake_adapter.py
@@ -1,0 +1,126 @@
+"""Unit coverage for :class:`IntakeEntryAdapter`.
+
+The adapter is the thin real work-entry seam: it maps a stored
+``ClientRequest`` onto a ``WorkItem`` and hands it to the work
+pipeline spine. It owns no request-store / lock / reconciliation
+(that stays in the controller background task).
+"""
+
+from typing import Any
+
+import pytest
+
+from synthorg.client.models import ClientRequest, TaskRequirement
+from synthorg.core.enums import Complexity, Priority, TaskStatus, TaskType
+from synthorg.engine.pipeline.entry.intake_adapter import IntakeEntryAdapter
+from synthorg.engine.pipeline.entry.protocol import WorkEntryAdapter
+from synthorg.engine.pipeline.errors import WorkIntakeRejectedError
+from synthorg.engine.pipeline.models import (
+    ExecutionPath,
+    RoutingVerdict,
+    WorkItem,
+    WorkPhaseResult,
+    WorkPipelineResult,
+    WorkSource,
+)
+from synthorg.engine.pipeline.protocol import WorkPipeline
+from tests._shared import mock_of
+
+pytestmark = pytest.mark.unit
+
+_DEFAULT_PROJECT = "client-intake"
+
+
+def _request(**overrides: Any) -> ClientRequest:
+    base: dict[str, Any] = {
+        "request_id": "req-42",
+        "client_id": "acme-co",
+        "requirement": TaskRequirement(
+            title="Ship the status endpoint",
+            description="Return a JSON status body from /status.",
+            task_type=TaskType.DEVELOPMENT,
+            priority=Priority.HIGH,
+            estimated_complexity=Complexity.COMPLEX,
+            acceptance_criteria=("returns 200", "body has status key"),
+        ),
+    }
+    base.update(overrides)
+    return ClientRequest(**base)
+
+
+def _result(work_item: WorkItem) -> WorkPipelineResult:
+    return WorkPipelineResult(
+        work_item=work_item,
+        verdict=RoutingVerdict.LEAF,
+        execution_path=ExecutionPath.SOLO,
+        task_id="task-7",
+        final_task_status=TaskStatus.IN_REVIEW,
+        phases=(WorkPhaseResult(phase="intake", success=True, duration_seconds=0.0),),
+        total_duration_seconds=0.1,
+    )
+
+
+def _adapter(pipeline: WorkPipeline) -> IntakeEntryAdapter:
+    return IntakeEntryAdapter(
+        work_pipeline=pipeline,
+        default_project=_DEFAULT_PROJECT,
+    )
+
+
+def test_is_work_entry_adapter() -> None:
+    adapter = _adapter(mock_of[WorkPipeline]())
+    assert isinstance(adapter, WorkEntryAdapter)
+    assert adapter.source is WorkSource.INTAKE
+
+
+async def test_submit_maps_request_to_work_item() -> None:
+    pipeline = mock_of[WorkPipeline]()
+    captured: dict[str, WorkItem] = {}
+
+    async def _run(work_item: WorkItem) -> WorkPipelineResult:
+        captured["item"] = work_item
+        return _result(work_item)
+
+    pipeline.run.side_effect = _run
+    request = _request()
+
+    result = await _adapter(pipeline).submit(request)
+
+    item = captured["item"]
+    assert item.source is WorkSource.INTAKE
+    assert item.correlation_id == request.request_id
+    assert item.project == _DEFAULT_PROJECT
+    assert item.title == request.requirement.title
+    assert item.raw_intent == request.requirement.description
+    assert item.requested_by == request.client_id
+    assert item.priority is Priority.HIGH
+    assert item.task_type is TaskType.DEVELOPMENT
+    assert item.estimated_complexity is Complexity.COMPLEX
+    assert item.acceptance_criteria == request.requirement.acceptance_criteria
+    assert result.task_id == "task-7"
+
+
+async def test_submit_folds_scoping_notes_into_raw_intent() -> None:
+    pipeline = mock_of[WorkPipeline]()
+    captured: dict[str, WorkItem] = {}
+
+    async def _run(work_item: WorkItem) -> WorkPipelineResult:
+        captured["item"] = work_item
+        return _result(work_item)
+
+    pipeline.run.side_effect = _run
+    request = _request(metadata={"scoping_notes": "Focus on the JSON shape."})
+
+    await _adapter(pipeline).submit(request)
+
+    raw = captured["item"].raw_intent
+    assert request.requirement.description in raw
+    assert "## Reviewer scoping notes" in raw
+    assert "Focus on the JSON shape." in raw
+
+
+async def test_submit_propagates_pipeline_error() -> None:
+    pipeline = mock_of[WorkPipeline]()
+    pipeline.run.side_effect = WorkIntakeRejectedError("nope")
+    with pytest.raises(WorkIntakeRejectedError):
+        await _adapter(pipeline).submit(_request())

--- a/tests/unit/settings/test_intake_settings.py
+++ b/tests/unit/settings/test_intake_settings.py
@@ -51,6 +51,35 @@ def test_intake_model_registered() -> None:
     assert defn.restart_required is True
 
 
+def test_intake_default_project_registered() -> None:
+    defn = get_registry().get("simulations", "intake_default_project")
+    assert defn is not None
+    assert defn.type is SettingType.STRING
+    assert defn.default == "client-intake"
+    assert defn.read_only_post_init is True
+    assert defn.restart_required is True
+
+
+def test_intake_default_project_bootstrap_default() -> None:
+    resolved = resolve_init_value(
+        SettingNamespace.SIMULATIONS,
+        "intake_default_project",
+        env={},
+    )
+    assert resolved.value == "client-intake"
+    assert resolved.source is SettingSource.DEFAULT
+
+
+def test_intake_default_project_bootstrap_env_override() -> None:
+    resolved = resolve_init_value(
+        SettingNamespace.SIMULATIONS,
+        "intake_default_project",
+        env={"SYNTHORG_SIMULATIONS_INTAKE_DEFAULT_PROJECT": "ops-intake"},
+    )
+    assert resolved.value == "ops-intake"
+    assert resolved.source is SettingSource.ENVIRONMENT
+
+
 async def test_intake_strategy_default_resolves(service: SettingsService) -> None:
     result = await service.get("simulations", "intake_strategy")
     assert result.value == "direct"

--- a/web/src/api/types/openapi.gen.ts
+++ b/web/src/api/types/openapi.gen.ts
@@ -19693,8 +19693,8 @@ export interface operations {
         };
         readonly requestBody?: never;
         readonly responses: {
-            /** @description Document created, URL follows */
-            readonly 201: {
+            /** @description Request accepted, processing continues off-line */
+            readonly 202: {
                 headers: {
                     readonly [name: string]: unknown;
                 };

--- a/web/src/api/types/websocket.ts
+++ b/web/src/api/types/websocket.ts
@@ -42,7 +42,7 @@ export const WS_EVENT_TYPE_VALUES = [
   'project.created', 'project.deleted', 'project.status_changed',
   'memory.fine_tune.progress', 'memory.fine_tune.stage_changed', 'memory.fine_tune.completed', 'memory.fine_tune.failed',
   'client.created', 'client.updated', 'client.deactivated', 'client.deleted',
-  'request.submitted', 'request.scoped', 'request.approved', 'request.rejected', 'request.status_changed',
+  'request.submitted', 'request.scoped', 'request.approved', 'request.task_created', 'request.rejected', 'request.status_changed',
   'simulation.started', 'simulation.running', 'simulation.paused', 'simulation.cancelled', 'simulation.completed', 'simulation.failed',
   'review.stage_completed', 'review.stage_decided', 'review.pipeline_completed',
   'interrupt.created', 'interrupt.resumed',
@@ -468,6 +468,7 @@ export interface WsEventPayloadMap {
   'request.submitted': WsRequestEventPayload
   'request.scoped': WsRequestEventPayload
   'request.approved': WsRequestEventPayload
+  'request.task_created': WsRequestEventPayload
   'request.rejected': WsRequestEventPayload
   'request.status_changed': WsRequestStatusChangedPayload
   'simulation.started': WsSimulationEventPayload

--- a/web/src/api/types/websocket.ts
+++ b/web/src/api/types/websocket.ts
@@ -356,6 +356,18 @@ export interface WsRequestEventPayload {
   status: string
 }
 
+/**
+ * Payload for ``request.task_created``. Mirrors
+ * ``WsRequestTaskCreatedPayload`` in
+ * ``src/synthorg/api/ws_payloads/_domain.py``: the backend stamps
+ * ``task_id`` on every emission of this event so the dashboard can
+ * navigate straight to the spawned task without a second
+ * ``GET /requests/{id}`` round-trip.
+ */
+export interface WsRequestTaskCreatedPayload extends WsRequestEventPayload {
+  task_id: string
+}
+
 export interface WsRequestStatusChangedPayload extends WsRequestEventPayload {
   previous_status?: string | null
 }
@@ -468,7 +480,7 @@ export interface WsEventPayloadMap {
   'request.submitted': WsRequestEventPayload
   'request.scoped': WsRequestEventPayload
   'request.approved': WsRequestEventPayload
-  'request.task_created': WsRequestEventPayload
+  'request.task_created': WsRequestTaskCreatedPayload
   'request.rejected': WsRequestEventPayload
   'request.status_changed': WsRequestStatusChangedPayload
   'simulation.started': WsSimulationEventPayload

--- a/web/src/mocks/handlers/clients.ts
+++ b/web/src/mocks/handlers/clients.ts
@@ -154,6 +154,10 @@ export const clientsHandlers = [
       successFor<typeof approveRequest>(
         buildRequest({ request_id: String(params.id), status: 'approved' }),
       ),
+      // 202 Accepted: approval is acknowledged synchronously; the
+      // request runs through the work pipeline in the background and
+      // reaches its terminal state asynchronously.
+      { status: 202 },
     ),
   ),
   http.post('/api/v1/requests/:id/reject', async ({ params, request }) => {


### PR DESCRIPTION
Closes #1962. Child of EPIC #1955.

## Summary

Wires `DirectIntake`/`AgentIntake` as a live, non-simulated work-entry path. A real `ClientRequest` submitted via `POST /requests` and approved via `POST /requests/{id}/approve` now flows through the work pipeline spine so an agent actually executes it (proven under the simulation harness with a scripted provider).

The pipeline spine (#1960) already maps `WorkItem -> ClientRequest -> intake_engine.process()` in its intake phase; the gap was that `approve_request` called `intake_engine.process()` directly and produced a `CREATED` task no agent ever ran. This PR introduces a thin work-entry adapter seam, hands approve at `POST /requests/{id}/approve` to a background pipeline run, and reconciles the stored request to its terminal status.

## What changed

- **New `WorkEntryAdapter` protocol + `IntakeEntryAdapter` + `build_work_entry_adapter` factory** under `src/synthorg/engine/pipeline/entry/`. Source-keyed dispatch (`WorkSource.INTAKE` ships now; siblings #1963 / #1964 add their arms here).
- **`POST /requests/{id}/approve` rewritten** to return **HTTP 202 Accepted** with the request walked to `APPROVED`; a background coroutine (`process_intake_pipeline`) drives the adapter -> pipeline and reconciles the stored request to `TASK_CREATED` (or `CANCELLED` on intake rejection / pipeline failure). Terminal failures log ERROR + cancel the request as a fallback so a request can never silently hang in `APPROVED`. `AgentRuntimeNotConfiguredError` (409, taxonomy 4014) when no adapter / pipeline is wired (empty company).
- **New `simulations.intake_default_project` setting** (`read_only_post_init`, default `"client-intake"`); the project is created at boot if absent. One resolved value drives both the intake strategy's `project=` and the adapter's `WorkItem.project`, so the pipeline's project-existence check and the created task agree.
- **New `WsEventType.REQUEST_TASK_CREATED`** + matching `WsRequestTaskCreatedPayload`; the terminal hop now has a dedicated event (the intermediate `request.approved` still fires for the sync `APPROVED` walk).
- **`AppState.intake_entry_adapter` seam** (once-only set + has_ + swap, mirrors `work_pipeline`); boot wiring in `engine.pipeline.entry.boot.wire_real_intake_entry` is called from both `_install_runtime_services` and the post-setup `_rebuild_runtime_services`.
- **Manifest discipline (hard EPIC criterion)**: `scripts/_ghost_wiring_manifest.txt` now has `ENFORCED` lines for `DirectIntake`, `AgentIntake`, `IntakeEntryAdapter`, `build_work_entry_adapter`. The `no-ghost-wiring` gate passes.
- **Docs**: `docs/design/client-simulation.md` documents the real work-entry path + the new setting + the new factory row; `docs/design/verification-quality.md` banner updated (intake engine online); `docs/design/page-structure.md` URL routing map gains the `/clients` / `/clients/requests` / `/clients/simulations` / `/clients/reviews/:taskId` / `/clients/:clientId` routes.
- **Frontend**: regenerated `web/src/api/types/openapi.gen.ts` for the 202 status, added `'request.task_created'` to `websocket.ts`, updated the MSW approve mock to return 202.

## Tests

- New unit tests: `tests/unit/engine/pipeline/entry/{test_intake_adapter,test_factory,test_boot}.py`, `tests/unit/api/controllers/test_requests_intake_pipeline.py` (success / WorkIntakeRejected / WorkPipelineError / concurrent-terminal / MemoryError re-raise), `tests/unit/api/test_state.py` adapter seam, `tests/unit/client/test_runtime_builder.py` default-project threading + `intake_default_project` env override, `tests/unit/settings/test_intake_settings.py`.
- New integration tests in `tests/integration/api/controllers/test_client_simulation.py`: approve returns 202 + spawns the pipeline task; approve without an adapter returns 409.
- New e2e `tests/e2e/test_real_intake_entry_e2e.py`: builds the production runtime via `build_runtime_services` + `ScriptedDriver` + `DirectIntake`, drives `process_intake_pipeline`, asserts request reaches `TASK_CREATED` and the task is past `CREATED` (proof an agent ran). A second case covers a scoped request with reviewer notes.

Validation run on this branch: 29468 unit tests pass (full suite), 3183 web unit tests pass; e2e + the new integration suite pass under the simulation-harness substrate (zero real LLM spend).

## Pre-PR review

Reviewed by 10 core agents (python-reviewer, security-reviewer, async-concurrency-reviewer, conventions-enforcer, test-quality-reviewer, api-contract-drift, silent-failure-hunter, issue-resolution-verifier, comment-quality-rot, docs-consistency). All valid findings implemented:

- Wrapped `process_intake_pipeline`'s terminal reconciliation in `_safe_finalize` so a reconcile failure can never leave a request stuck in `APPROVED`: ERROR with `request_id` + fallback `CANCELLED`, with `release_request_lock_if_idle` in `finally`.
- Hardened `_ensure_project` to tolerate a `DuplicateRecordError` race (post-setup reinit) and log ERROR with project id on any other create failure.
- Explicit `except asyncio.CancelledError: raise` ahead of the broad handler.
- `_current_if_approved` vanished-request now logs ERROR (invariant break, not a routine warning).
- `_ensure_project(project_id: NotBlankStr)` and a comment on `_spawn_intake_pipeline` documenting why a detached task (not `TaskGroup`) is correct for the 202-return contract.
- Added the dedicated `request.task_created` WS event (+ `WsRequestTaskCreatedPayload`) so terminal-hop semantics are no longer multiplexed onto `request.approved`.
- Doc fixes: `verification-quality.md` banner, `client-simulation.md` settings enumeration + factory table, `page-structure.md` routing map.

Agent claims that the project-wide `except A, B:` (PEP 758 / Python 3.14) syntax was a "Python 3 syntax error" were rejected with primary-source evidence (ruff, mypy, the full 29468-test unit suite, and all 73 pre-push gates pass; the pattern is pre-existing in `pipeline/service.py` and `simulations.py`).