### PR TITLE
chore: lazy vale sync per worktree via pre-push wrapper

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,12 +18,14 @@ ci:
   #     too slow / toolchain-heavy for the cloud runner.
   #     lychee is also a Rust binary not bundled with pre-commit-uv;
   #     operators install it via `bash scripts/install_cli_tools.sh`,
-  #     and CI runs it via .github/workflows/lychee.yml. vale follows the
-  #     same shape: a Go binary not bundled with pre-commit-uv, operators
-  #     install it via `bash scripts/install_cli_tools.sh vale` (which
-  #     also runs `vale sync` to materialise the Google style package
-  #     under the gitignored `.vale/styles/Google/`). vale has no CI
-  #     workflow yet; pre-push is the only gate.
+  #     and CI runs it via .github/workflows/lychee.yml. vale follows
+  #     the same binary-install shape (operators install the binary
+  #     once per machine via `bash scripts/install_cli_tools.sh vale`),
+  #     but the gitignored `.vale/styles/Google/` package is populated
+  #     lazily by the `scripts/vale-prepush.sh` wrapper on the first
+  #     push in each worktree, so new worktrees do not need an explicit
+  #     sync step. vale has no CI workflow yet; pre-push is the only
+  #     gate.
   #   - no-em-dashes / no-redundant-timeout / forbidden-literals /
   #     persistence-boundary / no-new-logger-exception-str-exc /
   #     orphan-fixtures / boundary-typed / setting-to-startup-trace /
@@ -432,14 +434,18 @@ repos:
 
       - id: vale
         name: vale (prose linter -- Google style + British vocab)
-        entry: vale
+        # Wrapper that lazily runs `vale sync` when a worktree's
+        # gitignored `.vale/styles/Google/` cache is missing, then execs
+        # vale on the staged files. Subsequent pushes pay a single
+        # stat() call. The vale binary itself is installed once per
+        # machine via `bash scripts/install_cli_tools.sh vale`; the
+        # wrapper prints a clear pointer if it is missing.
+        #
         # MinAlertLevel = suggestion is set in `.vale.ini` itself
         # (single source of truth). The corpus is drained to zero
         # findings against the strictest level, so any future regression
-        # blocks pre-push. The package files live under
-        # `.vale/styles/Google/` (gitignored) and are populated by
-        # `vale sync` from scripts/install_cli_tools.sh.
-        args: ["--config", ".vale.ini"]
+        # blocks pre-push.
+        entry: bash scripts/vale-prepush.sh
         language: system
         # Same glob as lychee + markdownlint: README, every CLAUDE.md
         # tier, and every Markdown under docs/. Pre-push only -- vale

--- a/.vale.ini
+++ b/.vale.ini
@@ -5,8 +5,10 @@
 # Section F documents the exemption ledger that gates this rollout.
 #
 # Single-source-of-truth pin lives in scripts/install_cli_tools.sh
-# (VALE_VERSION); the binary is installed there and `vale sync`
-# populates .vale/styles/Google/ (gitignored).
+# (VALE_VERSION). The binary is installed once per machine by that
+# script; the gitignored .vale/styles/Google/ package is populated
+# lazily on the first pre-push in each worktree by
+# scripts/vale-prepush.sh (the wrapper wired into the pre-push hook).
 #
 # British is MANDATORY per docs/reference/conventions.md and
 # CLAUDE.md: the Vocab below adds British forms to every spelling

--- a/.vale/.gitignore
+++ b/.vale/.gitignore
@@ -1,7 +1,10 @@
 # Vale sync output: the Google style package is downloaded by
-# `vale sync` from scripts/install_cli_tools.sh, never committed.
-# Run `bash scripts/install_cli_tools.sh vale` on a fresh clone to
-# materialise it. The vocabulary under styles/config/ IS committed
-# (the .gitignore excludes only the synced upstream packages).
+# `vale sync`, never committed. The pre-push wrapper
+# (scripts/vale-prepush.sh) materialises this lazily on the first push
+# in each worktree, so new worktrees do not need an explicit sync
+# step. Operators can still pre-warm it by running
+# `bash scripts/install_cli_tools.sh vale` (idempotent: skips when the
+# package is already present). The vocabulary under styles/config/ IS
+# committed (the .gitignore excludes only the synced upstream packages).
 styles/Google/
 styles/.vale-config/

--- a/docs/reference/convention-gates.md
+++ b/docs/reference/convention-gates.md
@@ -96,7 +96,7 @@ Three third-party linters run as pre-push hooks on Markdown to enforce style + l
 
 - `markdownlint` (`igorshubovych/markdownlint-cli`): Markdown formatting rules (list indent, heading levels, fenced-code language tags, blanks-around-lists). Config in `.markdownlint.json`; version pinned in `.pre-commit-config.yaml`. Runs on README + every CLAUDE.md tier + `docs/**/*.md` at pre-commit stage.
 - `lychee` (`lycheeverse/lychee`): Markdown link-checker. Config in `lychee.toml`. Runs on the same glob as markdownlint, but at pre-push stage (network probes take 8-15s). Binary installed via `bash scripts/install_cli_tools.sh lychee`; CI runs it via `.github/workflows/lychee.yml`.
-- `vale` (`errata-ai/vale`): prose linter for Google style + a British-English vocabulary. Config in `.vale.ini`; vocabularies under `.vale/styles/config/vocabularies/{British,SynthOrg}/`. Runs on the same glob as markdownlint + lychee, at pre-push stage. Binary installed via `bash scripts/install_cli_tools.sh vale` (which also runs `vale sync` to materialise the gitignored `.vale/styles/Google/` style package).
+- `vale` (`errata-ai/vale`): prose linter for Google style + a British-English vocabulary. Config in `.vale.ini`; vocabularies under `.vale/styles/config/vocabularies/{British,SynthOrg}/`. Runs on the same glob as markdownlint + lychee, at pre-push stage. Binary installed once per machine via `bash scripts/install_cli_tools.sh vale`; the gitignored `.vale/styles/Google/` style package is then materialised lazily by `scripts/vale-prepush.sh` (the pre-push wrapper) on the first push in each worktree, so additional worktrees need no extra setup step.
 
 ## Registration procedure
 

--- a/scripts/install_cli_tools.sh
+++ b/scripts/install_cli_tools.sh
@@ -535,15 +535,27 @@ install_vale() {
 
 # Lifted out of install_vale so the early `return 0` on the
 # already-installed path does NOT skip the sync -- a fresh worktree with the
-# binary already on PATH still needs `.vale/styles/Google/` populated. Cheap
-# when the package is already current.
+# binary already on PATH still needs `.vale/styles/Google/` populated.
+#
+# Idempotent: skips the network round-trip when the Google package's
+# Acronyms.yml sentinel is already present. The pre-push wrapper
+# (scripts/vale-prepush.sh) uses the same sentinel and runs `vale sync`
+# lazily on first push in a worktree, so explicitly invoking this
+# function from `install_cli_tools.sh vale` is now only useful for
+# pre-warming a worktree before going offline. Re-running is cheap.
 sync_vale_packages() {
   local repo_root vale_ini vale_bin install_dir binary_name
+
   repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   vale_ini="${repo_root}/.vale.ini"
 
   if [ ! -f "${vale_ini}" ]; then
     echo "vale sync skipped: no .vale.ini at ${vale_ini} (this branch may pre-date the vale wiring)"
+    return 0
+  fi
+
+  if [ -s "${repo_root}/.vale/styles/Google/Acronyms.yml" ]; then
+    echo "vale sync skipped: Google style package already present at ${repo_root}/.vale/styles/Google/"
     return 0
   fi
 

--- a/scripts/vale-prepush.sh
+++ b/scripts/vale-prepush.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Vale pre-push wrapper.
+#
+# Vale's Google style package lives under .vale/styles/Google/ which is
+# gitignored (it is a 52 KB upstream package downloaded by `vale sync`,
+# not source we want to vendor). Each git worktree therefore starts with
+# an empty styles dir and would normally need a manual
+# `bash scripts/install_cli_tools.sh vale` before vale can run.
+#
+# This wrapper makes that lazy: it checks for a sentinel file in the
+# styles dir and only runs `vale sync` when missing. After the first
+# push in a worktree the check is a single stat() call; subsequent
+# pushes pay no extra cost.
+#
+# The vale BINARY itself is still installed once per machine via
+# scripts/install_cli_tools.sh (it has to land on PATH before this
+# wrapper can run); if missing, this script prints a clear pointer
+# rather than the opaque shell "command not found".
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+if ! command -v vale >/dev/null 2>&1; then
+  echo "error: vale binary not found on PATH" >&2
+  echo "       run 'bash scripts/install_cli_tools.sh vale' once on this machine" >&2
+  exit 1
+fi
+
+# Acronyms.yml is shipped by the Google style package; using a real file
+# (rather than `ls -A`) is faster and avoids the empty-directory edge case.
+if [ ! -s .vale/styles/Google/Acronyms.yml ]; then
+  echo "vale: Google style package missing for this worktree, running 'vale sync'..."
+  vale --config .vale.ini sync
+fi
+
+exec vale --config .vale.ini "$@"


### PR DESCRIPTION
## Summary

The Google style package under `.vale/styles/Google/` is gitignored and downloaded by `vale sync`. Each git worktree is a separate path with its own `.vale/styles/` tree, so every new worktree previously needed a manual `bash scripts/install_cli_tools.sh vale` to populate the cache before the pre-push vale hook could run, and re-running that script always re-downloaded the package.

Move the sync to a pre-push wrapper (`scripts/vale-prepush.sh`) that sentinels on `.vale/styles/Google/Acronyms.yml` and only runs `vale sync` when missing. First push in a fresh worktree adds a ~1s download; subsequent pushes pay a single `stat()` call. The vale binary itself is still installed once per machine via `install_cli_tools.sh`; the wrapper prints a clear pointer if the binary is missing.

Also make `sync_vale_packages` idempotent (same sentinel check) so re-running `install_cli_tools.sh vale` on an already-warmed worktree is free.

## Files

- `scripts/vale-prepush.sh` (new) — sentinel-checks the styles cache, syncs on miss, execs vale.
- `.pre-commit-config.yaml` — vale hook entry now `bash scripts/vale-prepush.sh`.
- `scripts/install_cli_tools.sh` — `sync_vale_packages` idempotent.
- `.vale.ini`, `.vale/.gitignore`, `docs/reference/convention-gates.md` — comment/doc updates.

## Test plan

- Cold worktree (no `Google/` dir): wrapper runs `vale sync` (~1s) then vale clean. ✓
- Warm worktree: no sync message; total runtime ~1.2s (vale itself). ✓
- `install_cli_tools.sh vale` on warmed checkout: both branches skip cleanly. ✓
- `uv run pre-commit run vale --hook-stage pre-push --all-files`: Passed. ✓
- Full pre-push gate suite on `git push`: all Passed.

## Review coverage

Pre-PR agent review was skipped per user request (mini PR, dev-tooling only, no runtime-code changes).