### PR TITLE
feat: surface safety-spine state in runtime-services boot log (closes #2096)

### DIFF
--- a/scripts/_module_size_baseline.json
+++ b/scripts/_module_size_baseline.json
@@ -156,6 +156,6 @@
     "src/synthorg/tools/sandbox/subprocess_sandbox.py": 630,
     "src/synthorg/workers/claim.py": 612,
     "src/synthorg/workers/execution_service.py": 772,
-    "src/synthorg/workers/runtime_builder.py": 840
+    "src/synthorg/workers/runtime_builder.py": 842
   }
 }

--- a/scripts/_module_size_baseline.json
+++ b/scripts/_module_size_baseline.json
@@ -67,7 +67,6 @@
     "src/synthorg/engine/workflow/execution_service.py": 587,
     "src/synthorg/engine/workflow/strategies/milestone_driven.py": 541,
     "src/synthorg/engine/workflow/strategies/throughput_adaptive.py": 567,
-    "src/synthorg/engine/workspace/git_backend/external_remote.py": 523,
     "src/synthorg/engine/workspace/git_worktree.py": 712,
     "src/synthorg/hr/activity_service.py": 636,
     "src/synthorg/hr/performance/tracker.py": 873,
@@ -157,6 +156,6 @@
     "src/synthorg/tools/sandbox/subprocess_sandbox.py": 630,
     "src/synthorg/workers/claim.py": 612,
     "src/synthorg/workers/execution_service.py": 772,
-    "src/synthorg/workers/runtime_builder.py": 809
+    "src/synthorg/workers/runtime_builder.py": 817
   }
 }

--- a/scripts/_module_size_baseline.json
+++ b/scripts/_module_size_baseline.json
@@ -156,6 +156,6 @@
     "src/synthorg/tools/sandbox/subprocess_sandbox.py": 630,
     "src/synthorg/workers/claim.py": 612,
     "src/synthorg/workers/execution_service.py": 772,
-    "src/synthorg/workers/runtime_builder.py": 817
+    "src/synthorg/workers/runtime_builder.py": 840
   }
 }

--- a/src/synthorg/workers/execution_service.py
+++ b/src/synthorg/workers/execution_service.py
@@ -1,3 +1,4 @@
+# module-kind: service
 """Backend-side service called by the worker-callable execute endpoint.
 
 When the worker pool fetches a JetStream claim, it posts to

--- a/src/synthorg/workers/runtime_builder.py
+++ b/src/synthorg/workers/runtime_builder.py
@@ -831,6 +831,8 @@ async def build_runtime_services(
         work_pipeline_wired=work_pipeline is not None,
         red_team_wired=red_team_runtime is not None,
         vision_gate_wired=vision_gate is not None,
+        security_enabled=security.enabled,
+        security_enforcement_mode=security.enforcement_mode.value,
     )
     return RuntimeServices(
         worker_execution_service=worker_execution_service,

--- a/src/synthorg/workers/runtime_builder.py
+++ b/src/synthorg/workers/runtime_builder.py
@@ -1,3 +1,4 @@
+# module-kind: orchestrator
 """Provider-present switch: build the boot runtime services.
 
 This is the construction site for the agent runtime. With a provider
@@ -572,15 +573,28 @@ async def _build_runtime_coordinator(
     (one routing surface, no divergence). The resolved decomposition
     model is returned so the ``llm-judged`` routing policy reuses it.
     """
-    async with asyncio.TaskGroup() as tg:
-        model_task = tg.create_task(
-            app_state.config_resolver.get_str(
-                _DECOMPOSITION_NS,
-                _DECOMPOSITION_KEY,
+    try:
+        async with asyncio.TaskGroup() as tg:
+            model_task = tg.create_task(
+                app_state.config_resolver.get_str(
+                    _DECOMPOSITION_NS,
+                    _DECOMPOSITION_KEY,
+                )
             )
+            scorer_task = tg.create_task(_resolve_routing_scorer_config(app_state))
+            workspace_task = tg.create_task(_build_workspace_strategy(app_state))
+    except MemoryError, RecursionError:
+        raise
+    except Exception as exc:
+        log_exception_redacted(
+            logger,
+            API_APP_STARTUP,
+            exc,
+            service="coordinator",
+            context="resolve_failed",
+            note="decomposition / routing-scorer / workspace config resolve failed",
         )
-        scorer_task = tg.create_task(_resolve_routing_scorer_config(app_state))
-        workspace_task = tg.create_task(_build_workspace_strategy(app_state))
+        raise
     decomposition_model = model_task.result()
     routing_scorer_config = scorer_task.result()
     workspace_strategy, workspace_config = workspace_task.result()
@@ -804,16 +818,26 @@ async def build_runtime_services(
         provider_name=names[0],
         seed=red_team_seed,
     )
+    vision_gate = _build_vision_gate_or_none(
+        app_state=app_state,
+        workspace_root=workspace_root,
+        provider=provider,
+    )
+    logger.info(
+        API_APP_STARTUP,
+        service="runtime_services",
+        mode="agent_engine_built",
+        coordinator_wired=coordinator is not None,
+        work_pipeline_wired=work_pipeline is not None,
+        red_team_wired=red_team_runtime is not None,
+        vision_gate_wired=vision_gate is not None,
+    )
     return RuntimeServices(
         worker_execution_service=worker_execution_service,
         coordinator=coordinator,
         work_pipeline=work_pipeline,
         red_team_runtime=red_team_runtime,
-        vision_gate=_build_vision_gate_or_none(
-            app_state=app_state,
-            workspace_root=workspace_root,
-            provider=provider,
-        ),
+        vision_gate=vision_gate,
     )
 
 

--- a/src/synthorg/workers/runtime_builder.py
+++ b/src/synthorg/workers/runtime_builder.py
@@ -181,12 +181,15 @@ def _select_active_provider(
     Logs the empty-company path and the unsupported multi-provider
     fan-in so the boot decision is observable.
     """
+    security = app_state.config.security
     if not app_state.has_active_provider:
         logger.info(
             API_APP_STARTUP,
             service="runtime_services",
             mode="no_provider",
             note="empty company -- task execution rejected at the seam",
+            security_enabled=security.enabled,
+            security_enforcement_mode=security.enforcement_mode.value,
         )
         return None
 
@@ -198,6 +201,8 @@ def _select_active_provider(
             service="runtime_services",
             mode="no_provider",
             note="provider registry present but empty",
+            security_enabled=security.enabled,
+            security_enforcement_mode=security.enforcement_mode.value,
         )
         return None
     if len(names) > 1:
@@ -752,12 +757,15 @@ async def build_runtime_services(
         provider,
         coordination_metrics_collector,
     )
+    security = app_state.config.security
     logger.info(
         API_APP_STARTUP,
         service="runtime_services",
         mode="agent_engine",
         provider=names[0],
         tool_count=tool_count,
+        security_enabled=security.enabled,
+        security_enforcement_mode=security.enforcement_mode.value,
     )
     # The env runner provisions the declaration into the same backend the
     # build/test tool categories resolve to (not necessarily Docker), so

--- a/tests/unit/workers/test_runtime_builder.py
+++ b/tests/unit/workers/test_runtime_builder.py
@@ -67,6 +67,7 @@ def _provider_app_state(  # noqa: PLR0913 -- test builder with keyword-only knob
     workspace: Path,
     *,
     bridge_config_error: Exception | None = None,
+    decomposition_error: Exception | None = None,
     cost_tracker: CostTracker | None = None,
     coordination_metrics_store: CoordinationMetricsStore | None = None,
     simulation_runtime: bool = False,
@@ -75,6 +76,9 @@ def _provider_app_state(  # noqa: PLR0913 -- test builder with keyword-only knob
 
     ``bridge_config_error`` makes ``get_engine_bridge_config`` raise, to
     exercise the fail-open routing-scorer-config resolve branch.
+    ``decomposition_error`` makes ``get_str`` raise on the
+    ``decomposition_model`` key, to exercise the
+    ``_build_runtime_coordinator`` redacted-log + re-raise branch.
     ``cost_tracker`` (and the paired ``coordination_metrics_store``)
     drive the coordination-metrics collector wiring: absent, the
     collector is not constructed (mirrors the empty/degraded path).
@@ -83,6 +87,20 @@ def _provider_app_state(  # noqa: PLR0913 -- test builder with keyword-only knob
         bridge_mock = AsyncMock(return_value=EngineBridgeConfig())
     else:
         bridge_mock = AsyncMock(side_effect=bridge_config_error)
+    if decomposition_error is None:
+        get_str_mock = AsyncMock(side_effect=_get_str)
+    else:
+        # Narrow-raise on the decomposition key only so the upstream
+        # boot calls (browser settings, sandbox images, etc.) still
+        # resolve normally; we want the failure to surface from the
+        # `_build_runtime_coordinator` TaskGroup, not from
+        # `_build_tool_registry` upstream of it.
+        async def _get_str_failing(namespace: str, key: str) -> str:
+            if key == "decomposition_model":
+                raise decomposition_error
+            return await _get_str(namespace, key)
+
+        get_str_mock = AsyncMock(side_effect=_get_str_failing)
     # ``mock_of[T](...)`` is ``Any`` by design; cast back to the spec so
     # the helper keeps a precise signature for its callers.
     return cast(
@@ -93,7 +111,7 @@ def _provider_app_state(  # noqa: PLR0913 -- test builder with keyword-only knob
             config=RootConfig(company_name="test-corp"),
             config_resolver=mock_of[ConfigResolver](
                 get_float=AsyncMock(return_value=30.0),
-                get_str=AsyncMock(side_effect=_get_str),
+                get_str=get_str_mock,
                 get_int=AsyncMock(return_value=1),
                 get_engine_bridge_config=bridge_mock,
             ),
@@ -310,6 +328,7 @@ class TestBootLogSafetySpineState:
         self,
         tmp_path: Path,
     ) -> None:
+        """Empty-company boot still emits the safety-spine fields."""
         app_state = mock_of[AppState](
             has_active_provider=False,
             config=RootConfig(company_name="empty-co"),
@@ -326,6 +345,7 @@ class TestBootLogSafetySpineState:
         self,
         tmp_path: Path,
     ) -> None:
+        """Provider-registry-empty boot still emits the safety-spine fields."""
         app_state = mock_of[AppState](
             has_active_provider=True,
             provider_registry=ProviderRegistry({}),
@@ -342,6 +362,13 @@ class TestBootLogSafetySpineState:
         self,
         tmp_path: Path,
     ) -> None:
+        """Provider-present boot emits the spine fields on both startup events.
+
+        The ``agent_engine`` decision log AND the post-construction
+        ``agent_engine_built`` summary log must both surface the spine
+        state -- otherwise operators reading the boot trail see schema
+        drift between the two ``runtime_services`` events.
+        """
         registry = ProviderRegistry.from_config(
             {"test-provider": ProviderConfig(driver="scripted")}
         )
@@ -352,6 +379,81 @@ class TestBootLogSafetySpineState:
         agent_engine = next(e for e in runtime_logs if e.get("mode") == "agent_engine")
         assert agent_engine["security_enabled"] is True
         assert agent_engine["security_enforcement_mode"] == "active"
+        agent_engine_built = next(
+            e for e in runtime_logs if e.get("mode") == "agent_engine_built"
+        )
+        assert agent_engine_built["security_enabled"] is True
+        assert agent_engine_built["security_enforcement_mode"] == "active"
+
+
+class TestRuntimeCoordinatorResolveFailure:
+    """The coordinator resolve-failure path logs redacted context and re-raises.
+
+    The ``_build_runtime_coordinator`` TaskGroup runs three independent
+    config resolves (decomposition model, routing-scorer bridge,
+    workspace strategy). When any of them raises an
+    ``ExceptionGroup``-propagated error, the wrapper must record the
+    failure with the SecOps-safe redactor and surface the exception to
+    the boot caller so the API doesn't come up with a half-wired
+    coordinator.
+    """
+
+    async def test_resolve_failure_logs_and_propagates(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Decomposition resolve failure surfaces a redacted log + raises."""
+        registry = ProviderRegistry.from_config(
+            {"test-provider": ProviderConfig(driver="scripted")}
+        )
+        app_state = _provider_app_state(
+            registry,
+            tmp_path,
+            decomposition_error=RuntimeError("decomposition backend unreachable"),
+        )
+        with (
+            capture_logs() as logs,
+            pytest.raises(BaseExceptionGroup) as excinfo,
+        ):
+            await build_runtime_services(app_state, workspace_root=tmp_path)
+        # TaskGroup collapses task failures into a BaseExceptionGroup
+        # whose ``str()`` is the generic "unhandled errors in a TaskGroup"
+        # banner -- the original RuntimeError must travel inside it
+        # (asserted by manual unwrap, not by ``pytest.raises(match=...)``
+        # which only matches the outer banner).
+        flattened = list(excinfo.value.exceptions)
+        assert any(
+            isinstance(exc, RuntimeError)
+            and "decomposition backend unreachable" in str(exc)
+            for exc in flattened
+        )
+        coordinator_failure = next(
+            (
+                entry
+                for entry in logs
+                if entry.get("event") == API_APP_STARTUP
+                and entry.get("service") == "coordinator"
+                and entry.get("context") == "resolve_failed"
+            ),
+            None,
+        )
+        assert coordinator_failure is not None, (
+            "coordinator resolve_failed log not emitted"
+        )
+        # The redactor surfaces the typed exception name and the
+        # canonical ``{Type}: {scrubbed-message}`` shape, never the raw
+        # traceback -- attaching ``exc_info`` would serialise the
+        # frame-locals (incl. any in-scope credential) into the record.
+        # ``_build_runtime_coordinator`` catches the TaskGroup's
+        # ExceptionGroup wrapper, so the typed name on the log is
+        # ``ExceptionGroup`` (the original ``RuntimeError`` is asserted
+        # above on the propagated exception).
+        assert coordinator_failure["error_type"] == "ExceptionGroup"
+        assert coordinator_failure["error"].startswith("ExceptionGroup")
+        assert coordinator_failure["note"].startswith(
+            "decomposition / routing-scorer / workspace config resolve failed"
+        )
+        assert "exc_info" not in coordinator_failure
 
 
 class TestCoordinationMetricsWiring:

--- a/tests/unit/workers/test_runtime_builder.py
+++ b/tests/unit/workers/test_runtime_builder.py
@@ -1,10 +1,12 @@
 """Unit tests for the provider-present runtime-services switch."""
 
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
+from structlog.testing import capture_logs
 
 from synthorg.api.state import AppState
 from synthorg.budget.coordination_collector import CoordinationMetricsCollector
@@ -19,6 +21,7 @@ from synthorg.engine.intake.models import IntakeResult
 from synthorg.engine.pipeline.service import DefaultWorkPipeline
 from synthorg.engine.task_engine import TaskEngine
 from synthorg.hr.registry import AgentRegistryService
+from synthorg.observability.events.api import API_APP_STARTUP
 from synthorg.persistence.project_protocol import ProjectRepository
 from synthorg.persistence.protocol import PersistenceBackend
 from synthorg.providers.registry import ProviderRegistry
@@ -281,6 +284,74 @@ class TestProviderPresentSwitch:
         )
         assert isinstance(result.coordinator, MultiAgentCoordinator)
         assert deep.is_dir()
+
+
+class TestBootLogSafetySpineState:
+    """The boot log carries the safety-spine state on every branch.
+
+    Operators reading ``synthorg.log`` must see whether the SecOps
+    interceptor is ``active`` / ``shadow`` / ``disabled`` at startup
+    without grepping config files; the agent runtime's go/no-go decision
+    log is the single observable place for it.
+    """
+
+    @staticmethod
+    def _runtime_services_logs(
+        logs: Sequence[Mapping[str, Any]],
+    ) -> list[Mapping[str, Any]]:
+        return [
+            entry
+            for entry in logs
+            if entry.get("event") == API_APP_STARTUP
+            and entry.get("service") == "runtime_services"
+        ]
+
+    async def test_no_provider_log_carries_safety_spine_state(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        app_state = mock_of[AppState](
+            has_active_provider=False,
+            config=RootConfig(company_name="empty-co"),
+        )
+        with capture_logs() as logs:
+            await build_runtime_services(app_state, workspace_root=tmp_path)
+        runtime_logs = self._runtime_services_logs(logs)
+        assert runtime_logs, "no runtime_services boot log captured"
+        no_provider = next(e for e in runtime_logs if e.get("mode") == "no_provider")
+        assert no_provider["security_enabled"] is True
+        assert no_provider["security_enforcement_mode"] == "active"
+
+    async def test_empty_registry_log_carries_safety_spine_state(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        app_state = mock_of[AppState](
+            has_active_provider=True,
+            provider_registry=ProviderRegistry({}),
+            config=RootConfig(company_name="registry-empty-co"),
+        )
+        with capture_logs() as logs:
+            await build_runtime_services(app_state, workspace_root=tmp_path)
+        runtime_logs = self._runtime_services_logs(logs)
+        no_provider = next(e for e in runtime_logs if e.get("mode") == "no_provider")
+        assert no_provider["security_enabled"] is True
+        assert no_provider["security_enforcement_mode"] == "active"
+
+    async def test_provider_present_log_carries_safety_spine_state(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        registry = ProviderRegistry.from_config(
+            {"test-provider": ProviderConfig(driver="scripted")}
+        )
+        app_state = _provider_app_state(registry, tmp_path)
+        with capture_logs() as logs:
+            await build_runtime_services(app_state, workspace_root=tmp_path)
+        runtime_logs = self._runtime_services_logs(logs)
+        agent_engine = next(e for e in runtime_logs if e.get("mode") == "agent_engine")
+        assert agent_engine["security_enabled"] is True
+        assert agent_engine["security_enforcement_mode"] == "active"
 
 
 class TestCoordinationMetricsWiring:


### PR DESCRIPTION
## Summary

Audit follow-up to merged #1956 (PR #2003 "Agent runtime online + minimal safety spine"). The audit found 13 of 14 acceptance / scope items PASS; the only WEAK item (composed end-to-end test) was already covered by `tests/e2e/test_runtime_online_seam.py`. The single genuine gap was operator observability of the SecOps spine state at boot. This PR closes that gap.

Closes #2096.

## What changed

**Runtime-services boot log carries the safety-spine state** so operators reading `synthorg.log` can see, at a glance, whether the SecOps interceptor will be `active` / `shadow` / `disabled` once a provider runs. Two structured kwargs (`security_enabled`, `security_enforcement_mode`) added to all three `logger.info(API_APP_STARTUP, service="runtime_services", ...)` call sites in `src/synthorg/workers/runtime_builder.py` (the two no-provider branches in `_select_active_provider` and the provider-present branch in `build_runtime_services`).

**Three pre-PR-review findings folded in by user request:**

- `# module-kind: orchestrator` header added to `src/synthorg/workers/runtime_builder.py` (was defaulting to `code` tier with cap 500 but is an orchestrator at 840 gate-LOC; cap is now correctly `orchestrator` 600 with the baseline carrying the actual size).
- `# module-kind: service` header added to `src/synthorg/workers/execution_service.py` (sibling classification gap; same shape).
- Try / except around the `_build_runtime_coordinator` TaskGroup so a failure in decomposition / routing-scorer / workspace config resolve logs operator context (via `log_exception_redacted`) before propagating, instead of escaping silently.
- New summary `logger.info(API_APP_STARTUP, mode="agent_engine_built", ...)` at the end of `build_runtime_services` reporting which optional subsystems (coordinator, work pipeline, red team, vision gate) wired, so operators can see the final boot shape in one line.

## Test plan

- `tests/unit/workers/test_runtime_builder.py` adds a `TestBootLogSafetySpineState` class with three tests asserting the new `security_enabled` + `security_enforcement_mode` kwargs appear on each of the three boot branches (no-provider, empty-registry, provider-present), using `structlog.testing.capture_logs`.
- Pre-push gates ran clean locally: ruff, ruff-format, mypy (affected), pytest-unit (affected), all convention gates including `module-size budget` and `no-ghost-wiring`.
- E2E acceptance is already proven by `tests/e2e/test_runtime_online_seam.py::test_runtime_executes_task_through_seam_with_safety_spine` (unchanged).

## Review coverage

Pre-reviewed by 4 agents per "reduced agent count" instruction: `code-reviewer` (APPROVED), `python-reviewer` (APPROVED), `logging-audit` (COMPLIANT), `conventions-enforcer` (1 MAJOR + 1 MEDIUM). Mandatory `docs-consistency` / `comment-quality-rot` / mini-pass agents skipped per explicit user instruction (no docs, no comment narrative, no ghost wiring introduced).

All four valid findings (MAJOR + MEDIUM + 2 SUGGESTION) applied in this PR per user direction.

## Files

- `src/synthorg/workers/runtime_builder.py` (+23 gate-LOC: 3 log sites + 2 local vars + try / except wrapper + summary log + module-kind header)
- `src/synthorg/workers/execution_service.py` (module-kind header only; 0 gate-LOC)
- `tests/unit/workers/test_runtime_builder.py` (new `TestBootLogSafetySpineState` class; +73 lines)
- `scripts/_module_size_baseline.json` (mechanical baseline bump 809 to 840 for `runtime_builder.py`; user-approved)
- `.codespellrc` (added `.test_durations.unit,.test_durations.integration` to skip list; was blocking pre-commit on a deliberate `parse_bool` test parametrize ID)

## Manifest

No new `_ghost_wiring_manifest.txt` entries. `AgentEngine` is already `ENFORCED` from #1956.