### PR TITLE
refactor(web): PR A foundation, decompose oversized utils/hooks/lib (#2092)

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -4,7 +4,7 @@
 # real filename, so we use ``*package-lock.json`` (path-separator agnostic)
 # to match the lock files on both POSIX and Windows. ``.codespellrc`` is
 # self-skipped so this file's own directives are never scanned as content.
-skip = .venv,.git,.mypy_cache,.ruff_cache,.pytest_cache,.cache,.claude,node_modules,build,dist,htmlcov,coverage,.coverage,logs,*.log,*.log.*,*.lock,*.png,*.svg,*.jpg,*.jpeg,*.ico,*.gif,*.webp,*.pdf,*.bin,*_pb2.py,*.gen.*,*.min.js,_vendor,web/dist,web/build,storybook-static,site,_site,_audit,*.svg.gz,scripts/_codespell_baseline.txt,*package-lock.json,uv.lock,.codespellrc
+skip = .venv,.git,.mypy_cache,.ruff_cache,.pytest_cache,.cache,.claude,node_modules,build,dist,htmlcov,coverage,.coverage,logs,*.log,*.log.*,*.lock,*.png,*.svg,*.jpg,*.jpeg,*.ico,*.gif,*.webp,*.pdf,*.bin,*_pb2.py,*.gen.*,*.min.js,_vendor,web/dist,web/build,storybook-static,site,_site,_audit,*.svg.gz,scripts/_codespell_baseline.txt,*package-lock.json,uv.lock,.codespellrc,.test_durations.unit,.test_durations.integration
 # Project vocabulary lives in .vale/styles/Vocab/SynthOrg/accept.txt (one term per line).
 # Vale (when wired) consumes the same file; sharing it keeps the two spellers in lock-step.
 ignore-words = .vale/styles/Vocab/SynthOrg/accept.txt

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -7,6 +7,7 @@
   "_comment_MD041": "first-line-heading: docs start with MkDocs frontmatter, not an H1",
   "_comment_MD046": "code-block-style: MkDocs Material tabbed content requires indented prose that markdownlint misreads as code",
   "_comment_MD025": "single-title: pages carry a front-matter `title:` (used by MkDocs nav) AND an in-body `# Heading` (used by direct GitHub rendering). Empty `front_matter_title` tells markdownlint not to count the front-matter title as a top-level heading.",
+  "_comment_MD060": "table-column-style: separator rows (|---|---|) read compact; data rows carry padding for readability. Tables in this project are content-heavy (exemption ledgers, tier tables, audit tables) and the mixed style is intentional.",
   "default": true,
   "MD013": false,
   "MD024": false,
@@ -15,5 +16,6 @@
   "MD033": false,
   "MD036": false,
   "MD041": false,
-  "MD046": false
+  "MD046": false,
+  "MD060": false
 }

--- a/docs/decisions/0006-tiered-module-size-policy.md
+++ b/docs/decisions/0006-tiered-module-size-policy.md
@@ -322,7 +322,7 @@ and closed for the project to reach 100% strict enforcement.
 | Ruff `ERA001` (49 sites) | Issue #2063: "Remove commented-out code (ERA001)" | Small |
 | Ruff `DOC201/202/501` on `src/synthorg/**` | Issue #2065: "Docstring Returns/Raises backfill + interrogate threshold flip" | Large |
 | Interrogate `fail_under` 90 -> 95 | Same as DOC backfill | Medium |
-| ESLint `complexity / max-lines / max-lines-per-function / max-params` exempted on `src/**/*.{ts,tsx}` | EPIC #2066: "Web component-size ratchet: decompose oversized React components" | Large (no existing PR in EPIC) |
+| ESLint `complexity / max-lines / max-lines-per-function / max-params` exempted on `src/**/*.{ts,tsx}` | EPIC #2066: "Web component-size ratchet: decompose oversized React components", sliced into 4 sub-issues: #2092 (Foundation: utils + hooks + lib), #2093 (Stores incl. websocket), #2094 (Components + API types/endpoints), #2095 (Pages + override deletion). The override block at `web/eslint.config.js:141-167` grows an `ignores:` list per sub-issue; PR D deletes the block. | Large (4 PRs filed) |
 | Go `gocyclo / funlen / gocognit / nestif / revive` path-excluded across `cli/internal/**` + `cmd/**` | Issue #2067: "CLI complexity ratchet: per-package lift" | Medium |
 | `vulture` `ignore_names` (7 entries) | Issue #2073: "Replace vulture ignore_names with explicit unused-marker pattern" | Trivial |
 | `sqlfluff` `rules = ambiguous, references` (layout/capitalisation/aliasing all disabled) | EPIC #2076: "SQL style cleanup: enable full sqlfluff ruleset" | Large |

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -105,6 +105,12 @@ See [docs/reference/web-design-system.md](../docs/reference/web-design-system.md
 
 Lint runs via `npm --prefix web run lint` with `--max-warnings 0`. To enumerate stale `eslint-disable` directives after a rule reshuffle: `npm --prefix web run lint -- --report-unused-disable-directives-severity=warn`.
 
+### Tiered caps + per-bucket ratchet (EPIC #2066)
+
+The four caps (`complexity: 8`, `max-lines: 400`, `max-lines-per-function: 80`, `max-params: 5`) mirror the Python pylint thresholds and the module-size tier table in `docs/decisions/0006-tiered-module-size-policy.md`. They apply globally except where the override block at `web/eslint.config.js:141-167` disables them; the override gains an `ignores:` entry per EPIC #2066 sub-issue as each bucket lands, and the final PR deletes the block entirely. New code in an already-cleaned bucket MUST respect the caps.
+
+The canonical refactor pattern for keeping a function under `complexity: 8` is **table-driven dispatch**: replace a multi-arm `if`/`switch` ladder with a `Readonly<Record<K, V>>` lookup, optionally typed with `as const satisfies Record<K, V>` for exhaustiveness against an enum/union. See `utils/errors.ts` (`CONFLICT_MESSAGES`, `CATEGORY_TITLES`, `STATUS_TITLES`, `STATUS_FALLBACK_MESSAGES`), `utils/provider-status.ts` (`_hasRequiredCredentials` exhaustive `Record<AuthType, boolean>`), `hooks/use-list-shortcuts.ts` (`KEY_TO_ACTION`), and `hooks/useToolbarKeyboardNav.ts` (`TOOLBAR_INDEX_FNS`) for worked examples. For a function whose body is too long, extract per-stage helpers (`utils/fetch-with-retry.ts` splits the retry loop into `_decideRetryWait` / `_performRetrySleep` / `_shouldKeepRetrying`); for an oversized hook, extract sub-hooks (`hooks/usePolling.ts::usePollRefs`, `hooks/useAgentDetailData.ts::{useDetailStoreSlice, useDetailLifecycle, useDetailWebSocket}`). Sub-hook names MUST start with `use` (rules-of-hooks); no leading underscore.
+
 ## Post-Training Reference
 
 TypeScript 6 and Storybook 10 were released after Claude's training cutoff. Key gotchas: TS6 `baseUrl` is deprecated and `esModuleInterop` is always true; `types` defaults to `[]` so `vitest/globals` etc. need explicit listing. Storybook 10 is ESM-only; essentials are built into core, but `@storybook/addon-docs` is now separate; imports moved to `storybook/test` and `storybook/actions`.

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -142,10 +142,22 @@ export default tseslint.config(
     // Existing src/ files exceed the new caps in 500+ sites. Mirroring
     // the Python ruff per-file-ignore pattern for src/synthorg/**, the
     // same rules are absorbed here until later decomposition (controllers,
-    // store slicing) brings the surface under the tier limits. New
-    // components landing in clean modules can re-enable locally; the
-    // top-level config block declares the cap globally.
+    // store slicing) brings the surface under the tier limits.
+    //
+    // EPIC #2066 lifts the override one bucket at a time. Each PR moves
+    // a cleaned area into the `ignores:` list (which excludes those
+    // paths from this override block, so the global four caps apply).
+    // The final PR deletes the whole override block.
+    //
+    // Cleaned (rules apply normally):
+    //   PR A (#2092): src/utils/**, src/hooks/**, src/lib/**, src/cookie-shim.ts
     files: ['src/**/*.{ts,tsx}'],
+    ignores: [
+      'src/utils/**',
+      'src/hooks/**',
+      'src/lib/**',
+      'src/cookie-shim.ts',
+    ],
     rules: {
       complexity: 'off',
       'max-lines': 'off',

--- a/web/src/__tests__/utils/errors.test.ts
+++ b/web/src/__tests__/utils/errors.test.ts
@@ -1,16 +1,25 @@
 import { AxiosError, type AxiosResponse } from 'axios'
-import { formatBatchErrors, getErrorMessage, getErrorDetail, isAxiosError } from '@/utils/errors'
+import {
+  formatBatchErrors,
+  getCrudErrorTitle,
+  getErrorCode,
+  getErrorDetail,
+  getErrorMessage,
+  isAxiosError,
+} from '@/utils/errors'
 import { ErrorCategory, ErrorCode, type ErrorDetail } from '@/api/types/errors'
 
 function makeAxiosError(
   status: number | undefined,
   data?: Record<string, unknown>,
   headers: Record<string, string> = {},
+  url?: string,
 ): AxiosError {
+  const config = { url: url ?? '' } as AxiosResponse['config']
   const error = new AxiosError(
     'Request failed',
     status ? 'ERR_BAD_RESPONSE' : 'ERR_NETWORK',
-    undefined,
+    config,
     undefined,
     status
       ? {
@@ -18,11 +27,27 @@ function makeAxiosError(
           data,
           headers,
           statusText: 'Error',
-          config: {} as AxiosResponse['config'],
+          config,
         } as AxiosResponse
       : undefined,
   )
   return error
+}
+
+function makeDetail(
+  category: ErrorCategory,
+  code: ErrorCode = ErrorCode.RESOURCE_NOT_FOUND,
+): ErrorDetail {
+  return {
+    detail: 'test detail',
+    error_code: code,
+    error_category: category,
+    retryable: false,
+    retry_after: null,
+    instance: 'req-x',
+    title: 'Test',
+    type: 'https://docs.example.com/errors/test',
+  }
 }
 
 describe('isAxiosError', () => {
@@ -170,6 +195,61 @@ describe('getErrorMessage', () => {
     expect(getErrorMessage(error)).toContain('connectivity')
   })
 
+  it('returns transient connectivity hint for 504', () => {
+    const error = makeAxiosError(504)
+    expect(getErrorMessage(error)).toContain('connectivity')
+  })
+
+  it('mentions setup-completion in 429 toast when the request hit /setup/complete', () => {
+    const error = makeAxiosError(429, undefined, {}, '/api/v1/setup/complete')
+    expect(getErrorMessage(error)).toContain('setup completion')
+  })
+
+  it('mentions setup-completion in 409 toast when the request hit /setup/complete', () => {
+    const error = makeAxiosError(409, undefined, {}, '/api/v1/setup/complete')
+    expect(getErrorMessage(error)).toContain('Setup is already complete')
+  })
+
+  it('falls back to generic 422 message when data.error is a Pydantic-shaped string and detail is absent', () => {
+    // Pydantic v2 phrasing such as "Input should be a valid integer" leaks
+    // internal type names; the helper must suppress it and return the
+    // curated message instead.
+    const error = makeAxiosError(422, { error: 'Input should be a valid integer' })
+    expect(getErrorMessage(error)).toBe(
+      'Validation error. Please check the highlighted fields and try again.',
+    )
+  })
+
+  it('surfaces clean (non-Pydantic) data.error string verbatim for 422 when structured detail is absent', () => {
+    const error = makeAxiosError(422, { error: 'Project name must be unique within the workspace.' })
+    expect(getErrorMessage(error)).toBe(
+      'Project name must be unique within the workspace.',
+    )
+  })
+
+  it('falls back to generic 4xx copy for an unmapped client status (418)', () => {
+    const error = makeAxiosError(418)
+    expect(getErrorMessage(error)).toBe('Request failed (418). Please check your input.')
+  })
+
+  it('returns 1-minute (not 1 minutes) for a 60s Retry-After', () => {
+    const error = makeAxiosError(429, undefined, { 'retry-after': '60' })
+    expect(getErrorMessage(error)).toContain('1 minute')
+    expect(getErrorMessage(error)).not.toContain('1 minutes')
+  })
+
+  it('returns 1-hour (not 1 hours) for a 3600s Retry-After', () => {
+    const error = makeAxiosError(429, undefined, { 'retry-after': '3600' })
+    expect(getErrorMessage(error)).toContain('1 hour')
+    expect(getErrorMessage(error)).not.toContain('1 hours')
+  })
+
+  it('parses HTTP-date Retry-After header into a future duration', () => {
+    const future = new Date(Date.now() + 90_000).toUTCString()
+    const error = makeAxiosError(429, undefined, { 'retry-after': future })
+    expect(getErrorMessage(error)).toContain('Try again in')
+  })
+
   it('returns Error.message for non-axios Error with short message', () => {
     expect(getErrorMessage(new Error('Something went wrong'))).toBe('Something went wrong')
   })
@@ -229,6 +309,77 @@ describe('formatBatchErrors', () => {
   it('preserves first-occurrence ordering across distinct reasons', () => {
     const out = formatBatchErrors(['a', 'b', 'a'])
     expect(out).toBe('2× a; b')
+  })
+})
+
+describe('getCrudErrorTitle', () => {
+  it('returns the fallback title for non-axios errors with no detail', () => {
+    expect(getCrudErrorTitle(new Error('boom'), 'Failed to save project').title).toBe(
+      'Failed to save project',
+    )
+  })
+
+  it('returns "Permission denied" for 403 even if a structured AUTH detail is present', () => {
+    // 403 short-circuits before the structured-category switch so the
+    // operator sees "denied" not "Authentication failed".
+    const error = makeAxiosError(403, { error_detail: makeDetail(ErrorCategory.AUTH) })
+    expect(getCrudErrorTitle(error, 'Failed').title).toBe('Permission denied')
+  })
+
+  it('maps each ErrorCategory to its expected title', () => {
+    const cases: Array<[ErrorCategory, string]> = [
+      [ErrorCategory.AUTH, 'Authentication failed'],
+      [ErrorCategory.VALIDATION, 'Validation failed'],
+      [ErrorCategory.CONFLICT, 'Resource conflict'],
+      [ErrorCategory.RATE_LIMIT, 'Rate limit reached'],
+      [ErrorCategory.NOT_FOUND, 'Not found'],
+      [ErrorCategory.BUDGET_EXHAUSTED, 'Budget exhausted'],
+      [ErrorCategory.PROVIDER_ERROR, 'Provider error'],
+    ]
+    for (const [category, expected] of cases) {
+      const error = makeAxiosError(400, { error_detail: makeDetail(category) })
+      expect(getCrudErrorTitle(error, 'fallback').title).toBe(expected)
+    }
+  })
+
+  it('falls through ErrorCategory.INTERNAL to the HTTP-status / fallback branch', () => {
+    // 500 INTERNAL detail with no special status mapping should land on
+    // the caller-supplied fallback string, not a category-derived title.
+    const error = makeAxiosError(500, { error_detail: makeDetail(ErrorCategory.INTERNAL) })
+    expect(getCrudErrorTitle(error, 'Failed to save').title).toBe('Failed to save')
+  })
+
+  it('uses HTTP-status fallback titles when no structured detail is present', () => {
+    const cases: Array<[number, string]> = [
+      [401, 'Authentication failed'],
+      [404, 'Not found'],
+      [409, 'Resource conflict'],
+      [422, 'Validation failed'],
+      [429, 'Rate limit reached'],
+    ]
+    for (const [status, expected] of cases) {
+      expect(getCrudErrorTitle(makeAxiosError(status), 'fallback').title).toBe(expected)
+    }
+  })
+
+  it('returns the caller fallback for non-axios errors', () => {
+    expect(getCrudErrorTitle('a string', 'Failed to update agent').title).toBe(
+      'Failed to update agent',
+    )
+  })
+})
+
+describe('getErrorCode', () => {
+  it('returns the structured error_code when present', () => {
+    const detail = makeDetail(ErrorCategory.CONFLICT, ErrorCode.DUPLICATE_RECORD)
+    expect(getErrorCode(makeAxiosError(409, { error_detail: detail }))).toBe(
+      ErrorCode.DUPLICATE_RECORD,
+    )
+  })
+
+  it('returns null when no structured detail is present', () => {
+    expect(getErrorCode(makeAxiosError(500))).toBeNull()
+    expect(getErrorCode(new Error('boom'))).toBeNull()
   })
 })
 

--- a/web/src/cookie-shim.ts
+++ b/web/src/cookie-shim.ts
@@ -52,43 +52,57 @@ export const cookieJar: Record<string, string> = Object.create(null) as Record<
   string
 >
 
+const RESERVED_COOKIE_NAMES = new Set(['__proto__', 'constructor', 'prototype'])
+
+function _isReservedCookieName(name: string): boolean {
+  return name === '' || RESERVED_COOKIE_NAMES.has(name)
+}
+
+/**
+ * Inspect one attribute segment of a `Set-Cookie` string. Returns true
+ * when the segment encodes a deletion (Max-Age=0 or a past Expires).
+ */
+function _segmentMarksDelete(segment: string): boolean {
+  const attr = segment.trim().toLowerCase()
+  if (attr === 'max-age=0') return true
+  if (!attr.startsWith('expires=')) return false
+  const expiresAt = Date.parse(attr.slice('expires='.length))
+  return Number.isFinite(expiresAt) && expiresAt <= Date.now()
+}
+
+function _attrsRequestDelete(segments: readonly string[]): boolean {
+  return segments.some(_segmentMarksDelete)
+}
+
+function _commitCookieWrite(raw: string): void {
+  if (typeof raw !== 'string') return
+  const segments = raw.split(';')
+  const pair = segments[0] ?? ''
+  const eq = pair.indexOf('=')
+  if (eq === -1) return
+  const name = pair.slice(0, eq).trim()
+  if (_isReservedCookieName(name)) return
+  const value = pair.slice(eq + 1).trim()
+  if (_attrsRequestDelete(segments.slice(1))) {
+    delete cookieJar[name]
+    return
+  }
+  cookieJar[name] = value
+}
+
+function _readCookieHeader(): string {
+  return Object.entries(cookieJar)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('; ')
+}
+
 export function installCookieShim(seedCsrf?: string): void {
   if (typeof document === 'undefined') return
 
   Object.defineProperty(Document.prototype, 'cookie', {
     configurable: true,
-    get: () =>
-      Object.entries(cookieJar)
-        .map(([k, v]) => `${k}=${v}`)
-        .join('; '),
-    set: (raw: string) => {
-      if (typeof raw !== 'string') return
-      const segments = raw.split(';')
-      const pair = segments[0] ?? ''
-      const eq = pair.indexOf('=')
-      if (eq === -1) return
-      const name = pair.slice(0, eq).trim()
-      const value = pair.slice(eq + 1).trim()
-      if (
-        !name ||
-        name === '__proto__' ||
-        name === 'constructor' ||
-        name === 'prototype'
-      )
-        return
-      const isDelete = segments.slice(1).some((segment) => {
-        const attr = segment.trim().toLowerCase()
-        if (attr === 'max-age=0') return true
-        if (!attr.startsWith('expires=')) return false
-        const expiresAt = Date.parse(attr.slice('expires='.length))
-        return Number.isFinite(expiresAt) && expiresAt <= Date.now()
-      })
-      if (isDelete) {
-        delete cookieJar[name]
-        return
-      }
-      cookieJar[name] = value
-    },
+    get: _readCookieHeader,
+    set: _commitCookieWrite,
   })
 
   if (seedCsrf !== undefined) {

--- a/web/src/hooks/use-list-shortcuts.ts
+++ b/web/src/hooks/use-list-shortcuts.ts
@@ -9,7 +9,7 @@ export interface UseListShortcutsOptions {
   onEdit?: (index: number) => void
   /** Handler when user presses Delete or Backspace on the selected row (destructive). */
   onDelete?: (index: number) => void
-  /** Handler for `/` -- focus the list's search input. */
+  /** Handler for `/`: focus the list's search input. */
   onFocusSearch?: () => void
   /** Disable all shortcuts (e.g. when a modal is open). */
   disabled?: boolean
@@ -20,11 +20,112 @@ export interface UseListShortcutsResult {
   setSelectedIndex: (index: number | null) => void
 }
 
+/** Two-press window for the `gg` jump-to-top shortcut. */
+const DOUBLE_G_WINDOW_MS = 500
+
 function isEditable(el: Element | null): boolean {
   if (!el) return false
   const tag = el.tagName
   if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
   return (el as HTMLElement).isContentEditable === true
+}
+
+interface ShortcutDeps {
+  readonly itemCount: number
+  readonly selectedIndex: number | null
+  readonly lastGRef: React.MutableRefObject<number>
+  readonly setSelectedIndex: React.Dispatch<React.SetStateAction<number | null>>
+  readonly onOpen?: (index: number) => void
+  readonly onEdit?: (index: number) => void
+  readonly onDelete?: (index: number) => void
+  readonly onFocusSearch?: () => void
+}
+
+type ShortcutAction = (event: KeyboardEvent, deps: ShortcutDeps) => void
+
+function _moveDown(event: KeyboardEvent, deps: ShortcutDeps): void {
+  if (deps.itemCount === 0) return
+  event.preventDefault()
+  deps.setSelectedIndex((prev) =>
+    prev === null ? 0 : Math.min(deps.itemCount - 1, prev + 1),
+  )
+}
+
+function _moveUp(event: KeyboardEvent, deps: ShortcutDeps): void {
+  if (deps.itemCount === 0) return
+  event.preventDefault()
+  deps.setSelectedIndex((prev) =>
+    prev === null ? 0 : Math.max(0, prev - 1),
+  )
+}
+
+function _jumpToTop(event: KeyboardEvent, deps: ShortcutDeps): void {
+  const now = Date.now()
+  if (now - deps.lastGRef.current >= DOUBLE_G_WINDOW_MS) {
+    deps.lastGRef.current = now
+    return
+  }
+  // Within the two-press window: reset the timer first (so a stale
+  // `g` does not chain with a future single `g`) then jump.
+  deps.lastGRef.current = 0
+  if (deps.itemCount === 0) return
+  event.preventDefault()
+  deps.setSelectedIndex(0)
+}
+
+function _jumpToBottom(event: KeyboardEvent, deps: ShortcutDeps): void {
+  if (deps.itemCount === 0) return
+  event.preventDefault()
+  deps.setSelectedIndex(deps.itemCount - 1)
+}
+
+function _invokeAt(
+  event: KeyboardEvent,
+  selectedIndex: number | null,
+  callback: ((index: number) => void) | undefined,
+): void {
+  if (selectedIndex === null || !callback) return
+  event.preventDefault()
+  callback(selectedIndex)
+}
+
+function _focusSearchAction(event: KeyboardEvent, deps: ShortcutDeps): void {
+  if (!deps.onFocusSearch) return
+  event.preventDefault()
+  deps.onFocusSearch()
+}
+
+/**
+ * Key-to-action dispatch table. Adding a new shortcut is a one-line
+ * insert here plus a small named handler above; the event handler in
+ * the effect stays a constant-complexity table lookup.
+ */
+const KEY_TO_ACTION: Readonly<Record<string, ShortcutAction>> = {
+  j: _moveDown,
+  ArrowDown: _moveDown,
+  k: _moveUp,
+  ArrowUp: _moveUp,
+  g: _jumpToTop,
+  G: _jumpToBottom,
+  Enter: (e, d) => _invokeAt(e, d.selectedIndex, d.onOpen),
+  e: (e, d) => _invokeAt(e, d.selectedIndex, d.onEdit),
+  Delete: (e, d) => _invokeAt(e, d.selectedIndex, d.onDelete),
+  Backspace: (e, d) => _invokeAt(e, d.selectedIndex, d.onDelete),
+  '/': _focusSearchAction,
+}
+
+function _isModifierEvent(event: KeyboardEvent): boolean {
+  return event.metaKey || event.ctrlKey || event.altKey
+}
+
+function _clampSelection(
+  prev: number | null,
+  itemCount: number,
+): number | null {
+  if (prev === null) return null
+  if (itemCount <= 0) return null
+  if (prev >= itemCount) return itemCount - 1
+  return prev
 }
 
 /**
@@ -52,99 +153,32 @@ export function useListShortcuts({
   const lastGRef = useRef<number>(0)
 
   // Clamp the selection when the list shrinks (or becomes empty) so we never
-  // keep a stale index pointing past the end of the array. We call
-  // setSelectedIndex via the functional updater so React coalesces the update
-  // when the previous and next values already match.
+  // keep a stale index pointing past the end of the array. The functional
+  // updater lets React coalesce no-op updates.
   useEffect(() => {
     // eslint-disable-next-line @eslint-react/set-state-in-effect -- itemCount-driven reconciliation, not a derived-state anti-pattern
-    setSelectedIndex((prev) => {
-      if (prev === null) return null
-      if (itemCount <= 0) return null
-      if (prev >= itemCount) return itemCount - 1
-      return prev
-    })
+    setSelectedIndex((prev) => _clampSelection(prev, itemCount))
   }, [itemCount])
 
   useEffect(() => {
     if (disabled) return
-    const handler = (event: KeyboardEvent) => {
-      if (event.metaKey || event.ctrlKey || event.altKey) return
+    const handler = (event: KeyboardEvent): void => {
+      if (_isModifierEvent(event)) return
       if (isEditable(document.activeElement)) return
-
-      const key = event.key
-      switch (key) {
-        case 'j':
-        case 'ArrowDown':
-          if (itemCount === 0) return
-          event.preventDefault()
-          setSelectedIndex((prev) => {
-            if (prev === null) return 0
-            return Math.min(itemCount - 1, prev + 1)
-          })
-          break
-        case 'k':
-        case 'ArrowUp':
-          if (itemCount === 0) return
-          event.preventDefault()
-          setSelectedIndex((prev) => {
-            if (prev === null) return 0
-            return Math.max(0, prev - 1)
-          })
-          break
-        case 'g': {
-          // Shift+g yields event.key === 'G' (handled below), so the
-          // lowercase branch only runs for the `g g` (jump-to-top) sequence.
-          const now = Date.now()
-          if (now - lastGRef.current < 500) {
-            if (itemCount === 0) {
-              // No items: clear the two-press window but do not set a
-              // phantom selection.
-              lastGRef.current = 0
-              return
-            }
-            event.preventDefault()
-            setSelectedIndex(0)
-            lastGRef.current = 0
-          } else {
-            lastGRef.current = now
-          }
-          break
-        }
-        case 'G':
-          if (itemCount === 0) return
-          event.preventDefault()
-          setSelectedIndex(itemCount - 1)
-          break
-        case 'Enter':
-          if (selectedIndex !== null && onOpen) {
-            event.preventDefault()
-            onOpen(selectedIndex)
-          }
-          break
-        case 'e':
-          if (selectedIndex !== null && onEdit) {
-            event.preventDefault()
-            onEdit(selectedIndex)
-          }
-          break
-        case 'Delete':
-        case 'Backspace':
-          if (selectedIndex !== null && onDelete) {
-            event.preventDefault()
-            onDelete(selectedIndex)
-          }
-          break
-        case '/':
-          if (onFocusSearch) {
-            event.preventDefault()
-            onFocusSearch()
-          }
-          break
-        default:
-          break
+      const action = KEY_TO_ACTION[event.key]
+      if (!action) return
+      const deps: ShortcutDeps = {
+        itemCount,
+        selectedIndex,
+        lastGRef,
+        setSelectedIndex,
+        onOpen,
+        onEdit,
+        onDelete,
+        onFocusSearch,
       }
+      action(event, deps)
     }
-
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
   }, [disabled, itemCount, onDelete, onEdit, onFocusSearch, onOpen, selectedIndex])

--- a/web/src/hooks/use-unsaved-changes-guard.ts
+++ b/web/src/hooks/use-unsaved-changes-guard.ts
@@ -225,19 +225,13 @@ export function useUnsavedChangesGuard<T = unknown>({
 
   const proceed = useCallback(() => {
     if (blocker.state !== 'blocked') return
-    // Kill any pending debounced write first so proceed() never leaves a
-    // phantom draft behind after the user confirmed discard.
-    if (draft.draftTimerRef.current) {
-      clearTimeout(draft.draftTimerRef.current)
-      draft.draftTimerRef.current = null
-    }
-    if (draftKey) {
-      removeDraft(draftKey)
-      draft.setHasDraft(false)
-    }
+    // discardDraft() centralises the cancel-timer / remove-storage /
+    // flip-state sequence; calling it here keeps proceed() from
+    // reimplementing the same teardown.
+    draft.discardDraft()
     onDiscard?.()
     blocker.proceed()
-  }, [blocker, draftKey, onDiscard, draft])
+  }, [blocker, onDiscard, draft])
 
   const cancel = useCallback(() => {
     if (blocker.state === 'blocked') blocker.reset()

--- a/web/src/hooks/use-unsaved-changes-guard.ts
+++ b/web/src/hooks/use-unsaved-changes-guard.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react'
 import { useBlocker } from 'react-router'
 import { createLogger } from '@/lib/logger'
 import { sanitizeForLog } from '@/utils/logging'
@@ -30,9 +30,9 @@ export interface UseUnsavedChangesGuardOptions {
 export interface UseUnsavedChangesGuardResult<T = unknown> {
   /** True when a confirmation dialog should be shown (navigation is pending). */
   confirmOpen: boolean
-  /** Confirm discard -- allows the pending navigation to proceed. */
+  /** Confirm discard: allows the pending navigation to proceed. */
   proceed: () => void
-  /** Cancel the discard -- keeps the user on the current page. */
+  /** Cancel the discard: keeps the user on the current page. */
   cancel: () => void
   /** Configured discard message (pass to ConfirmDialog as description). */
   message: string
@@ -78,6 +78,115 @@ function removeDraft(key: string): void {
   }
 }
 
+function _hasStoredDraft(key: string | undefined): boolean {
+  if (!key || typeof window === 'undefined') return false
+  try {
+    return window.localStorage.getItem(key) !== null
+  } catch (err) {
+    log.warn('failed to read draft on mount', { key: sanitizeForLog(key) }, err)
+    return false
+  }
+}
+
+interface UseBeforeUnloadGuardArgs {
+  readonly when: boolean
+}
+
+/**
+ * Wire `window.beforeunload` so the browser shows its native discard
+ * dialog when the user closes / reloads the tab with unsaved changes.
+ */
+function useBeforeUnloadGuard({ when }: UseBeforeUnloadGuardArgs): void {
+  useEffect(() => {
+    if (!when) return
+    const handler = (event: BeforeUnloadEvent): void => {
+      event.preventDefault()
+      // Chrome requires returnValue to be set (legacy).
+      event.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [when])
+}
+
+interface UseDraftPersistenceArgs {
+  readonly when: boolean
+  readonly draftKey?: string
+  readonly draftData?: () => unknown
+  readonly draftTrigger?: unknown
+  readonly draftDebounceMs: number
+}
+
+interface DraftPersistence<T> {
+  readonly hasDraft: boolean
+  readonly setHasDraft: (v: boolean) => void
+  readonly draftTimerRef: RefObject<ReturnType<typeof setTimeout> | null>
+  readonly restoreDraft: () => T | null
+  readonly discardDraft: () => void
+}
+
+/**
+ * Sub-hook owning localStorage draft persistence: initial mount state,
+ * debounced writes on every edit, and a `discardDraft` action that
+ * cancels any pending write before clearing storage.
+ */
+function useDraftPersistence<T>(args: UseDraftPersistenceArgs): DraftPersistence<T> {
+  const { when, draftKey, draftData, draftTrigger, draftDebounceMs } = args
+  const [hasDraft, setHasDraft] = useState<boolean>(() => _hasStoredDraft(draftKey))
+  const draftTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const draftDataRef = useRef(draftData)
+  draftDataRef.current = draftData
+
+  // Refresh hasDraft whenever draftKey changes so callers see the correct
+  // state after navigating between forms that share the hook.
+  useEffect(() => {
+    // eslint-disable-next-line @eslint-react/set-state-in-effect -- draftKey-driven reconciliation
+    setHasDraft(_hasStoredDraft(draftKey))
+  }, [draftKey])
+
+  // Debounced draft persistence. `draftTrigger` is any serialisable marker
+  // derived from the form payload that changes on every edit; we reschedule
+  // the debounce whenever it changes so subsequent edits land in storage too.
+  useEffect(() => {
+    if (!draftKey || !draftDataRef.current || !when) return
+    if (draftTimerRef.current) clearTimeout(draftTimerRef.current)
+    draftTimerRef.current = setTimeout(() => {
+      const serializer = draftDataRef.current
+      if (!serializer) return
+      // Only flip hasDraft to true on a successful write: a quota/privacy
+      // failure must not claim "you have a draft saved" when nothing is.
+      const wrote = writeDraft(draftKey, serializer())
+      if (wrote) setHasDraft(true)
+      draftTimerRef.current = null
+    }, draftDebounceMs)
+    return () => {
+      if (draftTimerRef.current) {
+        clearTimeout(draftTimerRef.current)
+        draftTimerRef.current = null
+      }
+    }
+  }, [when, draftKey, draftDebounceMs, draftTrigger])
+
+  const restoreDraft = useCallback<() => T | null>(
+    () => readDraft<T>(draftKey),
+    [draftKey],
+  )
+
+  const discardDraft = useCallback(() => {
+    if (!draftKey) return
+    // Cancel any in-flight debounced write so a queued setTimeout can't
+    // resurrect the draft immediately after we remove it.
+    if (draftTimerRef.current) {
+      clearTimeout(draftTimerRef.current)
+      draftTimerRef.current = null
+    }
+    removeDraft(draftKey)
+    setHasDraft(false)
+  }, [draftKey])
+
+  return { hasDraft, setHasDraft, draftTimerRef, restoreDraft, discardDraft }
+}
+
 /**
  * Intercept navigation while a form is dirty.
  *
@@ -104,120 +213,34 @@ export function useUnsavedChangesGuard<T = unknown>({
   const blocker = useBlocker(when)
   const confirmOpen = blocker.state === 'blocked'
 
-  // ---- beforeunload (tab close / reload) ----
-  useEffect(() => {
-    if (!when) return
-    const handler = (event: BeforeUnloadEvent) => {
-      event.preventDefault()
-      // Chrome requires returnValue to be set (legacy)
-      event.returnValue = ''
-    }
-    window.addEventListener('beforeunload', handler)
-    return () => window.removeEventListener('beforeunload', handler)
-  }, [when])
+  useBeforeUnloadGuard({ when })
 
-  // ---- localStorage draft persistence ----
-  const [hasDraft, setHasDraft] = useState<boolean>(() => {
-    if (!draftKey || typeof window === 'undefined') return false
-    // getItem itself can throw under storage quota / privacy / access
-    // restrictions. Treat a read failure as "no draft" rather than letting
-    // the hook mount throw.
-    try {
-      return window.localStorage.getItem(draftKey) !== null
-    } catch (err) {
-      log.warn('failed to read draft on mount', { key: sanitizeForLog(draftKey) }, err)
-      return false
-    }
+  const draft = useDraftPersistence<T>({
+    when,
+    draftKey,
+    draftData,
+    draftTrigger,
+    draftDebounceMs,
   })
-  const draftTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const draftDataRef = useRef(draftData)
-  draftDataRef.current = draftData
 
-  // Refresh hasDraft whenever draftKey changes so callers see the correct
-  // state after navigating between forms that share the hook.
-  useEffect(() => {
-    if (!draftKey || typeof window === 'undefined') {
-      // eslint-disable-next-line @eslint-react/set-state-in-effect -- draftKey-driven reconciliation
-      setHasDraft(false)
-      return
-    }
-    try {
-      // eslint-disable-next-line @eslint-react/set-state-in-effect -- draftKey-driven reconciliation
-      setHasDraft(window.localStorage.getItem(draftKey) !== null)
-    } catch (err) {
-      log.warn('failed to refresh hasDraft', { key: sanitizeForLog(draftKey) }, err)
-      // eslint-disable-next-line @eslint-react/set-state-in-effect -- draftKey-driven reconciliation
-      setHasDraft(false)
-    }
-  }, [draftKey])
-
-  // Debounced draft persistence. The caller passes a `draftTrigger` value
-  // (any serialisable marker derived from the form payload) that changes on
-  // every edit; when it changes we reschedule the debounce so subsequent
-  // edits also land in localStorage instead of only the first one.
-  useEffect(() => {
-    if (!draftKey || !draftDataRef.current) return
-    if (!when) return
-
-    if (draftTimerRef.current) clearTimeout(draftTimerRef.current)
-    draftTimerRef.current = setTimeout(() => {
-      const serializer = draftDataRef.current
-      if (!serializer) return
-      // Only flip hasDraft to true on a successful write -- a quota/privacy
-      // failure must not claim "you have a draft saved" when nothing is
-      // actually in storage.
-      const wrote = writeDraft(draftKey, serializer())
-      if (wrote) setHasDraft(true)
-      draftTimerRef.current = null
-    }, draftDebounceMs)
-
-    return () => {
-      if (draftTimerRef.current) {
-        clearTimeout(draftTimerRef.current)
-        draftTimerRef.current = null
-      }
-    }
-  }, [when, draftKey, draftDebounceMs, draftTrigger])
-
-  const restoreDraft = useCallback<() => T | null>(() => {
-    return readDraft<T>(draftKey)
-  }, [draftKey])
-
-  const discardDraft = useCallback(() => {
-    if (!draftKey) return
-    // Cancel any in-flight debounced write so a queued setTimeout can't
-    // resurrect the draft immediately after we remove it.
-    if (draftTimerRef.current) {
-      clearTimeout(draftTimerRef.current)
-      draftTimerRef.current = null
-    }
-    removeDraft(draftKey)
-    setHasDraft(false)
-  }, [draftKey])
-
-  // ---- blocker proceed / cancel ----
   const proceed = useCallback(() => {
-    if (blocker.state === 'blocked') {
-      // Kill any pending debounced write first so proceed() never leaves a
-      // phantom draft behind after the user confirmed discard.
-      if (draftTimerRef.current) {
-        clearTimeout(draftTimerRef.current)
-        draftTimerRef.current = null
-      }
-      if (draftKey) {
-        // User discarded changes; remove the draft so it doesn't confuse them next visit.
-        removeDraft(draftKey)
-        setHasDraft(false)
-      }
-      onDiscard?.()
-      blocker.proceed()
+    if (blocker.state !== 'blocked') return
+    // Kill any pending debounced write first so proceed() never leaves a
+    // phantom draft behind after the user confirmed discard.
+    if (draft.draftTimerRef.current) {
+      clearTimeout(draft.draftTimerRef.current)
+      draft.draftTimerRef.current = null
     }
-  }, [blocker, draftKey, onDiscard])
+    if (draftKey) {
+      removeDraft(draftKey)
+      draft.setHasDraft(false)
+    }
+    onDiscard?.()
+    blocker.proceed()
+  }, [blocker, draftKey, onDiscard, draft])
 
   const cancel = useCallback(() => {
-    if (blocker.state === 'blocked') {
-      blocker.reset()
-    }
+    if (blocker.state === 'blocked') blocker.reset()
   }, [blocker])
 
   return {
@@ -225,8 +248,8 @@ export function useUnsavedChangesGuard<T = unknown>({
     proceed,
     cancel,
     message,
-    hasDraft,
-    restoreDraft,
-    discardDraft,
+    hasDraft: draft.hasDraft,
+    restoreDraft: draft.restoreDraft,
+    discardDraft: draft.discardDraft,
   }
 }

--- a/web/src/hooks/useAgentDetailData.ts
+++ b/web/src/hooks/useAgentDetailData.ts
@@ -51,17 +51,32 @@ export interface UseAgentDetailDataReturn {
   fetchMoreActivity: () => void
 }
 
-export function useAgentDetailData(agentName: string): UseAgentDetailDataReturn {
-  const agent = useAgentsStore((s) => s.selectedAgent)
-  const performance = useAgentsStore((s) => s.performance)
-  const agentTasks = useAgentsStore((s) => s.agentTasks)
-  const activity = useAgentsStore((s) => s.activity)
-  const activityTotal = useAgentsStore((s) => s.activityTotal)
-  const careerHistory = useAgentsStore((s) => s.careerHistory)
-  const loading = useAgentsStore((s) => s.detailLoading)
-  const error = useAgentsStore((s) => s.detailError)
+interface DetailStoreSlice {
+  readonly agent: AgentConfig | null
+  readonly performance: AgentPerformanceSummary | null
+  readonly agentTasks: readonly Task[]
+  readonly activity: readonly AgentActivityEvent[]
+  readonly activityTotal: number
+  readonly careerHistory: readonly CareerEvent[]
+  readonly loading: boolean
+  readonly error: string | null
+}
 
-  // Initial fetch -- skip when agentName is empty (missing route param)
+function useDetailStoreSlice(): DetailStoreSlice {
+  return {
+    agent: useAgentsStore((s) => s.selectedAgent),
+    performance: useAgentsStore((s) => s.performance),
+    agentTasks: useAgentsStore((s) => s.agentTasks),
+    activity: useAgentsStore((s) => s.activity),
+    activityTotal: useAgentsStore((s) => s.activityTotal),
+    careerHistory: useAgentsStore((s) => s.careerHistory),
+    loading: useAgentsStore((s) => s.detailLoading),
+    error: useAgentsStore((s) => s.detailError),
+  }
+}
+
+function useDetailLifecycle(agentName: string): void {
+  // Initial fetch / cleanup. Skip when agentName is empty (missing route param).
   useEffect(() => {
     if (!agentName) {
       useAgentsStore.getState().clearDetail()
@@ -73,13 +88,11 @@ export function useAgentDetailData(agentName: string): UseAgentDetailDataReturn 
     }
   }, [agentName])
 
-  // Polling for refreshes -- only when agentName is truthy
   const pollFn = useCallback(async () => {
     if (!agentName) return
     await useAgentsStore.getState().fetchAgentDetail(agentName)
   }, [agentName])
   const polling = usePolling(pollFn, DETAIL_POLL_INTERVAL)
-
   useEffect(() => {
     if (!agentName) return
     polling.start()
@@ -88,8 +101,14 @@ export function useAgentDetailData(agentName: string): UseAgentDetailDataReturn 
     // including it would restart polling on every render
     // eslint-disable-next-line @eslint-react/exhaustive-deps
   }, [agentName])
+}
 
-  // WebSocket -- debounce to coalesce burst events into a single refetch
+interface DetailWsState {
+  readonly wsConnected: boolean
+  readonly wsSetupError: string | null
+}
+
+function useDetailWebSocket(agentName: string): DetailWsState {
   const wsDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const agentNameRef = useRef(agentName)
   agentNameRef.current = agentName
@@ -123,23 +142,27 @@ export function useAgentDetailData(agentName: string): UseAgentDetailDataReturn 
     [agentName],
   )
 
-  const { connected: wsConnected, setupError: wsSetupError } = useWebSocket({ bindings })
+  const { connected, setupError } = useWebSocket({ bindings })
+  return { wsConnected: connected, wsSetupError: setupError }
+}
 
-  // Derived data
+export function useAgentDetailData(agentName: string): UseAgentDetailDataReturn {
+  const slice = useDetailStoreSlice()
+  useDetailLifecycle(agentName)
+  const { wsConnected, wsSetupError } = useDetailWebSocket(agentName)
+
   const performanceCards = useMemo(
-    () => (performance ? computePerformanceCards(performance) : []),
-    [performance],
+    () => (slice.performance ? computePerformanceCards(slice.performance) : []),
+    [slice.performance],
   )
-
   const insights = useMemo(
-    () => (agent ? generateInsights(agent, performance) : []),
-    [agent, performance],
+    () => (slice.agent ? generateInsights(slice.agent, slice.performance) : []),
+    [slice.agent, slice.performance],
   )
 
-  // Load more activity -- store-level activityLoading prevents duplicates.
-  // Cursor state is held on the store (``activityNextCursor`` /
-  // ``activityHasMore``); the hook just kicks off the fetch when
-  // invoked by the UI.
+  // Load more activity. Store-level activityLoading prevents duplicates.
+  // Cursor state is held on the store (`activityNextCursor` /
+  // `activityHasMore`); the hook just kicks off the fetch when invoked.
   const fetchMoreActivity = useCallback(() => {
     if (!agentName) return
     void useAgentsStore.getState().fetchMoreActivity(agentName)
@@ -148,16 +171,9 @@ export function useAgentDetailData(agentName: string): UseAgentDetailDataReturn 
   if (!agentName) return EMPTY_RETURN
 
   return {
-    agent,
-    performance,
+    ...slice,
     performanceCards,
     insights,
-    agentTasks,
-    activity,
-    activityTotal,
-    careerHistory,
-    loading,
-    error,
     wsConnected,
     wsSetupError,
     fetchMoreActivity,

--- a/web/src/hooks/useCommunicationEdges.ts
+++ b/web/src/hooks/useCommunicationEdges.ts
@@ -45,6 +45,40 @@ function fetchReducer(_state: FetchState, action: FetchAction): FetchState {
   }
 }
 
+interface CollectedMessages {
+  readonly messages: Array<{ sender: string; to: string }>
+  readonly truncated: boolean
+}
+
+/**
+ * Walk up to MAX_PAGES of the messages endpoint into a flat sender/to
+ * list. Returns null when the abort signal fires mid-walk so the caller
+ * can skip the success dispatch.
+ */
+async function _collectAllMessages(
+  signal: AbortSignal,
+): Promise<CollectedMessages | null> {
+  const messages: Array<{ sender: string; to: string }> = []
+  let cursor: string | null = null
+  let truncated = false
+  for (let page = 0; page < MAX_PAGES; page++) {
+    if (signal.aborted) return null
+    const result = await listMessages({ cursor, limit: PAGE_LIMIT, signal })
+    for (const msg of result.data) {
+      messages.push({ sender: msg.sender, to: msg.to })
+    }
+    const exhausted = !result.hasMore || result.data.length === 0
+    if (exhausted) break
+    cursor = result.nextCursor
+    if (page === MAX_PAGES - 1) truncated = true
+  }
+  return { messages, truncated }
+}
+
+function _toErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : 'Failed to fetch messages'
+}
+
 /**
  * Fetch inter-agent messages and aggregate into communication links.
  *
@@ -64,42 +98,22 @@ export function useCommunicationEdges(enabled = true): UseCommunicationEdgesRetu
       dispatch({ type: 'reset' })
       return
     }
-
     const controller = new AbortController()
     dispatch({ type: 'loading' })
-
-    async function fetchAll() {
+    async function fetchAll(): Promise<void> {
       try {
-        const allMessages: Array<{ sender: string; to: string }> = []
-        let cursor: string | null = null
-        let truncated = false
-        for (let page = 0; page < MAX_PAGES; page++) {
-          if (controller.signal.aborted) return
-          const result = await listMessages({
-            cursor,
-            limit: PAGE_LIMIT,
-            signal: controller.signal,
-          })
-          for (const msg of result.data) {
-            allMessages.push({ sender: msg.sender, to: msg.to })
-          }
-          if (!result.hasMore || result.data.length === 0) break
-          cursor = result.nextCursor
-          if (page === MAX_PAGES - 1 && result.hasMore) {
-            truncated = true
-          }
-        }
-
-        if (!controller.signal.aborted) {
-          dispatch({ type: 'success', messages: allMessages, truncated })
-        }
+        const result = await _collectAllMessages(controller.signal)
+        if (controller.signal.aborted || result === null) return
+        dispatch({
+          type: 'success',
+          messages: result.messages,
+          truncated: result.truncated,
+        })
       } catch (err) {
-        if (!controller.signal.aborted) {
-          dispatch({ type: 'error', error: err instanceof Error ? err.message : 'Failed to fetch messages' })
-        }
+        if (controller.signal.aborted) return
+        dispatch({ type: 'error', error: _toErrorMessage(err) })
       }
     }
-
     void fetchAll()
     return () => { controller.abort() }
   }, [enabled])

--- a/web/src/hooks/useConnectionsData.ts
+++ b/web/src/hooks/useConnectionsData.ts
@@ -19,38 +19,75 @@ export interface UseConnectionsDataReturn {
   checkingHealth: readonly string[]
 }
 
+const HEALTH_ORDER: Record<ConnectionHealthStatus, number> = {
+  unhealthy: 0,
+  degraded: 1,
+  unknown: 2,
+  healthy: 3,
+}
+
+function _effectiveHealth(
+  conn: Connection,
+  healthMap: Record<string, HealthReport>,
+): ConnectionHealthStatus {
+  return healthMap[conn.name]?.status ?? conn.health_status ?? 'unknown'
+}
+
+type ConnComparator = (
+  a: Connection,
+  b: Connection,
+  healthMap: Record<string, HealthReport>,
+) => number
+
+/**
+ * Comparator per `ConnectionSortKey`. `satisfies` keeps the table
+ * exhaustive: a new sort key added to the type breaks the build until
+ * a comparator is supplied here.
+ */
+const CONN_COMPARATORS = {
+  name: (a, b) => a.name.localeCompare(b.name),
+  type: (a, b) => a.connection_type.localeCompare(b.connection_type),
+  created_at: (a, b) => (a.created_at ?? '').localeCompare(b.created_at ?? ''),
+  health: (a, b, h) =>
+    HEALTH_ORDER[_effectiveHealth(a, h)] - HEALTH_ORDER[_effectiveHealth(b, h)],
+} as const satisfies Record<ConnectionSortKey, ConnComparator>
+
 function sortConnections(
   connections: readonly Connection[],
   healthMap: Record<string, HealthReport>,
   sortBy: ConnectionSortKey,
   direction: 'asc' | 'desc',
 ): readonly Connection[] {
-  const sorted = [...connections]
+  const compare = CONN_COMPARATORS[sortBy]
   const multiplier = direction === 'asc' ? 1 : -1
-  const healthOrder: Record<ConnectionHealthStatus, number> = {
-    unhealthy: 0,
-    degraded: 1,
-    unknown: 2,
-    healthy: 3,
+  return [...connections].sort((a, b) => compare(a, b, healthMap) * multiplier)
+}
+
+interface FilterCriteria {
+  readonly healthMap: Record<string, HealthReport>
+  readonly typeFilter: string | null
+  readonly healthFilter: ConnectionHealthStatus | null
+  readonly query: string
+}
+
+function _matchesFilters(conn: Connection, criteria: FilterCriteria): boolean {
+  if (criteria.typeFilter !== null && conn.connection_type !== criteria.typeFilter) {
+    return false
   }
-  sorted.sort((a, b) => {
-    switch (sortBy) {
-      case 'name':
-        return a.name.localeCompare(b.name) * multiplier
-      case 'type':
-        return a.connection_type.localeCompare(b.connection_type) * multiplier
-      case 'created_at':
-        return (a.created_at ?? '').localeCompare(b.created_at ?? '') * multiplier
-      case 'health': {
-        const aHealth = healthMap[a.name]?.status ?? a.health_status ?? 'unknown'
-        const bHealth = healthMap[b.name]?.status ?? b.health_status ?? 'unknown'
-        return (healthOrder[aHealth] - healthOrder[bHealth]) * multiplier
-      }
-      default:
-        return 0
-    }
-  })
-  return sorted
+  if (criteria.healthFilter !== null) {
+    if (_effectiveHealth(conn, criteria.healthMap) !== criteria.healthFilter) return false
+  }
+  if (criteria.query.length > 0) {
+    return conn.name.toLowerCase().includes(criteria.query)
+  }
+  return true
+}
+
+function filterConnections(
+  connections: readonly Connection[],
+  criteria: FilterCriteria,
+): readonly Connection[] {
+  return connections.filter((conn) => _matchesFilters(conn, criteria))
 }
 
 export function useConnectionsData(): UseConnectionsDataReturn {
@@ -77,19 +114,11 @@ export function useConnectionsData(): UseConnectionsDataReturn {
   }, [])
 
   const filteredConnections = useMemo(() => {
-    const normalizedQuery = searchQuery.trim().toLowerCase()
-    const filtered = connections.filter((conn) => {
-      if (typeFilter !== null && conn.connection_type !== typeFilter) {
-        return false
-      }
-      if (healthFilter !== null) {
-        const effectiveHealth = healthMap[conn.name]?.status ?? conn.health_status ?? 'unknown'
-        if (effectiveHealth !== healthFilter) return false
-      }
-      if (normalizedQuery.length > 0) {
-        return conn.name.toLowerCase().includes(normalizedQuery)
-      }
-      return true
+    const filtered = filterConnections(connections, {
+      healthMap,
+      typeFilter,
+      healthFilter,
+      query: searchQuery.trim().toLowerCase(),
     })
     return sortConnections(filtered, healthMap, sortBy, sortDirection)
   }, [connections, healthMap, searchQuery, typeFilter, healthFilter, sortBy, sortDirection])

--- a/web/src/hooks/useFlash.ts
+++ b/web/src/hooks/useFlash.ts
@@ -22,17 +22,25 @@ interface UseFlashReturn {
 }
 
 /**
+ * Resolve the total flash duration (flash + hold + fade), falling back
+ * to the design-system timing constants when the caller omits an
+ * override.
+ */
+function _resolveTotalMs(options?: UseFlashOptions): number {
+  const flashMs = options?.flashMs ?? STATUS_FLASH.flashMs
+  const holdMs = options?.holdMs ?? STATUS_FLASH.holdMs
+  const fadeMs = options?.fadeMs ?? STATUS_FLASH.fadeMs
+  return flashMs + holdMs + fadeMs
+}
+
+/**
  * Hook for triggering a real-time update flash effect.
  *
  * Uses the STATUS_FLASH timing constants from the motion system.
  * Multiple rapid triggers reset the timer rather than stacking.
  */
 export function useFlash(options?: UseFlashOptions): UseFlashReturn {
-  const flashMs = options?.flashMs ?? STATUS_FLASH.flashMs
-  const holdMs = options?.holdMs ?? STATUS_FLASH.holdMs
-  const fadeMs = options?.fadeMs ?? STATUS_FLASH.fadeMs
-  const totalMs = flashMs + holdMs + fadeMs
-
+  const totalMs = _resolveTotalMs(options)
   const [flashing, setFlashing] = useState(false)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -41,9 +49,7 @@ export function useFlash(options?: UseFlashOptions): UseFlashReturn {
     if (timerRef.current !== null) {
       clearTimeout(timerRef.current)
     }
-
     setFlashing(true)
-
     timerRef.current = setTimeout(() => {
       setFlashing(false)
       timerRef.current = null

--- a/web/src/hooks/useOrgChartData.ts
+++ b/web/src/hooks/useOrgChartData.ts
@@ -63,6 +63,115 @@ function buildCommunicationEdges(
   }))
 }
 
+type OrgTree = ReturnType<typeof buildOrgTree>
+
+/**
+ * Strip child agents whose parent department is collapsed, mark the
+ * collapsed dept nodes with `isCollapsed: true`, and prune edges that
+ * pointed at removed nodes. Mutates the tree in place so the dagre
+ * pass that follows sees the smaller set.
+ */
+function _applyCollapse(tree: OrgTree, collapsedDeptIds: ReadonlySet<string>): void {
+  tree.nodes = tree.nodes
+    .filter((n) => !(n.parentId && collapsedDeptIds.has(n.parentId)))
+    .map((n) =>
+      n.type === 'department' && collapsedDeptIds.has(n.id)
+        ? { ...n, data: { ...n.data, isCollapsed: true } }
+        : n,
+    )
+  const remainingNodeIds = new Set(tree.nodes.map((n) => n.id))
+  tree.edges = tree.edges.filter(
+    (e) => remainingNodeIds.has(e.source) && remainingNodeIds.has(e.target),
+  )
+}
+
+/**
+ * Force view: only agent/ceo nodes (no department groups, no owner
+ * nodes, no hidden layout edges). Communication view is about agent-
+ * to-agent message flow, so the hierarchy scaffold is intentionally
+ * stripped.
+ */
+function _buildForceView(
+  tree: OrgTree,
+  commLinks: CommunicationLink[],
+): { nodes: Node[]; edges: Edge[] } {
+  const agentNodes = tree.nodes.filter((n) => n.type === 'agent' || n.type === 'ceo')
+  const freeNodes = agentNodes.map((n) => ({ ...n, parentId: undefined }))
+  const visibleIds = new Set(freeNodes.map((n) => n.id))
+  const filteredLinks = commLinks.filter(
+    (l) => visibleIds.has(l.source) && visibleIds.has(l.target),
+  )
+  return {
+    nodes: computeForceLayout(freeNodes, filteredLinks),
+    edges: buildCommunicationEdges(filteredLinks),
+  }
+}
+
+interface DagrePrefs {
+  readonly showBudgetBar: boolean
+  readonly showStatusDots: boolean
+  readonly showAddAgentButton: boolean
+}
+
+interface DeriveViewArgs {
+  readonly tree: OrgTree
+  readonly viewMode: ViewMode
+  readonly collapsedDeptIds?: ReadonlySet<string>
+  readonly commLinks: CommunicationLink[]
+  readonly prefs: DagrePrefs
+}
+
+/**
+ * Derive the rendered React Flow nodes/edges from a built org tree.
+ * Returns `allNodes` snapshot BEFORE collapse filtering so consumers
+ * (e.g. search) can index every node regardless of which departments
+ * are collapsed.
+ */
+function _deriveView(args: DeriveViewArgs): {
+  nodes: Node[]
+  edges: Edge[]
+  allNodes: Node[]
+} {
+  const allNodes = [...args.tree.nodes]
+  if (
+    args.viewMode === 'hierarchy'
+    && args.collapsedDeptIds
+    && args.collapsedDeptIds.size > 0
+  ) {
+    _applyCollapse(args.tree, args.collapsedDeptIds)
+  }
+  if (args.viewMode === 'force') {
+    const force = _buildForceView(args.tree, args.commLinks)
+    return { ...force, allNodes }
+  }
+  const layoutNodes = applyDagreLayout(args.tree.nodes, args.tree.edges, args.prefs)
+  return { nodes: layoutNodes, edges: args.tree.edges, allNodes }
+}
+
+/**
+ * Sequential initial fetch: department health depends on config being
+ * loaded. Polling starts only after the initial fetch completes (or
+ * fails) so we never race the first response.
+ */
+function useOrgInitialFetch(start: () => void, stop: () => void): void {
+  useEffect(() => {
+    const companyStore = useCompanyStore.getState()
+    companyStore.fetchCompanyData().then(() => {
+      if (useCompanyStore.getState().config) {
+        companyStore.fetchDepartmentHealths().catch((err: unknown) => {
+          log.warn('fetchDepartmentHealths failed:', err)
+        })
+      }
+      start()
+    }).catch((err: unknown) => {
+      log.warn('fetchCompanyData failed:', err)
+      start()
+    })
+    return () => stop()
+    // eslint-disable-next-line @eslint-react/exhaustive-deps -- mount-only effect; start / stop are stable
+  }, [])
+}
+
 export function useOrgChartData(
   viewMode: ViewMode = 'hierarchy',
   collapsedDeptIds?: ReadonlySet<string>,
@@ -92,30 +201,11 @@ export function useOrgChartData(
     return [{ id: currentUser.id, displayName: currentUser.username }]
   }, [currentUser])
 
-  // Polling for department health refresh
   const pollFn = useCallback(async () => {
     await useCompanyStore.getState().fetchDepartmentHealths()
   }, [])
   const polling = usePolling(pollFn, ORG_POLL_INTERVAL)
-
-  // Initial data fetch (sequential: health depends on config being loaded)
-  // Polling starts only after initial fetch completes to avoid racing
-  useEffect(() => {
-    const companyStore = useCompanyStore.getState()
-    companyStore.fetchCompanyData().then(() => {
-      if (useCompanyStore.getState().config) {
-        companyStore.fetchDepartmentHealths().catch((err: unknown) => {
-          log.warn('fetchDepartmentHealths failed:', err)
-        })
-      }
-      polling.start()
-    }).catch((err: unknown) => {
-      log.warn('fetchCompanyData failed:', err)
-      polling.start()
-    })
-    return () => polling.stop()
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- mount-only effect; polling ref identity is stable
-  }, [])
+  useOrgInitialFetch(polling.start, polling.stop)
 
   // WebSocket bindings for real-time updates
   const bindings: ChannelBinding[] = useMemo(
@@ -139,73 +229,21 @@ export function useOrgChartData(
     viewMode === 'force',
   )
 
-  // Derive React Flow nodes/edges from store data
   const { nodes, edges, allNodes } = useMemo(() => {
     if (!config) return { nodes: [], edges: [], allNodes: [] }
-
-    const tree = buildOrgTree(config, runtimeStatuses, departmentHealths, owners, [], currentUser?.id)
-
-    // Snapshot the full tree BEFORE collapse filtering so consumers
-    // (e.g. search) can index every node regardless of which
-    // departments are collapsed.
-    const allNodes = [...tree.nodes]
-
-    // Filter out child agents of collapsed departments BEFORE layout
-    // so the dagre pass computes correct (smaller) dept box sizes.
-    // The dept group nodes themselves stay, with an `isCollapsed`
-    // flag injected into their data so the UI can render the correct
-    // chevron state.  Only applies in hierarchy mode -- the force
-    // view strips departments entirely, so collapsing is irrelevant.
-    if (viewMode === 'hierarchy' && collapsedDeptIds && collapsedDeptIds.size > 0) {
-      tree.nodes = tree.nodes
-        .filter((n) => !(n.parentId && collapsedDeptIds.has(n.parentId)))
-        .map((n) =>
-          n.type === 'department' && collapsedDeptIds.has(n.id)
-            ? { ...n, data: { ...n.data, isCollapsed: true } }
-            : n,
-        )
-      const remainingNodeIds = new Set(tree.nodes.map((n) => n.id))
-      tree.edges = tree.edges.filter(
-        (e) => remainingNodeIds.has(e.source) && remainingNodeIds.has(e.target),
-      )
-    }
-
-    if (viewMode === 'force') {
-      // Force view: only agent/ceo nodes (no department groups, no
-      // owner nodes, no hidden layout edges).  Communication view is
-      // about agent-to-agent message flow, so the hierarchy scaffold
-      // is intentionally stripped.
-      const agentNodes = tree.nodes.filter((n) => n.type === 'agent' || n.type === 'ceo')
-      // Remove parentId so nodes are not grouped inside departments
-      const freeNodes = agentNodes.map((n) => ({ ...n, parentId: undefined }))
-      // Filter links to only include edges between visible nodes
-      const visibleIds = new Set(freeNodes.map((n) => n.id))
-      const filteredLinks = commLinks.filter(
-        (l) => visibleIds.has(l.source) && visibleIds.has(l.target),
-      )
-      const layoutNodes = computeForceLayout(freeNodes, filteredLinks)
-      const commEdges = buildCommunicationEdges(filteredLinks)
-      return { nodes: layoutNodes, edges: commEdges, allNodes }
-    }
-
-    // Hierarchy view: dagre layout with department groups
-    const layoutNodes = applyDagreLayout(tree.nodes, tree.edges, {
-      showBudgetBar,
-      showStatusDots,
-      showAddAgentButton,
+    const tree = buildOrgTree(
+      config, runtimeStatuses, departmentHealths, owners, [], currentUser?.id,
+    )
+    return _deriveView({
+      tree,
+      viewMode,
+      collapsedDeptIds,
+      commLinks,
+      prefs: { showBudgetBar, showStatusDots, showAddAgentButton },
     })
-    return { nodes: layoutNodes, edges: tree.edges, allNodes }
   }, [
-    config,
-    runtimeStatuses,
-    departmentHealths,
-    viewMode,
-    commLinks,
-    owners,
-    collapsedDeptIds,
-    showBudgetBar,
-    showStatusDots,
-    showAddAgentButton,
+    config, runtimeStatuses, departmentHealths, viewMode, commLinks, owners,
+    collapsedDeptIds, showBudgetBar, showStatusDots, showAddAgentButton,
     currentUser?.id,
   ])
 

--- a/web/src/hooks/useOrgChartData.ts
+++ b/web/src/hooks/useOrgChartData.ts
@@ -155,19 +155,37 @@ function _deriveView(args: DeriveViewArgs): {
  */
 function useOrgInitialFetch(start: () => void, stop: () => void): void {
   useEffect(() => {
+    // Mounted flag prevents `start()` from arming a polling timer
+    // after the component has unmounted (the fetch promises resolve
+    // asynchronously, so without the guard a quick navigation away
+    // orphans the polling loop). Cleanup also calls `stop()` so any
+    // in-flight schedule is torn down even on the happy path.
+    let mounted = true
     const companyStore = useCompanyStore.getState()
-    companyStore.fetchCompanyData().then(() => {
-      if (useCompanyStore.getState().config) {
-        companyStore.fetchDepartmentHealths().catch((err: unknown) => {
-          log.warn('fetchDepartmentHealths failed:', err)
-        })
-      }
-      start()
-    }).catch((err: unknown) => {
-      log.warn('fetchCompanyData failed:', err)
-      start()
-    })
-    return () => stop()
+    void companyStore.fetchCompanyData()
+      .then(async () => {
+        if (!mounted) return
+        // Await the initial health fetch BEFORE arming polling, so
+        // the first polling tick cannot overlap the initial health
+        // load and produce out-of-order store writes.
+        if (useCompanyStore.getState().config) {
+          try {
+            await companyStore.fetchDepartmentHealths()
+          } catch (err: unknown) {
+            log.warn('fetchDepartmentHealths failed:', err)
+          }
+        }
+      })
+      .catch((err: unknown) => {
+        log.warn('fetchCompanyData failed:', err)
+      })
+      .finally(() => {
+        if (mounted) start()
+      })
+    return () => {
+      mounted = false
+      stop()
+    }
     // eslint-disable-next-line @eslint-react/exhaustive-deps -- mount-only effect; start / stop are stable
   }, [])
 }

--- a/web/src/hooks/useOrgEditData.ts
+++ b/web/src/hooks/useOrgEditData.ts
@@ -51,38 +51,37 @@ export interface UseOrgEditDataReturn {
   optimisticReorderAgents: (deptName: string, orderedIds: string[]) => () => void
 }
 
-export function useOrgEditData(): UseOrgEditDataReturn {
-  const config = useCompanyStore((s) => s.config)
-  const departmentHealths = useCompanyStore((s) => s.departmentHealths)
-  const loading = useCompanyStore((s) => s.loading)
-  const error = useCompanyStore((s) => s.error)
-  const saving = useCompanyStore((s) => s.savingCount > 0)
-  const saveError = useCompanyStore((s) => s.saveError)
+type CompanyMutations = Pick<
+  UseOrgEditDataReturn,
+  | 'updateCompany'
+  | 'createDepartment' | 'updateDepartment' | 'deleteDepartment' | 'reorderDepartments'
+  | 'createAgent' | 'updateAgent' | 'deleteAgent' | 'reorderAgents'
+  | 'createTeam' | 'updateTeam' | 'deleteTeam' | 'reorderTeams'
+  | 'optimisticReorderDepartments' | 'optimisticReorderAgents'
+>
 
-  // Mutations (stable references via store actions)
-  const updateCompany = useCompanyStore((s) => s.updateCompany)
-  const createDepartment = useCompanyStore((s) => s.createDepartment)
-  const updateDepartment = useCompanyStore((s) => s.updateDepartment)
-  const deleteDepartment = useCompanyStore((s) => s.deleteDepartment)
-  const reorderDepartments = useCompanyStore((s) => s.reorderDepartments)
-  const createAgent = useCompanyStore((s) => s.createAgent)
-  const updateAgent = useCompanyStore((s) => s.updateAgent)
-  const deleteAgent = useCompanyStore((s) => s.deleteAgent)
-  const reorderAgents = useCompanyStore((s) => s.reorderAgents)
-  const createTeam = useCompanyStore((s) => s.createTeam)
-  const updateTeam = useCompanyStore((s) => s.updateTeam)
-  const deleteTeam = useCompanyStore((s) => s.deleteTeam)
-  const reorderTeams = useCompanyStore((s) => s.reorderTeams)
-  const optimisticReorderDepartments = useCompanyStore((s) => s.optimisticReorderDepartments)
-  const optimisticReorderAgents = useCompanyStore((s) => s.optimisticReorderAgents)
+function useCompanyMutations(): CompanyMutations {
+  return {
+    updateCompany: useCompanyStore((s) => s.updateCompany),
+    createDepartment: useCompanyStore((s) => s.createDepartment),
+    updateDepartment: useCompanyStore((s) => s.updateDepartment),
+    deleteDepartment: useCompanyStore((s) => s.deleteDepartment),
+    reorderDepartments: useCompanyStore((s) => s.reorderDepartments),
+    createAgent: useCompanyStore((s) => s.createAgent),
+    updateAgent: useCompanyStore((s) => s.updateAgent),
+    deleteAgent: useCompanyStore((s) => s.deleteAgent),
+    reorderAgents: useCompanyStore((s) => s.reorderAgents),
+    createTeam: useCompanyStore((s) => s.createTeam),
+    updateTeam: useCompanyStore((s) => s.updateTeam),
+    deleteTeam: useCompanyStore((s) => s.deleteTeam),
+    reorderTeams: useCompanyStore((s) => s.reorderTeams),
+    optimisticReorderDepartments: useCompanyStore((s) => s.optimisticReorderDepartments),
+    optimisticReorderAgents: useCompanyStore((s) => s.optimisticReorderAgents),
+  }
+}
 
-  // Polling for department health refresh
-  const pollFn = useCallback(async () => {
-    await useCompanyStore.getState().fetchDepartmentHealths()
-  }, [])
-  const polling = usePolling(pollFn, ORG_EDIT_POLL_INTERVAL)
-
-  // Initial data fetch (sequential: health depends on config)
+/** Sequential initial fetch: department health depends on config being loaded. */
+function useCompanyInitialFetch(start: () => void, stop: () => void): void {
   useEffect(() => {
     let mounted = true
     const store = useCompanyStore.getState()
@@ -94,19 +93,34 @@ export function useOrgEditData(): UseOrgEditDataReturn {
         }
       })
       .then(() => {
-        if (mounted) polling.start()
+        if (mounted) start()
       })
       .catch(() => {
         // Errors are set in store state by the respective fetch methods
       })
     return () => {
       mounted = false
-      polling.stop()
+      stop()
     }
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- mount-only effect; polling ref identity is stable
+    // eslint-disable-next-line @eslint-react/exhaustive-deps -- mount-only effect; start / stop are stable
   }, [])
+}
 
-  // WebSocket bindings for real-time updates
+export function useOrgEditData(): UseOrgEditDataReturn {
+  const config = useCompanyStore((s) => s.config)
+  const departmentHealths = useCompanyStore((s) => s.departmentHealths)
+  const loading = useCompanyStore((s) => s.loading)
+  const error = useCompanyStore((s) => s.error)
+  const saving = useCompanyStore((s) => s.savingCount > 0)
+  const saveError = useCompanyStore((s) => s.saveError)
+  const mutations = useCompanyMutations()
+
+  const pollFn = useCallback(async () => {
+    await useCompanyStore.getState().fetchDepartmentHealths()
+  }, [])
+  const polling = usePolling(pollFn, ORG_EDIT_POLL_INTERVAL)
+  useCompanyInitialFetch(polling.start, polling.stop)
+
   const bindings: ChannelBinding[] = useMemo(
     () =>
       ORG_EDIT_CHANNELS.map((channel) => ({
@@ -117,10 +131,7 @@ export function useOrgEditData(): UseOrgEditDataReturn {
       })),
     [],
   )
-
-  const { connected: wsConnected, setupError: wsSetupError } = useWebSocket({
-    bindings,
-  })
+  const { connected: wsConnected, setupError: wsSetupError } = useWebSocket({ bindings })
 
   return {
     config,
@@ -131,20 +142,6 @@ export function useOrgEditData(): UseOrgEditDataReturn {
     saveError,
     wsConnected,
     wsSetupError,
-    updateCompany,
-    createDepartment,
-    updateDepartment,
-    deleteDepartment,
-    reorderDepartments,
-    createAgent,
-    updateAgent,
-    deleteAgent,
-    reorderAgents,
-    createTeam,
-    updateTeam,
-    deleteTeam,
-    reorderTeams,
-    optimisticReorderDepartments,
-    optimisticReorderAgents,
+    ...mutations,
   }
 }

--- a/web/src/hooks/usePolling.ts
+++ b/web/src/hooks/usePolling.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react'
 import { getErrorMessage } from '@/utils/errors'
 import { createLogger } from '@/lib/logger'
 
@@ -9,7 +9,7 @@ const MIN_POLL_INTERVAL = 100
 export interface UsePollingOptions {
   /**
    * Optional gate evaluated immediately before each scheduled tick.
-   * Returning ``true`` causes the tick to be skipped (the poll
+   * Returning `true` causes the tick to be skipped (the poll
    * function does not run) and a new timer is armed for the next
    * interval. Use for "we already have fresh data from a different
    * source" branches (typically WebSocket push freshness) so the
@@ -32,16 +32,136 @@ export interface UsePollingReturn {
   stop: () => void
 }
 
+interface PollRefs {
+  readonly activeRef: RefObject<boolean>
+  readonly timerRef: RefObject<ReturnType<typeof setTimeout> | null>
+  readonly fnRef: RefObject<() => Promise<void>>
+  readonly skipIfFreshRef: RefObject<(() => boolean) | undefined>
+  readonly runIdRef: RefObject<number>
+  readonly inFlightRef: RefObject<boolean>
+  readonly pendingResumeRef: RefObject<boolean>
+}
+
+interface PollHandlers {
+  readonly setError: (e: string | null) => void
+  readonly setIsRefetching: (v: boolean) => void
+}
+
+/**
+ * Wraps the caller-supplied freshness gate so a throw from the user's
+ * callback cannot bubble past the scheduling code and leave the timer
+ * un-armed. Returning false on error means "treat as not fresh":
+ * we err on the side of polling so we never silently freeze the loop.
+ */
+function _shouldSkipIfFresh(
+  refs: PollRefs,
+  setError: (e: string | null) => void,
+): boolean {
+  const gate = refs.skipIfFreshRef.current
+  if (!gate) return false
+  try {
+    return Boolean(gate())
+  } catch (err) {
+    setError(getErrorMessage(err))
+    log.error('Polling freshness gate threw:', err)
+    return false
+  }
+}
+
+/** Cheap pre-flight: same run generation + tab visible + freshness gate not set. */
+function _shouldRunPoll(
+  refs: PollRefs,
+  runId: number,
+  handlers: PollHandlers,
+): boolean {
+  if (!refs.activeRef.current || runId !== refs.runIdRef.current) return false
+  if (typeof document !== 'undefined' && document.hidden) return false
+  if (_shouldSkipIfFresh(refs, handlers.setError)) return false
+  return true
+}
+
+/**
+ * Invoke `fnRef.current()` exactly once, observing the in-flight flag
+ * and the isRefetching state. Errors surface as a setError + log.error;
+ * the helper never throws.
+ */
+async function _invokePoll(refs: PollRefs, handlers: PollHandlers): Promise<void> {
+  refs.inFlightRef.current = true
+  handlers.setIsRefetching(true)
+  try {
+    await refs.fnRef.current()
+    handlers.setError(null)
+  } catch (err) {
+    handlers.setError(getErrorMessage(err))
+    log.error('Polling error:', err)
+  } finally {
+    refs.inFlightRef.current = false
+    handlers.setIsRefetching(false)
+  }
+}
+
+/**
+ * Allocate all of the polling refs as a single bundle. Hoisting the
+ * useRef calls into a sub-hook keeps `usePolling`'s body under the
+ * function-length cap; the rule-of-hooks contract is preserved because
+ * the helper is always called at the top level of `usePolling`.
+ */
+function usePollRefs(
+  fn: () => Promise<void>,
+  options: UsePollingOptions,
+): PollRefs {
+  const activeRef = useRef(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const fnRef = useRef(fn)
+  const skipIfFreshRef = useRef(options.skipIfFresh)
+  const runIdRef = useRef(0)
+  const inFlightRef = useRef(false)
+  const pendingResumeRef = useRef(false)
+  fnRef.current = fn
+  skipIfFreshRef.current = options.skipIfFresh
+  return {
+    activeRef, timerRef, fnRef, skipIfFreshRef,
+    runIdRef, inFlightRef, pendingResumeRef,
+  }
+}
+
+/** Create the visibilitychange handler used by the resume effect. */
+function _buildVisibilityHandler(
+  refs: PollRefs,
+  scheduleTick: (runId: number, delay?: number) => void,
+): () => void {
+  return () => {
+    if (document.hidden) return
+    if (!refs.activeRef.current) return
+    // Defer the resume tick if a poll-function call is currently
+    // awaiting; scheduling a new 0ms tick alongside an in-flight call
+    // would let two `fn()` invocations interleave and produce out-of-
+    // order store writes. The currently-running tick consumes
+    // `pendingResumeRef` on completion.
+    if (refs.inFlightRef.current) {
+      refs.pendingResumeRef.current = true
+      return
+    }
+    // No poll in flight: cancel any armed scheduled tick and arm a 0ms
+    // tick on the same run generation so the resume runs immediately.
+    if (refs.timerRef.current) {
+      clearTimeout(refs.timerRef.current)
+      refs.timerRef.current = null
+    }
+    scheduleTick(refs.runIdRef.current, 0)
+  }
+}
+
 /**
  * Poll a function at a fixed interval with cleanup on unmount.
  * Uses setTimeout-based scheduling to prevent overlapping async calls.
  * A run generation counter prevents stale in-flight runs from spawning
  * duplicate loops after stop/start cycles.
  *
- * Background-tab discipline: when ``document.hidden === true`` the
+ * Background-tab discipline: when `document.hidden === true` the
  * scheduled tick skips the poll and reschedules instead, so a tab
  * left open in the background does not burn battery / API budget.
- * A ``visibilitychange`` listener re-arms a near-immediate tick when
+ * A `visibilitychange` listener re-arms a near-immediate tick when
  * the tab becomes visible again so the user sees fresh data on
  * return.
  */
@@ -53,81 +173,35 @@ export function usePolling(
   const [active, setActive] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [isRefetching, setIsRefetching] = useState(false)
-  const activeRef = useRef(false)
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const fnRef = useRef(fn)
-  const skipIfFreshRef = useRef(options.skipIfFresh)
-  const runIdRef = useRef(0)
-  // True while a poll-function invocation is awaiting. Used by the
-  // visibility-resume handler to avoid scheduling a 0ms tick that
-  // would race the in-flight ``fnRef.current()`` call.
-  const inFlightRef = useRef(false)
-  // Set by the visibility handler when it cannot schedule directly
-  // because a poll was already in flight. The currently-running
-  // tick consumes the flag on completion and arms one extra tick.
-  const pendingResumeRef = useRef(false)
-  fnRef.current = fn
-  skipIfFreshRef.current = options.skipIfFresh
-
-  // Validate at start, not during render
+  const refs = usePollRefs(fn, options)
+  const handlers: PollHandlers = { setError, setIsRefetching }
+  const { activeRef, timerRef, runIdRef, pendingResumeRef } = refs
   const isValidInterval = Number.isFinite(intervalMs) && intervalMs >= MIN_POLL_INTERVAL
 
-  // Wraps the caller-supplied freshness gate so a throw from the
-  // user's callback cannot bubble past the scheduling code and leave
-  // the timer un-armed. Returning false on error means "treat as not
-  // fresh" -- erring on the side of polling so we never silently
-  // freeze the loop.
-  const shouldSkipIfFresh = useCallback((): boolean => {
-    if (!skipIfFreshRef.current) return false
-    try {
-      return Boolean(skipIfFreshRef.current())
-    } catch (err) {
-      setError(getErrorMessage(err))
-      log.error('Polling freshness gate threw:', err)
-      return false
-    }
-  }, [])
-
-  const scheduleTick = useCallback((runId: number, delayMs: number = intervalMs) => {
-    if (!activeRef.current || runId !== runIdRef.current) return
-    const tick = async () => {
+  const scheduleTick = useCallback(
+    (runId: number, delayMs: number = intervalMs) => {
       if (!activeRef.current || runId !== runIdRef.current) return
-      // Hidden tab: skip the poll and reschedule. Cheaper than
-      // running fetch -> render -> dropping the result.
-      if (typeof document !== 'undefined' && document.hidden) {
+      const tick = async (): Promise<void> => {
+        if (!_shouldRunPoll(refs, runId, handlers)) {
+          if (activeRef.current && runId === runIdRef.current) scheduleTick(runId)
+          return
+        }
+        await _invokePoll(refs, handlers)
+        // Visibility resume deferred a tick because we were in-flight:
+        // honour it now with a 0ms reschedule, then clear the flag so
+        // the catch-up only fires once per pending resume.
+        if (pendingResumeRef.current) {
+          pendingResumeRef.current = false
+          scheduleTick(runId, 0)
+          return
+        }
         scheduleTick(runId)
-        return
       }
-      // WS-driven freshness: skip when the caller's recent-update
-      // gate says we already have fresh state.
-      if (shouldSkipIfFresh()) {
-        scheduleTick(runId)
-        return
-      }
-      inFlightRef.current = true
-      setIsRefetching(true)
-      try {
-        await fnRef.current()
-        setError(null)
-      } catch (err) {
-        setError(getErrorMessage(err))
-        log.error('Polling error:', err)
-      } finally {
-        inFlightRef.current = false
-        setIsRefetching(false)
-      }
-      // Visibility resume deferred a tick because we were in-flight:
-      // honour it now with a 0ms reschedule, then clear the flag so
-      // the catch-up only fires once per pending resume.
-      if (pendingResumeRef.current) {
-        pendingResumeRef.current = false
-        scheduleTick(runId, 0)
-        return
-      }
-      scheduleTick(runId)
-    }
-    timerRef.current = setTimeout(() => { void tick() }, delayMs)
-  }, [intervalMs, shouldSkipIfFresh])
+      timerRef.current = setTimeout(() => { void tick() }, delayMs)
+    },
+    // eslint-disable-next-line @eslint-react/exhaustive-deps -- refs / handlers are derived from refs that don't trigger re-render
+    [intervalMs],
+  )
 
   const start = useCallback(() => {
     if (!isValidInterval) {
@@ -139,44 +213,12 @@ export function usePolling(
     setActive(true)
     setError(null)
     const runId = ++runIdRef.current
-    const immediate = async () => {
-      if (!activeRef.current || runId !== runIdRef.current) return
-      // Mirror the visibility / freshness gates from the scheduled
-      // tick path so the initial-mount poll obeys the same rules.
-      if (typeof document !== 'undefined' && document.hidden) {
-        scheduleTick(runId)
-        return
-      }
-      if (shouldSkipIfFresh()) {
-        scheduleTick(runId)
-        return
-      }
-      inFlightRef.current = true
-      setIsRefetching(true)
-      try {
-        await fnRef.current()
-      } catch (err) {
-        setError(getErrorMessage(err))
-        log.error('Polling error:', err)
-      } finally {
-        inFlightRef.current = false
-        setIsRefetching(false)
-      }
+    void (async () => {
+      if (_shouldRunPoll(refs, runId, handlers)) await _invokePoll(refs, handlers)
       scheduleTick(runId)
-    }
-    immediate().catch((err) => {
-      // Defensive: the inner try/catch above already converts a
-      // rejected ``fn()`` into a setError + log; this catch only
-      // fires if scheduleTick itself rejects, which should never
-      // happen. Belt-and-braces so an unexpected throw cannot leak.
-      // Guard against a stale start/stop cycle: if the run generation
-      // has already moved on, the error belongs to a discarded run
-      // and must not clobber the active state.
-      if (!activeRef.current || runId !== runIdRef.current) return
-      setError(getErrorMessage(err))
-      log.error('Polling initial run failed:', err)
-    })
-  }, [scheduleTick, shouldSkipIfFresh, isValidInterval, intervalMs])
+    })()
+    // eslint-disable-next-line @eslint-react/exhaustive-deps -- refs / handlers are derived from refs that don't trigger re-render
+  }, [scheduleTick, isValidInterval, intervalMs])
 
   const stop = useCallback(() => {
     activeRef.current = false
@@ -187,50 +229,18 @@ export function usePolling(
       clearTimeout(timerRef.current)
       timerRef.current = null
     }
+    // eslint-disable-next-line @eslint-react/exhaustive-deps -- ref handles are stable identities; the rule lists them because they were destructured from a non-ref local
   }, [])
 
-  // Cleanup on unmount
-  useEffect(() => {
-    return () => {
-      stop()
-    }
-  }, [stop])
+  useEffect(() => stop, [stop])
 
-  // Visibilitychange resume: when the tab becomes visible, kick a
-  // near-immediate refresh so the user sees fresh data without
-  // waiting up to ``intervalMs`` for the next scheduled tick.
   useEffect(() => {
     if (typeof document === 'undefined') return
-    const handler = () => {
-      if (document.hidden) return
-      if (!activeRef.current) return
-      // Defer the resume tick if a poll-function call is currently
-      // awaiting; scheduling a new 0ms tick alongside an in-flight
-      // call would let two ``fn()`` invocations interleave and
-      // produce out-of-order store writes. The currently-running
-      // tick consumes ``pendingResumeRef`` on completion.
-      if (inFlightRef.current) {
-        pendingResumeRef.current = true
-        return
-      }
-      // No poll in flight: cancel any armed scheduled tick and arm a
-      // 0ms tick on the same run generation so the resume runs
-      // immediately. Bumping the generation would race any future
-      // tick; reusing it is safe because we just confirmed nothing
-      // is awaiting.
-      if (timerRef.current) {
-        clearTimeout(timerRef.current)
-        timerRef.current = null
-      }
-      scheduleTick(runIdRef.current, 0)
-    }
+    const handler = _buildVisibilityHandler(refs, scheduleTick)
     document.addEventListener('visibilitychange', handler)
-    return () => {
-      document.removeEventListener('visibilitychange', handler)
-    }
+    return () => document.removeEventListener('visibilitychange', handler)
+    // eslint-disable-next-line @eslint-react/exhaustive-deps -- refs is derived from refs that don't trigger re-render
   }, [scheduleTick])
 
-  // start/stop are stable useCallback refs; return a plain object so consumers
-  // depend on the individual refs, not an object whose identity changes on every state update.
   return { active, error, isRefetching, start, stop }
 }

--- a/web/src/hooks/usePolling.ts
+++ b/web/src/hooks/usePolling.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type RefObject } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react'
 import { getErrorMessage } from '@/utils/errors'
 import { createLogger } from '@/lib/logger'
 
@@ -117,12 +117,21 @@ function usePollRefs(
   const runIdRef = useRef(0)
   const inFlightRef = useRef(false)
   const pendingResumeRef = useRef(false)
+  // Stabilise the refs bundle so consumers can list it in dependency
+  // arrays without forcing an `eslint-disable @eslint-react/exhaustive-deps`
+  // override. Ref identities themselves are stable across renders, but
+  // returning a fresh object literal each render would re-trigger any
+  // memoised hook that depends on `refs`.
+  const refs = useMemo<PollRefs>(
+    () => ({
+      activeRef, timerRef, fnRef, skipIfFreshRef,
+      runIdRef, inFlightRef, pendingResumeRef,
+    }),
+    [],
+  )
   fnRef.current = fn
   skipIfFreshRef.current = options.skipIfFresh
-  return {
-    activeRef, timerRef, fnRef, skipIfFreshRef,
-    runIdRef, inFlightRef, pendingResumeRef,
-  }
+  return refs
 }
 
 /** Create the visibilitychange handler used by the resume effect. */
@@ -174,7 +183,12 @@ export function usePolling(
   const [error, setError] = useState<string | null>(null)
   const [isRefetching, setIsRefetching] = useState(false)
   const refs = usePollRefs(fn, options)
-  const handlers: PollHandlers = { setError, setIsRefetching }
+  // `setError` / `setIsRefetching` are stable identities from `useState`,
+  // so the memoised handlers object is also stable across renders.
+  const handlers = useMemo<PollHandlers>(
+    () => ({ setError, setIsRefetching }),
+    [],
+  )
   const { activeRef, timerRef, runIdRef, pendingResumeRef } = refs
   const isValidInterval = Number.isFinite(intervalMs) && intervalMs >= MIN_POLL_INTERVAL
 

--- a/web/src/hooks/useSettingsDirtyState.ts
+++ b/web/src/hooks/useSettingsDirtyState.ts
@@ -8,6 +8,57 @@ import { saveSettingsBatch } from '@/pages/settings/utils'
 
 const log = createLogger('useSettingsDirtyState')
 
+interface RunBatchSaveArgs {
+  readonly dirtyValues: Map<string, string>
+  readonly updateSetting: (
+    ns: SettingNamespace,
+    key: string,
+    value: string,
+  ) => Promise<unknown | null>
+  readonly setDirtyValues: React.Dispatch<React.SetStateAction<Map<string, string>>>
+}
+
+/**
+ * Run one batch-save pass: persist every pending edit, then prune the
+ * dirty map for the keys that landed cleanly. Failures are passed
+ * back via the `failedKeys` returned by `saveSettingsBatch`; those
+ * stay in the dirty map for retry. No aggregate success/failure toast
+ * fires here because the store fires one toast per mutation per the
+ * CRUD contract.
+ */
+async function _runBatchSave(args: RunBatchSaveArgs): Promise<void> {
+  const pending = new Map(args.dirtyValues)
+  const failedKeys = await saveSettingsBatch(pending, args.updateSetting)
+  args.setDirtyValues((prev) => {
+    const next = new Map(prev)
+    for (const [key, value] of pending) {
+      if (!failedKeys.has(key) && next.get(key) === value) {
+        next.delete(key)
+      }
+    }
+    return next
+  })
+}
+
+/**
+ * Defence-in-depth fallback: per-mutation failures are tracked via
+ * `failedKeys` and toasted at the store layer, so this only fires on
+ * programming errors, network failures in the batch coordinator, or
+ * exceptions in the state updater. Log + toast so the user sees
+ * feedback and the dirty state stays intact for retry.
+ */
+function _onBatchSaveError(error: unknown, dirtyValues: Map<string, string>): void {
+  log.error('Unexpected error during batch save', {
+    pendingKeys: Array.from(dirtyValues.keys()).map(sanitizeForLog),
+    error: sanitizeForLog(getErrorMessage(error)),
+  })
+  useToastStore.getState().add({
+    variant: 'error',
+    title: 'Save failed',
+    description: 'Some settings could not be saved. Please try again.',
+  })
+}
+
 export interface UseSettingsDirtyStateReturn {
   dirtyValues: Map<string, string>
   setDirtyValues: React.Dispatch<
@@ -62,49 +113,13 @@ export function useSettingsDirtyState(
   }, [])
 
   const isSavingRef = useRef(false)
-
   const handleSave = useCallback(async () => {
     if (isSavingRef.current) return
     isSavingRef.current = true
     try {
-      const pending = new Map(dirtyValues)
-      const failedKeys = await saveSettingsBatch(
-        pending,
-        updateSetting,
-      )
-
-      setDirtyValues((prev) => {
-        const next = new Map(prev)
-        for (const [key, value] of pending) {
-          if (
-            !failedKeys.has(key) &&
-            next.get(key) === value
-          ) {
-            next.delete(key)
-          }
-        }
-        return next
-      })
-
-      // No aggregate toast (success or failure) on batch saves: the
-      // store fires one toast per mutation per the CRUD contract,
-      // so an aggregate at this level would just stack on top.
+      await _runBatchSave({ dirtyValues, updateSetting, setDirtyValues })
     } catch (error) {
-      // Defence-in-depth: per-mutation failures are tracked via
-      // ``failedKeys`` and toasted at the store layer, so this catch
-      // should only fire on programming errors, network failures in
-      // the batch coordination logic, or exceptions in the state
-      // updater.  Log + toast so the user sees feedback and the
-      // dirty state stays intact for retry.
-      log.error('Unexpected error during batch save', {
-        pendingKeys: Array.from(dirtyValues.keys()).map(sanitizeForLog),
-        error: sanitizeForLog(getErrorMessage(error)),
-      })
-      useToastStore.getState().add({
-        variant: 'error',
-        title: 'Save failed',
-        description: 'Some settings could not be saved. Please try again.',
-      })
+      _onBatchSaveError(error, dirtyValues)
     } finally {
       isSavingRef.current = false
     }

--- a/web/src/hooks/useToolbarKeyboardNav.ts
+++ b/web/src/hooks/useToolbarKeyboardNav.ts
@@ -26,6 +26,63 @@ const FOCUSABLE_SELECTOR = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(',')
 
+function _hasModifier<T extends HTMLElement>(event: KeyboardEvent<T>): boolean {
+  return event.ctrlKey || event.metaKey || event.altKey || event.shiftKey
+}
+
+/**
+ * True when arrow / Home / End should belong to the focused element
+ * rather than the toolbar (caret nav inside a text input, content-
+ * editable region, etc.).
+ */
+function _isEditableElement(el: Element | null): boolean {
+  if (!(el instanceof HTMLElement)) return false
+  const tag = el.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
+  return el.isContentEditable
+}
+
+type IndexFn = (activeIndex: number, count: number) => number
+
+/** Forward wrap: -1 starts from the first item; everywhere else moves cyclically. */
+const _forward: IndexFn = (i, n) => (i < 0 ? 0 : (i + 1) % n)
+/** Backward wrap: -1 starts from the last item; everywhere else moves cyclically. */
+const _backward: IndexFn = (i, n) => (i < 0 ? n - 1 : (i - 1 + n) % n)
+const _first: IndexFn = () => 0
+const _last: IndexFn = (_i, n) => n - 1
+
+const TOOLBAR_INDEX_FNS: Readonly<Record<string, IndexFn>> = {
+  ArrowRight: _forward,
+  ArrowDown: _forward,
+  ArrowLeft: _backward,
+  ArrowUp: _backward,
+  Home: _first,
+  End: _last,
+}
+
+/**
+ * Cyclic index of the next focusable child given an arrow / Home / End
+ * key. Returns null for any other key so the caller knows to skip the
+ * focus move. `activeIndex < 0` means no toolbar child is currently
+ * focused, so a forward key lands on the first item and a backward key
+ * on the last.
+ */
+function _nextToolbarIndex(
+  key: string,
+  activeIndex: number,
+  count: number,
+): number | null {
+  const fn = TOOLBAR_INDEX_FNS[key]
+  if (!fn) return null
+  return fn(activeIndex, count)
+}
+
+function _collectToolbarItems(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  ).filter((el) => !el.hasAttribute('data-toolbar-skip'))
+}
+
 export function useToolbarKeyboardNav<
   T extends HTMLElement = HTMLDivElement,
 >(): ToolbarKeyboardNav<T> {
@@ -34,65 +91,18 @@ export function useToolbarKeyboardNav<
   const onKeyDown = useCallback((event: KeyboardEvent<T>) => {
     const container = ref.current
     if (!container) return
-
     // Let nested composite controls own the event when they call
     // preventDefault themselves (e.g. a Menu or Combobox inside the
     // toolbar). Without this guard the toolbar would re-handle the
     // arrow key and move focus away mid-interaction.
     if (event.defaultPrevented) return
-
-    // Preserve browser and assistive-tech shortcuts (Ctrl/Cmd/Alt/Shift
-    // chords) -- the toolbar only owns plain arrow/Home/End navigation.
-    if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) {
-      return
-    }
-
-    // Do not intercept arrow keys inside editable controls -- the
-    // native caret/value navigation must take precedence. Home/End
-    // inside inputs also matters for text editing and we intentionally
-    // leave them to the browser.
-    const active = document.activeElement
-    if (active instanceof HTMLElement) {
-      const editable =
-        active.tagName === 'INPUT' ||
-        active.tagName === 'TEXTAREA' ||
-        active.tagName === 'SELECT' ||
-        active.isContentEditable
-      if (editable) return
-    }
-
-    const items = Array.from(
-      container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
-    ).filter((el) => !el.hasAttribute('data-toolbar-skip'))
+    if (_hasModifier(event)) return
+    if (_isEditableElement(document.activeElement)) return
+    const items = _collectToolbarItems(container)
     if (items.length === 0) return
-
-    const activeIndex = items.indexOf(active as HTMLElement)
-
-    let nextIndex: number
-    switch (event.key) {
-      case 'ArrowRight':
-      case 'ArrowDown':
-        // -1 (no active item) starts from the first control; from any
-        // live index, wrap forward via the cyclic modulo.
-        nextIndex = activeIndex < 0 ? 0 : (activeIndex + 1) % items.length
-        break
-      case 'ArrowLeft':
-      case 'ArrowUp':
-        nextIndex =
-          activeIndex < 0
-            ? items.length - 1
-            : (activeIndex - 1 + items.length) % items.length
-        break
-      case 'Home':
-        nextIndex = 0
-        break
-      case 'End':
-        nextIndex = items.length - 1
-        break
-      default:
-        return
-    }
-
+    const activeIndex = items.indexOf(document.activeElement as HTMLElement)
+    const nextIndex = _nextToolbarIndex(event.key, activeIndex, items.length)
+    if (nextIndex === null) return
     event.preventDefault()
     items[nextIndex]?.focus()
   }, [])

--- a/web/src/lib/csp.ts
+++ b/web/src/lib/csp.ts
@@ -37,21 +37,24 @@ let cached: string | undefined | typeof UNREAD = UNREAD
  * unpredictable (Caddy's `{http.request.uuid}` placeholder, a 128-bit
  * UUID generated per request) to prevent replay across requests.
  */
-export function getCspNonce(): string | undefined {
-  if (cached !== UNREAD) return cached
-
-  const meta = document.querySelector<HTMLMetaElement>(
-    'meta[name="csp-nonce"]',
-  )
-  const value = meta?.content?.trim()
-
+/**
+ * Log any deployment-readiness issue surfaced by the meta-tag content.
+ * Split from the main reader so the caller stays under the complexity
+ * cap; the logging branches are themselves a small isolated ladder.
+ */
+function _logCspNonceIssue(
+  meta: HTMLMetaElement | null,
+  value: string | undefined,
+): void {
   if (!meta) {
-    // Missing meta tag: local dev without nginx in the path, or a
+    // Missing meta tag: local dev without Caddy in the path, or a
     // deployment misconfiguration. Inline <style> tags will be unsigned.
     log.warn('CSP nonce meta tag missing', {
       impact: 'inline <style> elements will not carry a nonce',
     })
-  } else if (value?.includes('{{placeholder')) {
+    return
+  }
+  if (value?.includes('{{placeholder')) {
     // Go template placeholder survived: in production this means Caddy's
     // templates directive is misconfigured and the CSP will block every
     // injected <style>. In the Vite dev server the placeholder is always
@@ -62,16 +65,34 @@ export function getCspNonce(): string | undefined {
       })
     } else {
       log.error('CSP nonce placeholder not substituted', {
-        impact: 'Caddy templates directive is misconfigured -- CSP will block inline styles',
+        impact: 'Caddy templates directive is misconfigured: CSP will block inline styles',
       })
     }
-  } else if (!value) {
+    return
+  }
+  if (!value) {
     log.warn('CSP nonce meta tag present but empty')
   }
+}
 
-  // Reject the un-substituted Caddy template placeholder: if {{placeholder
-  // "..."}} appears literally, the templates directive is misconfigured (or
-  // we are in dev), and the value is not a real nonce.
-  cached = value && !value.includes('{{placeholder') ? value : undefined
+/**
+ * Reject the un-substituted Caddy template placeholder: if
+ * `{{placeholder "..."}}` appears literally, the templates directive is
+ * misconfigured (or we are in dev), and the value is not a real nonce.
+ */
+function _validNonce(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  if (value.includes('{{placeholder')) return undefined
+  return value
+}
+
+export function getCspNonce(): string | undefined {
+  if (cached !== UNREAD) return cached
+  const meta = document.querySelector<HTMLMetaElement>(
+    'meta[name="csp-nonce"]',
+  )
+  const value = meta?.content?.trim()
+  _logCspNonceIssue(meta, value)
+  cached = _validNonce(value)
   return cached
 }

--- a/web/src/lib/error-classify.ts
+++ b/web/src/lib/error-classify.ts
@@ -1,3 +1,5 @@
+import type { AxiosError } from 'axios'
+
 import { isAxiosError, getErrorMessage } from '@/utils/errors'
 
 export interface ClassifiedError {
@@ -14,6 +16,117 @@ export interface ClassifiedError {
   guidance?: string
 }
 
+type StatusClassifier = (message: string, status: number) => ClassifiedError
+
+/**
+ * Per-status classification rules. Statuses not present here fall
+ * through to the generic 4xx / 5xx ladder in `_classifyAxiosWithResponse`.
+ */
+const HTTP_STATUS_CLASSIFIERS: Readonly<Record<number, StatusClassifier>> = {
+  401: (message, status) => ({
+    message,
+    status,
+    isTransient: false,
+    isClient: true,
+    retryable: false,
+    guidance: 'Your session may have expired. Please sign in again.',
+  }),
+  403: (message, status) => ({
+    message,
+    status,
+    isTransient: false,
+    isClient: true,
+    retryable: false,
+    guidance: 'You do not have permission for this action. Contact an administrator.',
+  }),
+  404: (message, status) => ({
+    message,
+    status,
+    isTransient: false,
+    isClient: true,
+    retryable: false,
+    guidance: 'The requested resource was not found. It may have been deleted.',
+  }),
+  408: (message, status) => ({
+    message,
+    status,
+    isTransient: true,
+    isClient: false,
+    retryable: true,
+  }),
+  409: (message, status) => ({
+    message,
+    status,
+    isTransient: false,
+    isClient: true,
+    // Conflicts require user action (refresh + re-submit with new state);
+    // callers that loop on `retryable` would otherwise thrash against the
+    // server without resolution.
+    retryable: false,
+    guidance: 'Someone else modified this resource. Refresh and try again.',
+  }),
+  429: (message, status) => ({
+    message,
+    status,
+    isTransient: true,
+    isClient: false,
+    retryable: true,
+    guidance: 'Rate limited. Wait a moment before retrying.',
+  }),
+}
+
+function _defaultClassification(message: string): ClassifiedError {
+  // Non-axios errors (TypeError, SyntaxError, ...) default to non-retryable.
+  return { message, isTransient: false, isClient: false, retryable: false }
+}
+
+function _classifyAxiosWithResponse(
+  message: string,
+  status: number,
+): ClassifiedError {
+  if (status >= 500) {
+    return { message, status, isTransient: true, isClient: false, retryable: true }
+  }
+  const specific = HTTP_STATUS_CLASSIFIERS[status]
+  if (specific) return specific(message, status)
+  if (status >= 400 && status < 500) {
+    return {
+      message,
+      status,
+      isTransient: false,
+      isClient: true,
+      retryable: false,
+      guidance: 'Check your input and try again.',
+    }
+  }
+  return _defaultClassification(message)
+}
+
+function _classifyAxiosError(error: AxiosError, message: string): ClassifiedError {
+  // Canceled requests (AbortController / axios cancel) are not retryable.
+  // Emit them with the normal shape but no transient/retryable flag so
+  // callers don't loop a user-initiated cancel.
+  if (error.code === 'ERR_CANCELED') {
+    return {
+      message,
+      isTransient: false,
+      isClient: false,
+      retryable: false,
+      guidance: 'Request was canceled.',
+    }
+  }
+  if (!error.response) {
+    return {
+      message,
+      isTransient: true,
+      isClient: false,
+      retryable: true,
+      guidance: 'Check your network connection and try again.',
+    }
+  }
+  return _classifyAxiosWithResponse(message, error.response.status)
+}
+
 /**
  * Classify an error into transient / client / unknown categories so the UI
  * can choose between "Retry" (transient) vs "Check configuration" (client)
@@ -21,119 +134,6 @@ export interface ClassifiedError {
  */
 export function classifyError(error: unknown): ClassifiedError {
   const message = getErrorMessage(error)
-
-  if (isAxiosError(error)) {
-    const status = error.response?.status
-
-    // Canceled requests (AbortController / axios cancel) are not retryable.
-    // Emit them with the normal shape but no transient/retryable flag so
-    // callers don't loop a user-initiated cancel.
-    if (error.code === 'ERR_CANCELED') {
-      return {
-        message,
-        isTransient: false,
-        isClient: false,
-        retryable: false,
-        guidance: 'Request was canceled.',
-      }
-    }
-
-    // Network-level failures have no response.
-    if (!error.response) {
-      return {
-        message,
-        isTransient: true,
-        isClient: false,
-        retryable: true,
-        guidance: 'Check your network connection and try again.',
-      }
-    }
-
-    if (status !== undefined && status >= 500) {
-      return {
-        message,
-        status,
-        isTransient: true,
-        isClient: false,
-        retryable: true,
-      }
-    }
-
-    if (status === 408 || status === 429) {
-      return {
-        message,
-        status,
-        isTransient: true,
-        isClient: false,
-        retryable: true,
-        guidance: status === 429 ? 'Rate limited. Wait a moment before retrying.' : undefined,
-      }
-    }
-
-    if (status === 401) {
-      return {
-        message,
-        status,
-        isTransient: false,
-        isClient: true,
-        retryable: false,
-        guidance: 'Your session may have expired. Please sign in again.',
-      }
-    }
-
-    if (status === 403) {
-      return {
-        message,
-        status,
-        isTransient: false,
-        isClient: true,
-        retryable: false,
-        guidance: 'You do not have permission for this action. Contact an administrator.',
-      }
-    }
-
-    if (status === 404) {
-      return {
-        message,
-        status,
-        isTransient: false,
-        isClient: true,
-        retryable: false,
-        guidance: 'The requested resource was not found. It may have been deleted.',
-      }
-    }
-
-    if (status === 409) {
-      return {
-        message,
-        status,
-        isTransient: false,
-        isClient: true,
-        // Conflicts require user action (refresh + re-submit with new state);
-        // callers that loop on `retryable` would otherwise thrash against the
-        // server without resolution.
-        retryable: false,
-        guidance: 'Someone else modified this resource. Refresh and try again.',
-      }
-    }
-
-    if (status !== undefined && status >= 400 && status < 500) {
-      return {
-        message,
-        status,
-        isTransient: false,
-        isClient: true,
-        retryable: false,
-        guidance: 'Check your input and try again.',
-      }
-    }
-  }
-
-  // Non-axios errors (TypeError, SyntaxError, ...) default to non-retryable.
-  return {
-    message,
-    isTransient: false,
-    isClient: false,
-    retryable: false,
-  }
+  if (isAxiosError(error)) return _classifyAxiosError(error, message)
+  return _defaultClassification(message)
 }

--- a/web/src/utils/agents.ts
+++ b/web/src/utils/agents.ts
@@ -110,34 +110,33 @@ const STATUS_RANK: Record<AgentStatus, number> = {
   active: 0, onboarding: 1, on_leave: 2, terminated: 3,
 }
 
+/**
+ * Pull the comparison key for one agent given a sort field. Ordinal
+ * fields (`level`, `status`) are resolved through their semantic rank
+ * tables so the sort respects the documented order rather than alpha.
+ */
+function _sortValue(agent: DashboardAgentConfig, sortBy: AgentSortKey): string | number {
+  if (sortBy === 'level') return LEVEL_RANK[agent.level]
+  if (sortBy === 'status') return STATUS_RANK[agent.status ?? 'active']
+  return agent[sortBy] ?? ''
+}
+
+function _compare(a: string | number, b: string | number, dir: number): number {
+  if (a < b) return -1 * dir
+  if (a > b) return 1 * dir
+  return 0
+}
+
 /** Sort agents by a given key. Does not mutate the input. */
 export function sortAgents(
   agents: readonly DashboardAgentConfig[],
   sortBy: AgentSortKey,
   direction: 'asc' | 'desc' = 'asc',
 ): DashboardAgentConfig[] {
-  const sorted = [...agents]
   const dir = direction === 'asc' ? 1 : -1
-
-  sorted.sort((a, b) => {
-    let va: string | number = a[sortBy] ?? ''
-    let vb: string | number = b[sortBy] ?? ''
-
-    // Use semantic rank for ordinal fields
-    if (sortBy === 'level') {
-      va = LEVEL_RANK[a.level]
-      vb = LEVEL_RANK[b.level]
-    } else if (sortBy === 'status') {
-      va = STATUS_RANK[a.status ?? 'active']
-      vb = STATUS_RANK[b.status ?? 'active']
-    }
-
-    if (va < vb) return -1 * dir
-    if (va > vb) return 1 * dir
-    return 0
-  })
-
-  return sorted
+  return [...agents].sort((a, b) =>
+    _compare(_sortValue(a, sortBy), _sortValue(b, sortBy), dir),
+  )
 }
 
 // ── Formatting ─────────────────────────────────────────────
@@ -162,50 +161,71 @@ export function formatCostPerTask(cost: number | null): string {
 
 type PerformanceCardData = Omit<MetricCardProps, 'className'>
 
+type PerformanceWindow = AgentPerformanceSummary['windows'][number]
+
+/**
+ * Project sparkline arrays from a performance summary. Returns
+ * `undefined` per series when there are fewer than 2 windows so the
+ * downstream MetricCard renders a value-only tile rather than a flat
+ * line. Nullable per-window metrics are coerced to 0 / 100 as
+ * appropriate so the sparkline area never collapses on a sparse window.
+ */
+function _buildSparklines(perf: AgentPerformanceSummary): {
+  readonly task?: number[]
+  readonly time?: number[]
+  readonly success?: number[]
+  readonly cost?: number[]
+} {
+  if (perf.windows.length < 2) return {}
+  const w = perf.windows
+  return {
+    task: w.map((x: PerformanceWindow) => x.tasks_completed),
+    time: w.map((x: PerformanceWindow) => x.avg_completion_time_seconds ?? 0),
+    success: w.map((x: PerformanceWindow) =>
+      x.success_rate != null ? x.success_rate * 100 : 0,
+    ),
+    cost: w.map((x: PerformanceWindow) => x.avg_cost_per_task ?? 0),
+  }
+}
+
+function _successRateText(perf: AgentPerformanceSummary): string {
+  return perf.success_rate_percent != null
+    ? `${perf.success_rate_percent.toFixed(1)}%`
+    : '--'
+}
+
+function _successSubText(perf: AgentPerformanceSummary): string | undefined {
+  if (perf.tasks_completed_30d <= 0) return undefined
+  return `across ${perf.tasks_completed_30d} tasks (30d)`
+}
+
 /** Map an AgentPerformanceSummary to 4 MetricCard props. */
 export function computePerformanceCards(
   perf: AgentPerformanceSummary,
 ): PerformanceCardData[] {
-  const hasSparkline = perf.windows.length >= 2
-
-  // Build sparkline arrays from window metrics (nullable fields filtered to numbers)
-  const taskSparkline = hasSparkline
-    ? perf.windows.map((w) => w.tasks_completed)
-    : undefined
-  const timeSparkline = hasSparkline
-    ? perf.windows.map((w) => w.avg_completion_time_seconds ?? 0)
-    : undefined
-  const successSparkline = hasSparkline
-    ? perf.windows.map((w) => w.success_rate != null ? w.success_rate * 100 : 0)
-    : undefined
-  const costSparkline = hasSparkline
-    ? perf.windows.map((w) => w.avg_cost_per_task ?? 0)
-    : undefined
-
+  const sparklines = _buildSparklines(perf)
   return [
     {
       label: 'TASKS COMPLETED',
       value: perf.tasks_completed_total,
       subText: `${perf.tasks_completed_7d} this week`,
-      sparklineData: taskSparkline,
+      sparklineData: sparklines.task,
     },
     {
       label: 'AVG COMPLETION TIME',
       value: formatCompletionTime(perf.avg_completion_time_seconds ?? null),
-      sparklineData: timeSparkline,
+      sparklineData: sparklines.time,
     },
     {
       label: 'SUCCESS RATE',
-      value: perf.success_rate_percent != null ? `${perf.success_rate_percent.toFixed(1)}%` : '--',
-      subText: perf.tasks_completed_30d > 0
-        ? `across ${perf.tasks_completed_30d} tasks (30d)`
-        : undefined,
-      sparklineData: successSparkline,
+      value: _successRateText(perf),
+      subText: _successSubText(perf),
+      sparklineData: sparklines.success,
     },
     {
       label: 'COST PER TASK',
       value: formatCostPerTask(perf.cost_per_task ?? null),
-      sparklineData: costSparkline,
+      sparklineData: sparklines.cost,
     },
   ]
 }

--- a/web/src/utils/budget.ts
+++ b/web/src/utils/budget.ts
@@ -315,6 +315,69 @@ export function filterCfoEvents(
   return activities.filter((a) => CFO_EVENT_TYPES.has(a.action_type))
 }
 
+interface BudgetCardContext {
+  readonly overview: OverviewMetrics
+  readonly budgetConfig: BudgetConfig | null
+  readonly forecast: ForecastResponse | null
+  readonly currency: string | undefined
+}
+
+function _buildSpendCard(ctx: BudgetCardContext): BudgetMetricCardData {
+  const { overview, currency } = ctx
+  const totalMonthly = ctx.budgetConfig?.total_monthly ?? 0
+  const hasBudget = totalMonthly > 0
+  return {
+    label: 'SPEND THIS PERIOD',
+    value: formatCurrency(overview.total_cost, currency),
+    sparklineData: overview.cost_7d_trend.map((p) => p.value),
+    change: computeSpendTrend(overview.cost_7d_trend),
+    ...(hasBudget && {
+      progress: { current: overview.total_cost, total: totalMonthly },
+      subText: `of ${formatCurrency(totalMonthly, currency)} budget`,
+    }),
+  }
+}
+
+function _buildRemainingCard(ctx: BudgetCardContext): BudgetMetricCardData {
+  const { overview, currency } = ctx
+  const remainingPct = Math.round(Math.max(0, 100 - overview.budget_used_percent))
+  return {
+    label: 'BUDGET REMAINING',
+    value: formatCurrency(overview.budget_remaining, currency),
+    subText: `${remainingPct}% of budget`,
+  }
+}
+
+function _buildAvgDayCard(ctx: BudgetCardContext): BudgetMetricCardData {
+  return {
+    label: 'AVG DAILY SPEND',
+    value: formatCurrency(ctx.forecast?.avg_daily_spend ?? 0, ctx.currency),
+  }
+}
+
+/**
+ * Pick the sub-text line for the "days until exhausted" card. When the
+ * forecast knows the exhaustion horizon we render its calendar date;
+ * otherwise we fall back to the next budget-reset countdown.
+ */
+function _daysLeftSubText(ctx: BudgetCardContext): string | undefined {
+  const days = ctx.forecast?.days_until_exhausted
+  if (days != null) {
+    return computeExhaustionDate(days) ?? undefined
+  }
+  if (ctx.budgetConfig === null) return undefined
+  return `Resets in ${daysUntilBudgetReset(ctx.budgetConfig.reset_day)} days`
+}
+
+function _buildDaysLeftCard(ctx: BudgetCardContext): BudgetMetricCardData {
+  const days = ctx.forecast?.days_until_exhausted
+  return {
+    label: 'DAYS UNTIL EXHAUSTED',
+    value: days != null ? String(days) : 'N/A',
+    subText: _daysLeftSubText(ctx),
+  }
+}
+
 /**
  * Compute metric card data for the Budget page header.
  *
@@ -325,44 +388,18 @@ export function computeBudgetMetricCards(
   budgetConfig: BudgetConfig | null,
   forecast: ForecastResponse | null,
 ): BudgetMetricCardData[] {
-  const currency = overview.currency ?? budgetConfig?.currency
-  const totalMonthly = budgetConfig?.total_monthly ?? 0
-
-  const spendCard: BudgetMetricCardData = {
-    label: 'SPEND THIS PERIOD',
-    value: formatCurrency(overview.total_cost, currency),
-    sparklineData: overview.cost_7d_trend.map((p) => p.value),
-    change: computeSpendTrend(overview.cost_7d_trend),
-    ...(totalMonthly > 0 && {
-      progress: { current: overview.total_cost, total: totalMonthly },
-      subText: `of ${formatCurrency(totalMonthly, currency)} budget`,
-    }),
+  const ctx: BudgetCardContext = {
+    overview,
+    budgetConfig,
+    forecast,
+    currency: overview.currency ?? budgetConfig?.currency,
   }
-
-  const remainingCard: BudgetMetricCardData = {
-    label: 'BUDGET REMAINING',
-    value: formatCurrency(overview.budget_remaining, currency),
-    subText: `${Math.round(Math.max(0, 100 - overview.budget_used_percent))}% of budget`,
-  }
-
-  const avgDayCard: BudgetMetricCardData = {
-    label: 'AVG DAILY SPEND',
-    value: formatCurrency(forecast?.avg_daily_spend ?? 0, currency),
-  }
-
-  const daysLeftCard: BudgetMetricCardData = {
-    label: 'DAYS UNTIL EXHAUSTED',
-    value: forecast?.days_until_exhausted != null
-      ? String(forecast.days_until_exhausted)
-      : 'N/A',
-    subText: forecast?.days_until_exhausted != null
-      ? computeExhaustionDate(forecast.days_until_exhausted) ?? undefined
-      : budgetConfig
-        ? `Resets in ${daysUntilBudgetReset(budgetConfig.reset_day)} days`
-        : undefined,
-  }
-
-  return [spendCard, remainingCard, avgDayCard, daysLeftCard]
+  return [
+    _buildSpendCard(ctx),
+    _buildRemainingCard(ctx),
+    _buildAvgDayCard(ctx),
+    _buildDaysLeftCard(ctx),
+  ]
 }
 
 // ── Pack-Apply Budget Preview ─────────────────────────────

--- a/web/src/utils/dashboard.ts
+++ b/web/src/utils/dashboard.ts
@@ -111,33 +111,65 @@ export function describeEvent(eventType: WsEventType): string {
 
 let wsActivityCounter = 0
 
+type WsEventPayload = NonNullable<WsEvent['payload']>
+
+function _isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value !== ''
+}
+
+function _resolveAgentName(payload: WsEventPayload): string {
+  if (_isNonEmptyString(payload.agent_name)) return payload.agent_name
+  if (_isNonEmptyString(payload.assigned_to)) return payload.assigned_to
+  return 'System'
+}
+
+function _resolveTaskId(payload: WsEventPayload): string | null {
+  return _isNonEmptyString(payload.task_id) ? payload.task_id : null
+}
+
+function _resolveDepartment(payload: WsEventPayload): ActivityItem['department'] {
+  if (
+    typeof payload.department === 'string'
+    && isDepartmentName(payload.department)
+  ) {
+    return payload.department
+  }
+  return null
+}
+
+function _resolveDescription(
+  payload: WsEventPayload,
+  eventType: WsEventType,
+): string {
+  if (_isNonEmptyString(payload.description)) return payload.description
+  return describeEvent(eventType)
+}
+
+interface ActivityIdArgs {
+  readonly event: WsEvent
+  readonly payload: WsEventPayload
+  readonly taskId: string | null
+  readonly agentName: string
+}
+
+function _resolveActivityId({ event, payload, taskId, agentName }: ActivityIdArgs): string {
+  if (_isNonEmptyString(payload.id)) return payload.id
+  if (taskId !== null) return taskId
+  wsActivityCounter += 1
+  return `${event.timestamp}-${event.event_type}-${agentName}-${wsActivityCounter}`
+}
+
 export function wsEventToActivityItem(event: WsEvent): ActivityItem {
-  const payload = event.payload ?? {}
-  const agentName =
-    (typeof payload.agent_name === 'string' && payload.agent_name) ||
-    (typeof payload.assigned_to === 'string' && payload.assigned_to) ||
-    'System'
-  const taskId =
-    typeof payload.task_id === 'string' ? payload.task_id : null
-  const department =
-    typeof payload.department === 'string' && isDepartmentName(payload.department)
-      ? payload.department
-      : null
-
-  const description =
-    typeof payload.description === 'string' && payload.description
-      ? payload.description
-      : describeEvent(event.event_type)
-
+  const payload = (event.payload ?? {}) as WsEventPayload
+  const agentName = _resolveAgentName(payload)
+  const taskId = _resolveTaskId(payload)
   return {
-    id: (typeof payload.id === 'string' && payload.id)
-      || taskId
-      || `${event.timestamp}-${event.event_type}-${agentName}-${++wsActivityCounter}`,
+    id: _resolveActivityId({ event, payload, taskId, agentName }),
     timestamp: event.timestamp,
     agent_name: agentName,
     action_type: event.event_type,
-    description,
+    description: _resolveDescription(payload, event.event_type),
     task_id: taskId,
-    department,
+    department: _resolveDepartment(payload),
   }
 }

--- a/web/src/utils/dashboard.ts
+++ b/web/src/utils/dashboard.ts
@@ -113,6 +113,14 @@ let wsActivityCounter = 0
 
 type WsEventPayload = NonNullable<WsEvent['payload']>
 
+/**
+ * Typed empty payload used when a WsEvent arrives without a payload.
+ * Every WsEventPayload field is optional, so an empty object is a
+ * valid value; binding it to a named constant of the precise type
+ * avoids the looser `as WsEventPayload` cast on the read site.
+ */
+const EMPTY_WS_EVENT_PAYLOAD: WsEventPayload = {}
+
 function _isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value !== ''
 }
@@ -160,7 +168,7 @@ function _resolveActivityId({ event, payload, taskId, agentName }: ActivityIdArg
 }
 
 export function wsEventToActivityItem(event: WsEvent): ActivityItem {
-  const payload = (event.payload ?? {}) as WsEventPayload
+  const payload: WsEventPayload = event.payload ?? EMPTY_WS_EVENT_PAYLOAD
   const agentName = _resolveAgentName(payload)
   const taskId = _resolveTaskId(payload)
   return {

--- a/web/src/utils/errors.ts
+++ b/web/src/utils/errors.ts
@@ -308,8 +308,10 @@ function _extractBackendClientError(
   status: number | undefined,
 ): string | null {
   if (!_isClientStatus(status)) return null
-  const err = data?.error
-  return typeof err === 'string' ? err : null
+  // Empty / whitespace `data.error` must not short-circuit the
+  // fallback chain; blank strings would otherwise surface as an
+  // empty user-visible message in `_formatAxiosErrorMessage`.
+  return _trimmedOrNull(data?.error)
 }
 
 /** Canned per-status copy from `STATUS_FALLBACK_MESSAGES`, or null. */

--- a/web/src/utils/errors.ts
+++ b/web/src/utils/errors.ts
@@ -5,6 +5,110 @@ import { createLogger } from '@/lib/logger'
 import { sanitizeForLog } from '@/utils/logging'
 import { ErrorCategory, ErrorCode, type ErrorDetail } from '@/api/types/errors'
 
+const log = createLogger('errors')
+
+/**
+ * Cap on prose error messages reaching the user surface. Backend validators
+ * can emit very long descriptions (e.g. enumerating every invalid field on
+ * a bulk import); without a ceiling a multi-kilobyte string would blow up
+ * toast and banner layouts. The truncation marker keeps the message
+ * recognisably incomplete so users know to ask for the full detail in
+ * support.
+ */
+const MAX_ERROR_MESSAGE_LEN = 1000
+
+const GENERIC_FALLBACK_MESSAGE =
+  'An unexpected error occurred. Please refresh the page or contact support if this persists.'
+
+const NETWORK_ERROR_MESSAGE = 'Network error. Please check your connection.'
+
+const INTERNAL_SERVER_ERROR_MESSAGE =
+  'An unexpected server error occurred. Please try again later or '
+  + 'contact support if this persists.'
+
+const GENERIC_VALIDATION_MESSAGE =
+  'Validation error. Please check the highlighted fields and try again.'
+
+/**
+ * Per-HTTP-status canned copy used by `getErrorMessage` when no
+ * specialised handler claimed the response. 502 / 504 are grouped
+ * because both manifest as the same transient upstream hop failure.
+ */
+const STATUS_FALLBACK_MESSAGES: Readonly<Record<number, string>> = {
+  400: 'Invalid request. Please check your input.',
+  401: 'Authentication required. Please log in.',
+  403: 'You do not have permission to perform this action.',
+  404: 'The requested resource was not found.',
+  502: 'Temporary connectivity issue. Please retry shortly.',
+  504: 'Temporary connectivity issue. Please retry shortly.',
+}
+
+/** Pydantic v1 / v2 leak patterns; see `_isPydanticishMessage` for use. */
+const PYDANTIC_PHRASE_PATTERN =
+  /(field required|value is not a valid|string too (short|long)|input should|string should|list should|dict should)/i
+
+/**
+ * 409 toast copy keyed by structured `ErrorCode`. Both DUPLICATE_*
+ * variants share the duplicate-name copy; both VERSION_* variants share
+ * the optimistic-concurrency copy. The lookup keeps `_handleConflict`
+ * under the complexity cap by replacing the per-code `||` ladder with a
+ * single table read.
+ */
+const CONFLICT_MESSAGES: Readonly<Partial<Record<ErrorCode, string>>> = {
+  [ErrorCode.DUPLICATE_RECORD]:
+    'A resource with this name already exists. Pick a different name.',
+  [ErrorCode.ONTOLOGY_DUPLICATE]:
+    'A resource with this name already exists. Pick a different name.',
+  [ErrorCode.VERSION_CONFLICT]:
+    'This resource was edited by someone else. Reload to see the latest version, then retry.',
+  [ErrorCode.TASK_VERSION_CONFLICT]:
+    'This resource was edited by someone else. Reload to see the latest version, then retry.',
+}
+
+/**
+ * Toast titles keyed by structured `ErrorCategory`. `INTERNAL` is null
+ * so the helper falls through to the HTTP-status / caller-fallback
+ * branches: a 5xx-class internal failure carries a more specific
+ * status-based message than the generic "Internal error" copy would.
+ * Using `satisfies Record<ErrorCategory, ...>` makes the table
+ * exhaustive: a new ErrorCategory value added to the backend breaks
+ * the build until a title (or explicit fall-through) is supplied here.
+ */
+const CATEGORY_TITLES = {
+  [ErrorCategory.AUTH]: 'Authentication failed',
+  [ErrorCategory.VALIDATION]: 'Validation failed',
+  [ErrorCategory.NOT_FOUND]: 'Not found',
+  [ErrorCategory.CONFLICT]: 'Resource conflict',
+  [ErrorCategory.RATE_LIMIT]: 'Rate limit reached',
+  [ErrorCategory.BUDGET_EXHAUSTED]: 'Budget exhausted',
+  [ErrorCategory.PROVIDER_ERROR]: 'Provider error',
+  [ErrorCategory.INTERNAL]: null,
+} as const satisfies Record<ErrorCategory, string | null>
+
+/**
+ * HTTP-status fallbacks for toast titles when no structured detail is
+ * present. 403 is handled inline by `getCrudErrorTitle` (it short-
+ * circuits the category switch with "Permission denied").
+ */
+const STATUS_TITLES: Readonly<Record<number, string>> = {
+  401: 'Authentication failed',
+  404: 'Not found',
+  409: 'Resource conflict',
+  422: 'Validation failed',
+  429: 'Rate limit reached',
+}
+
+/**
+ * Shape of the JSON envelope axios responses carry under
+ * `response.data`. Captures only the fields the helpers in this module
+ * read; backend additions stay tolerated by the index-signature.
+ */
+interface AxiosErrorData {
+  error?: string
+  error_detail?: ErrorDetail
+  success?: boolean
+}
+
 /**
  * Format a millisecond duration as user-facing British English copy
  * for "try again in X" toasts. The granularity ladder is hour /
@@ -27,18 +131,12 @@ function formatRetryAfter(ms: number): string {
 }
 
 /**
- * Read the ``Retry-After`` HTTP header value from an axios error
- * response and return the wait duration in milliseconds (or ``null``
- * when the header is absent or unparseable). Distinct from
- * ``parseRetryAfterMs`` in ``@/utils/retry-after``: that helper caps
- * the result against the auto-retry budget and returns a sentinel,
- * which is the wrong contract for user-facing toast copy where we
- * want the literal wait duration even when it exceeds the budget.
+ * Parse the textual `Retry-After` header value into a wait duration in
+ * milliseconds. Accepts both delta-seconds (`"90"`) and HTTP-date
+ * (`"Wed, 21 Oct 2026 07:28:00 GMT"`) forms per RFC 9110 §10.2.3.
+ * Returns null when the value cannot be interpreted as either form.
  */
-function readRetryAfterHeaderMs(error: AxiosError): number | null {
-  const raw = error.response?.headers?.['retry-after']
-  if (typeof raw !== 'string' || raw.trim() === '') return null
-  const trimmed = raw.trim()
+function _parseRetryAfterValue(trimmed: string): number | null {
   if (/^\d+$/.test(trimmed)) {
     const seconds = Number.parseInt(trimmed, 10)
     return Number.isFinite(seconds) && seconds >= 0 ? seconds * 1000 : null
@@ -48,27 +146,32 @@ function readRetryAfterHeaderMs(error: AxiosError): number | null {
   return Math.max(0, parsedDate - Date.now())
 }
 
-const log = createLogger('errors')
-
 /**
- * Cap on prose error messages reaching the user surface. Backend validators
- * can emit very long descriptions (e.g. enumerating every invalid field on
- * a bulk import); without a ceiling a multi-kilobyte string would blow up
- * toast and banner layouts. The truncation marker keeps the message
- * recognisably incomplete so users know to ask for the full detail in
- * support.
+ * Read the `Retry-After` HTTP header value from an axios error
+ * response and return the wait duration in milliseconds (or null
+ * when the header is absent or unparseable). Distinct from
+ * `parseRetryAfterMs` in `@/utils/retry-after`: that helper caps
+ * the result against the auto-retry budget and returns a sentinel,
+ * which is the wrong contract for user-facing toast copy where we
+ * want the literal wait duration even when it exceeds the budget.
  */
-const MAX_ERROR_MESSAGE_LEN = 1000
+function readRetryAfterHeaderMs(error: AxiosError): number | null {
+  const raw = error.response?.headers?.['retry-after']
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (trimmed === '') return null
+  return _parseRetryAfterValue(trimmed)
+}
 
 /**
- * Duck-typed check for ``ApiRequestError`` instances without importing
- * the class. Importing ``@/api/client`` here would pull ``axios.create()``
- * into utility modules that test code mocks ``axios`` for, breaking
- * the property-based tests in ``errors.property.test.ts``.
+ * Duck-typed check for `ApiRequestError` instances without importing
+ * the class. Importing `@/api/client` here would pull `axios.create()`
+ * into utility modules that test code mocks `axios` for, breaking
+ * the property-based tests in `errors.property.test.ts`.
  *
- * The class lives in ``@/api/client`` and sets ``this.name = 'ApiRequestError'``
+ * The class lives in `@/api/client` and sets `this.name = 'ApiRequestError'`
  * in its constructor; matching on the name plus the public
- * ``errorDetail`` field is sufficient for the read-only access path.
+ * `errorDetail` field is sufficient for the read-only access path.
  */
 function isApiRequestError(error: unknown): error is { errorDetail: ErrorDetail | null } {
   return (
@@ -78,11 +181,189 @@ function isApiRequestError(error: unknown): error is { errorDetail: ErrorDetail 
   )
 }
 
-/**
- * Check if an error is an Axios error.
- */
+/** Check if an error is an Axios error. */
 export function isAxiosError(error: unknown): error is AxiosError {
   return axios.isAxiosError(error)
+}
+
+/**
+ * Backend rate limits are per-operation (per_op_rate_limit_from_policy),
+ * not global; the toast hint tells the operator which operation hit the
+ * cap so they do not assume the whole dashboard is throttled.
+ */
+function _handleRateLimited(error: AxiosError): string {
+  const opHint = _urlOf(error).includes('/setup/complete')
+    ? 'Too many setup completion attempts'
+    : 'Too many requests for this operation'
+  const ms = readRetryAfterHeaderMs(error)
+  if (ms !== null && ms > 0) {
+    return `${opHint}. Try again in ${formatRetryAfter(ms)}.`
+  }
+  return `${opHint}. Try again in a few seconds.`
+}
+
+function _handleServiceUnavailable(error: AxiosError): string {
+  const ms = readRetryAfterHeaderMs(error)
+  if (ms !== null) {
+    return `The service is restarting. Try again in ${formatRetryAfter(ms)}.`
+  }
+  return 'The service is unavailable. Contact the operator if this persists.'
+}
+
+/** Return the lower-case request URL of an axios error, or empty string. */
+function _urlOf(error: AxiosError): string {
+  return error.config?.url ?? ''
+}
+
+/**
+ * Branch on the structured `error_code` so duplicate /
+ * version-conflict / generic-conflict cases each get actionable copy.
+ * Setup completion is the most common 409 with no structured code
+ * (RESOURCE_CONFLICT): the backend rejects a second `/setup/complete`
+ * after the flag is already set. Surface that case with copy that
+ * points operators at the right next step.
+ */
+function _handleConflict(error: AxiosError, data: AxiosErrorData | undefined): string {
+  const code = data?.error_detail?.error_code
+  const fromCode = code !== undefined ? CONFLICT_MESSAGES[code] : undefined
+  if (fromCode !== undefined) return fromCode
+  if (_urlOf(error).includes('/setup/complete')) {
+    return 'Setup is already complete. Reload to see the current dashboard.'
+  }
+  return 'The resource state changed. Refresh the page and try again.'
+}
+
+/**
+ * Pydantic v2 standardises on "Input should be ...", "String should
+ * have at least/most N ...", "List should ...", "Dict should ..." in
+ * addition to the v1-era "field required" / "value is not a valid" /
+ * "string too short|long" phrasings. Catch the whole family so none of
+ * them leak verbatim to end users.
+ */
+function _isPydanticishMessage(raw: string): boolean {
+  return (
+    /validation error for /i.test(raw)
+    || PYDANTIC_PHRASE_PATTERN.test(raw)
+  )
+}
+
+/** Return `value` trimmed, or null if it is not a non-blank string. */
+function _trimmedOrNull(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed === '' ? null : trimmed
+}
+
+/**
+ * 422 prefers the structured `error_detail.detail` envelope (RFC 9457)
+ * over the plain `data.error` string so the user sees the curated
+ * message the backend chose for THIS validation failure rather than the
+ * raw Pydantic surface. `data.error` is only surfaced when it does NOT
+ * look like a raw Pydantic ValueError string.
+ */
+function _handleValidation(data: AxiosErrorData | undefined): string {
+  const structuredDetail = _trimmedOrNull(data?.error_detail?.detail)
+  if (structuredDetail !== null) return structuredDetail
+  const raw = _trimmedOrNull(data?.error)
+  if (raw !== null && !_isPydanticishMessage(raw)) return raw
+  return GENERIC_VALIDATION_MESSAGE
+}
+
+/**
+ * Specialised per-status handlers for axios errors where the canned
+ * `STATUS_FALLBACK_MESSAGES` table is not enough. Returns null when no
+ * specialised handler applies, so the caller can fall through to the
+ * generic `data.error` / status-table / network / 5xx ladder.
+ *
+ * 409 / 429 / 503 are differentiated BEFORE the generic `data.error`
+ * early-return so a backend that always populates `data.error` does not
+ * flatten the structured copy below into a single uninformative line.
+ * 422 is in this set because its structured `error_detail.detail`
+ * wins inside `_handleValidation`.
+ */
+function _handleSpecialisedAxiosStatus(
+  error: AxiosError,
+  data: AxiosErrorData | undefined,
+  status: number | undefined,
+): string | null {
+  if (status === 429) return _handleRateLimited(error)
+  if (status === 503) return _handleServiceUnavailable(error)
+  if (status === 409) return _handleConflict(error, data)
+  if (status === 422) return _handleValidation(data)
+  return null
+}
+
+/** True when `status` is in the 4xx client-error band. */
+function _isClientStatus(status: number | undefined): status is number {
+  return status !== undefined && status >= 400 && status < 500
+}
+
+/**
+ * For 4xx (non-422; 422 is handled in `_handleValidation`), surface the
+ * backend's `data.error` string verbatim when present. Returns null
+ * when no usable string is available.
+ */
+function _extractBackendClientError(
+  data: AxiosErrorData | undefined,
+  status: number | undefined,
+): string | null {
+  if (!_isClientStatus(status)) return null
+  const err = data?.error
+  return typeof err === 'string' ? err : null
+}
+
+/** Canned per-status copy from `STATUS_FALLBACK_MESSAGES`, or null. */
+function _statusFallback(status: number | undefined): string | null {
+  if (status === undefined) return null
+  return STATUS_FALLBACK_MESSAGES[status] ?? null
+}
+
+/**
+ * Final ladder when no specialised handler / backend string / status-
+ * table entry matched: network errors, generic client errors, and
+ * the 5xx escalation message. 5xx that did not match a specialised
+ * handler (500, 505, ...): generic message + escalation hint avoids
+ * leaking server internals while signalling whether to retry
+ * transiently or escalate.
+ */
+function _fallbackAxiosMessage(error: AxiosError, status: number | undefined): string {
+  if (!error.response) return NETWORK_ERROR_MESSAGE
+  if (_isClientStatus(status)) {
+    return `Request failed (${status}). Please check your input.`
+  }
+  return INTERNAL_SERVER_ERROR_MESSAGE
+}
+
+function _formatAxiosErrorMessage(error: AxiosError): string {
+  const status = error.response?.status
+  const data = error.response?.data as AxiosErrorData | undefined
+  return (
+    _handleSpecialisedAxiosStatus(error, data, status)
+    ?? _extractBackendClientError(data, status)
+    ?? _statusFallback(status)
+    ?? _fallbackAxiosMessage(error, status)
+  )
+}
+
+/**
+ * Pass-through for plain Error instances. JSON-shaped messages are
+ * suppressed because they typically carry a backend stack trace or
+ * structured envelope leaked through to the client. Plain prose passes
+ * through up to MAX_ERROR_MESSAGE_LEN characters so genuine long
+ * validation messages reach the user without breaking layouts when an
+ * upstream emits a multi-kilobyte description.
+ */
+function _formatStandardErrorMessage(error: Error): string {
+  const msg = error.message
+  if (msg && !/^\{/.test(msg)) {
+    if (msg.length <= MAX_ERROR_MESSAGE_LEN) return msg
+    return `${msg.slice(0, MAX_ERROR_MESSAGE_LEN)}…`
+  }
+  log.warn(
+    'Error message suppressed (JSON-shaped)',
+    sanitizeForLog({ preview: msg?.slice(0, 300) }),
+  )
+  return GENERIC_FALLBACK_MESSAGE
 }
 
 /**
@@ -90,163 +371,9 @@ export function isAxiosError(error: unknown): error is AxiosError {
  * Filters raw 5xx backend error strings to prevent leaking internal details.
  */
 export function getErrorMessage(error: unknown): string {
-  if (isAxiosError(error)) {
-    const status = error.response?.status
-    const data = error.response?.data as
-      | { error?: string; error_detail?: ErrorDetail; success?: boolean }
-      | undefined
-
-    // 409 / 429 / 503 are differentiated BEFORE the generic
-    // data.error early-return so a backend that always populates
-    // data.error does not flatten the structured copy below into a
-    // single uninformative line. 422 is excluded for the same reason
-    // (its structured error_detail.detail wins inside the switch).
-    if (status === 429) {
-      const ms = readRetryAfterHeaderMs(error)
-      // Backend rate limits are per-operation (per_op_rate_limit_from_policy),
-      // not global; call out which operation hit the cap so the operator
-      // does not assume the whole dashboard is throttled.
-      const url = error.config?.url ?? ''
-      const opHint = url.includes('/setup/complete')
-        ? 'Too many setup completion attempts'
-        : 'Too many requests for this operation'
-      if (ms !== null && ms > 0) {
-        return `${opHint}. Try again in ${formatRetryAfter(ms)}.`
-      }
-      return `${opHint}. Try again in a few seconds.`
-    }
-    if (status === 503) {
-      const ms = readRetryAfterHeaderMs(error)
-      if (ms !== null) {
-        return `The service is restarting. Try again in ${formatRetryAfter(ms)}.`
-      }
-      return 'The service is unavailable. Contact the operator if this persists.'
-    }
-    if (status === 409) {
-      // Branch on the structured error_code so duplicate /
-      // version-conflict / generic-conflict cases each get actionable
-      // copy. Falls through to the existing generic message when the
-      // envelope did not carry a code.
-      const code = data?.error_detail?.error_code
-      if (code === ErrorCode.DUPLICATE_RECORD || code === ErrorCode.ONTOLOGY_DUPLICATE) {
-        return 'A resource with this name already exists. Pick a different name.'
-      }
-      if (code === ErrorCode.VERSION_CONFLICT || code === ErrorCode.TASK_VERSION_CONFLICT) {
-        return 'This resource was edited by someone else. Reload to see the latest version, then retry.'
-      }
-      // Setup completion is the most common 409 with no structured
-      // code (RESOURCE_CONFLICT) -- the backend rejects a second
-      // /setup/complete after the flag is already set. Surface that
-      // case with copy that points operators at the right next step
-      // instead of the generic resource-state message.
-      const url = error.config?.url ?? ''
-      if (url.includes('/setup/complete')) {
-        return 'Setup is already complete. Reload to see the current dashboard.'
-      }
-      return 'The resource state changed. Refresh the page and try again.'
-    }
-
-    // For 4xx errors, surface the backend's validation message.
-    // 422 is excluded so the structured ``error_detail.detail`` branch
-    // below can prefer the field-specific RFC 9457 detail over the
-    // generic ``data.error`` string when both are present.
-    if (
-      data?.error
-      && typeof data.error === 'string'
-      && status !== undefined
-      && status < 500
-      && status !== 422
-    ) {
-      return data.error
-    }
-
-    switch (status) {
-      case 400:
-        return 'Invalid request. Please check your input.'
-      case 401:
-        return 'Authentication required. Please log in.'
-      case 403:
-        return 'You do not have permission to perform this action.'
-      case 404:
-        return 'The requested resource was not found.'
-      case 422: {
-        // Prefer the structured ``error_detail.detail`` envelope (RFC
-        // 9457) over the plain ``data.error`` string so the user sees
-        // the curated message the backend chose for THIS validation
-        // failure rather than the raw Pydantic surface.
-        const structuredDetail = data?.error_detail?.detail
-        if (typeof structuredDetail === 'string' && structuredDetail.trim() !== '') {
-          return structuredDetail
-        }
-        // Fall back to ``data.error`` only when it does NOT look like a
-        // raw Pydantic ValueError string. Pydantic emits patterns like
-        // "1 validation error for X: field required" / "value is not a
-        // valid X" which leak internal type / field names and read as
-        // developer copy. When we detect those shapes, prefer the
-        // generic message; otherwise the backend wrote a clean string
-        // and we surface it verbatim.
-        if (typeof data?.error === 'string' && data.error.trim() !== '') {
-          const raw = data.error
-          // Pydantic v2 standardises on "Input should be ...",
-          // "String should have at least/most N ...", "List should
-          // ...", "Dict should ..." in addition to the v1-era
-          // "field required" / "value is not a valid" / "string too
-          // short|long" phrasings. Catch the whole family so none of
-          // them leak verbatim to end users.
-          const looksPydanticy =
-            /validation error for /i.test(raw)
-            || /(field required|value is not a valid|string too (short|long)|input should|string should|list should|dict should)/i.test(raw)
-          if (!looksPydanticy) return raw
-        }
-        return 'Validation error. Please check the highlighted fields and try again.'
-      }
-      case 502:
-      case 504:
-        return 'Temporary connectivity issue. Please retry shortly.'
-      default:
-        break
-    }
-
-    if (!error.response) {
-      return 'Network error. Please check your connection.'
-    }
-
-    // For unhandled 4xx, surface a generic client error
-    if (status !== undefined && status >= 400 && status < 500) {
-      return `Request failed (${status}). Please check your input.`
-    }
-
-    // For other 5xx (500, 505, ...): generic message + escalation hint.
-    // Avoids leaking server internals while signalling to the operator
-    // whether to retry transiently or escalate.
-    return (
-      'An unexpected server error occurred. Please try again later or '
-      + 'contact support if this persists.'
-    )
-  }
-
-  if (error instanceof Error) {
-    // JSON-shaped messages are suppressed because they typically carry a
-    // backend stack trace or structured envelope leaked through to the
-    // client. Plain prose passes through up to ``MAX_ERROR_MESSAGE_LEN``
-    // characters so genuine long validation messages reach the user
-    // without breaking toast / banner layouts when an upstream emits a
-    // multi-kilobyte description.
-    const msg = error.message
-    if (msg && !/^\{/.test(msg)) {
-      if (msg.length <= MAX_ERROR_MESSAGE_LEN) {
-        return msg
-      }
-      return `${msg.slice(0, MAX_ERROR_MESSAGE_LEN)}…`
-    }
-    log.warn(
-      'Error message suppressed (JSON-shaped)',
-      sanitizeForLog({ preview: msg?.slice(0, 300) }),
-    )
-    return 'An unexpected error occurred. Please refresh the page or contact support if this persists.'
-  }
-
-  return 'An unexpected error occurred. Please refresh the page or contact support if this persists.'
+  if (isAxiosError(error)) return _formatAxiosErrorMessage(error)
+  if (error instanceof Error) return _formatStandardErrorMessage(error)
+  return GENERIC_FALLBACK_MESSAGE
 }
 
 /**
@@ -266,14 +393,14 @@ export function getErrorDetail(error: unknown): ErrorDetail | null {
 }
 
 /**
- * Convenience accessor: pull ``error_detail.error_code`` from any
- * thrown error shape the API surface produces (Axios 4xx/5xx,
- * ``ApiRequestError`` from ``unwrap``). Returns ``null`` when the
- * envelope did not carry a structured code -- callers fall back to
- * the human-readable message in that case.
+ * Convenience accessor: pull `error_detail.error_code` from any thrown
+ * error shape the API surface produces (Axios 4xx/5xx,
+ * `ApiRequestError` from `unwrap`). Returns null when the envelope
+ * did not carry a structured code; callers fall back to the human-
+ * readable message in that case.
  *
  * Use this when the UI wants to discriminate on a specific code
- * (e.g. ``ErrorCode.PROVIDER_TIER_COVERAGE_INSUFFICIENT``) to surface
+ * (e.g. `ErrorCode.PROVIDER_TIER_COVERAGE_INSUFFICIENT`) to surface
  * a targeted action instead of a generic Retry button.
  */
 export function getErrorCode(error: unknown): ErrorCode | null {
@@ -285,65 +412,41 @@ export function getErrorCode(error: unknown): ErrorCode | null {
  *
  * Auth / validation / conflict / rate-limit failures get specific
  * titles; everything else falls back to the caller's generic
- * ``Failed to {action} {entity}`` shape. The category derives from
- * ``error_category`` on the structured envelope, with HTTP-status
+ * `Failed to {action} {entity}` shape. The category derives from
+ * `error_category` on the structured envelope, with HTTP-status
  * fallbacks for network errors that never carry a structured
  * ErrorDetail.
  *
  * Returns an object so callers can keep their existing
- * ``description: getErrorMessage(err)`` line and only swap the title.
+ * `description: getErrorMessage(err)` line and only swap the title.
  */
+function _statusFromError(error: unknown): number | undefined {
+  return isAxiosError(error) ? error.response?.status : undefined
+}
+
+function _titleFromDetail(detail: ErrorDetail | null): string | null {
+  if (detail === null) return null
+  return CATEGORY_TITLES[detail.error_category]
+}
+
+function _titleFromStatus(status: number | undefined): string | null {
+  if (status === undefined) return null
+  return STATUS_TITLES[status] ?? null
+}
+
 export function getCrudErrorTitle(
   error: unknown,
   fallback: string,
 ): { title: string } {
-  // 403 (authorization) is a distinct title from 401 (authentication)
-  // -- the user IS authenticated, just not allowed. Resolve the
-  // status FIRST so 403 short-circuits the structured-detail switch
-  // (the structured envelope's "auth" category covers both 401 and
-  // 403, but at the toast-title layer the user needs to know which).
-  const status = isAxiosError(error) ? error.response?.status : undefined
+  // 403 (authorization) is a distinct title from 401 (authentication):
+  // the user IS authenticated, just not allowed. Resolve the status
+  // FIRST so 403 short-circuits the structured-detail switch.
+  const status = _statusFromError(error)
   if (status === 403) return { title: 'Permission denied' }
-  const detail = getErrorDetail(error)
-  if (detail) {
-    // Match against the exported ``ErrorCategory`` constants
-    // (re-exported from the generated ``error-codes.gen.ts``) instead
-    // of raw string literals so a backend rename surfaces as a
-    // TypeScript error in lockstep with the contract.
-    switch (detail.error_category) {
-      case ErrorCategory.AUTH:
-        return { title: 'Authentication failed' }
-      case ErrorCategory.VALIDATION:
-        return { title: 'Validation failed' }
-      case ErrorCategory.CONFLICT:
-        return { title: 'Resource conflict' }
-      case ErrorCategory.RATE_LIMIT:
-        return { title: 'Rate limit reached' }
-      case ErrorCategory.NOT_FOUND:
-        return { title: 'Not found' }
-      case ErrorCategory.BUDGET_EXHAUSTED:
-        return { title: 'Budget exhausted' }
-      case ErrorCategory.PROVIDER_ERROR:
-        return { title: 'Provider error' }
-      case ErrorCategory.INTERNAL:
-        // Fall through to the HTTP-status / caller-fallback branches
-        // below; 5xx-class internal failures get a more specific
-        // status-based message than the generic category copy.
-        break
-      default:
-        // Exhaustiveness guard: a new ErrorCategory added to the
-        // backend without a matching arm here breaks the build instead
-        // of silently falling through to the caller's generic fallback.
-        ((_: never) => _)(detail.error_category)
-    }
-  }
-  if (status !== undefined) {
-    if (status === 401) return { title: 'Authentication failed' }
-    if (status === 404) return { title: 'Not found' }
-    if (status === 409) return { title: 'Resource conflict' }
-    if (status === 422) return { title: 'Validation failed' }
-    if (status === 429) return { title: 'Rate limit reached' }
-  }
+  const fromCategory = _titleFromDetail(getErrorDetail(error))
+  if (fromCategory) return { title: fromCategory }
+  const fromStatus = _titleFromStatus(status)
+  if (fromStatus) return { title: fromStatus }
   return { title: fallback }
 }
 

--- a/web/src/utils/fetch-with-retry.ts
+++ b/web/src/utils/fetch-with-retry.ts
@@ -110,14 +110,79 @@ function isRetriable(
 }
 
 /**
- * ``window.fetch``-compatible wrapper that retries 429s up to
- * {@link MAX_RATE_LIMIT_RETRIES} times, honouring ``Retry-After``.
+ * Pick the active AbortSignal: explicit `init.signal` wins, otherwise
+ * the `Request` object's own signal so callers passing a pre-built
+ * Request still see cancellation propagate into the retry sleep.
+ */
+function _resolveSignal(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+): AbortSignal | undefined {
+  return init?.signal ?? (input instanceof Request ? input.signal : undefined)
+}
+
+/** Does the current response warrant another retry attempt? */
+function _shouldKeepRetrying(
+  response: Response,
+  attempt: number,
+  retriable: boolean,
+): boolean {
+  return (
+    response.status === HTTP_TOO_MANY_REQUESTS
+    && retriable
+    && attempt < MAX_RATE_LIMIT_RETRIES
+  )
+}
+
+/**
+ * Run one retry sleep, honouring the caller-supplied sleep helper when
+ * provided. Tests inject a fake sleep to avoid real waits; production
+ * uses `defaultSleep` which integrates with the abort signal.
+ */
+async function _performRetrySleep(
+  waitMs: number,
+  signal: AbortSignal | undefined,
+  sleep: ((ms: number) => Promise<void>) | undefined,
+): Promise<void> {
+  if (sleep) {
+    await sleep(waitMs)
+    return
+  }
+  await defaultSleep(waitMs, signal)
+}
+
+interface RetryBail {
+  /** The helper should immediately return this response. */
+  readonly bail: Response
+}
+
+/**
+ * Compute the wait + decide whether to bail before sleeping. Returns
+ * `bail` when the server says "give up" (`DO_NOT_RETRY`) or the caller
+ * has aborted. Returns the raw `waitMs` otherwise.
+ */
+function _decideRetryWait(
+  response: Response,
+  signal: AbortSignal | undefined,
+): RetryBail | number {
+  const waitMs = parseRetryAfterMs(
+    response.headers.get('Retry-After') ?? undefined,
+    null,
+  )
+  if (waitMs === DO_NOT_RETRY) return { bail: response }
+  if (signal?.aborted) return { bail: response }
+  return waitMs
+}
+
+/**
+ * `window.fetch`-compatible wrapper that retries 429s up to
+ * {@link MAX_RATE_LIMIT_RETRIES} times, honouring `Retry-After`.
  *
- * Returns the final ``Response`` -- successful, 4xx other than 429, or
+ * Returns the final `Response`: successful, 4xx other than 429, or
  * 429 once the retry budget is exhausted (the caller decides what to
- * do with it). Network errors propagate as raw ``fetch`` rejections.
+ * do with it). Network errors propagate as raw `fetch` rejections.
  *
- * If ``init.signal`` aborts during a retry sleep, the helper short-
+ * If `init.signal` aborts during a retry sleep, the helper short-
  * circuits and returns the most recent 429 response immediately so the
  * caller's cancellation is observed without waiting out the full
  * Retry-After budget.
@@ -128,39 +193,16 @@ export async function fetchWithRetryAfter(
   opts?: FetchWithRetryOptions,
 ): Promise<Response> {
   const fetchImpl = opts?.fetchImpl ?? fetch
-  // ``signal`` is read from ``init.signal`` for raw URL/string inputs and
-  // falls back to the ``Request`` object's signal so callers passing a
-  // pre-built Request still see cancellation propagate into the retry
-  // sleep below.
-  const signal =
-    init?.signal ?? (input instanceof Request ? input.signal : undefined)
+  const signal = _resolveSignal(input, init)
   const sleep = opts?.sleep
   const retriable = isRetriable(input, init, opts)
   let attempt = 0
   let response = await fetchImpl(input, init)
-  while (
-    response.status === HTTP_TOO_MANY_REQUESTS &&
-    retriable &&
-    attempt < MAX_RATE_LIMIT_RETRIES
-  ) {
-    const waitMs = parseRetryAfterMs(
-      response.headers.get('Retry-After') ?? undefined,
-      null,
-    )
-    if (waitMs === DO_NOT_RETRY) {
-      return response
-    }
-    if (signal?.aborted) {
-      return response
-    }
-    if (sleep) {
-      await sleep(waitMs)
-    } else {
-      await defaultSleep(waitMs, signal)
-    }
-    if (signal?.aborted) {
-      return response
-    }
+  while (_shouldKeepRetrying(response, attempt, retriable)) {
+    const decision = _decideRetryWait(response, signal)
+    if (typeof decision !== 'number') return decision.bail
+    await _performRetrySleep(decision, signal, sleep)
+    if (signal?.aborted) return response
     attempt += 1
     response = await fetchImpl(input, init)
   }

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -52,11 +52,39 @@ function resolveLocale(locale: string): string {
 }
 
 /**
- * Parse {@link DateInput} to a ``Date`` (or ``null`` on invalid input).
+ * Parse a `YYYY-MM-DD` string as the local-timezone midnight of that
+ * calendar day. Returns null when the string is not in the recognised
+ * shape or when it overflows (e.g. `2025-02-30`).
  *
- * Date-only ISO strings (``YYYY-MM-DD``) are parsed into the local
+ * `new Date(2025, 1, 30)` silently wraps to 2025-03-02; reject
+ * overflowed inputs by comparing the round-tripped year/month/day
+ * against the parsed digits.
+ */
+function _parseDateOnlyToLocal(value: string): Date | null {
+  const match = DATE_ONLY_RE.exec(value)
+  if (!match) return null
+  const [, y, m, d] = match
+  const year = Number(y)
+  const monthIdx = Number(m) - 1
+  const day = Number(d)
+  const local = new Date(year, monthIdx, day)
+  if (
+    Number.isNaN(local.getTime())
+    || local.getFullYear() !== year
+    || local.getMonth() !== monthIdx
+    || local.getDate() !== day
+  ) {
+    return null
+  }
+  return local
+}
+
+/**
+ * Parse {@link DateInput} to a `Date` (or `null` on invalid input).
+ *
+ * Date-only ISO strings (`YYYY-MM-DD`) are parsed into the local
  * midnight of that calendar day rather than the UTC midnight
- * ``new Date(string)`` would produce -- the latter can shift the
+ * `new Date(string)` would produce: the latter can shift the
  * displayed day backward for viewers in negative-UTC timezones.
  */
 function toDate(value: DateInput): Date | null {
@@ -65,26 +93,8 @@ function toDate(value: DateInput): Date | null {
     return Number.isNaN(value.getTime()) ? null : value
   }
   if (typeof value === 'string') {
-    const match = DATE_ONLY_RE.exec(value)
-    if (match) {
-      const [, y, m, d] = match
-      const year = Number(y)
-      const monthIdx = Number(m) - 1
-      const day = Number(d)
-      const local = new Date(year, monthIdx, day)
-      // ``new Date(2025, 1, 30)`` silently wraps to 2025-03-02; reject
-      // overflowed inputs (e.g. ``2025-02-30``) so only true calendar
-      // days are accepted.
-      if (
-        Number.isNaN(local.getTime()) ||
-        local.getFullYear() !== year ||
-        local.getMonth() !== monthIdx ||
-        local.getDate() !== day
-      ) {
-        return null
-      }
-      return local
-    }
+    const local = _parseDateOnlyToLocal(value)
+    if (local !== null) return local
   }
   const date = new Date(value)
   return Number.isNaN(date.getTime()) ? null : date
@@ -187,34 +197,46 @@ export function formatTodayLabel(locale: string = getLocale()): string {
  * Falls back to {@link formatDateTime} for dates older than a week, for
  * future dates, and for invalid/missing input.
  */
+/**
+ * Pick the appropriate `(value, unit)` pair for `Intl.RelativeTimeFormat`
+ * given a backward-looking delta in seconds. Caller is responsible for
+ * making sure `diffSec < SEC_PER_WEEK` (the "older than a week" fallback
+ * to absolute time is done at the call site).
+ */
+function _relativeUnit(diffSec: number): {
+  value: number
+  unit: Intl.RelativeTimeFormatUnit
+} {
+  if (diffSec < SEC_PER_MIN) return { value: diffSec, unit: 'second' }
+  if (diffSec < SEC_PER_HOUR) {
+    return { value: Math.floor(diffSec / SEC_PER_MIN), unit: 'minute' }
+  }
+  if (diffSec < SEC_PER_DAY) {
+    return { value: Math.floor(diffSec / SEC_PER_HOUR), unit: 'hour' }
+  }
+  return { value: Math.floor(diffSec / SEC_PER_DAY), unit: 'day' }
+}
+
 export function formatRelativeTime(
   iso: string | null | undefined,
   locale: string = getLocale(),
 ): string {
   if (!iso) return '--'
-  // Route through ``toDate`` so ``YYYY-MM-DD`` strings are read as
-  // local midnight (same parsing contract as ``formatDateTime`` and
-  // siblings). ``new Date(iso)`` would read them as UTC midnight and
+  // Route through `toDate` so `YYYY-MM-DD` strings are read as
+  // local midnight (same parsing contract as `formatDateTime` and
+  // siblings). `new Date(iso)` would read them as UTC midnight and
   // shift the displayed day in negative-UTC timezones.
   const date = toDate(iso)
   if (!date) return '--'
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
+  const diffMs = Date.now() - date.getTime()
   if (diffMs < 0) return formatDateTime(iso, locale)
   const diffSec = Math.floor(diffMs / MS_PER_SECOND)
   if (diffSec >= SEC_PER_WEEK) return formatDateTime(iso, locale)
-
   const rtf = new Intl.RelativeTimeFormat(resolveLocale(locale), {
     numeric: 'auto',
   })
-  if (diffSec < SEC_PER_MIN) return rtf.format(-diffSec, 'second')
-  if (diffSec < SEC_PER_HOUR) {
-    return rtf.format(-Math.floor(diffSec / SEC_PER_MIN), 'minute')
-  }
-  if (diffSec < SEC_PER_DAY) {
-    return rtf.format(-Math.floor(diffSec / SEC_PER_HOUR), 'hour')
-  }
-  return rtf.format(-Math.floor(diffSec / SEC_PER_DAY), 'day')
+  const { value, unit } = _relativeUnit(diffSec)
+  return rtf.format(-value, unit)
 }
 
 /**
@@ -224,23 +246,54 @@ export function formatRelativeTime(
  * `NaNs`. The components are written in British English with single-
  * letter unit suffixes for monospace columns.
  */
+interface ElapsedTier {
+  /** Divisor for the major component (e.g. SEC_PER_MIN for "m s" output). */
+  readonly major: number
+  /** Divisor for the minor component (e.g. 1 for "m s", SEC_PER_MIN for "h m"). */
+  readonly minor: number
+  readonly majorUnit: 'm' | 'h' | 'd'
+  readonly minorUnit: 's' | 'm' | 'h'
+}
+
+/**
+ * Format the major/minor split of an elapsed-seconds value using a
+ * shared tier descriptor. Omitting the minor component when zero keeps
+ * the "5h" / "3d" shape rather than the noisier "5h 0m" / "3d 0h".
+ */
+function _formatElapsedTier(total: number, tier: ElapsedTier): string {
+  const major = Math.floor(total / tier.major)
+  const minor = Math.floor((total % tier.major) / tier.minor)
+  return minor === 0
+    ? `${major}${tier.majorUnit}`
+    : `${major}${tier.majorUnit} ${minor}${tier.minorUnit}`
+}
+
+const ELAPSED_TIER_MINUTES: ElapsedTier = {
+  major: SEC_PER_MIN,
+  minor: 1,
+  majorUnit: 'm',
+  minorUnit: 's',
+}
+const ELAPSED_TIER_HOURS: ElapsedTier = {
+  major: SEC_PER_HOUR,
+  minor: SEC_PER_MIN,
+  majorUnit: 'h',
+  minorUnit: 'm',
+}
+const ELAPSED_TIER_DAYS: ElapsedTier = {
+  major: SEC_PER_DAY,
+  minor: SEC_PER_HOUR,
+  majorUnit: 'd',
+  minorUnit: 'h',
+}
+
 export function formatElapsed(seconds: number): string {
   if (!Number.isFinite(seconds) || seconds < 0) return '--'
   const total = Math.floor(seconds)
   if (total < SEC_PER_MIN) return `${total}s`
-  if (total < SEC_PER_HOUR) {
-    const minutes = Math.floor(total / SEC_PER_MIN)
-    const remainingSeconds = total % SEC_PER_MIN
-    return remainingSeconds === 0 ? `${minutes}m` : `${minutes}m ${remainingSeconds}s`
-  }
-  if (total < SEC_PER_DAY) {
-    const hours = Math.floor(total / SEC_PER_HOUR)
-    const remainingMinutes = Math.floor((total % SEC_PER_HOUR) / SEC_PER_MIN)
-    return remainingMinutes === 0 ? `${hours}h` : `${hours}h ${remainingMinutes}m`
-  }
-  const days = Math.floor(total / SEC_PER_DAY)
-  const remainingHours = Math.floor((total % SEC_PER_DAY) / SEC_PER_HOUR)
-  return remainingHours === 0 ? `${days}d` : `${days}d ${remainingHours}h`
+  if (total < SEC_PER_HOUR) return _formatElapsedTier(total, ELAPSED_TIER_MINUTES)
+  if (total < SEC_PER_DAY) return _formatElapsedTier(total, ELAPSED_TIER_HOURS)
+  return _formatElapsedTier(total, ELAPSED_TIER_DAYS)
 }
 
 /** ISO 4217 currencies that use zero decimal places. */

--- a/web/src/utils/logging.ts
+++ b/web/src/utils/logging.ts
@@ -1,3 +1,5 @@
+const DEFAULT_MAX_LEN = 500
+
 /** Unicode BIDI override and direction control ranges that can manipulate log display. */
 function isBidiControl(code: number): boolean {
   return (code >= 0x200b && code <= 0x200f)
@@ -6,25 +8,43 @@ function isBidiControl(code: number): boolean {
     || (code >= 0xfff9 && code <= 0xfffb)
 }
 
-/** Sanitize a value for safe logging (strip control chars + BIDI overrides, truncate). */
-export function sanitizeForLog(value: unknown, maxLen = 500): string {
-  const cap = Number.isFinite(maxLen) ? Math.max(0, Math.floor(maxLen)) : 500
-  if (cap === 0) return ''
-  let raw: string
+/** True for ASCII control characters and the C1 control block. */
+function _isAsciiControl(code: number): boolean {
+  return code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f)
+}
+
+/** Clamp the caller-supplied cap, falling back to the default. */
+function _coerceCap(maxLen: number): number {
+  if (!Number.isFinite(maxLen)) return DEFAULT_MAX_LEN
+  return Math.max(0, Math.floor(maxLen))
+}
+
+/**
+ * Coerce any value into a string suitable for sanitisation. Errors get
+ * their stack (or message) so the call site sees the trace; everything
+ * else gets a defensive `String()` with a fallback for objects whose
+ * `toString` throws.
+ */
+function _extractRawString(value: unknown): string {
   if (value instanceof Error) {
-    raw = value.stack ?? value.message ?? String(value)
-  } else {
-    try {
-      raw = String(value)
-    } catch {
-      raw = '[unstringifiable]'
-    }
+    return value.stack ?? value.message ?? String(value)
   }
+  try {
+    return String(value)
+  } catch {
+    return '[unstringifiable]'
+  }
+}
+
+/** Sanitize a value for safe logging (strip control chars + BIDI overrides, truncate). */
+export function sanitizeForLog(value: unknown, maxLen = DEFAULT_MAX_LEN): string {
+  const cap = _coerceCap(maxLen)
+  if (cap === 0) return ''
+  const raw = _extractRawString(value)
   let result = ''
   for (const ch of raw) {
     const code = ch.codePointAt(0) ?? 0
-    const isControl = code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f)
-    result += (!isControl && !isBidiControl(code)) ? ch : ' '
+    result += (!_isAsciiControl(code) && !isBidiControl(code)) ? ch : ' '
     if (result.length >= cap) break
   }
   return result

--- a/web/src/utils/provider-status.ts
+++ b/web/src/utils/provider-status.ts
@@ -1,23 +1,24 @@
 import type { AgentRuntimeStatus } from '@/lib/utils'
 import type { AuthType, ProviderConfig } from '@/api/types/providers'
 
+/**
+ * True when the credential slot the provider needs has been filled in.
+ * `none`-auth providers are credential-less, so they always read as
+ * idle. The `satisfies` makes the table exhaustive: a new `AuthType`
+ * value breaks the build until it is mapped here.
+ */
+function _hasRequiredCredentials(config: ProviderConfig): boolean {
+  const checks = {
+    none: true,
+    api_key: config.has_api_key,
+    oauth: config.has_oauth_credentials,
+    custom_header: config.has_custom_header,
+    subscription: config.has_subscription_token,
+  } as const satisfies Record<AuthType, boolean>
+  return checks[config.auth_type]
+}
+
 /** Derive provider status from auth type and credential indicators. */
 export function getProviderStatus(config: ProviderConfig): AgentRuntimeStatus {
-  const authType: AuthType = config.auth_type
-  switch (authType) {
-    case 'none':
-      return 'idle'
-    case 'api_key':
-      return config.has_api_key ? 'idle' : 'error'
-    case 'oauth':
-      return config.has_oauth_credentials ? 'idle' : 'error'
-    case 'custom_header':
-      return config.has_custom_header ? 'idle' : 'error'
-    case 'subscription':
-      return config.has_subscription_token ? 'idle' : 'error'
-    default: {
-      const _exhaustive: never = authType
-      return _exhaustive
-    }
-  }
+  return _hasRequiredCredentials(config) ? 'idle' : 'error'
 }

--- a/web/src/utils/retry-after.ts
+++ b/web/src/utils/retry-after.ts
@@ -23,11 +23,36 @@ export const MAX_RETRY_AFTER_MS = 5_000
 /** Sentinel returned by {@link parseRetryAfterMs} when we must NOT auto-retry. */
 export const DO_NOT_RETRY = -1
 
+/** Pick the raw header / envelope string to parse, or null when absent. */
+function _resolveRetryAfterRaw(
+  headerValue: string | undefined,
+  errorDetail: ErrorDetail | null | undefined,
+): string | null {
+  if (headerValue !== undefined) return headerValue
+  const fromDetail = errorDetail?.retry_after
+  if (fromDetail == null) return null
+  return String(fromDetail)
+}
+
+/** Parse a delta-seconds Retry-After value into milliseconds, or null. */
+function _parseRetryAfterDelta(trimmed: string): number | null {
+  if (!/^\d+$/.test(trimmed)) return null
+  const seconds = Number.parseInt(trimmed, 10)
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds * 1000 : null
+}
+
+/** Parse an HTTP-date Retry-After value into milliseconds, or null. */
+function _parseRetryAfterDate(trimmed: string): number | null {
+  const parsedDate = Date.parse(trimmed)
+  if (!Number.isFinite(parsedDate)) return null
+  return Math.max(0, parsedDate - Date.now())
+}
+
 /**
- * Parse an RFC 9110 ``Retry-After`` header (delta-seconds or HTTP-date)
- * with the RFC 9457 envelope's ``retry_after`` field as a fallback.
+ * Parse an RFC 9110 `Retry-After` header (delta-seconds or HTTP-date)
+ * with the RFC 9457 envelope's `retry_after` field as a fallback.
  *
- * Returns ``0`` when neither source is present (caller may retry
+ * Returns `0` when neither source is present (caller may retry
  * immediately) or {@link DO_NOT_RETRY} when the requested wait exceeds
  * {@link MAX_RETRY_AFTER_MS} so the caller surfaces the 429 to the user
  * instead of pegging the back-off loop on a hostile delay.
@@ -36,30 +61,19 @@ export function parseRetryAfterMs(
   headerValue: string | undefined,
   errorDetail: ErrorDetail | null | undefined,
 ): number {
-  const raw =
-    headerValue ??
-    (errorDetail?.retry_after != null ? String(errorDetail.retry_after) : undefined)
-  if (!raw) return 0
-  let ms: number
+  const raw = _resolveRetryAfterRaw(headerValue, errorDetail)
+  if (raw === null) return 0
   const trimmed = raw.trim()
-  const seconds = Number.parseInt(trimmed, 10)
-  if (/^\d+$/.test(trimmed) && Number.isFinite(seconds) && seconds >= 0) {
-    ms = seconds * 1000
-  } else {
-    const parsedDate = Date.parse(trimmed)
-    if (!Number.isFinite(parsedDate)) {
-      // A malformed Retry-After header (neither delta-seconds nor a
-      // valid HTTP-date) is silently treated as ``retry now`` per
-      // the long-standing behaviour. Surface it as a structured warn
-      // so a misconfigured backend or hostile proxy is visible in
-      // ops dashboards instead of merely producing tight retry loops.
-      log.warn(
-        'Malformed Retry-After header',
-        sanitizeForLog({ value: trimmed }),
-      )
-      return 0
-    }
-    ms = Math.max(0, parsedDate - Date.now())
+  if (trimmed === '') return 0
+  const ms = _parseRetryAfterDelta(trimmed) ?? _parseRetryAfterDate(trimmed)
+  if (ms === null) {
+    // A malformed Retry-After header (neither delta-seconds nor a
+    // valid HTTP-date) is silently treated as "retry now" per the
+    // long-standing behaviour. Surface it as a structured warn so a
+    // misconfigured backend or hostile proxy is visible in ops
+    // dashboards instead of merely producing tight retry loops.
+    log.warn('Malformed Retry-After header', sanitizeForLog({ value: trimmed }))
+    return 0
   }
   if (ms > MAX_RETRY_AFTER_MS) return DO_NOT_RETRY
   return ms

--- a/web/src/utils/tasks.ts
+++ b/web/src/utils/tasks.ts
@@ -161,45 +161,49 @@ export interface TaskBoardFilters {
   dateTo?: string
 }
 
+type TaskPredicate = (task: Task) => boolean
+
+function _searchPredicate(search: string): TaskPredicate {
+  const query = search.toLowerCase()
+  return (t) =>
+    t.title.toLowerCase().includes(query)
+    || t.description.toLowerCase().includes(query)
+}
+
+function _dateFromPredicate(from: string): TaskPredicate {
+  return (t) => Boolean(t.deadline) && t.deadline! >= from
+}
+
+function _dateToPredicate(rawTo: string): TaskPredicate {
+  // A date-only string ("2026-05-24") clamps to end-of-day so a task
+  // whose deadline lives anywhere inside that calendar day is included.
+  const to = rawTo.includes('T') ? rawTo : `${rawTo}T23:59:59.999Z`
+  return (t) => Boolean(t.deadline) && t.deadline! <= to
+}
+
+/**
+ * Build the active filter predicates from the caller's filter selection.
+ * Each entry in the table corresponds to one optional filter; entries
+ * with falsy filter values produce no predicate. Keeping the per-field
+ * branching here (not in `filterTasks`) keeps the dispatcher under the
+ * complexity cap.
+ */
+function _buildTaskPredicates(filters: TaskBoardFilters): TaskPredicate[] {
+  const preds: TaskPredicate[] = []
+  if (filters.status) preds.push((t) => t.status === filters.status)
+  if (filters.priority) preds.push((t) => t.priority === filters.priority)
+  if (filters.assignee) preds.push((t) => t.assigned_to === filters.assignee)
+  if (filters.taskType) preds.push((t) => t.type === filters.taskType)
+  if (filters.search) preds.push(_searchPredicate(filters.search))
+  if (filters.dateFrom) preds.push(_dateFromPredicate(filters.dateFrom))
+  if (filters.dateTo) preds.push(_dateToPredicate(filters.dateTo))
+  return preds
+}
+
 export function filterTasks(tasks: readonly Task[], filters: TaskBoardFilters): Task[] {
-  let result = tasks as Task[]
-
-  if (filters.status) {
-    result = result.filter((t) => t.status === filters.status)
-  }
-
-  if (filters.priority) {
-    result = result.filter((t) => t.priority === filters.priority)
-  }
-
-  if (filters.assignee) {
-    result = result.filter((t) => t.assigned_to === filters.assignee)
-  }
-
-  if (filters.taskType) {
-    result = result.filter((t) => t.type === filters.taskType)
-  }
-
-  if (filters.search) {
-    const query = filters.search.toLowerCase()
-    result = result.filter(
-      (t) =>
-        t.title.toLowerCase().includes(query) ||
-        t.description.toLowerCase().includes(query),
-    )
-  }
-
-  if (filters.dateFrom) {
-    const from = filters.dateFrom
-    result = result.filter((t) => t.deadline && t.deadline >= from)
-  }
-
-  if (filters.dateTo) {
-    const to = filters.dateTo.includes('T') ? filters.dateTo : filters.dateTo + 'T23:59:59.999Z'
-    result = result.filter((t) => t.deadline && t.deadline <= to)
-  }
-
-  return result
+  const preds = _buildTaskPredicates(filters)
+  if (preds.length === 0) return [...tasks]
+  return tasks.filter((t) => preds.every((p) => p(t)))
 }
 
 // ── Status transition validation ────────────────────────────

--- a/web/src/utils/yaml.ts
+++ b/web/src/utils/yaml.ts
@@ -24,6 +24,35 @@ export function parseYaml(yamlStr: string): Record<string, unknown> {
   return result as Record<string, unknown>
 }
 
+type CompanyYamlValidator = (parsed: Record<string, unknown>) => string | null
+
+/**
+ * Per-field validators run in order until one returns a non-null
+ * message. Splitting out per-field validators keeps the dispatcher
+ * under the complexity cap and lets each rule read as a single
+ * declarative statement.
+ */
+const COMPANY_YAML_VALIDATORS: readonly CompanyYamlValidator[] = [
+  (p) => (typeof p.company_name !== 'string' || p.company_name.trim() === '')
+    ? 'company_name must be a non-empty string'
+    : null,
+  (p) => ('agents' in p && !Array.isArray(p.agents))
+    ? 'agents must be an array'
+    : null,
+  (p) => ('departments' in p && !Array.isArray(p.departments))
+    ? 'departments must be an array'
+    : null,
+  (p) => ('autonomy_level' in p && typeof p.autonomy_level !== 'string')
+    ? 'autonomy_level must be a string'
+    : null,
+  (p) => ('budget_monthly' in p && typeof p.budget_monthly !== 'number')
+    ? 'budget_monthly must be a number'
+    : null,
+  (p) => ('communication_pattern' in p && typeof p.communication_pattern !== 'string')
+    ? 'communication_pattern must be a string'
+    : null,
+]
+
 /**
  * Validate that a parsed YAML object has the expected CompanyConfig shape.
  *
@@ -34,23 +63,9 @@ export function parseYaml(yamlStr: string): Record<string, unknown> {
  * Returns an error message string, or null if valid.
  */
 export function validateCompanyYaml(parsed: Record<string, unknown>): string | null {
-  if (typeof parsed.company_name !== 'string' || parsed.company_name.trim() === '') {
-    return 'company_name must be a non-empty string'
-  }
-  if ('agents' in parsed && !Array.isArray(parsed.agents)) {
-    return 'agents must be an array'
-  }
-  if ('departments' in parsed && !Array.isArray(parsed.departments)) {
-    return 'departments must be an array'
-  }
-  if ('autonomy_level' in parsed && typeof parsed.autonomy_level !== 'string') {
-    return 'autonomy_level must be a string'
-  }
-  if ('budget_monthly' in parsed && typeof parsed.budget_monthly !== 'number') {
-    return 'budget_monthly must be a number'
-  }
-  if ('communication_pattern' in parsed && typeof parsed.communication_pattern !== 'string') {
-    return 'communication_pattern must be a string'
+  for (const validate of COMPANY_YAML_VALIDATORS) {
+    const err = validate(parsed)
+    if (err !== null) return err
   }
   return null
 }


### PR DESCRIPTION
Closes #2092. Part of EPIC #2066. Section F item 11 of `docs/decisions/0006-tiered-module-size-policy.md`.

## Summary

First of 4 sub-issues that progressively lift the ESLint override block at `web/eslint.config.js:141-167`. This PR cleans the Foundation bucket (utils + hooks + lib + `cookie-shim.ts`) so the four caps (`complexity: 8`, `max-lines: 400`, `max-lines-per-function: 80`, `max-params: 5`) now apply globally to those paths. The override block grows an `ignores:` list per merged PR; PR D (#2095) deletes the block entirely.

**Refactor surface:** 524 production-code violations across ~50 files when the four rules are forced on. PR A handles all of `src/utils/`, `src/hooks/`, `src/lib/`, `src/cookie-shim.ts`: 27 files modified, +2083/-1352.

**Canonical pattern (used by every sub-issue):** table-driven dispatch with `Readonly<Record<K, V>>` (optionally `as const satisfies Record<K, V>` for exhaustiveness against an enum/union). Worked examples now documented in `web/CLAUDE.md` "Tiered caps + per-bucket ratchet" subsection.

## Highest-cyclomatic-complexity targets, before/after

| Function | Before | After | Mechanism |
| --- | ---: | ---: | --- |
| `utils/errors.ts::getErrorMessage` | 53 (103 lines) | 5 | Per-status handlers (`_handleRateLimited`, `_handleServiceUnavailable`, `_handleConflict`, `_handleValidation`) + `_handleSpecialisedAxiosStatus` dispatch + status fallback table |
| `utils/errors.ts::getCrudErrorTitle` | 19 | 5 | Exhaustive `CATEGORY_TITLES` over `ErrorCategory` + `STATUS_TITLES` |
| `lib/error-classify.ts::classifyError` | 17 | 3 | `HTTP_STATUS_CLASSIFIERS` table + `_classifyAxiosError` + `_defaultClassification` |
| `utils/fetch-with-retry.ts::fetchWithRetryAfter` | 17 | 7 | `_decideRetryWait` / `_performRetrySleep` / `_shouldKeepRetrying` / `_resolveSignal` |
| `utils/logging.ts::sanitizeForLog` | 16 | 7 | `_coerceCap` / `_extractRawString` / `_isAsciiControl` |
| `utils/budget.ts::computeBudgetMetricCards` | 14 | 5 | Per-card builders sharing `BudgetCardContext` |
| `utils/dashboard.ts::wsEventToActivityItem` | 14 | 3 | Per-field resolvers |
| `hooks/use-list-shortcuts.ts` keyboard arrow | 28 | 4 | `KEY_TO_ACTION` dispatch with `ShortcutAction` type |
| `hooks/useToolbarKeyboardNav.ts::onKeyDown` arrow | 22 | 4 | `TOOLBAR_INDEX_FNS` direction-fn table + `_hasModifier` / `_isEditableElement` / `_collectToolbarItems` |
| `hooks/useCommunicationEdges.ts::fetchAll` | 12 | 4 | `_collectAllMessages` + `_toErrorMessage` |
| `hooks/usePolling.ts::usePolling` | 137 lines | <80 | `usePollRefs` sub-hook + `_shouldRunPoll` / `_invokePoll` / `_buildVisibilityHandler` |

**Other oversized hooks brought under the cap** via sub-hook extraction: `useDraftPersistence` + `useBeforeUnloadGuard` (in `use-unsaved-changes-guard`), `useDetailStoreSlice` + `useDetailLifecycle` + `useDetailWebSocket` (in `useAgentDetailData`), `useCompanyMutations` + `useCompanyInitialFetch` (in `useOrgEditData`), `useOrgInitialFetch` + `_deriveView` + `_applyCollapse` + `_buildForceView` (in `useOrgChartData`), `_runBatchSave` + `_onBatchSaveError` (in `useSettingsDirtyState`). Sub-hook names start with `use` per rules-of-hooks (no leading underscore).

## Override-narrowing diff

```diff
   {
     files: ['src/**/*.{ts,tsx}'],
+    ignores: [
+      'src/utils/**',
+      'src/hooks/**',
+      'src/lib/**',
+      'src/cookie-shim.ts',
+    ],
     rules: { complexity: 'off', /* ... */ },
   },
```

New code under those paths must now respect the four caps.

## Tests

- 1100 passing across `__tests__/utils/`, `__tests__/hooks/`, `__tests__/lib/`. Active-handle gate green.
- 18 new characterisation tests in `__tests__/utils/errors.test.ts` pin `getErrorMessage` / `getCrudErrorTitle` / `getErrorCode` behaviour BEFORE the splits landed: 422 Pydantic-suppression, 429 + /setup/complete URL hint, 409 + /setup/complete special-case, 409 + DUPLICATE_RECORD / VERSION_CONFLICT structured branches, `1 minute` vs `1 minutes` British plural, HTTP-date `Retry-After` parsing, structured-detail vs plain-string priority for 422, all 7 mapped `ErrorCategory` values + `INTERNAL` fall-through for `getCrudErrorTitle`, 504 transient-connectivity branch.

## Bundled config cleanup (gate-surfaced)

Two pre-commit gaps surfaced during this push, fixed in-scope:

- `.markdownlint.json`: disabled MD060 (table-column-style). The project already disables MD024/MD030/MD033/MD036/MD041/MD046 for the same content-heavy-tables reason; MD060 fired on every exemption-ledger separator row in `docs/decisions/`.
- `.codespellrc`: added `.test_durations.unit,.test_durations.integration` to the skip list. Those generated pytest-durations dumps landed in #2087 and carry random test names with typo-looking tokens; the skip list missed them.

## Review coverage

Pre-reviewed by 4 agents (reduced set, per user request, for a web-only Foundation refactor):

- **issue-resolution-verifier**: PASS on all 5 acceptance criteria for #2092.
- **frontend-reviewer**: 0 findings. Production-ready. All rules-of-hooks preserved (sub-hook names start with `use`), no `any`/unsafe `as`, behaviour preserved across the refactored modules, fetch-with-retry abort-signal short-circuits intact.
- **comment-quality-rot**: 0 violations.
- **docs-consistency**: 2 MAJOR + 1 MEDIUM. Fixed in commit a28eb6f4 (ADR-0006 Section F row + `web/CLAUDE.md` ESLint section); skipped 1 no-drift item per `feedback_docs_hygiene`.

## Next

PR B (#2093 Stores incl. websocket) starts after this merges. Override `ignores:` gains `'src/stores/**'` then.