### PR TITLE
docs: align runtime banners and README with EPIC #1955 close-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ SynthOrg is a self-contained, self-hostable platform for **synthetic organisatio
 
 It is provider-agnostic (<!--RS:providers_via_litellm-->2700+<!--/RS--> LLMs via [LiteLLM](https://github.com/BerriAI/litellm)), configuration-driven ([Pydantic v2](https://docs.pydantic.dev/) models), and licensed BUSL-1.1 (converts to Apache 2.0 at the Change Date).
 
-> **Project status (read this).** The framework and infrastructure are built and tested (<!--RS:tests-->33,000+<!--/RS--> tests, 80%+ coverage): API, dashboard, CLI, dual-backend persistence, the provider layer, and every subsystem as importable, unit-tested components. The autonomous agent **runtime** that makes the organisation actually execute work is **in active development** and tracked openly on the [roadmap](https://synthorg.io/docs/roadmap/) and the [issue tracker](https://github.com/Aureliolo/synthorg/issues). Today, starting SynthOrg brings up the platform and dashboard; running a company end to end is the work in flight. We would rather you see exactly what is built versus in progress than discover it later.
+> **Project status (read this).** SynthOrg is **pre-alpha**. The framework, infrastructure, and runtime are built and tested (<!--RS:tests-->33,000+<!--/RS--> tests, 80%+ coverage): API, dashboard, CLI, dual-backend persistence, the provider layer, the agent runtime, the multi-agent coordinator, the work pipeline spine, the intake engine, sandbox lifecycle dispatch, and the distributed-path consumers are all wired and exercised by deterministic e2e harnesses with a scripted provider (no real LLM spend). Operator-facing onboarding (real provider, real workloads, dashboard polish) has not been exercised end to end by a human. Expect bugs, rough edges, and missing polish; use it for research and contribution, not for production workloads. Progress is tracked openly on the [roadmap](https://synthorg.io/docs/roadmap/) and the [issue tracker](https://github.com/Aureliolo/synthorg/issues).
 
 ## What is available now
 
@@ -30,22 +30,25 @@ A tested platform you can run, inspect, and build on:
 - **Dual-backend persistence**: SQLite (single-node default) and PostgreSQL (multi-instance), conformance-tested for parity, with in-process yoyo schema migrations and ISO 4217 currency stamping on every cost-bearing row.
 - **Provider layer**: any LLM via LiteLLM with built-in retry and rate-limit handling; local model management for Ollama and LM Studio.
 - **Configuration and templates**: define a company in YAML; importable/shareable agent, department, and company templates with personality presets.
-- **Subsystem libraries, tested as components**: the engine, memory, budget, security, and coordination modules exist as importable, unit-tested code. Note honestly: these are exercised by their test suites, not yet by a running agent (see below).
-- **Client-simulation intake runtime**: the intake engine is wired into boot via the client-simulation runtime and driven end-to-end by a deterministic simulation harness (synthetic clients, scripted provider, zero LLM spend), which is also the acceptance substrate for the runtime work in flight.
+- **Agent runtime**: a configured provider boots a real agent runtime that executes tasks (LLM + sandboxed tools) under a minimal safety spine (autonomy/trust verdict on tool actions, approval-queue producer for sensitive actions). An empty company (no provider) cleanly rejects task submission. Exercised by a deterministic e2e simulation harness (synthetic clients, scripted provider, zero LLM spend).
+- **Multi-agent coordinator + work pipeline spine**: `/coordinate` runs decompose, route, parallel execution, then rollup end to end behind the provider-present switch. The shared work pipeline (intake to projects to decompose to solo/team to execute to coordination metrics) is the single integration point every entry adapter feeds, with solo-vs-team decided internally by decomposition.
+- **Entry adapters**: real work-entry paths for the intake engine (`POST /requests/{id}/approve`), the task board (`POST /tasks`), and stated objectives (`POST /objectives`), all driving the pipeline spine.
+- **Sandbox lifecycle dispatch**: `DockerSandbox.execute()` honours `owner_id` and dispatches to the configured per-call / per-agent / per-task lifecycle strategy, with grace-period teardown.
 - **Operations**: structured logging with redaction and correlation, Prometheus metrics and OTLP, HttpOnly-cookie multi-user sessions with CSRF protection, Chainguard distroless images with Trivy + Grype scanning, cosign signatures, and SLSA L3 provenance.
-- **Distributed dispatch plumbing**: NATS JetStream queue and a worker pool. The dispatch path exists; the task-execute endpoint currently advances task state and does not yet invoke an agent.
+- **Distributed dispatch**: NATS JetStream queue, worker pool, dead-letter consumer, dedup pruner, and heartbeat subscriber, validated under multi-worker synthetic load (no loss, no duplication).
 
 ## In active development
 
-These are the capabilities that make SynthOrg an autonomous studio. They are designed and largely written as components, but not yet wired into a running product. Each is tracked in the open:
+The runtime, coordinator, intake, work pipeline, sandbox dispatch, and distributed-path consumers are wired and exercised by deterministic harnesses. What remains in flight is the operator-facing maturity that turns the wired runtime into a polished autonomous studio:
 
-- **Agent runtime online**: agents actually executing tasks (LLM + sandboxed tools) under a minimal safety spine. This is the foundational item everything else depends on.
-- **Conversational org interface**: talk to the company in natural language. v1 lands clarify-and-propose against the Chief of Staff (asks clarifying questions when the request is underspecified, then parks one or more concrete `WorkItem`s in the human approval queue; on approval they run through the work pipeline). Still no autonomous acting; direct MCP acting under governance is the separate follow-up child.
+- **Conversational org interface**: talking to the company in natural language. v1 lands clarify-and-propose against the Chief of Staff (asks clarifying questions when the request is underspecified, then parks one or more concrete `WorkItem`s in the human approval queue; on approval they run through the work pipeline). Direct MCP acting under governance is the follow-up child.
 - **Autonomous product studio substrate**: persistent project workspace with pluggable git, brownfield codebase intake, living documentation, and a deep requirements interview.
-- **Best-in-class operate tier**: a golden-company benchmark, mission control with run replay, a cost forecast/kill-switch dial, a measurable learning curve, deterministic replay, run narratives, and an adversarial red-team.
-- **Agent capability layer**: a knowledge and provenance retrieval substrate, research mode, continual improvement, governed external API access, headless-browser and virtual-desktop testing, and more.
+- **Best-in-class operate tier**: a golden-company benchmark, mission control with run replay, a cost forecast / kill-switch dial, a measurable learning curve, deterministic replay, run narratives, and an adversarial red-team.
+- **Agent capability layer**: knowledge and provenance retrieval substrate, research mode, continual improvement, governed external API access, headless-browser and virtual-desktop testing.
+- **Self-improvement loop**: company-wide signals from existing subsystems producing deployment and product-level improvement proposals through a rule-first hybrid pipeline with mandatory human approval. Components built and unit-tested; live end-to-end run pending.
+- **Real-provider acceptance**: the e2e harness drives the runtime against a deterministic scripted provider, not a real LLM. A real-provider golden-company benchmark and run narrative arrive with the operate tier.
 
-The multi-agent coordinator runs end to end behind the provider-present switch (decompose, route, parallel execution, rollup; `/coordinate` returns a real result when a provider is configured). Coordination metrics, autonomy/trust enforcement on a live run, and the self-improvement loop are designed and unit-tested but not yet exercised end to end. The design for each lives in the [Design Specification](https://synthorg.io/docs/design/).
+The design for each lives in the [Design Specification](https://synthorg.io/docs/design/).
 
 ## Quick Start
 

--- a/docs/design/agent-execution.md
+++ b/docs/design/agent-execution.md
@@ -5,10 +5,6 @@ description: Agent execution status, execution loops (ReAct, Plan-and-Execute, H
 
 # Agent Execution
 
-!!! warning "Designed behaviour; runtime in active development"
-
-    This page is the source of truth for the **designed** behaviour of this subsystem. The autonomous agent runtime that exercises it end to end is in active development (see the [Roadmap](../roadmap/index.md)); the code described here is built and unit-tested as components but not yet run by a live agent.
-
 This page covers the agent-side execution plane: how a single agent runs a task. The engine dispatches work via the [TaskEngine](engine.md#taskengine-centralized-state-coordination); the agent receives it, enters an execution loop, and iterates through LLM turns and tool calls until completion or handoff. The loop type, prompt profile, stagnation guards, and context-budget policies are all pluggable per agent.
 
 ## Agent Execution Status

--- a/docs/design/agents.md
+++ b/docs/design/agents.md
@@ -5,10 +5,6 @@ description: Agent identity system. Personality dimensions, structured skill mod
 
 # Agents
 
-!!! warning "Designed behaviour; runtime in active development"
-
-    This page is the source of truth for the **designed** behaviour of this subsystem. The autonomous agent runtime that exercises it end to end is in active development (see the [Roadmap](../roadmap/index.md)); the code described here is built and unit-tested as components but not yet run by a live agent.
-
 Every agent is a composition of **immutable config** (identity, personality, skills, model, tool permissions, authority) and **mutable runtime state** (execution status, active task, cost accumulation). This page covers the identity layer. The HR lifecycle (seniority, hiring, firing, performance, evolution) lives on a dedicated [HR & Agent Lifecycle](hr-lifecycle.md) page.
 
 ## Agent Identity Card
@@ -275,8 +271,8 @@ entries to cite the exact charter version that was active during execution.
 ### Generic Infrastructure
 
 The versioning system lives in `src/synthorg/versioning/` and is intentionally
-entity-agnostic so it can be reused for other versioned entity types (tracked in
-#1113):
+entity-agnostic so it can be reused for other versioned entity types (tracked
+in issue #1113):
 
 - **`VersionSnapshot[T]`** (`versioning/models.py`): Generic frozen Pydantic model
   with fields `entity_id`, `version`, `content_hash`, `snapshot: T`, `saved_by`,

--- a/docs/design/budget.md
+++ b/docs/design/budget.md
@@ -5,10 +5,6 @@ description: Hierarchical budgets, cost tracking, CFO agent responsibilities, co
 
 # Budget & Cost Management
 
-!!! warning "Designed behaviour; runtime in active development"
-
-    This page is the source of truth for the **designed** behaviour of this subsystem. Budget enforcement is built and unit-tested as components; enforcement on a live run is performed by the agent runtime, which is in active development and not yet wired (see the [Roadmap](../roadmap/index.md)).
-
 SynthOrg treats money as a first-class runtime constraint. Every LLM call carries a currency-stamped `CostRecord`, budgets cascade from the company down to individual teams, and three layers of enforcement (pre-flight, in-flight, task-boundary) prevent runaway spending without breaking in-progress work. The agent execution pipeline that drives each layer is documented in [Agent Execution > AgentEngine Orchestrator](agent-execution.md#agentengine-orchestrator).
 
 ---

--- a/docs/design/communication.md
+++ b/docs/design/communication.md
@@ -5,10 +5,6 @@ description: Message bus architecture, communication patterns, standards, messag
 
 # Communication
 
-!!! warning "Designed behaviour; runtime in active development"
-
-    This page is the source of truth for the **designed** behaviour of this subsystem. The autonomous agent runtime that exercises it end to end is in active development (see the [Roadmap](../roadmap/index.md)); the code described here is built and unit-tested as components but not yet run by a live agent.
-
 The communication architecture defines how agents exchange information. This
 page covers transport-level concerns: patterns, standards, the message
 contract, and bus configuration. Federation, orchestration, and the event

--- a/docs/design/coordination.md
+++ b/docs/design/coordination.md
@@ -5,10 +5,6 @@ description: Agent crash recovery, graceful shutdown protocol, concurrent worksp
 
 # Coordination & Resilience
 
-!!! warning "Designed behaviour; runtime in active development"
-
-    This page is the source of truth for the **designed** behaviour of this subsystem. The multi-agent coordinator is wired at boot behind the provider-present switch: with a provider configured, `/coordinate` runs decompose, route, parallel execution, then rollup end to end; an empty company (no provider) still returns 503. The surrounding resilience features on this page (crash recovery with checkpoint resume, graceful shutdown, the self-improvement loop) remain in active development (see the [Roadmap](../roadmap/index.md)).
-
 This page covers system-level features that span multiple agents and protect against failure: crash recovery with checkpoint resume, graceful shutdown strategies, concurrent workspace isolation (Git worktrees / virtual filesystem / per-branch), and multi-agent coordination topology (centralized, decentralized, context-dependent dispatchers).
 
 ## Agent Crash Recovery
@@ -423,6 +419,7 @@ Events emitted: `PROJECT_WORKSPACE_PROVISIONED`,
 `WORKSPACE_PUSH_QUEUE_FAILED`, `WORKSPACE_PUSH_QUEUE_WORKER_FAILED`.
 
 **Modules**:
+
 - `src/synthorg/engine/workspace/project_workspace_service.py`
 - `src/synthorg/engine/workspace/git_backend/` (protocol + 3 strategies + factory)
 - `src/synthorg/engine/workspace/push_queue.py`
@@ -471,6 +468,7 @@ Events emitted: `ENVIRONMENT_PROVISION_START`, `ENVIRONMENT_PROVISIONED`,
 `ENVIRONMENT_IMAGE_BUILD_RETRY`.
 
 **Modules**:
+
 - `src/synthorg/engine/workspace/environment/` (protocol + 3 strategies +
   factory + service + committer + hash cache + image builder + templates)
 - `src/synthorg/tools/sandbox/active_environment.py` (ambient contextvar)

--- a/docs/design/distributed-runtime.md
+++ b/docs/design/distributed-runtime.md
@@ -5,10 +5,6 @@ description: Pluggable distributed bus backend design, NATS JetStream first impl
 
 # Distributed Runtime
 
-!!! warning "Designed behaviour; runtime in active development"
-
-    This page is the source of truth for the **designed** behaviour of this subsystem. The dispatch plumbing (NATS JetStream queue and worker pool) exists, but the task-execute endpoint currently advances task state without invoking an agent; end-to-end distributed execution depends on the agent runtime, which is in active development (see the [Roadmap](../roadmap/index.md)).
-
 SynthOrg runs in a single Python process by default. Agents communicate over an in-memory `MessageBus` (per-(channel, subscriber) `asyncio.Queue`) and the `TaskEngine` dispatches work through its own single-writer mutation queue inside that same process. For a laptop running one synthetic org, this is the right answer: lowest latency, no extra containers, nothing to operate.
 
 This page describes the **first distributed backend** that plugs into the existing `MessageBus` protocol without changing it, and the **distributed task queue** that sits on top of that backend. Both are opt-in. The in-memory path stays the default and must remain byte-identical in behavior for users who do not turn on distribution.
@@ -112,8 +108,8 @@ A single JetStream stream named `SYNTHORG_BUS` holds all message bus traffic.
 
 - **Retention policy**: `LimitsPolicy` with `MaxMsgsPerSubject = config.retention.max_messages_per_channel`. This preserves the existing per-channel history-bound semantic natively, without application-level bookkeeping. The in-memory backend bounds each channel's `deque`; the NATS backend bounds each subject's retained messages. Same semantic, different mechanism.
 - **Subject taxonomy**:
-    - `synthorg.bus.channel.<sanitized_name>` for `TOPIC` and `BROADCAST` channels
-    - `synthorg.bus.direct.<a>:<b>` for lazily-created `DIRECT` channels (where `a < b` are the sorted agent IDs, matching the in-memory `@a:b` convention)
+  - `synthorg.bus.channel.<sanitized_name>` for `TOPIC` and `BROADCAST` channels
+  - `synthorg.bus.direct.<a>:<b>` for lazily-created `DIRECT` channels (where `a < b` are the sorted agent IDs, matching the in-memory `@a:b` convention)
 - **Sanitization**: JetStream subject tokens accept alphanumerics, `-`, `_`, and `.` as a separator. Channel names with any other character get a stable sanitization pass before they become subject tokens. The original channel name stays in the `Channel` registry so protocol callers see the names they passed in.
 
 The Phase 4 task queue uses a **separate** stream `SYNTHORG_TASKS` with `WorkQueuePolicy` retention. Separation matters because the two streams have incompatible retention requirements: the bus retains the last N messages per subject, the task queue deletes messages after ack.

--- a/docs/design/engine.md
+++ b/docs/design/engine.md
@@ -5,10 +5,6 @@ description: Task lifecycle, task definition, workflow types (sequential, parall
 
 # Task & Workflow Engine
 
-!!! warning "Designed behaviour; runtime in active development"
-
-    This page is the source of truth for the **designed** behaviour of this subsystem. The autonomous agent runtime that exercises it end to end is in active development (see the [Roadmap](../roadmap/index.md)); the code described here is built and unit-tested as components but not yet run by a live agent.
-
 The task and workflow engine orchestrates how work flows through a synthetic
 organization, from task creation and assignment through to review and
 completion. This page covers the task-engine core: lifecycle, workflows,
@@ -176,11 +172,11 @@ exclusive file access, error isolation, and progress tracking.
 
 ### Kanban Board
 
-| Backlog | Ready | In Progress | Review | Done  |
-|---------|-------|-------------|--------|-------|
-| o       | o     | *           | o      | * * * |
-| o       | o     | *           |        | * *   |
-| o       |       |             |        | *     |
+| Backlog | Ready | In Progress | Review | Done        |
+|---------|-------|-------------|--------|-------------|
+| o       | o     | \*          | o      | \* \* \*    |
+| o       | o     | \*          |        | \* \*       |
+| o       |       |             |        | \*          |
 
 The `KanbanColumn` enum defines five columns that map bidirectionally to
 `TaskStatus` (Backlog=CREATED, Ready=ASSIGNED, In Progress=IN_PROGRESS,

--- a/docs/design/hr-lifecycle.md
+++ b/docs/design/hr-lifecycle.md
@@ -5,10 +5,6 @@ description: Seniority and authority levels, role catalog, dynamic roles, hiring
 
 # HR & Agent Lifecycle
 
-!!! warning "Designed behaviour; runtime in active development"
-
-    This page is the source of truth for the **designed** behaviour of this subsystem. The autonomous agent runtime that exercises it end to end is in active development (see the [Roadmap](../roadmap/index.md)); the code described here is built and unit-tested as components but not yet run by a live agent.
-
 This page covers the operational lifecycle of every agent in a synthetic organisation, from hiring through performance tracking, promotion, evolution, and offboarding. The HR subsystem is how SynthOrg simulates a workforce: closed-loop hiring when new skills are needed, performance-driven pruning when agents fail to deliver, and pluggable evolution for agents that need to adapt their identity.
 
 See [Agents](agents.md) for the identity layer (personality, skills, tool namespaces, identity versioning).
@@ -162,8 +158,8 @@ human review required. Idempotent by plan ID.
 The pruning service automates performance-driven agent removal with mandatory human approval.
 
 - **`PruningPolicy`** protocol with two implementations:
-    - `ThresholdPruningPolicy`: prunes agents with quality AND collaboration below thresholds for N+ consecutive windows (7d/30d/90d).
-    - `TrendPruningPolicy`: prunes agents with declining Theil-Sen trend across all three windows.
+  - `ThresholdPruningPolicy`: prunes agents with quality AND collaboration below thresholds for N+ consecutive windows (7d/30d/90d).
+  - `TrendPruningPolicy`: prunes agents with declining Theil-Sen trend across all three windows.
 - **`PruningService`** runs as a periodic background task, evaluates all active agents, and creates CRITICAL-risk approval items for eligible candidates.
 - On human approval, delegates to `OffboardingService` with `FiringReason.PERFORMANCE`.
 - Approval deduplication prevents multiple pending approvals per agent.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -74,21 +74,20 @@ development, business operations, creative work, or any domain.
 - Not a toy/demo: designed for real, production-quality output
 - Not a reasoning parallelizer. Single-agent reasoning is typically more token-efficient on isolated multi-hop questions, and SynthOrg's [auto topology selector](coordination.md#task-decomposability--coordination-topology) defaults to single-agent for such tasks. SynthOrg's value is role-specialized work-stream parallelism, organizational simulation fidelity, and audit-grade decision trails, not reasoning parallelism. See [S1 Multi-Agent Architecture Decision](../research/s1-multi-agent-decision.md) for the full reconciliation.
 
-!!! warning "How to read the design specification (important)"
+!!! warning "Pre-alpha: heavy development, not yet usable"
+
+    SynthOrg is in active pre-alpha development. The framework is not yet
+    production-ready: expect bugs, rough edges, missing polish, and
+    breaking changes between releases. Operator-facing onboarding (real
+    provider, real workloads, dashboard polish) has not been exercised end
+    to end. Use it for research and contribution, not for real workloads.
 
     These pages describe the **designed** behaviour of SynthOrg and are the
-    source of truth for that design. They are documented upfront to inform
-    architecture; protocol interfaces are designed even where the behaviour
-    is not yet wired. Be specific about current state: the autonomous agent
-    **runtime** that makes the organisation execute work is in active
-    development and not yet wired (`AgentEngine` is not constructed in the
-    shipped path), so subsystems that depend on a running agent
-    (coordination, coordination metrics, intake, approval enforcement,
-    self-improvement, and the agent execution loop itself) are designed and
-    unit-tested as components but not exercised end to end. Treat any gap
-    between a spec and the code as the work, not the spec. For exactly what
-    is available now versus in active development, see the
-    [Roadmap](../roadmap/index.md).
+    source of truth for that design. Protocol interfaces and pluggable
+    strategies are designed upfront to inform architecture; individual
+    subsystems may still have a gap between the spec and the code. Treat
+    any such gap as the work, not the spec. For what is shipped now versus
+    on the roadmap, see the [Roadmap](../roadmap/index.md).
 
 ## Configuration Philosophy
 

--- a/docs/design/knowledge-substrate.md
+++ b/docs/design/knowledge-substrate.md
@@ -5,13 +5,6 @@ description: Heavy-duty document/knowledge RAG with citation tracking, distinct 
 
 # Knowledge and Provenance Substrate
 
-!!! warning "Designed behaviour; runtime in active development"
-
-    This page is the source of truth for the **designed** behaviour of this
-    subsystem. The components are built and unit-tested; the ingestion and
-    retrieval pipeline runs inside a live agent, which is in active development
-    (see the [Roadmap](../roadmap/index.md)).
-
 SynthOrg separates three storage concerns:
 
 - **Agent memory** (Mem0): what an agent remembers about a run. See

--- a/docs/design/memory.md
+++ b/docs/design/memory.md
@@ -5,10 +5,6 @@ description: Agent memory architecture, memory types, memory levels, MemoryBacke
 
 # Memory and Persistence
 
-!!! warning "Designed behaviour; runtime in active development"
-
-    This page is the source of truth for the **designed** behaviour of this subsystem. The memory components exist as tested code, but the memory pipeline runs only inside a live agent, which is in active development (see the [Roadmap](../roadmap/index.md)). Persistence storage (SQLite/Postgres) is shipped and available now.
-
 The SynthOrg framework separates two distinct storage concerns:
 
 - **Agent memory**: what agents know, remember, and learn (working, episodic, semantic, procedural, social)
@@ -22,11 +18,11 @@ consolidation / retention pipeline.
 
 ## Related design docs
 
-* [Shared Organizational Memory](memory-organizational.md): company-wide knowledge (policies, ADRs, procedures) behind `OrgMemoryBackend`.
-* [Operational Data Persistence](memory-operational.md): `PersistenceBackend` protocol, per-entity repositories, SQLite + Postgres backends, schema strategy, multi-tenancy, database-enforced invariants.
-* [Memory Learning and Injection](memory-learning.md): procedural memory auto-generation (failure + success capture), cross-agent skill pool, injection strategies (context / tool-based / self-editing), `MemoryService` REST + MCP entry point.
-* [Living Documentation](living-documentation.md): per-project documentation as a dual-purpose wiki + RAG namespace, integrated via the `PROJECT_DOC` memory category and `ProjectAwareMemoryFacade`.
-* [Knowledge and Provenance Substrate](knowledge-substrate.md): heavy-duty document/knowledge RAG over an ingested external corpus (specs, codebases, web pages, tickets) with citation tracking, reusing the hybrid retrieval stack via the `KNOWLEDGE` memory category.
+- [Shared Organizational Memory](memory-organizational.md): company-wide knowledge (policies, ADRs, procedures) behind `OrgMemoryBackend`.
+- [Operational Data Persistence](memory-operational.md): `PersistenceBackend` protocol, per-entity repositories, SQLite + Postgres backends, schema strategy, multi-tenancy, database-enforced invariants.
+- [Memory Learning and Injection](memory-learning.md): procedural memory auto-generation (failure + success capture), cross-agent skill pool, injection strategies (context / tool-based / self-editing), `MemoryService` REST + MCP entry point.
+- [Living Documentation](living-documentation.md): per-project documentation as a dual-purpose wiki + RAG namespace, integrated via the `PROJECT_DOC` memory category and `ProjectAwareMemoryFacade`.
+- [Knowledge and Provenance Substrate](knowledge-substrate.md): heavy-duty document/knowledge RAG over an ingested external corpus (specs, codebases, web pages, tickets) with citation tracking, reusing the hybrid retrieval stack via the `KNOWLEDGE` memory category.
 
 ---
 

--- a/docs/design/ontology.md
+++ b/docs/design/ontology.md
@@ -5,10 +5,6 @@ description: Shared entity vocabulary, versioned definitions, drift detection, a
 
 # Semantic Ontology
 
-!!! warning "Designed behaviour; runtime in active development"
-
-    This page is the source of truth for the **designed** behaviour of this subsystem. The autonomous agent runtime that exercises it end to end is in active development (see the [Roadmap](../roadmap/index.md)); the code described here is built and unit-tested as components but not yet run by a live agent.
-
 The ontology subsystem provides a shared, versioned vocabulary of entity
 definitions that agents use to communicate unambiguously. Every core concept
 (Task, Agent, Role, etc.) has a canonical definition registered at startup,

--- a/docs/design/organization.md
+++ b/docs/design/organization.md
@@ -5,10 +5,6 @@ description: Company types, organizational hierarchy, department configuration, 
 
 # Organization & Templates
 
-!!! warning "Designed behaviour; runtime in active development"
-
-    This page is the source of truth for the **designed** behaviour of this subsystem. The template and configuration system is available now; the running-organisation behaviour it configures depends on the agent runtime, which is in active development (see the [Roadmap](../roadmap/index.md)).
-
 ## Company Types
 
 SynthOrg provides pre-built company templates for common organizational patterns:

--- a/docs/design/research-mode.md
+++ b/docs/design/research-mode.md
@@ -5,13 +5,6 @@ description: A real research subsystem for synthetic organisations. A research b
 
 # Research Mode
 
-!!! warning "Designed behaviour; runtime in active development"
-    Research mode is wired at boot behind the `research.enabled` setting and a
-    configured provider plus model. Like the rest of the agent capability
-    layer, the per-task tool loader that surfaces the `research` tool to a
-    running agent lands with the broader runtime-wiring programme; the
-    subsystem, its MCP surface, and its eval lane are complete and tested.
-
 Today "an agent does research" is a curl in a sandbox. Research mode replaces
 that with a real pipeline: a research **brief** becomes a synthesised,
 citation-backed **report** whose every claim resolves to a retrievable

--- a/docs/design/self-improvement.md
+++ b/docs/design/self-improvement.md
@@ -1,9 +1,5 @@
 # Self-Improving Company
 
-!!! warning "Designed behaviour; runtime in active development"
-
-    This page is the source of truth for the **designed** behaviour of this subsystem. The self-improvement loop runs only when agents run; it is in active development (see the [Roadmap](../roadmap/index.md)). The code described here is built and unit-tested as components but not yet exercised end to end.
-
 The self-improvement meta-loop observes company-wide signals from 7 existing subsystems and produces deployment and product-level improvement proposals through a rule-first hybrid pipeline with mandatory human approval.
 
 Company autonomy ships at `supervised` so most state-mutating agent actions queue for approval before execution; raise to `semi` or `full` via `company.autonomy_level` (or `config.autonomy.level` in the company YAML) once operators trust the organization. Rank order: `full` > `semi` > `supervised` > `locked`.

--- a/docs/design/tools.md
+++ b/docs/design/tools.md
@@ -5,10 +5,6 @@ description: Tool categories, concurrent execution model, layered sandboxing, MC
 
 # Tools & Capabilities
 
-!!! warning "Designed behaviour; runtime in active development"
-
-    This page is the source of truth for the **designed** behaviour of this subsystem. Tool execution runs via the agent runtime, which is in active development (see the [Roadmap](../roadmap/index.md)); the code described here is built and unit-tested as components but not yet run by a live agent.
-
 Agents act on the world through tools. SynthOrg defines a pluggable tool system with 15+ categories (file system, git, web, database, terminal, sandbox, MCP bridge, analytics, communication, design, headless browser, governed external data access, virtual desktop), layered sandboxing (subprocess for low-risk, Docker for high-risk, Kubernetes for future multi-tenant), MCP server integration, and a progressive-disclosure model that limits the surface an agent sees to what its role, seniority, and autonomy tier permit.
 
 ## Tool Categories

--- a/docs/design/verification-quality.md
+++ b/docs/design/verification-quality.md
@@ -5,10 +5,6 @@ description: Verification stage, harness middleware layer, review pipeline, and 
 
 # Verification & Quality
 
-!!! warning "Designed behaviour; runtime in active development"
-
-    This page is the source of truth for the **designed** behaviour of this subsystem. The intake engine is online: the real work-entry path (`POST /requests/{id}/approve`) drives an approved request through the pipeline spine so an agent executes it. The verification stage runs with the agent runtime, which is in active development (see the [Roadmap](../roadmap/index.md)); that code is built and unit-tested as components but not yet exercised by a live verification agent.
-
 This page covers the quality-assurance pipeline attached to agent output: the verification stage that runs after an agent completes a task, the harness middleware that wraps every agent invocation, the review pipeline that validates produced artifacts, and the intake engine that ingests new work.
 
 ## Verification Stage


### PR DESCRIPTION
## Summary

EPIC #1955 ("Bring the agent runtime online") has all 11 children CLOSED COMPLETED. The runtime IS wired and exercised by deterministic harnesses, but the design pages and README still claimed the runtime was "in active development" and "not yet wired". This PR drops the stale claims and replaces them with honest pre-alpha framing.

### Diff

- **17 design pages**: removed the per-page `!!! warning "Designed behaviour; runtime in active development"` admonition. The runtime is no longer "in active development" in the sense those banners meant.
- **`docs/design/index.md`**: replaced the site-level admonition that claimed `AgentEngine is not constructed in the shipped path` with `!!! warning "Pre-alpha: heavy development, not yet usable"`. Honest about the gap that remains: operator-facing onboarding has not been exercised end to end against a real provider by a human, even though the code path is wired and harness-tested.
- **`README.md`**: same framing pass on the Project-status paragraph, "What is available now", and "In active development" sections. Lists what's now wired (agent runtime, multi-agent coordinator, work pipeline spine, entry adapters, sandbox lifecycle dispatch, distributed-path consumers); calls out that the e2e harness drives the runtime against a deterministic scripted provider, not a real LLM; keeps the operate-tier polish, conversational interface, brownfield substrate, capability layer, and self-improvement loop in the "in flight" section honestly.
- **Pre-existing markdownlint fixes** exposed by touching these files: table-cell `*` escaping in `engine.md`, bullet style in `memory.md`, UL indent in `distributed-runtime.md` and `hr-lifecycle.md`, blank-line-before-list in `coordination.md` "Modules" sections, ATX-heading collision on `#1113` in `agents.md`.

### Validation evidence (for the epic, not just this PR)

Full sign-off comment with the per-child verification matrix lives on #1955.

- Manifest gate: `scripts/check_no_ghost_wiring.py` -> exit 0 (every runtime symbol the epic wired is `ENFORCED` in `scripts/_ghost_wiring_manifest.txt`).
- `tests/e2e/` -> 33 passed in 28.33s, covering #1956 (runtime root + safety spine), #1957 (governance), #1958 (multi-agent coordinator), #1960 (work pipeline spine), #1961 (client-simulation harness), #1962 (real intake), #1963 (task-board adapter), #1964 (objective adapter), and the single-agent + cassette-replay + cockpit + conversational-propose + charter-to-run + stakes-routing seams.
- `tests/integration/workers/test_distributed_path_nats.py` -> 3 passed in 22.58s, covering #1966 (multi-worker no-loss/no-dup under synthetic load; ack-extend on long execution; max-deliver dead-letter routing).
- `tests/unit/tools/sandbox/test_docker_sandbox.py` + `test_lifecycle_per_agent.py` -> 84 passed in 10.63s, covering #1965 (`DockerSandbox.execute()` honours `owner_id`; per-agent reuse + grace teardown; contextvar fallback).
- `tests/integration/api/test_task_create_empty_company.py` -> 2 passed in 17.47s, covering #1956 empty-company rejection (`error_code 4014`).

### Test plan

Docs-only diff. No new code paths. The pre-commit and pre-push hook chains already validated the markdown (markdownlint + lychee link-check + no-em-dashes + codespell + the convention-gate inventory).

### Review coverage

Pre-reviewed by 4 agents: docs-consistency (1 MAJOR README drift, fixed in this PR), comment-quality-rot (0 findings), diagram-syntax-validator (0 findings across 9 d2/mermaid files), issue-resolution-verifier (epic resolved; 1 MINOR cosmetic checkbox tick handled).

Closes #1955
