### PR TITLE
ci: fix paths-filter shallow-clone race and scorecard allowlist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,15 @@ jobs:
       # requires push access to the upstream.
       is_release_please: ${{ (github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'synthorg-repo-bot[bot]') || (github.event_name != 'pull_request' && startsWith(github.ref, 'refs/heads/release-please--')) }}
     steps:
+      # fetch-depth: 0 needed by paths-filter on push: events. With a shallow
+      # checkout it falls back to two back-to-back `git fetch --depth=1` calls
+      # (base SHA + main) that both rewrite `.git/shallow`; the second races
+      # the first and dies with `fatal: shallow file has changed since we
+      # read it`. Full history skips the remote fetches entirely.
       - uses: Aureliolo/synthorg/.github/actions/checkout@25921183f274c930bf473dc0339376bda0961eaf
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: "0"
           persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
@@ -228,9 +234,17 @@ jobs:
     permissions:
       contents: read
     steps:
+      # fetch-depth: 0 needed by the "Enforce at most one new revision per
+      # PR" step below: `git diff base...HEAD` uses the three-dot merge-base
+      # form, which is undefined on a shallow clone (no shared ancestry).
+      # Without full history the rule either misses additions or fires
+      # false positives, depending on which commit happens to be the
+      # shallow root. The cost (one checkout) is small; this job already
+      # runs full schema-drift validation.
       - uses: Aureliolo/synthorg/.github/actions/checkout@25921183f274c930bf473dc0339376bda0961eaf
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: "0"
           persist-credentials: false
       - uses: ./.github/actions/setup-python-uv
 
@@ -239,7 +253,7 @@ jobs:
         env:
           GH_BASE_REF: ${{ github.base_ref }}
         run: |
-          git fetch origin "$GH_BASE_REF" --depth=1
+          git fetch origin "$GH_BASE_REF"
           base_ref="origin/$GH_BASE_REF"
           mapfile -t new_revs < <(
             git diff --name-only --diff-filter=A "$base_ref"...HEAD -- \

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -32,9 +32,12 @@ jobs:
     outputs:
       changed: ${{ steps.filter.outputs.cli || startsWith(github.ref, 'refs/tags/v') }}
     steps:
+      # fetch-depth: 0. See ci.yml Detect Changes for full rationale:
+      # paths-filter on push: events races on shallow checkouts.
       - uses: Aureliolo/synthorg/.github/actions/checkout@25921183f274c930bf473dc0339376bda0961eaf
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: "0"
           persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -58,9 +58,12 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
       web: ${{ steps.filter.outputs.web }}
     steps:
+      # fetch-depth: 0. See ci.yml Detect Changes for full rationale:
+      # paths-filter on push: events races on shallow checkouts.
       - uses: Aureliolo/synthorg/.github/actions/checkout@25921183f274c930bf473dc0339376bda0961eaf
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: "0"
           persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,9 +65,12 @@ jobs:
       fine-tune: ${{ steps.filter.outputs.fine-tune }}
       web: ${{ steps.filter.outputs.web }}
     steps:
+      # fetch-depth: 0. See ci.yml Detect Changes for full rationale:
+      # paths-filter on push: events races on shallow checkouts.
       - uses: Aureliolo/synthorg/.github/actions/checkout@25921183f274c930bf473dc0339376bda0961eaf
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: "0"
           persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,7 +19,11 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: Aureliolo/synthorg/.github/actions/checkout@25921183f274c930bf473dc0339376bda0961eaf
+      # ossf/scorecard-action enforces a workflow-step allowlist on the job
+      # that contains it. The local retry-wrapped checkout composite is not
+      # allowlisted, so we must call actions/checkout directly here. SHA
+      # matches the one pinned inside .github/actions/checkout (v6).
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.sha }}
           persist-credentials: false


### PR DESCRIPTION
## What

Two infra bugs caused every recent push to `main` to show red. Both are CI-infra failures, not code regressions.

## Why

**1. `dorny/paths-filter` races on shallow checkouts (push events to `main`).**

The action compares the pushed range by fetching `${{ github.event.before }}` and `main` with two back-to-back `git fetch --depth=1` calls. Both rewrite `.git/shallow`, and the second loses with:

```
fatal: shallow file has changed since we read it
##[error]The process '/usr/bin/git' failed with exit code 128
```

The whole `Detect Changes` job dies, so every downstream job (`Lint`, `Type Check`, all the unit / integration test shards, etc.) is skipped and `CI Pass` fails. The race only fires on `push:` events because, on PRs, `actions/checkout` has already fetched the base and paths-filter's local `git cat-file -e` check short-circuits both fetches.

The race is intermittent (depends on git/fs timing on the runner), which is why `codspeed.yml` and `docker.yml` have the same setup but happened to win recent rolls. Last four commits to `main` all lost: 917d98a, adedc6a, 72c6648, 2592118.

Fix: add `fetch-depth: "0"` to the `Detect Changes` checkout in every workflow that runs paths-filter on a `push:` trigger. With both refs already local, paths-filter skips the remote fetches entirely. Workflows touched:

- `ci.yml` (was failing)
- `cli.yml` (was failing)
- `codspeed.yml` (preemptive — same shape, same race waiting to fire)
- `docker.yml` (preemptive — same shape)

`lighthouse.yml` is `pull_request`-only and unaffected; left alone.

**2. `ossf/scorecard-action` rejects the local retry-wrapped checkout composite.**

Scorecard enforces a workflow-step allowlist on the job containing it. Our local `Aureliolo/synthorg/.github/actions/checkout` composite is not on that allowlist, so every push (and the weekly schedule) returns:

```
http response 400, status: 400 Bad Request, error: {"code":400,"message":
"workflow verification failed: workflow verification failed: job has
unallowed step: Aureliolo/synthorg/.github/actions/checkout, see
https://github.com/ossf/scorecard-action#workflow-restrictions for details."}
```

Fix: in `scorecard.yml`, the `scorecard` job switches to `actions/checkout@de0fac2…` (same v6 SHA pinned inside the composite). The `report-failure` job keeps the retry-wrapped composite — the allowlist only applies to the job containing `scorecard-action`.

## Latent similar bug surfaced during the sweep

The `schema-validate` job's "Enforce at most one new revision per PR" step runs:

```yaml
git fetch origin "$GH_BASE_REF" --depth=1
git diff --name-only --diff-filter=A "$base_ref"...HEAD -- ...
```

`A...B` (three-dot) is `git diff $(git merge-base A B) B`, which is undefined when the local clone has no ancestry shared between the two shallow tips. Depending on which commit happened to be the shallow root, the gate would either miss legitimate additions or fire false positives. Added `fetch-depth: "0"` on the same checkout and dropped the now-redundant `--depth=1` from the explicit fetch.

## Holistic sweep (negative findings)

To make sure this fix is complete, I grepped for the two underlying patterns across `.github/` and `scripts/`:

- **Shallow clone + git history operations.** Only `ci.yml:248` was buggy. `auto-rollover.yml`, `dev-release.yml`, `graduate.yml`, `secret-scan.yml`, and the `cli` perf-regression job (line 207) already set `fetch-depth: 0` where they need it.
- **Other allowlist-restricted actions** (`ossf/*`, `step-security/harden-runner`, `github/codeql-action/init`). Only Scorecard restricts caller steps; nothing else uses the local composite under a similar policy.
- **Scripts called from CI that touch git history** (`check_cli_bench_regression.sh`, `check_no_review_origin_in_code.py`, `check_no_migration_framing.py`, `compute_release_cadence.py`). The only one that needs history is `check_cli_bench_regression.sh`, and its caller already has `fetch-depth: 0`.

## Intentionally NOT doing

- Not bumping `dorny/paths-filter` — the race is shallow-clone semantics, not a paths-filter bug.
- Not changing the composite checkout's `fetch-depth: 1` default — that's correct for most jobs; only detect-changes-style jobs need the override.
- Not requesting allowlisting of the local composite from upstream OSSF — slow, uncertain, and direct `actions/checkout` is a clean one-line workflow change.

## Verification

- Local pre-push gates: actionlint, yamllint, zizmor all `Passed` on the five modified workflows.
- CI on this branch will exercise the paths-filter fix on the PR event (no race possible) and on push-to-main after merge (the fix's actual target).
- Scorecard runs only on `push:` to main and the weekly schedule, so the allowlist fix will be exercised on the first post-merge push.
