### PR TITLE
chore: close EPIC #1973 (Windows-safe workspace rmtree + unit-tier discipline)

### DIFF
--- a/src/synthorg/engine/workspace/project_workspace_service.py
+++ b/src/synthorg/engine/workspace/project_workspace_service.py
@@ -14,8 +14,12 @@ the new backend reports).
 
 import asyncio
 import shutil
+import stat
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 from synthorg.core.clock import Clock, SystemClock
 from synthorg.core.enums import GitBackendType
@@ -44,6 +48,28 @@ logger = get_logger(__name__)
 
 _PROJECTS_SUBDIR: Final[str] = "projects"
 _DEFAULT_BRANCH: NotBlankStr = NotBlankStr("main")
+
+
+def _force_writable_then_retry(
+    func: Callable[[str], object],
+    path: str,
+    exc: BaseException,
+) -> None:
+    """``shutil.rmtree`` ``onexc`` handler: strip read-only, retry once.
+
+    Git pack-object files under ``.git/objects`` are written read-only
+    on Windows. ``shutil.rmtree`` raises ``PermissionError`` rather than
+    stripping the attribute, which would leave an orphan ``.git`` tree
+    behind after a backend kind switch (the exact regression
+    ``test_embedded_to_local_path_preserves_row`` guards against).
+    """
+    if not isinstance(exc, PermissionError):
+        raise exc
+    try:
+        Path(path).chmod(stat.S_IWRITE)
+    except OSError:
+        raise exc from None
+    func(path)
 
 
 class ProjectWorkspaceService:
@@ -132,7 +158,9 @@ class ProjectWorkspaceService:
         if not await asyncio.to_thread(git_dir.exists):
             return
         try:
-            await asyncio.to_thread(shutil.rmtree, git_dir)
+            await asyncio.to_thread(
+                shutil.rmtree, git_dir, onexc=_force_writable_then_retry
+            )
         except OSError as exc:
             # Best-effort: surface the failure but let the new
             # backend's provision report whatever it sees on disk.

--- a/src/synthorg/engine/workspace/project_workspace_service.py
+++ b/src/synthorg/engine/workspace/project_workspace_service.py
@@ -60,13 +60,21 @@ def _force_writable_then_retry(
     Git pack-object files under ``.git/objects`` are written read-only
     on Windows. ``shutil.rmtree`` raises ``PermissionError`` rather than
     stripping the attribute, which would leave an orphan ``.git`` tree
-    behind after a backend kind switch (the exact regression
-    ``test_embedded_to_local_path_preserves_row`` guards against).
+    behind after a backend kind switch. The next backend's
+    ``is_git_repo`` short-circuit would then keep the old layout alive
+    despite the persisted row claiming the new kind.
+
+    The chmod ORs the write bit into the existing mode (rather than
+    replacing it) so read + execute bits are preserved; without them a
+    directory entry would lose traversability mid-walk. ``lstat`` +
+    ``follow_symlinks=False`` keep the operation pinned to the named
+    entry instead of any symlink target a third-party repo planted.
     """
     if not isinstance(exc, PermissionError):
         raise exc
     try:
-        Path(path).chmod(stat.S_IWRITE)
+        current_mode = Path(path).lstat().st_mode
+        Path(path).chmod(current_mode | stat.S_IWRITE, follow_symlinks=False)
     except OSError:
         raise exc from None
     func(path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -436,14 +436,15 @@ DISALLOWED_VENDOR_NAMES: frozenset[str] = frozenset(
 # Disabled for fuzz profile where 10k examples per test routinely
 # exceed the limit.
 #
-# 12s (was 8s) absorbs the migration chain that intrinsic-migration
-# tests (e.g. ``test_migrate_creates_tables``, ``test_save_and_get``)
-# pay on the worker that generates the cross-worker template; the
-# chain is ~8s on Windows under xdist contention and grows with every
-# new yoyo revision. Tests that ran in <8s before still run in <8s
-# (the gate's job is to catch new regressions, not to pin a moving
-# floor).
-_UNIT_TEST_WALL_CLOCK_LIMIT = 12.0  # seconds
+# The one-time per-worker migration-template build is credited via
+# ``_template_build_secs`` and subtracted from the guard comparison
+# (see ``pytest_runtest_teardown``), so this budget is for the test
+# work itself, not setup spillover. The worst recorded unit test on
+# this repo is 5.75s; a 6s cap leaves headroom for xdist-contention
+# spikes while firing the moment a unit test starts doing genuine
+# integration work (real subprocess, real network, real heavy I/O)
+# that belongs in ``tests/integration/`` instead.
+_UNIT_TEST_WALL_CLOCK_LIMIT = 6.0  # seconds
 _FUZZ_PROFILE_ACTIVE = os.environ.get("HYPOTHESIS_PROFILE") in ("fuzz", "extreme")
 _start_key = pytest.StashKey[float]()
 # Accumulator for unit-only wall-clock time, summed across tests in

--- a/tests/integration/engine/workspace/git_backend/test_seed.py
+++ b/tests/integration/engine/workspace/git_backend/test_seed.py
@@ -1,9 +1,14 @@
-"""Unit tests for ``GitBackend.seed`` (brownfield source import).
+"""Integration tests for ``GitBackend.seed`` (brownfield source import).
 
 The embedded and local-path backends run real git in ``tmp_path`` so the
 shared fetch/reset import mechanics are exercised end-to-end offline. The
 external-remote backend mocks ``run_git_subprocess`` (no live forge) and
 asserts seed imports the source then pushes.
+
+Marked ``integration`` (not ``unit``) because every test shells out to
+the system ``git`` binary multiple times via
+``asyncio.create_subprocess_exec``; on Windows under xdist contention
+that legitimately exceeds the unit-tier wall-clock budget.
 """
 
 import asyncio
@@ -24,7 +29,7 @@ from synthorg.engine.workspace.git_backend.protocol import (
 )
 from tests._shared import FakeClock
 
-pytestmark = pytest.mark.unit
+pytestmark = pytest.mark.integration
 
 
 def _clean_env() -> dict[str, str]:

--- a/tests/unit/engine/workspace/test_project_workspace_service.py
+++ b/tests/unit/engine/workspace/test_project_workspace_service.py
@@ -1,6 +1,7 @@
 """Unit tests for ``ProjectWorkspaceService.get_or_provision``."""
 
 import asyncio
+import stat
 from pathlib import Path
 
 import pytest
@@ -15,6 +16,7 @@ from synthorg.engine.workspace.git_backend import (
 )
 from synthorg.engine.workspace.project_workspace_service import (
     ProjectWorkspaceService,
+    _force_writable_then_retry,
 )
 from tests._shared import FakeClock, mock_of
 
@@ -134,3 +136,42 @@ class TestProjectWorkspaceService:
         assert a == b
         backend.provision.assert_awaited_once()  # type: ignore[attr-defined]
         assert repo.save_calls == 1
+
+
+class TestForceWritableThenRetry:
+    """``shutil.rmtree`` ``onexc`` handler for Windows-read-only git packs."""
+
+    def test_strips_read_only_and_retries(self, tmp_path: Path) -> None:
+        target = tmp_path / "pack-readonly.idx"
+        target.write_text("placeholder")
+        target.chmod(stat.S_IREAD)
+        calls: list[str] = []
+
+        def _retry(path: str) -> None:
+            calls.append(path)
+            Path(path).unlink()
+
+        _force_writable_then_retry(_retry, str(target), PermissionError("WinError 5"))
+
+        assert calls == [str(target)]
+        assert not target.exists()
+
+    def test_re_raises_non_permission_error(self, tmp_path: Path) -> None:
+        target = tmp_path / "irrelevant"
+
+        def _never_called(path: str) -> None:
+            pytest.fail(f"unexpected retry of {path}")
+
+        original = OSError("not a permission failure")
+        with pytest.raises(OSError, match="not a permission failure"):
+            _force_writable_then_retry(_never_called, str(target), original)
+
+    def test_re_raises_when_chmod_itself_fails(self, tmp_path: Path) -> None:
+        missing = tmp_path / "does-not-exist"
+
+        def _never_called(path: str) -> None:
+            pytest.fail(f"unexpected retry of {path}")
+
+        original = PermissionError("WinError 5")
+        with pytest.raises(PermissionError, match="WinError 5"):
+            _force_writable_then_retry(_never_called, str(missing), original)

--- a/tests/unit/engine/workspace/test_project_workspace_service.py
+++ b/tests/unit/engine/workspace/test_project_workspace_service.py
@@ -175,3 +175,18 @@ class TestForceWritableThenRetry:
         original = PermissionError("WinError 5")
         with pytest.raises(PermissionError, match="WinError 5"):
             _force_writable_then_retry(_never_called, str(missing), original)
+
+    def test_func_exception_propagates_after_chmod_success(
+        self, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "pack-readonly.idx"
+        target.write_text("placeholder")
+        target.chmod(stat.S_IREAD)
+
+        def _retry_raises(path: str) -> None:
+            raise FileNotFoundError(path)
+
+        with pytest.raises(FileNotFoundError):
+            _force_writable_then_retry(
+                _retry_raises, str(target), PermissionError("WinError 5")
+            )


### PR DESCRIPTION
## Summary

Final close-out PR for **EPIC #1973 (Autonomous product studio substrate)**. All 5 children (#1974, #1975, #1976, #1977, #1978) are already merged and CLOSED; this PR ships the remaining workspace bug fix and unit-tier hardening surfaced after the substrate landed.

### Changes (5 files, +109 / -11 vs `origin/main`)

1. **`src/synthorg/engine/workspace/project_workspace_service.py`** — adds `_force_writable_then_retry`, a `shutil.rmtree` `onexc` handler used by `_purge_old_git_dir` to strip the read-only attribute that Windows applies to `.git/objects` pack files and retry once. Without it, a backend-kind switch left an orphan `.git/` tree, and the next backend's `is_git_repo` short-circuit kept the old layout alive despite the persisted row claiming the new kind. The handler:
   - re-raises non-`PermissionError` exceptions unchanged;
   - OR-s `stat.S_IWRITE` into the existing mode via `lstat()` + `chmod(..., follow_symlinks=False)` so read/execute/traversal bits survive and a symlink planted by a third-party repo is not re-targeted;
   - re-raises the original `PermissionError` (with `from None`) if the chmod itself fails, so the call site's existing best-effort `except OSError` path logs and continues.

2. **`tests/conftest.py`** — lowers the per-unit-test wall-clock cap from 12.0s to 6.0s. The per-worker migration-template build is already credited via `_template_build_secs` and subtracted from the guard comparison, so the budget now covers test work only. The worst recorded unit test on this repo is 5.75s; 6s leaves xdist headroom while firing the moment a unit test starts doing real subprocess / network / heavy I/O that belongs in `tests/integration/`.

3. **`tests/unit/engine/workspace/git_backend/test_seed.py` -> `tests/integration/engine/workspace/git_backend/test_seed.py`** — relocates real-git seed tests to the integration tier (every test shells out to the system `git` binary multiple times via `asyncio.create_subprocess_exec`; on Windows under xdist contention that legitimately exceeds the unit budget). `pytestmark` flipped from `unit` to `integration`; `__init__.py` added under the new path.

4. **`tests/unit/engine/workspace/test_project_workspace_service.py`** — adds `TestForceWritableThenRetry` with 4 branch tests (strip-and-retry, non-`PermissionError` re-raise, chmod-fails re-raise, func-exception propagates after successful chmod).

## EPIC close-out checklist

- [x] #1974 Persistent project workspace + pluggable git + agent-concurrency model (CLOSED)
- [x] #1975 Brownfield codebase intake (CLOSED)
- [x] #1976 Living documentation: dual-purpose wiki (CLOSED)
- [x] #1977 Deep CEO interview -> project charter (CLOSED)
- [x] #1978 GitButler concept-only research evaluation (CLOSED)
- [x] Manifest discipline: N/A — `_force_writable_then_retry` is a private module-scoped helper, not a new boot-wired runtime component
- [x] `scripts/check_no_ghost_wiring.py` PASS
- [x] `scripts/check_schema_drift_revisions.py --backend sqlite|postgres` PASS
- [x] Dual-backend conformance (SQLite + Postgres) PASS

## Test plan

- `uv run ruff check src/ tests/ --fix`: PASS
- `uv run ruff format src/ tests/`: 4557 files unchanged
- `uv run mypy --num-workers=4 src/ tests/`: PASS (4557 files, 0 issues)
- `uv run python -m pytest tests/ -m unit`: 31318 passed, 21 skipped in 1:54
- New `TestForceWritableThenRetry` covers 4 branches of the onexc handler.

## Pre-PR review

Reviewed locally by `code-reviewer` and `issue-resolution-verifier`. Round 1 findings (preserve mode + skip symlinks; docstring rewrite; 4th branch test) were applied in commits on this branch. Round 2 returned 0 critical / 0 important / 0 medium / 0 suggestion across both agents. See `_audit/pre-pr-review/triage.md` (local).

Closes #1973
