### PR TITLE
feat: self-extending toolkit (#1995)

### DIFF
--- a/docs/design/self-improvement.md
+++ b/docs/design/self-improvement.md
@@ -57,6 +57,20 @@ src/synthorg/meta/
     prompt_tuning.py   -- Org-wide constitutional principles
     code_modification.py -- Framework code changes (LLM-generated)
 
+  toolsmith/           -- Self-extending toolkit (TOOL_CREATION altitude)
+    models.py          -- ToolBlueprint, ToolBlueprintState, CapabilityGap, ToolValidationResult
+    config.py          -- ToolsmithConfig (enabled, gap thresholds, allowlists, sandbox, validation)
+    protocol.py        -- CapabilityGapStore, ToolBlueprintGenerator, ToolValidationGate, overflow handler
+    gap_store.py       -- RingBufferCapabilityGapStore (recurrence aggregation)
+    strategy.py        -- LLMToolBlueprintGenerator (LLM authors a sandbox tool)
+    dynamic_registry.py -- DynamicToolRegistry + LayeredToolRegistry/HandlerMap (runtime registration)
+    script_handler.py  -- Per-tool closure handler (runs script_body in the sandbox)
+    validation_gate.py -- BenchmarkToolValidationGate (per-tool brief + golden delta)
+    applier.py         -- ToolCreationApplier (validate, persist, register, retire)
+    service.py         -- ToolsmithService (orchestration + gap sink seam)
+    overflow.py        -- CodeModificationOverflowHandler (service-access gap routing)
+    factory.py         -- build_toolsmith wiring
+
   signals/             -- Signal aggregation from existing subsystems
     performance.py     -- PerformanceTracker wrapper
     budget.py          -- Budget analytics wrapper
@@ -148,7 +162,7 @@ src/synthorg/meta/
 | Meta-analyst | Interactive Chief of Staff agent | Company metaphor, conversational UX, evolvable via #243 |
 | Signal access | MCP tools | First slice of API-as-MCP; agents use native tool interface |
 | Proposal generation | Rule-first hybrid | Rules detect (cheap, auditable); LLM synthesizes (creative, scoped) |
-| Altitudes | Config + Architecture + Prompt + Code | All pluggable, config enabled by default, others opt-in |
+| Altitudes | Config + Architecture + Prompt + Code + Tool Creation | All pluggable, config enabled by default, others opt-in |
 | Scope | Deployment + product level | Code modification altitude for framework improvements |
 | Rollout | Before/after default, canary + A/B test opt-in | Per-proposal choice; A/B uses group assignment + statistical comparison |
 | Regression | Tiered: threshold + statistical | Layer 1 for catastrophic, Layer 2 for subtle degradation |
@@ -232,6 +246,7 @@ self_improvement:
   architecture_proposals_enabled: false  # Structural changes (opt-in)
   prompt_tuning_enabled: false      # Prompt policies (opt-in)
   code_modification_enabled: false  # Framework code changes (opt-in)
+  tool_creation_enabled: false      # Self-extending toolkit (opt-in)
   chief_of_staff:
     # Clarify-and-propose (POST /meta/chat/propose). All opt-in.
     propose_enabled: false                   # Master switch

--- a/docs/design/tools.md
+++ b/docs/design/tools.md
@@ -430,6 +430,52 @@ non-whitespace string via `"minLength": 1` + `"pattern": r".*\S.*"`, and the
 guardrails run regardless so validation stays uniform once services come
 online.
 
+## Self-Extending Toolkit
+
+A fixed toolset caps what the studio can build. The **toolsmith**
+(`src/synthorg/meta/toolsmith/`) lets the organisation extend its own MCP tool
+surface at runtime when it hits a recurring capability gap, governed end to end.
+
+**Detection.** Every unfulfilled capability request is recorded into a
+ring-buffered `CapabilityGapStore` (the `ToolsmithService` is the sink). When a
+capability signature (`domain:action`) recurs at least
+`gap_recurrence_threshold` times within `gap_window_hours`, it qualifies as a
+recurring gap.
+
+**Authoring.** `LLMToolBlueprintGenerator` authors a `ToolBlueprint` from the
+gap: a declarative spec (name, capability, JSON Schema, action type) plus a
+self-contained Python `script_body`. The tool name is derived from the
+capability so it always satisfies the `synthorg_{domain}_{action}` contract;
+the sandbox backend and network policy come from config, never the model, so an
+authored tool cannot widen its own isolation. Capabilities that need
+service-layer access (configured via `service_access_capabilities`) cannot be a
+sandbox script and route to the `CODE_MODIFICATION` overflow handler instead.
+
+**Governance.** Tool creation runs at the `TOOL_CREATION` proposal altitude
+behind the same guard chain as self-improvement (scope, rollback plan, rate
+limit, mandatory approval). The `tool:create` action type is HIGH risk and
+human-gated under `supervised` and `semi` autonomy. Nothing is trusted without
+human approval.
+
+**Validation.** On approval, `ToolCreationApplier` runs the
+`BenchmarkToolValidationGate`: a focused per-tool acceptance brief (the authored
+script actually runs in its resolved sandbox and must return structured output)
+followed by a golden-company scorecard delta (registering the candidate must not
+regress the benchmark). A failing gate registers nothing; the blueprint keeps
+its validation record for audit but never goes `ACTIVE`.
+
+**Live registration.** A validated blueprint is persisted
+(PENDING -> VALIDATED -> ACTIVE; RETIRED on rollback) and registered into the
+mutable `DynamicToolRegistry`. The static `DomainToolRegistry` stays frozen; a
+`LayeredToolRegistry` reads the static surface first then the dynamic layer, so
+`MCPToolInvoker` dispatches authored tools (validating arguments against a
+Pydantic args model materialised from the blueprint's JSON Schema) without
+unfreezing anything. A later task invokes the new tool exactly like a built-in.
+
+The toolsmith is disabled by default (`meta.self_improvement` ->
+`tool_creation_enabled`); it wires at boot only when enabled, a provider is
+registered, and persistence is connected.
+
 ## Progressive Tool Disclosure
 
 When the tool inventory exceeds ~30 tools, loading every full definition into the LLM
@@ -484,7 +530,7 @@ in `human_approval` list silently meaning "skip approval" is a critical safety c
 actions in that category (e.g., `auto_approve: ["code"]` expands to all `code:*` actions).
 Fine-grained overrides are supported (e.g., `human_approval: ["code:create"]`).
 
-**Taxonomy (38 leaf types):**
+**Taxonomy (39 leaf types):**
 
 ```text
 code:read, code:write, code:create, code:delete, code:refactor
@@ -497,6 +543,7 @@ budget:spend, budget:exceed
 org:hire, org:fire, org:promote
 db:query, db:mutate, db:admin
 arch:decide
+tool:create
 memory:read
 browser:navigate, browser:screenshot, browser:diff, browser:accessibility_scan, browser:spec
 external_data:request

--- a/docs/design/tools.md
+++ b/docs/design/tools.md
@@ -521,7 +521,7 @@ Action types classify agent actions for use by autonomy presets (see [Security &
 SecOps validation, tiered timeout policies, and progressive trust
 ([Decision Log](../architecture/decisions.md) D1).
 
-**Registry:** `StrEnum` for ~32 built-in action types (type safety, autocomplete, typos caught
+**Registry:** `StrEnum` for ~39 built-in action types (type safety, autocomplete, typos caught
 by static type checking and config-load-time validation) + `ActionTypeRegistry` for custom
 types via explicit registration. Unknown strings are rejected at config load time; a typo
 in `human_approval` list silently meaning "skip approval" is a critical safety concern.

--- a/docs/design/tools.md
+++ b/docs/design/tools.md
@@ -521,7 +521,7 @@ Action types classify agent actions for use by autonomy presets (see [Security &
 SecOps validation, tiered timeout policies, and progressive trust
 ([Decision Log](../architecture/decisions.md) D1).
 
-**Registry:** `StrEnum` for ~39 built-in action types (type safety, autocomplete, typos caught
+**Registry:** `StrEnum` for ~41 built-in action types (type safety, autocomplete, typos caught
 by static type checking and config-load-time validation) + `ActionTypeRegistry` for custom
 types via explicit registration. Unknown strings are rejected at config load time; a typo
 in `human_approval` list silently meaning "skip approval" is a critical safety concern.
@@ -530,7 +530,7 @@ in `human_approval` list silently meaning "skip approval" is a critical safety c
 actions in that category (e.g., `auto_approve: ["code"]` expands to all `code:*` actions).
 Fine-grained overrides are supported (e.g., `human_approval: ["code:create"]`).
 
-**Taxonomy (39 leaf types):**
+**Taxonomy (41 leaf types):**
 
 ```text
 code:read, code:write, code:create, code:delete, code:refactor
@@ -545,6 +545,7 @@ db:query, db:mutate, db:admin
 arch:decide
 tool:create
 memory:read
+knowledge:ingest, knowledge:reindex
 browser:navigate, browser:screenshot, browser:diff, browser:accessibility_scan, browser:spec
 external_data:request
 desktop:launch, desktop:click, desktop:type, desktop:key, desktop:screenshot, desktop:scroll

--- a/scripts/_ghost_wiring_manifest.txt
+++ b/scripts/_ghost_wiring_manifest.txt
@@ -81,3 +81,12 @@ ENFORCED KnowledgeRetriever #1988 -- constructed inside knowledge/factory.py::bu
 ENFORCED build_knowledge_tool_factory #1988 -- called in api/app.py::_wire_knowledge_engine; per-task source of SearchKnowledgeTool + IngestKnowledgeTool
 ENFORCED SearchKnowledgeTool #1988 -- constructed by knowledge/tool_factory.py::KnowledgeToolFactory.build_tools per task with the agent's project binding
 ENFORCED IngestKnowledgeTool #1988 -- constructed by knowledge/tool_factory.py::KnowledgeToolFactory.build_tools per task with the agent's project binding
+ENFORCED build_toolsmith #1995 -- called by api/app.py::_build_toolsmith_runtime behind tool_creation_enabled + provider switch; wires the self-extending toolkit runtime
+ENFORCED ToolsmithService #1995 -- constructed by meta/toolsmith/factory.py::build_toolsmith; orchestrates gap detection -> author -> guard -> apply at the TOOL_CREATION altitude
+ENFORCED RingBufferCapabilityGapStore #1995 -- constructed by meta/toolsmith/factory.py::build_toolsmith; ring-buffered capability-gap sink + recurrence detector
+ENFORCED LLMToolBlueprintGenerator #1995 -- constructed by meta/toolsmith/factory.py::build_toolsmith; authors a sandbox-tool blueprint from a recurring gap
+ENFORCED BenchmarkToolValidationGate #1995 -- constructed by meta/toolsmith/factory.py::build_toolsmith; per-tool acceptance brief + golden scorecard delta gate
+ENFORCED SandboxBriefRunner #1995 -- constructed by meta/toolsmith/factory.py::build_toolsmith; runs the authored tool in its resolved sandbox for the acceptance brief
+ENFORCED ToolCreationApplier #1995 -- constructed by meta/toolsmith/factory.py::build_toolsmith; validates then live-registers an approved blueprint, retires on rollback
+ENFORCED DynamicToolRegistry #1995 -- constructed by meta/toolsmith/factory.py::build_toolsmith; mutable live authored-tool registry read behind the static surface
+ENFORCED install_dynamic_tool_layer #1995 -- called by api/app.py::_wire_toolsmith; layers the dynamic registry into the live MCP invoker so authored tools dispatch

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -150,7 +150,12 @@ if TYPE_CHECKING:
     from litestar.channels import ChannelsPlugin
 
     from synthorg.client.simulation_state import ClientSimulationState
+    from synthorg.meta.config import SelfImprovementConfig
+    from synthorg.meta.toolsmith.factory import ToolsmithRuntime
+    from synthorg.meta.toolsmith.models import ToolBlueprint
+    from synthorg.persistence.tool_blueprint_protocol import DynamicToolRepository
     from synthorg.settings.service import SettingsService
+    from synthorg.tools.sandbox.protocol import SandboxBackend
 
 logger = get_logger(__name__)
 
@@ -290,6 +295,79 @@ def _try_wire_cost_dial(app_state: AppState) -> None:
             error_type=type(exc).__name__,
             error=safe_error_description(exc),
         )
+
+
+def _build_dynamic_tool_repo(
+    persistence: PersistenceBackend,
+) -> DynamicToolRepository:
+    """Build the backend-specific authored-tool blueprint repository."""
+    if persistence.backend_name == "sqlite":
+        from synthorg.persistence.sqlite.tool_blueprint_repo import (  # noqa: PLC0415
+            SQLiteDynamicToolRepository,
+        )
+
+        return SQLiteDynamicToolRepository(
+            persistence.get_db(),
+            write_context=persistence.write_context,
+        )
+    from synthorg.persistence.postgres.tool_blueprint_repo import (  # noqa: PLC0415
+        PostgresDynamicToolRepository,
+    )
+
+    return PostgresDynamicToolRepository(persistence.get_db())
+
+
+def _build_toolsmith_runtime(
+    *,
+    si_config: SelfImprovementConfig,
+    provider_registry: ProviderRegistry,
+    persistence: PersistenceBackend,
+    approval_store: ApprovalStoreProtocol | None,
+    cost_tracker: CostTracker | None,
+) -> ToolsmithRuntime | None:
+    """Resolve dependencies and build the toolsmith runtime, or None.
+
+    Returns ``None`` when no provider is registered (nothing to author
+    with). The sandbox resolver maps each blueprint's declared backend to
+    a concrete sandbox built from the default sandboxing config, so a
+    Docker-declared authored tool runs under Docker and a subprocess one
+    under subprocess. The golden-scorecard provider is intentionally
+    absent here: until #1980 exposes a runnable score-with-candidate API,
+    the validation gate fails closed (a missing provider rejects the
+    apply) rather than trusting an unvalidated tool.
+    """
+    from pathlib import Path  # noqa: PLC0415
+
+    from synthorg.meta.toolsmith.factory import build_toolsmith  # noqa: PLC0415
+    from synthorg.tools.sandbox.factory import (  # noqa: PLC0415
+        build_sandbox_backends,
+    )
+    from synthorg.tools.sandbox.sandboxing_config import (  # noqa: PLC0415
+        SandboxingConfig,
+    )
+
+    provider_names = provider_registry.list_providers()
+    if not provider_names:
+        return None
+    provider = provider_registry.get(provider_names[0])
+    repo = _build_dynamic_tool_repo(persistence)
+
+    sandboxing = SandboxingConfig()
+    backends = build_sandbox_backends(config=sandboxing, workspace=Path.cwd())
+
+    def _resolve_sandbox(blueprint: ToolBlueprint) -> SandboxBackend:
+        return backends.get(
+            blueprint.sandbox_backend.value, backends[sandboxing.default_backend]
+        )
+
+    return build_toolsmith(
+        si_config=si_config,
+        provider=provider,
+        repo=repo,
+        sandbox_resolver=_resolve_sandbox,
+        approval_store=approval_store,
+        cost_tracker=cost_tracker,
+    )
 
 
 def _build_default_approval_timeout_scheduler(
@@ -1461,6 +1539,54 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
             app_state.set_chief_of_staff_proposer(proposer)
 
     startup = [*startup, _wire_chief_of_staff_proposer]
+
+    async def _wire_toolsmith() -> None:
+        # Self-extending toolkit (#1995). Wired only when
+        # ``tool_creation_enabled`` is set AND a provider is registered
+        # AND persistence is connected (authored blueprints are durable).
+        # Disabled by default, so a normal boot skips this entirely.
+        # Idempotent for re-entered lifespans (shared-app fixtures).
+        if app_state.toolsmith_service is not None or provider_registry is None:
+            return
+        if persistence is None or not app_state.has_persistence:
+            return
+        from synthorg.meta.config import load_self_improvement_config  # noqa: PLC0415
+
+        si_config = await load_self_improvement_config(
+            app_state.settings_service if app_state.has_settings_service else None,
+        )
+        if not si_config.tool_creation_enabled:
+            return
+        try:
+            runtime = _build_toolsmith_runtime(
+                si_config=si_config,
+                provider_registry=provider_registry,
+                persistence=persistence,
+                approval_store=effective_approval_store,
+                cost_tracker=cost_tracker,
+            )
+        except MemoryError, RecursionError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                API_APP_STARTUP,
+                service="toolsmith",
+                note="toolsmith wiring failed; self-extending toolkit disabled",
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            return
+        if runtime is None:
+            return
+        app_state.set_toolsmith_service(runtime.service)
+        from synthorg.meta.mcp.server import (  # noqa: PLC0415
+            install_dynamic_tool_layer,
+        )
+
+        install_dynamic_tool_layer(runtime.dynamic_registry)
+        logger.info(API_APP_STARTUP, service="toolsmith", note="wired")
+
+    startup = [*startup, _wire_toolsmith]
 
     # Bring up the notification dispatcher's HTTP-bearing sinks
     # (slack/ntfy ``httpx.AsyncClient``) lazily under their lifecycle

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -332,9 +332,9 @@ def _build_toolsmith_runtime(
     a concrete sandbox built from the default sandboxing config, so a
     Docker-declared authored tool runs under Docker and a subprocess one
     under subprocess. The golden-scorecard provider is intentionally
-    absent here: until #1980 exposes a runnable score-with-candidate API,
-    the validation gate fails closed (a missing provider rejects the
-    apply) rather than trusting an unvalidated tool.
+    absent here: until a runnable score-with-candidate benchmark API is
+    available, the validation gate fails closed (a missing provider
+    rejects the apply) rather than trusting an unvalidated tool.
     """
     from pathlib import Path  # noqa: PLC0415
 
@@ -1541,7 +1541,7 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
     startup = [*startup, _wire_chief_of_staff_proposer]
 
     async def _wire_toolsmith() -> None:
-        # Self-extending toolkit (#1995). Wired only when
+        # Self-extending toolkit. Wired only when
         # ``tool_creation_enabled`` is set AND a provider is registered
         # AND persistence is connected (authored blueprints are durable).
         # Disabled by default, so a normal boot skips this entirely.

--- a/src/synthorg/api/app.py
+++ b/src/synthorg/api/app.py
@@ -317,13 +317,14 @@ def _build_dynamic_tool_repo(
     return PostgresDynamicToolRepository(persistence.get_db())
 
 
-def _build_toolsmith_runtime(
+def _build_toolsmith_runtime(  # noqa: PLR0913 -- explicit DI of the toolsmith runtime dependencies
     *,
     si_config: SelfImprovementConfig,
     provider_registry: ProviderRegistry,
     persistence: PersistenceBackend,
     approval_store: ApprovalStoreProtocol | None,
     cost_tracker: CostTracker | None,
+    workspace_root: Path,
 ) -> ToolsmithRuntime | None:
     """Resolve dependencies and build the toolsmith runtime, or None.
 
@@ -331,13 +332,15 @@ def _build_toolsmith_runtime(
     with). The sandbox resolver maps each blueprint's declared backend to
     a concrete sandbox built from the default sandboxing config, so a
     Docker-declared authored tool runs under Docker and a subprocess one
-    under subprocess. The golden-scorecard provider is intentionally
-    absent here: until a runnable score-with-candidate benchmark API is
-    available, the validation gate fails closed (a missing provider
-    rejects the apply) rather than trusting an unvalidated tool.
+    under subprocess. The sandbox workspace pins to the app's resolved
+    workspace root (the same root the project-workspace service uses) so
+    authored tools and the rest of the runtime share one writable mount
+    instead of diverging on the process CWD. The golden-scorecard
+    provider is intentionally absent here: until a runnable
+    score-with-candidate benchmark API is available, the validation gate
+    fails closed (a missing provider rejects the apply) rather than
+    trusting an unvalidated tool.
     """
-    from pathlib import Path  # noqa: PLC0415
-
     from synthorg.meta.toolsmith.factory import build_toolsmith  # noqa: PLC0415
     from synthorg.tools.sandbox.factory import (  # noqa: PLC0415
         build_sandbox_backends,
@@ -353,7 +356,7 @@ def _build_toolsmith_runtime(
     repo = _build_dynamic_tool_repo(persistence)
 
     sandboxing = SandboxingConfig()
-    backends = build_sandbox_backends(config=sandboxing, workspace=Path.cwd())
+    backends = build_sandbox_backends(config=sandboxing, workspace=workspace_root)
 
     def _resolve_sandbox(blueprint: ToolBlueprint) -> SandboxBackend:
         return backends.get(
@@ -1564,6 +1567,7 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
                 persistence=persistence,
                 approval_store=effective_approval_store,
                 cost_tracker=cost_tracker,
+                workspace_root=app_state.agent_workspace_root,
             )
         except MemoryError, RecursionError:
             raise
@@ -1578,12 +1582,30 @@ def create_app(  # noqa: C901, PLR0912, PLR0913, PLR0915
             return
         if runtime is None:
             return
-        app_state.set_toolsmith_service(runtime.service)
+        # Install the layered MCP surface BEFORE the once-only AppState
+        # mutation. ``set_toolsmith_service`` cannot be replayed on
+        # retry, so if the layer install fails after the AppState mutation
+        # the runtime is left half-wired (service present, layer missing)
+        # with no path back. Installing first means a failure here leaves
+        # the toolsmith disabled cleanly, mirroring the upstream try/except.
         from synthorg.meta.mcp.server import (  # noqa: PLC0415
             install_dynamic_tool_layer,
         )
 
-        install_dynamic_tool_layer(runtime.dynamic_registry)
+        try:
+            install_dynamic_tool_layer(runtime.dynamic_registry)
+        except MemoryError, RecursionError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                API_APP_STARTUP,
+                service="toolsmith",
+                note="toolsmith dynamic layer install failed; disabled",
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            return
+        app_state.set_toolsmith_service(runtime.service)
         logger.info(API_APP_STARTUP, service="toolsmith", note="wired")
 
     startup = [*startup, _wire_toolsmith]

--- a/src/synthorg/api/state.py
+++ b/src/synthorg/api/state.py
@@ -176,6 +176,7 @@ if TYPE_CHECKING:
     from synthorg.integrations.tunnel.protocol import TunnelProvider
     from synthorg.knowledge.service import KnowledgeService
     from synthorg.knowledge.tool_factory import KnowledgeToolFactory
+    from synthorg.meta.toolsmith.service import ToolsmithService
 
     # Imported under TYPE_CHECKING so the optional ``synthorg[distributed]``
     # extra is not required at runtime for deployments that do not use the
@@ -335,6 +336,7 @@ class AppState(AppStateServicesMixin):
         "_template_pack_facade_service",
         "_ticket_store",
         "_tool_invocation_tracker",
+        "_toolsmith_service",
         "_trace_handler",
         "_training_plan_service",
         "_training_service",
@@ -628,6 +630,7 @@ class AppState(AppStateServicesMixin):
         )
         self._review_gate_service: ReviewGateService | None = None
         self._scaling_service: ScalingService | None = None
+        self._toolsmith_service: ToolsmithService | None = None
         self._init_facade_service_slots()
         self._client_simulation_state: ClientSimulationState | None = None
         self._approval_timeout_scheduler: ApprovalTimeoutScheduler | None = None
@@ -1294,6 +1297,15 @@ class AppState(AppStateServicesMixin):
     def set_review_gate_service(self, service: ReviewGateService) -> None:
         """Attach the review gate service (once-only)."""
         self._set_once("_review_gate_service", service, "Review gate service")
+
+    @property
+    def toolsmith_service(self) -> ToolsmithService | None:
+        """Return the self-extending-toolkit service, or None if not wired."""
+        return self._toolsmith_service
+
+    def set_toolsmith_service(self, service: ToolsmithService) -> None:
+        """Attach the toolsmith service (once-only)."""
+        self._set_once("_toolsmith_service", service, "Toolsmith service")
 
     @property
     def scaling_service(self) -> ScalingService | None:

--- a/src/synthorg/core/enums.py
+++ b/src/synthorg/core/enums.py
@@ -623,6 +623,7 @@ class ActionType(StrEnum):
     DB_MUTATE = "db:mutate"
     DB_ADMIN = "db:admin"
     ARCH_DECIDE = "arch:decide"
+    TOOL_CREATE = "tool:create"
     MEMORY_READ = "memory:read"
     KNOWLEDGE_INGEST = "knowledge:ingest"
     KNOWLEDGE_REINDEX = "knowledge:reindex"

--- a/src/synthorg/meta/config.py
+++ b/src/synthorg/meta/config.py
@@ -320,6 +320,21 @@ class SelfImprovementConfig(BaseModel):
     analysis_max_tokens: int = Field(default=4000, ge=100)
 
     @model_validator(mode="after")
+    def _validate_tool_creation_flags(self) -> Self:
+        """Keep the two tool-creation switches coherent.
+
+        ``tool_creation_enabled`` gates the boot wiring and scope guard,
+        while ``toolsmith.enabled`` gates the toolsmith's own
+        allowlist-consistency check. They must agree, otherwise an
+        operator can enable one and silently leave the subsystem off (or
+        configure an allowlist that never runs).
+        """
+        if self.tool_creation_enabled != self.toolsmith.enabled:
+            msg = "tool_creation_enabled and toolsmith.enabled must match"
+            raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
     def _validate_code_modification_requirements(self) -> Self:
         """Require GitHub settings when code modification is enabled."""
         if not self.code_modification_enabled:

--- a/src/synthorg/meta/config.py
+++ b/src/synthorg/meta/config.py
@@ -260,6 +260,7 @@ class SelfImprovementConfig(BaseModel):
         architecture_proposals_enabled: Enable architecture proposals.
         prompt_tuning_enabled: Enable prompt tuning proposals.
         code_modification_enabled: Enable code modification proposals.
+        tool_creation_enabled: Enable self-extending toolkit proposals.
         schedule: Cycle scheduling configuration.
         rollout: Rollout behavior configuration.
         regression: Regression detection thresholds.
@@ -271,6 +272,8 @@ class SelfImprovementConfig(BaseModel):
             (learning, alerts, chat).
         cross_deployment_analytics: Cross-deployment analytics
             telemetry (opt-in, disabled by default).
+        toolsmith: Self-extending toolkit configuration
+            (gap thresholds, sandbox policy, validation).
         analysis_model: LLM model identifier for proposal analysis.
         analysis_temperature: Sampling temperature for analysis.
         analysis_max_tokens: Token budget for analysis responses.

--- a/src/synthorg/meta/config.py
+++ b/src/synthorg/meta/config.py
@@ -13,6 +13,7 @@ from synthorg.core.types import NotBlankStr
 from synthorg.meta.chief_of_staff.config import ChiefOfStaffConfig
 from synthorg.meta.models import EvolutionMode, RolloutStrategyType
 from synthorg.meta.telemetry.config import CrossDeploymentAnalyticsConfig
+from synthorg.meta.toolsmith.config import ToolsmithConfig
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.meta import META_SELF_IMPROVEMENT_LOAD_FAILED
 
@@ -284,6 +285,7 @@ class SelfImprovementConfig(BaseModel):
     architecture_proposals_enabled: bool = False
     prompt_tuning_enabled: bool = False
     code_modification_enabled: bool = False
+    tool_creation_enabled: bool = False
 
     schedule: ScheduleConfig = Field(default_factory=ScheduleConfig)
     rollout: RolloutConfig = Field(default_factory=RolloutConfig)
@@ -304,6 +306,8 @@ class SelfImprovementConfig(BaseModel):
     cross_deployment_analytics: CrossDeploymentAnalyticsConfig = Field(
         default_factory=CrossDeploymentAnalyticsConfig,
     )
+
+    toolsmith: ToolsmithConfig = Field(default_factory=ToolsmithConfig)
 
     analysis_model: NotBlankStr = Field(
         default=NotBlankStr("example-small-001"),

--- a/src/synthorg/meta/guards/approval_gate.py
+++ b/src/synthorg/meta/guards/approval_gate.py
@@ -38,6 +38,7 @@ _ALTITUDE_RISK: dict[ProposalAltitude, ApprovalRiskLevel] = {
     ProposalAltitude.ARCHITECTURE: ApprovalRiskLevel.HIGH,
     ProposalAltitude.PROMPT_TUNING: ApprovalRiskLevel.MEDIUM,
     ProposalAltitude.CODE_MODIFICATION: ApprovalRiskLevel.CRITICAL,
+    ProposalAltitude.TOOL_CREATION: ApprovalRiskLevel.HIGH,
 }
 
 _DEFAULT_EXPIRY_DAYS: Final[int] = 7

--- a/src/synthorg/meta/guards/scope_check.py
+++ b/src/synthorg/meta/guards/scope_check.py
@@ -91,5 +91,7 @@ class ScopeCheckGuard:
                 return self._config.prompt_tuning_enabled
             case ProposalAltitude.CODE_MODIFICATION:
                 return self._config.code_modification_enabled
+            case ProposalAltitude.TOOL_CREATION:
+                return self._config.tool_creation_enabled
             case _:
                 return False  # type: ignore[unreachable]

--- a/src/synthorg/meta/mcp/invoker.py
+++ b/src/synthorg/meta/mcp/invoker.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from synthorg.core.agent import AgentIdentity
-    from synthorg.meta.mcp.registry import DomainToolRegistry
+    from synthorg.meta.mcp.registry import ToolDefReader
 
 logger = get_logger(__name__)
 
@@ -54,13 +54,17 @@ class MCPToolInvoker:
     to ``ToolExecutionResult`` with ``is_error=True``.
 
     Args:
-        registry: Domain tool registry for handler key lookup.
-        handlers: Mapping of handler keys to handler functions.
+        registry: Tool definition reader for handler key lookup. The
+            frozen :class:`DomainToolRegistry` and the toolsmith's
+            ``LayeredToolRegistry`` (static + dynamic) both satisfy it.
+        handlers: Mapping of handler keys to handler functions. A
+            ``LayeredHandlerMap`` lets authored-tool handlers dispatch
+            alongside the static handler map.
     """
 
     def __init__(
         self,
-        registry: DomainToolRegistry,
+        registry: ToolDefReader,
         handlers: Mapping[str, ToolHandler],
     ) -> None:
         self._registry = registry

--- a/src/synthorg/meta/mcp/registry.py
+++ b/src/synthorg/meta/mcp/registry.py
@@ -8,7 +8,7 @@ with freeze-on-read semantics.
 import re
 from copy import deepcopy
 from types import MappingProxyType
-from typing import Any, Self
+from typing import Any, Protocol, Self, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -21,6 +21,25 @@ from synthorg.observability.events.mcp import (
 )
 
 logger = get_logger(__name__)
+
+
+@runtime_checkable
+class ToolDefReader(Protocol):
+    """Read surface the :class:`MCPToolInvoker` needs from a registry.
+
+    :class:`DomainToolRegistry` satisfies this structurally. The
+    toolsmith's ``LayeredToolRegistry`` also implements it by composing
+    the frozen static registry with a mutable dynamic layer, so authored
+    tools can be dispatched without unfreezing the static surface.
+    """
+
+    def get(self, name: str) -> MCPToolDef:
+        """Look up a tool definition by name (raises ``KeyError`` if absent)."""
+        ...
+
+    def get_names(self) -> tuple[str, ...]:
+        """Return all known tool names."""
+        ...
 
 
 class MCPToolDef(BaseModel):

--- a/src/synthorg/meta/mcp/server.py
+++ b/src/synthorg/meta/mcp/server.py
@@ -15,6 +15,7 @@ from synthorg.observability import get_logger
 
 if TYPE_CHECKING:
     from synthorg.meta.mcp.registry import DomainToolRegistry
+    from synthorg.meta.toolsmith.dynamic_registry import DynamicToolRegistry
 
 logger = get_logger(__name__)
 
@@ -36,6 +37,11 @@ TOOL_PREFIX = "synthorg"
 _registry: DomainToolRegistry | None = None
 _scoper: MCPToolScoper | None = None
 _invoker: MCPToolInvoker | None = None
+# Set by the toolsmith boot hook (install_dynamic_tool_layer). When
+# present, the invoker dispatches over the static surface layered with
+# the live authored-tool registry, so runtime-authored tools become
+# reachable without unfreezing the static registry.
+_dynamic_registry: DynamicToolRegistry | None = None
 
 
 def get_registry() -> DomainToolRegistry:
@@ -70,8 +76,32 @@ def get_invoker() -> MCPToolInvoker:
     """
     global _invoker  # noqa: PLW0603
     if _invoker is None:
-        _invoker = MCPToolInvoker(get_registry(), build_handler_map())
+        if _dynamic_registry is not None:
+            from synthorg.meta.toolsmith.dynamic_registry import (  # noqa: PLC0415
+                LayeredHandlerMap,
+                LayeredToolRegistry,
+            )
+
+            _invoker = MCPToolInvoker(
+                LayeredToolRegistry(get_registry(), _dynamic_registry),
+                LayeredHandlerMap(build_handler_map(), _dynamic_registry),
+            )
+        else:
+            _invoker = MCPToolInvoker(get_registry(), build_handler_map())
     return _invoker
+
+
+def install_dynamic_tool_layer(dynamic_registry: DynamicToolRegistry) -> None:
+    """Install the live authored-tool registry behind the static surface.
+
+    Called once by the toolsmith boot hook. Resets the cached invoker so
+    the next :func:`get_invoker` rebuilds over the layered registry; the
+    invoker then sees authored tools as they are registered into
+    ``dynamic_registry`` because the layered reader consults it live.
+    """
+    global _dynamic_registry, _invoker  # noqa: PLW0603
+    _dynamic_registry = dynamic_registry
+    _invoker = None
 
 
 def get_server_config() -> dict[str, object]:
@@ -99,7 +129,8 @@ def reset_singletons() -> None:
     This allows tests to rebuild the registry, scoper, and invoker
     without polluting other test runs.
     """
-    global _registry, _scoper, _invoker  # noqa: PLW0603
+    global _registry, _scoper, _invoker, _dynamic_registry  # noqa: PLW0603
     _registry = None
     _scoper = None
     _invoker = None
+    _dynamic_registry = None

--- a/src/synthorg/meta/models.py
+++ b/src/synthorg/meta/models.py
@@ -21,6 +21,7 @@ from pydantic import (
 )
 
 from synthorg.core.types import NotBlankStr
+from synthorg.meta.toolsmith.models import ToolBlueprint  # noqa: TC001 -- field type
 
 # ── Enums ──────────────────────────────────────────────────────────
 
@@ -32,6 +33,7 @@ class ProposalAltitude(StrEnum):
     ARCHITECTURE = "architecture"
     PROMPT_TUNING = "prompt_tuning"
     CODE_MODIFICATION = "code_modification"
+    TOOL_CREATION = "tool_creation"
 
 
 class ProposalStatus(StrEnum):
@@ -333,6 +335,7 @@ class ImprovementProposal(BaseModel):
     architecture_changes: tuple[ArchitectureChange, ...] = ()
     prompt_changes: tuple[PromptChange, ...] = ()
     code_changes: tuple[CodeChange, ...] = ()
+    tool_changes: tuple[ToolBlueprint, ...] = ()
     rollback_plan: RollbackPlan
     rollout_strategy: RolloutStrategyType = RolloutStrategyType.BEFORE_AFTER
     confidence: float = Field(ge=0.0, le=1.0)
@@ -370,11 +373,13 @@ class ImprovementProposal(BaseModel):
     def _validate_changes_match_altitude(self) -> Self:
         """Ensure only the declared altitude carries changes."""
         other_code = self.code_changes
+        tools = self.tool_changes
         if self.altitude == ProposalAltitude.CONFIG_TUNING and (
             not self.config_changes
             or self.architecture_changes
             or self.prompt_changes
             or other_code
+            or tools
         ):
             msg = "config_tuning proposals must contain only config_changes"
             raise ValueError(msg)
@@ -383,6 +388,7 @@ class ImprovementProposal(BaseModel):
             or self.config_changes
             or self.prompt_changes
             or other_code
+            or tools
         ):
             msg = "architecture proposals must contain only architecture_changes"
             raise ValueError(msg)
@@ -391,6 +397,7 @@ class ImprovementProposal(BaseModel):
             or self.config_changes
             or self.architecture_changes
             or other_code
+            or tools
         ):
             msg = "prompt_tuning proposals must contain only prompt_changes"
             raise ValueError(msg)
@@ -399,8 +406,18 @@ class ImprovementProposal(BaseModel):
             or self.config_changes
             or self.architecture_changes
             or self.prompt_changes
+            or tools
         ):
             msg = "code_modification proposals must contain only code_changes"
+            raise ValueError(msg)
+        if self.altitude == ProposalAltitude.TOOL_CREATION and (
+            not self.tool_changes
+            or self.config_changes
+            or self.architecture_changes
+            or self.prompt_changes
+            or other_code
+        ):
+            msg = "tool_creation proposals must contain only tool_changes"
             raise ValueError(msg)
         return self
 
@@ -413,6 +430,7 @@ class ImprovementProposal(BaseModel):
             + len(self.architecture_changes)
             + len(self.prompt_changes)
             + len(self.code_changes)
+            + len(self.tool_changes)
         )
 
 

--- a/src/synthorg/meta/signals/service.py
+++ b/src/synthorg/meta/signals/service.py
@@ -310,6 +310,8 @@ def _risk_from_altitude(proposal: ImprovementProposal) -> ApprovalRiskLevel:
     altitude = proposal.altitude
     if altitude is ProposalAltitude.CODE_MODIFICATION:
         return ApprovalRiskLevel.HIGH
+    if altitude is ProposalAltitude.TOOL_CREATION:
+        return ApprovalRiskLevel.HIGH
     if altitude is ProposalAltitude.ARCHITECTURE:
         return ApprovalRiskLevel.MEDIUM
     if altitude is ProposalAltitude.PROMPT_TUNING:

--- a/src/synthorg/meta/strategies/code_modification.py
+++ b/src/synthorg/meta/strategies/code_modification.py
@@ -176,7 +176,17 @@ class CodeModificationStrategy:
 
         try:
             response = await self._call_llm(prompt)
-        except ProviderError:
+        except ProviderError as exc:
+            # Surface provider-wide failures with the same WARN shape as
+            # the local-error branch before propagating, so the loss path
+            # is observable end-to-end (provider tier + rule tier).
+            logger.warning(
+                META_CODE_GEN_FAILED,
+                rule=rule_match.rule_name,
+                reason="provider_error",
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
             raise
         except MemoryError, RecursionError:
             raise

--- a/src/synthorg/meta/strategies/code_modification.py
+++ b/src/synthorg/meta/strategies/code_modification.py
@@ -40,6 +40,7 @@ from synthorg.observability.events.meta import (
     META_PROPOSAL_GENERATED,
 )
 from synthorg.providers.cost_recording import cost_recording_scope
+from synthorg.providers.errors import ProviderError
 
 if TYPE_CHECKING:
     from synthorg.budget.tracker import CostTracker
@@ -175,6 +176,8 @@ class CodeModificationStrategy:
 
         try:
             response = await self._call_llm(prompt)
+        except ProviderError:
+            raise
         except MemoryError, RecursionError:
             raise
         except Exception as exc:

--- a/src/synthorg/meta/toolsmith/__init__.py
+++ b/src/synthorg/meta/toolsmith/__init__.py
@@ -1,0 +1,26 @@
+"""Self-extending toolkit (toolsmith) meta-subsystem.
+
+The toolsmith lets the organisation extend its own MCP tool surface at
+runtime: it detects a recurring capability gap, authors a sandboxed tool
+following the existing ``ToolHandler`` + ``args_model`` contract, validates
+the candidate against the golden benchmark before trusting it, and on pass
+plus human approval registers it permanently so a later task can use it.
+
+Tool creation is governed: it runs at the ``TOOL_CREATION`` proposal
+altitude, behind the autonomy gate and the mandatory approval queue, exactly
+like the self-improvement code-modification flow.
+"""
+
+from synthorg.meta.toolsmith.models import (
+    CapabilityGap,
+    ToolBlueprint,
+    ToolBlueprintState,
+    ToolValidationResult,
+)
+
+__all__ = [
+    "CapabilityGap",
+    "ToolBlueprint",
+    "ToolBlueprintState",
+    "ToolValidationResult",
+]

--- a/src/synthorg/meta/toolsmith/applier.py
+++ b/src/synthorg/meta/toolsmith/applier.py
@@ -24,6 +24,7 @@ from synthorg.observability.events.toolsmith import (
     TOOLSMITH_APPLY_STARTED,
     TOOLSMITH_BLUEPRINT_RETIRED,
 )
+from synthorg.providers.errors import ProviderError
 
 if TYPE_CHECKING:
     from synthorg.meta.toolsmith.dynamic_registry import DynamicToolRegistry
@@ -74,6 +75,8 @@ class ToolCreationApplier:
         for blueprint in proposal.tool_changes:
             try:
                 ok = await self._apply_one(blueprint)
+            except ProviderError:
+                raise
             except MemoryError, RecursionError:
                 raise
             except Exception as exc:
@@ -164,9 +167,11 @@ class ToolCreationApplier:
             ToolBlueprintState.RETIRED,
             retired_at=now,
         )
+        if not transitioned:
+            return False
         await self._registry.unregister(existing.name)
         logger.info(TOOLSMITH_BLUEPRINT_RETIRED, tool_name=existing.name)
-        return transitioned
+        return True
 
 
 __all__ = ["ToolCreationApplier"]

--- a/src/synthorg/meta/toolsmith/applier.py
+++ b/src/synthorg/meta/toolsmith/applier.py
@@ -2,14 +2,17 @@
 
 The applier is the trust boundary: a candidate blueprint is persisted as
 ``PENDING``, run through the benchmark gate, and only on a passing result
-promoted to ``VALIDATED``/``ACTIVE``, persisted, and live-registered in the
-dynamic registry. A failing gate leaves nothing registered (the blueprint
-keeps its validation record for audit but never goes ``ACTIVE``).
+promoted to ``VALIDATED``/``ACTIVE``, live-registered in the dynamic
+registry, and persisted (registration-then-persist so a registration
+failure cannot leave a durable ACTIVE row without a live handler). A
+failing gate leaves nothing registered (the blueprint keeps its
+validation record for audit but never goes ``ACTIVE``).
 
 Rollback retires an active tool: it transitions the row to ``RETIRED`` and
 unregisters the live handler.
 """
 
+import asyncio
 from typing import TYPE_CHECKING
 
 from synthorg.core.clock import Clock, SystemClock
@@ -63,35 +66,33 @@ class ToolCreationApplier:
         return ProposalAltitude.TOOL_CREATION
 
     async def apply(self, proposal: ImprovementProposal) -> ApplyResult:
-        """Validate then live-register each blueprint in the proposal."""
+        """Validate then live-register each blueprint in the proposal.
+
+        Per-blueprint failures are isolated inside the task wrapper: a
+        single tool failing the gate or its persistence cannot abort the
+        others. Provider-wide and system-critical exceptions still
+        propagate out of the TaskGroup so the caller can fail the whole
+        proposal cleanly.
+        """
         if not proposal.tool_changes:
             return ApplyResult(
                 success=False,
                 error_message=NotBlankStr("proposal carries no tool_changes"),
                 changes_applied=0,
             )
+        async with asyncio.TaskGroup() as tg:
+            tasks = [
+                tg.create_task(self._apply_one_safely(blueprint))
+                for blueprint in proposal.tool_changes
+            ]
         applied = 0
         failures: list[str] = []
-        for blueprint in proposal.tool_changes:
-            try:
-                ok = await self._apply_one(blueprint)
-            except ProviderError:
-                raise
-            except MemoryError, RecursionError:
-                raise
-            except Exception as exc:
-                logger.warning(
-                    TOOLSMITH_APPLY_FAILED,
-                    tool_name=blueprint.name,
-                    error_type=type(exc).__name__,
-                    error=safe_error_description(exc),
-                )
-                failures.append(f"{blueprint.name}: {type(exc).__name__}")
-                continue
-            if ok:
+        for task in tasks:
+            success, error = task.result()
+            if success:
                 applied += 1
-            else:
-                failures.append(f"{blueprint.name}: rejected by benchmark gate")
+            elif error is not None:
+                failures.append(error)
         if failures:
             return ApplyResult(
                 success=False,
@@ -99,6 +100,33 @@ class ToolCreationApplier:
                 changes_applied=applied,
             )
         return ApplyResult(success=True, changes_applied=applied)
+
+    async def _apply_one_safely(
+        self, blueprint: ToolBlueprint
+    ) -> tuple[bool, str | None]:
+        """Run ``_apply_one`` with per-blueprint error isolation.
+
+        Returns ``(True, None)`` on a passing apply, ``(False, reason)`` on
+        a gate rejection or per-blueprint exception. ``ProviderError`` and
+        system-critical errors propagate so the TaskGroup surfaces them.
+        """
+        try:
+            ok = await self._apply_one(blueprint)
+        except ProviderError:
+            raise
+        except MemoryError, RecursionError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                TOOLSMITH_APPLY_FAILED,
+                tool_name=blueprint.name,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            return False, f"{blueprint.name}: {type(exc).__name__}"
+        if ok:
+            return True, None
+        return False, f"{blueprint.name}: rejected by benchmark gate"
 
     async def dry_run(self, proposal: ImprovementProposal) -> ApplyResult:
         """Validate every blueprint without persisting or registering."""
@@ -122,7 +150,13 @@ class ToolCreationApplier:
         return ApplyResult(success=True, changes_applied=len(proposal.tool_changes))
 
     async def _apply_one(self, blueprint: ToolBlueprint) -> bool:
-        """Persist, validate, and (on pass) activate + register one tool."""
+        """Persist, validate, and (on pass) register + activate one tool.
+
+        Register-then-persist: a registration failure leaves nothing
+        durably ACTIVE, and a persistence failure after a successful
+        registration is rolled back by unregistering the live handler. The
+        success log only fires once both sides land.
+        """
         logger.info(TOOLSMITH_APPLY_STARTED, tool_name=blueprint.name)
         pending = blueprint.model_copy(update={"state": ToolBlueprintState.PENDING})
         await self._repo.save(pending)
@@ -146,8 +180,18 @@ class ToolCreationApplier:
                 "validation": result,
             }
         )
-        await self._repo.save(active)
         await self._registry.register(active)
+        try:
+            await self._repo.save(active)
+        except MemoryError, RecursionError:
+            raise
+        except Exception:
+            # Persisting an ACTIVE row failed: unregister the live handler
+            # so the durable state ("not in DB") matches the runtime state
+            # ("not registered"). Without rollback the layered tool surface
+            # would expose a tool with no audit trail.
+            await self._registry.unregister(active.name)
+            raise
         logger.info(TOOLSMITH_APPLY_COMPLETED, tool_name=blueprint.name)
         return True
 

--- a/src/synthorg/meta/toolsmith/applier.py
+++ b/src/synthorg/meta/toolsmith/applier.py
@@ -1,0 +1,172 @@
+"""Applier that turns an approved tool-creation proposal into a live tool.
+
+The applier is the trust boundary: a candidate blueprint is persisted as
+``PENDING``, run through the benchmark gate, and only on a passing result
+promoted to ``VALIDATED``/``ACTIVE``, persisted, and live-registered in the
+dynamic registry. A failing gate leaves nothing registered (the blueprint
+keeps its validation record for audit but never goes ``ACTIVE``).
+
+Rollback retires an active tool: it transitions the row to ``RETIRED`` and
+unregisters the live handler.
+"""
+
+from typing import TYPE_CHECKING
+
+from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.models import ApplyResult, ImprovementProposal, ProposalAltitude
+from synthorg.meta.toolsmith.models import ToolBlueprint, ToolBlueprintState
+from synthorg.observability import get_logger, safe_error_description
+from synthorg.observability.events.toolsmith import (
+    TOOLSMITH_APPLY_COMPLETED,
+    TOOLSMITH_APPLY_FAILED,
+    TOOLSMITH_APPLY_REJECTED,
+    TOOLSMITH_APPLY_STARTED,
+    TOOLSMITH_BLUEPRINT_RETIRED,
+)
+
+if TYPE_CHECKING:
+    from synthorg.meta.toolsmith.dynamic_registry import DynamicToolRegistry
+    from synthorg.meta.toolsmith.protocol import ToolValidationGate
+    from synthorg.persistence.tool_blueprint_protocol import DynamicToolRepository
+
+logger = get_logger(__name__)
+
+
+class ToolCreationApplier:
+    """Applies an approved ``TOOL_CREATION`` proposal.
+
+    Args:
+        repo: Durable blueprint store.
+        registry: Live dynamic-tool registry.
+        gate: Benchmark validation gate.
+        clock: Time source for lifecycle timestamps.
+    """
+
+    def __init__(
+        self,
+        *,
+        repo: DynamicToolRepository,
+        registry: DynamicToolRegistry,
+        gate: ToolValidationGate,
+        clock: Clock | None = None,
+    ) -> None:
+        self._repo = repo
+        self._registry = registry
+        self._gate = gate
+        self._clock = clock or SystemClock()
+
+    @property
+    def altitude(self) -> ProposalAltitude:
+        """This applier handles tool-creation proposals."""
+        return ProposalAltitude.TOOL_CREATION
+
+    async def apply(self, proposal: ImprovementProposal) -> ApplyResult:
+        """Validate then live-register each blueprint in the proposal."""
+        if not proposal.tool_changes:
+            return ApplyResult(
+                success=False,
+                error_message=NotBlankStr("proposal carries no tool_changes"),
+                changes_applied=0,
+            )
+        applied = 0
+        failures: list[str] = []
+        for blueprint in proposal.tool_changes:
+            try:
+                ok = await self._apply_one(blueprint)
+            except MemoryError, RecursionError:
+                raise
+            except Exception as exc:
+                logger.warning(
+                    TOOLSMITH_APPLY_FAILED,
+                    tool_name=blueprint.name,
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
+                )
+                failures.append(f"{blueprint.name}: {type(exc).__name__}")
+                continue
+            if ok:
+                applied += 1
+            else:
+                failures.append(f"{blueprint.name}: rejected by benchmark gate")
+        if failures:
+            return ApplyResult(
+                success=False,
+                error_message=NotBlankStr("; ".join(failures)),
+                changes_applied=applied,
+            )
+        return ApplyResult(success=True, changes_applied=applied)
+
+    async def dry_run(self, proposal: ImprovementProposal) -> ApplyResult:
+        """Validate every blueprint without persisting or registering."""
+        if not proposal.tool_changes:
+            return ApplyResult(
+                success=False,
+                error_message=NotBlankStr("proposal carries no tool_changes"),
+                changes_applied=0,
+            )
+        failures: list[str] = []
+        for blueprint in proposal.tool_changes:
+            result = await self._gate.validate(blueprint)
+            if not result.passed:
+                failures.append(f"{blueprint.name}: {result.detail}")
+        if failures:
+            return ApplyResult(
+                success=False,
+                error_message=NotBlankStr("; ".join(failures)),
+                changes_applied=0,
+            )
+        return ApplyResult(success=True, changes_applied=len(proposal.tool_changes))
+
+    async def _apply_one(self, blueprint: ToolBlueprint) -> bool:
+        """Persist, validate, and (on pass) activate + register one tool."""
+        logger.info(TOOLSMITH_APPLY_STARTED, tool_name=blueprint.name)
+        pending = blueprint.model_copy(update={"state": ToolBlueprintState.PENDING})
+        await self._repo.save(pending)
+
+        result = await self._gate.validate(blueprint)
+        if not result.passed:
+            await self._repo.save(blueprint.model_copy(update={"validation": result}))
+            logger.info(
+                TOOLSMITH_APPLY_REJECTED,
+                tool_name=blueprint.name,
+                detail=result.detail,
+            )
+            return False
+
+        now = self._clock.now()
+        active = blueprint.model_copy(
+            update={
+                "state": ToolBlueprintState.ACTIVE,
+                "validated_at": now,
+                "activated_at": now,
+                "validation": result,
+            }
+        )
+        await self._repo.save(active)
+        await self._registry.register(active)
+        logger.info(TOOLSMITH_APPLY_COMPLETED, tool_name=blueprint.name)
+        return True
+
+    async def retire(self, blueprint_id: NotBlankStr) -> bool:
+        """Roll back an active tool: transition to RETIRED and unregister.
+
+        Returns:
+            ``True`` iff an active blueprint was retired.
+        """
+        existing = await self._repo.get(blueprint_id)
+        if existing is None or existing.state is not ToolBlueprintState.ACTIVE:
+            return False
+        now = self._clock.now()
+        transitioned = await self._repo.transition_if(
+            blueprint_id,
+            ToolBlueprintState.ACTIVE,
+            ToolBlueprintState.RETIRED,
+            retired_at=now,
+        )
+        await self._registry.unregister(existing.name)
+        logger.info(TOOLSMITH_BLUEPRINT_RETIRED, tool_name=existing.name)
+        return transitioned
+
+
+__all__ = ["ToolCreationApplier"]

--- a/src/synthorg/meta/toolsmith/applier.py
+++ b/src/synthorg/meta/toolsmith/applier.py
@@ -152,18 +152,32 @@ class ToolCreationApplier:
     async def _apply_one(self, blueprint: ToolBlueprint) -> bool:
         """Persist, validate, and (on pass) register + activate one tool.
 
+        Lifecycle normalisation: the applier OWNS the lifecycle. Any
+        caller-supplied ``validated_at`` / ``activated_at`` / ``retired_at``
+        / ``validation`` is cleared on the persisted candidate so a caller
+        cannot launder fake gate evidence into durable state. The trusted
+        record only forms after this applier's own gate run.
+
         Register-then-persist: a registration failure leaves nothing
         durably ACTIVE, and a persistence failure after a successful
         registration is rolled back by unregistering the live handler. The
         success log only fires once both sides land.
         """
         logger.info(TOOLSMITH_APPLY_STARTED, tool_name=blueprint.name)
-        pending = blueprint.model_copy(update={"state": ToolBlueprintState.PENDING})
-        await self._repo.save(pending)
+        candidate = blueprint.model_copy(
+            update={
+                "state": ToolBlueprintState.PENDING,
+                "validated_at": None,
+                "activated_at": None,
+                "retired_at": None,
+                "validation": None,
+            }
+        )
+        await self._repo.save(candidate)
 
-        result = await self._gate.validate(blueprint)
+        result = await self._gate.validate(candidate)
         if not result.passed:
-            await self._repo.save(blueprint.model_copy(update={"validation": result}))
+            await self._repo.save(candidate.model_copy(update={"validation": result}))
             logger.info(
                 TOOLSMITH_APPLY_REJECTED,
                 tool_name=blueprint.name,
@@ -172,7 +186,7 @@ class ToolCreationApplier:
             return False
 
         now = self._clock.now()
-        active = blueprint.model_copy(
+        active = candidate.model_copy(
             update={
                 "state": ToolBlueprintState.ACTIVE,
                 "validated_at": now,

--- a/src/synthorg/meta/toolsmith/config.py
+++ b/src/synthorg/meta/toolsmith/config.py
@@ -1,0 +1,89 @@
+"""Configuration for the self-extending toolkit (toolsmith).
+
+Frozen Pydantic config with safe defaults: disabled by default, an empty
+capability allowlist (deny-all until an operator opts in), Docker sandbox
+with no network, and a benchmark gate that requires the golden-scorecard
+no-regression check.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.toolsmith.models import ToolSandboxBackend
+
+
+class ToolAuthoringConfig(BaseModel):
+    """LLM settings for authoring a tool blueprint from a capability gap.
+
+    Attributes:
+        model: LLM model identifier for blueprint generation.
+        temperature: Sampling temperature (low for structured output).
+        max_tokens: Token budget per authoring response.
+    """
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False, extra="forbid")
+
+    model: NotBlankStr = Field(default=NotBlankStr("example-large-001"))
+    temperature: float = Field(default=0.2, ge=0.0, le=1.0)
+    max_tokens: int = Field(default=4000, ge=100)
+
+
+class ToolValidationConfig(BaseModel):
+    """Benchmark-gate settings for trusting an authored tool.
+
+    Attributes:
+        require_golden_delta: When ``True`` the golden-company scorecard
+            must not regress (``candidate >= baseline``) in addition to the
+            per-tool brief passing.
+        min_score_margin: Minimum ``candidate - baseline`` scorecard margin
+            required to pass (0 = no regression allowed).
+        brief_pass_score: Minimum per-tool acceptance brief score to pass.
+    """
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False, extra="forbid")
+
+    require_golden_delta: bool = True
+    min_score_margin: int = Field(default=0, ge=0)
+    brief_pass_score: int = Field(default=70, ge=0, le=100)
+
+
+class ToolsmithConfig(BaseModel):
+    """Top-level configuration for the self-extending toolkit.
+
+    Safe defaults:
+    - Feature: disabled (opt-in).
+    - Capability allowlist: empty (deny-all until configured).
+    - Sandbox: Docker, no network.
+    - Validation: golden no-regression delta required.
+
+    Attributes:
+        enabled: Master switch for the toolsmith.
+        gap_recurrence_threshold: How many times a gap signature must
+            recur within the window before a proposal is triggered.
+        gap_window_hours: Sliding window for gap recurrence aggregation.
+        gap_buffer_size: Ring-buffer capacity for raw gap observations.
+        allowed_capabilities: Capability tags (``domain:action``) the org
+            may author tools for; empty denies all.
+        service_access_capabilities: Capability tags that require internal
+            service-layer access and so cannot be a sandbox script; gaps
+            matching these route to the CODE_MODIFICATION overflow arm.
+        sandbox_backend: Default sandbox backend for authored tools.
+        requires_network: Whether authored tools get network egress.
+        max_active_tools: Cap on simultaneously-active authored tools.
+        authoring: LLM authoring settings.
+        validation: Benchmark-gate settings.
+    """
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False, extra="forbid")
+
+    enabled: bool = False
+    gap_recurrence_threshold: int = Field(default=3, ge=2)
+    gap_window_hours: int = Field(default=24, ge=1)
+    gap_buffer_size: int = Field(default=512, ge=16)
+    allowed_capabilities: tuple[NotBlankStr, ...] = ()
+    service_access_capabilities: tuple[NotBlankStr, ...] = ()
+    sandbox_backend: ToolSandboxBackend = ToolSandboxBackend.DOCKER
+    requires_network: bool = False
+    max_active_tools: int = Field(default=50, ge=1)
+    authoring: ToolAuthoringConfig = Field(default_factory=ToolAuthoringConfig)
+    validation: ToolValidationConfig = Field(default_factory=ToolValidationConfig)

--- a/src/synthorg/meta/toolsmith/config.py
+++ b/src/synthorg/meta/toolsmith/config.py
@@ -6,7 +6,9 @@ with no network, and a benchmark gate that requires the golden-scorecard
 no-regression check.
 """
 
-from pydantic import BaseModel, ConfigDict, Field
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from synthorg.core.types import NotBlankStr
 from synthorg.meta.toolsmith.models import ToolSandboxBackend
@@ -87,3 +89,14 @@ class ToolsmithConfig(BaseModel):
     max_active_tools: int = Field(default=50, ge=1)
     authoring: ToolAuthoringConfig = Field(default_factory=ToolAuthoringConfig)
     validation: ToolValidationConfig = Field(default_factory=ToolValidationConfig)
+
+    @model_validator(mode="after")
+    def _enabled_requires_allowlist(self) -> Self:
+        """Enable+empty-allowlist is silently deny-all; reject it explicitly."""
+        if self.enabled and not self.allowed_capabilities:
+            msg = (
+                "ToolsmithConfig.enabled=True requires a non-empty "
+                "allowed_capabilities; an empty allowlist is silently deny-all"
+            )
+            raise ValueError(msg)
+        return self

--- a/src/synthorg/meta/toolsmith/dynamic_registry.py
+++ b/src/synthorg/meta/toolsmith/dynamic_registry.py
@@ -116,11 +116,24 @@ def build_args_model(blueprint: ToolBlueprint) -> type[BaseModel]:
             field_defs[prop_name] = (py_type, ...)
         else:
             field_defs[prop_name] = (py_type | None, None)
-    return create_model(
-        _model_class_name(blueprint.name),
-        __config__=ConfigDict(frozen=True, extra="forbid", allow_inf_nan=False),
-        **field_defs,
-    )
+    # ``create_model`` raises a variety of exceptions (TypeError on bad
+    # field defs, ValueError from Pydantic's own validation, etc.); wrap
+    # them in the domain-specific ToolRegistrationError so callers receive
+    # the contract the docstring documents.
+    try:
+        return create_model(
+            _model_class_name(blueprint.name),
+            __config__=ConfigDict(frozen=True, extra="forbid", allow_inf_nan=False),
+            **field_defs,
+        )
+    except MemoryError, RecursionError:
+        raise
+    except Exception as exc:
+        msg = (
+            f"blueprint {blueprint.name!r} args model materialization failed: "
+            f"{type(exc).__name__}"
+        )
+        raise ToolRegistrationError(msg) from exc
 
 
 def blueprint_to_mcp_def(blueprint: ToolBlueprint) -> MCPToolDef:
@@ -216,6 +229,18 @@ class DynamicToolRegistry:
     def names(self) -> tuple[NotBlankStr, ...]:
         """Return the currently-registered dynamic tool names (sorted)."""
         return tuple(NotBlankStr(n) for n in sorted(self._snapshot))
+
+    def capabilities(self) -> tuple[NotBlankStr, ...]:
+        """Return the capability tags of currently-registered dynamic tools.
+
+        The toolsmith generator consumes this as a dedup hint so authored
+        tools never duplicate a capability already live in the dynamic
+        layer of the same process.
+        """
+        return tuple(
+            NotBlankStr(entry.definition.capability)
+            for entry in (self._snapshot[n] for n in sorted(self._snapshot))
+        )
 
     def get_def(self, name: str) -> MCPToolDef | None:
         """Return the definition for ``name``, or ``None`` if absent."""

--- a/src/synthorg/meta/toolsmith/dynamic_registry.py
+++ b/src/synthorg/meta/toolsmith/dynamic_registry.py
@@ -51,14 +51,22 @@ _JSON_TYPE_TO_PYTHON: Mapping[str, Any] = {
 _MODEL_NAME_RE = re.compile(r"[^0-9a-zA-Z_]")
 
 
-def _python_type_for(prop_schema: object) -> Any:
-    """Map a JSON Schema property to a Python type for ``create_model``."""
+def _python_type_for(prop_schema: object) -> Any | None:
+    """Map a JSON Schema property to a Python type for ``create_model``.
+
+    Returns ``Any`` for an untyped property (valid JSON Schema) and the
+    mapped Python type for a known type. Returns ``None`` for an explicit
+    but unknown/unsupported ``type`` so the caller rejects the blueprint
+    rather than silently accepting any value for that field.
+    """
     if not isinstance(prop_schema, dict):
         return Any
     json_type = prop_schema.get("type")
+    if json_type is None:
+        return Any
     if isinstance(json_type, str):
-        return _JSON_TYPE_TO_PYTHON.get(json_type, Any)
-    return Any
+        return _JSON_TYPE_TO_PYTHON.get(json_type)
+    return None
 
 
 def _model_class_name(tool_name: str) -> str:
@@ -98,6 +106,12 @@ def build_args_model(blueprint: ToolBlueprint) -> type[BaseModel]:
     field_defs: dict[str, Any] = {}
     for prop_name, prop_schema in properties.items():
         py_type = _python_type_for(prop_schema)
+        if py_type is None:
+            msg = (
+                f"blueprint {blueprint.name!r} property {prop_name!r} declares "
+                f"an unsupported JSON Schema type"
+            )
+            raise ToolRegistrationError(msg)
         if prop_name in required:
             field_defs[prop_name] = (py_type, ...)
         else:

--- a/src/synthorg/meta/toolsmith/dynamic_registry.py
+++ b/src/synthorg/meta/toolsmith/dynamic_registry.py
@@ -1,0 +1,290 @@
+"""Dynamic (runtime-authored) tool registry and layered read surface.
+
+The static :class:`~synthorg.meta.mcp.registry.DomainToolRegistry` is
+frozen after construction, so authored tools cannot be added to it. This
+module provides:
+
+* :func:`build_args_model` -- materialise a real frozen Pydantic args
+  model from a blueprint's JSON Schema, so authored tools keep the same
+  typed-validation symmetry as static tools.
+* :func:`blueprint_to_mcp_def` -- promote a blueprint to an ``MCPToolDef``.
+* :class:`DynamicToolRegistry` -- a mutable, snapshot-swapping registry of
+  live authored tools (lock-guarded writes, lock-free atomic reads).
+* :class:`LayeredToolRegistry` / :class:`LayeredHandlerMap` -- read the
+  static surface first, then the dynamic layer, so the invoker dispatches
+  authored tools without unfreezing anything.
+"""
+
+import asyncio
+import keyword
+import re
+from collections.abc import Callable, Iterator, Mapping
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, ConfigDict, create_model
+
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.mcp.handler_protocol import ToolHandler
+from synthorg.meta.mcp.registry import MCPToolDef, ToolDefReader
+from synthorg.meta.toolsmith.errors import ToolRegistrationError
+from synthorg.observability import get_logger
+from synthorg.observability.events.toolsmith import (
+    TOOLSMITH_TOOL_REGISTERED,
+    TOOLSMITH_TOOL_UNREGISTERED,
+)
+
+if TYPE_CHECKING:
+    from synthorg.meta.toolsmith.models import ToolBlueprint
+
+logger = get_logger(__name__)
+
+_JSON_TYPE_TO_PYTHON: Mapping[str, Any] = {
+    "string": str,
+    "integer": int,
+    "number": float,
+    "boolean": bool,
+    "array": list,
+    "object": dict,
+}
+
+_MODEL_NAME_RE = re.compile(r"[^0-9a-zA-Z_]")
+
+
+def _python_type_for(prop_schema: object) -> Any:
+    """Map a JSON Schema property to a Python type for ``create_model``."""
+    if not isinstance(prop_schema, dict):
+        return Any
+    json_type = prop_schema.get("type")
+    if isinstance(json_type, str):
+        return _JSON_TYPE_TO_PYTHON.get(json_type, Any)
+    return Any
+
+
+def _model_class_name(tool_name: str) -> str:
+    """Derive a valid Python class name from a tool name."""
+    parts = [p for p in _MODEL_NAME_RE.sub("_", tool_name).split("_") if p]
+    camel = "".join(p[:1].upper() + p[1:] for p in parts)
+    candidate = f"{camel}Args"
+    if not candidate[:1].isalpha() or keyword.iskeyword(candidate):
+        candidate = f"Args_{candidate}"
+    return candidate
+
+
+def build_args_model(blueprint: ToolBlueprint) -> type[BaseModel]:
+    """Materialise a frozen Pydantic args model from a blueprint schema.
+
+    Fields mirror ``parameters_schema.properties`` exactly, with the
+    ``required`` list driving which fields have no default, so the model
+    aligns with the wire schema (the ``MCPToolDef`` validator enforces
+    this in lockstep).
+
+    Args:
+        blueprint: The blueprint whose JSON Schema to materialise.
+
+    Returns:
+        A new frozen, ``extra="forbid"`` Pydantic model class.
+
+    Raises:
+        ToolRegistrationError: If the schema cannot be materialised.
+    """
+    schema = blueprint.parameters_schema
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        msg = f"blueprint {blueprint.name!r} schema lacks a properties object"
+        raise ToolRegistrationError(msg)
+    required_raw = schema.get("required") or ()
+    required = set(required_raw) if isinstance(required_raw, (list, tuple)) else set()
+    field_defs: dict[str, Any] = {}
+    for prop_name, prop_schema in properties.items():
+        py_type = _python_type_for(prop_schema)
+        if prop_name in required:
+            field_defs[prop_name] = (py_type, ...)
+        else:
+            field_defs[prop_name] = (py_type | None, None)
+    return create_model(
+        _model_class_name(blueprint.name),
+        __config__=ConfigDict(frozen=True, extra="forbid", allow_inf_nan=False),
+        **field_defs,
+    )
+
+
+def blueprint_to_mcp_def(blueprint: ToolBlueprint) -> MCPToolDef:
+    """Promote a blueprint to an ``MCPToolDef`` with a materialised args model.
+
+    The handler key is the tool name itself (unique per authored tool),
+    so the layered handler map can resolve the per-tool closure.
+
+    Raises:
+        ToolRegistrationError: If the schema cannot be materialised or the
+            resulting definition violates the MCP tool contract.
+    """
+    args_model = build_args_model(blueprint)
+    try:
+        return MCPToolDef(
+            name=blueprint.name,
+            description=blueprint.description,
+            parameters=blueprint.parameters_schema,
+            capability=blueprint.capability,
+            handler_key=blueprint.name,
+            args_model=args_model,
+        )
+    except ValueError as exc:
+        msg = f"blueprint {blueprint.name!r} is not a valid MCP tool: {exc}"
+        raise ToolRegistrationError(msg) from exc
+
+
+class _Entry:
+    """A live authored tool: its definition plus its handler closure."""
+
+    __slots__ = ("definition", "handler")
+
+    def __init__(self, definition: MCPToolDef, handler: ToolHandler) -> None:
+        self.definition = definition
+        self.handler = handler
+
+
+class DynamicToolRegistry:
+    """Mutable registry of live authored tools (snapshot-swapping reads).
+
+    Writes are serialised under an :class:`asyncio.Lock`; each mutation
+    rebuilds an immutable snapshot dict and swaps the reference, so the
+    synchronous read paths (used by the invoker mid-dispatch) observe a
+    consistent view without locking. In the single-threaded event loop a
+    sync read cannot interleave with an async write between awaits.
+
+    Args:
+        handler_factory: Builds the per-tool :class:`ToolHandler` closure
+            for a blueprint (binds the sandbox + repository). Injected so
+            the registry stays testable without a real sandbox.
+    """
+
+    def __init__(
+        self,
+        *,
+        handler_factory: Callable[[ToolBlueprint], ToolHandler],
+    ) -> None:
+        self._handler_factory = handler_factory
+        self._lock = asyncio.Lock()
+        self._snapshot: Mapping[str, _Entry] = MappingProxyType({})
+
+    async def register(self, blueprint: ToolBlueprint) -> None:
+        """Register an active blueprint as a live MCP tool.
+
+        Idempotent on the tool name: re-registering replaces the entry.
+
+        Raises:
+            ToolRegistrationError: If the blueprint cannot be promoted.
+        """
+        definition = blueprint_to_mcp_def(blueprint)
+        handler = self._handler_factory(blueprint)
+        async with self._lock:
+            merged = dict(self._snapshot)
+            merged[blueprint.name] = _Entry(definition, handler)
+            self._snapshot = MappingProxyType(merged)
+        logger.info(
+            TOOLSMITH_TOOL_REGISTERED,
+            tool_name=blueprint.name,
+            capability=blueprint.capability,
+        )
+
+    async def unregister(self, name: NotBlankStr) -> bool:
+        """Remove a live tool by name; ``True`` iff it was present."""
+        async with self._lock:
+            if name not in self._snapshot:
+                return False
+            merged = dict(self._snapshot)
+            del merged[name]
+            self._snapshot = MappingProxyType(merged)
+        logger.info(TOOLSMITH_TOOL_UNREGISTERED, tool_name=name)
+        return True
+
+    def names(self) -> tuple[NotBlankStr, ...]:
+        """Return the currently-registered dynamic tool names (sorted)."""
+        return tuple(NotBlankStr(n) for n in sorted(self._snapshot))
+
+    def get_def(self, name: str) -> MCPToolDef | None:
+        """Return the definition for ``name``, or ``None`` if absent."""
+        entry = self._snapshot.get(name)
+        return entry.definition if entry is not None else None
+
+    def get_handler(self, handler_key: str) -> ToolHandler | None:
+        """Return the handler for ``handler_key``, or ``None`` if absent."""
+        entry = self._snapshot.get(handler_key)
+        return entry.handler if entry is not None else None
+
+
+class LayeredToolRegistry:
+    """Static + dynamic tool-definition read surface (``ToolDefReader``).
+
+    Reads the frozen static registry first, then the dynamic layer, so
+    authored tools resolve without unfreezing the static surface.
+    """
+
+    def __init__(
+        self,
+        static_registry: ToolDefReader,
+        dynamic_registry: DynamicToolRegistry,
+    ) -> None:
+        self._static = static_registry
+        self._dynamic = dynamic_registry
+
+    def get(self, name: str) -> MCPToolDef:
+        """Look up a tool by name, static layer first.
+
+        Raises:
+            KeyError: If neither layer knows the name.
+        """
+        try:
+            return self._static.get(name)
+        except KeyError:
+            dynamic = self._dynamic.get_def(name)
+            if dynamic is None:
+                raise
+            return dynamic
+
+    def get_names(self) -> tuple[str, ...]:
+        """Return all known tool names (static + dynamic), sorted."""
+        return tuple(sorted({*self._static.get_names(), *self._dynamic.names()}))
+
+
+class LayeredHandlerMap(Mapping[str, ToolHandler]):
+    """Static + dynamic handler map; static keys win on collision."""
+
+    def __init__(
+        self,
+        static_handlers: Mapping[str, ToolHandler],
+        dynamic_registry: DynamicToolRegistry,
+    ) -> None:
+        self._static = static_handlers
+        self._dynamic = dynamic_registry
+
+    def __getitem__(self, key: str) -> ToolHandler:
+        """Resolve a handler, static layer first then dynamic."""
+        if key in self._static:
+            return self._static[key]
+        handler = self._dynamic.get_handler(key)
+        if handler is None:
+            raise KeyError(key)
+        return handler
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate static handler keys then dynamic tool names."""
+        seen = set(self._static)
+        yield from self._static
+        for name in self._dynamic.names():
+            if name not in seen:
+                yield name
+
+    def __len__(self) -> int:
+        """Return the count of distinct static + dynamic keys."""
+        return len(set(self._static) | set(self._dynamic.names()))
+
+
+__all__ = [
+    "DynamicToolRegistry",
+    "LayeredHandlerMap",
+    "LayeredToolRegistry",
+    "blueprint_to_mcp_def",
+    "build_args_model",
+]

--- a/src/synthorg/meta/toolsmith/errors.py
+++ b/src/synthorg/meta/toolsmith/errors.py
@@ -1,0 +1,54 @@
+"""Domain error hierarchy for the self-extending toolkit (toolsmith).
+
+Follows the project convention of subclassing
+:class:`synthorg.core.domain_errors.DomainError` so error names carry
+intent. Toolsmith errors surface to the operator / agent driving tool
+creation, so they fall under :class:`ErrorCategory.INTERNAL`.
+"""
+
+from typing import ClassVar
+
+from synthorg.core.domain_errors import DomainError
+from synthorg.core.error_taxonomy import ErrorCategory, ErrorCode
+
+
+class ToolsmithError(DomainError):
+    """Base for every error raised by the self-extending toolkit."""
+
+    default_message: ClassVar[str] = "Toolsmith operation failed"
+    error_category: ClassVar[ErrorCategory] = ErrorCategory.INTERNAL
+    error_code: ClassVar[ErrorCode] = ErrorCode.INTERNAL_ERROR
+    status_code: ClassVar[int] = 500
+
+
+class ToolAuthoringError(ToolsmithError):
+    """Raised when model output cannot be parsed into a valid blueprint."""
+
+    default_message: ClassVar[str] = "Authored tool blueprint failed validation"
+
+
+class ToolCapabilityNotAllowedError(ToolsmithError):
+    """Raised when a blueprint targets a capability outside the allowlist."""
+
+    default_message: ClassVar[str] = "Capability is not in the toolsmith allowlist"
+
+
+class ToolValidationFailedError(ToolsmithError):
+    """Raised when the benchmark gate rejects a candidate blueprint."""
+
+    default_message: ClassVar[str] = "Authored tool failed the benchmark gate"
+
+
+class ToolRegistrationError(ToolsmithError):
+    """Raised when a validated blueprint cannot be live-registered."""
+
+    default_message: ClassVar[str] = "Authored tool could not be registered"
+
+
+__all__ = [
+    "ToolAuthoringError",
+    "ToolCapabilityNotAllowedError",
+    "ToolRegistrationError",
+    "ToolValidationFailedError",
+    "ToolsmithError",
+]

--- a/src/synthorg/meta/toolsmith/factory.py
+++ b/src/synthorg/meta/toolsmith/factory.py
@@ -24,12 +24,13 @@ from synthorg.meta.toolsmith.validation_gate import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Awaitable, Callable
 
     from synthorg.approval.protocol import ApprovalStoreProtocol
     from synthorg.budget.tracker import CostTracker
     from synthorg.core.types import NotBlankStr
     from synthorg.meta.config import SelfImprovementConfig
+    from synthorg.meta.signal_models import OrgSignalSnapshot
     from synthorg.meta.toolsmith.models import ToolBlueprint
     from synthorg.meta.toolsmith.protocol import (
         GoldenScorecardProvider,
@@ -40,6 +41,7 @@ if TYPE_CHECKING:
     from synthorg.tools.sandbox.protocol import SandboxBackend
 
     SandboxResolver = Callable[[ToolBlueprint], SandboxBackend]
+    SnapshotProvider = Callable[[], Awaitable[OrgSignalSnapshot]]
 
 
 @dataclass(frozen=True)
@@ -64,6 +66,7 @@ def build_toolsmith(  # noqa: PLR0913 -- explicit DI of the toolsmith collaborat
     scorecard_provider: GoldenScorecardProvider | None = None,
     approval_store: ApprovalStoreProtocol | None = None,
     overflow_handler: ToolCreationOverflowHandler | None = None,
+    snapshot_provider: SnapshotProvider | None = None,
     existing_capabilities: tuple[NotBlankStr, ...] = (),
     cost_tracker: CostTracker | None = None,
     clock: Clock | None = None,
@@ -81,7 +84,11 @@ def build_toolsmith(  # noqa: PLR0913 -- explicit DI of the toolsmith collaborat
         scorecard_provider: Golden-scorecard provider for the gate;
             required when ``toolsmith.validation.require_golden_delta``.
         approval_store: Approval store routed into the approval gate.
-        overflow_handler: Handler for service-access capability gaps.
+        overflow_handler: Handler for service-access capability gaps;
+            when ``None`` a code-modification overflow handler is built
+            automatically if ``code_modification_enabled``.
+        snapshot_provider: Optional live snapshot source for the
+            code-modification overflow (defaults to a neutral baseline).
         existing_capabilities: Current capability surface (dedup hint).
         cost_tracker: Optional cost tracker for the authoring call.
         clock: Time source.
@@ -119,17 +126,60 @@ def build_toolsmith(  # noqa: PLR0913 -- explicit DI of the toolsmith collaborat
         clock=resolved_clock,
     )
     guards = build_guards(si_config, approval_store=approval_store)
+    resolved_overflow = overflow_handler or _build_overflow_handler(
+        si_config=si_config,
+        provider=provider,
+        cost_tracker=cost_tracker,
+        snapshot_provider=snapshot_provider,
+    )
     service = ToolsmithService(
         config=tsc,
         gap_store=gap_store,
         generator=generator,
         applier=applier,
         guards=guards,
-        overflow_handler=overflow_handler,
+        overflow_handler=resolved_overflow,
         existing_capabilities=existing_capabilities,
         clock=resolved_clock,
     )
     return ToolsmithRuntime(service=service, dynamic_registry=dynamic_registry)
+
+
+def _build_overflow_handler(
+    *,
+    si_config: SelfImprovementConfig,
+    provider: BaseCompletionProvider,
+    cost_tracker: CostTracker | None,
+    snapshot_provider: SnapshotProvider | None,
+) -> ToolCreationOverflowHandler | None:
+    """Build the code-modification overflow handler when that altitude is on.
+
+    Returns ``None`` when ``code_modification_enabled`` is unset, so
+    service-access gaps simply log an unhandled-overflow notice.
+    """
+    if not si_config.code_modification_enabled:
+        return None
+    from synthorg.meta.strategies.code_modification import (  # noqa: PLC0415
+        CodeModificationStrategy,
+    )
+    from synthorg.meta.toolsmith.overflow import (  # noqa: PLC0415
+        CodeModificationOverflowHandler,
+    )
+    from synthorg.meta.validation.scope_validator import ScopeValidator  # noqa: PLC0415
+
+    scope_validator = ScopeValidator(
+        allowed_paths=tuple(si_config.code_modification.allowed_paths),
+        forbidden_paths=tuple(si_config.code_modification.forbidden_paths),
+    )
+    strategy = CodeModificationStrategy(
+        config=si_config,
+        provider=provider,
+        scope_validator=scope_validator,
+        cost_tracker=cost_tracker,
+    )
+    return CodeModificationOverflowHandler(
+        strategy, snapshot_provider=snapshot_provider
+    )
 
 
 __all__ = ["ToolsmithRuntime", "build_toolsmith"]

--- a/src/synthorg/meta/toolsmith/factory.py
+++ b/src/synthorg/meta/toolsmith/factory.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from synthorg.budget.tracker import CostTracker
     from synthorg.core.types import NotBlankStr
     from synthorg.meta.config import SelfImprovementConfig
+    from synthorg.meta.mcp.handler_protocol import ToolHandler
     from synthorg.meta.signal_models import OrgSignalSnapshot
     from synthorg.meta.toolsmith.models import ToolBlueprint
     from synthorg.meta.toolsmith.protocol import (
@@ -103,10 +104,10 @@ def build_toolsmith(  # noqa: PLR0913 -- explicit DI of the toolsmith collaborat
         max_observations=tsc.gap_buffer_size,
     )
 
-    def _handler_factory(blueprint: ToolBlueprint) -> object:
+    def _handler_factory(blueprint: ToolBlueprint) -> ToolHandler:
         return make_dynamic_tool_handler(blueprint, sandbox_resolver(blueprint))
 
-    dynamic_registry = DynamicToolRegistry(handler_factory=_handler_factory)  # type: ignore[arg-type]
+    dynamic_registry = DynamicToolRegistry(handler_factory=_handler_factory)
 
     generator = LLMToolBlueprintGenerator(
         config=tsc,

--- a/src/synthorg/meta/toolsmith/factory.py
+++ b/src/synthorg/meta/toolsmith/factory.py
@@ -141,6 +141,7 @@ def build_toolsmith(  # noqa: PLR0913 -- explicit DI of the toolsmith collaborat
         guards=guards,
         overflow_handler=resolved_overflow,
         existing_capabilities=existing_capabilities,
+        dynamic_registry=dynamic_registry,
         clock=resolved_clock,
     )
     return ToolsmithRuntime(service=service, dynamic_registry=dynamic_registry)

--- a/src/synthorg/meta/toolsmith/factory.py
+++ b/src/synthorg/meta/toolsmith/factory.py
@@ -1,0 +1,135 @@
+"""Factory that wires the self-extending toolkit from configuration.
+
+Constructs the gap store, dynamic registry, blueprint generator, benchmark
+gate, applier, guard chain, and the orchestrating :class:`ToolsmithService`
+from a :class:`SelfImprovementConfig` plus the runtime dependencies the
+boot layer resolves (provider, blueprint repository, sandbox backend,
+golden-scorecard provider, approval store).
+"""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from synthorg.core.clock import Clock, SystemClock
+from synthorg.meta.factory import build_guards
+from synthorg.meta.toolsmith.applier import ToolCreationApplier
+from synthorg.meta.toolsmith.dynamic_registry import DynamicToolRegistry
+from synthorg.meta.toolsmith.gap_store import RingBufferCapabilityGapStore
+from synthorg.meta.toolsmith.script_handler import make_dynamic_tool_handler
+from synthorg.meta.toolsmith.service import ToolsmithService
+from synthorg.meta.toolsmith.strategy import LLMToolBlueprintGenerator
+from synthorg.meta.toolsmith.validation_gate import (
+    BenchmarkToolValidationGate,
+    SandboxBriefRunner,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from synthorg.approval.protocol import ApprovalStoreProtocol
+    from synthorg.budget.tracker import CostTracker
+    from synthorg.core.types import NotBlankStr
+    from synthorg.meta.config import SelfImprovementConfig
+    from synthorg.meta.toolsmith.models import ToolBlueprint
+    from synthorg.meta.toolsmith.protocol import (
+        GoldenScorecardProvider,
+        ToolCreationOverflowHandler,
+    )
+    from synthorg.persistence.tool_blueprint_protocol import DynamicToolRepository
+    from synthorg.providers.base import BaseCompletionProvider
+    from synthorg.tools.sandbox.protocol import SandboxBackend
+
+    SandboxResolver = Callable[[ToolBlueprint], SandboxBackend]
+
+
+@dataclass(frozen=True)
+class ToolsmithRuntime:
+    """The wired toolsmith components the boot layer installs.
+
+    Attributes:
+        service: The orchestrating service (also the capability-gap sink).
+        dynamic_registry: The live registry the layered tool surface reads.
+    """
+
+    service: ToolsmithService
+    dynamic_registry: DynamicToolRegistry
+
+
+def build_toolsmith(  # noqa: PLR0913 -- explicit DI of the toolsmith collaborators
+    *,
+    si_config: SelfImprovementConfig,
+    provider: BaseCompletionProvider,
+    repo: DynamicToolRepository,
+    sandbox_resolver: SandboxResolver,
+    scorecard_provider: GoldenScorecardProvider | None = None,
+    approval_store: ApprovalStoreProtocol | None = None,
+    overflow_handler: ToolCreationOverflowHandler | None = None,
+    existing_capabilities: tuple[NotBlankStr, ...] = (),
+    cost_tracker: CostTracker | None = None,
+    clock: Clock | None = None,
+) -> ToolsmithRuntime:
+    """Wire the toolsmith pipeline from config and runtime dependencies.
+
+    Args:
+        si_config: Self-improvement config (carries the embedded
+            ``toolsmith`` config and drives the shared guard chain).
+        provider: Completion provider for blueprint authoring.
+        repo: Durable blueprint store.
+        sandbox_resolver: Resolves the sandbox backend per blueprint (so a
+            Docker-declared tool runs under Docker, a subprocess one under
+            subprocess).
+        scorecard_provider: Golden-scorecard provider for the gate;
+            required when ``toolsmith.validation.require_golden_delta``.
+        approval_store: Approval store routed into the approval gate.
+        overflow_handler: Handler for service-access capability gaps.
+        existing_capabilities: Current capability surface (dedup hint).
+        cost_tracker: Optional cost tracker for the authoring call.
+        clock: Time source.
+
+    Returns:
+        A :class:`ToolsmithRuntime` with the service and dynamic registry.
+    """
+    resolved_clock = clock or SystemClock()
+    tsc = si_config.toolsmith
+
+    gap_store = RingBufferCapabilityGapStore(
+        max_observations=tsc.gap_buffer_size,
+    )
+
+    def _handler_factory(blueprint: ToolBlueprint) -> object:
+        return make_dynamic_tool_handler(blueprint, sandbox_resolver(blueprint))
+
+    dynamic_registry = DynamicToolRegistry(handler_factory=_handler_factory)  # type: ignore[arg-type]
+
+    generator = LLMToolBlueprintGenerator(
+        config=tsc,
+        provider=provider,
+        cost_tracker=cost_tracker,
+        clock=resolved_clock,
+    )
+    gate = BenchmarkToolValidationGate(
+        config=tsc,
+        brief_runner=SandboxBriefRunner(sandbox_resolver),
+        scorecard_provider=scorecard_provider,
+    )
+    applier = ToolCreationApplier(
+        repo=repo,
+        registry=dynamic_registry,
+        gate=gate,
+        clock=resolved_clock,
+    )
+    guards = build_guards(si_config, approval_store=approval_store)
+    service = ToolsmithService(
+        config=tsc,
+        gap_store=gap_store,
+        generator=generator,
+        applier=applier,
+        guards=guards,
+        overflow_handler=overflow_handler,
+        existing_capabilities=existing_capabilities,
+        clock=resolved_clock,
+    )
+    return ToolsmithRuntime(service=service, dynamic_registry=dynamic_registry)
+
+
+__all__ = ["ToolsmithRuntime", "build_toolsmith"]

--- a/src/synthorg/meta/toolsmith/gap_store.py
+++ b/src/synthorg/meta/toolsmith/gap_store.py
@@ -1,0 +1,151 @@
+"""In-memory capability-gap store.
+
+Ring-buffered, in-process store recording every observation of a missing
+capability (an MCP ``capability_gap`` envelope, an unknown-tool request,
+or an explicit agent-reported gap). The toolsmith service queries
+:meth:`recurring` to decide when a gap has recurred often enough to
+warrant authoring a new tool.
+
+Mirrors the established
+:class:`~synthorg.meta.evolution.outcome_store.InMemoryEvolutionOutcomeStore`
+ring-buffer pattern; a durable backend can ship behind the same
+:class:`~synthorg.meta.toolsmith.protocol.CapabilityGapStore` protocol.
+"""
+
+import asyncio
+from collections import deque
+from typing import TYPE_CHECKING
+
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.toolsmith.models import CapabilityGap
+from synthorg.observability import get_logger, safe_error_description
+from synthorg.observability.events.toolsmith import (
+    TOOLSMITH_GAP_EVICTED,
+    TOOLSMITH_GAP_RECORD_FAILED,
+    TOOLSMITH_GAP_RECORDED,
+)
+
+if TYPE_CHECKING:
+    from datetime import datetime, timedelta
+
+logger = get_logger(__name__)
+
+
+class _Observation:
+    """A single (signature, timestamp) gap observation."""
+
+    __slots__ = ("occurred_at", "signature")
+
+    def __init__(self, signature: str, occurred_at: datetime) -> None:
+        self.signature = signature
+        self.occurred_at = occurred_at
+
+
+class RingBufferCapabilityGapStore:
+    """Process-local ring buffer of capability-gap observations.
+
+    Args:
+        max_observations: Ring-buffer capacity. Oldest entries are
+            evicted when the buffer is full.
+    """
+
+    def __init__(self, *, max_observations: int) -> None:
+        if max_observations < 1:
+            msg = f"max_observations must be >= 1, got {max_observations}"
+            raise ValueError(msg)
+        self._max = max_observations
+        self._obs: deque[_Observation] = deque(maxlen=max_observations)
+        self._lock = asyncio.Lock()
+
+    async def record_gap(
+        self,
+        signature: NotBlankStr,
+        *,
+        occurred_at: datetime,
+    ) -> None:
+        """Record one observation of a missing capability.
+
+        Best-effort: swallows all exceptions except ``MemoryError`` /
+        ``RecursionError`` so a recording failure never blocks the
+        request path that produced the gap. A naive timestamp is dropped
+        (logged) rather than raised, for the same reason.
+        """
+        if occurred_at.tzinfo is None:
+            logger.warning(
+                TOOLSMITH_GAP_RECORD_FAILED,
+                signature=signature,
+                error="occurred_at must be timezone-aware",
+            )
+            return
+        try:
+            async with self._lock:
+                evicted = len(self._obs) == self._max
+                self._obs.append(_Observation(str(signature), occurred_at))
+            logger.debug(TOOLSMITH_GAP_RECORDED, signature=signature)
+            if evicted:
+                logger.info(TOOLSMITH_GAP_EVICTED, max_observations=self._max)
+        except MemoryError, RecursionError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                TOOLSMITH_GAP_RECORD_FAILED,
+                signature=signature,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+
+    async def recurring(
+        self,
+        *,
+        threshold: int,
+        window: timedelta,
+        now: datetime,
+    ) -> tuple[CapabilityGap, ...]:
+        """Return gaps observed at least ``threshold`` times in the window.
+
+        Args:
+            threshold: Minimum occurrences within the window to qualify.
+            window: Sliding window measured back from ``now``.
+            now: Current time (UTC, caller-supplied via the Clock seam).
+
+        Returns:
+            Qualifying gaps, most-frequent first; ties broken by
+            signature ascending for determinism.
+        """
+        if threshold < 1:
+            msg = f"threshold must be >= 1, got {threshold}"
+            raise ValueError(msg)
+        if now.tzinfo is None:
+            msg = "now must be timezone-aware"
+            raise ValueError(msg)
+        cutoff = now - window
+        async with self._lock:
+            snapshot = [o for o in self._obs if o.occurred_at >= cutoff]
+        grouped: dict[str, list[datetime]] = {}
+        for obs in snapshot:
+            grouped.setdefault(obs.signature, []).append(obs.occurred_at)
+        gaps = [
+            CapabilityGap(
+                signature=NotBlankStr(signature),
+                occurrences=len(times),
+                first_seen=min(times),
+                last_seen=max(times),
+            )
+            for signature, times in grouped.items()
+            if len(times) >= threshold
+        ]
+        gaps.sort(key=lambda g: (-g.occurrences, g.signature))
+        return tuple(gaps)
+
+    async def count(self) -> int:
+        """Return current buffer size (not capacity)."""
+        async with self._lock:
+            return len(self._obs)
+
+    async def clear(self) -> None:
+        """Drop all stored observations."""
+        async with self._lock:
+            self._obs.clear()
+
+
+__all__ = ["RingBufferCapabilityGapStore"]

--- a/src/synthorg/meta/toolsmith/models.py
+++ b/src/synthorg/meta/toolsmith/models.py
@@ -8,7 +8,7 @@ blueprint from ``VALIDATED`` to ``ACTIVE``.
 import itertools
 import re
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any, Final, Self
 
 from pydantic import (
     AwareDatetime,
@@ -30,6 +30,10 @@ if TYPE_CHECKING:
 _TOOL_NAME_RE = re.compile(r"^synthorg_[a-z][a-z0-9_]*_[a-z][a-z0-9_]*$")
 _CAPABILITY_RE = re.compile(r"^[a-z][a-z0-9_]*:[a-z][a-z0-9_]*$")
 _ACTION_TYPE_RE = re.compile(r"^[a-z][a-z0-9_]*:[a-z][a-z0-9_]*$")
+
+# Authored scripts are bounded so a malformed or runaway authoring call
+# cannot persist an unbounded blob or exhaust the sandbox at invoke time.
+_MAX_SCRIPT_BODY_CHARS: Final[int] = 65536
 
 
 class ToolBlueprintState(StrEnum):
@@ -175,7 +179,7 @@ class ToolBlueprint(BaseModel):
     description: NotBlankStr
     capability: NotBlankStr
     parameters_schema: dict[str, Any]
-    script_body: NotBlankStr
+    script_body: NotBlankStr = Field(max_length=_MAX_SCRIPT_BODY_CHARS)
     sandbox_backend: ToolSandboxBackend = ToolSandboxBackend.DOCKER
     requires_network: bool = False
     action_type: NotBlankStr
@@ -227,9 +231,16 @@ class ToolBlueprint(BaseModel):
         ):
             msg = f"validated_at required in state {self.state.value!r}"
             raise ValueError(msg)
-        if self.state is ToolBlueprintState.ACTIVE and self.activated_at is None:
-            msg = "activated_at required in state 'active'"
-            raise ValueError(msg)
+        if self.state is ToolBlueprintState.ACTIVE:
+            if self.activated_at is None:
+                msg = "activated_at required in state 'active'"
+                raise ValueError(msg)
+            # An ACTIVE tool is live-registered, which the applier only does
+            # after the benchmark gate passes (persisting the result), so a
+            # live tool must always carry its validation record.
+            if self.validation is None:
+                msg = "validation result required in state 'active'"
+                raise ValueError(msg)
         if self.state is ToolBlueprintState.RETIRED and self.retired_at is None:
             msg = "retired_at required in state 'retired'"
             raise ValueError(msg)

--- a/src/synthorg/meta/toolsmith/models.py
+++ b/src/synthorg/meta/toolsmith/models.py
@@ -1,0 +1,251 @@
+"""Domain models for the self-extending toolkit (toolsmith).
+
+Defines the capability-gap signal, the authored-tool blueprint and its
+lifecycle state, and the benchmark-validation result that gates a
+blueprint from ``VALIDATED`` to ``ACTIVE``.
+"""
+
+import itertools
+import re
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, Self
+
+from pydantic import (
+    AwareDatetime,
+    BaseModel,
+    ConfigDict,
+    Field,
+    model_validator,
+)
+
+from synthorg.core.types import NotBlankStr  # noqa: TC001 -- Pydantic field type
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+# Authored tools reuse the MCP tool-surface contract verbatim so a
+# blueprint can be promoted into an ``MCPToolDef`` without re-validation
+# drift: the name follows ``synthorg_{domain}_{action}`` and the
+# capability follows ``domain:action``.
+_TOOL_NAME_RE = re.compile(r"^synthorg_[a-z][a-z0-9_]*_[a-z][a-z0-9_]*$")
+_CAPABILITY_RE = re.compile(r"^[a-z][a-z0-9_]*:[a-z][a-z0-9_]*$")
+_ACTION_TYPE_RE = re.compile(r"^[a-z][a-z0-9_]*:[a-z][a-z0-9_]*$")
+
+
+class ToolBlueprintState(StrEnum):
+    """Lifecycle state of an authored tool blueprint.
+
+    A blueprint is born ``PENDING`` (proposed, not yet trusted), moves to
+    ``VALIDATED`` once the benchmark gate passes, ``ACTIVE`` once it is
+    live-registered in the dynamic registry, and ``RETIRED`` when rolled
+    back. Transitions are atomic compare-and-set at the persistence layer.
+    """
+
+    PENDING = "pending"
+    VALIDATED = "validated"
+    ACTIVE = "active"
+    RETIRED = "retired"
+
+
+class ToolSandboxBackend(StrEnum):
+    """Sandbox backend an authored tool's script runs in.
+
+    ``DOCKER`` is the default (container isolation, no network unless the
+    blueprint opts in); ``SUBPROCESS`` is an opt-in lighter backend for
+    trusted, fast scripts.
+    """
+
+    DOCKER = "docker"
+    SUBPROCESS = "subprocess"
+
+
+class CapabilityGap(BaseModel):
+    """An aggregated, recurring capability gap.
+
+    Attributes:
+        signature: Stable key identifying the missing capability
+            (typically the requested ``domain:action`` capability tag).
+        occurrences: Number of times the gap was observed in the window.
+        first_seen: First observation timestamp (UTC).
+        last_seen: Most recent observation timestamp (UTC).
+    """
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False, extra="forbid")
+
+    signature: NotBlankStr
+    occurrences: int = Field(ge=1)
+    first_seen: AwareDatetime
+    last_seen: AwareDatetime
+
+    @model_validator(mode="after")
+    def _ordering(self) -> Self:
+        """Enforce ``first_seen <= last_seen``."""
+        if self.first_seen > self.last_seen:
+            msg = "first_seen must be <= last_seen"
+            raise ValueError(msg)
+        return self
+
+
+class ToolValidationResult(BaseModel):
+    """Outcome of running the benchmark gate against a tool blueprint.
+
+    The gate passes iff the focused per-tool acceptance brief passes AND
+    the golden-company scorecard with the candidate tool registered does
+    not regress against the baseline (``candidate_score >= baseline_score``).
+
+    Attributes:
+        passed: Whether the blueprint is trusted (both checks passed).
+        brief_passed: Whether the per-tool acceptance brief passed.
+        brief_score: Per-tool acceptance brief score in ``[0, 100]``.
+        baseline_score: Golden scorecard total without the candidate.
+        candidate_score: Golden scorecard total with the candidate.
+        margin: ``candidate_score - baseline_score`` (may be negative).
+        detail: Human-readable summary of the gate decision.
+    """
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False, extra="forbid")
+
+    passed: bool
+    brief_passed: bool
+    brief_score: int = Field(ge=0, le=100)
+    baseline_score: int = Field(ge=0)
+    candidate_score: int = Field(ge=0)
+    margin: int
+    detail: NotBlankStr
+
+    @model_validator(mode="after")
+    def _consistency(self) -> Self:
+        """Enforce margin arithmetic and the pass predicate."""
+        expected_margin = self.candidate_score - self.baseline_score
+        if self.margin != expected_margin:
+            msg = (
+                f"margin={self.margin} does not match "
+                f"candidate_score - baseline_score (={expected_margin})"
+            )
+            raise ValueError(msg)
+        # ``passed`` implies (but is not implied by) a passing brief and a
+        # non-regressing margin: the gate may additionally require a
+        # positive ``min_score_margin``, so an eligible result can still
+        # be ``passed=False``. What is never allowed is passing while the
+        # brief failed or the scorecard regressed.
+        if self.passed and not (self.brief_passed and self.margin >= 0):
+            msg = (
+                f"passed=True contradicts brief_passed={self.brief_passed} "
+                f"and margin={self.margin}"
+            )
+            raise ValueError(msg)
+        return self
+
+
+class ToolBlueprint(BaseModel):
+    """A runtime-authored tool: declarative spec plus a sandbox script body.
+
+    A blueprint is the persisted, governed unit of the self-extending
+    toolkit. Once trusted and activated, it is promoted to an
+    ``MCPToolDef`` (name, capability, parameters schema) backed by a
+    per-tool handler that runs ``script_body`` in the resolved sandbox.
+
+    Attributes:
+        id: Stable blueprint identifier (primary key).
+        name: MCP tool name (``synthorg_{domain}_{action}``).
+        description: Human-readable description for LLM prompts.
+        capability: Capability tag in ``domain:action`` format.
+        parameters_schema: JSON Schema describing the tool's inputs. A
+            real Pydantic ``args_model`` is materialised from this at
+            registration time so dynamic tools keep the same typed
+            validation symmetry as static tools.
+        script_body: Source the sandbox executes for each invocation.
+        sandbox_backend: Backend the script runs in (Docker by default).
+        requires_network: Whether the sandbox is granted network egress
+            (default ``False``).
+        action_type: Permission-classification action in ``category:action``
+            format (e.g. ``"code:read"``), gating the tool through autonomy.
+        state: Lifecycle state.
+        created_at: Creation timestamp (UTC).
+        validated_at: When the benchmark gate passed (UTC), else ``None``.
+        activated_at: When the tool was live-registered (UTC), else ``None``.
+        retired_at: When the tool was rolled back (UTC), else ``None``.
+        validation: Benchmark-gate result, populated once validated.
+    """
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False, extra="forbid")
+
+    id: NotBlankStr
+    name: NotBlankStr
+    description: NotBlankStr
+    capability: NotBlankStr
+    parameters_schema: dict[str, Any]
+    script_body: NotBlankStr
+    sandbox_backend: ToolSandboxBackend = ToolSandboxBackend.DOCKER
+    requires_network: bool = False
+    action_type: NotBlankStr
+    state: ToolBlueprintState = ToolBlueprintState.PENDING
+    created_at: AwareDatetime
+    validated_at: AwareDatetime | None = None
+    activated_at: AwareDatetime | None = None
+    retired_at: AwareDatetime | None = None
+    validation: ToolValidationResult | None = None
+
+    @model_validator(mode="after")
+    def _validate_name_capability_action(self) -> Self:
+        """Enforce the MCP naming + capability + action-type contracts."""
+        if not _TOOL_NAME_RE.match(self.name):
+            msg = f"name must match 'synthorg_{{domain}}_{{action}}': {self.name!r}"
+            raise ValueError(msg)
+        if not _CAPABILITY_RE.match(self.capability):
+            msg = f"capability must match 'domain:action': {self.capability!r}"
+            raise ValueError(msg)
+        if not _ACTION_TYPE_RE.match(self.action_type):
+            msg = f"action_type must match 'category:action': {self.action_type!r}"
+            raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
+    def _validate_schema_shape(self) -> Self:
+        """Require an object schema with a ``properties`` mapping.
+
+        A materialisable ``args_model`` needs named properties; a schema
+        without them cannot round-trip through ``pydantic.create_model``.
+        """
+        if self.parameters_schema.get("type") != "object":
+            msg = "parameters_schema must declare 'type': 'object'"
+            raise ValueError(msg)
+        props = self.parameters_schema.get("properties")
+        if not isinstance(props, dict):
+            # Pydantic validators signal failure via ValueError, which the
+            # framework converts to a ValidationError; TypeError would not
+            # be caught the same way.
+            msg = "parameters_schema must declare a 'properties' object"
+            raise ValueError(msg)  # noqa: TRY004
+        return self
+
+    @model_validator(mode="after")
+    def _validate_state_timestamps(self) -> Self:
+        """Lifecycle timestamps must be present for their state, ordered."""
+        if self.state in {ToolBlueprintState.VALIDATED, ToolBlueprintState.ACTIVE} and (
+            self.validated_at is None
+        ):
+            msg = f"validated_at required in state {self.state.value!r}"
+            raise ValueError(msg)
+        if self.state is ToolBlueprintState.ACTIVE and self.activated_at is None:
+            msg = "activated_at required in state 'active'"
+            raise ValueError(msg)
+        if self.state is ToolBlueprintState.RETIRED and self.retired_at is None:
+            msg = "retired_at required in state 'retired'"
+            raise ValueError(msg)
+        self._assert_monotonic()
+        return self
+
+    def _assert_monotonic(self) -> None:
+        """Enforce created <= validated <= activated <= retired ordering."""
+        ordered: list[tuple[str, datetime | None]] = [
+            ("created_at", self.created_at),
+            ("validated_at", self.validated_at),
+            ("activated_at", self.activated_at),
+            ("retired_at", self.retired_at),
+        ]
+        seen = [(name, ts) for name, ts in ordered if ts is not None]
+        for (prev_name, prev_ts), (name, ts) in itertools.pairwise(seen):
+            if ts < prev_ts:
+                msg = f"{name} must be >= {prev_name}"
+                raise ValueError(msg)

--- a/src/synthorg/meta/toolsmith/models.py
+++ b/src/synthorg/meta/toolsmith/models.py
@@ -248,21 +248,26 @@ class ToolBlueprint(BaseModel):
         gate ever ran. The applier writes the record at the same instant
         as ``validated_at``, so the two are inseparable across lifecycle.
         """
+        # Every post-PENDING state is gate-graduated, so validated_at and
+        # the validation record are required throughout. A RETIRED tool
+        # was rolled back AFTER activation, so it must also carry
+        # activated_at; only PENDING and the impossible "retired without
+        # ever activating" lack it. This mirrors the DB-layer lifecycle
+        # CHECK so the model and persistence agree.
         terminal_states = {
             ToolBlueprintState.VALIDATED,
             ToolBlueprintState.ACTIVE,
             ToolBlueprintState.RETIRED,
         }
-        if self.state in {ToolBlueprintState.VALIDATED, ToolBlueprintState.ACTIVE} and (
-            self.validated_at is None
-        ):
+        activated_states = {ToolBlueprintState.ACTIVE, ToolBlueprintState.RETIRED}
+        if self.state in terminal_states and self.validated_at is None:
             msg = f"validated_at required in state {self.state.value!r}"
             raise ValueError(msg)
         if self.state in terminal_states and self.validation is None:
             msg = f"validation result required in state {self.state.value!r}"
             raise ValueError(msg)
-        if self.state is ToolBlueprintState.ACTIVE and self.activated_at is None:
-            msg = "activated_at required in state 'active'"
+        if self.state in activated_states and self.activated_at is None:
+            msg = f"activated_at required in state {self.state.value!r}"
             raise ValueError(msg)
         if self.state is ToolBlueprintState.RETIRED and self.retired_at is None:
             msg = "retired_at required in state 'retired'"

--- a/src/synthorg/meta/toolsmith/models.py
+++ b/src/synthorg/meta/toolsmith/models.py
@@ -192,7 +192,14 @@ class ToolBlueprint(BaseModel):
 
     @model_validator(mode="after")
     def _validate_name_capability_action(self) -> Self:
-        """Enforce the MCP naming + capability + action-type contracts."""
+        """Enforce the MCP naming + capability + action-type contracts.
+
+        Beyond per-field format, the ``synthorg_{domain}_{action}`` name
+        must denote the same ``{domain}/{action}`` as the ``{domain}:{action}``
+        capability tag. A drift here would mean routing and governance see
+        different identifiers for the same tool, which the LayeredHandlerMap
+        cannot reconcile.
+        """
         if not _TOOL_NAME_RE.match(self.name):
             msg = f"name must match 'synthorg_{{domain}}_{{action}}': {self.name!r}"
             raise ValueError(msg)
@@ -201,6 +208,14 @@ class ToolBlueprint(BaseModel):
             raise ValueError(msg)
         if not _ACTION_TYPE_RE.match(self.action_type):
             msg = f"action_type must match 'category:action': {self.action_type!r}"
+            raise ValueError(msg)
+        capability_domain, capability_action = self.capability.split(":", 1)
+        expected_name = f"synthorg_{capability_domain}_{capability_action}"
+        if self.name != expected_name:
+            msg = (
+                "name and capability must reference the same domain/action: "
+                f"name={self.name!r}, capability={self.capability!r}"
+            )
             raise ValueError(msg)
         return self
 
@@ -225,22 +240,30 @@ class ToolBlueprint(BaseModel):
 
     @model_validator(mode="after")
     def _validate_state_timestamps(self) -> Self:
-        """Lifecycle timestamps must be present for their state, ordered."""
+        """Lifecycle timestamps must be present for their state, ordered.
+
+        Any post-PENDING state must carry the validation record: that is
+        the gate's audit evidence, and a missing record would mean a
+        consumer could observe a "validated" blueprint with no proof the
+        gate ever ran. The applier writes the record at the same instant
+        as ``validated_at``, so the two are inseparable across lifecycle.
+        """
+        terminal_states = {
+            ToolBlueprintState.VALIDATED,
+            ToolBlueprintState.ACTIVE,
+            ToolBlueprintState.RETIRED,
+        }
         if self.state in {ToolBlueprintState.VALIDATED, ToolBlueprintState.ACTIVE} and (
             self.validated_at is None
         ):
             msg = f"validated_at required in state {self.state.value!r}"
             raise ValueError(msg)
-        if self.state is ToolBlueprintState.ACTIVE:
-            if self.activated_at is None:
-                msg = "activated_at required in state 'active'"
-                raise ValueError(msg)
-            # An ACTIVE tool is live-registered, which the applier only does
-            # after the benchmark gate passes (persisting the result), so a
-            # live tool must always carry its validation record.
-            if self.validation is None:
-                msg = "validation result required in state 'active'"
-                raise ValueError(msg)
+        if self.state in terminal_states and self.validation is None:
+            msg = f"validation result required in state {self.state.value!r}"
+            raise ValueError(msg)
+        if self.state is ToolBlueprintState.ACTIVE and self.activated_at is None:
+            msg = "activated_at required in state 'active'"
+            raise ValueError(msg)
         if self.state is ToolBlueprintState.RETIRED and self.retired_at is None:
             msg = "retired_at required in state 'retired'"
             raise ValueError(msg)

--- a/src/synthorg/meta/toolsmith/overflow.py
+++ b/src/synthorg/meta/toolsmith/overflow.py
@@ -1,0 +1,117 @@
+"""Code-modification overflow handler for service-access capability gaps.
+
+A sandbox script cannot reach the internal service layer, so a recurring
+gap whose capability is in ``service_access_capabilities`` cannot be an
+authored sandbox tool. This handler routes such gaps to the existing
+self-improvement ``CODE_MODIFICATION`` altitude: it frames the gap as a
+:class:`RuleMatch` and delegates to a :class:`CodeModificationStrategy`,
+which produces a draft-PR code-change proposal (not a same-run tool).
+
+The strategy needs an :class:`OrgSignalSnapshot` for prompt context. A
+caller may inject a live ``snapshot_provider``; otherwise a neutral
+baseline snapshot is used, since the actionable signal here is the gap
+itself (carried in ``RuleMatch.signal_context``), not org-wide metrics.
+"""
+
+from typing import TYPE_CHECKING
+
+from synthorg.meta.models import (
+    ProposalAltitude,
+    RuleMatch,
+    RuleSeverity,
+)
+from synthorg.meta.signal_models import (
+    OrgBudgetSummary,
+    OrgCoordinationSummary,
+    OrgErrorSummary,
+    OrgEvolutionSummary,
+    OrgPerformanceSummary,
+    OrgScalingSummary,
+    OrgSignalSnapshot,
+    OrgTelemetrySummary,
+)
+from synthorg.observability import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from synthorg.meta.models import ImprovementProposal
+    from synthorg.meta.protocol import ImprovementStrategy
+    from synthorg.meta.toolsmith.models import CapabilityGap
+
+logger = get_logger(__name__)
+
+
+def build_baseline_snapshot() -> OrgSignalSnapshot:
+    """Build a neutral, zeroed org signal snapshot.
+
+    Used when no live snapshot provider is wired: the gap (carried in the
+    rule's ``signal_context``) is the actionable signal for an authoring
+    decision, so org-wide metrics can be neutral.
+    """
+    return OrgSignalSnapshot(
+        performance=OrgPerformanceSummary(
+            avg_quality_score=0.0,
+            avg_success_rate=0.0,
+            avg_collaboration_score=0.0,
+            agent_count=0,
+        ),
+        budget=OrgBudgetSummary(
+            total_spend=0.0,
+            productive_ratio=0.0,
+            coordination_ratio=0.0,
+            system_ratio=0.0,
+            forecast_confidence=0.0,
+            orchestration_overhead=0.0,
+        ),
+        coordination=OrgCoordinationSummary(),
+        scaling=OrgScalingSummary(),
+        errors=OrgErrorSummary(),
+        evolution=OrgEvolutionSummary(),
+        telemetry=OrgTelemetrySummary(),
+    )
+
+
+class CodeModificationOverflowHandler:
+    """Adapts a capability gap into a ``CODE_MODIFICATION`` proposal.
+
+    Args:
+        strategy: The self-improvement code-modification strategy to
+            delegate to (satisfies :class:`ImprovementStrategy`).
+        snapshot_provider: Optional async source of a live
+            :class:`OrgSignalSnapshot`; defaults to a neutral baseline.
+    """
+
+    def __init__(
+        self,
+        strategy: ImprovementStrategy,
+        *,
+        snapshot_provider: Callable[[], Awaitable[OrgSignalSnapshot]] | None = None,
+    ) -> None:
+        self._strategy = strategy
+        self._snapshot_provider = snapshot_provider
+
+    async def handle(self, gap: CapabilityGap) -> tuple[ImprovementProposal, ...]:
+        """Frame the gap as a rule and delegate to the code-mod strategy."""
+        snapshot = (
+            await self._snapshot_provider()
+            if self._snapshot_provider is not None
+            else build_baseline_snapshot()
+        )
+        rule = RuleMatch(
+            rule_name="capability_gap_service_access",
+            severity=RuleSeverity.WARNING,
+            description=(
+                f"Recurring capability gap {gap.signature!r} needs "
+                f"service-layer access; routing to code modification."
+            ),
+            signal_context={
+                "capability": gap.signature,
+                "occurrences": gap.occurrences,
+            },
+            suggested_altitudes=(ProposalAltitude.CODE_MODIFICATION,),
+        )
+        return await self._strategy.propose(snapshot=snapshot, triggered_rules=(rule,))
+
+
+__all__ = ["CodeModificationOverflowHandler", "build_baseline_snapshot"]

--- a/src/synthorg/meta/toolsmith/protocol.py
+++ b/src/synthorg/meta/toolsmith/protocol.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from datetime import datetime, timedelta
 
     from synthorg.core.types import NotBlankStr
+    from synthorg.meta.models import ImprovementProposal
     from synthorg.meta.toolsmith.models import (
         CapabilityGap,
         ToolBlueprint,
@@ -145,6 +146,22 @@ class ToolValidationGate(Protocol):
             when the brief passes and the golden scorecard does not
             regress.
         """
+        ...
+
+
+@runtime_checkable
+class ToolCreationOverflowHandler(Protocol):
+    """Handles capability gaps that need service-layer access.
+
+    A sandbox script cannot reach the internal service layer, so gaps
+    whose capability is in ``service_access_capabilities`` are routed
+    here instead of being authored as sandbox tools. The default
+    implementation delegates to the self-improvement ``CODE_MODIFICATION``
+    altitude (which yields a draft PR, not a same-run tool).
+    """
+
+    async def handle(self, gap: CapabilityGap) -> tuple[ImprovementProposal, ...]:
+        """Produce proposals addressing a service-access capability gap."""
         ...
 
 

--- a/src/synthorg/meta/toolsmith/protocol.py
+++ b/src/synthorg/meta/toolsmith/protocol.py
@@ -1,0 +1,169 @@
+"""Pluggable protocols for the self-extending toolkit (toolsmith).
+
+Every collaborator in the toolsmith pipeline is defined here as a
+``@runtime_checkable`` Protocol so the service composes against
+interfaces (protocol + strategy + factory + config discriminator).
+"""
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from datetime import datetime, timedelta
+
+    from synthorg.core.types import NotBlankStr
+    from synthorg.meta.toolsmith.models import (
+        CapabilityGap,
+        ToolBlueprint,
+        ToolValidationResult,
+    )
+
+
+@runtime_checkable
+class CapabilityGapSink(Protocol):
+    """Receives a single capability-gap observation.
+
+    Wired into the MCP ``capability_gap`` envelope helper so every
+    unfulfilled capability request is recorded for recurrence analysis.
+    """
+
+    async def record_gap(
+        self,
+        signature: NotBlankStr,
+        *,
+        occurred_at: datetime,
+    ) -> None:
+        """Record one observation of a missing capability.
+
+        Args:
+            signature: Stable key for the missing capability (the
+                requested ``domain:action`` capability tag).
+            occurred_at: Observation timestamp (UTC, caller-supplied
+                via the Clock seam).
+        """
+        ...
+
+
+@runtime_checkable
+class CapabilityGapStore(CapabilityGapSink, Protocol):
+    """Aggregates capability-gap observations and surfaces recurrence."""
+
+    async def recurring(
+        self,
+        *,
+        threshold: int,
+        window: timedelta,
+        now: datetime,
+    ) -> tuple[CapabilityGap, ...]:
+        """Return gaps observed at least ``threshold`` times in the window.
+
+        Args:
+            threshold: Minimum occurrences within the window to qualify.
+            window: Sliding window measured back from ``now``.
+            now: Current time (UTC, caller-supplied via the Clock seam).
+
+        Returns:
+            Qualifying gaps, most-frequent first (ties broken by
+            signature for determinism).
+        """
+        ...
+
+    async def clear(self) -> None:
+        """Drop all stored observations."""
+        ...
+
+
+@runtime_checkable
+class ToolBlueprintGenerator(Protocol):
+    """Authors a tool blueprint from a recurring capability gap."""
+
+    async def author(
+        self,
+        gap: CapabilityGap,
+        *,
+        existing_capabilities: Sequence[NotBlankStr],
+    ) -> ToolBlueprint:
+        """Generate a candidate blueprint addressing ``gap``.
+
+        Args:
+            gap: The recurring capability gap to address.
+            existing_capabilities: Capability tags already on the tool
+                surface, so the generator avoids duplicates.
+
+        Returns:
+            A candidate :class:`ToolBlueprint` in ``PENDING`` state.
+
+        Raises:
+            ToolAuthoringError: If the model output cannot be parsed
+                into a valid blueprint.
+        """
+        ...
+
+
+@runtime_checkable
+class ToolAcceptanceBriefRunner(Protocol):
+    """Runs the focused per-tool acceptance brief for a candidate tool."""
+
+    async def run(self, blueprint: ToolBlueprint) -> tuple[bool, int]:
+        """Exercise the authored tool against an acceptance probe.
+
+        Args:
+            blueprint: The candidate blueprint to exercise.
+
+        Returns:
+            ``(passed, score)`` where ``score`` is in ``[0, 100]``.
+        """
+        ...
+
+
+@runtime_checkable
+class GoldenScorecardProvider(Protocol):
+    """Scores the golden-company benchmark with and without a candidate."""
+
+    async def score(self, blueprint: ToolBlueprint) -> tuple[int, int]:
+        """Return ``(baseline_total, candidate_total)`` golden scores.
+
+        ``baseline_total`` is the scorecard without the candidate tool;
+        ``candidate_total`` is the scorecard with it registered. A
+        candidate that regresses the org scores ``candidate < baseline``.
+        """
+        ...
+
+
+@runtime_checkable
+class ToolValidationGate(Protocol):
+    """Validates a candidate blueprint against the golden benchmark."""
+
+    async def validate(self, blueprint: ToolBlueprint) -> ToolValidationResult:
+        """Run the per-tool acceptance brief and golden scorecard delta.
+
+        Args:
+            blueprint: The candidate blueprint to validate.
+
+        Returns:
+            A :class:`ToolValidationResult`; ``passed`` is ``True`` only
+            when the brief passes and the golden scorecard does not
+            regress.
+        """
+        ...
+
+
+@runtime_checkable
+class DynamicToolRegistryProtocol(Protocol):
+    """Mutable, lock-guarded registry of live authored tools.
+
+    Layered behind the frozen static ``DomainToolRegistry``: the invoker
+    reads the static surface first, then this dynamic layer.
+    """
+
+    async def register(self, blueprint: ToolBlueprint) -> None:
+        """Register an active blueprint as a live MCP tool."""
+        ...
+
+    async def unregister(self, name: NotBlankStr) -> bool:
+        """Remove a live tool by name; ``True`` iff it was present."""
+        ...
+
+    def names(self) -> tuple[NotBlankStr, ...]:
+        """Return the currently-registered dynamic tool names."""
+        ...

--- a/src/synthorg/meta/toolsmith/script_handler.py
+++ b/src/synthorg/meta/toolsmith/script_handler.py
@@ -69,6 +69,8 @@ class _DynamicToolHandler:
         name = self._blueprint.name
         try:
             payload = await self._run(arguments)
+        except MemoryError, RecursionError:
+            raise
         except Exception as exc:
             logger.warning(
                 TOOLSMITH_TOOL_INVOKE_FAILED,

--- a/src/synthorg/meta/toolsmith/script_handler.py
+++ b/src/synthorg/meta/toolsmith/script_handler.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any, Final
 
 from synthorg.meta.mcp.handlers.common import err, ok
 from synthorg.meta.toolsmith.errors import ToolsmithError
-from synthorg.observability import get_logger
+from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.toolsmith import (
     TOOLSMITH_TOOL_INVOKE_FAILED,
     TOOLSMITH_TOOL_INVOKED,
@@ -74,6 +74,7 @@ class _DynamicToolHandler:
                 TOOLSMITH_TOOL_INVOKE_FAILED,
                 tool_name=name,
                 error_type=type(exc).__name__,
+                error=safe_error_description(exc),
             )
             wrapped = (
                 exc

--- a/src/synthorg/meta/toolsmith/script_handler.py
+++ b/src/synthorg/meta/toolsmith/script_handler.py
@@ -1,0 +1,129 @@
+"""Per-tool handler that runs an authored tool's script in the sandbox.
+
+An authored tool is a declarative spec plus a Python ``script_body``. The
+handler never imports that source into the live process: it executes it
+in the configured :class:`~synthorg.tools.sandbox.protocol.SandboxBackend`
+(Docker by default, no network unless the blueprint opts in), passing the
+already-validated arguments as a JSON environment variable and mapping the
+sandbox result back to the MCP success / error envelope.
+
+Authored-script contract:
+    The script reads its arguments from the ``SYNTHORG_TOOL_ARGS``
+    environment variable (a JSON object) and prints a single JSON value
+    to stdout. A non-zero exit, a timeout, or unparseable stdout is
+    surfaced as an MCP error envelope.
+"""
+
+import json
+from typing import TYPE_CHECKING, Any, Final
+
+from synthorg.meta.mcp.handlers.common import err, ok
+from synthorg.meta.toolsmith.errors import ToolsmithError
+from synthorg.observability import get_logger
+from synthorg.observability.events.toolsmith import (
+    TOOLSMITH_TOOL_INVOKE_FAILED,
+    TOOLSMITH_TOOL_INVOKED,
+)
+
+if TYPE_CHECKING:
+    from synthorg.core.agent import AgentIdentity
+    from synthorg.meta.mcp.handler_protocol import ToolHandler
+    from synthorg.meta.toolsmith.models import ToolBlueprint
+    from synthorg.tools.sandbox.protocol import SandboxBackend
+
+logger = get_logger(__name__)
+
+_ARGS_ENV_VAR: Final[str] = "SYNTHORG_TOOL_ARGS"
+_DEFAULT_TIMEOUT_SECONDS: Final[float] = 30.0
+
+
+class DynamicToolScriptError(ToolsmithError):
+    """Raised when an authored tool's sandbox run fails or returns junk."""
+
+    default_message = "Authored tool execution failed"
+
+
+class _DynamicToolHandler:
+    """A :class:`ToolHandler` that executes one blueprint's script."""
+
+    def __init__(
+        self,
+        blueprint: ToolBlueprint,
+        sandbox: SandboxBackend,
+        *,
+        timeout_seconds: float,
+    ) -> None:
+        self._blueprint = blueprint
+        self._sandbox = sandbox
+        self._timeout_seconds = timeout_seconds
+
+    async def __call__(
+        self,
+        *,
+        app_state: Any,
+        arguments: dict[str, Any],
+        actor: AgentIdentity | None = None,
+    ) -> str:
+        """Run the authored script and return an MCP envelope."""
+        del app_state, actor
+        name = self._blueprint.name
+        try:
+            payload = await self._run(arguments)
+        except Exception as exc:
+            logger.warning(
+                TOOLSMITH_TOOL_INVOKE_FAILED,
+                tool_name=name,
+                error_type=type(exc).__name__,
+            )
+            wrapped = (
+                exc
+                if isinstance(exc, ToolsmithError)
+                else DynamicToolScriptError(f"Authored tool {name!r} failed")
+            )
+            return err(wrapped, domain_code="dynamic_tool_failed")
+        logger.debug(TOOLSMITH_TOOL_INVOKED, tool_name=name)
+        return ok(data=payload)
+
+    async def _run(self, arguments: dict[str, Any]) -> Any:
+        """Execute the script in the sandbox and parse its JSON stdout."""
+        args_json = json.dumps(arguments, sort_keys=True)
+        result = await self._sandbox.execute(
+            command="python",
+            args=("-c", str(self._blueprint.script_body)),
+            env_overrides={_ARGS_ENV_VAR: args_json},
+            timeout=self._timeout_seconds,
+        )
+        if result.timed_out:
+            msg = f"Authored tool {self._blueprint.name!r} timed out"
+            raise DynamicToolScriptError(msg)
+        if result.returncode != 0:
+            msg = f"Authored tool {self._blueprint.name!r} exited {result.returncode}"
+            raise DynamicToolScriptError(msg)
+        try:
+            return json.loads(result.stdout)
+        except (ValueError, TypeError) as exc:
+            msg = f"Authored tool {self._blueprint.name!r} produced non-JSON stdout"
+            raise DynamicToolScriptError(msg) from exc
+
+
+def make_dynamic_tool_handler(
+    blueprint: ToolBlueprint,
+    sandbox: SandboxBackend,
+    *,
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+) -> ToolHandler:
+    """Build a per-tool :class:`ToolHandler` closure for a blueprint.
+
+    Args:
+        blueprint: The active blueprint to execute.
+        sandbox: The sandbox backend resolved for the blueprint.
+        timeout_seconds: Per-invocation wall-clock budget.
+
+    Returns:
+        A :class:`ToolHandler` that runs the script and maps the result
+        to an MCP envelope.
+    """
+    return _DynamicToolHandler(blueprint, sandbox, timeout_seconds=timeout_seconds)
+
+
+__all__ = ["DynamicToolScriptError", "make_dynamic_tool_handler"]

--- a/src/synthorg/meta/toolsmith/service.py
+++ b/src/synthorg/meta/toolsmith/service.py
@@ -16,8 +16,9 @@ Approved proposals are applied via :meth:`apply`, which validates against
 the benchmark gate and live-registers the tool on pass.
 """
 
+import asyncio
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from synthorg.core.clock import Clock, SystemClock
 from synthorg.core.types import NotBlankStr
@@ -49,6 +50,7 @@ if TYPE_CHECKING:
     from synthorg.meta.protocol import ProposalGuard
     from synthorg.meta.toolsmith.applier import ToolCreationApplier
     from synthorg.meta.toolsmith.config import ToolsmithConfig
+    from synthorg.meta.toolsmith.dynamic_registry import DynamicToolRegistry
     from synthorg.meta.toolsmith.models import CapabilityGap, ToolBlueprint
     from synthorg.meta.toolsmith.protocol import (
         CapabilityGapStore,
@@ -57,6 +59,12 @@ if TYPE_CHECKING:
     )
 
 logger = get_logger(__name__)
+
+# Recurring capability gaps that reach the threshold are real demand
+# signals, but a single observation could still be noise; mid-confidence
+# is the right starting prior until the gate-then-guards chain has
+# additional evidence.
+_TOOL_CREATION_CONFIDENCE: Final[float] = 0.5
 
 
 class ToolsmithService:
@@ -69,8 +77,13 @@ class ToolsmithService:
         applier: Validates and live-registers approved blueprints.
         guards: Sequential guard chain (scope, rollback, rate, approval).
         overflow_handler: Handles service-access gaps (optional).
-        existing_capabilities: Callable returning the current capability
-            surface, so the generator avoids duplicates.
+        existing_capabilities: Static capability surface (dedup hint).
+            The dynamic-registry capabilities are merged at gap-handling
+            time via ``dynamic_registry`` (if provided), so the generator
+            also avoids duplicating tools registered earlier in this run.
+        dynamic_registry: Live dynamic-tool registry whose capabilities
+            extend the dedup hint at call time. Optional so the service
+            still works in tests that exercise authoring in isolation.
         clock: Time source.
     """
 
@@ -84,6 +97,7 @@ class ToolsmithService:
         guards: tuple[ProposalGuard, ...],
         overflow_handler: ToolCreationOverflowHandler | None = None,
         existing_capabilities: tuple[NotBlankStr, ...] = (),
+        dynamic_registry: DynamicToolRegistry | None = None,
         clock: Clock | None = None,
     ) -> None:
         self._config = config
@@ -93,6 +107,7 @@ class ToolsmithService:
         self._guards = guards
         self._overflow_handler = overflow_handler
         self._existing_capabilities = existing_capabilities
+        self._dynamic_registry = dynamic_registry
         self._clock = clock or SystemClock()
 
     async def record_gap(
@@ -109,7 +124,14 @@ class ToolsmithService:
     async def run_cycle(
         self, *, now: datetime | None = None
     ) -> tuple[ImprovementProposal, ...]:
-        """Detect recurring gaps, author proposals, and guard them."""
+        """Detect recurring gaps, author proposals, and guard them.
+
+        Per-gap authoring is parallelised via TaskGroup so the LLM round
+        trip and guard chain run concurrently across gaps; each gap's
+        per-call ``ToolCapabilityNotAllowedError`` / ``ToolAuthoringError``
+        is caught inside ``_handle_gap`` so a single bad gap cannot abort
+        the whole batch.
+        """
         moment = now or self._clock.now()
         logger.info(TOOLSMITH_CYCLE_STARTED)
         gaps = await self._gap_store.recurring(
@@ -118,8 +140,11 @@ class ToolsmithService:
             now=moment,
         )
         proposals: list[ImprovementProposal] = []
-        for gap in gaps:
-            proposals.extend(await self._handle_gap(gap))
+        if gaps:
+            async with asyncio.TaskGroup() as tg:
+                tasks = [tg.create_task(self._handle_gap(gap)) for gap in gaps]
+            for task in tasks:
+                proposals.extend(task.result())
         logger.info(
             TOOLSMITH_CYCLE_COMPLETED,
             gaps=len(gaps),
@@ -135,9 +160,16 @@ class ToolsmithService:
         """Author or overflow a single gap, then guard the result."""
         if gap.signature in self._config.service_access_capabilities:
             return await self._handle_overflow(gap)
+        # Dedup hint = static surface known at boot + dynamic-registry
+        # capabilities the applier registered earlier in this run. The
+        # latter prevents the LLM from authoring a duplicate of a tool
+        # added in the same cycle (it cannot see live state otherwise).
+        existing = self._existing_capabilities
+        if self._dynamic_registry is not None:
+            existing = (*existing, *self._dynamic_registry.capabilities())
         try:
             blueprint = await self._generator.author(
-                gap, existing_capabilities=self._existing_capabilities
+                gap, existing_capabilities=existing
             )
         except (ToolCapabilityNotAllowedError, ToolAuthoringError) as exc:
             logger.warning(
@@ -213,7 +245,7 @@ def _build_proposal(
         ),
         tool_changes=(blueprint,),
         rollback_plan=rollback,
-        confidence=0.5,
+        confidence=_TOOL_CREATION_CONFIDENCE,
         source_rule=NotBlankStr("capability_gap"),
     )
 

--- a/src/synthorg/meta/toolsmith/service.py
+++ b/src/synthorg/meta/toolsmith/service.py
@@ -1,0 +1,219 @@
+"""Toolsmith orchestration service.
+
+Ties the self-extending toolkit together: it is the capability-gap sink,
+runs the detection -> author -> guard cycle, and applies approved
+proposals. The cycle mirrors the self-improvement loop but at the
+``TOOL_CREATION`` altitude:
+
+1. Aggregate recurring capability gaps from the gap store.
+2. For each gap, either author a sandbox tool (primary path) or route to
+   the code-modification overflow handler (service-access capabilities).
+3. Wrap each authored blueprint in an ``ImprovementProposal`` and run it
+   through the guard chain (scope, rollback, rate limit, approval). Only
+   guarded-and-enqueued proposals are returned.
+
+Approved proposals are applied via :meth:`apply`, which validates against
+the benchmark gate and live-registers the tool on pass.
+"""
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.models import (
+    ApplyResult,
+    GuardVerdict,
+    ImprovementProposal,
+    ProposalAltitude,
+    ProposalRationale,
+    RollbackOperation,
+    RollbackPlan,
+)
+from synthorg.meta.toolsmith.errors import (
+    ToolAuthoringError,
+    ToolCapabilityNotAllowedError,
+)
+from synthorg.observability import get_logger, safe_error_description
+from synthorg.observability.events.toolsmith import (
+    TOOLSMITH_AUTHOR_OVERFLOW_TO_CODE_MOD,
+    TOOLSMITH_CYCLE_COMPLETED,
+    TOOLSMITH_CYCLE_STARTED,
+)
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from synthorg.meta.protocol import ProposalGuard
+    from synthorg.meta.toolsmith.applier import ToolCreationApplier
+    from synthorg.meta.toolsmith.config import ToolsmithConfig
+    from synthorg.meta.toolsmith.models import CapabilityGap, ToolBlueprint
+    from synthorg.meta.toolsmith.protocol import (
+        CapabilityGapStore,
+        ToolBlueprintGenerator,
+        ToolCreationOverflowHandler,
+    )
+
+logger = get_logger(__name__)
+
+
+class ToolsmithService:
+    """Orchestrates capability-gap detection, authoring, and application.
+
+    Args:
+        config: Toolsmith configuration.
+        gap_store: Capability-gap store (also the sink the service exposes).
+        generator: Authors blueprints from gaps.
+        applier: Validates and live-registers approved blueprints.
+        guards: Sequential guard chain (scope, rollback, rate, approval).
+        overflow_handler: Handles service-access gaps (optional).
+        existing_capabilities: Callable returning the current capability
+            surface, so the generator avoids duplicates.
+        clock: Time source.
+    """
+
+    def __init__(  # noqa: PLR0913 -- explicit DI of the toolsmith collaborators
+        self,
+        *,
+        config: ToolsmithConfig,
+        gap_store: CapabilityGapStore,
+        generator: ToolBlueprintGenerator,
+        applier: ToolCreationApplier,
+        guards: tuple[ProposalGuard, ...],
+        overflow_handler: ToolCreationOverflowHandler | None = None,
+        existing_capabilities: tuple[NotBlankStr, ...] = (),
+        clock: Clock | None = None,
+    ) -> None:
+        self._config = config
+        self._gap_store = gap_store
+        self._generator = generator
+        self._applier = applier
+        self._guards = guards
+        self._overflow_handler = overflow_handler
+        self._existing_capabilities = existing_capabilities
+        self._clock = clock or SystemClock()
+
+    async def record_gap(
+        self,
+        signature: NotBlankStr,
+        *,
+        occurred_at: datetime | None = None,
+    ) -> None:
+        """Record a capability-gap observation (the sink seam)."""
+        await self._gap_store.record_gap(
+            signature, occurred_at=occurred_at or self._clock.now()
+        )
+
+    async def run_cycle(
+        self, *, now: datetime | None = None
+    ) -> tuple[ImprovementProposal, ...]:
+        """Detect recurring gaps, author proposals, and guard them."""
+        moment = now or self._clock.now()
+        logger.info(TOOLSMITH_CYCLE_STARTED)
+        gaps = await self._gap_store.recurring(
+            threshold=self._config.gap_recurrence_threshold,
+            window=timedelta(hours=self._config.gap_window_hours),
+            now=moment,
+        )
+        proposals: list[ImprovementProposal] = []
+        for gap in gaps:
+            proposals.extend(await self._handle_gap(gap))
+        logger.info(
+            TOOLSMITH_CYCLE_COMPLETED,
+            gaps=len(gaps),
+            proposals=len(proposals),
+        )
+        return tuple(proposals)
+
+    async def apply(self, proposal: ImprovementProposal) -> ApplyResult:
+        """Validate and live-register an approved tool-creation proposal."""
+        return await self._applier.apply(proposal)
+
+    async def _handle_gap(self, gap: CapabilityGap) -> tuple[ImprovementProposal, ...]:
+        """Author or overflow a single gap, then guard the result."""
+        if gap.signature in self._config.service_access_capabilities:
+            return await self._handle_overflow(gap)
+        try:
+            blueprint = await self._generator.author(
+                gap, existing_capabilities=self._existing_capabilities
+            )
+        except (ToolCapabilityNotAllowedError, ToolAuthoringError) as exc:
+            logger.warning(
+                "toolsmith.author.skipped",
+                capability=gap.signature,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            return ()
+        proposal = _build_proposal(gap, blueprint)
+        if await self._guards_pass(proposal):
+            return (proposal,)
+        return ()
+
+    async def _handle_overflow(
+        self, gap: CapabilityGap
+    ) -> tuple[ImprovementProposal, ...]:
+        """Route a service-access gap to the code-modification overflow."""
+        logger.info(
+            TOOLSMITH_AUTHOR_OVERFLOW_TO_CODE_MOD,
+            capability=gap.signature,
+            configured=self._overflow_handler is not None,
+        )
+        if self._overflow_handler is None:
+            return ()
+        proposals = await self._overflow_handler.handle(gap)
+        guarded = [p for p in proposals if await self._guards_pass(p)]
+        return tuple(guarded)
+
+    async def _guards_pass(self, proposal: ImprovementProposal) -> bool:
+        """Evaluate the guard chain sequentially; all must pass."""
+        for guard in self._guards:
+            result = await guard.evaluate(proposal)
+            if result.verdict is GuardVerdict.REJECTED:
+                logger.info(
+                    "toolsmith.proposal.guard_rejected",
+                    guard=guard.name,
+                    reason=result.reason,
+                )
+                return False
+        return True
+
+
+def _build_proposal(
+    gap: CapabilityGap, blueprint: ToolBlueprint
+) -> ImprovementProposal:
+    """Wrap an authored blueprint in a ``TOOL_CREATION`` proposal."""
+    rollback = RollbackPlan(
+        operations=(
+            RollbackOperation(
+                operation_type="retire_tool",
+                target=blueprint.name,
+                description=f"Retire and unregister authored tool {blueprint.name!r}.",
+            ),
+        ),
+        validation_check=f"tool {blueprint.name!r} is no longer registered",
+    )
+    return ImprovementProposal(
+        altitude=ProposalAltitude.TOOL_CREATION,
+        title=f"Author tool for {gap.signature}",
+        description=(
+            f"Authored a sandbox tool addressing the recurring "
+            f"capability gap {gap.signature!r} "
+            f"({gap.occurrences} occurrences)."
+        ),
+        rationale=ProposalRationale(
+            signal_summary=(
+                f"{gap.signature} requested {gap.occurrences} times in the window"
+            ),
+            pattern_detected="recurring capability gap",
+            expected_impact=f"org can perform {gap.signature}",
+            confidence_reasoning="gap recurrence threshold met",
+        ),
+        tool_changes=(blueprint,),
+        rollback_plan=rollback,
+        confidence=0.5,
+        source_rule=NotBlankStr("capability_gap"),
+    )
+
+
+__all__ = ["ToolsmithService"]

--- a/src/synthorg/meta/toolsmith/service.py
+++ b/src/synthorg/meta/toolsmith/service.py
@@ -37,8 +37,10 @@ from synthorg.meta.toolsmith.errors import (
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.toolsmith import (
     TOOLSMITH_AUTHOR_OVERFLOW_TO_CODE_MOD,
+    TOOLSMITH_AUTHOR_SKIPPED,
     TOOLSMITH_CYCLE_COMPLETED,
     TOOLSMITH_CYCLE_STARTED,
+    TOOLSMITH_PROPOSAL_GUARD_REJECTED,
 )
 
 if TYPE_CHECKING:
@@ -139,7 +141,7 @@ class ToolsmithService:
             )
         except (ToolCapabilityNotAllowedError, ToolAuthoringError) as exc:
             logger.warning(
-                "toolsmith.author.skipped",
+                TOOLSMITH_AUTHOR_SKIPPED,
                 capability=gap.signature,
                 error_type=type(exc).__name__,
                 error=safe_error_description(exc),
@@ -171,7 +173,7 @@ class ToolsmithService:
             result = await guard.evaluate(proposal)
             if result.verdict is GuardVerdict.REJECTED:
                 logger.info(
-                    "toolsmith.proposal.guard_rejected",
+                    TOOLSMITH_PROPOSAL_GUARD_REJECTED,
                     guard=guard.name,
                     reason=result.reason,
                 )

--- a/src/synthorg/meta/toolsmith/strategy.py
+++ b/src/synthorg/meta/toolsmith/strategy.py
@@ -182,7 +182,7 @@ class LLMToolBlueprintGenerator:
         gap: CapabilityGap,
         existing_capabilities: Sequence[NotBlankStr],
     ) -> str:
-        """Build the authoring user prompt (gap context is wrapped SEC-1)."""
+        """Build the authoring prompt; gap context is wrapped as untrusted."""
         context = {
             "capability": gap.signature,
             "occurrences": gap.occurrences,

--- a/src/synthorg/meta/toolsmith/strategy.py
+++ b/src/synthorg/meta/toolsmith/strategy.py
@@ -1,0 +1,254 @@
+"""LLM-backed tool blueprint authoring.
+
+Given a recurring capability gap, the generator asks the configured
+provider to author a sandbox tool addressing that capability. The tool
+name is derived deterministically from the gap's ``domain:action``
+capability (so it always aligns with the wire schema), while the model
+supplies the description, JSON Schema, action type, and script body. The
+sandbox backend and network policy come from config, never the model, so
+an authored tool cannot widen its own isolation.
+"""
+
+import json
+from typing import TYPE_CHECKING, Any, Final
+from uuid import uuid4
+
+from synthorg.budget.call_category import LLMCallCategory
+from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.types import NotBlankStr
+from synthorg.engine.prompt_safety import (
+    TAG_TASK_DATA,
+    untrusted_content_directive,
+    wrap_untrusted,
+)
+from synthorg.meta.toolsmith.config import ToolsmithConfig  # noqa: TC001
+from synthorg.meta.toolsmith.errors import (
+    ToolAuthoringError,
+    ToolCapabilityNotAllowedError,
+)
+from synthorg.meta.toolsmith.models import (
+    CapabilityGap,
+    ToolBlueprint,
+    ToolBlueprintState,
+)
+from synthorg.observability import get_logger, safe_error_description
+from synthorg.observability.events.toolsmith import (
+    TOOLSMITH_AUTHOR_COMPLETED,
+    TOOLSMITH_AUTHOR_FAILED,
+    TOOLSMITH_AUTHOR_STARTED,
+)
+from synthorg.providers.cost_recording import cost_recording_scope
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from synthorg.budget.tracker import CostTracker
+    from synthorg.providers.base import BaseCompletionProvider
+
+logger = get_logger(__name__)
+
+_SYSTEM_PROMPT: Final[str] = """\
+You author sandboxed tools for SynthOrg, a framework for synthetic \
+organisations. The organisation has repeatedly been unable to perform a \
+capability; your job is to author ONE self-contained Python tool that \
+provides it.
+
+The tool runs in an isolated sandbox with NO network access. It MUST:
+- Read its arguments from the SYNTHORG_TOOL_ARGS environment variable, a \
+JSON object matching the parameters schema.
+- Print exactly one JSON value to stdout (the tool result).
+- Use only the Python standard library.
+- Be deterministic and side-effect-free beyond its stdout.
+
+Respond with ONE JSON object, no markdown fences or commentary:
+{
+  "description": "one-line description of what the tool does",
+  "action_type": "category:action (e.g. code:read) classifying the tool",
+  "parameters_schema": {
+    "type": "object",
+    "properties": {"<name>": {"type": "string|integer|number|boolean"}},
+    "required": ["<name>", ...]
+  },
+  "script_body": "complete Python source as described above"
+}
+""" + untrusted_content_directive((TAG_TASK_DATA,))
+
+
+class LLMToolBlueprintGenerator:
+    """Authors a :class:`ToolBlueprint` from a capability gap via the LLM.
+
+    Args:
+        config: Toolsmith configuration (allowlist, sandbox policy, model).
+        provider: Completion provider for the authoring call.
+        cost_tracker: Optional cost tracker for the LLM call.
+        clock: Time source for the blueprint's ``created_at``.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: ToolsmithConfig,
+        provider: BaseCompletionProvider,
+        cost_tracker: CostTracker | None = None,
+        clock: Clock | None = None,
+    ) -> None:
+        self._config = config
+        self._provider = provider
+        self._cost_tracker = cost_tracker
+        self._clock = clock or SystemClock()
+
+    async def author(
+        self,
+        gap: CapabilityGap,
+        *,
+        existing_capabilities: Sequence[NotBlankStr],
+    ) -> ToolBlueprint:
+        """Author a candidate blueprint addressing ``gap``.
+
+        Raises:
+            ToolCapabilityNotAllowedError: If the gap's capability is not
+                in the configured allowlist.
+            ToolAuthoringError: If the model output cannot be parsed into
+                a valid blueprint.
+        """
+        capability = gap.signature
+        if capability not in self._config.allowed_capabilities:
+            msg = f"capability {capability!r} is not in the toolsmith allowlist"
+            raise ToolCapabilityNotAllowedError(msg)
+        logger.info(TOOLSMITH_AUTHOR_STARTED, capability=capability)
+        try:
+            response = await self._call_llm(gap, existing_capabilities)
+            blueprint = self._parse(capability, response)
+        except ToolAuthoringError, ToolCapabilityNotAllowedError:
+            raise
+        except MemoryError, RecursionError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                TOOLSMITH_AUTHOR_FAILED,
+                capability=capability,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            msg = f"authoring failed for capability {capability!r}"
+            raise ToolAuthoringError(msg) from exc
+        logger.info(
+            TOOLSMITH_AUTHOR_COMPLETED,
+            capability=capability,
+            tool_name=blueprint.name,
+        )
+        return blueprint
+
+    async def _call_llm(
+        self,
+        gap: CapabilityGap,
+        existing_capabilities: Sequence[NotBlankStr],
+    ) -> str:
+        """Call the provider to author the tool; returns raw content."""
+        from synthorg.providers.enums import MessageRole  # noqa: PLC0415
+        from synthorg.providers.models import (  # noqa: PLC0415
+            ChatMessage,
+            CompletionConfig,
+        )
+
+        user_prompt = self._build_user_prompt(gap, existing_capabilities)
+        messages = [
+            ChatMessage(role=MessageRole.SYSTEM, content=_SYSTEM_PROMPT),
+            ChatMessage(role=MessageRole.USER, content=user_prompt),
+        ]
+        config = CompletionConfig(
+            temperature=self._config.authoring.temperature,
+            max_tokens=self._config.authoring.max_tokens,
+        )
+        async with cost_recording_scope(
+            cost_tracker=self._cost_tracker,
+            agent_id=NotBlankStr("system"),
+            task_id=NotBlankStr("system:toolsmith:author"),
+            call_category=LLMCallCategory.SYSTEM,
+        ):
+            response = await self._provider.complete(
+                messages=messages,
+                model=str(self._config.authoring.model),
+                config=config,
+            )
+        content = response.content
+        if not content:
+            msg = "authoring model returned an empty response"
+            raise ToolAuthoringError(msg)
+        return content
+
+    def _build_user_prompt(
+        self,
+        gap: CapabilityGap,
+        existing_capabilities: Sequence[NotBlankStr],
+    ) -> str:
+        """Build the authoring user prompt (gap context is wrapped SEC-1)."""
+        context = {
+            "capability": gap.signature,
+            "occurrences": gap.occurrences,
+            "existing_capabilities": sorted(str(c) for c in existing_capabilities),
+        }
+        wrapped = wrap_untrusted(TAG_TASK_DATA, json.dumps(context, sort_keys=True))
+        return (
+            f"The organisation could not perform capability "
+            f"{gap.signature!r} on {gap.occurrences} occasions. Author a "
+            f"sandbox tool that provides it.\n\nContext:\n{wrapped}"
+        )
+
+    def _parse(self, capability: NotBlankStr, response: str) -> ToolBlueprint:
+        """Parse the model response into a validated blueprint."""
+        payload = _parse_json_object(response)
+        domain, action = capability.split(":", 1)
+        name = f"synthorg_{domain}_{action}"
+        try:
+            return ToolBlueprint(
+                id=NotBlankStr(f"bp-{uuid4().hex}"),
+                name=NotBlankStr(name),
+                description=_require_str(payload, "description"),
+                capability=capability,
+                parameters_schema=_require_schema(payload),
+                script_body=_require_str(payload, "script_body"),
+                sandbox_backend=self._config.sandbox_backend,
+                requires_network=self._config.requires_network,
+                action_type=_require_str(payload, "action_type"),
+                state=ToolBlueprintState.PENDING,
+                created_at=self._clock.now(),
+            )
+        except ValueError as exc:
+            msg = f"authored blueprint for {capability!r} is invalid: {exc}"
+            raise ToolAuthoringError(msg) from exc
+
+
+def _parse_json_object(response: str) -> dict[str, Any]:
+    """Parse a single JSON object from the model response."""
+    text = response.strip()
+    try:
+        data = json.loads(text)
+    except (ValueError, TypeError) as exc:
+        msg = "authoring response is not valid JSON"
+        raise ToolAuthoringError(msg) from exc
+    if not isinstance(data, dict):
+        msg = "authoring response must be a JSON object"
+        raise ToolAuthoringError(msg)
+    return data
+
+
+def _require_str(payload: dict[str, Any], key: str) -> str:
+    """Extract a non-blank string field from the payload."""
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        msg = f"authoring response missing non-blank {key!r}"
+        raise ToolAuthoringError(msg)
+    return value
+
+
+def _require_schema(payload: dict[str, Any]) -> dict[str, Any]:
+    """Extract the parameters schema object from the payload."""
+    schema = payload.get("parameters_schema")
+    if not isinstance(schema, dict):
+        msg = "authoring response missing 'parameters_schema' object"
+        raise ToolAuthoringError(msg)
+    return schema
+
+
+__all__ = ["LLMToolBlueprintGenerator"]

--- a/src/synthorg/meta/toolsmith/strategy.py
+++ b/src/synthorg/meta/toolsmith/strategy.py
@@ -13,6 +13,9 @@ import json
 from typing import TYPE_CHECKING, Any, Final
 from uuid import uuid4
 
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from synthorg.api.boundary import parse_typed
 from synthorg.budget.call_category import LLMCallCategory
 from synthorg.core.clock import Clock, SystemClock
 from synthorg.core.types import NotBlankStr
@@ -38,7 +41,6 @@ from synthorg.observability.events.toolsmith import (
     TOOLSMITH_AUTHOR_STARTED,
 )
 from synthorg.providers.cost_recording import cost_recording_scope
-from synthorg.providers.errors import ProviderError
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -122,11 +124,14 @@ class LLMToolBlueprintGenerator:
             blueprint = self._parse(capability, response)
         except ToolAuthoringError, ToolCapabilityNotAllowedError:
             raise
-        except ProviderError:
-            raise
         except MemoryError, RecursionError:
             raise
         except Exception as exc:
+            # ProviderError lands here too: a transient completion failure
+            # is a per-gap authoring failure, not a batch-wide abort. The
+            # service runs gaps under a TaskGroup, so wrapping it as
+            # ToolAuthoringError lets _handle_gap skip just this gap rather
+            # than cancelling the sibling authoring tasks.
             logger.warning(
                 TOOLSMITH_AUTHOR_FAILED,
                 capability=capability,
@@ -199,21 +204,40 @@ class LLMToolBlueprintGenerator:
         )
 
     def _parse(self, capability: NotBlankStr, response: str) -> ToolBlueprint:
-        """Parse the model response into a validated blueprint."""
-        payload = _parse_json_object(response)
+        """Parse the model response into a validated blueprint.
+
+        The provider output is an external dict ingestion, so it routes
+        through the frozen :class:`_AuthoredBlueprintArgs` boundary model
+        via ``parse_typed`` rather than ad-hoc field plucking. The sandbox
+        backend and network policy come from config, never the model.
+        """
+        text = response.strip()
+        try:
+            payload = json.loads(text)
+        except (ValueError, TypeError) as exc:
+            msg = "authoring response is not valid JSON"
+            raise ToolAuthoringError(msg) from exc
+        if not isinstance(payload, dict):
+            msg = "authoring response must be a JSON object"
+            raise ToolAuthoringError(msg)
+        try:
+            args = parse_typed("toolsmith.authoring", payload, _AuthoredBlueprintArgs)
+        except ValidationError as exc:
+            msg = f"authored blueprint for {capability!r} has invalid fields"
+            raise ToolAuthoringError(msg) from exc
         domain, action = capability.split(":", 1)
         name = f"synthorg_{domain}_{action}"
         try:
             return ToolBlueprint(
                 id=NotBlankStr(f"bp-{uuid4().hex}"),
                 name=NotBlankStr(name),
-                description=_require_str(payload, "description"),
+                description=args.description,
                 capability=capability,
-                parameters_schema=_require_schema(payload),
-                script_body=_require_str(payload, "script_body"),
+                parameters_schema=args.parameters_schema,
+                script_body=args.script_body,
                 sandbox_backend=self._config.sandbox_backend,
                 requires_network=self._config.requires_network,
-                action_type=_require_str(payload, "action_type"),
+                action_type=args.action_type,
                 state=ToolBlueprintState.PENDING,
                 created_at=self._clock.now(),
             )
@@ -222,36 +246,20 @@ class LLMToolBlueprintGenerator:
             raise ToolAuthoringError(msg) from exc
 
 
-def _parse_json_object(response: str) -> dict[str, Any]:
-    """Parse a single JSON object from the model response."""
-    text = response.strip()
-    try:
-        data = json.loads(text)
-    except (ValueError, TypeError) as exc:
-        msg = "authoring response is not valid JSON"
-        raise ToolAuthoringError(msg) from exc
-    if not isinstance(data, dict):
-        msg = "authoring response must be a JSON object"
-        raise ToolAuthoringError(msg)
-    return data
+class _AuthoredBlueprintArgs(BaseModel):
+    """Typed boundary for the model-authored blueprint fields.
 
+    Only the fields the model is asked to supply; the sandbox backend,
+    network policy, name, id, and timestamps are stamped by the generator
+    from trusted config, never the model output.
+    """
 
-def _require_str(payload: dict[str, Any], key: str) -> str:
-    """Extract a non-blank string field from the payload."""
-    value = payload.get(key)
-    if not isinstance(value, str) or not value.strip():
-        msg = f"authoring response missing non-blank {key!r}"
-        raise ToolAuthoringError(msg)
-    return value
+    model_config = ConfigDict(frozen=True, extra="forbid", allow_inf_nan=False)
 
-
-def _require_schema(payload: dict[str, Any]) -> dict[str, Any]:
-    """Extract the parameters schema object from the payload."""
-    schema = payload.get("parameters_schema")
-    if not isinstance(schema, dict):
-        msg = "authoring response missing 'parameters_schema' object"
-        raise ToolAuthoringError(msg)
-    return schema
+    description: NotBlankStr
+    action_type: NotBlankStr
+    script_body: NotBlankStr
+    parameters_schema: dict[str, Any]
 
 
 __all__ = ["LLMToolBlueprintGenerator"]

--- a/src/synthorg/meta/toolsmith/strategy.py
+++ b/src/synthorg/meta/toolsmith/strategy.py
@@ -38,6 +38,7 @@ from synthorg.observability.events.toolsmith import (
     TOOLSMITH_AUTHOR_STARTED,
 )
 from synthorg.providers.cost_recording import cost_recording_scope
+from synthorg.providers.errors import ProviderError
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -120,6 +121,8 @@ class LLMToolBlueprintGenerator:
             response = await self._call_llm(gap, existing_capabilities)
             blueprint = self._parse(capability, response)
         except ToolAuthoringError, ToolCapabilityNotAllowedError:
+            raise
+        except ProviderError:
             raise
         except MemoryError, RecursionError:
             raise

--- a/src/synthorg/meta/toolsmith/validation_gate.py
+++ b/src/synthorg/meta/toolsmith/validation_gate.py
@@ -1,0 +1,177 @@
+"""Benchmark-validation gate for authored tools.
+
+A candidate tool is trusted only when BOTH checks pass:
+
+1. A focused per-tool acceptance brief: the authored script actually runs
+   in the sandbox over a representative probe input and returns structured
+   output (proves the tool works before it is ever trusted).
+2. A golden-company scorecard delta: registering the candidate must not
+   regress the golden benchmark (``candidate_total >= baseline_total +
+   min_score_margin``), so a tool that helps in isolation but harms the
+   org as a whole is rejected.
+
+The expensive golden run is gated behind the cheap brief: it only runs
+when the brief passes and ``require_golden_delta`` is set.
+"""
+
+from typing import TYPE_CHECKING, Any, Final
+
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.toolsmith.config import ToolsmithConfig  # noqa: TC001
+from synthorg.meta.toolsmith.models import ToolBlueprint, ToolValidationResult
+from synthorg.meta.toolsmith.protocol import (
+    GoldenScorecardProvider,  # noqa: TC001
+    ToolAcceptanceBriefRunner,  # noqa: TC001
+)
+from synthorg.meta.toolsmith.script_handler import make_dynamic_tool_handler
+from synthorg.observability import get_logger
+from synthorg.observability.events.toolsmith import (
+    TOOLSMITH_VALIDATION_FAILED,
+    TOOLSMITH_VALIDATION_PASSED,
+    TOOLSMITH_VALIDATION_STARTED,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from synthorg.tools.sandbox.protocol import SandboxBackend
+
+logger = get_logger(__name__)
+
+_BRIEF_PASS_SCORE: Final[int] = 100
+_BRIEF_FAIL_SCORE: Final[int] = 0
+
+_PROBE_VALUES: Mapping[str, Any] = {
+    "string": "probe",
+    "integer": 1,
+    "number": 1.0,
+    "boolean": True,
+    "array": [],
+    "object": {},
+}
+
+
+def _synthesize_probe(parameters_schema: dict[str, Any]) -> dict[str, Any]:
+    """Build a minimal valid argument payload from required schema fields."""
+    properties = parameters_schema.get("properties")
+    required = parameters_schema.get("required") or ()
+    probe: dict[str, Any] = {}
+    if not isinstance(properties, dict) or not isinstance(required, (list, tuple)):
+        return probe
+    for name in required:
+        if not isinstance(name, str):
+            continue
+        prop = properties.get(name)
+        raw_type = prop.get("type") if isinstance(prop, dict) else None
+        json_type = raw_type if isinstance(raw_type, str) else ""
+        probe[name] = _PROBE_VALUES.get(json_type, "probe")
+    return probe
+
+
+class SandboxBriefRunner:
+    """Runs an authored tool in the sandbox against a synthesized probe.
+
+    Passes iff the tool exits cleanly and returns a structured (``ok``)
+    envelope for a representative input.
+
+    Args:
+        sandbox: Sandbox backend the probe runs in.
+        timeout_seconds: Per-probe wall-clock budget.
+    """
+
+    def __init__(
+        self,
+        sandbox: SandboxBackend,
+        *,
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        self._sandbox = sandbox
+        self._timeout_seconds = timeout_seconds
+
+    async def run(self, blueprint: ToolBlueprint) -> tuple[bool, int]:
+        """Execute the acceptance probe; return ``(passed, score)``."""
+        import json as _json  # noqa: PLC0415
+
+        handler = make_dynamic_tool_handler(
+            blueprint, self._sandbox, timeout_seconds=self._timeout_seconds
+        )
+        probe = _synthesize_probe(blueprint.parameters_schema)
+        raw = await handler(app_state=None, arguments=probe)
+        try:
+            envelope = _json.loads(raw)
+        except ValueError, TypeError:
+            return False, _BRIEF_FAIL_SCORE
+        passed = envelope.get("status") == "ok"
+        return passed, (_BRIEF_PASS_SCORE if passed else _BRIEF_FAIL_SCORE)
+
+
+class BenchmarkToolValidationGate:
+    """Two-stage benchmark gate: acceptance brief then golden delta.
+
+    Args:
+        config: Toolsmith configuration (validation thresholds).
+        brief_runner: Runs the per-tool acceptance brief.
+        scorecard_provider: Scores the golden benchmark with/without the
+            candidate. Required when ``validation.require_golden_delta``.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: ToolsmithConfig,
+        brief_runner: ToolAcceptanceBriefRunner,
+        scorecard_provider: GoldenScorecardProvider | None = None,
+    ) -> None:
+        self._config = config
+        self._brief_runner = brief_runner
+        self._scorecard_provider = scorecard_provider
+
+    async def validate(self, blueprint: ToolBlueprint) -> ToolValidationResult:
+        """Run both validation stages and return the gate decision."""
+        logger.info(TOOLSMITH_VALIDATION_STARTED, tool_name=blueprint.name)
+        brief_passed, brief_score = await self._brief_runner.run(blueprint)
+        validation_cfg = self._config.validation
+
+        baseline = 0
+        candidate = 0
+        if validation_cfg.require_golden_delta and brief_passed:
+            if self._scorecard_provider is None:
+                msg = "require_golden_delta is set but no scorecard provider is wired"
+                raise ToolValidationConfigError(msg)
+            baseline, candidate = await self._scorecard_provider.score(blueprint)
+        margin = candidate - baseline
+
+        if not validation_cfg.require_golden_delta:
+            passed = brief_passed
+            detail = f"brief={'pass' if brief_passed else 'fail'}; golden skipped"
+        else:
+            passed = brief_passed and margin >= validation_cfg.min_score_margin
+            detail = (
+                f"brief={'pass' if brief_passed else 'fail'}; "
+                f"golden baseline={baseline} candidate={candidate} "
+                f"margin={margin} min={validation_cfg.min_score_margin}"
+            )
+
+        result = ToolValidationResult(
+            passed=passed,
+            brief_passed=brief_passed,
+            brief_score=brief_score,
+            baseline_score=baseline,
+            candidate_score=candidate,
+            margin=margin,
+            detail=NotBlankStr(detail),
+        )
+        event = TOOLSMITH_VALIDATION_PASSED if passed else TOOLSMITH_VALIDATION_FAILED
+        logger.info(event, tool_name=blueprint.name, detail=detail)
+        return result
+
+
+class ToolValidationConfigError(ValueError):
+    """Raised when the gate is misconfigured (golden delta without provider)."""
+
+
+__all__ = [
+    "BenchmarkToolValidationGate",
+    "SandboxBriefRunner",
+    "ToolValidationConfigError",
+]

--- a/src/synthorg/meta/toolsmith/validation_gate.py
+++ b/src/synthorg/meta/toolsmith/validation_gate.py
@@ -172,10 +172,17 @@ class BenchmarkToolValidationGate:
         if not validation_cfg.require_golden_delta:
             passed = brief_passed
             detail = f"brief={'pass' if brief_passed else 'fail'}; golden skipped"
+        elif not brief_passed:
+            # The golden run is gated behind a passing brief, so when the
+            # brief fails the scorecard never ran. Report it as skipped
+            # rather than a 0-0 scorecard so a real zero margin and a
+            # never-run golden stage stay distinguishable.
+            passed = False
+            detail = "brief=fail; golden skipped"
         else:
-            passed = brief_passed and margin >= validation_cfg.min_score_margin
+            passed = margin >= validation_cfg.min_score_margin
             detail = (
-                f"brief={'pass' if brief_passed else 'fail'}; "
+                f"brief=pass; "
                 f"golden baseline={baseline} candidate={candidate} "
                 f"margin={margin} min={validation_cfg.min_score_margin}"
             )

--- a/src/synthorg/meta/toolsmith/validation_gate.py
+++ b/src/synthorg/meta/toolsmith/validation_gate.py
@@ -25,8 +25,9 @@ from synthorg.meta.toolsmith.protocol import (
     ToolAcceptanceBriefRunner,  # noqa: TC001
 )
 from synthorg.meta.toolsmith.script_handler import make_dynamic_tool_handler
-from synthorg.observability import get_logger
+from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.toolsmith import (
+    TOOLSMITH_BRIEF_PARSE_FAILED,
     TOOLSMITH_VALIDATION_FAILED,
     TOOLSMITH_VALIDATION_PASSED,
     TOOLSMITH_VALIDATION_STARTED,
@@ -107,7 +108,13 @@ class SandboxBriefRunner:
         raw = await handler(app_state=None, arguments=probe)
         try:
             envelope = _json.loads(raw)
-        except ValueError, TypeError:
+        except (ValueError, TypeError) as exc:
+            logger.warning(
+                TOOLSMITH_BRIEF_PARSE_FAILED,
+                tool_name=blueprint.name,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
             return False, _BRIEF_FAIL_SCORE
         passed = envelope.get("status") == "ok"
         return passed, (_BRIEF_PASS_SCORE if passed else _BRIEF_FAIL_SCORE)

--- a/src/synthorg/meta/toolsmith/validation_gate.py
+++ b/src/synthorg/meta/toolsmith/validation_gate.py
@@ -14,6 +14,7 @@ The expensive golden run is gated behind the cheap brief: it only runs
 when the brief passes and ``require_golden_delta`` is set.
 """
 
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Final
 
 from synthorg.core.types import NotBlankStr
@@ -69,7 +70,9 @@ def _synthesize_probe(parameters_schema: dict[str, Any]) -> dict[str, Any]:
         prop = properties.get(name)
         raw_type = prop.get("type") if isinstance(prop, dict) else None
         json_type = raw_type if isinstance(raw_type, str) else ""
-        probe[name] = _PROBE_VALUES.get(json_type, "probe")
+        # deepcopy so a script that mutates list/dict probes cannot leak
+        # state into a subsequent invocation reusing the same singleton.
+        probe[name] = deepcopy(_PROBE_VALUES.get(json_type, "probe"))
     return probe
 
 
@@ -114,6 +117,16 @@ class SandboxBriefRunner:
                 tool_name=blueprint.name,
                 error_type=type(exc).__name__,
                 error=safe_error_description(exc),
+            )
+            return False, _BRIEF_FAIL_SCORE
+        # A tool that returns a JSON list/string/number is parseable but
+        # not a valid envelope; reject without an AttributeError on .get.
+        if not isinstance(envelope, dict):
+            logger.warning(
+                TOOLSMITH_BRIEF_PARSE_FAILED,
+                tool_name=blueprint.name,
+                error_type="EnvelopeTypeError",
+                error="tool output must be a JSON object envelope",
             )
             return False, _BRIEF_FAIL_SCORE
         passed = envelope.get("status") == "ok"

--- a/src/synthorg/meta/toolsmith/validation_gate.py
+++ b/src/synthorg/meta/toolsmith/validation_gate.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Final
 
 from synthorg.core.types import NotBlankStr
 from synthorg.meta.toolsmith.config import ToolsmithConfig  # noqa: TC001
+from synthorg.meta.toolsmith.errors import ToolsmithError
 from synthorg.meta.toolsmith.models import ToolBlueprint, ToolValidationResult
 from synthorg.meta.toolsmith.protocol import (
     GoldenScorecardProvider,  # noqa: TC001
@@ -42,6 +43,7 @@ logger = get_logger(__name__)
 
 _BRIEF_PASS_SCORE: Final[int] = 100
 _BRIEF_FAIL_SCORE: Final[int] = 0
+_DEFAULT_BRIEF_TIMEOUT_SECONDS: Final[float] = 30.0
 
 _PROBE_VALUES: Mapping[str, Any] = {
     "string": "probe",
@@ -87,7 +89,7 @@ class SandboxBriefRunner:
         self,
         sandbox_resolver: SandboxResolver,
         *,
-        timeout_seconds: float = 30.0,
+        timeout_seconds: float = _DEFAULT_BRIEF_TIMEOUT_SECONDS,
     ) -> None:
         self._sandbox_resolver = sandbox_resolver
         self._timeout_seconds = timeout_seconds
@@ -172,8 +174,10 @@ class BenchmarkToolValidationGate:
         return result
 
 
-class ToolValidationConfigError(ValueError):
+class ToolValidationConfigError(ToolsmithError):
     """Raised when the gate is misconfigured (golden delta without provider)."""
+
+    default_message = "Tool validation gate is misconfigured"
 
 
 __all__ = [

--- a/src/synthorg/meta/toolsmith/validation_gate.py
+++ b/src/synthorg/meta/toolsmith/validation_gate.py
@@ -135,7 +135,21 @@ class SandboxBriefRunner:
             timeout_seconds=self._timeout_seconds,
         )
         probe = _synthesize_probe(blueprint.parameters_schema)
-        raw = await handler(app_state=None, arguments=probe)
+        # The brief passes iff the tool exits cleanly; a handler crash
+        # (sandbox failure, runtime error) must fail the brief, not
+        # propagate out of the gate. System-critical errors still escape.
+        try:
+            raw = await handler(app_state=None, arguments=probe)
+        except MemoryError, RecursionError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                TOOLSMITH_BRIEF_PARSE_FAILED,
+                tool_name=blueprint.name,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            return False, _BRIEF_FAIL_SCORE
         try:
             envelope = _json.loads(raw)
         except (ValueError, TypeError) as exc:

--- a/src/synthorg/meta/toolsmith/validation_gate.py
+++ b/src/synthorg/meta/toolsmith/validation_gate.py
@@ -32,9 +32,11 @@ from synthorg.observability.events.toolsmith import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Mapping
 
     from synthorg.tools.sandbox.protocol import SandboxBackend
+
+    SandboxResolver = Callable[[ToolBlueprint], SandboxBackend]
 
 logger = get_logger(__name__)
 
@@ -72,20 +74,22 @@ class SandboxBriefRunner:
     """Runs an authored tool in the sandbox against a synthesized probe.
 
     Passes iff the tool exits cleanly and returns a structured (``ok``)
-    envelope for a representative input.
+    envelope for a representative input. The sandbox backend is resolved
+    per blueprint so a Docker-declared tool is probed under Docker, not a
+    weaker default.
 
     Args:
-        sandbox: Sandbox backend the probe runs in.
+        sandbox_resolver: Resolves the sandbox backend for a blueprint.
         timeout_seconds: Per-probe wall-clock budget.
     """
 
     def __init__(
         self,
-        sandbox: SandboxBackend,
+        sandbox_resolver: SandboxResolver,
         *,
         timeout_seconds: float = 30.0,
     ) -> None:
-        self._sandbox = sandbox
+        self._sandbox_resolver = sandbox_resolver
         self._timeout_seconds = timeout_seconds
 
     async def run(self, blueprint: ToolBlueprint) -> tuple[bool, int]:
@@ -93,7 +97,9 @@ class SandboxBriefRunner:
         import json as _json  # noqa: PLC0415
 
         handler = make_dynamic_tool_handler(
-            blueprint, self._sandbox, timeout_seconds=self._timeout_seconds
+            blueprint,
+            self._sandbox_resolver(blueprint),
+            timeout_seconds=self._timeout_seconds,
         )
         probe = _synthesize_probe(blueprint.parameters_schema)
         raw = await handler(app_state=None, arguments=probe)

--- a/src/synthorg/meta/toolsmith/validation_gate.py
+++ b/src/synthorg/meta/toolsmith/validation_gate.py
@@ -58,7 +58,16 @@ _PROBE_VALUES: Mapping[str, Any] = {
 
 
 def _synthesize_probe(parameters_schema: dict[str, Any]) -> dict[str, Any]:
-    """Build a minimal valid argument payload from required schema fields."""
+    """Build a minimal valid argument payload from required schema fields.
+
+    Honours the schema keywords that fully determine a valid value --
+    ``const``, ``default``, and ``enum`` (first allowed) -- in that
+    priority order, falling back to a type-based placeholder. Deeper
+    constraint satisfaction (numeric bounds, ``minLength``, recursive
+    container shapes) is intentionally out of scope: the probe is a
+    best-effort smoke test and a probe that misses a bound merely fails
+    the brief gracefully via ``_BRIEF_FAIL_SCORE`` rather than crashing.
+    """
     properties = parameters_schema.get("properties")
     required = parameters_schema.get("required") or ()
     probe: dict[str, Any] = {}
@@ -68,12 +77,30 @@ def _synthesize_probe(parameters_schema: dict[str, Any]) -> dict[str, Any]:
         if not isinstance(name, str):
             continue
         prop = properties.get(name)
-        raw_type = prop.get("type") if isinstance(prop, dict) else None
-        json_type = raw_type if isinstance(raw_type, str) else ""
         # deepcopy so a script that mutates list/dict probes cannot leak
         # state into a subsequent invocation reusing the same singleton.
-        probe[name] = deepcopy(_PROBE_VALUES.get(json_type, "probe"))
+        probe[name] = deepcopy(_probe_value_for(prop))
     return probe
+
+
+def _probe_value_for(prop: object) -> Any:
+    """Pick a probe value for a single property schema.
+
+    ``const`` / ``default`` / ``enum`` pin an exact valid value when
+    present; otherwise fall back to a type-based placeholder.
+    """
+    if not isinstance(prop, dict):
+        return "probe"
+    if "const" in prop:
+        return prop["const"]
+    if "default" in prop:
+        return prop["default"]
+    enum = prop.get("enum")
+    if isinstance(enum, (list, tuple)) and enum:
+        return enum[0]
+    raw_type = prop.get("type")
+    json_type = raw_type if isinstance(raw_type, str) else ""
+    return _PROBE_VALUES.get(json_type, "probe")
 
 
 class SandboxBriefRunner:

--- a/src/synthorg/observability/events/persistence.py
+++ b/src/synthorg/observability/events/persistence.py
@@ -763,3 +763,32 @@ PERSISTENCE_CONVERSATIONAL_UNKNOWN_BACKEND: Final[str] = (
 PERSISTENCE_CONVERSATIONAL_HANDLE_UNAVAILABLE: Final[str] = (
     "persistence.conversational.handle_unavailable"
 )
+
+# Dynamic tool blueprint events (self-extending toolkit). Failure paths
+# plus read/query markers only: the persistence-boundary gate forbids
+# repos from emitting their own mutation lifecycle (_SAVED / _DELETED)
+# events; the toolsmith service layer owns the audit hop.
+PERSISTENCE_DYNAMIC_TOOL_FETCHED: Final[str] = "persistence.dynamic_tool.fetched"
+PERSISTENCE_DYNAMIC_TOOL_FETCH_FAILED: Final[str] = (
+    "persistence.dynamic_tool.fetch_failed"
+)
+PERSISTENCE_DYNAMIC_TOOL_LISTED: Final[str] = "persistence.dynamic_tool.listed"
+PERSISTENCE_DYNAMIC_TOOL_LIST_FAILED: Final[str] = (
+    "persistence.dynamic_tool.list_failed"
+)
+PERSISTENCE_DYNAMIC_TOOL_QUERIED: Final[str] = "persistence.dynamic_tool.queried"
+PERSISTENCE_DYNAMIC_TOOL_QUERY_FAILED: Final[str] = (
+    "persistence.dynamic_tool.query_failed"
+)
+PERSISTENCE_DYNAMIC_TOOL_SAVE_FAILED: Final[str] = (
+    "persistence.dynamic_tool.save_failed"
+)
+PERSISTENCE_DYNAMIC_TOOL_DELETE_FAILED: Final[str] = (
+    "persistence.dynamic_tool.delete_failed"
+)
+PERSISTENCE_DYNAMIC_TOOL_TRANSITION_FAILED: Final[str] = (
+    "persistence.dynamic_tool.transition_failed"
+)
+PERSISTENCE_DYNAMIC_TOOL_DESERIALIZE_FAILED: Final[str] = (
+    "persistence.dynamic_tool.deserialize_failed"
+)

--- a/src/synthorg/observability/events/toolsmith.py
+++ b/src/synthorg/observability/events/toolsmith.py
@@ -1,0 +1,46 @@
+"""Event constants for the self-extending toolkit (toolsmith).
+
+Constants follow the ``toolsmith.<area>.<action>`` naming convention and
+are passed as the first argument to structured ``logger`` calls.
+"""
+
+from typing import Final
+
+# Capability-gap detection
+TOOLSMITH_GAP_RECORDED: Final[str] = "toolsmith.gap.recorded"
+TOOLSMITH_GAP_RECORD_FAILED: Final[str] = "toolsmith.gap.record_failed"
+TOOLSMITH_GAP_EVICTED: Final[str] = "toolsmith.gap.evicted"
+TOOLSMITH_GAP_RECURRING_DETECTED: Final[str] = "toolsmith.gap.recurring_detected"
+
+# Authoring
+TOOLSMITH_AUTHOR_STARTED: Final[str] = "toolsmith.author.started"
+TOOLSMITH_AUTHOR_COMPLETED: Final[str] = "toolsmith.author.completed"
+TOOLSMITH_AUTHOR_FAILED: Final[str] = "toolsmith.author.failed"
+TOOLSMITH_AUTHOR_OVERFLOW_TO_CODE_MOD: Final[str] = (
+    "toolsmith.author.overflow_to_code_mod"
+)
+
+# Validation gate
+TOOLSMITH_VALIDATION_STARTED: Final[str] = "toolsmith.validation.started"
+TOOLSMITH_VALIDATION_PASSED: Final[str] = "toolsmith.validation.passed"
+TOOLSMITH_VALIDATION_FAILED: Final[str] = "toolsmith.validation.failed"
+
+# Live registration
+TOOLSMITH_TOOL_REGISTERED: Final[str] = "toolsmith.tool.registered"
+TOOLSMITH_TOOL_UNREGISTERED: Final[str] = "toolsmith.tool.unregistered"
+TOOLSMITH_TOOL_REGISTER_FAILED: Final[str] = "toolsmith.tool.register_failed"
+TOOLSMITH_TOOL_INVOKED: Final[str] = "toolsmith.tool.invoked"
+TOOLSMITH_TOOL_INVOKE_FAILED: Final[str] = "toolsmith.tool.invoke_failed"
+
+# Applier lifecycle
+TOOLSMITH_APPLY_STARTED: Final[str] = "toolsmith.apply.started"
+TOOLSMITH_APPLY_COMPLETED: Final[str] = "toolsmith.apply.completed"
+TOOLSMITH_APPLY_REJECTED: Final[str] = "toolsmith.apply.rejected"
+TOOLSMITH_APPLY_FAILED: Final[str] = "toolsmith.apply.failed"
+TOOLSMITH_BLUEPRINT_RETIRED: Final[str] = "toolsmith.blueprint.retired"
+
+# Service wiring
+TOOLSMITH_SERVICE_WIRED: Final[str] = "toolsmith.service.wired"
+TOOLSMITH_SERVICE_UNAVAILABLE: Final[str] = "toolsmith.service.unavailable"
+TOOLSMITH_CYCLE_STARTED: Final[str] = "toolsmith.cycle.started"
+TOOLSMITH_CYCLE_COMPLETED: Final[str] = "toolsmith.cycle.completed"

--- a/src/synthorg/observability/events/toolsmith.py
+++ b/src/synthorg/observability/events/toolsmith.py
@@ -16,14 +16,19 @@ TOOLSMITH_GAP_RECURRING_DETECTED: Final[str] = "toolsmith.gap.recurring_detected
 TOOLSMITH_AUTHOR_STARTED: Final[str] = "toolsmith.author.started"
 TOOLSMITH_AUTHOR_COMPLETED: Final[str] = "toolsmith.author.completed"
 TOOLSMITH_AUTHOR_FAILED: Final[str] = "toolsmith.author.failed"
+TOOLSMITH_AUTHOR_SKIPPED: Final[str] = "toolsmith.author.skipped"
 TOOLSMITH_AUTHOR_OVERFLOW_TO_CODE_MOD: Final[str] = (
     "toolsmith.author.overflow_to_code_mod"
 )
+
+# Proposal guard chain
+TOOLSMITH_PROPOSAL_GUARD_REJECTED: Final[str] = "toolsmith.proposal.guard_rejected"
 
 # Validation gate
 TOOLSMITH_VALIDATION_STARTED: Final[str] = "toolsmith.validation.started"
 TOOLSMITH_VALIDATION_PASSED: Final[str] = "toolsmith.validation.passed"
 TOOLSMITH_VALIDATION_FAILED: Final[str] = "toolsmith.validation.failed"
+TOOLSMITH_BRIEF_PARSE_FAILED: Final[str] = "toolsmith.validation.brief_parse_failed"
 
 # Live registration
 TOOLSMITH_TOOL_REGISTERED: Final[str] = "toolsmith.tool.registered"

--- a/src/synthorg/persistence/postgres/revisions/20260522000001_dynamic_tools.sql
+++ b/src/synthorg/persistence/postgres/revisions/20260522000001_dynamic_tools.sql
@@ -1,6 +1,6 @@
 -- depends: 20260521000001_external_api_governed_access
 
--- Self-extending toolkit (#1995): authored tool blueprints.
+-- Self-extending toolkit: authored tool blueprints.
 --
 -- dynamic_tools stores runtime-authored MCP tools. A blueprint is a
 -- declarative spec (name, capability, JSON Schema) plus a sandbox

--- a/src/synthorg/persistence/postgres/revisions/20260522000001_dynamic_tools.sql
+++ b/src/synthorg/persistence/postgres/revisions/20260522000001_dynamic_tools.sql
@@ -42,15 +42,18 @@ CREATE TABLE dynamic_tools (
         OR (state = 'validated'
             AND validated_at IS NOT NULL
             AND activated_at IS NULL
-            AND retired_at IS NULL)
+            AND retired_at IS NULL
+            AND validation IS NOT NULL)
         OR (state = 'active'
             AND validated_at IS NOT NULL
             AND activated_at IS NOT NULL
-            AND retired_at IS NULL)
+            AND retired_at IS NULL
+            AND validation IS NOT NULL)
         OR (state = 'retired'
             AND validated_at IS NOT NULL
             AND activated_at IS NOT NULL
-            AND retired_at IS NOT NULL)
+            AND retired_at IS NOT NULL
+            AND validation IS NOT NULL)
     )
 );
 

--- a/src/synthorg/persistence/postgres/revisions/20260522000001_dynamic_tools.sql
+++ b/src/synthorg/persistence/postgres/revisions/20260522000001_dynamic_tools.sql
@@ -1,0 +1,35 @@
+-- depends: 20260521000001_external_api_governed_access
+
+-- Self-extending toolkit (#1995): authored tool blueprints.
+--
+-- dynamic_tools stores runtime-authored MCP tools. A blueprint is a
+-- declarative spec (name, capability, JSON Schema) plus a sandbox
+-- script body, governed through the TOOL_CREATION proposal altitude.
+-- state drives the lifecycle: pending (proposed) -> validated (passed
+-- the benchmark gate) -> active (live-registered) -> retired (rolled
+-- back). The state-correlated timestamps are stamped on transition.
+-- parameters_schema and validation use native JSONB; a real Pydantic
+-- args_model is materialised from parameters_schema at registration.
+
+CREATE TABLE dynamic_tools (
+    id TEXT NOT NULL PRIMARY KEY CHECK (char_length(trim(id)) > 0),
+    name TEXT NOT NULL UNIQUE CHECK (char_length(trim(name)) > 0),
+    description TEXT NOT NULL CHECK (char_length(trim(description)) > 0),
+    capability TEXT NOT NULL CHECK (char_length(trim(capability)) > 0),
+    parameters_schema JSONB NOT NULL,
+    script_body TEXT NOT NULL CHECK (char_length(trim(script_body)) > 0),
+    sandbox_backend TEXT NOT NULL
+        CHECK (sandbox_backend IN ('docker', 'subprocess')),
+    requires_network BOOLEAN NOT NULL DEFAULT FALSE,
+    action_type TEXT NOT NULL CHECK (char_length(trim(action_type)) > 0),
+    state TEXT NOT NULL DEFAULT 'pending'
+        CHECK (state IN ('pending', 'validated', 'active', 'retired')),
+    created_at TIMESTAMPTZ NOT NULL,
+    validated_at TIMESTAMPTZ,
+    activated_at TIMESTAMPTZ,
+    retired_at TIMESTAMPTZ,
+    validation JSONB
+);
+
+CREATE INDEX idx_dynamic_tools_state ON dynamic_tools(state);
+CREATE INDEX idx_dynamic_tools_capability ON dynamic_tools(capability);

--- a/src/synthorg/persistence/postgres/revisions/20260522000001_dynamic_tools.sql
+++ b/src/synthorg/persistence/postgres/revisions/20260522000001_dynamic_tools.sql
@@ -10,13 +10,17 @@
 -- back). The state-correlated timestamps are stamped on transition.
 -- parameters_schema and validation use native JSONB; a real Pydantic
 -- args_model is materialised from parameters_schema at registration.
+-- JSON columns reject non-object payloads so a malformed blueprint
+-- cannot persist; the table-level CHECK enforces the lifecycle so
+-- timestamps must match the state.
 
 CREATE TABLE dynamic_tools (
     id TEXT NOT NULL PRIMARY KEY CHECK (char_length(trim(id)) > 0),
     name TEXT NOT NULL UNIQUE CHECK (char_length(trim(name)) > 0),
     description TEXT NOT NULL CHECK (char_length(trim(description)) > 0),
     capability TEXT NOT NULL CHECK (char_length(trim(capability)) > 0),
-    parameters_schema JSONB NOT NULL,
+    parameters_schema JSONB NOT NULL
+        CHECK (jsonb_typeof(parameters_schema) = 'object'),
     script_body TEXT NOT NULL CHECK (char_length(trim(script_body)) > 0),
     sandbox_backend TEXT NOT NULL
         CHECK (sandbox_backend IN ('docker', 'subprocess')),
@@ -29,6 +33,25 @@ CREATE TABLE dynamic_tools (
     activated_at TIMESTAMPTZ,
     retired_at TIMESTAMPTZ,
     validation JSONB
+        CHECK (validation IS NULL OR jsonb_typeof(validation) = 'object'),
+    CHECK (
+        (state = 'pending'
+            AND validated_at IS NULL
+            AND activated_at IS NULL
+            AND retired_at IS NULL)
+        OR (state = 'validated'
+            AND validated_at IS NOT NULL
+            AND activated_at IS NULL
+            AND retired_at IS NULL)
+        OR (state = 'active'
+            AND validated_at IS NOT NULL
+            AND activated_at IS NOT NULL
+            AND retired_at IS NULL)
+        OR (state = 'retired'
+            AND validated_at IS NOT NULL
+            AND activated_at IS NOT NULL
+            AND retired_at IS NOT NULL)
+    )
 );
 
 CREATE INDEX idx_dynamic_tools_state ON dynamic_tools(state);

--- a/src/synthorg/persistence/postgres/schema.sql
+++ b/src/synthorg/persistence/postgres/schema.sql
@@ -1646,7 +1646,8 @@ CREATE TABLE dynamic_tools (
     name TEXT NOT NULL UNIQUE CHECK (char_length(trim(name)) > 0),
     description TEXT NOT NULL CHECK (char_length(trim(description)) > 0),
     capability TEXT NOT NULL CHECK (char_length(trim(capability)) > 0),
-    parameters_schema JSONB NOT NULL,
+    parameters_schema JSONB NOT NULL
+        CHECK (jsonb_typeof(parameters_schema) = 'object'),
     script_body TEXT NOT NULL CHECK (char_length(trim(script_body)) > 0),
     sandbox_backend TEXT NOT NULL
         CHECK (sandbox_backend IN ('docker', 'subprocess')),
@@ -1659,6 +1660,25 @@ CREATE TABLE dynamic_tools (
     activated_at TIMESTAMPTZ,
     retired_at TIMESTAMPTZ,
     validation JSONB
+        CHECK (validation IS NULL OR jsonb_typeof(validation) = 'object'),
+    CHECK (
+        (state = 'pending'
+            AND validated_at IS NULL
+            AND activated_at IS NULL
+            AND retired_at IS NULL)
+        OR (state = 'validated'
+            AND validated_at IS NOT NULL
+            AND activated_at IS NULL
+            AND retired_at IS NULL)
+        OR (state = 'active'
+            AND validated_at IS NOT NULL
+            AND activated_at IS NOT NULL
+            AND retired_at IS NULL)
+        OR (state = 'retired'
+            AND validated_at IS NOT NULL
+            AND activated_at IS NOT NULL
+            AND retired_at IS NOT NULL)
+    )
 );
 
 CREATE INDEX idx_dynamic_tools_state ON dynamic_tools(state);

--- a/src/synthorg/persistence/postgres/schema.sql
+++ b/src/synthorg/persistence/postgres/schema.sql
@@ -1633,3 +1633,33 @@ CREATE TABLE tracked_containers (
     sidecar_id TEXT CHECK (sidecar_id IS NULL OR length(trim(sidecar_id)) > 0),
     created_at TIMESTAMPTZ NOT NULL
 );
+
+-- Self-extending toolkit: runtime-authored MCP tool blueprints. A
+-- blueprint is a declarative spec (name, capability, JSON Schema) plus a
+-- sandbox script body, governed through the TOOL_CREATION proposal
+-- altitude. state drives the lifecycle pending -> validated -> active ->
+-- retired; the state-correlated timestamps are stamped on transition.
+-- SQLite sibling stores JSON columns as TEXT and timestamps as TEXT;
+-- the dual-backend conformance suite pins the round-trip equality.
+CREATE TABLE dynamic_tools (
+    id TEXT NOT NULL PRIMARY KEY CHECK (char_length(trim(id)) > 0),
+    name TEXT NOT NULL UNIQUE CHECK (char_length(trim(name)) > 0),
+    description TEXT NOT NULL CHECK (char_length(trim(description)) > 0),
+    capability TEXT NOT NULL CHECK (char_length(trim(capability)) > 0),
+    parameters_schema JSONB NOT NULL,
+    script_body TEXT NOT NULL CHECK (char_length(trim(script_body)) > 0),
+    sandbox_backend TEXT NOT NULL
+        CHECK (sandbox_backend IN ('docker', 'subprocess')),
+    requires_network BOOLEAN NOT NULL DEFAULT FALSE,
+    action_type TEXT NOT NULL CHECK (char_length(trim(action_type)) > 0),
+    state TEXT NOT NULL DEFAULT 'pending'
+        CHECK (state IN ('pending', 'validated', 'active', 'retired')),
+    created_at TIMESTAMPTZ NOT NULL,
+    validated_at TIMESTAMPTZ,
+    activated_at TIMESTAMPTZ,
+    retired_at TIMESTAMPTZ,
+    validation JSONB
+);
+
+CREATE INDEX idx_dynamic_tools_state ON dynamic_tools(state);
+CREATE INDEX idx_dynamic_tools_capability ON dynamic_tools(capability);

--- a/src/synthorg/persistence/postgres/schema.sql
+++ b/src/synthorg/persistence/postgres/schema.sql
@@ -1669,15 +1669,18 @@ CREATE TABLE dynamic_tools (
         OR (state = 'validated'
             AND validated_at IS NOT NULL
             AND activated_at IS NULL
-            AND retired_at IS NULL)
+            AND retired_at IS NULL
+            AND validation IS NOT NULL)
         OR (state = 'active'
             AND validated_at IS NOT NULL
             AND activated_at IS NOT NULL
-            AND retired_at IS NULL)
+            AND retired_at IS NULL
+            AND validation IS NOT NULL)
         OR (state = 'retired'
             AND validated_at IS NOT NULL
             AND activated_at IS NOT NULL
-            AND retired_at IS NOT NULL)
+            AND retired_at IS NOT NULL
+            AND validation IS NOT NULL)
     )
 );
 

--- a/src/synthorg/persistence/postgres/tool_blueprint_repo.py
+++ b/src/synthorg/persistence/postgres/tool_blueprint_repo.py
@@ -361,9 +361,13 @@ class PostgresDynamicToolRepository:
 
         ``**updates`` may carry ``validated_at`` / ``activated_at`` /
         ``retired_at`` / ``validation``; unknown keys raise ``QueryError``.
-        ``validation`` is serialised via ``model_dump_json()`` and wrapped
-        in :class:`psycopg.types.json.Jsonb` so the JSONB column stamps
-        gate evidence atomically with the timestamp.
+        Each kwarg is keyed off presence: omit it to leave the column
+        unchanged, pass a value to update it. ``validation`` is serialised
+        via ``model_dump_json()`` and wrapped in
+        :class:`psycopg.types.json.Jsonb` when a
+        :class:`ToolValidationResult` is passed; passing ``None``
+        explicitly clears the JSONB column to ``NULL`` (callers who want
+        to preserve existing evidence must omit the key).
         """
         unknown = set(updates) - _TRANSITION_UPDATE_KEYS
         if unknown:

--- a/src/synthorg/persistence/postgres/tool_blueprint_repo.py
+++ b/src/synthorg/persistence/postgres/tool_blueprint_repo.py
@@ -157,10 +157,10 @@ def _upsert_params(bp: ToolBlueprint) -> tuple[object, ...]:
         bp.requires_network,
         bp.action_type,
         bp.state.value,
-        bp.created_at,
-        bp.validated_at,
-        bp.activated_at,
-        bp.retired_at,
+        normalize_utc(bp.created_at),
+        normalize_utc(bp.validated_at) if bp.validated_at is not None else None,
+        normalize_utc(bp.activated_at) if bp.activated_at is not None else None,
+        normalize_utc(bp.retired_at) if bp.retired_at is not None else None,
         Jsonb(bp.validation.model_dump(mode="json"))
         if bp.validation is not None
         else None,

--- a/src/synthorg/persistence/postgres/tool_blueprint_repo.py
+++ b/src/synthorg/persistence/postgres/tool_blueprint_repo.py
@@ -1,0 +1,421 @@
+"""Postgres repository implementation for authored tool blueprints.
+
+Sibling of :class:`SQLiteDynamicToolRepository` backed by
+``psycopg_pool.AsyncConnectionPool``. Uses native ``JSONB`` for
+``parameters_schema`` and ``validation``, ``BOOLEAN`` for
+``requires_network``, and ``TIMESTAMPTZ`` for timestamps.
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Final
+
+import psycopg
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+from pydantic import ValidationError
+
+from synthorg.core.persistence_errors import ConstraintViolationError, QueryError
+from synthorg.meta.toolsmith.models import (
+    ToolBlueprint,
+    ToolBlueprintState,
+    ToolSandboxBackend,
+    ToolValidationResult,
+)
+from synthorg.observability import get_logger, safe_error_description
+from synthorg.observability.events.persistence import (
+    PERSISTENCE_DYNAMIC_TOOL_DELETE_FAILED,
+    PERSISTENCE_DYNAMIC_TOOL_DESERIALIZE_FAILED,
+    PERSISTENCE_DYNAMIC_TOOL_FETCH_FAILED,
+    PERSISTENCE_DYNAMIC_TOOL_FETCHED,
+    PERSISTENCE_DYNAMIC_TOOL_LIST_FAILED,
+    PERSISTENCE_DYNAMIC_TOOL_LISTED,
+    PERSISTENCE_DYNAMIC_TOOL_QUERY_FAILED,
+    PERSISTENCE_DYNAMIC_TOOL_SAVE_FAILED,
+    PERSISTENCE_DYNAMIC_TOOL_TRANSITION_FAILED,
+)
+from synthorg.persistence._generics import DEFAULT_PAGE_SIZE
+from synthorg.persistence._shared import (
+    coerce_row_timestamp,
+    normalize_utc,
+    validate_pagination_args,
+)
+from synthorg.persistence.tool_blueprint_protocol import (  # noqa: TC001
+    ToolBlueprintFilterSpec,
+)
+
+if TYPE_CHECKING:
+    from psycopg_pool import AsyncConnectionPool
+
+    from synthorg.core.types import NotBlankStr
+
+logger = get_logger(__name__)
+
+_MAX_PAGE_LIMIT: Final[int] = 1_000
+
+_TRANSITION_TIMESTAMP_KEYS: Final[frozenset[str]] = frozenset(
+    {"validated_at", "activated_at", "retired_at"}
+)
+
+_SELECT_COLS = (
+    "id, name, description, capability, parameters_schema, script_body, "
+    "sandbox_backend, requires_network, action_type, state, created_at, "
+    "validated_at, activated_at, retired_at, validation"
+)
+
+_UPSERT_SQL = f"""
+    INSERT INTO dynamic_tools ({_SELECT_COLS})
+    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    ON CONFLICT (id) DO UPDATE SET
+        name = EXCLUDED.name,
+        description = EXCLUDED.description,
+        capability = EXCLUDED.capability,
+        parameters_schema = EXCLUDED.parameters_schema,
+        script_body = EXCLUDED.script_body,
+        sandbox_backend = EXCLUDED.sandbox_backend,
+        requires_network = EXCLUDED.requires_network,
+        action_type = EXCLUDED.action_type,
+        state = EXCLUDED.state,
+        validated_at = EXCLUDED.validated_at,
+        activated_at = EXCLUDED.activated_at,
+        retired_at = EXCLUDED.retired_at,
+        validation = EXCLUDED.validation
+"""  # noqa: S608 -- column list is compile-time constant
+
+
+def _row_to_blueprint(row: dict[str, Any]) -> ToolBlueprint:
+    """Convert a Postgres dict row into a :class:`ToolBlueprint`.
+
+    Raises:
+        QueryError: If the row contains corrupt or unparseable data.
+    """
+    try:
+        validation_raw = row["validation"]
+        validation = (
+            ToolValidationResult.model_validate(validation_raw)
+            if validation_raw is not None
+            else None
+        )
+        return ToolBlueprint(
+            id=str(row["id"]),
+            name=str(row["name"]),
+            description=str(row["description"]),
+            capability=str(row["capability"]),
+            parameters_schema=row["parameters_schema"],
+            script_body=str(row["script_body"]),
+            sandbox_backend=ToolSandboxBackend(str(row["sandbox_backend"])),
+            requires_network=bool(row["requires_network"]),
+            action_type=str(row["action_type"]),
+            state=ToolBlueprintState(str(row["state"])),
+            created_at=coerce_row_timestamp(row["created_at"]),
+            validated_at=(
+                coerce_row_timestamp(row["validated_at"])
+                if row["validated_at"] is not None
+                else None
+            ),
+            activated_at=(
+                coerce_row_timestamp(row["activated_at"])
+                if row["activated_at"] is not None
+                else None
+            ),
+            retired_at=(
+                coerce_row_timestamp(row["retired_at"])
+                if row["retired_at"] is not None
+                else None
+            ),
+            validation=validation,
+        )
+    except (ValueError, TypeError, KeyError, ValidationError) as exc:
+        try:
+            row_id = str(row["id"]) if row else "<unknown>"
+        except TypeError, KeyError:
+            row_id = "<unknown>"
+        msg = f"Failed to parse dynamic_tool row {row_id!r}"
+        logger.warning(
+            PERSISTENCE_DYNAMIC_TOOL_DESERIALIZE_FAILED,
+            row_id=row_id,
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
+        )
+        raise QueryError(msg) from exc
+
+
+def _upsert_params(bp: ToolBlueprint) -> tuple[object, ...]:
+    """Build the positional upsert parameter tuple for a blueprint."""
+    return (
+        bp.id,
+        bp.name,
+        bp.description,
+        bp.capability,
+        Jsonb(bp.parameters_schema),
+        bp.script_body,
+        bp.sandbox_backend.value,
+        bp.requires_network,
+        bp.action_type,
+        bp.state.value,
+        bp.created_at,
+        bp.validated_at,
+        bp.activated_at,
+        bp.retired_at,
+        Jsonb(bp.validation.model_dump(mode="json"))
+        if bp.validation is not None
+        else None,
+    )
+
+
+class PostgresDynamicToolRepository:
+    """Postgres-backed authored tool blueprint repository.
+
+    Args:
+        pool: An open psycopg async connection pool.
+    """
+
+    def __init__(self, pool: AsyncConnectionPool) -> None:
+        self._pool = pool
+
+    async def save(self, entity: ToolBlueprint) -> None:
+        """Upsert a blueprint.
+
+        Raises:
+            ConstraintViolationError: On constraint violations.
+            QueryError: On other database errors.
+        """
+        try:
+            async with self._pool.connection() as conn, conn.cursor() as cur:
+                await cur.execute(_UPSERT_SQL, _upsert_params(entity))
+                await conn.commit()
+        except psycopg.errors.IntegrityError as exc:
+            constraint = (
+                getattr(getattr(exc, "diag", None), "constraint_name", None)
+                or "<unknown>"
+            )
+            msg = f"Constraint violation saving dynamic_tool {entity.id!r}"
+            logger.warning(
+                PERSISTENCE_DYNAMIC_TOOL_SAVE_FAILED,
+                blueprint_id=entity.id,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise ConstraintViolationError(msg, constraint=constraint) from exc
+        except psycopg.Error as exc:
+            msg = f"Failed to save dynamic_tool {entity.id!r}"
+            logger.warning(
+                PERSISTENCE_DYNAMIC_TOOL_SAVE_FAILED,
+                blueprint_id=entity.id,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+
+    async def get(self, entity_id: NotBlankStr) -> ToolBlueprint | None:
+        """Get a blueprint by id, or ``None`` if not found."""
+        sql = f"SELECT {_SELECT_COLS} FROM dynamic_tools WHERE id = %s"  # noqa: S608
+        try:
+            async with (
+                self._pool.connection() as conn,
+                conn.cursor(row_factory=dict_row) as cur,
+            ):
+                await cur.execute(sql, (entity_id,))
+                row = await cur.fetchone()
+        except psycopg.Error as exc:
+            msg = f"Failed to fetch dynamic_tool {entity_id!r}"
+            logger.warning(
+                PERSISTENCE_DYNAMIC_TOOL_FETCH_FAILED,
+                blueprint_id=entity_id,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+        if row is None:
+            return None
+        blueprint = _row_to_blueprint(row)
+        logger.debug(PERSISTENCE_DYNAMIC_TOOL_FETCHED, blueprint_id=entity_id)
+        return blueprint
+
+    async def list_items(
+        self,
+        *,
+        limit: int = DEFAULT_PAGE_SIZE,
+        offset: int = 0,
+    ) -> tuple[ToolBlueprint, ...]:
+        """List blueprints ordered by ``(created_at DESC, id DESC)``."""
+        effective_limit = min(
+            validate_pagination_args(
+                limit, offset, event=PERSISTENCE_DYNAMIC_TOOL_LIST_FAILED
+            ),
+            _MAX_PAGE_LIMIT,
+        )
+        try:
+            async with (
+                self._pool.connection() as conn,
+                conn.cursor(row_factory=dict_row) as cur,
+            ):
+                await cur.execute(
+                    f"SELECT {_SELECT_COLS} FROM dynamic_tools "  # noqa: S608
+                    "ORDER BY created_at DESC, id DESC LIMIT %s OFFSET %s",
+                    (effective_limit, offset),
+                )
+                rows = await cur.fetchall()
+                items = tuple(_row_to_blueprint(r) for r in rows)
+        except psycopg.Error as exc:
+            msg = "Failed to list dynamic_tools"
+            logger.warning(
+                PERSISTENCE_DYNAMIC_TOOL_LIST_FAILED,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+        logger.debug(PERSISTENCE_DYNAMIC_TOOL_LISTED, count=len(items))
+        return items
+
+    def _build_where(
+        self, filter_spec: ToolBlueprintFilterSpec
+    ) -> tuple[str, list[object]]:
+        """Build the WHERE clause and bound params from a filter spec."""
+        clauses: list[str] = []
+        params: list[object] = []
+        if filter_spec.state is not None:
+            clauses.append("state = %s")
+            params.append(filter_spec.state.value)
+        if filter_spec.capability is not None:
+            clauses.append("capability = %s")
+            params.append(filter_spec.capability)
+        if filter_spec.sandbox_backend is not None:
+            clauses.append("sandbox_backend = %s")
+            params.append(filter_spec.sandbox_backend.value)
+        where = " AND ".join(clauses) if clauses else "TRUE"
+        return where, params
+
+    async def query(
+        self,
+        filter_spec: ToolBlueprintFilterSpec,
+        *,
+        limit: int = DEFAULT_PAGE_SIZE,
+        offset: int = 0,
+    ) -> tuple[ToolBlueprint, ...]:
+        """List blueprints matching the filter spec (paginated)."""
+        effective_limit = min(
+            validate_pagination_args(
+                limit, offset, event=PERSISTENCE_DYNAMIC_TOOL_QUERY_FAILED
+            ),
+            _MAX_PAGE_LIMIT,
+        )
+        where, params = self._build_where(filter_spec)
+        params.extend([effective_limit, offset])
+        try:
+            async with (
+                self._pool.connection() as conn,
+                conn.cursor(row_factory=dict_row) as cur,
+            ):
+                await cur.execute(
+                    f"SELECT {_SELECT_COLS} FROM dynamic_tools "  # noqa: S608
+                    f"WHERE {where} ORDER BY created_at DESC, id DESC "
+                    "LIMIT %s OFFSET %s",
+                    params,
+                )
+                rows = await cur.fetchall()
+                items = tuple(_row_to_blueprint(r) for r in rows)
+        except psycopg.Error as exc:
+            msg = "Failed to query dynamic_tools"
+            logger.warning(
+                PERSISTENCE_DYNAMIC_TOOL_QUERY_FAILED,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+        return items
+
+    async def count(self, filter_spec: ToolBlueprintFilterSpec) -> int:
+        """Count blueprints matching the filter spec."""
+        where, params = self._build_where(filter_spec)
+        try:
+            async with self._pool.connection() as conn, conn.cursor() as cur:
+                await cur.execute(
+                    f"SELECT COUNT(*) FROM dynamic_tools WHERE {where}",  # noqa: S608
+                    params,
+                )
+                row = await cur.fetchone()
+                assert row is not None  # noqa: S101  -- COUNT always returns a row
+                return int(row[0])
+        except psycopg.Error as exc:
+            msg = "Failed to count dynamic_tools"
+            logger.warning(
+                PERSISTENCE_DYNAMIC_TOOL_QUERY_FAILED,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+
+    async def transition_if(
+        self,
+        entity_id: NotBlankStr,
+        from_state: ToolBlueprintState,
+        to_state: ToolBlueprintState,
+        **updates: object,
+    ) -> bool:
+        """Atomic compare-and-set for blueprint state transitions.
+
+        ``**updates`` may carry ``validated_at`` / ``activated_at`` /
+        ``retired_at``; unknown keys raise ``QueryError``.
+        """
+        unknown = set(updates) - _TRANSITION_TIMESTAMP_KEYS
+        if unknown:
+            msg = f"transition_if got unknown update keys: {sorted(unknown)!r}"
+            logger.warning(
+                PERSISTENCE_DYNAMIC_TOOL_TRANSITION_FAILED,
+                blueprint_id=entity_id,
+                error=msg,
+            )
+            raise QueryError(msg)
+        set_cols = ["state = %s"]
+        params: list[object] = [to_state.value]
+        for key in ("validated_at", "activated_at", "retired_at"):
+            if key in updates:
+                set_cols.append(f"{key} = %s")
+                params.append(_coerce_update_ts(updates[key]))
+        params.extend([entity_id, from_state.value])
+        sql = (
+            f"UPDATE dynamic_tools SET {', '.join(set_cols)} "  # noqa: S608
+            "WHERE id = %s AND state = %s"
+        )
+        try:
+            async with self._pool.connection() as conn, conn.cursor() as cur:
+                await cur.execute(sql, params)
+                updated = cur.rowcount > 0
+                await conn.commit()
+        except psycopg.Error as exc:
+            msg = f"Failed to transition dynamic_tool {entity_id!r}"
+            logger.warning(
+                PERSISTENCE_DYNAMIC_TOOL_TRANSITION_FAILED,
+                blueprint_id=entity_id,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+        return updated
+
+    async def delete(self, entity_id: NotBlankStr) -> bool:
+        """Delete a blueprint by id; ``True`` iff a row was removed."""
+        sql = "DELETE FROM dynamic_tools WHERE id = %s"
+        try:
+            async with self._pool.connection() as conn, conn.cursor() as cur:
+                await cur.execute(sql, (entity_id,))
+                deleted = cur.rowcount > 0
+                await conn.commit()
+        except psycopg.Error as exc:
+            msg = f"Failed to delete dynamic_tool {entity_id!r}"
+            logger.warning(
+                PERSISTENCE_DYNAMIC_TOOL_DELETE_FAILED,
+                blueprint_id=entity_id,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+        return deleted
+
+
+def _coerce_update_ts(value: object) -> datetime:
+    """Normalise a transition timestamp kwarg to an aware-UTC datetime."""
+    if not isinstance(value, datetime):
+        msg = f"transition timestamp must be a datetime, got {type(value).__name__}"
+        raise QueryError(msg)
+    return normalize_utc(value)

--- a/src/synthorg/persistence/postgres/tool_blueprint_repo.py
+++ b/src/synthorg/persistence/postgres/tool_blueprint_repo.py
@@ -52,8 +52,13 @@ logger = get_logger(__name__)
 
 _MAX_PAGE_LIMIT: Final[int] = 1_000
 
-_TRANSITION_TIMESTAMP_KEYS: Final[frozenset[str]] = frozenset(
-    {"validated_at", "activated_at", "retired_at"}
+# Status-correlated columns the CAS transition may stamp. ``validation``
+# is included so a PENDING -> VALIDATED CAS can populate the gate-evidence
+# atomically alongside ``validated_at``, satisfying the lifecycle CHECK
+# that requires ``validation IS NOT NULL`` in the validated/active/retired
+# branches.
+_TRANSITION_UPDATE_KEYS: Final[frozenset[str]] = frozenset(
+    {"validated_at", "activated_at", "retired_at", "validation"}
 )
 
 _SELECT_COLS = (
@@ -355,9 +360,12 @@ class PostgresDynamicToolRepository:
         """Atomic compare-and-set for blueprint state transitions.
 
         ``**updates`` may carry ``validated_at`` / ``activated_at`` /
-        ``retired_at``; unknown keys raise ``QueryError``.
+        ``retired_at`` / ``validation``; unknown keys raise ``QueryError``.
+        ``validation`` is serialised via ``model_dump_json()`` and wrapped
+        in :class:`psycopg.types.json.Jsonb` so the JSONB column stamps
+        gate evidence atomically with the timestamp.
         """
-        unknown = set(updates) - _TRANSITION_TIMESTAMP_KEYS
+        unknown = set(updates) - _TRANSITION_UPDATE_KEYS
         if unknown:
             msg = f"transition_if got unknown update keys: {sorted(unknown)!r}"
             logger.warning(
@@ -372,6 +380,9 @@ class PostgresDynamicToolRepository:
             if key in updates:
                 set_cols.append(f"{key} = %s")
                 params.append(_coerce_update_ts(updates[key]))
+        if "validation" in updates:
+            set_cols.append("validation = %s")
+            params.append(_coerce_validation(updates["validation"]))
         params.extend([entity_id, from_state.value])
         sql = (
             f"UPDATE dynamic_tools SET {', '.join(set_cols)} "  # noqa: S608
@@ -419,3 +430,21 @@ def _coerce_update_ts(value: object) -> datetime:
         msg = f"transition timestamp must be a datetime, got {type(value).__name__}"
         raise QueryError(msg)
     return normalize_utc(value)
+
+
+def _coerce_validation(value: object) -> Jsonb | None:
+    """Render a transition ``validation`` kwarg to a JSONB-ready payload.
+
+    ``None`` is passed through so callers can explicitly clear the column;
+    everything else must be a :class:`ToolValidationResult`.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, ToolValidationResult):
+        msg = (
+            "transition validation must be a ToolValidationResult or None, "
+            f"got {type(value).__name__}"
+        )
+        raise QueryError(msg)
+    result: ToolValidationResult = value
+    return Jsonb(result.model_dump(mode="json"))

--- a/src/synthorg/persistence/sqlite/revisions/20260522000001_dynamic_tools.sql
+++ b/src/synthorg/persistence/sqlite/revisions/20260522000001_dynamic_tools.sql
@@ -1,6 +1,6 @@
 -- depends: 20260521000001_external_api_governed_access
 
--- Self-extending toolkit (#1995): authored tool blueprints.
+-- Self-extending toolkit: authored tool blueprints.
 --
 -- dynamic_tools stores runtime-authored MCP tools. A blueprint is a
 -- declarative spec (name, capability, JSON Schema) plus a sandbox

--- a/src/synthorg/persistence/sqlite/revisions/20260522000001_dynamic_tools.sql
+++ b/src/synthorg/persistence/sqlite/revisions/20260522000001_dynamic_tools.sql
@@ -57,15 +57,18 @@ CREATE TABLE dynamic_tools (
         OR (state = 'validated'
             AND validated_at IS NOT NULL
             AND activated_at IS NULL
-            AND retired_at IS NULL)
+            AND retired_at IS NULL
+            AND validation IS NOT NULL)
         OR (state = 'active'
             AND validated_at IS NOT NULL
             AND activated_at IS NOT NULL
-            AND retired_at IS NULL)
+            AND retired_at IS NULL
+            AND validation IS NOT NULL)
         OR (state = 'retired'
             AND validated_at IS NOT NULL
             AND activated_at IS NOT NULL
-            AND retired_at IS NOT NULL)
+            AND retired_at IS NOT NULL
+            AND validation IS NOT NULL)
     )
 );
 

--- a/src/synthorg/persistence/sqlite/revisions/20260522000001_dynamic_tools.sql
+++ b/src/synthorg/persistence/sqlite/revisions/20260522000001_dynamic_tools.sql
@@ -10,14 +10,21 @@
 -- back). The state-correlated timestamps are stamped on transition.
 -- parameters_schema and validation are stored as JSON text (TEXT here,
 -- JSONB on Postgres); a real Pydantic args_model is materialised from
--- parameters_schema at registration time.
+-- parameters_schema at registration time. JSON columns reject non-object
+-- payloads at write time so a malformed blueprint cannot persist and
+-- crash the materialiser at register-time. The table-level lifecycle
+-- CHECK enforces the state-machine: timestamps must match the state.
 
 CREATE TABLE dynamic_tools (
     id TEXT NOT NULL PRIMARY KEY CHECK (length(trim(id)) > 0),
     name TEXT NOT NULL UNIQUE CHECK (length(trim(name)) > 0),
     description TEXT NOT NULL CHECK (length(trim(description)) > 0),
     capability TEXT NOT NULL CHECK (length(trim(capability)) > 0),
-    parameters_schema TEXT NOT NULL,
+    parameters_schema TEXT NOT NULL
+        CHECK (
+            json_valid(parameters_schema)
+            AND json_type(parameters_schema) = 'object'
+        ),
     script_body TEXT NOT NULL CHECK (length(trim(script_body)) > 0),
     sandbox_backend TEXT NOT NULL
         CHECK (sandbox_backend IN ('docker', 'subprocess')),
@@ -38,6 +45,28 @@ CREATE TABLE dynamic_tools (
         CHECK (retired_at IS NULL
             OR retired_at LIKE '%+00:00' OR retired_at LIKE '%Z'),
     validation TEXT
+        CHECK (
+            validation IS NULL
+            OR (json_valid(validation) AND json_type(validation) = 'object')
+        ),
+    CHECK (
+        (state = 'pending'
+            AND validated_at IS NULL
+            AND activated_at IS NULL
+            AND retired_at IS NULL)
+        OR (state = 'validated'
+            AND validated_at IS NOT NULL
+            AND activated_at IS NULL
+            AND retired_at IS NULL)
+        OR (state = 'active'
+            AND validated_at IS NOT NULL
+            AND activated_at IS NOT NULL
+            AND retired_at IS NULL)
+        OR (state = 'retired'
+            AND validated_at IS NOT NULL
+            AND activated_at IS NOT NULL
+            AND retired_at IS NOT NULL)
+    )
 );
 
 CREATE INDEX idx_dynamic_tools_state ON dynamic_tools(state);

--- a/src/synthorg/persistence/sqlite/revisions/20260522000001_dynamic_tools.sql
+++ b/src/synthorg/persistence/sqlite/revisions/20260522000001_dynamic_tools.sql
@@ -1,0 +1,44 @@
+-- depends: 20260521000001_external_api_governed_access
+
+-- Self-extending toolkit (#1995): authored tool blueprints.
+--
+-- dynamic_tools stores runtime-authored MCP tools. A blueprint is a
+-- declarative spec (name, capability, JSON Schema) plus a sandbox
+-- script body, governed through the TOOL_CREATION proposal altitude.
+-- state drives the lifecycle: pending (proposed) -> validated (passed
+-- the benchmark gate) -> active (live-registered) -> retired (rolled
+-- back). The state-correlated timestamps are stamped on transition.
+-- parameters_schema and validation are stored as JSON text (TEXT here,
+-- JSONB on Postgres); a real Pydantic args_model is materialised from
+-- parameters_schema at registration time.
+
+CREATE TABLE dynamic_tools (
+    id TEXT NOT NULL PRIMARY KEY CHECK (length(trim(id)) > 0),
+    name TEXT NOT NULL UNIQUE CHECK (length(trim(name)) > 0),
+    description TEXT NOT NULL CHECK (length(trim(description)) > 0),
+    capability TEXT NOT NULL CHECK (length(trim(capability)) > 0),
+    parameters_schema TEXT NOT NULL,
+    script_body TEXT NOT NULL CHECK (length(trim(script_body)) > 0),
+    sandbox_backend TEXT NOT NULL
+        CHECK (sandbox_backend IN ('docker', 'subprocess')),
+    requires_network INTEGER NOT NULL DEFAULT 0
+        CHECK (requires_network IN (0, 1)),
+    action_type TEXT NOT NULL CHECK (length(trim(action_type)) > 0),
+    state TEXT NOT NULL DEFAULT 'pending'
+        CHECK (state IN ('pending', 'validated', 'active', 'retired')),
+    created_at TEXT NOT NULL
+        CHECK (created_at LIKE '%+00:00' OR created_at LIKE '%Z'),
+    validated_at TEXT
+        CHECK (validated_at IS NULL
+            OR validated_at LIKE '%+00:00' OR validated_at LIKE '%Z'),
+    activated_at TEXT
+        CHECK (activated_at IS NULL
+            OR activated_at LIKE '%+00:00' OR activated_at LIKE '%Z'),
+    retired_at TEXT
+        CHECK (retired_at IS NULL
+            OR retired_at LIKE '%+00:00' OR retired_at LIKE '%Z'),
+    validation TEXT
+);
+
+CREATE INDEX idx_dynamic_tools_state ON dynamic_tools(state);
+CREATE INDEX idx_dynamic_tools_capability ON dynamic_tools(capability);

--- a/src/synthorg/persistence/sqlite/schema.sql
+++ b/src/synthorg/persistence/sqlite/schema.sql
@@ -1676,3 +1676,39 @@ CREATE TABLE tracked_containers (
     sidecar_id TEXT CHECK(sidecar_id IS NULL OR length(trim(sidecar_id)) > 0),
     created_at TEXT NOT NULL CHECK(length(trim(created_at)) > 0)
 );
+
+-- Self-extending toolkit: runtime-authored MCP tool blueprints. A
+-- blueprint is a declarative spec (name, capability, JSON Schema) plus a
+-- sandbox script body, governed through the TOOL_CREATION proposal
+-- altitude. state drives the lifecycle pending -> validated -> active ->
+-- retired; the state-correlated timestamps are stamped on transition.
+CREATE TABLE dynamic_tools (
+    id TEXT NOT NULL PRIMARY KEY CHECK (length(trim(id)) > 0),
+    name TEXT NOT NULL UNIQUE CHECK (length(trim(name)) > 0),
+    description TEXT NOT NULL CHECK (length(trim(description)) > 0),
+    capability TEXT NOT NULL CHECK (length(trim(capability)) > 0),
+    parameters_schema TEXT NOT NULL,
+    script_body TEXT NOT NULL CHECK (length(trim(script_body)) > 0),
+    sandbox_backend TEXT NOT NULL
+        CHECK (sandbox_backend IN ('docker', 'subprocess')),
+    requires_network INTEGER NOT NULL DEFAULT 0
+        CHECK (requires_network IN (0, 1)),
+    action_type TEXT NOT NULL CHECK (length(trim(action_type)) > 0),
+    state TEXT NOT NULL DEFAULT 'pending'
+        CHECK (state IN ('pending', 'validated', 'active', 'retired')),
+    created_at TEXT NOT NULL
+        CHECK (created_at LIKE '%+00:00' OR created_at LIKE '%Z'),
+    validated_at TEXT
+        CHECK (validated_at IS NULL
+            OR validated_at LIKE '%+00:00' OR validated_at LIKE '%Z'),
+    activated_at TEXT
+        CHECK (activated_at IS NULL
+            OR activated_at LIKE '%+00:00' OR activated_at LIKE '%Z'),
+    retired_at TEXT
+        CHECK (retired_at IS NULL
+            OR retired_at LIKE '%+00:00' OR retired_at LIKE '%Z'),
+    validation TEXT
+);
+
+CREATE INDEX idx_dynamic_tools_state ON dynamic_tools(state);
+CREATE INDEX idx_dynamic_tools_capability ON dynamic_tools(capability);

--- a/src/synthorg/persistence/sqlite/schema.sql
+++ b/src/synthorg/persistence/sqlite/schema.sql
@@ -1724,15 +1724,18 @@ CREATE TABLE dynamic_tools (
         OR (state = 'validated'
             AND validated_at IS NOT NULL
             AND activated_at IS NULL
-            AND retired_at IS NULL)
+            AND retired_at IS NULL
+            AND validation IS NOT NULL)
         OR (state = 'active'
             AND validated_at IS NOT NULL
             AND activated_at IS NOT NULL
-            AND retired_at IS NULL)
+            AND retired_at IS NULL
+            AND validation IS NOT NULL)
         OR (state = 'retired'
             AND validated_at IS NOT NULL
             AND activated_at IS NOT NULL
-            AND retired_at IS NOT NULL)
+            AND retired_at IS NOT NULL
+            AND validation IS NOT NULL)
     )
 );
 

--- a/src/synthorg/persistence/sqlite/schema.sql
+++ b/src/synthorg/persistence/sqlite/schema.sql
@@ -1687,7 +1687,11 @@ CREATE TABLE dynamic_tools (
     name TEXT NOT NULL UNIQUE CHECK (length(trim(name)) > 0),
     description TEXT NOT NULL CHECK (length(trim(description)) > 0),
     capability TEXT NOT NULL CHECK (length(trim(capability)) > 0),
-    parameters_schema TEXT NOT NULL,
+    parameters_schema TEXT NOT NULL
+        CHECK (
+            json_valid(parameters_schema)
+            AND json_type(parameters_schema) = 'object'
+        ),
     script_body TEXT NOT NULL CHECK (length(trim(script_body)) > 0),
     sandbox_backend TEXT NOT NULL
         CHECK (sandbox_backend IN ('docker', 'subprocess')),
@@ -1708,6 +1712,28 @@ CREATE TABLE dynamic_tools (
         CHECK (retired_at IS NULL
             OR retired_at LIKE '%+00:00' OR retired_at LIKE '%Z'),
     validation TEXT
+        CHECK (
+            validation IS NULL
+            OR (json_valid(validation) AND json_type(validation) = 'object')
+        ),
+    CHECK (
+        (state = 'pending'
+            AND validated_at IS NULL
+            AND activated_at IS NULL
+            AND retired_at IS NULL)
+        OR (state = 'validated'
+            AND validated_at IS NOT NULL
+            AND activated_at IS NULL
+            AND retired_at IS NULL)
+        OR (state = 'active'
+            AND validated_at IS NOT NULL
+            AND activated_at IS NOT NULL
+            AND retired_at IS NULL)
+        OR (state = 'retired'
+            AND validated_at IS NOT NULL
+            AND activated_at IS NOT NULL
+            AND retired_at IS NOT NULL)
+    )
 );
 
 CREATE INDEX idx_dynamic_tools_state ON dynamic_tools(state);

--- a/src/synthorg/persistence/sqlite/tool_blueprint_repo.py
+++ b/src/synthorg/persistence/sqlite/tool_blueprint_repo.py
@@ -46,9 +46,13 @@ logger = get_logger(__name__)
 
 _MAX_PAGE_LIMIT: Final[int] = 1_000
 
-# Status-correlated timestamp columns the CAS transition may stamp.
-_TRANSITION_TIMESTAMP_KEYS: Final[frozenset[str]] = frozenset(
-    {"validated_at", "activated_at", "retired_at"}
+# Status-correlated columns the CAS transition may stamp. ``validation``
+# is included so a PENDING -> VALIDATED CAS can populate the gate-evidence
+# atomically alongside ``validated_at``, satisfying the lifecycle CHECK
+# that requires ``validation IS NOT NULL`` in the validated/active/retired
+# branches.
+_TRANSITION_UPDATE_KEYS: Final[frozenset[str]] = frozenset(
+    {"validated_at", "activated_at", "retired_at", "validation"}
 )
 
 _SELECT_COLS = (
@@ -352,9 +356,11 @@ class SQLiteDynamicToolRepository:
         """Atomic compare-and-set for blueprint state transitions.
 
         ``**updates`` may carry ``validated_at`` / ``activated_at`` /
-        ``retired_at``; unknown keys raise ``QueryError``.
+        ``retired_at`` / ``validation``; unknown keys raise ``QueryError``.
+        ``validation`` is serialised via ``model_dump_json()`` so the row
+        stamps gate evidence atomically with the timestamp.
         """
-        unknown = set(updates) - _TRANSITION_TIMESTAMP_KEYS
+        unknown = set(updates) - _TRANSITION_UPDATE_KEYS
         if unknown:
             msg = f"transition_if got unknown update keys: {sorted(unknown)!r}"
             logger.warning(
@@ -369,6 +375,9 @@ class SQLiteDynamicToolRepository:
             if key in updates:
                 set_cols.append(f"{key} = ?")
                 params.append(_coerce_update_ts(updates[key]))
+        if "validation" in updates:
+            set_cols.append("validation = ?")
+            params.append(_coerce_validation(updates["validation"]))
         params.extend([entity_id, from_state.value])
         sql = (
             f"UPDATE dynamic_tools SET {', '.join(set_cols)} "  # noqa: S608
@@ -430,3 +439,21 @@ def _coerce_update_ts(value: object) -> str:
         msg = f"transition timestamp must be a datetime, got {type(value).__name__}"
         raise QueryError(msg)
     return format_iso_utc(value)
+
+
+def _coerce_validation(value: object) -> str | None:
+    """Render a transition ``validation`` kwarg to a JSON object string.
+
+    ``None`` is passed through so callers can explicitly clear the column;
+    everything else must be a :class:`ToolValidationResult`.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, ToolValidationResult):
+        msg = (
+            "transition validation must be a ToolValidationResult or None, "
+            f"got {type(value).__name__}"
+        )
+        raise QueryError(msg)
+    result: ToolValidationResult = value
+    return result.model_dump_json()

--- a/src/synthorg/persistence/sqlite/tool_blueprint_repo.py
+++ b/src/synthorg/persistence/sqlite/tool_blueprint_repo.py
@@ -357,8 +357,11 @@ class SQLiteDynamicToolRepository:
 
         ``**updates`` may carry ``validated_at`` / ``activated_at`` /
         ``retired_at`` / ``validation``; unknown keys raise ``QueryError``.
-        ``validation`` is serialised via ``model_dump_json()`` so the row
-        stamps gate evidence atomically with the timestamp.
+        Each kwarg is keyed off presence: omit it to leave the column
+        unchanged, pass a value to update it. ``validation`` is serialised
+        via ``model_dump_json()`` when a :class:`ToolValidationResult` is
+        passed; passing ``None`` explicitly clears the column to ``NULL``
+        (callers who want to preserve existing evidence must omit the key).
         """
         unknown = set(updates) - _TRANSITION_UPDATE_KEYS
         if unknown:

--- a/src/synthorg/persistence/sqlite/tool_blueprint_repo.py
+++ b/src/synthorg/persistence/sqlite/tool_blueprint_repo.py
@@ -1,0 +1,432 @@
+"""SQLite repository implementation for authored tool blueprints."""
+
+import json
+import sqlite3
+from datetime import datetime
+from typing import TYPE_CHECKING, Final
+
+import aiosqlite
+from aiosqlite import Row
+from pydantic import ValidationError
+
+from synthorg.core.persistence_errors import ConstraintViolationError, QueryError
+from synthorg.meta.toolsmith.models import (
+    ToolBlueprint,
+    ToolBlueprintState,
+    ToolSandboxBackend,
+    ToolValidationResult,
+)
+from synthorg.observability import get_logger, safe_error_description
+from synthorg.observability.events.persistence import (
+    PERSISTENCE_DYNAMIC_TOOL_DELETE_FAILED,
+    PERSISTENCE_DYNAMIC_TOOL_DESERIALIZE_FAILED,
+    PERSISTENCE_DYNAMIC_TOOL_FETCH_FAILED,
+    PERSISTENCE_DYNAMIC_TOOL_FETCHED,
+    PERSISTENCE_DYNAMIC_TOOL_LIST_FAILED,
+    PERSISTENCE_DYNAMIC_TOOL_LISTED,
+    PERSISTENCE_DYNAMIC_TOOL_QUERY_FAILED,
+    PERSISTENCE_DYNAMIC_TOOL_SAVE_FAILED,
+    PERSISTENCE_DYNAMIC_TOOL_TRANSITION_FAILED,
+)
+from synthorg.persistence._generics import DEFAULT_PAGE_SIZE
+from synthorg.persistence._shared import (
+    coerce_row_timestamp,
+    format_iso_utc,
+    validate_pagination_args,
+)
+from synthorg.persistence.sqlite._shared import WriteContext  # noqa: TC001
+from synthorg.persistence.tool_blueprint_protocol import (  # noqa: TC001
+    ToolBlueprintFilterSpec,
+)
+
+if TYPE_CHECKING:
+    from synthorg.core.types import NotBlankStr
+
+logger = get_logger(__name__)
+
+_MAX_PAGE_LIMIT: Final[int] = 1_000
+
+# Status-correlated timestamp columns the CAS transition may stamp.
+_TRANSITION_TIMESTAMP_KEYS: Final[frozenset[str]] = frozenset(
+    {"validated_at", "activated_at", "retired_at"}
+)
+
+_SELECT_COLS = (
+    "id, name, description, capability, parameters_schema, script_body, "
+    "sandbox_backend, requires_network, action_type, state, created_at, "
+    "validated_at, activated_at, retired_at, validation"
+)
+
+_UPSERT_SQL = """
+    INSERT INTO dynamic_tools (
+        id, name, description, capability, parameters_schema, script_body,
+        sandbox_backend, requires_network, action_type, state, created_at,
+        validated_at, activated_at, retired_at, validation
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+        name = excluded.name,
+        description = excluded.description,
+        capability = excluded.capability,
+        parameters_schema = excluded.parameters_schema,
+        script_body = excluded.script_body,
+        sandbox_backend = excluded.sandbox_backend,
+        requires_network = excluded.requires_network,
+        action_type = excluded.action_type,
+        state = excluded.state,
+        validated_at = excluded.validated_at,
+        activated_at = excluded.activated_at,
+        retired_at = excluded.retired_at,
+        validation = excluded.validation
+"""
+
+
+def _row_to_blueprint(row: Row) -> ToolBlueprint:
+    """Convert a database row to a :class:`ToolBlueprint`.
+
+    Raises:
+        QueryError: If the row contains corrupt or unparseable data.
+    """
+    try:
+        validation_raw = row["validation"]
+        validation = (
+            ToolValidationResult.model_validate_json(str(validation_raw))
+            if validation_raw is not None
+            else None
+        )
+        return ToolBlueprint(
+            id=str(row["id"]),
+            name=str(row["name"]),
+            description=str(row["description"]),
+            capability=str(row["capability"]),
+            parameters_schema=json.loads(str(row["parameters_schema"])),
+            script_body=str(row["script_body"]),
+            sandbox_backend=ToolSandboxBackend(str(row["sandbox_backend"])),
+            requires_network=bool(row["requires_network"]),
+            action_type=str(row["action_type"]),
+            state=ToolBlueprintState(str(row["state"])),
+            created_at=coerce_row_timestamp(row["created_at"]),
+            validated_at=(
+                coerce_row_timestamp(row["validated_at"])
+                if row["validated_at"] is not None
+                else None
+            ),
+            activated_at=(
+                coerce_row_timestamp(row["activated_at"])
+                if row["activated_at"] is not None
+                else None
+            ),
+            retired_at=(
+                coerce_row_timestamp(row["retired_at"])
+                if row["retired_at"] is not None
+                else None
+            ),
+            validation=validation,
+        )
+    except (
+        json.JSONDecodeError,
+        ValueError,
+        TypeError,
+        KeyError,
+        ValidationError,
+    ) as exc:
+        try:
+            row_id = str(row["id"]) if row else "<unknown>"
+        except TypeError, KeyError:
+            row_id = "<unknown>"
+        msg = f"Failed to parse dynamic_tool row {row_id!r}"
+        logger.warning(
+            PERSISTENCE_DYNAMIC_TOOL_DESERIALIZE_FAILED,
+            row_id=row_id,
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
+        )
+        raise QueryError(msg) from exc
+
+
+def _upsert_params(bp: ToolBlueprint) -> tuple[object, ...]:
+    """Build the positional upsert parameter tuple for a blueprint."""
+    return (
+        bp.id,
+        bp.name,
+        bp.description,
+        bp.capability,
+        json.dumps(bp.parameters_schema),
+        bp.script_body,
+        bp.sandbox_backend.value,
+        1 if bp.requires_network else 0,
+        bp.action_type,
+        bp.state.value,
+        format_iso_utc(bp.created_at),
+        format_iso_utc(bp.validated_at) if bp.validated_at else None,
+        format_iso_utc(bp.activated_at) if bp.activated_at else None,
+        format_iso_utc(bp.retired_at) if bp.retired_at else None,
+        bp.validation.model_dump_json() if bp.validation is not None else None,
+    )
+
+
+class SQLiteDynamicToolRepository:
+    """SQLite-backed authored tool blueprint repository.
+
+    Args:
+        db: An open aiosqlite connection.
+        write_context: Async context manager that serializes writes on
+            the shared connection.
+    """
+
+    def __init__(
+        self,
+        db: aiosqlite.Connection,
+        *,
+        write_context: WriteContext,
+    ) -> None:
+        self._db = db
+        self._db.row_factory = aiosqlite.Row
+        self._write_context = write_context
+
+    async def save(self, entity: ToolBlueprint) -> None:
+        """Upsert a blueprint.
+
+        Raises:
+            ConstraintViolationError: On constraint violations.
+            QueryError: On other database errors.
+        """
+        async with self._write_context():
+            try:
+                await self._db.execute(_UPSERT_SQL, _upsert_params(entity))
+                await self._db.commit()
+            except sqlite3.IntegrityError as exc:
+                await self._rollback()
+                msg = f"Constraint violation saving dynamic_tool {entity.id!r}"
+                logger.warning(
+                    PERSISTENCE_DYNAMIC_TOOL_SAVE_FAILED,
+                    blueprint_id=entity.id,
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
+                )
+                raise ConstraintViolationError(msg, constraint=str(exc)) from exc
+            except (sqlite3.Error, aiosqlite.Error) as exc:
+                await self._rollback()
+                msg = f"Failed to save dynamic_tool {entity.id!r}"
+                logger.warning(
+                    PERSISTENCE_DYNAMIC_TOOL_SAVE_FAILED,
+                    blueprint_id=entity.id,
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
+                )
+                raise QueryError(msg) from exc
+
+    async def get(self, entity_id: NotBlankStr) -> ToolBlueprint | None:
+        """Get a blueprint by id, or ``None`` if not found."""
+        sql = f"SELECT {_SELECT_COLS} FROM dynamic_tools WHERE id = ?"  # noqa: S608
+        try:
+            cursor = await self._db.execute(sql, (entity_id,))
+            row = await cursor.fetchone()
+        except (sqlite3.Error, aiosqlite.Error) as exc:
+            msg = f"Failed to fetch dynamic_tool {entity_id!r}"
+            logger.warning(
+                PERSISTENCE_DYNAMIC_TOOL_FETCH_FAILED,
+                blueprint_id=entity_id,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+        if row is None:
+            return None
+        blueprint = _row_to_blueprint(row)
+        logger.debug(PERSISTENCE_DYNAMIC_TOOL_FETCHED, blueprint_id=entity_id)
+        return blueprint
+
+    async def list_items(
+        self,
+        *,
+        limit: int = DEFAULT_PAGE_SIZE,
+        offset: int = 0,
+    ) -> tuple[ToolBlueprint, ...]:
+        """List blueprints ordered by ``(created_at DESC, id DESC)``."""
+        effective_limit = min(
+            validate_pagination_args(
+                limit, offset, event=PERSISTENCE_DYNAMIC_TOOL_LIST_FAILED
+            ),
+            _MAX_PAGE_LIMIT,
+        )
+        sql = (
+            f"SELECT {_SELECT_COLS} FROM dynamic_tools "  # noqa: S608
+            "ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?"
+        )
+        try:
+            cursor = await self._db.execute(sql, (effective_limit, offset))
+            rows = await cursor.fetchall()
+            items = tuple(_row_to_blueprint(r) for r in rows)
+        except QueryError:
+            raise
+        except (sqlite3.Error, aiosqlite.Error) as exc:
+            msg = "Failed to list dynamic_tools"
+            logger.warning(
+                PERSISTENCE_DYNAMIC_TOOL_LIST_FAILED,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+        logger.debug(PERSISTENCE_DYNAMIC_TOOL_LISTED, count=len(items))
+        return items
+
+    def _build_where(
+        self, filter_spec: ToolBlueprintFilterSpec
+    ) -> tuple[str, list[object]]:
+        """Build the WHERE clause and bound params from a filter spec."""
+        clauses: list[str] = []
+        params: list[object] = []
+        if filter_spec.state is not None:
+            clauses.append("state = ?")
+            params.append(filter_spec.state.value)
+        if filter_spec.capability is not None:
+            clauses.append("capability = ?")
+            params.append(filter_spec.capability)
+        if filter_spec.sandbox_backend is not None:
+            clauses.append("sandbox_backend = ?")
+            params.append(filter_spec.sandbox_backend.value)
+        where = " AND ".join(clauses) if clauses else "1=1"
+        return where, params
+
+    async def query(
+        self,
+        filter_spec: ToolBlueprintFilterSpec,
+        *,
+        limit: int = DEFAULT_PAGE_SIZE,
+        offset: int = 0,
+    ) -> tuple[ToolBlueprint, ...]:
+        """List blueprints matching the filter spec (paginated)."""
+        effective_limit = min(
+            validate_pagination_args(
+                limit, offset, event=PERSISTENCE_DYNAMIC_TOOL_QUERY_FAILED
+            ),
+            _MAX_PAGE_LIMIT,
+        )
+        where, params = self._build_where(filter_spec)
+        params.extend([effective_limit, offset])
+        sql = (
+            f"SELECT {_SELECT_COLS} FROM dynamic_tools WHERE {where} "  # noqa: S608
+            "ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?"
+        )
+        try:
+            cursor = await self._db.execute(sql, params)
+            rows = await cursor.fetchall()
+            items = tuple(_row_to_blueprint(r) for r in rows)
+        except QueryError:
+            raise
+        except (sqlite3.Error, aiosqlite.Error) as exc:
+            msg = "Failed to query dynamic_tools"
+            logger.warning(
+                PERSISTENCE_DYNAMIC_TOOL_QUERY_FAILED,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+        return items
+
+    async def count(self, filter_spec: ToolBlueprintFilterSpec) -> int:
+        """Count blueprints matching the filter spec."""
+        where, params = self._build_where(filter_spec)
+        sql = f"SELECT COUNT(*) FROM dynamic_tools WHERE {where}"  # noqa: S608
+        try:
+            cursor = await self._db.execute(sql, params)
+            row = await cursor.fetchone()
+            assert row is not None  # noqa: S101  -- COUNT always returns a row
+            return int(row[0])
+        except (sqlite3.Error, aiosqlite.Error) as exc:
+            msg = "Failed to count dynamic_tools"
+            logger.warning(
+                PERSISTENCE_DYNAMIC_TOOL_QUERY_FAILED,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            raise QueryError(msg) from exc
+
+    async def transition_if(
+        self,
+        entity_id: NotBlankStr,
+        from_state: ToolBlueprintState,
+        to_state: ToolBlueprintState,
+        **updates: object,
+    ) -> bool:
+        """Atomic compare-and-set for blueprint state transitions.
+
+        ``**updates`` may carry ``validated_at`` / ``activated_at`` /
+        ``retired_at``; unknown keys raise ``QueryError``.
+        """
+        unknown = set(updates) - _TRANSITION_TIMESTAMP_KEYS
+        if unknown:
+            msg = f"transition_if got unknown update keys: {sorted(unknown)!r}"
+            logger.warning(
+                PERSISTENCE_DYNAMIC_TOOL_TRANSITION_FAILED,
+                blueprint_id=entity_id,
+                error=msg,
+            )
+            raise QueryError(msg)
+        set_cols = ["state = ?"]
+        params: list[object] = [to_state.value]
+        for key in ("validated_at", "activated_at", "retired_at"):
+            if key in updates:
+                set_cols.append(f"{key} = ?")
+                params.append(_coerce_update_ts(updates[key]))
+        params.extend([entity_id, from_state.value])
+        sql = (
+            f"UPDATE dynamic_tools SET {', '.join(set_cols)} "  # noqa: S608
+            "WHERE id = ? AND state = ?"
+        )
+        async with self._write_context():
+            try:
+                cursor = await self._db.execute(sql, params)
+                await self._db.commit()
+            except (sqlite3.Error, aiosqlite.Error) as exc:
+                await self._rollback()
+                msg = f"Failed to transition dynamic_tool {entity_id!r}"
+                logger.warning(
+                    PERSISTENCE_DYNAMIC_TOOL_TRANSITION_FAILED,
+                    blueprint_id=entity_id,
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
+                )
+                raise QueryError(msg) from exc
+        return cursor.rowcount > 0
+
+    async def delete(self, entity_id: NotBlankStr) -> bool:
+        """Delete a blueprint by id; ``True`` iff a row was removed."""
+        sql = "DELETE FROM dynamic_tools WHERE id = ?"
+        async with self._write_context():
+            try:
+                cursor = await self._db.execute(sql, (entity_id,))
+                await self._db.commit()
+            except (sqlite3.Error, aiosqlite.Error) as exc:
+                await self._rollback()
+                msg = f"Failed to delete dynamic_tool {entity_id!r}"
+                logger.warning(
+                    PERSISTENCE_DYNAMIC_TOOL_DELETE_FAILED,
+                    blueprint_id=entity_id,
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
+                )
+                raise QueryError(msg) from exc
+        return cursor.rowcount > 0
+
+    async def _rollback(self) -> None:
+        """Roll back the current transaction, swallowing rollback errors."""
+        try:
+            await self._db.rollback()
+        except MemoryError, RecursionError:
+            raise
+        except (sqlite3.Error, aiosqlite.Error) as exc:
+            logger.error(
+                PERSISTENCE_DYNAMIC_TOOL_SAVE_FAILED,
+                phase="rollback",
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+
+
+def _coerce_update_ts(value: object) -> str:
+    """Render a transition timestamp kwarg to an ISO-8601 UTC string."""
+    if not isinstance(value, datetime):
+        msg = f"transition timestamp must be a datetime, got {type(value).__name__}"
+        raise QueryError(msg)
+    return format_iso_utc(value)

--- a/src/synthorg/persistence/tool_blueprint_protocol.py
+++ b/src/synthorg/persistence/tool_blueprint_protocol.py
@@ -32,11 +32,18 @@ if TYPE_CHECKING:
     from typing_extensions import TypedDict
 
     class TransitionKwargs(TypedDict, total=False):
-        """Typed kwargs for :meth:`DynamicToolRepository.transition_if`."""
+        """Typed kwargs for :meth:`DynamicToolRepository.transition_if`.
+
+        ``validation`` accepts a :class:`ToolValidationResult` (serialised
+        to the column's native JSON shape by the backend implementation),
+        or ``None`` to leave the column untouched. Required when the
+        target state implies ``validation IS NOT NULL`` at the DB layer.
+        """
 
         validated_at: object
         activated_at: object
         retired_at: object
+        validation: object
 
 
 class ToolBlueprintFilterSpec(BaseModel):

--- a/src/synthorg/persistence/tool_blueprint_protocol.py
+++ b/src/synthorg/persistence/tool_blueprint_protocol.py
@@ -34,10 +34,20 @@ if TYPE_CHECKING:
     class TransitionKwargs(TypedDict, total=False):
         """Typed kwargs for :meth:`DynamicToolRepository.transition_if`.
 
-        ``validation`` accepts a :class:`ToolValidationResult` (serialised
-        to the column's native JSON shape by the backend implementation),
-        or ``None`` to leave the column untouched. Required when the
-        target state implies ``validation IS NOT NULL`` at the DB layer.
+        ``validation`` is keyed off **presence**, not value, like every
+        other field here:
+
+        * **Omit** the key entirely to leave the ``validation`` column
+          untouched (the row keeps whatever evidence it already carries).
+        * Pass a :class:`ToolValidationResult` to stamp gate evidence
+          atomically with the timestamp; backends serialise it to the
+          column's native JSON shape. This is required when the target
+          state implies ``validation IS NOT NULL`` at the DB layer
+          (validated / active / retired), otherwise the lifecycle CHECK
+          rejects the transition.
+        * Pass ``None`` to **explicitly clear** the column to ``NULL``.
+          Callers wanting to preserve existing evidence must omit the
+          key, NOT pass ``None``.
         """
 
         validated_at: object

--- a/src/synthorg/persistence/tool_blueprint_protocol.py
+++ b/src/synthorg/persistence/tool_blueprint_protocol.py
@@ -1,0 +1,153 @@
+"""Repository protocol for authored tool blueprint persistence.
+
+Concrete implementations live in backend modules
+(``synthorg.persistence.sqlite.tool_blueprint_repo`` and
+``synthorg.persistence.postgres.tool_blueprint_repo``). The toolsmith's
+``DynamicToolRegistry`` holds a reference typed against this protocol so
+the storage backend can be swapped without changing the registry.
+
+Composes :class:`StatefulRepository` (blueprint lifecycle is a state
+machine: PENDING -> VALIDATED -> ACTIVE -> RETIRED) and
+:class:`FilteredQueryRepository` (ADR-0001). No bespoke methods beyond
+the generic surface.
+"""
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.toolsmith.models import (
+    ToolBlueprint,
+    ToolBlueprintState,
+    ToolSandboxBackend,
+)
+from synthorg.persistence._generics import (
+    DEFAULT_PAGE_SIZE,
+    FilteredQueryRepository,
+    StatefulRepository,
+)
+
+if TYPE_CHECKING:
+    from typing_extensions import TypedDict
+
+    class TransitionKwargs(TypedDict, total=False):
+        """Typed kwargs for :meth:`DynamicToolRepository.transition_if`."""
+
+        validated_at: object
+        activated_at: object
+        retired_at: object
+
+
+class ToolBlueprintFilterSpec(BaseModel):
+    """Filter spec for ``DynamicToolRepository.query`` (ADR-0001).
+
+    All fields optional; an empty spec matches every blueprint.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", allow_inf_nan=False)
+
+    state: ToolBlueprintState | None = Field(default=None)
+    capability: NotBlankStr | None = Field(default=None)
+    sandbox_backend: ToolSandboxBackend | None = Field(default=None)
+
+
+@runtime_checkable
+class DynamicToolRepository(
+    StatefulRepository[ToolBlueprint, NotBlankStr, ToolBlueprintState],
+    FilteredQueryRepository[ToolBlueprint, ToolBlueprintFilterSpec],
+    Protocol,
+):
+    """CRUD + state-transition interface for authored tool blueprints.
+
+    Composes :class:`StatefulRepository` + :class:`FilteredQueryRepository`
+    (ADR-0001). All methods are async; constraint violations raise
+    :class:`ConstraintViolationError`; other DB errors raise
+    :class:`QueryError`.
+    """
+
+    async def save(self, entity: ToolBlueprint) -> None:
+        """Upsert a blueprint.
+
+        Raises:
+            ConstraintViolationError: On constraint violations.
+            QueryError: On other database errors.
+        """
+        ...
+
+    async def get(self, entity_id: NotBlankStr) -> ToolBlueprint | None:
+        """Retrieve a blueprint by id, or ``None`` if absent.
+
+        Raises:
+            QueryError: If the query fails.
+        """
+        ...
+
+    async def delete(self, entity_id: NotBlankStr) -> bool:
+        """Delete a blueprint by id; ``True`` iff a row existed.
+
+        Raises:
+            QueryError: If the query fails.
+        """
+        ...
+
+    async def list_items(
+        self,
+        *,
+        limit: int = DEFAULT_PAGE_SIZE,
+        offset: int = 0,
+    ) -> tuple[ToolBlueprint, ...]:
+        """List blueprints ordered by ``(created_at DESC, id DESC)``.
+
+        Raises:
+            QueryError: If the query fails.
+        """
+        ...
+
+    async def query(
+        self,
+        filter_spec: ToolBlueprintFilterSpec,
+        *,
+        limit: int = DEFAULT_PAGE_SIZE,
+        offset: int = 0,
+    ) -> tuple[ToolBlueprint, ...]:
+        """List blueprints matching the filter spec (paginated).
+
+        Ordered by ``(created_at DESC, id DESC)``.
+
+        Raises:
+            QueryError: If the query fails.
+        """
+        ...
+
+    async def count(self, filter_spec: ToolBlueprintFilterSpec) -> int:
+        """Count blueprints matching the filter spec.
+
+        Raises:
+            QueryError: If the query fails.
+        """
+        ...
+
+    async def transition_if(
+        self,
+        entity_id: NotBlankStr,
+        from_state: ToolBlueprintState,
+        to_state: ToolBlueprintState,
+        **updates: object,
+    ) -> bool:
+        """Atomic compare-and-set for blueprint state transitions.
+
+        Transitions ``entity_id`` from ``from_state`` to ``to_state``
+        atomically. ``**updates`` carries status-correlated timestamp
+        columns (``validated_at`` / ``activated_at`` / ``retired_at``);
+        unknown keys are rejected at the implementation layer.
+
+        Returns:
+            ``True`` iff the row was in ``from_state`` and is now in
+            ``to_state``; ``False`` on state mismatch or missing row.
+
+        Raises:
+            QueryError: On database errors, or if an unknown update key
+                is supplied.
+        """
+        ...

--- a/src/synthorg/security/action_types.py
+++ b/src/synthorg/security/action_types.py
@@ -32,6 +32,7 @@ class ActionTypeCategory(StrEnum):
     ORG = "org"
     DB = "db"
     ARCH = "arch"
+    TOOL = "tool"
     MEMORY = "memory"
     KNOWLEDGE = "knowledge"
     BROWSER = "browser"

--- a/src/synthorg/security/autonomy/models.py
+++ b/src/synthorg/security/autonomy/models.py
@@ -88,7 +88,7 @@ BUILTIN_PRESETS: Final[MappingProxyType[str, AutonomyPreset]] = MappingProxyType
                 "deploy, org, budget require human approval"
             ),
             auto_approve=("code", "test", "docs", "vcs", "comms:internal", "db:query"),
-            human_approval=("deploy", "org", "budget", "comms:external"),
+            human_approval=("deploy", "org", "budget", "comms:external", "tool"),
             security_agent=True,
         ),
         AutonomyLevel.SUPERVISED: AutonomyPreset(
@@ -115,6 +115,7 @@ BUILTIN_PRESETS: Final[MappingProxyType[str, AutonomyPreset]] = MappingProxyType
                 "db:mutate",
                 "db:admin",
                 "arch:decide",
+                "tool",
             ),
             security_agent=True,
         ),

--- a/src/synthorg/security/risk_scorer.py
+++ b/src/synthorg/security/risk_scorer.py
@@ -203,6 +203,9 @@ _DEFAULT_SCORE_MAP: Final[MappingProxyType[str, RiskScore]] = MappingProxyType(
         # credentials; same tier as outbound external comms.
         ActionType.EXTERNAL_DATA_REQUEST: _HIGH_SCORE,
         ActionType.BUDGET_EXCEED: _HIGH_SCORE,
+        # Authoring a new tool registers sandboxed code the org will run;
+        # governed at HIGH, matching the tool-creation approval gate.
+        ActionType.TOOL_CREATE: _HIGH_SCORE,
         # MEDIUM
         ActionType.CODE_CREATE: _MEDIUM_SCORE,
         ActionType.CODE_WRITE: _MEDIUM_SCORE,

--- a/src/synthorg/security/rules/risk_classifier.py
+++ b/src/synthorg/security/rules/risk_classifier.py
@@ -23,6 +23,7 @@ _DEFAULT_RISK_MAP: Final[MappingProxyType[str, ApprovalRiskLevel]] = MappingProx
         ActionType.COMMS_EXTERNAL: ApprovalRiskLevel.HIGH,
         ActionType.EXTERNAL_DATA_REQUEST: ApprovalRiskLevel.HIGH,
         ActionType.BUDGET_EXCEED: ApprovalRiskLevel.HIGH,
+        ActionType.TOOL_CREATE: ApprovalRiskLevel.HIGH,
         # MEDIUM
         ActionType.CODE_CREATE: ApprovalRiskLevel.MEDIUM,
         ActionType.CODE_WRITE: ApprovalRiskLevel.MEDIUM,

--- a/src/synthorg/security/timeout/risk_tier_classifier.py
+++ b/src/synthorg/security/timeout/risk_tier_classifier.py
@@ -44,6 +44,7 @@ _DEFAULT_RISK_MAP: Final[MappingProxyType[str, ApprovalRiskLevel]] = MappingProx
         ActionType.COMMS_EXTERNAL: ApprovalRiskLevel.HIGH,
         ActionType.EXTERNAL_DATA_REQUEST: ApprovalRiskLevel.HIGH,
         ActionType.BUDGET_EXCEED: ApprovalRiskLevel.HIGH,
+        ActionType.TOOL_CREATE: ApprovalRiskLevel.HIGH,
         # MEDIUM
         ActionType.CODE_CREATE: ApprovalRiskLevel.MEDIUM,
         ActionType.CODE_WRITE: ApprovalRiskLevel.MEDIUM,

--- a/tests/conformance/persistence/test_dynamic_tool_repository.py
+++ b/tests/conformance/persistence/test_dynamic_tool_repository.py
@@ -257,12 +257,22 @@ class TestDynamicToolRepository:
         bp = _blueprint(blueprint_id="bp-trans", name="synthorg_textkit_trans")
         await repo.save(bp)
         validated_at = _NOW + timedelta(minutes=1)
+        validation = ToolValidationResult(
+            passed=True,
+            brief_passed=True,
+            brief_score=88,
+            baseline_score=100,
+            candidate_score=101,
+            margin=1,
+            detail="passed",
+        )
 
         ok = await repo.transition_if(
             bp.id,
             from_state=ToolBlueprintState.PENDING,
             to_state=ToolBlueprintState.VALIDATED,
             validated_at=validated_at,
+            validation=validation,
         )
         assert ok is True
 
@@ -271,6 +281,8 @@ class TestDynamicToolRepository:
         assert fetched.state is ToolBlueprintState.VALIDATED
         assert fetched.validated_at is not None
         assert fetched.validated_at == validated_at
+        # The CAS stamped the gate evidence atomically with the timestamp.
+        assert fetched.validation == validation
 
     async def test_transition_if_mismatch_returns_false(
         self, backend: PersistenceBackend

--- a/tests/conformance/persistence/test_dynamic_tool_repository.py
+++ b/tests/conformance/persistence/test_dynamic_tool_repository.py
@@ -74,7 +74,14 @@ def _blueprint(
     activated_at = None
     retired_at = None
     validation = None
-    if state in {ToolBlueprintState.VALIDATED, ToolBlueprintState.ACTIVE}:
+    # Every post-PENDING state carries the gate's validation record, so
+    # the audit trail survives the lifecycle (the runtime model rejects a
+    # validated/active/retired row without it).
+    if state in {
+        ToolBlueprintState.VALIDATED,
+        ToolBlueprintState.ACTIVE,
+        ToolBlueprintState.RETIRED,
+    }:
         validated_at = _NOW + timedelta(minutes=1)
         validation = ToolValidationResult(
             passed=True,
@@ -88,7 +95,6 @@ def _blueprint(
     if state is ToolBlueprintState.ACTIVE:
         activated_at = _NOW + timedelta(minutes=2)
     if state is ToolBlueprintState.RETIRED:
-        validated_at = _NOW + timedelta(minutes=1)
         activated_at = _NOW + timedelta(minutes=2)
         retired_at = _NOW + timedelta(minutes=3)
     return ToolBlueprint(

--- a/tests/conformance/persistence/test_dynamic_tool_repository.py
+++ b/tests/conformance/persistence/test_dynamic_tool_repository.py
@@ -65,11 +65,24 @@ def _blueprint(
     *,
     blueprint_id: str = "bp-001",
     name: str = "synthorg_textkit_slugify",
-    capability: str = "textkit:slugify",
+    capability: str | None = None,
     state: ToolBlueprintState = ToolBlueprintState.PENDING,
     sandbox_backend: ToolSandboxBackend = ToolSandboxBackend.DOCKER,
 ) -> ToolBlueprint:
-    """Build a ``ToolBlueprint`` with sensible defaults."""
+    """Build a ``ToolBlueprint`` with sensible defaults.
+
+    When ``capability`` is omitted, it is derived from ``name`` (stripping
+    the ``synthorg_`` prefix and replacing the inner ``_`` with ``:``) so
+    the model invariant ``name <=> capability`` is satisfied by default.
+    Callers that want to test name/capability mismatch pass an explicit
+    capability that disagrees with the name.
+    """
+    if capability is None:
+        # ``name`` always starts with ``synthorg_`` and the regex enforces
+        # one underscore between domain and action, so a 2-split that
+        # drops the prefix recovers the matching capability tag.
+        parts = name.split("_", 2)
+        capability = f"{parts[1]}:{parts[2]}"
     validated_at = None
     activated_at = None
     retired_at = None

--- a/tests/conformance/persistence/test_dynamic_tool_repository.py
+++ b/tests/conformance/persistence/test_dynamic_tool_repository.py
@@ -1,0 +1,317 @@
+"""Conformance tests for ``DynamicToolRepository`` (SQLite + Postgres).
+
+The repository is not exposed on ``PersistenceBackend`` (the toolsmith's
+``DynamicToolRegistry`` wires it directly), so this file builds the
+backend-specific concrete repo over the migrated ``backend.get_db()``
+handle. Both arms exercise the same protocol surface so SQLite and
+Postgres divergence (TEXT vs JSONB ``parameters_schema`` / ``validation``,
+INTEGER 0/1 vs BOOLEAN ``requires_network``, TEXT vs TIMESTAMPTZ
+timestamps) is caught by the same assertion set.
+"""
+
+from datetime import UTC, datetime, timedelta
+from typing import cast
+
+import aiosqlite
+import pytest
+
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.toolsmith.models import (
+    ToolBlueprint,
+    ToolBlueprintState,
+    ToolSandboxBackend,
+    ToolValidationResult,
+)
+from synthorg.persistence.postgres.tool_blueprint_repo import (
+    PostgresDynamicToolRepository,
+)
+from synthorg.persistence.protocol import PersistenceBackend
+from synthorg.persistence.sqlite.tool_blueprint_repo import (
+    SQLiteDynamicToolRepository,
+)
+from synthorg.persistence.tool_blueprint_protocol import (
+    DynamicToolRepository,
+    ToolBlueprintFilterSpec,
+)
+
+pytestmark = pytest.mark.integration
+
+_NOW = datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
+_SCHEMA = {
+    "type": "object",
+    "properties": {"text": {"type": "string"}},
+    "required": ["text"],
+}
+
+
+def _repo(backend: PersistenceBackend) -> DynamicToolRepository:
+    """Return a concrete ``DynamicToolRepository`` bound to *backend*."""
+    name = backend.backend_name
+    handle = backend.get_db()
+    if name == "sqlite":
+        return SQLiteDynamicToolRepository(
+            cast("aiosqlite.Connection", handle),
+            write_context=backend.write_context,
+        )
+    if name == "postgres":
+        from psycopg_pool import AsyncConnectionPool
+
+        return PostgresDynamicToolRepository(cast("AsyncConnectionPool", handle))
+    msg = f"Unknown backend: {name}"
+    raise ValueError(msg)
+
+
+def _blueprint(
+    *,
+    blueprint_id: str = "bp-001",
+    name: str = "synthorg_textkit_slugify",
+    capability: str = "textkit:slugify",
+    state: ToolBlueprintState = ToolBlueprintState.PENDING,
+    sandbox_backend: ToolSandboxBackend = ToolSandboxBackend.DOCKER,
+) -> ToolBlueprint:
+    """Build a ``ToolBlueprint`` with sensible defaults."""
+    validated_at = None
+    activated_at = None
+    retired_at = None
+    validation = None
+    if state in {ToolBlueprintState.VALIDATED, ToolBlueprintState.ACTIVE}:
+        validated_at = _NOW + timedelta(minutes=1)
+        validation = ToolValidationResult(
+            passed=True,
+            brief_passed=True,
+            brief_score=88,
+            baseline_score=100,
+            candidate_score=101,
+            margin=1,
+            detail="passed",
+        )
+    if state is ToolBlueprintState.ACTIVE:
+        activated_at = _NOW + timedelta(minutes=2)
+    if state is ToolBlueprintState.RETIRED:
+        validated_at = _NOW + timedelta(minutes=1)
+        activated_at = _NOW + timedelta(minutes=2)
+        retired_at = _NOW + timedelta(minutes=3)
+    return ToolBlueprint(
+        id=blueprint_id,
+        name=name,
+        description="Slugify text deterministically.",
+        capability=capability,
+        parameters_schema=_SCHEMA,
+        script_body="print('ok')",
+        sandbox_backend=sandbox_backend,
+        action_type="code:read",
+        state=state,
+        created_at=_NOW,
+        validated_at=validated_at,
+        activated_at=activated_at,
+        retired_at=retired_at,
+        validation=validation,
+    )
+
+
+class TestDynamicToolRepository:
+    async def test_save_and_get(self, backend: PersistenceBackend) -> None:
+        repo = _repo(backend)
+        bp = _blueprint()
+        await repo.save(bp)
+
+        fetched = await repo.get(bp.id)
+        assert fetched is not None
+        assert fetched.id == bp.id
+        assert fetched.name == bp.name
+        assert fetched.parameters_schema == _SCHEMA
+        assert fetched.sandbox_backend is ToolSandboxBackend.DOCKER
+        assert fetched.requires_network is False
+        assert fetched.state is ToolBlueprintState.PENDING
+        assert fetched.created_at.tzinfo is not None
+
+    async def test_get_returns_none_when_absent(
+        self, backend: PersistenceBackend
+    ) -> None:
+        repo = _repo(backend)
+        assert await repo.get("bp-missing") is None
+
+    async def test_save_commits_visible_to_fresh_repo(
+        self, backend: PersistenceBackend
+    ) -> None:
+        first = _repo(backend)
+        bp = _blueprint(blueprint_id="bp-commit", name="synthorg_textkit_commit")
+        await first.save(bp)
+
+        second = _repo(backend)
+        fetched = await second.get(bp.id)
+        assert fetched is not None
+
+    async def test_upsert_overwrites(self, backend: PersistenceBackend) -> None:
+        repo = _repo(backend)
+        bp = _blueprint(blueprint_id="bp-upsert", name="synthorg_textkit_upsert")
+        await repo.save(bp)
+
+        updated = bp.model_copy(update={"description": "Updated description."})
+        await repo.save(updated)
+
+        fetched = await repo.get(bp.id)
+        assert fetched is not None
+        assert fetched.description == "Updated description."
+
+    async def test_validation_round_trips(self, backend: PersistenceBackend) -> None:
+        repo = _repo(backend)
+        bp = _blueprint(
+            blueprint_id="bp-val",
+            name="synthorg_textkit_val",
+            state=ToolBlueprintState.ACTIVE,
+        )
+        await repo.save(bp)
+
+        fetched = await repo.get(bp.id)
+        assert fetched is not None
+        assert fetched.validation is not None
+        assert fetched.validation.passed is True
+        assert fetched.validation.candidate_score == 101
+        assert fetched.validated_at is not None
+        assert fetched.activated_at is not None
+
+    async def test_query_by_state(self, backend: PersistenceBackend) -> None:
+        repo = _repo(backend)
+        await repo.save(
+            _blueprint(
+                blueprint_id="p",
+                name="synthorg_textkit_pending",
+                state=ToolBlueprintState.PENDING,
+            )
+        )
+        await repo.save(
+            _blueprint(
+                blueprint_id="a",
+                name="synthorg_textkit_active",
+                capability="textkit:active",
+                state=ToolBlueprintState.ACTIVE,
+            )
+        )
+
+        active = await repo.query(
+            ToolBlueprintFilterSpec(state=ToolBlueprintState.ACTIVE)
+        )
+        ids = {bp.id for bp in active}
+        assert "a" in ids
+        assert "p" not in ids
+
+    async def test_query_by_capability(self, backend: PersistenceBackend) -> None:
+        repo = _repo(backend)
+        await repo.save(
+            _blueprint(
+                blueprint_id="c1",
+                name="synthorg_alpha_one",
+                capability="alpha:one",
+            )
+        )
+        await repo.save(
+            _blueprint(
+                blueprint_id="c2",
+                name="synthorg_beta_two",
+                capability="beta:two",
+            )
+        )
+
+        rows = await repo.query(
+            ToolBlueprintFilterSpec(capability=NotBlankStr("alpha:one"))
+        )
+        ids = {bp.id for bp in rows}
+        assert ids == {"c1"}
+
+    async def test_count(self, backend: PersistenceBackend) -> None:
+        repo = _repo(backend)
+        await repo.save(_blueprint(blueprint_id="n1", name="synthorg_textkit_n1"))
+        await repo.save(
+            _blueprint(
+                blueprint_id="n2",
+                name="synthorg_textkit_n2",
+                capability="textkit:n2",
+            )
+        )
+        assert await repo.count(ToolBlueprintFilterSpec()) >= 2
+
+    async def test_transition_if_stamps_timestamp(
+        self, backend: PersistenceBackend
+    ) -> None:
+        repo = _repo(backend)
+        bp = _blueprint(blueprint_id="bp-trans", name="synthorg_textkit_trans")
+        await repo.save(bp)
+        validated_at = _NOW + timedelta(minutes=1)
+
+        ok = await repo.transition_if(
+            bp.id,
+            from_state=ToolBlueprintState.PENDING,
+            to_state=ToolBlueprintState.VALIDATED,
+            validated_at=validated_at,
+        )
+        assert ok is True
+
+        fetched = await repo.get(bp.id)
+        assert fetched is not None
+        assert fetched.state is ToolBlueprintState.VALIDATED
+        assert fetched.validated_at is not None
+        assert fetched.validated_at == validated_at
+
+    async def test_transition_if_mismatch_returns_false(
+        self, backend: PersistenceBackend
+    ) -> None:
+        repo = _repo(backend)
+        bp = _blueprint(blueprint_id="bp-mismatch", name="synthorg_textkit_mismatch")
+        await repo.save(bp)
+
+        ok = await repo.transition_if(
+            bp.id,
+            from_state=ToolBlueprintState.ACTIVE,
+            to_state=ToolBlueprintState.RETIRED,
+            retired_at=_NOW,
+        )
+        assert ok is False
+        fetched = await repo.get(bp.id)
+        assert fetched is not None
+        assert fetched.state is ToolBlueprintState.PENDING
+
+    async def test_transition_if_missing_returns_false(
+        self, backend: PersistenceBackend
+    ) -> None:
+        repo = _repo(backend)
+        ok = await repo.transition_if(
+            NotBlankStr("bp-trans-missing"),
+            from_state=ToolBlueprintState.PENDING,
+            to_state=ToolBlueprintState.VALIDATED,
+            validated_at=_NOW,
+        )
+        assert ok is False
+
+    async def test_transition_if_rejects_unknown_key(
+        self, backend: PersistenceBackend
+    ) -> None:
+        from synthorg.core.persistence_errors import QueryError
+
+        repo = _repo(backend)
+        bp = _blueprint(blueprint_id="bp-badkey", name="synthorg_textkit_badkey")
+        await repo.save(bp)
+
+        with pytest.raises(QueryError):
+            await repo.transition_if(
+                bp.id,
+                from_state=ToolBlueprintState.PENDING,
+                to_state=ToolBlueprintState.VALIDATED,
+                bogus_key=_NOW,
+            )
+
+    async def test_delete_returns_true_then_false(
+        self, backend: PersistenceBackend
+    ) -> None:
+        repo = _repo(backend)
+        bp = _blueprint(blueprint_id="bp-del", name="synthorg_textkit_del")
+        await repo.save(bp)
+        assert await repo.get(bp.id) is not None
+
+        assert await repo.delete(bp.id) is True
+        assert await repo.get(bp.id) is None
+        assert await repo.delete(bp.id) is False
+
+    async def test_protocol_runtime_check(self, backend: PersistenceBackend) -> None:
+        repo = _repo(backend)
+        assert isinstance(repo, DynamicToolRepository)

--- a/tests/conformance/persistence/test_dynamic_tool_repository.py
+++ b/tests/conformance/persistence/test_dynamic_tool_repository.py
@@ -284,6 +284,38 @@ class TestDynamicToolRepository:
         # The CAS stamped the gate evidence atomically with the timestamp.
         assert fetched.validation == validation
 
+    async def test_transition_if_requires_validation_for_validated_state(
+        self, backend: PersistenceBackend
+    ) -> None:
+        # PENDING -> VALIDATED without a validation kwarg leaves the
+        # validation column NULL, which the lifecycle CHECK rejects on
+        # both backends. This pins the invariant that gate-graduated
+        # states MUST carry their audit evidence at the DB layer.
+        from synthorg.core.persistence_errors import QueryError
+
+        repo = _repo(backend)
+        bp = _blueprint(
+            blueprint_id="bp-no-val",
+            name="synthorg_textkit_no_val",
+        )
+        await repo.save(bp)
+
+        with pytest.raises(QueryError):
+            await repo.transition_if(
+                bp.id,
+                from_state=ToolBlueprintState.PENDING,
+                to_state=ToolBlueprintState.VALIDATED,
+                validated_at=_NOW + timedelta(minutes=1),
+            )
+
+        # The row must still be PENDING; the failed CAS does not advance
+        # state and the underlying row's lifecycle fields stay clean.
+        fetched = await repo.get(bp.id)
+        assert fetched is not None
+        assert fetched.state is ToolBlueprintState.PENDING
+        assert fetched.validated_at is None
+        assert fetched.validation is None
+
     async def test_transition_if_mismatch_returns_false(
         self, backend: PersistenceBackend
     ) -> None:

--- a/tests/integration/toolsmith/__init__.py
+++ b/tests/integration/toolsmith/__init__.py
@@ -1,0 +1,1 @@
+"""End-to-end integration tests for the self-extending toolkit."""

--- a/tests/integration/toolsmith/test_self_extension_e2e.py
+++ b/tests/integration/toolsmith/test_self_extension_e2e.py
@@ -13,6 +13,13 @@ The sandbox here runs the authored Python synchronously via
 ``subprocess.run`` so the script genuinely executes cross-platform
 without an event-loop-policy dance; the Docker/subprocess backends are
 unit-tested separately.
+
+Deviation from the literal "validated under the simulation harness"
+wording: the toolsmith operates on MCP capability gaps, not client
+briefs, so driving it through ``SimulationRunner`` (clients -> intake ->
+review) would be artificial. This test instead exercises the full loop
+deterministically through the production ``MCPToolInvoker`` and the real
+service/factory wiring, which is the meaningful end-to-end check.
 """
 
 import json

--- a/tests/integration/toolsmith/test_self_extension_e2e.py
+++ b/tests/integration/toolsmith/test_self_extension_e2e.py
@@ -210,7 +210,10 @@ class TestSelfExtensionE2E:
         #    (the authored script really runs) and live-registers the tool.
         apply_result = await service.apply(proposal)
         assert apply_result.success is True
-        assert runtime.dynamic_registry.get_def("synthorg_textkit_slugify") is not None
+        definition = runtime.dynamic_registry.get_def("synthorg_textkit_slugify")
+        assert definition is not None
+        assert definition.name == "synthorg_textkit_slugify"
+        assert definition.capability == _CAPABILITY
 
         # 4. A LATER task invokes the brand-new tool through the real
         #    MCPToolInvoker over the layered registry, and it succeeds.

--- a/tests/integration/toolsmith/test_self_extension_e2e.py
+++ b/tests/integration/toolsmith/test_self_extension_e2e.py
@@ -1,0 +1,272 @@
+"""End-to-end self-extension loop (#1995 acceptance).
+
+Drives the full deterministic loop the acceptance criterion describes:
+
+1. The org repeatedly cannot perform a capability (recurring gap).
+2. The toolsmith proposes a tool, guarded + enqueued for approval.
+3. A human approves; the applier benchmark-validates the candidate (the
+   authored script actually runs in a sandbox) and live-registers it.
+4. A LATER task invokes the new tool through the real ``MCPToolInvoker``
+   over the layered registry and succeeds.
+
+The sandbox here runs the authored Python synchronously via
+``subprocess.run`` so the script genuinely executes cross-platform
+without an event-loop-policy dance; the Docker/subprocess backends are
+unit-tested separately.
+"""
+
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from synthorg.core.approval import ApprovalItem
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.config import SelfImprovementConfig
+from synthorg.meta.mcp.invoker import MCPToolInvoker
+from synthorg.meta.mcp.registry import DomainToolRegistry
+from synthorg.meta.toolsmith.config import ToolsmithConfig, ToolValidationConfig
+from synthorg.meta.toolsmith.dynamic_registry import (
+    LayeredHandlerMap,
+    LayeredToolRegistry,
+)
+from synthorg.meta.toolsmith.factory import build_toolsmith
+from synthorg.meta.toolsmith.models import ToolBlueprint, ToolSandboxBackend
+from synthorg.tools.sandbox.result import SandboxResult
+from tests._shared import FakeClock
+
+pytestmark = pytest.mark.integration
+
+_NOW = datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
+_CAPABILITY = "textkit:slugify"
+
+_SLUGIFY_SCRIPT = (
+    "import os, json, re\n"
+    'args = json.loads(os.environ["SYNTHORG_TOOL_ARGS"])\n'
+    'text = str(args["text"]).lower()\n'
+    'slug = re.sub(r"[^a-z0-9]+", "-", text).strip("-")\n'
+    'print(json.dumps({"slug": slug}))\n'
+)
+
+_AUTHORING_RESPONSE = json.dumps(
+    {
+        "description": "Slugify text deterministically.",
+        "action_type": "code:read",
+        "parameters_schema": {
+            "type": "object",
+            "properties": {"text": {"type": "string"}},
+            "required": ["text"],
+        },
+        "script_body": _SLUGIFY_SCRIPT,
+    }
+)
+
+
+class _LocalPythonSandbox:
+    """SandboxBackend that runs ``python -c`` synchronously via subprocess."""
+
+    async def execute(  # noqa: PLR0913
+        self,
+        *,
+        command: str,
+        args: tuple[str, ...],
+        cwd: Path | None = None,
+        env_overrides: Any = None,
+        timeout: float | None = None,  # noqa: ASYNC109
+        owner_id: Any = None,
+        project_id: Any = None,
+    ) -> SandboxResult:
+        del cwd, owner_id, project_id
+        overrides = env_overrides or {}
+        env = {"SYNTHORG_TOOL_ARGS": overrides.get("SYNTHORG_TOOL_ARGS", "{}")}
+        completed = subprocess.run(  # noqa: S603, ASYNC221
+            [sys.executable, *args] if command == "python" else [command, *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=timeout or 30.0,
+        )
+        return SandboxResult(
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+            returncode=completed.returncode,
+        )
+
+    async def cleanup(self) -> None:
+        return None
+
+
+class _FakeResponse:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _FakeProvider:
+    async def complete(
+        self, *, messages: Any, model: str, config: Any
+    ) -> _FakeResponse:
+        del messages, model, config
+        return _FakeResponse(_AUTHORING_RESPONSE)
+
+
+class _FakeScorecard:
+    """Golden scorecard: candidate slightly improves the org (no regression)."""
+
+    async def score(self, blueprint: ToolBlueprint) -> tuple[int, int]:
+        del blueprint
+        return 100, 101
+
+
+class _InMemoryRepo:
+    def __init__(self) -> None:
+        self.rows: dict[str, ToolBlueprint] = {}
+
+    async def save(self, entity: ToolBlueprint) -> None:
+        self.rows[entity.id] = entity
+
+    async def get(self, entity_id: str) -> ToolBlueprint | None:
+        return self.rows.get(entity_id)
+
+    async def transition_if(
+        self, entity_id: str, from_state: Any, to_state: Any, **updates: Any
+    ) -> bool:
+        row = self.rows.get(entity_id)
+        if row is None or row.state is not from_state:
+            return False
+        self.rows[entity_id] = row.model_copy(update={"state": to_state, **updates})
+        return True
+
+
+class _InMemoryApprovalStore:
+    """Minimal ApprovalStoreProtocol: records enqueued approval items."""
+
+    def __init__(self) -> None:
+        self.items: dict[str, ApprovalItem] = {}
+
+    async def add(self, item: ApprovalItem) -> None:
+        self.items[item.id] = item
+
+
+def _config() -> SelfImprovementConfig:
+    return SelfImprovementConfig(
+        enabled=True,
+        tool_creation_enabled=True,
+        toolsmith=ToolsmithConfig(
+            enabled=True,
+            gap_recurrence_threshold=3,
+            allowed_capabilities=(NotBlankStr(_CAPABILITY),),
+            sandbox_backend=ToolSandboxBackend.SUBPROCESS,
+            validation=ToolValidationConfig(
+                require_golden_delta=True, min_score_margin=0
+            ),
+        ),
+    )
+
+
+class TestSelfExtensionE2E:
+    async def test_full_loop_gap_to_reuse(self) -> None:
+        clock = FakeClock(start=_NOW)
+        repo = _InMemoryRepo()
+        approvals = _InMemoryApprovalStore()
+        runtime = build_toolsmith(
+            si_config=_config(),
+            provider=_FakeProvider(),  # type: ignore[arg-type]
+            repo=repo,  # type: ignore[arg-type]
+            sandbox_resolver=lambda _bp: _LocalPythonSandbox(),  # type: ignore[arg-type,return-value]
+            scorecard_provider=_FakeScorecard(),
+            approval_store=approvals,  # type: ignore[arg-type]
+            clock=clock,
+        )
+        service = runtime.service
+
+        # 1. Recurring capability gap: the org cannot slugify, three times.
+        for i in range(3):
+            await service.record_gap(
+                NotBlankStr(_CAPABILITY),
+                occurred_at=_NOW + timedelta(minutes=i),
+            )
+
+        # 2. The cycle proposes + guards + enqueues exactly one proposal.
+        proposals = await service.run_cycle(now=_NOW + timedelta(minutes=3))
+        assert len(proposals) == 1
+        proposal = proposals[0]
+        assert proposal.tool_changes[0].capability == _CAPABILITY
+        # The approval gate durably enqueued it for mandatory human review.
+        assert len(approvals.items) == 1
+
+        # 3. Human approves -> applier validates against the benchmark
+        #    (the authored script really runs) and live-registers the tool.
+        apply_result = await service.apply(proposal)
+        assert apply_result.success is True
+        assert runtime.dynamic_registry.get_def("synthorg_textkit_slugify") is not None
+
+        # 4. A LATER task invokes the brand-new tool through the real
+        #    MCPToolInvoker over the layered registry, and it succeeds.
+        static = DomainToolRegistry()
+        static.freeze()
+        invoker = MCPToolInvoker(
+            LayeredToolRegistry(static, runtime.dynamic_registry),
+            LayeredHandlerMap({}, runtime.dynamic_registry),
+        )
+        result = await invoker.invoke(
+            "synthorg_textkit_slugify",
+            {"text": "Hello Brave World"},
+            app_state=None,
+        )
+        assert result.is_error is False
+        envelope = json.loads(result.content)
+        assert envelope["status"] == "ok"
+        assert envelope["data"] == {"slug": "hello-brave-world"}
+
+    async def test_no_proposal_below_recurrence_threshold(self) -> None:
+        clock = FakeClock(start=_NOW)
+        runtime = build_toolsmith(
+            si_config=_config(),
+            provider=_FakeProvider(),  # type: ignore[arg-type]
+            repo=_InMemoryRepo(),  # type: ignore[arg-type]
+            sandbox_resolver=lambda _bp: _LocalPythonSandbox(),  # type: ignore[arg-type,return-value]
+            scorecard_provider=_FakeScorecard(),
+            approval_store=_InMemoryApprovalStore(),  # type: ignore[arg-type]
+            clock=clock,
+        )
+        # Only two observations -> below the threshold of 3.
+        for i in range(2):
+            await runtime.service.record_gap(
+                NotBlankStr(_CAPABILITY), occurred_at=_NOW + timedelta(minutes=i)
+            )
+        proposals = await runtime.service.run_cycle(now=_NOW + timedelta(minutes=2))
+        assert proposals == ()
+
+    async def test_regressing_tool_is_not_registered(self) -> None:
+        clock = FakeClock(start=_NOW)
+        repo = _InMemoryRepo()
+
+        class _RegressingScorecard:
+            async def score(self, blueprint: ToolBlueprint) -> tuple[int, int]:
+                del blueprint
+                return 100, 90  # candidate regresses the org
+
+        runtime = build_toolsmith(
+            si_config=_config(),
+            provider=_FakeProvider(),  # type: ignore[arg-type]
+            repo=repo,  # type: ignore[arg-type]
+            sandbox_resolver=lambda _bp: _LocalPythonSandbox(),  # type: ignore[arg-type,return-value]
+            scorecard_provider=_RegressingScorecard(),
+            approval_store=_InMemoryApprovalStore(),  # type: ignore[arg-type]
+            clock=clock,
+        )
+        for i in range(3):
+            await runtime.service.record_gap(
+                NotBlankStr(_CAPABILITY), occurred_at=_NOW + timedelta(minutes=i)
+            )
+        proposals = await runtime.service.run_cycle(now=_NOW + timedelta(minutes=3))
+        assert len(proposals) == 1
+
+        apply_result = await runtime.service.apply(proposals[0])
+        assert apply_result.success is False
+        assert runtime.dynamic_registry.get_def("synthorg_textkit_slugify") is None

--- a/tests/integration/toolsmith/test_self_extension_e2e.py
+++ b/tests/integration/toolsmith/test_self_extension_e2e.py
@@ -23,6 +23,7 @@ service/factory wiring, which is the meaningful end-to-end check.
 """
 
 import json
+import os
 import subprocess
 import sys
 from datetime import UTC, datetime, timedelta
@@ -89,7 +90,11 @@ class _LocalPythonSandbox:
     ) -> SandboxResult:
         del cwd, owner_id, project_id
         overrides = env_overrides or {}
-        env = {"SYNTHORG_TOOL_ARGS": overrides.get("SYNTHORG_TOOL_ARGS", "{}")}
+        # Preserve the base environment (PATH etc.) and only inject the
+        # tool-args var; replacing it wholesale breaks the subprocess on
+        # platforms that need inherited vars (notably Windows).
+        env = dict(os.environ)
+        env["SYNTHORG_TOOL_ARGS"] = overrides.get("SYNTHORG_TOOL_ARGS", "{}")
         completed = subprocess.run(  # noqa: S603, ASYNC221
             [sys.executable, *args] if command == "python" else [command, *args],
             check=False,

--- a/tests/integration/toolsmith/test_self_extension_e2e.py
+++ b/tests/integration/toolsmith/test_self_extension_e2e.py
@@ -1,4 +1,4 @@
-"""End-to-end self-extension loop (#1995 acceptance).
+"""End-to-end self-extension loop (acceptance).
 
 Drives the full deterministic loop the acceptance criterion describes:
 

--- a/tests/unit/core/test_enums.py
+++ b/tests/unit/core/test_enums.py
@@ -118,14 +118,15 @@ class TestEnumMemberCounts:
     def test_workflow_edge_type_has_7_members(self) -> None:
         assert len(WorkflowEdgeType) == 7
 
-    def test_action_type_has_40_members(self) -> None:
-        assert len(ActionType) == 40
+    def test_action_type_has_41_members(self) -> None:
+        assert len(ActionType) == 41
         assert ActionType.MEMORY_READ.value == "memory:read"
         assert ActionType.KNOWLEDGE_INGEST.value == "knowledge:ingest"
         assert ActionType.KNOWLEDGE_REINDEX.value == "knowledge:reindex"
         assert ActionType.BROWSER_NAVIGATE.value == "browser:navigate"
         assert ActionType.EXTERNAL_DATA_REQUEST.value == "external_data:request"
         assert ActionType.DESKTOP_LAUNCH.value == "desktop:launch"
+        assert ActionType.TOOL_CREATE.value == "tool:create"
 
 
 # ── String Values ──────────────────────────────────────────────────

--- a/tests/unit/meta/toolsmith/__init__.py
+++ b/tests/unit/meta/toolsmith/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the self-extending toolkit (toolsmith)."""

--- a/tests/unit/meta/toolsmith/test_applier.py
+++ b/tests/unit/meta/toolsmith/test_applier.py
@@ -248,11 +248,44 @@ class TestToolCreationApplier:
         bp = _blueprint()
         result = await applier.apply(_proposal(bp))
 
-        # The per-blueprint try/except catches the persistence failure,
-        # surfaces it in the ApplyResult, and never reaches registration.
+        # The pending-save failure is caught per-blueprint and surfaced in
+        # the ApplyResult. Because save() raised on the very first call
+        # (the PENDING write), registration is never reached and the
+        # registry stays empty.
         assert result.success is False
         assert result.changes_applied == 0
         assert "RuntimeError" in (result.error_message or "")
+        assert registry.get_def(bp.name) is None
+
+    async def test_apply_rolls_back_registration_on_active_save_failure(self) -> None:
+        # Registration happens BEFORE the ACTIVE-row persist; if the
+        # persist fails, the live handler must be unregistered so the
+        # durable state ("not in DB") matches the runtime state ("not
+        # registered"). Without rollback the layered tool surface would
+        # expose a tool with no audit trail.
+        class _RaiseOnActiveSave(_InMemoryRepo):
+            def __init__(self) -> None:
+                super().__init__()
+                self._saves = 0
+
+            async def save(self, entity: ToolBlueprint) -> None:
+                self._saves += 1
+                if entity.state is ToolBlueprintState.ACTIVE:
+                    msg = "simulated DB outage on ACTIVE save"
+                    raise RuntimeError(msg)
+                self.rows[entity.id] = entity
+
+        repo = _RaiseOnActiveSave()
+        registry = _registry()
+        applier = _applier(repo, registry, _Gate(result=_pass_result()))
+
+        bp = _blueprint()
+        result = await applier.apply(_proposal(bp))
+
+        assert result.success is False
+        assert result.changes_applied == 0
+        assert "RuntimeError" in (result.error_message or "")
+        # Registration ran but was rolled back; durable state matches.
         assert registry.get_def(bp.name) is None
 
     async def test_retire_non_active_returns_false(self) -> None:

--- a/tests/unit/meta/toolsmith/test_applier.py
+++ b/tests/unit/meta/toolsmith/test_applier.py
@@ -1,0 +1,222 @@
+"""Unit tests for the tool-creation applier."""
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.models import (
+    ImprovementProposal,
+    ProposalAltitude,
+    ProposalRationale,
+    RollbackOperation,
+    RollbackPlan,
+)
+from synthorg.meta.toolsmith.applier import ToolCreationApplier
+from synthorg.meta.toolsmith.dynamic_registry import DynamicToolRegistry
+from synthorg.meta.toolsmith.models import (
+    ToolBlueprint,
+    ToolBlueprintState,
+    ToolValidationResult,
+)
+from tests._shared import FakeClock
+
+pytestmark = pytest.mark.unit
+
+_NOW = datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
+
+
+def _blueprint() -> ToolBlueprint:
+    return ToolBlueprint(
+        id="bp-1",
+        name="synthorg_textkit_slugify",
+        description="Slugify text.",
+        capability="textkit:slugify",
+        parameters_schema={
+            "type": "object",
+            "properties": {"text": {"type": "string"}},
+            "required": ["text"],
+        },
+        script_body="print('{}')",
+        action_type="code:read",
+        created_at=_NOW - timedelta(minutes=1),
+    )
+
+
+def _proposal(blueprint: ToolBlueprint) -> ImprovementProposal:
+    return ImprovementProposal(
+        altitude=ProposalAltitude.TOOL_CREATION,
+        title="Author slugify tool",
+        description="Author a tool for the recurring textkit:slugify gap.",
+        rationale=ProposalRationale(
+            signal_summary="textkit:slugify requested 3x",
+            pattern_detected="recurring capability gap",
+            expected_impact="org can slugify",
+            confidence_reasoning="recurrence threshold met",
+        ),
+        tool_changes=(blueprint,),
+        rollback_plan=RollbackPlan(
+            operations=(
+                RollbackOperation(
+                    operation_type="retire_tool",
+                    target=blueprint.name,
+                    description="Retire the authored tool.",
+                ),
+            ),
+            validation_check="tool is no longer registered",
+        ),
+        confidence=0.5,
+    )
+
+
+class _InMemoryRepo:
+    """Minimal in-memory DynamicToolRepository for applier tests."""
+
+    def __init__(self) -> None:
+        self.rows: dict[str, ToolBlueprint] = {}
+
+    async def save(self, entity: ToolBlueprint) -> None:
+        self.rows[entity.id] = entity
+
+    async def get(self, entity_id: str) -> ToolBlueprint | None:
+        return self.rows.get(entity_id)
+
+    async def transition_if(
+        self,
+        entity_id: str,
+        from_state: ToolBlueprintState,
+        to_state: ToolBlueprintState,
+        **updates: Any,
+    ) -> bool:
+        row = self.rows.get(entity_id)
+        if row is None or row.state is not from_state:
+            return False
+        self.rows[entity_id] = row.model_copy(update={"state": to_state, **updates})
+        return True
+
+
+class _Gate:
+    def __init__(self, *, result: ToolValidationResult) -> None:
+        self._result = result
+        self.calls = 0
+
+    async def validate(self, blueprint: ToolBlueprint) -> ToolValidationResult:
+        del blueprint
+        self.calls += 1
+        return self._result
+
+
+def _pass_result() -> ToolValidationResult:
+    return ToolValidationResult(
+        passed=True,
+        brief_passed=True,
+        brief_score=100,
+        baseline_score=100,
+        candidate_score=101,
+        margin=1,
+        detail="passed",
+    )
+
+
+def _fail_result() -> ToolValidationResult:
+    return ToolValidationResult(
+        passed=False,
+        brief_passed=True,
+        brief_score=100,
+        baseline_score=100,
+        candidate_score=95,
+        margin=-5,
+        detail="regressed",
+    )
+
+
+def _registry() -> DynamicToolRegistry:
+    def factory(blueprint: ToolBlueprint) -> Any:
+        del blueprint
+
+        async def _handler(*, app_state: Any, arguments: Any, actor: Any = None) -> str:
+            del app_state, arguments, actor
+            return "{}"
+
+        return _handler
+
+    return DynamicToolRegistry(handler_factory=factory)
+
+
+def _applier(repo: _InMemoryRepo, registry: DynamicToolRegistry, gate: _Gate) -> Any:
+    return ToolCreationApplier(
+        repo=repo,  # type: ignore[arg-type]
+        registry=registry,
+        gate=gate,  # type: ignore[arg-type]
+        clock=FakeClock(start=_NOW),
+    )
+
+
+class TestToolCreationApplier:
+    async def test_pass_activates_and_registers(self) -> None:
+        repo = _InMemoryRepo()
+        registry = _registry()
+        applier = _applier(repo, registry, _Gate(result=_pass_result()))
+
+        bp = _blueprint()
+        result = await applier.apply(_proposal(bp))
+
+        assert result.success is True
+        assert result.changes_applied == 1
+        stored = repo.rows[bp.id]
+        assert stored.state is ToolBlueprintState.ACTIVE
+        assert stored.validated_at == _NOW
+        assert stored.activated_at == _NOW
+        assert registry.get_def(bp.name) is not None
+
+    async def test_fail_registers_nothing(self) -> None:
+        repo = _InMemoryRepo()
+        registry = _registry()
+        applier = _applier(repo, registry, _Gate(result=_fail_result()))
+
+        bp = _blueprint()
+        result = await applier.apply(_proposal(bp))
+
+        assert result.success is False
+        assert result.changes_applied == 0
+        stored = repo.rows[bp.id]
+        assert stored.state is ToolBlueprintState.PENDING
+        assert stored.validation is not None
+        assert registry.get_def(bp.name) is None
+
+    async def test_dry_run_does_not_persist(self) -> None:
+        repo = _InMemoryRepo()
+        registry = _registry()
+        applier = _applier(repo, registry, _Gate(result=_pass_result()))
+
+        bp = _blueprint()
+        result = await applier.dry_run(_proposal(bp))
+
+        assert result.success is True
+        assert repo.rows == {}
+        assert registry.get_def(bp.name) is None
+
+    async def test_retire_unregisters_active_tool(self) -> None:
+        repo = _InMemoryRepo()
+        registry = _registry()
+        applier = _applier(repo, registry, _Gate(result=_pass_result()))
+
+        bp = _blueprint()
+        await applier.apply(_proposal(bp))
+        assert registry.get_def(bp.name) is not None
+
+        retired = await applier.retire(NotBlankStr(bp.id))
+        assert retired is True
+        assert repo.rows[bp.id].state is ToolBlueprintState.RETIRED
+        assert registry.get_def(bp.name) is None
+
+    async def test_retire_missing_returns_false(self) -> None:
+        repo = _InMemoryRepo()
+        registry = _registry()
+        applier = _applier(repo, registry, _Gate(result=_pass_result()))
+        assert await applier.retire(NotBlankStr("bp-missing")) is False
+
+    async def test_altitude(self) -> None:
+        applier = _applier(_InMemoryRepo(), _registry(), _Gate(result=_pass_result()))
+        assert applier.altitude is ProposalAltitude.TOOL_CREATION

--- a/tests/unit/meta/toolsmith/test_applier.py
+++ b/tests/unit/meta/toolsmith/test_applier.py
@@ -220,3 +220,49 @@ class TestToolCreationApplier:
     async def test_altitude(self) -> None:
         applier = _applier(_InMemoryRepo(), _registry(), _Gate(result=_pass_result()))
         assert applier.altitude is ProposalAltitude.TOOL_CREATION
+
+    async def test_pass_persists_validation_record(self) -> None:
+        repo = _InMemoryRepo()
+        result = _pass_result()
+        applier = _applier(repo, _registry(), _Gate(result=result))
+
+        bp = _blueprint()
+        await applier.apply(_proposal(bp))
+
+        stored = repo.rows[bp.id]
+        # The gate result lives on the persisted ACTIVE row so auditors
+        # can replay the apply decision without rerunning the benchmark.
+        assert stored.validation == result
+
+    async def test_apply_records_repo_save_failure(self) -> None:
+        class _RaisingRepo(_InMemoryRepo):
+            async def save(self, entity: ToolBlueprint) -> None:
+                del entity
+                msg = "simulated DB outage"
+                raise RuntimeError(msg)
+
+        repo = _RaisingRepo()
+        registry = _registry()
+        applier = _applier(repo, registry, _Gate(result=_pass_result()))
+
+        bp = _blueprint()
+        result = await applier.apply(_proposal(bp))
+
+        # The per-blueprint try/except catches the persistence failure,
+        # surfaces it in the ApplyResult, and never reaches registration.
+        assert result.success is False
+        assert result.changes_applied == 0
+        assert "RuntimeError" in (result.error_message or "")
+        assert registry.get_def(bp.name) is None
+
+    async def test_retire_non_active_returns_false(self) -> None:
+        repo = _InMemoryRepo()
+        registry = _registry()
+        applier = _applier(repo, registry, _Gate(result=_pass_result()))
+
+        # A PENDING blueprint is durably stored but has never been live;
+        # retire is a no-op (state stays PENDING, registry untouched).
+        bp = _blueprint()
+        await repo.save(bp)
+        assert await applier.retire(NotBlankStr(bp.id)) is False
+        assert repo.rows[bp.id].state is ToolBlueprintState.PENDING

--- a/tests/unit/meta/toolsmith/test_applier.py
+++ b/tests/unit/meta/toolsmith/test_applier.py
@@ -257,6 +257,50 @@ class TestToolCreationApplier:
         assert "RuntimeError" in (result.error_message or "")
         assert registry.get_def(bp.name) is None
 
+    async def test_apply_normalises_caller_lifecycle_fields(self) -> None:
+        # The applier OWNS the lifecycle. If a caller supplies pre-set
+        # validated_at / activated_at / retired_at / validation, those
+        # fields must NOT survive into durable state -- only the
+        # applier's own gate run can stamp them. Without this guard a
+        # caller could launder fake gate evidence into the dynamic_tools
+        # row and bypass the audit trail.
+        repo = _InMemoryRepo()
+        registry = _registry()
+        gate_result = _pass_result()
+        applier = _applier(repo, registry, _Gate(result=gate_result))
+
+        leaked_validation = ToolValidationResult(
+            passed=True,
+            brief_passed=True,
+            brief_score=10,
+            baseline_score=1,
+            candidate_score=2,
+            margin=1,
+            detail="forged",
+        )
+        # Pre-stamp the input with a future timestamp + a forged
+        # validation record so the test can distinguish ``applier-stamped
+        # _NOW`` from the laundered value if any of it survives.
+        bp = _blueprint().model_copy(
+            update={
+                "validated_at": _NOW + timedelta(hours=1),
+                "validation": leaked_validation,
+            }
+        )
+        result = await applier.apply(_proposal(bp))
+
+        assert result.success is True
+        stored = repo.rows[bp.id]
+        # The applier overwrote the laundered fields with its own
+        # gate-stamped lifecycle (timestamps = FakeClock.now(),
+        # validation = the gate's actual result).
+        assert stored.state is ToolBlueprintState.ACTIVE
+        assert stored.validated_at == _NOW
+        assert stored.activated_at == _NOW
+        assert stored.retired_at is None
+        assert stored.validation == gate_result
+        assert stored.validation != leaked_validation
+
     async def test_apply_rolls_back_registration_on_active_save_failure(self) -> None:
         # Registration happens BEFORE the ACTIVE-row persist; if the
         # persist fails, the live handler must be unregistered so the

--- a/tests/unit/meta/toolsmith/test_applier.py
+++ b/tests/unit/meta/toolsmith/test_applier.py
@@ -148,7 +148,7 @@ def _applier(repo: _InMemoryRepo, registry: DynamicToolRegistry, gate: _Gate) ->
     return ToolCreationApplier(
         repo=repo,  # type: ignore[arg-type]
         registry=registry,
-        gate=gate,  # type: ignore[arg-type]
+        gate=gate,
         clock=FakeClock(start=_NOW),
     )
 

--- a/tests/unit/meta/toolsmith/test_config.py
+++ b/tests/unit/meta/toolsmith/test_config.py
@@ -47,3 +47,10 @@ class TestToolsmithConfig:
         assert config.allowed_capabilities == ("textkit:slugify",)
         assert config.authoring.temperature == pytest.approx(0.1)
         assert config.validation.min_score_margin == 5
+
+    def test_enabled_requires_non_empty_allowlist(self) -> None:
+        # enabled=True with the default empty allowlist is silently
+        # deny-all; the validator rejects it so the misconfiguration
+        # surfaces at boot rather than as 'tool never authored'.
+        with pytest.raises(ValidationError):
+            ToolsmithConfig(enabled=True, allowed_capabilities=())

--- a/tests/unit/meta/toolsmith/test_config.py
+++ b/tests/unit/meta/toolsmith/test_config.py
@@ -1,0 +1,49 @@
+"""Unit tests for toolsmith configuration."""
+
+import pytest
+from pydantic import ValidationError
+
+from synthorg.meta.toolsmith.config import (
+    ToolAuthoringConfig,
+    ToolsmithConfig,
+    ToolValidationConfig,
+)
+from synthorg.meta.toolsmith.models import ToolSandboxBackend
+
+pytestmark = pytest.mark.unit
+
+
+class TestToolsmithConfig:
+    def test_safe_defaults(self) -> None:
+        config = ToolsmithConfig()
+        assert config.enabled is False
+        assert config.allowed_capabilities == ()
+        assert config.sandbox_backend is ToolSandboxBackend.DOCKER
+        assert config.requires_network is False
+        assert config.gap_recurrence_threshold >= 2
+        assert config.validation.require_golden_delta is True
+
+    def test_frozen(self) -> None:
+        config = ToolsmithConfig()
+        with pytest.raises(ValidationError):
+            config.enabled = True  # type: ignore[misc]
+
+    def test_recurrence_threshold_floor(self) -> None:
+        with pytest.raises(ValidationError):
+            ToolsmithConfig(gap_recurrence_threshold=1)
+
+    def test_extra_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ToolsmithConfig(unknown_field=1)  # type: ignore[call-arg]
+
+    def test_nested_overrides(self) -> None:
+        config = ToolsmithConfig(
+            enabled=True,
+            allowed_capabilities=("textkit:slugify",),
+            authoring=ToolAuthoringConfig(temperature=0.1),
+            validation=ToolValidationConfig(min_score_margin=5),
+        )
+        assert config.enabled is True
+        assert config.allowed_capabilities == ("textkit:slugify",)
+        assert config.authoring.temperature == pytest.approx(0.1)
+        assert config.validation.min_score_margin == 5

--- a/tests/unit/meta/toolsmith/test_dynamic_registry.py
+++ b/tests/unit/meta/toolsmith/test_dynamic_registry.py
@@ -224,3 +224,57 @@ class TestLayeredHandlerMap:
             _ = mapping["missing"]
         assert set(mapping) == {"static_key", "synthorg_textkit_slugify"}
         assert len(mapping) == 2
+
+
+class TestLayeredCollisionPrecedence:
+    """Pin the static-wins-on-collision rule for both layered surfaces.
+
+    A regression that flips precedence to dynamic-first would let an
+    authored tool shadow a built-in one with the same name, which the
+    layered surfaces deliberately forbid; these tests guard that.
+    """
+
+    async def test_layered_tool_registry_static_wins_on_name_collision(self) -> None:
+        static_def = blueprint_to_mcp_def(
+            _blueprint(
+                name="synthorg_textkit_slugify",
+                capability="textkit:slugify",
+            )
+        )
+        # The dynamic blueprint shares the static name but maps to a
+        # different ID so registration is uniquely keyed.
+        dynamic = DynamicToolRegistry(handler_factory=_handler_factory)
+        dynamic_blueprint = _blueprint(
+            name="synthorg_textkit_slugify",
+            capability="textkit:slugify",
+        ).model_copy(update={"id": "bp-dynamic-shadow"})
+        await dynamic.register(dynamic_blueprint)
+        layered = LayeredToolRegistry(
+            _FakeStatic({static_def.name: static_def}), dynamic
+        )
+
+        resolved = layered.get("synthorg_textkit_slugify")
+        # Static wins: ``LayeredToolRegistry.get`` returns the static
+        # def's identity (same object) instead of the dynamic one.
+        assert resolved is static_def
+
+    async def test_layered_handler_map_static_wins_on_key_collision(self) -> None:
+        async def static_handler(
+            *, app_state: Any, arguments: dict[str, Any], actor: Any = None
+        ) -> str:
+            del app_state, arguments, actor
+            return "static"
+
+        dynamic = DynamicToolRegistry(handler_factory=_handler_factory)
+        await dynamic.register(_blueprint())
+        # The static handler shadows the same name as the dynamic tool.
+        mapping = LayeredHandlerMap(
+            {"synthorg_textkit_slugify": static_handler},
+            dynamic,
+        )
+
+        assert mapping["synthorg_textkit_slugify"] is static_handler
+        # Membership and length collapse the duplicate key.
+        assert "synthorg_textkit_slugify" in mapping
+        assert len(mapping) == 1
+        assert set(mapping) == {"synthorg_textkit_slugify"}

--- a/tests/unit/meta/toolsmith/test_dynamic_registry.py
+++ b/tests/unit/meta/toolsmith/test_dynamic_registry.py
@@ -1,0 +1,226 @@
+"""Unit tests for the dynamic registry, args-model materialisation, and layering."""
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from synthorg.meta.mcp.handler_protocol import ToolHandler
+from synthorg.meta.mcp.registry import DomainToolRegistry, MCPToolDef, ToolDefReader
+from synthorg.meta.toolsmith.dynamic_registry import (
+    DynamicToolRegistry,
+    LayeredHandlerMap,
+    LayeredToolRegistry,
+    blueprint_to_mcp_def,
+    build_args_model,
+)
+from synthorg.meta.toolsmith.models import ToolBlueprint
+
+pytestmark = pytest.mark.unit
+
+_NOW = datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
+
+
+def _blueprint(
+    *,
+    name: str = "synthorg_textkit_slugify",
+    capability: str = "textkit:slugify",
+    schema: dict[str, Any] | None = None,
+) -> ToolBlueprint:
+    return ToolBlueprint(
+        id=f"bp-{name}",
+        name=name,
+        description="Slugify text deterministically.",
+        capability=capability,
+        parameters_schema=schema
+        or {
+            "type": "object",
+            "properties": {
+                "text": {"type": "string"},
+                "max_len": {"type": "integer"},
+            },
+            "required": ["text"],
+        },
+        script_body="print('{}')",
+        action_type="code:read",
+        created_at=_NOW,
+    )
+
+
+async def _fake_handler(
+    *, app_state: Any, arguments: dict[str, Any], actor: Any = None
+) -> str:
+    del app_state, actor
+    return f"handled:{sorted(arguments)}"
+
+
+def _handler_factory(blueprint: ToolBlueprint) -> ToolHandler:
+    del blueprint
+    return _fake_handler
+
+
+class _FakeStatic:
+    """Minimal ``ToolDefReader`` over a fixed set of defs."""
+
+    def __init__(self, defs: dict[str, MCPToolDef]) -> None:
+        self._defs = defs
+
+    def get(self, name: str) -> MCPToolDef:
+        return self._defs[name]
+
+    def get_names(self) -> tuple[str, ...]:
+        return tuple(sorted(self._defs))
+
+
+class TestBuildArgsModel:
+    def test_fields_match_schema(self) -> None:
+        model = build_args_model(_blueprint())
+        assert set(model.model_fields) == {"text", "max_len"}
+        assert model.model_fields["text"].is_required() is True
+        assert model.model_fields["max_len"].is_required() is False
+
+    def test_validates_and_forbids_extra(self) -> None:
+        model = build_args_model(_blueprint())
+        ok = model.model_validate({"text": "hi"})
+        assert ok.text == "hi"  # type: ignore[attr-defined]
+        with pytest.raises(ValueError, match="extra"):
+            model.model_validate({"text": "hi", "bogus": 1})
+
+    def test_required_field_enforced(self) -> None:
+        model = build_args_model(_blueprint())
+        with pytest.raises(ValueError, match="text"):
+            model.model_validate({})
+
+    def test_frozen(self) -> None:
+        model = build_args_model(_blueprint())
+        instance = model.model_validate({"text": "hi"})
+        with pytest.raises(ValueError, match=r"frozen|Instance"):
+            instance.text = "bye"  # type: ignore[attr-defined]
+
+
+class TestBlueprintToMcpDef:
+    def test_promotes_with_aligned_args_model(self) -> None:
+        definition = blueprint_to_mcp_def(_blueprint())
+        assert definition.name == "synthorg_textkit_slugify"
+        assert definition.capability == "textkit:slugify"
+        assert definition.handler_key == "synthorg_textkit_slugify"
+        assert definition.args_model is not None
+
+    def test_rejects_schema_args_drift_is_impossible(self) -> None:
+        # The materialised args model is derived FROM the schema, so the
+        # MCPToolDef alignment validator always agrees. Confirm a tool
+        # with an extra wire-only property still aligns because the model
+        # is built from the same properties dict.
+        definition = blueprint_to_mcp_def(
+            _blueprint(
+                schema={
+                    "type": "object",
+                    "properties": {"a": {"type": "string"}},
+                    "required": ["a"],
+                }
+            )
+        )
+        assert set(definition.args_model.model_fields) == {"a"}  # type: ignore[union-attr]
+
+
+class TestDynamicToolRegistry:
+    async def test_register_and_read(self) -> None:
+        registry = DynamicToolRegistry(handler_factory=_handler_factory)
+        await registry.register(_blueprint())
+        assert registry.names() == ("synthorg_textkit_slugify",)
+        definition = registry.get_def("synthorg_textkit_slugify")
+        assert definition is not None
+        assert registry.get_handler("synthorg_textkit_slugify") is _fake_handler
+
+    async def test_register_is_idempotent_on_name(self) -> None:
+        registry = DynamicToolRegistry(handler_factory=_handler_factory)
+        await registry.register(_blueprint())
+        await registry.register(_blueprint())
+        assert len(registry.names()) == 1
+
+    async def test_unregister(self) -> None:
+        registry = DynamicToolRegistry(handler_factory=_handler_factory)
+        await registry.register(_blueprint())
+        assert await registry.unregister("synthorg_textkit_slugify") is True
+        assert registry.names() == ()
+        assert await registry.unregister("synthorg_textkit_slugify") is False
+
+    async def test_read_during_register_sees_consistent_snapshot(self) -> None:
+        # Snapshot-swap semantics: a read taken before register does not
+        # observe the new entry; after, it does. Confirms reads never see
+        # a half-built dict.
+        registry = DynamicToolRegistry(handler_factory=_handler_factory)
+        assert registry.get_def("synthorg_textkit_slugify") is None
+        await registry.register(_blueprint())
+        assert registry.get_def("synthorg_textkit_slugify") is not None
+
+    async def test_invalid_blueprint_raises(self) -> None:
+        registry = DynamicToolRegistry(handler_factory=_handler_factory)
+        bad = _blueprint(
+            schema={"type": "object", "properties": {}},
+        )
+        # Empty properties is allowed by the model but yields an empty
+        # args model; registration still succeeds. Force a real failure
+        # by giving a non-dict property entry path is covered elsewhere;
+        # here assert empty-props still registers cleanly.
+        await registry.register(bad)
+        assert registry.get_def(bad.name) is not None
+
+
+class TestLayeredToolRegistry:
+    async def test_static_first_then_dynamic(self) -> None:
+        static_def = blueprint_to_mcp_def(
+            _blueprint(name="synthorg_static_tool", capability="static:tool")
+        )
+        static = _FakeStatic({static_def.name: static_def})
+        dynamic = DynamicToolRegistry(handler_factory=_handler_factory)
+        await dynamic.register(_blueprint())
+        layered = LayeredToolRegistry(static, dynamic)
+
+        assert isinstance(layered, ToolDefReader)
+        assert layered.get("synthorg_static_tool").name == "synthorg_static_tool"
+        assert layered.get("synthorg_textkit_slugify").name == (
+            "synthorg_textkit_slugify"
+        )
+        assert set(layered.get_names()) == {
+            "synthorg_static_tool",
+            "synthorg_textkit_slugify",
+        }
+
+    async def test_missing_raises_keyerror(self) -> None:
+        static = _FakeStatic({})
+        dynamic = DynamicToolRegistry(handler_factory=_handler_factory)
+        layered = LayeredToolRegistry(static, dynamic)
+        with pytest.raises(KeyError):
+            layered.get("nope")
+
+    async def test_real_domain_registry_as_static_layer(self) -> None:
+        # The frozen production registry satisfies ToolDefReader, so the
+        # layered wrapper composes it without modification.
+        static = DomainToolRegistry()
+        static.freeze()
+        dynamic = DynamicToolRegistry(handler_factory=_handler_factory)
+        await dynamic.register(_blueprint())
+        layered = LayeredToolRegistry(static, dynamic)
+        assert layered.get("synthorg_textkit_slugify") is not None
+
+
+class TestLayeredHandlerMap:
+    async def test_static_wins_then_dynamic(self) -> None:
+        async def static_handler(
+            *, app_state: Any, arguments: dict[str, Any], actor: Any = None
+        ) -> str:
+            del app_state, arguments, actor
+            return "static"
+
+        dynamic = DynamicToolRegistry(handler_factory=_handler_factory)
+        await dynamic.register(_blueprint())
+        mapping = LayeredHandlerMap({"static_key": static_handler}, dynamic)
+
+        assert mapping["static_key"] is static_handler
+        assert mapping["synthorg_textkit_slugify"] is _fake_handler
+        assert "synthorg_textkit_slugify" in mapping
+        with pytest.raises(KeyError):
+            _ = mapping["missing"]
+        assert set(mapping) == {"static_key", "synthorg_textkit_slugify"}
+        assert len(mapping) == 2

--- a/tests/unit/meta/toolsmith/test_gap_store.py
+++ b/tests/unit/meta/toolsmith/test_gap_store.py
@@ -1,0 +1,101 @@
+"""Unit tests for the ring-buffer capability-gap store."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.toolsmith.gap_store import RingBufferCapabilityGapStore
+from synthorg.meta.toolsmith.protocol import CapabilityGapStore
+
+pytestmark = pytest.mark.unit
+
+_NOW = datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
+
+
+def _store(capacity: int = 64) -> RingBufferCapabilityGapStore:
+    return RingBufferCapabilityGapStore(max_observations=capacity)
+
+
+class TestRingBufferCapabilityGapStore:
+    def test_satisfies_protocol(self) -> None:
+        assert isinstance(_store(), CapabilityGapStore)
+
+    def test_rejects_zero_capacity(self) -> None:
+        with pytest.raises(ValueError, match="max_observations"):
+            RingBufferCapabilityGapStore(max_observations=0)
+
+    async def test_records_and_counts(self) -> None:
+        store = _store()
+        await store.record_gap(NotBlankStr("textkit:slugify"), occurred_at=_NOW)
+        await store.record_gap(NotBlankStr("textkit:slugify"), occurred_at=_NOW)
+        assert await store.count() == 2
+
+    async def test_recurring_requires_threshold(self) -> None:
+        store = _store()
+        for _ in range(2):
+            await store.record_gap(NotBlankStr("textkit:slugify"), occurred_at=_NOW)
+        # threshold 3 not met
+        assert (
+            await store.recurring(threshold=3, window=timedelta(hours=24), now=_NOW)
+            == ()
+        )
+
+    async def test_recurring_fires_on_threshold(self) -> None:
+        store = _store()
+        for i in range(3):
+            await store.record_gap(
+                NotBlankStr("textkit:slugify"),
+                occurred_at=_NOW + timedelta(minutes=i),
+            )
+        gaps = await store.recurring(
+            threshold=3, window=timedelta(hours=24), now=_NOW + timedelta(minutes=3)
+        )
+        assert len(gaps) == 1
+        assert gaps[0].signature == "textkit:slugify"
+        assert gaps[0].occurrences == 3
+        assert gaps[0].first_seen == _NOW
+        assert gaps[0].last_seen == _NOW + timedelta(minutes=2)
+
+    async def test_recurring_excludes_out_of_window(self) -> None:
+        store = _store()
+        # Two recent, one old (outside the 1h window)
+        await store.record_gap(
+            NotBlankStr("textkit:slugify"), occurred_at=_NOW - timedelta(hours=5)
+        )
+        await store.record_gap(NotBlankStr("textkit:slugify"), occurred_at=_NOW)
+        await store.record_gap(NotBlankStr("textkit:slugify"), occurred_at=_NOW)
+        gaps = await store.recurring(threshold=3, window=timedelta(hours=1), now=_NOW)
+        assert gaps == ()
+
+    async def test_recurring_ranks_by_frequency(self) -> None:
+        store = _store()
+        for _ in range(2):
+            await store.record_gap(NotBlankStr("a:one"), occurred_at=_NOW)
+        for _ in range(4):
+            await store.record_gap(NotBlankStr("b:two"), occurred_at=_NOW)
+        gaps = await store.recurring(threshold=2, window=timedelta(hours=1), now=_NOW)
+        assert [g.signature for g in gaps] == ["b:two", "a:one"]
+
+    async def test_naive_timestamp_rejected_in_record_is_swallowed(self) -> None:
+        store = _store()
+        # Naive timestamp -> recording is best-effort, swallowed, nothing stored.
+        await store.record_gap(
+            NotBlankStr("textkit:slugify"),
+            occurred_at=datetime(2026, 5, 21, 12, 0),  # noqa: DTZ001
+        )
+        assert await store.count() == 0
+
+    async def test_clear(self) -> None:
+        store = _store()
+        await store.record_gap(NotBlankStr("a:one"), occurred_at=_NOW)
+        await store.clear()
+        assert await store.count() == 0
+
+    async def test_eviction_at_capacity(self) -> None:
+        store = _store(capacity=2)
+        for i in range(4):
+            await store.record_gap(
+                NotBlankStr("a:one"), occurred_at=_NOW + timedelta(minutes=i)
+            )
+        assert await store.count() == 2

--- a/tests/unit/meta/toolsmith/test_invoker_layered.py
+++ b/tests/unit/meta/toolsmith/test_invoker_layered.py
@@ -1,0 +1,103 @@
+"""The real MCPToolInvoker dispatches authored tools via the layered surfaces."""
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from synthorg.meta.mcp.handler_protocol import ToolHandler
+from synthorg.meta.mcp.invoker import MCPToolInvoker
+from synthorg.meta.mcp.registry import DomainToolRegistry
+from synthorg.meta.toolsmith.dynamic_registry import (
+    DynamicToolRegistry,
+    LayeredHandlerMap,
+    LayeredToolRegistry,
+)
+from synthorg.meta.toolsmith.models import ToolBlueprint
+
+pytestmark = pytest.mark.unit
+
+_NOW = datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
+
+
+def _blueprint() -> ToolBlueprint:
+    return ToolBlueprint(
+        id="bp-1",
+        name="synthorg_textkit_slugify",
+        description="Slugify text.",
+        capability="textkit:slugify",
+        parameters_schema={
+            "type": "object",
+            "properties": {"text": {"type": "string"}},
+            "required": ["text"],
+        },
+        script_body="print('x')",
+        action_type="code:read",
+        created_at=_NOW,
+    )
+
+
+def _echo_factory(blueprint: ToolBlueprint) -> ToolHandler:
+    del blueprint
+
+    async def _handler(
+        *, app_state: Any, arguments: dict[str, Any], actor: Any = None
+    ) -> str:
+        del app_state, actor
+        return json.dumps({"status": "ok", "data": arguments})
+
+    return _handler
+
+
+async def _build_invoker() -> tuple[MCPToolInvoker, DynamicToolRegistry]:
+    static = DomainToolRegistry()
+    static.freeze()
+    dynamic = DynamicToolRegistry(handler_factory=_echo_factory)
+    registry = LayeredToolRegistry(static, dynamic)
+    handlers = LayeredHandlerMap({}, dynamic)
+    return MCPToolInvoker(registry, handlers), dynamic
+
+
+class TestInvokerLayeredDispatch:
+    async def test_dispatches_authored_tool_after_registration(self) -> None:
+        invoker, dynamic = await _build_invoker()
+        await dynamic.register(_blueprint())
+
+        result = await invoker.invoke(
+            "synthorg_textkit_slugify",
+            {"text": "Hello"},
+            app_state=None,
+        )
+        assert result.is_error is False
+        envelope = json.loads(result.content)
+        assert envelope["data"] == {"text": "Hello"}
+
+    async def test_args_model_validation_rejects_extra(self) -> None:
+        invoker, dynamic = await _build_invoker()
+        await dynamic.register(_blueprint())
+
+        result = await invoker.invoke(
+            "synthorg_textkit_slugify",
+            {"text": "Hello", "bogus": 1},
+            app_state=None,
+        )
+        assert result.is_error is True
+        envelope = json.loads(result.content)
+        assert envelope["domain_code"] == "invalid_argument"
+
+    async def test_args_model_validation_requires_field(self) -> None:
+        invoker, dynamic = await _build_invoker()
+        await dynamic.register(_blueprint())
+
+        result = await invoker.invoke(
+            "synthorg_textkit_slugify",
+            {},
+            app_state=None,
+        )
+        assert result.is_error is True
+
+    async def test_unknown_tool_is_error(self) -> None:
+        invoker, _ = await _build_invoker()
+        result = await invoker.invoke("synthorg_nope_nope", {}, app_state=None)
+        assert result.is_error is True

--- a/tests/unit/meta/toolsmith/test_models.py
+++ b/tests/unit/meta/toolsmith/test_models.py
@@ -1,0 +1,195 @@
+"""Unit tests for toolsmith domain models."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pydantic import ValidationError
+
+from synthorg.meta.toolsmith.models import (
+    CapabilityGap,
+    ToolBlueprint,
+    ToolBlueprintState,
+    ToolSandboxBackend,
+    ToolValidationResult,
+)
+
+pytestmark = pytest.mark.unit
+
+_NOW = datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
+_SCHEMA = {
+    "type": "object",
+    "properties": {"text": {"type": "string"}},
+    "required": ["text"],
+}
+
+
+def _blueprint(**overrides: object) -> ToolBlueprint:
+    base: dict[str, object] = {
+        "id": "bp-1",
+        "name": "synthorg_textkit_slugify",
+        "description": "Slugify text deterministically.",
+        "capability": "textkit:slugify",
+        "parameters_schema": _SCHEMA,
+        "script_body": "print('ok')",
+        "action_type": "code:read",
+        "created_at": _NOW,
+    }
+    base.update(overrides)
+    return ToolBlueprint(**base)  # type: ignore[arg-type]
+
+
+class TestCapabilityGap:
+    def test_valid(self) -> None:
+        gap = CapabilityGap(
+            signature="textkit:slugify",
+            occurrences=3,
+            first_seen=_NOW,
+            last_seen=_NOW + timedelta(hours=1),
+        )
+        assert gap.occurrences == 3
+
+    def test_occurrences_floor(self) -> None:
+        with pytest.raises(ValidationError):
+            CapabilityGap(
+                signature="x:y",
+                occurrences=0,
+                first_seen=_NOW,
+                last_seen=_NOW,
+            )
+
+    def test_ordering_enforced(self) -> None:
+        with pytest.raises(ValidationError):
+            CapabilityGap(
+                signature="x:y",
+                occurrences=1,
+                first_seen=_NOW,
+                last_seen=_NOW - timedelta(hours=1),
+            )
+
+
+class TestToolValidationResult:
+    def test_pass_requires_brief_and_nonnegative_margin(self) -> None:
+        result = ToolValidationResult(
+            passed=True,
+            brief_passed=True,
+            brief_score=90,
+            baseline_score=100,
+            candidate_score=100,
+            margin=0,
+            detail="ok",
+        )
+        assert result.passed
+
+    def test_margin_arithmetic_enforced(self) -> None:
+        with pytest.raises(ValidationError):
+            ToolValidationResult(
+                passed=True,
+                brief_passed=True,
+                brief_score=90,
+                baseline_score=100,
+                candidate_score=105,
+                margin=1,
+                detail="bad margin",
+            )
+
+    def test_pass_predicate_enforced(self) -> None:
+        with pytest.raises(ValidationError):
+            ToolValidationResult(
+                passed=True,
+                brief_passed=False,
+                brief_score=10,
+                baseline_score=100,
+                candidate_score=100,
+                margin=0,
+                detail="brief failed",
+            )
+
+    def test_regression_blocks_pass(self) -> None:
+        with pytest.raises(ValidationError):
+            ToolValidationResult(
+                passed=True,
+                brief_passed=True,
+                brief_score=90,
+                baseline_score=100,
+                candidate_score=95,
+                margin=-5,
+                detail="regressed",
+            )
+
+
+class TestToolBlueprint:
+    def test_defaults(self) -> None:
+        bp = _blueprint()
+        assert bp.state is ToolBlueprintState.PENDING
+        assert bp.sandbox_backend is ToolSandboxBackend.DOCKER
+        assert bp.requires_network is False
+        assert bp.validation is None
+
+    def test_frozen(self) -> None:
+        bp = _blueprint()
+        with pytest.raises(ValidationError):
+            bp.name = "synthorg_other_thing"  # type: ignore[misc]
+
+    @pytest.mark.parametrize(
+        "bad_name", ["slugify", "synthorg_slugify", "Synthorg_a_b"]
+    )
+    def test_name_contract(self, bad_name: str) -> None:
+        with pytest.raises(ValidationError):
+            _blueprint(name=bad_name)
+
+    @pytest.mark.parametrize("bad_cap", ["slugify", "textkit/slugify", "Text:Slug"])
+    def test_capability_contract(self, bad_cap: str) -> None:
+        with pytest.raises(ValidationError):
+            _blueprint(capability=bad_cap)
+
+    def test_action_type_contract(self) -> None:
+        with pytest.raises(ValidationError):
+            _blueprint(action_type="invalid")
+
+    def test_schema_must_be_object_with_properties(self) -> None:
+        with pytest.raises(ValidationError):
+            _blueprint(parameters_schema={"type": "string"})
+        with pytest.raises(ValidationError):
+            _blueprint(parameters_schema={"type": "object"})
+
+    def test_validated_state_requires_timestamp(self) -> None:
+        with pytest.raises(ValidationError):
+            _blueprint(state=ToolBlueprintState.VALIDATED)
+
+    def test_active_state_requires_timestamps(self) -> None:
+        with pytest.raises(ValidationError):
+            _blueprint(
+                state=ToolBlueprintState.ACTIVE,
+                validated_at=_NOW,
+            )
+
+    def test_retired_state_requires_timestamp(self) -> None:
+        with pytest.raises(ValidationError):
+            _blueprint(state=ToolBlueprintState.RETIRED)
+
+    def test_active_blueprint_round_trip(self) -> None:
+        bp = _blueprint(
+            state=ToolBlueprintState.ACTIVE,
+            validated_at=_NOW + timedelta(minutes=1),
+            activated_at=_NOW + timedelta(minutes=2),
+            validation=ToolValidationResult(
+                passed=True,
+                brief_passed=True,
+                brief_score=88,
+                baseline_score=100,
+                candidate_score=101,
+                margin=1,
+                detail="passed",
+            ),
+        )
+        assert bp.state is ToolBlueprintState.ACTIVE
+        assert bp.validation is not None
+        assert bp.validation.passed
+
+    def test_timestamp_ordering_enforced(self) -> None:
+        with pytest.raises(ValidationError):
+            _blueprint(
+                state=ToolBlueprintState.ACTIVE,
+                validated_at=_NOW + timedelta(minutes=5),
+                activated_at=_NOW + timedelta(minutes=2),
+            )

--- a/tests/unit/meta/toolsmith/test_models.py
+++ b/tests/unit/meta/toolsmith/test_models.py
@@ -205,3 +205,40 @@ class TestToolBlueprint:
                 activated_at=_NOW + timedelta(minutes=2),
                 validation=None,
             )
+
+    def test_validated_requires_validation_record(self) -> None:
+        # Same invariant as ACTIVE: a VALIDATED row without the gate
+        # result has lost the audit evidence the state name promises.
+        with pytest.raises(ValidationError):
+            _blueprint(
+                state=ToolBlueprintState.VALIDATED,
+                validated_at=_NOW + timedelta(minutes=1),
+                validation=None,
+            )
+
+    def test_retired_requires_validation_record(self) -> None:
+        # A RETIRED tool was once ACTIVE; the gate evidence MUST survive
+        # the lifecycle so post-retirement audits can replay the apply.
+        with pytest.raises(ValidationError):
+            _blueprint(
+                state=ToolBlueprintState.RETIRED,
+                validated_at=_NOW + timedelta(minutes=1),
+                activated_at=_NOW + timedelta(minutes=2),
+                retired_at=_NOW + timedelta(minutes=3),
+                validation=None,
+            )
+
+    def test_name_must_match_capability_domain_action(self) -> None:
+        # ``synthorg_textkit_slugify`` declares domain=textkit,
+        # action=slugify; if the capability disagrees, routing and
+        # governance see two different identifiers for the same tool.
+        with pytest.raises(ValidationError):
+            _blueprint(
+                name="synthorg_textkit_slugify",
+                capability="other:slugify",
+            )
+        with pytest.raises(ValidationError):
+            _blueprint(
+                name="synthorg_textkit_slugify",
+                capability="textkit:other",
+            )

--- a/tests/unit/meta/toolsmith/test_models.py
+++ b/tests/unit/meta/toolsmith/test_models.py
@@ -193,3 +193,15 @@ class TestToolBlueprint:
                 validated_at=_NOW + timedelta(minutes=5),
                 activated_at=_NOW + timedelta(minutes=2),
             )
+
+    def test_active_requires_validation_record(self) -> None:
+        # An ACTIVE tool is live-registered, which the applier only does
+        # after the benchmark gate passes and persists the result; a row
+        # in ACTIVE without a validation record indicates a corrupt write.
+        with pytest.raises(ValidationError):
+            _blueprint(
+                state=ToolBlueprintState.ACTIVE,
+                validated_at=_NOW + timedelta(minutes=1),
+                activated_at=_NOW + timedelta(minutes=2),
+                validation=None,
+            )

--- a/tests/unit/meta/toolsmith/test_overflow.py
+++ b/tests/unit/meta/toolsmith/test_overflow.py
@@ -101,7 +101,7 @@ class TestBaselineSnapshot:
 class TestCodeModificationOverflowHandler:
     async def test_delegates_to_strategy_with_gap_rule(self) -> None:
         strategy = _FakeStrategy()
-        handler = CodeModificationOverflowHandler(strategy)  # type: ignore[arg-type]
+        handler = CodeModificationOverflowHandler(strategy)
 
         proposals = await handler.handle(_gap())
 
@@ -123,7 +123,7 @@ class TestCodeModificationOverflowHandler:
             return sentinel
 
         handler = CodeModificationOverflowHandler(
-            strategy,  # type: ignore[arg-type]
+            strategy,
             snapshot_provider=_provider,
         )
         await handler.handle(_gap())

--- a/tests/unit/meta/toolsmith/test_overflow.py
+++ b/tests/unit/meta/toolsmith/test_overflow.py
@@ -1,0 +1,131 @@
+"""Unit tests for the code-modification overflow handler."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.models import (
+    ImprovementProposal,
+    ProposalAltitude,
+    ProposalRationale,
+    RollbackOperation,
+    RollbackPlan,
+    RuleMatch,
+)
+from synthorg.meta.signal_models import OrgSignalSnapshot
+from synthorg.meta.toolsmith.models import CapabilityGap
+from synthorg.meta.toolsmith.overflow import (
+    CodeModificationOverflowHandler,
+    build_baseline_snapshot,
+)
+
+pytestmark = pytest.mark.unit
+
+_NOW = datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
+
+
+def _gap() -> CapabilityGap:
+    return CapabilityGap(
+        signature=NotBlankStr("billing:reconcile"),
+        occurrences=4,
+        first_seen=_NOW,
+        last_seen=_NOW,
+    )
+
+
+def _code_proposal() -> ImprovementProposal:
+    from synthorg.meta.models import CodeChange, CodeOperation
+
+    return ImprovementProposal(
+        altitude=ProposalAltitude.CODE_MODIFICATION,
+        title="Add billing reconcile",
+        description="Adds a service-layer reconcile capability.",
+        rationale=ProposalRationale(
+            signal_summary="gap",
+            pattern_detected="gap",
+            expected_impact="impact",
+            confidence_reasoning="reason",
+        ),
+        code_changes=(
+            CodeChange(
+                file_path="src/synthorg/meta/strategies/x.py",
+                operation=CodeOperation.CREATE,
+                new_content="x = 1\n",
+                description="new",
+                reasoning="why",
+            ),
+        ),
+        rollback_plan=RollbackPlan(
+            operations=(
+                RollbackOperation(
+                    operation_type="revert_branch",
+                    target="meta/code-mod/abc",
+                    description="revert",
+                ),
+            ),
+            validation_check="branch deleted",
+        ),
+        confidence=0.5,
+    )
+
+
+class _FakeStrategy:
+    """Records the propose() call and returns a canned proposal."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[OrgSignalSnapshot, tuple[RuleMatch, ...]]] = []
+
+    @property
+    def altitude(self) -> ProposalAltitude:
+        return ProposalAltitude.CODE_MODIFICATION
+
+    async def propose(
+        self,
+        *,
+        snapshot: OrgSignalSnapshot,
+        triggered_rules: tuple[RuleMatch, ...],
+    ) -> tuple[ImprovementProposal, ...]:
+        self.calls.append((snapshot, triggered_rules))
+        return (_code_proposal(),)
+
+
+class TestBaselineSnapshot:
+    def test_constructs(self) -> None:
+        snap = build_baseline_snapshot()
+        assert isinstance(snap, OrgSignalSnapshot)
+        assert snap.performance.agent_count == 0
+        assert snap.budget.total_spend == pytest.approx(0.0)
+
+
+class TestCodeModificationOverflowHandler:
+    async def test_delegates_to_strategy_with_gap_rule(self) -> None:
+        strategy = _FakeStrategy()
+        handler = CodeModificationOverflowHandler(strategy)  # type: ignore[arg-type]
+
+        proposals = await handler.handle(_gap())
+
+        assert len(proposals) == 1
+        assert proposals[0].altitude is ProposalAltitude.CODE_MODIFICATION
+        assert len(strategy.calls) == 1
+        _snapshot, rules = strategy.calls[0]
+        assert len(rules) == 1
+        rule = rules[0]
+        assert ProposalAltitude.CODE_MODIFICATION in rule.suggested_altitudes
+        assert rule.signal_context["capability"] == "billing:reconcile"
+        assert rule.signal_context["occurrences"] == 4
+
+    async def test_uses_injected_snapshot_provider(self) -> None:
+        strategy = _FakeStrategy()
+        sentinel = build_baseline_snapshot()
+
+        async def _provider() -> OrgSignalSnapshot:
+            return sentinel
+
+        handler = CodeModificationOverflowHandler(
+            strategy,  # type: ignore[arg-type]
+            snapshot_provider=_provider,
+        )
+        await handler.handle(_gap())
+        used_snapshot, _rules = strategy.calls[0]
+        assert used_snapshot is sentinel

--- a/tests/unit/meta/toolsmith/test_script_handler.py
+++ b/tests/unit/meta/toolsmith/test_script_handler.py
@@ -1,0 +1,115 @@
+"""Unit tests for the authored-tool sandbox script handler."""
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from synthorg.meta.toolsmith.models import ToolBlueprint
+from synthorg.meta.toolsmith.script_handler import make_dynamic_tool_handler
+from synthorg.tools.sandbox.result import SandboxResult
+
+pytestmark = pytest.mark.unit
+
+_NOW = datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
+
+
+def _blueprint() -> ToolBlueprint:
+    return ToolBlueprint(
+        id="bp-1",
+        name="synthorg_textkit_slugify",
+        description="Slugify text.",
+        capability="textkit:slugify",
+        parameters_schema={
+            "type": "object",
+            "properties": {"text": {"type": "string"}},
+            "required": ["text"],
+        },
+        script_body="import os, json; print(json.dumps({'ok': True}))",
+        action_type="code:read",
+        created_at=_NOW,
+    )
+
+
+class _FakeSandbox:
+    """Records the last execute call and returns a canned result."""
+
+    def __init__(self, result: SandboxResult) -> None:
+        self._result = result
+        self.last_call: dict[str, Any] | None = None
+
+    async def execute(  # noqa: PLR0913
+        self,
+        *,
+        command: str,
+        args: tuple[str, ...],
+        cwd: Path | None = None,
+        env_overrides: Any = None,
+        timeout: float | None = None,  # noqa: ASYNC109
+        owner_id: Any = None,
+        project_id: Any = None,
+    ) -> SandboxResult:
+        del cwd, owner_id, project_id
+        self.last_call = {
+            "command": command,
+            "args": args,
+            "env_overrides": dict(env_overrides or {}),
+            "timeout": timeout,
+        }
+        return self._result
+
+    async def cleanup(self) -> None:
+        return None
+
+
+class TestDynamicToolHandler:
+    async def test_success_returns_ok_envelope(self) -> None:
+        sandbox = _FakeSandbox(
+            SandboxResult(stdout='{"slug": "hello-world"}', stderr="", returncode=0)
+        )
+        handler = make_dynamic_tool_handler(_blueprint(), sandbox)  # type: ignore[arg-type]
+
+        raw = await handler(app_state=None, arguments={"text": "Hello World"})
+        envelope = json.loads(raw)
+        assert envelope["status"] == "ok"
+        assert envelope["data"] == {"slug": "hello-world"}
+
+    async def test_arguments_passed_as_json_env_var(self) -> None:
+        sandbox = _FakeSandbox(
+            SandboxResult(stdout='{"ok": true}', stderr="", returncode=0)
+        )
+        handler = make_dynamic_tool_handler(_blueprint(), sandbox)  # type: ignore[arg-type]
+
+        await handler(app_state=None, arguments={"text": "hi"})
+        assert sandbox.last_call is not None
+        assert sandbox.last_call["command"] == "python"
+        env = sandbox.last_call["env_overrides"]
+        assert json.loads(env["SYNTHORG_TOOL_ARGS"]) == {"text": "hi"}
+
+    async def test_nonzero_exit_returns_error_envelope(self) -> None:
+        sandbox = _FakeSandbox(SandboxResult(stdout="", stderr="boom", returncode=1))
+        handler = make_dynamic_tool_handler(_blueprint(), sandbox)  # type: ignore[arg-type]
+
+        envelope = json.loads(await handler(app_state=None, arguments={"text": "x"}))
+        assert envelope["status"] == "error"
+        assert envelope["domain_code"] == "dynamic_tool_failed"
+
+    async def test_timeout_returns_error_envelope(self) -> None:
+        sandbox = _FakeSandbox(
+            SandboxResult(stdout="", stderr="", returncode=0, timed_out=True)
+        )
+        handler = make_dynamic_tool_handler(_blueprint(), sandbox)  # type: ignore[arg-type]
+
+        envelope = json.loads(await handler(app_state=None, arguments={"text": "x"}))
+        assert envelope["status"] == "error"
+
+    async def test_non_json_stdout_returns_error_envelope(self) -> None:
+        sandbox = _FakeSandbox(
+            SandboxResult(stdout="not json", stderr="", returncode=0)
+        )
+        handler = make_dynamic_tool_handler(_blueprint(), sandbox)  # type: ignore[arg-type]
+
+        envelope = json.loads(await handler(app_state=None, arguments={"text": "x"}))
+        assert envelope["status"] == "error"

--- a/tests/unit/meta/toolsmith/test_strategy.py
+++ b/tests/unit/meta/toolsmith/test_strategy.py
@@ -1,0 +1,147 @@
+"""Unit tests for the LLM tool blueprint generator."""
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.toolsmith.config import ToolsmithConfig
+from synthorg.meta.toolsmith.errors import (
+    ToolAuthoringError,
+    ToolCapabilityNotAllowedError,
+)
+from synthorg.meta.toolsmith.models import (
+    CapabilityGap,
+    ToolBlueprintState,
+    ToolSandboxBackend,
+)
+from synthorg.meta.toolsmith.strategy import LLMToolBlueprintGenerator
+from tests._shared import FakeClock
+
+pytestmark = pytest.mark.unit
+
+_NOW = datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
+
+_VALID_RESPONSE = json.dumps(
+    {
+        "description": "Slugify text deterministically.",
+        "action_type": "code:read",
+        "parameters_schema": {
+            "type": "object",
+            "properties": {"text": {"type": "string"}},
+            "required": ["text"],
+        },
+        "script_body": (
+            "import os, json, re\n"
+            "args = json.loads(os.environ['SYNTHORG_TOOL_ARGS'])\n"
+            "print(json.dumps({'slug': re.sub(r'\\\\W+', '-', "
+            "args['text']).strip('-').lower()}))"
+        ),
+    }
+)
+
+
+class _FakeResponse:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _FakeProvider:
+    """Structural BaseCompletionProvider stand-in returning canned content."""
+
+    def __init__(self, content: str) -> None:
+        self._content = content
+        self.calls = 0
+
+    async def complete(
+        self, *, messages: Any, model: str, config: Any
+    ) -> _FakeResponse:
+        del messages, model, config
+        self.calls += 1
+        return _FakeResponse(self._content)
+
+
+def _gap(signature: str = "textkit:slugify", occurrences: int = 3) -> CapabilityGap:
+    return CapabilityGap(
+        signature=NotBlankStr(signature),
+        occurrences=occurrences,
+        first_seen=_NOW,
+        last_seen=_NOW,
+    )
+
+
+def _generator(
+    *,
+    content: str = _VALID_RESPONSE,
+    allowed: tuple[str, ...] = ("textkit:slugify",),
+) -> LLMToolBlueprintGenerator:
+    config = ToolsmithConfig(
+        enabled=True,
+        allowed_capabilities=tuple(NotBlankStr(c) for c in allowed),
+        sandbox_backend=ToolSandboxBackend.DOCKER,
+    )
+    return LLMToolBlueprintGenerator(
+        config=config,
+        provider=_FakeProvider(content),  # type: ignore[arg-type]
+        clock=FakeClock(start=_NOW),
+    )
+
+
+class TestLLMToolBlueprintGenerator:
+    async def test_authors_valid_blueprint(self) -> None:
+        gen = _generator()
+        bp = await gen.author(_gap(), existing_capabilities=())
+        assert bp.name == "synthorg_textkit_slugify"
+        assert bp.capability == "textkit:slugify"
+        assert bp.action_type == "code:read"
+        assert bp.state is ToolBlueprintState.PENDING
+        assert bp.sandbox_backend is ToolSandboxBackend.DOCKER
+        assert bp.requires_network is False
+        assert bp.created_at == _NOW
+        assert "SYNTHORG_TOOL_ARGS" in bp.script_body
+
+    async def test_name_derived_from_capability_not_model(self) -> None:
+        # The tool name is derived from the capability so name/capability
+        # always align, regardless of anything the model emits.
+        gen = _generator(allowed=("datakit:parse",))
+        bp = await gen.author(
+            _gap(signature="datakit:parse"),
+            existing_capabilities=(),
+        )
+        assert bp.name == "synthorg_datakit_parse"
+        assert bp.capability == "datakit:parse"
+
+    async def test_capability_not_allowed_rejected(self) -> None:
+        gen = _generator(allowed=("other:thing",))
+        with pytest.raises(ToolCapabilityNotAllowedError):
+            await gen.author(_gap(), existing_capabilities=())
+
+    async def test_invalid_json_raises_authoring_error(self) -> None:
+        gen = _generator(content="not json")
+        with pytest.raises(ToolAuthoringError):
+            await gen.author(_gap(), existing_capabilities=())
+
+    async def test_missing_field_raises_authoring_error(self) -> None:
+        partial = json.dumps({"description": "x", "action_type": "code:read"})
+        gen = _generator(content=partial)
+        with pytest.raises(ToolAuthoringError):
+            await gen.author(_gap(), existing_capabilities=())
+
+    async def test_bad_action_type_raises_authoring_error(self) -> None:
+        bad = json.dumps(
+            {
+                "description": "x",
+                "action_type": "invalid",
+                "parameters_schema": {
+                    "type": "object",
+                    "properties": {"text": {"type": "string"}},
+                    "required": ["text"],
+                },
+                "script_body": "print('{}')",
+            }
+        )
+        gen = _generator(content=bad)
+        with pytest.raises(ToolAuthoringError):
+            await gen.author(_gap(), existing_capabilities=())

--- a/tests/unit/meta/toolsmith/test_validation_gate.py
+++ b/tests/unit/meta/toolsmith/test_validation_gate.py
@@ -1,0 +1,172 @@
+"""Unit tests for the benchmark tool-validation gate."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from synthorg.core.types import NotBlankStr
+from synthorg.meta.toolsmith.config import ToolsmithConfig, ToolValidationConfig
+from synthorg.meta.toolsmith.models import ToolBlueprint
+from synthorg.meta.toolsmith.validation_gate import (
+    BenchmarkToolValidationGate,
+    SandboxBriefRunner,
+    ToolValidationConfigError,
+)
+from synthorg.tools.sandbox.result import SandboxResult
+
+pytestmark = pytest.mark.unit
+
+_NOW = datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
+
+
+def _blueprint() -> ToolBlueprint:
+    return ToolBlueprint(
+        id="bp-1",
+        name="synthorg_textkit_slugify",
+        description="Slugify text.",
+        capability="textkit:slugify",
+        parameters_schema={
+            "type": "object",
+            "properties": {"text": {"type": "string"}},
+            "required": ["text"],
+        },
+        script_body="print('{}')",
+        action_type="code:read",
+        created_at=_NOW,
+    )
+
+
+class _FakeSandbox:
+    def __init__(self, result: SandboxResult) -> None:
+        self._result = result
+
+    async def execute(  # noqa: PLR0913
+        self,
+        *,
+        command: str,
+        args: tuple[str, ...],
+        cwd: Path | None = None,
+        env_overrides: Any = None,
+        timeout: float | None = None,  # noqa: ASYNC109
+        owner_id: Any = None,
+        project_id: Any = None,
+    ) -> SandboxResult:
+        del command, args, cwd, env_overrides, timeout, owner_id, project_id
+        return self._result
+
+    async def cleanup(self) -> None:
+        return None
+
+
+class _FakeScorecard:
+    def __init__(self, baseline: int, candidate: int) -> None:
+        self._baseline = baseline
+        self._candidate = candidate
+        self.calls = 0
+
+    async def score(self, blueprint: ToolBlueprint) -> tuple[int, int]:
+        del blueprint
+        self.calls += 1
+        return self._baseline, self._candidate
+
+
+class _FakeBrief:
+    def __init__(self, *, passed: bool, score: int) -> None:
+        self._passed = passed
+        self._score = score
+
+    async def run(self, blueprint: ToolBlueprint) -> tuple[bool, int]:
+        del blueprint
+        return self._passed, self._score
+
+
+def _config(*, require_golden: bool = True, min_margin: int = 0) -> ToolsmithConfig:
+    return ToolsmithConfig(
+        enabled=True,
+        allowed_capabilities=(NotBlankStr("textkit:slugify"),),
+        validation=ToolValidationConfig(
+            require_golden_delta=require_golden, min_score_margin=min_margin
+        ),
+    )
+
+
+class TestSandboxBriefRunner:
+    async def test_ok_envelope_passes(self) -> None:
+        sandbox = _FakeSandbox(
+            SandboxResult(stdout='{"slug": "x"}', stderr="", returncode=0)
+        )
+        runner = SandboxBriefRunner(sandbox)  # type: ignore[arg-type]
+        passed, score = await runner.run(_blueprint())
+        assert passed is True
+        assert score == 100
+
+    async def test_failure_envelope_fails(self) -> None:
+        sandbox = _FakeSandbox(SandboxResult(stdout="", stderr="boom", returncode=1))
+        runner = SandboxBriefRunner(sandbox)  # type: ignore[arg-type]
+        passed, score = await runner.run(_blueprint())
+        assert passed is False
+        assert score == 0
+
+
+class TestBenchmarkToolValidationGate:
+    async def test_brief_pass_and_no_regression_passes(self) -> None:
+        gate = BenchmarkToolValidationGate(
+            config=_config(),
+            brief_runner=_FakeBrief(passed=True, score=100),
+            scorecard_provider=_FakeScorecard(100, 101),
+        )
+        result = await gate.validate(_blueprint())
+        assert result.passed is True
+        assert result.margin == 1
+
+    async def test_regression_blocks(self) -> None:
+        gate = BenchmarkToolValidationGate(
+            config=_config(),
+            brief_runner=_FakeBrief(passed=True, score=100),
+            scorecard_provider=_FakeScorecard(100, 95),
+        )
+        result = await gate.validate(_blueprint())
+        assert result.passed is False
+        assert result.margin == -5
+
+    async def test_brief_failure_skips_golden(self) -> None:
+        scorecard = _FakeScorecard(100, 200)
+        gate = BenchmarkToolValidationGate(
+            config=_config(),
+            brief_runner=_FakeBrief(passed=False, score=0),
+            scorecard_provider=scorecard,
+        )
+        result = await gate.validate(_blueprint())
+        assert result.passed is False
+        assert scorecard.calls == 0  # golden gated behind the brief
+
+    async def test_min_margin_enforced(self) -> None:
+        gate = BenchmarkToolValidationGate(
+            config=_config(min_margin=5),
+            brief_runner=_FakeBrief(passed=True, score=100),
+            scorecard_provider=_FakeScorecard(100, 103),
+        )
+        result = await gate.validate(_blueprint())
+        assert result.passed is False  # margin 3 < min 5
+        assert result.margin == 3
+
+    async def test_golden_disabled_uses_brief_only(self) -> None:
+        gate = BenchmarkToolValidationGate(
+            config=_config(require_golden=False),
+            brief_runner=_FakeBrief(passed=True, score=100),
+        )
+        result = await gate.validate(_blueprint())
+        assert result.passed is True
+        assert result.baseline_score == 0
+        assert result.candidate_score == 0
+
+    async def test_golden_required_without_provider_raises(self) -> None:
+        gate = BenchmarkToolValidationGate(
+            config=_config(),
+            brief_runner=_FakeBrief(passed=True, score=100),
+            scorecard_provider=None,
+        )
+        with pytest.raises(ToolValidationConfigError):
+            await gate.validate(_blueprint())

--- a/tests/unit/meta/toolsmith/test_validation_gate.py
+++ b/tests/unit/meta/toolsmith/test_validation_gate.py
@@ -97,14 +97,14 @@ class TestSandboxBriefRunner:
         sandbox = _FakeSandbox(
             SandboxResult(stdout='{"slug": "x"}', stderr="", returncode=0)
         )
-        runner = SandboxBriefRunner(sandbox)  # type: ignore[arg-type]
+        runner = SandboxBriefRunner(lambda _bp: sandbox)  # type: ignore[arg-type,return-value]
         passed, score = await runner.run(_blueprint())
         assert passed is True
         assert score == 100
 
     async def test_failure_envelope_fails(self) -> None:
         sandbox = _FakeSandbox(SandboxResult(stdout="", stderr="boom", returncode=1))
-        runner = SandboxBriefRunner(sandbox)  # type: ignore[arg-type]
+        runner = SandboxBriefRunner(lambda _bp: sandbox)  # type: ignore[arg-type,return-value]
         passed, score = await runner.run(_blueprint())
         assert passed is False
         assert score == 0

--- a/tests/unit/observability/test_events.py
+++ b/tests/unit/observability/test_events.py
@@ -347,6 +347,9 @@ class TestEventConstants:
             "vision_verify",
             # Knowledge + provenance substrate ingestion / retrieval.
             "knowledge",
+            # Self-extending toolkit (#1995): capability-gap detection,
+            # authoring, benchmark validation, and live registration.
+            "toolsmith",
         }
         discovered = {info.name for info in pkgutil.iter_modules(events.__path__)}
         assert discovered == expected

--- a/tests/unit/observability/test_events.py
+++ b/tests/unit/observability/test_events.py
@@ -347,8 +347,8 @@ class TestEventConstants:
             "vision_verify",
             # Knowledge + provenance substrate ingestion / retrieval.
             "knowledge",
-            # Self-extending toolkit (#1995): capability-gap detection,
-            # authoring, benchmark validation, and live registration.
+            # Self-extending toolkit: capability-gap detection, authoring,
+            # benchmark validation, and live registration.
             "toolsmith",
         }
         discovered = {info.name for info in pkgutil.iter_modules(events.__path__)}

--- a/tests/unit/persistence/test_factory.py
+++ b/tests/unit/persistence/test_factory.py
@@ -118,12 +118,13 @@ class TestCreateBackend:
     ) -> None:
         """Each company config creates an isolated backend instance.
 
-        Reuses the session-wide migrated template (``_get_template_db``,
-        built once per worker and credited to the per-test wall-clock
-        guard) instead of running the full -- and ever-growing -- yoyo
-        chain per test, then copies it to each tenant path so the on-disk
-        layout stays symmetric with production. Running the chain inline
-        here tripped the unit wall-clock budget once the schema grew.
+        Both tenant databases are copied from the session-wide migrated
+        template (built once per session and amortised across the suite
+        via ``_get_template_db``) rather than re-running yoyo per test.
+        Re-migrating from scratch costs ~11s on Windows once the revision
+        chain grows, which trips the per-test wall-clock guard under
+        xdist load; copying the cached template keeps the on-disk layout
+        symmetric with production at negligible cost.
         """
         import shutil
 
@@ -132,9 +133,9 @@ class TestCreateBackend:
         path_a = str(tmp_path / "company-a.db")
         path_b = str(tmp_path / "company-b.db")
 
-        template = await _get_template_db(tmp_path_factory)
-        shutil.copyfile(str(template), path_a)
-        shutil.copyfile(str(template), path_b)
+        template_path = await _get_template_db(tmp_path_factory)
+        shutil.copyfile(template_path, path_a)
+        shutil.copyfile(template_path, path_b)
 
         config_a = PersistenceConfig(sqlite=SQLiteConfig(path=path_a))
         config_b = PersistenceConfig(sqlite=SQLiteConfig(path=path_b))

--- a/tests/unit/security/test_action_types.py
+++ b/tests/unit/security/test_action_types.py
@@ -26,6 +26,7 @@ class TestActionTypeCategory:
             (ActionTypeCategory.ORG, "org"),
             (ActionTypeCategory.DB, "db"),
             (ActionTypeCategory.ARCH, "arch"),
+            (ActionTypeCategory.TOOL, "tool"),
             (ActionTypeCategory.MEMORY, "memory"),
             (ActionTypeCategory.BROWSER, "browser"),
             (ActionTypeCategory.EXTERNAL_DATA, "external_data"),

--- a/tests/unit/security/test_action_types.py
+++ b/tests/unit/security/test_action_types.py
@@ -11,7 +11,7 @@ from synthorg.security.action_types import ActionTypeCategory, ActionTypeRegistr
 @pytest.mark.unit
 class TestActionTypeCategory:
     def test_has_expected_member_count(self) -> None:
-        assert len(ActionTypeCategory) == 15
+        assert len(ActionTypeCategory) == 16
 
     @pytest.mark.parametrize(
         ("member", "value"),
@@ -28,6 +28,7 @@ class TestActionTypeCategory:
             (ActionTypeCategory.ARCH, "arch"),
             (ActionTypeCategory.TOOL, "tool"),
             (ActionTypeCategory.MEMORY, "memory"),
+            (ActionTypeCategory.KNOWLEDGE, "knowledge"),
             (ActionTypeCategory.BROWSER, "browser"),
             (ActionTypeCategory.EXTERNAL_DATA, "external_data"),
             (ActionTypeCategory.DESKTOP, "desktop"),

--- a/web/src/api/types/enum-values.gen.ts
+++ b/web/src/api/types/enum-values.gen.ts
@@ -526,6 +526,7 @@ export const PROPOSAL_ALTITUDE_VALUES = [
     'architecture',
     'prompt_tuning',
     'code_modification',
+    'tool_creation',
 ] as const
 export type ProposalAltitude = (typeof PROPOSAL_ALTITUDE_VALUES)[number]
 

--- a/web/src/api/types/openapi.gen.ts
+++ b/web/src/api/types/openapi.gen.ts
@@ -10746,7 +10746,7 @@ export type components = {
          * @description Altitude of change a proposal targets.
          * @enum {string}
          */
-        readonly ProposalAltitude: "config_tuning" | "architecture" | "prompt_tuning" | "code_modification";
+        readonly ProposalAltitude: "config_tuning" | "architecture" | "prompt_tuning" | "code_modification" | "tool_creation";
         /** ProposedApprovalSummary */
         readonly ProposedApprovalSummary: {
             readonly approval_id: string;


### PR DESCRIPTION
Closes #1995.

## Summary

The org now extends its own toolkit at runtime: it detects a recurring capability gap, an LLM authors a new sandboxed MCP tool, the candidate is benchmark-validated, and on pass plus human approval it is live-registered so a later task in the same run uses it. Tool creation is governed via a new `TOOL_CREATION` proposal altitude (HIGH risk, mandatory approval) and a new `tool:create` action type.

- New package `src/synthorg/meta/toolsmith/`: models, config, errors, gap_store, dynamic_registry, script_handler, strategy (LLM blueprint authoring), validation_gate (per-tool acceptance brief + golden-scorecard delta), applier, service, factory, `CodeModificationOverflowHandler` for service-access gaps.
- Frozen registries stay frozen: a `LayeredToolRegistry` plus `LayeredHandlerMap` read by `MCPToolInvoker` overlay a snapshot-swapping `DynamicToolRegistry` on top of the static `DomainToolRegistry`. `build_args_model` materialises a real frozen Pydantic args model from the blueprint's JSON Schema so the strict `MCPToolDef` alignment validator keeps holding.
- Persistence: new `DynamicToolRepository` protocol composing `StatefulRepository` + `FilteredQueryRepository` (no bespoke methods per ADR-0001), SQLite + Postgres repos, yoyo revision `20260522000001_dynamic_tools`, schema.sql additions on both backends.
- Governance: `ProposalAltitude.TOOL_CREATION` plus `ImprovementProposal.tool_changes`, guard-chain wiring (scope, approval), `ActionType.TOOL_CREATE` with HIGH risk across the risk maps, autonomy presets gating `tool:create` behind human approval in supervised/semi.
- Boot: gated `_wire_toolsmith` hook (tool_creation_enabled + provider + persistence) installs the dynamic tool layer over the layered surface; falls back cleanly when any dependency is absent. The production golden-scorecard provider is fail-closed until #1980 exposes a runnable score-with-candidate API.

## Test plan

- 110+ new unit tests under `tests/unit/meta/toolsmith/` covering models, config, gap store, strategy, validation gate, applier (incl. repo-save-failure, retire-non-active, validation-persistence), dynamic registry, script handler, overflow handler, layered invoker.
- 14 conformance tests at `tests/conformance/persistence/test_dynamic_tool_repository.py` (SQLite + Postgres parity for the new repo, transition_if semantics, query/filter, unknown-key rejection).
- Acceptance e2e at `tests/integration/toolsmith/test_self_extension_e2e.py`: drives the full gap to author to guard to approve to validate to register to invoke loop through the real `MCPToolInvoker`, with a regression-case showing a regressing tool is rejected.
- Full pre-push gate clean: ruff, mypy strict, full unit suite, ghost-wiring manifest (9 ENFORCED symbols reachable), schema-drift (sqlite revisions + sqlite-vs-postgres parity), magic-numbers, domain-error-hierarchy, review-origin, persistence-boundary, frozen-extra-forbid, boundary-typed, dual-backend conformance parity, dependency-inversion.

## Review coverage

Reviewed by 17 agents (code-reviewer, python-reviewer, conventions-enforcer, security-reviewer, persistence-reviewer, async-concurrency-reviewer, silent-failure-hunter, type-design-analyzer, docs-consistency, comment-quality-rot, logging-audit, resilience-audit, test-quality-reviewer, pr-test-analyzer, api-contract-drift, issue-resolution-verifier, ghost-wiring mini-pass).

- **20 distinct findings, 14 valid + 6 invalid.** Triage in `_audit/pre-pr-review/triage.md`.
- The "Python 2 except syntax error" flagged by 5 agents is a false positive: PEP 758 makes `except A, B:` valid in 3.14, CLAUDE.md mandates the bare form, python-reviewer + resilience-audit explicitly confirmed it, and the pre-push (ruff + full mypy + 30k unit tests importing these modules) passed.
- Implemented in this branch: missing event constants, `ProviderError` propagation in `strategy.author()` / `applier.apply()` / `code_modification._generate_and_parse` (closes a real resilience hole flagged in the toolsmith delegation path), unknown-JSON-type rejection in `build_args_model`, silent brief-parse log, `error=` on the invoke-failed log, `retire()` race fix (unregister gated on transition success), bounded `script_body`, config validator (`enabled` requires non-empty allowlist), ACTIVE-blueprint requires validation record, expanded applier coverage tests, docs drift (action-type count, altitudes table, package structure, YAML defaults), and `#1995` stripped from the migration SQL headers.
- One outstanding triage item (V9): the schema-drift baseline reasons still embed `(#1995)` because the gate-suppression PreToolUse hook blocked the direct edit and the `--update-baseline` script preserves existing reasons. Cosmetic only (the review-origin gate passed and the baseline is data, not code); can be cleaned up in a follow-up by removing the 6 lines first, then re-running `--update-baseline` with a clean justification under fresh `ALLOW_BASELINE_GROWTH=1` approval.
- Documented dependency: production `GoldenScorecardProvider` (runnable golden-benchmark-with-candidate API) lands when #1980 exposes it; until then `require_golden_delta` is fail-closed at apply (a missing provider rejects), not a stub.
