### PR TITLE
refactor(tools): migrate streamablehttp_client to streamable_http_client (#2060)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -635,7 +635,7 @@ disable_error_code = ["explicit-override"]
 [[tool.mypy.overrides]]
 module = "synthorg.tools.*"
 disallow_any_explicit = false
-disable_error_code = ["explicit-override", "unused-awaitable", "deprecated"]
+disable_error_code = ["explicit-override", "unused-awaitable"]
 
 [[tool.mypy.overrides]]
 module = "synthorg.workers.*"

--- a/src/synthorg/tools/mcp/client.py
+++ b/src/synthorg/tools/mcp/client.py
@@ -99,79 +99,75 @@ class MCPClient:
                 server=self._config.name,
                 transport=self._config.transport,
             )
-            stack = AsyncExitStack()
-            await stack.__aenter__()
-            try:
-                coro = self._connect_with_stack(stack)
-                session = await asyncio.wait_for(
-                    coro,
-                    timeout=self._config.connect_timeout_seconds,
-                )
+            # ``async with`` handles cleanup on ANY exception (incl.
+            # ``CancelledError``); ``stack.pop_all()`` transfers
+            # ownership to ``self._exit_stack`` on the success path
+            # only, so ``disconnect()`` controls the eventual close.
+            async with AsyncExitStack() as stack:
+                try:
+                    coro = self._connect_with_stack(stack)
+                    session = await asyncio.wait_for(
+                        coro,
+                        timeout=self._config.connect_timeout_seconds,
+                    )
+                except TimeoutError as exc:
+                    msg = (
+                        f"Connection to {self._config.name!r} timed out "
+                        f"after {self._config.connect_timeout_seconds}s"
+                    )
+                    logger.warning(
+                        MCP_CLIENT_CONNECTION_FAILED,
+                        server=self._config.name,
+                        error=msg,
+                    )
+                    raise MCPConnectionError(
+                        msg,
+                        context={
+                            "server": self._config.name,
+                            "transport": self._config.transport,
+                        },
+                    ) from exc
+                except MCPConnectionError:
+                    raise
+                except Exception as exc:
+                    # WARNING (not ERROR/EXCEPTION) per CLAUDE.md
+                    # ``## Logging``: the policy prescribes
+                    # ``logger.warning`` on credential-bearing paths so
+                    # ``exc_info`` cannot re-bind ``str(exc)`` and
+                    # bypass the ``safe_error_description`` scrub. The
+                    # raise below propagates the failure for ops
+                    # alerting on ``MCPConnectionError`` rather than
+                    # relying on log severity to gate ops triage.
+                    logger.warning(
+                        MCP_CLIENT_CONNECTION_FAILED,
+                        server=self._config.name,
+                        error_type=type(exc).__name__,
+                        error=safe_error_description(exc),
+                    )
+                    # Never embed raw ``str(exc)`` in error messages;
+                    # the same scrubbing applied to log output via
+                    # ``safe_error_description`` must apply to the
+                    # message text that propagates back to API
+                    # surfaces. Raw exception args can leak
+                    # credentials for OAuth-token / Bearer-header /
+                    # connection-string paths.
+                    msg = (
+                        f"Failed to connect to {self._config.name!r}: "
+                        f"{safe_error_description(exc)}"
+                    )
+                    raise MCPConnectionError(
+                        msg,
+                        context={
+                            "server": self._config.name,
+                            "transport": self._config.transport,
+                        },
+                    ) from exc
                 self._session = session
-                self._exit_stack = stack
-                logger.info(
-                    MCP_CLIENT_CONNECTED,
-                    server=self._config.name,
-                )
-            except TimeoutError as exc:
-                await stack.aclose()
-                msg = (
-                    f"Connection to {self._config.name!r} timed out "
-                    f"after {self._config.connect_timeout_seconds}s"
-                )
-                logger.warning(
-                    MCP_CLIENT_CONNECTION_FAILED,
-                    server=self._config.name,
-                    error=msg,
-                )
-                raise MCPConnectionError(
-                    msg,
-                    context={
-                        "server": self._config.name,
-                        "transport": self._config.transport,
-                    },
-                ) from exc
-            except MCPConnectionError:
-                await stack.aclose()
-                raise
-            except Exception as exc:
-                await stack.aclose()
-                # WARNING (not ERROR/EXCEPTION) per CLAUDE.md
-                # ``## Logging``: the policy prescribes
-                # ``logger.warning`` on credential-bearing paths so
-                # ``exc_info`` cannot re-bind ``str(exc)`` and
-                # bypass the ``safe_error_description`` scrub. The
-                # raise below propagates the failure for ops
-                # alerting on ``MCPConnectionError`` rather than
-                # relying on log severity to gate ops triage.
-                logger.warning(
-                    MCP_CLIENT_CONNECTION_FAILED,
-                    server=self._config.name,
-                    error_type=type(exc).__name__,
-                    error=safe_error_description(exc),
-                )
-                # Never embed raw ``str(exc)`` in error messages --
-                # the same scrubbing applied to log output via
-                # ``safe_error_description`` must apply to the
-                # message text that propagates back to API surfaces.
-                # Raw exception args can leak credentials
-                # for OAuth-token / Bearer-header / connection-string
-                # paths.
-                msg = (
-                    f"Failed to connect to {self._config.name!r}: "
-                    f"{safe_error_description(exc)}"
-                )
-                raise MCPConnectionError(
-                    msg,
-                    context={
-                        "server": self._config.name,
-                        "transport": self._config.transport,
-                    },
-                ) from exc
-            except BaseException:
-                # CancelledError, KeyboardInterrupt -- still close the stack
-                await stack.aclose()
-                raise
+                self._exit_stack = stack.pop_all()
+            logger.info(
+                MCP_CLIENT_CONNECTED,
+                server=self._config.name,
+            )
 
     async def _connect_with_stack(
         self,

--- a/src/synthorg/tools/mcp/client.py
+++ b/src/synthorg/tools/mcp/client.py
@@ -11,7 +11,8 @@ from typing import TYPE_CHECKING, Any, Self
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
+from mcp.shared._httpx_utils import create_mcp_http_client
 
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.mcp import (
@@ -476,10 +477,15 @@ class MCPClient:
                 msg,
                 context={"server": self._config.name},
             )
+        http_client = await stack.enter_async_context(
+            create_mcp_http_client(
+                headers=dict(self._config.headers) if self._config.headers else None,
+            ),
+        )
         read_stream, write_stream, _ = await stack.enter_async_context(
-            streamablehttp_client(
+            streamable_http_client(
                 url=self._config.url,
-                headers=(dict(self._config.headers) if self._config.headers else None),
+                http_client=http_client,
             ),
         )
         return await stack.enter_async_context(

--- a/src/synthorg/tools/mcp/client.py
+++ b/src/synthorg/tools/mcp/client.py
@@ -106,8 +106,13 @@ class MCPClient:
             )
             async with AsyncExitStack() as stack:
                 session = await self._establish_session(stack)
-                self._session = session
+                # ``_exit_stack`` first so a CancelledError between
+                # these two assignments cannot leave a zombie state
+                # (``is_connected`` true, transport closed): once
+                # ``pop_all()`` lands on ``self``, ``disconnect()``
+                # owns cleanup regardless of which line is interrupted.
                 self._exit_stack = stack.pop_all()
+                self._session = session
             logger.info(
                 MCP_CLIENT_CONNECTED,
                 server=self._config.name,
@@ -140,6 +145,11 @@ class MCPClient:
             )
             self._raise_connection_error(msg, exc)
         except MCPConnectionError:
+            raise
+        except MemoryError, RecursionError:
+            # Interpreter-state failures bypass the broad-Exception
+            # wrapper so the orchestrator can surface them as
+            # catastrophic rather than transient transport errors.
             raise
         except Exception as exc:
             logger.warning(

--- a/src/synthorg/tools/mcp/client.py
+++ b/src/synthorg/tools/mcp/client.py
@@ -7,7 +7,7 @@ tool discovery and invocation through the MCP protocol.
 import asyncio
 import copy
 from contextlib import AsyncExitStack
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any, NoReturn, Self
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
@@ -81,6 +81,11 @@ class MCPClient:
     async def connect(self) -> None:
         """Establish a connection to the MCP server.
 
+        Uses ``AsyncExitStack`` for guaranteed cleanup on any
+        exception (including ``CancelledError``); ``stack.pop_all()``
+        transfers ownership to ``self._exit_stack`` on the success
+        path only, so ``disconnect()`` controls the eventual close.
+
         Raises:
             MCPConnectionError: If the connection fails.
             RuntimeError: If already connected.
@@ -99,75 +104,72 @@ class MCPClient:
                 server=self._config.name,
                 transport=self._config.transport,
             )
-            # ``async with`` handles cleanup on ANY exception (incl.
-            # ``CancelledError``); ``stack.pop_all()`` transfers
-            # ownership to ``self._exit_stack`` on the success path
-            # only, so ``disconnect()`` controls the eventual close.
             async with AsyncExitStack() as stack:
-                try:
-                    coro = self._connect_with_stack(stack)
-                    session = await asyncio.wait_for(
-                        coro,
-                        timeout=self._config.connect_timeout_seconds,
-                    )
-                except TimeoutError as exc:
-                    msg = (
-                        f"Connection to {self._config.name!r} timed out "
-                        f"after {self._config.connect_timeout_seconds}s"
-                    )
-                    logger.warning(
-                        MCP_CLIENT_CONNECTION_FAILED,
-                        server=self._config.name,
-                        error=msg,
-                    )
-                    raise MCPConnectionError(
-                        msg,
-                        context={
-                            "server": self._config.name,
-                            "transport": self._config.transport,
-                        },
-                    ) from exc
-                except MCPConnectionError:
-                    raise
-                except Exception as exc:
-                    # WARNING (not ERROR/EXCEPTION) per CLAUDE.md
-                    # ``## Logging``: the policy prescribes
-                    # ``logger.warning`` on credential-bearing paths so
-                    # ``exc_info`` cannot re-bind ``str(exc)`` and
-                    # bypass the ``safe_error_description`` scrub. The
-                    # raise below propagates the failure for ops
-                    # alerting on ``MCPConnectionError`` rather than
-                    # relying on log severity to gate ops triage.
-                    logger.warning(
-                        MCP_CLIENT_CONNECTION_FAILED,
-                        server=self._config.name,
-                        error_type=type(exc).__name__,
-                        error=safe_error_description(exc),
-                    )
-                    # Never embed raw ``str(exc)`` in error messages;
-                    # the same scrubbing applied to log output via
-                    # ``safe_error_description`` must apply to the
-                    # message text that propagates back to API
-                    # surfaces. Raw exception args can leak
-                    # credentials for OAuth-token / Bearer-header /
-                    # connection-string paths.
-                    msg = (
-                        f"Failed to connect to {self._config.name!r}: "
-                        f"{safe_error_description(exc)}"
-                    )
-                    raise MCPConnectionError(
-                        msg,
-                        context={
-                            "server": self._config.name,
-                            "transport": self._config.transport,
-                        },
-                    ) from exc
+                session = await self._establish_session(stack)
                 self._session = session
                 self._exit_stack = stack.pop_all()
             logger.info(
                 MCP_CLIENT_CONNECTED,
                 server=self._config.name,
             )
+
+    async def _establish_session(
+        self,
+        stack: AsyncExitStack,
+    ) -> ClientSession:
+        """Run the timeout-bounded connect and translate exceptions.
+
+        Failures are logged at WARNING (not EXCEPTION) so ``exc_info``
+        cannot re-bind ``str(exc)`` and bypass the
+        ``safe_error_description`` scrub on credential-bearing paths.
+        """
+        try:
+            return await asyncio.wait_for(
+                self._connect_with_stack(stack),
+                timeout=self._config.connect_timeout_seconds,
+            )
+        except TimeoutError as exc:
+            msg = (
+                f"Connection to {self._config.name!r} timed out "
+                f"after {self._config.connect_timeout_seconds}s"
+            )
+            logger.warning(
+                MCP_CLIENT_CONNECTION_FAILED,
+                server=self._config.name,
+                error=msg,
+            )
+            self._raise_connection_error(msg, exc)
+        except MCPConnectionError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                MCP_CLIENT_CONNECTION_FAILED,
+                server=self._config.name,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            # ``safe_error_description`` also scrubs the propagated
+            # message: raw exc args can leak OAuth tokens / Bearer
+            # headers / connection strings to upstream callers.
+            msg = (
+                f"Failed to connect to {self._config.name!r}: "
+                f"{safe_error_description(exc)}"
+            )
+            self._raise_connection_error(msg, exc)
+
+    def _raise_connection_error(
+        self,
+        message: str,
+        exc: BaseException,
+    ) -> NoReturn:
+        """Raise ``MCPConnectionError`` with the server context attached."""
+        raise MCPConnectionError(
+            message,
+            context={
+                "server": self._config.name,
+                "transport": self._config.transport,
+            },
+        ) from exc
 
     async def _connect_with_stack(
         self,

--- a/tests/unit/tools/mcp/test_client.py
+++ b/tests/unit/tools/mcp/test_client.py
@@ -337,19 +337,29 @@ class TestMCPClientHTTPTransport:
             name="test-http",
             transport="streamable_http",
             url="http://localhost:8080/mcp",
+            headers={"Authorization": "Bearer test-token"},
         )
         client = MCPClient(config)
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
+        mock_http_client = AsyncMock()
 
         with (
             patch(
-                "synthorg.tools.mcp.client.streamablehttp_client",
+                "synthorg.tools.mcp.client.create_mcp_http_client",
+            ) as mock_factory,
+            patch(
+                "synthorg.tools.mcp.client.streamable_http_client",
             ) as mock_http,
             patch(
                 "synthorg.tools.mcp.client.ClientSession",
             ) as mock_cls,
         ):
+            factory_cm = AsyncMock()
+            factory_cm.__aenter__ = AsyncMock(return_value=mock_http_client)
+            factory_cm.__aexit__ = AsyncMock(return_value=False)
+            mock_factory.return_value = factory_cm
+
             mock_cm = AsyncMock()
             mock_cm.__aenter__ = AsyncMock(
                 return_value=(AsyncMock(), AsyncMock(), AsyncMock()),
@@ -366,4 +376,11 @@ class TestMCPClientHTTPTransport:
 
             await client.connect()
 
+        mock_factory.assert_called_once_with(
+            headers={"Authorization": "Bearer test-token"},
+        )
+        mock_http.assert_called_once_with(
+            url="http://localhost:8080/mcp",
+            http_client=mock_http_client,
+        )
         assert client.is_connected

--- a/tests/unit/tools/mcp/test_client.py
+++ b/tests/unit/tools/mcp/test_client.py
@@ -3,6 +3,7 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from synthorg.tools.mcp.client import MCPClient
@@ -342,7 +343,77 @@ class TestMCPClientHTTPTransport:
         client = MCPClient(config)
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
-        mock_http_client = AsyncMock()
+        mock_http_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_read_stream = AsyncMock()
+        mock_write_stream = AsyncMock()
+        mock_session_id_cb = AsyncMock()
+
+        with (
+            patch(
+                "synthorg.tools.mcp.client.create_mcp_http_client",
+            ) as mock_factory,
+            patch(
+                "synthorg.tools.mcp.client.streamable_http_client",
+            ) as mock_http,
+            patch(
+                "synthorg.tools.mcp.client.ClientSession",
+            ) as mock_cls,
+        ):
+            factory_cm = AsyncMock()
+            factory_cm.__aenter__ = AsyncMock(return_value=mock_http_client)
+            factory_cm.__aexit__ = AsyncMock(return_value=False)
+            mock_factory.return_value = factory_cm
+
+            mock_cm = AsyncMock()
+            mock_cm.__aenter__ = AsyncMock(
+                return_value=(
+                    mock_read_stream,
+                    mock_write_stream,
+                    mock_session_id_cb,
+                ),
+            )
+            mock_cm.__aexit__ = AsyncMock(return_value=False)
+            mock_http.return_value = mock_cm
+
+            session_cm = AsyncMock()
+            session_cm.__aenter__ = AsyncMock(
+                return_value=mock_session,
+            )
+            session_cm.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = session_cm
+
+            await client.connect()
+
+        mock_factory.assert_called_once_with(
+            headers={"Authorization": "Bearer test-token"},
+        )
+        # Migrated code copies via ``dict(self._config.headers)``; the
+        # dict passed to the factory must be a fresh object, not aliased
+        # to the frozen-config field.
+        passed_headers = mock_factory.call_args.kwargs["headers"]
+        assert passed_headers is not config.headers
+        mock_http.assert_called_once_with(
+            url="http://localhost:8080/mcp",
+            http_client=mock_http_client,
+        )
+        mock_cls.assert_called_once_with(mock_read_stream, mock_write_stream)
+        mock_session.initialize.assert_called_once()
+        assert client.is_connected
+
+    async def test_connect_http_with_empty_headers_passes_none(self) -> None:
+        # The migrated code path is ``dict(...) if self._config.headers
+        # else None``; empty headers (the default factory value) must
+        # become ``None`` at the factory call site, not ``{}``.
+        config = MCPServerConfig(
+            name="test-http-empty",
+            transport="streamable_http",
+            url="http://localhost:8080/mcp",
+        )
+        assert config.headers == {}
+        client = MCPClient(config)
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock()
+        mock_http_client = AsyncMock(spec=httpx.AsyncClient)
 
         with (
             patch(
@@ -368,19 +439,82 @@ class TestMCPClientHTTPTransport:
             mock_http.return_value = mock_cm
 
             session_cm = AsyncMock()
-            session_cm.__aenter__ = AsyncMock(
-                return_value=mock_session,
-            )
+            session_cm.__aenter__ = AsyncMock(return_value=mock_session)
             session_cm.__aexit__ = AsyncMock(return_value=False)
             mock_cls.return_value = session_cm
 
             await client.connect()
 
-        mock_factory.assert_called_once_with(
+        mock_factory.assert_called_once_with(headers=None)
+        assert client.is_connected
+
+    async def test_connect_http_cleans_up_when_transport_fails(self) -> None:
+        # When ``streamable_http_client.__aenter__`` raises after the
+        # factory's client has been entered, the exit stack must invoke
+        # the factory's ``__aexit__`` so the httpx client is released.
+        config = MCPServerConfig(
+            name="test-http-transport-fail",
+            transport="streamable_http",
+            url="http://localhost:8080/mcp",
             headers={"Authorization": "Bearer test-token"},
         )
-        mock_http.assert_called_once_with(
+        client = MCPClient(config)
+        mock_http_client = AsyncMock(spec=httpx.AsyncClient)
+
+        with (
+            patch(
+                "synthorg.tools.mcp.client.create_mcp_http_client",
+            ) as mock_factory,
+            patch(
+                "synthorg.tools.mcp.client.streamable_http_client",
+            ) as mock_http,
+        ):
+            factory_cm = AsyncMock()
+            factory_cm.__aenter__ = AsyncMock(return_value=mock_http_client)
+            factory_cm.__aexit__ = AsyncMock(return_value=False)
+            mock_factory.return_value = factory_cm
+
+            transport_cm = AsyncMock()
+            transport_cm.__aenter__ = AsyncMock(
+                side_effect=RuntimeError("transport setup failed"),
+            )
+            transport_cm.__aexit__ = AsyncMock(return_value=False)
+            mock_http.return_value = transport_cm
+
+            with pytest.raises(MCPConnectionError):
+                await client.connect()
+
+        factory_cm.__aenter__.assert_awaited_once()
+        factory_cm.__aexit__.assert_awaited_once()
+        assert not client.is_connected
+
+    async def test_connect_http_propagates_factory_failure(self) -> None:
+        # When the factory's ``__aenter__`` raises, no http client was
+        # produced; ``streamable_http_client`` must NOT be invoked.
+        config = MCPServerConfig(
+            name="test-http-factory-fail",
+            transport="streamable_http",
             url="http://localhost:8080/mcp",
-            http_client=mock_http_client,
         )
-        assert client.is_connected
+        client = MCPClient(config)
+
+        with (
+            patch(
+                "synthorg.tools.mcp.client.create_mcp_http_client",
+            ) as mock_factory,
+            patch(
+                "synthorg.tools.mcp.client.streamable_http_client",
+            ) as mock_http,
+        ):
+            factory_cm = AsyncMock()
+            factory_cm.__aenter__ = AsyncMock(
+                side_effect=RuntimeError("factory setup failed"),
+            )
+            factory_cm.__aexit__ = AsyncMock(return_value=False)
+            mock_factory.return_value = factory_cm
+
+            with pytest.raises(MCPConnectionError):
+                await client.connect()
+
+        mock_http.assert_not_called()
+        assert not client.is_connected


### PR DESCRIPTION
## Summary

Closes #2060. EPIC #2046 / ADR-0006 Section F follow-up.

Drops `"deprecated"` from the `synthorg.tools.*` mypy override block (pyproject.toml:638) and migrates the single live deprecated-API call surfaced by the project mypy run:

- `src/synthorg/tools/mcp/client.py:_connect_http`: `streamablehttp_client(url, headers=...)` -> `create_mcp_http_client(headers=...)` (yields `httpx.AsyncClient`) + `streamable_http_client(url, http_client=...)`. Both contexts enter the existing `AsyncExitStack`; the `mcp` library's deprecated wrapper internally called the same helper with the same MCP-recommended defaults (`follow_redirects=True`, `httpx.Timeout(30, read=300)`), so the migration is behaviour-preserving.

The issue body cites "3 sites" but `uv run mypy --num-workers=4 src/synthorg/tools/` with the entry removed surfaces only 1 site on current main; the count was stale by one day vs. PR #2078 landing 2026-05-23. The normative criterion (override gone, mypy clean) is satisfied.

## Pre-PR review

12 review agents (`code-reviewer`, `python-reviewer`, `conventions-enforcer`, `async-concurrency-reviewer`, `security-reviewer`, `logging-audit`, `resilience-audit`, `test-quality-reviewer`, `pr-test-analyzer`, `docs-consistency`, `comment-quality-rot`, `issue-resolution-verifier`) launched in parallel. 12 findings consolidated; 11 implemented, 1 informational acknowledged.

Round-2 commit (`e2acee83`):

- `src/synthorg/tools/mcp/client.py::connect`: manual `stack = AsyncExitStack(); await stack.__aenter__()` + per-except `await stack.aclose()` replaced with `async with AsyncExitStack() as stack:` + `self._exit_stack = stack.pop_all()` on the success path. `pop_all()` transfers ownership to `self._exit_stack` so `disconnect()` still controls eventual close; cleanup of partially-entered contexts on `TimeoutError` / `MCPConnectionError` / `Exception` / `CancelledError` / `KeyboardInterrupt` is now delegated to `async with`'s `__aexit__`.
- `tests/unit/tools/mcp/test_client.py::TestMCPClientHTTPTransport`:
  - existing `test_connect_http_sets_session` now asserts `ClientSession(read, write)` was called with the named streams, asserts `session.initialize()` was awaited, asserts `mock_factory.call_args.kwargs["headers"]` is a fresh dict (not aliased to the frozen-config field), and uses `spec=httpx.AsyncClient` on the `mock_http_client` AsyncMock;
  - new `test_connect_http_with_empty_headers_passes_none`: default-headers config passes `headers=None`, not `headers={}`, to the factory;
  - new `test_connect_http_cleans_up_when_transport_fails`: when `streamable_http_client.__aenter__` raises after the factory's client has been entered, the stack invokes `factory_cm.__aexit__` so the httpx client is released;
  - new `test_connect_http_propagates_factory_failure`: when the factory's `__aenter__` raises, `streamable_http_client` is never invoked.

Skipped findings (with rationale):

- Async-reviewer LOW on `asyncio.wait_for` "timeout-under-lock complexity": agent stated "Not required, already handled".
- Pr-test-analyzer "URL-validation order" (5/10): the URL-None branch in `_connect_http` is unreachable via `MCPServerConfig`'s validator (already covered by `test_config.py::test_http_requires_url`); adding a defense-in-depth test for dead code adds noise.

## Test plan

- `uv run mypy --num-workers=4 src/synthorg/tools/`: clean.
- `uv run mypy --num-workers=4 src/ tests/`: clean.
- `uv run python -m pytest tests/unit/tools/mcp/test_client.py -v`: 24 passed (4 HTTP transport tests).
- `uv run ruff check src/synthorg/tools/ tests/unit/tools/`: clean.
- `uv run ruff format --check src/synthorg/tools/ tests/unit/tools/`: clean.
- Pre-push gates (mypy-affected + pytest-unit-affected + all convention gates): clean.

Closes #2060