### PR TITLE
refactor: use monkeypatch.setattr in org_mutations tests; enable method-assign mypy gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -679,7 +679,6 @@ disable_error_code = ["explicit-override", "unused-awaitable"]
 # docs/decisions/0006-tiered-module-size-policy.md Section F.1.
 #
 # * ``unused-awaitable`` (~23 sites): #2116
-# * ``method-assign`` (~17 sites): #2117
 # * ``explicit-override`` (~87 sites across ~48 files): #2118
 # * ``arg-type`` + ``redundant-cast`` + ``assignment`` +
 #   ``comparison-overlap`` + ``attr-defined`` (~75 sites): #2119
@@ -696,7 +695,6 @@ disallow_any_explicit = false  # #2121
 disable_error_code = [
     "explicit-override",     # #2118
     "unused-awaitable",      # #2116
-    "method-assign",         # #2117
     "arg-type",              # #2119
     "redundant-cast",        # #2119
     "assignment",            # #2119

--- a/tests/unit/api/services/test_org_mutations_atomic.py
+++ b/tests/unit/api/services/test_org_mutations_atomic.py
@@ -7,7 +7,6 @@ repository's CAS mechanism serialises concurrent writers.
 """
 
 import asyncio
-from collections.abc import Callable
 from typing import Any, cast
 
 import pytest
@@ -220,6 +219,7 @@ class TestCASRetry:
         self,
         service: OrgMutationService,
         persistence: FakePersistenceBackend,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """When a CAS conflict happens on the first attempt, the
         retry reads fresh data and succeeds.
@@ -260,21 +260,19 @@ class TestCASRetry:
                     )
             return cast("SettingRow | None", result)
 
-        persistence.settings.get = intercepting_get
-        try:
-            dept = await service.update_department(
-                "Engineering",
-                UpdateDepartmentRequest(head="bob"),
-            )
-            assert dept.head == "bob"
-            assert call_count >= 2, f"Expected retry (>= 2 reads), got {call_count}"
-        finally:
-            persistence.settings.get = original_get
+        monkeypatch.setattr(persistence.settings, "get", intercepting_get)
+        dept = await service.update_department(
+            "Engineering",
+            UpdateDepartmentRequest(head="bob"),
+        )
+        assert dept.head == "bob"
+        assert call_count >= 2, f"Expected retry (>= 2 reads), got {call_count}"
 
     async def test_raises_after_retry_exhausted(
         self,
         service: OrgMutationService,
         persistence: FakePersistenceBackend,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """When CAS fails on both attempts, VersionConflictError is raised."""
         # Seed a department
@@ -303,31 +301,34 @@ class TestCASRetry:
                 ),
             )
 
-        persistence.settings.set_if_unchanged = always_conflict_set_if_unchanged
-        try:
-            with pytest.raises(VersionConflictError):
-                await service.update_department(
-                    "Engineering",
-                    UpdateDepartmentRequest(head="bob"),
-                )
-        finally:
-            persistence.settings.set_if_unchanged = original_set_if_unchanged
+        monkeypatch.setattr(
+            persistence.settings,
+            "set_if_unchanged",
+            always_conflict_set_if_unchanged,
+        )
+        with pytest.raises(VersionConflictError):
+            await service.update_department(
+                "Engineering",
+                UpdateDepartmentRequest(head="bob"),
+            )
 
 
 # ── CAS retry coverage for the remaining 6 mutations ──────────
 
 
 def _always_conflict_for_key(
+    monkeypatch: pytest.MonkeyPatch,
     persistence: FakePersistenceBackend,
     target_key: str,
-) -> tuple[Callable[[], None], Callable[[], None]]:
-    """Return an install/uninstall pair that forces CAS conflicts on *target_key*.
+) -> None:
+    """Force CAS conflicts on *target_key* until test teardown.
 
     Used to verify that ``VersionConflictError`` propagates after retries
     are exhausted for every CAS-protected mutation.  Both ``set`` and
     ``set_many`` are intercepted so mutations that bundle multiple keys
     into a single transaction (like ``delete_department``) also surface
-    the conflict.
+    the conflict.  ``monkeypatch`` reverts both attributes when the test
+    function returns.
     """
     original_set_if_unchanged = persistence.settings.set_if_unchanged
     original_set_many = persistence.settings.set_many
@@ -364,15 +365,16 @@ def _always_conflict_for_key(
             ),
         )
 
-    def install() -> None:
-        persistence.settings.set_if_unchanged = always_conflict_set_if_unchanged
-        persistence.settings.set_many = always_conflict_set_many
-
-    def uninstall() -> None:
-        persistence.settings.set_if_unchanged = original_set_if_unchanged
-        persistence.settings.set_many = original_set_many
-
-    return install, uninstall
+    monkeypatch.setattr(
+        persistence.settings,
+        "set_if_unchanged",
+        always_conflict_set_if_unchanged,
+    )
+    monkeypatch.setattr(
+        persistence.settings,
+        "set_many",
+        always_conflict_set_many,
+    )
 
 
 async def _seed_dept(service: OrgMutationService, name: str) -> None:
@@ -408,107 +410,89 @@ class TestCASRetryCoverage:
         self,
         service: OrgMutationService,
         persistence: FakePersistenceBackend,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         await _seed_dept(service, "Engineering")
-        install, uninstall = _always_conflict_for_key(persistence, "departments")
-        install()
-        try:
-            with pytest.raises(VersionConflictError):
-                await service.delete_department("Engineering")
-        finally:
-            uninstall()
+        _always_conflict_for_key(monkeypatch, persistence, "departments")
+        with pytest.raises(VersionConflictError):
+            await service.delete_department("Engineering")
 
     async def test_reorder_departments_raises_after_retry_exhausted(
         self,
         service: OrgMutationService,
         persistence: FakePersistenceBackend,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         await _seed_dept(service, "Engineering")
         await _seed_dept(service, "Marketing")
-        install, uninstall = _always_conflict_for_key(persistence, "departments")
-        install()
-        try:
-            with pytest.raises(VersionConflictError):
-                await service.reorder_departments(
-                    ReorderDepartmentsRequest(
-                        department_names=("Marketing", "Engineering"),
-                    ),
-                )
-        finally:
-            uninstall()
+        _always_conflict_for_key(monkeypatch, persistence, "departments")
+        with pytest.raises(VersionConflictError):
+            await service.reorder_departments(
+                ReorderDepartmentsRequest(
+                    department_names=("Marketing", "Engineering"),
+                ),
+            )
 
     async def test_create_agent_raises_after_retry_exhausted(
         self,
         service: OrgMutationService,
         persistence: FakePersistenceBackend,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         await _seed_dept(service, "Engineering")
         # Seed an initial agent so the `company/agents` setting exists and
         # CAS has a version to compare against on subsequent writes.
         await _seed_agent(service, "alice-dev", "Engineering")
-        install, uninstall = _always_conflict_for_key(persistence, "agents")
-        install()
-        try:
-            with pytest.raises(VersionConflictError):
-                await service.create_agent(
-                    CreateAgentOrgRequest(
-                        name="bob-dev",
-                        role="Developer",
-                        department="Engineering",
-                        level=SeniorityLevel.MID,
-                    ),
-                )
-        finally:
-            uninstall()
+        _always_conflict_for_key(monkeypatch, persistence, "agents")
+        with pytest.raises(VersionConflictError):
+            await service.create_agent(
+                CreateAgentOrgRequest(
+                    name="bob-dev",
+                    role="Developer",
+                    department="Engineering",
+                    level=SeniorityLevel.MID,
+                ),
+            )
 
     async def test_update_agent_raises_after_retry_exhausted(
         self,
         service: OrgMutationService,
         persistence: FakePersistenceBackend,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         await _seed_dept(service, "Engineering")
         await _seed_agent(service, "alice-dev", "Engineering")
-        install, uninstall = _always_conflict_for_key(persistence, "agents")
-        install()
-        try:
-            with pytest.raises(VersionConflictError):
-                await service.update_agent(
-                    "alice-dev",
-                    UpdateAgentOrgRequest(role="Senior Developer"),
-                )
-        finally:
-            uninstall()
+        _always_conflict_for_key(monkeypatch, persistence, "agents")
+        with pytest.raises(VersionConflictError):
+            await service.update_agent(
+                "alice-dev",
+                UpdateAgentOrgRequest(role="Senior Developer"),
+            )
 
     async def test_delete_agent_raises_after_retry_exhausted(
         self,
         service: OrgMutationService,
         persistence: FakePersistenceBackend,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         await _seed_dept(service, "Engineering")
         await _seed_agent(service, "alice-dev", "Engineering")
-        install, uninstall = _always_conflict_for_key(persistence, "agents")
-        install()
-        try:
-            with pytest.raises(VersionConflictError):
-                await service.delete_agent("alice-dev")
-        finally:
-            uninstall()
+        _always_conflict_for_key(monkeypatch, persistence, "agents")
+        with pytest.raises(VersionConflictError):
+            await service.delete_agent("alice-dev")
 
     async def test_reorder_agents_raises_after_retry_exhausted(
         self,
         service: OrgMutationService,
         persistence: FakePersistenceBackend,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         await _seed_dept(service, "Engineering")
         await _seed_agent(service, "alice-dev", "Engineering")
         await _seed_agent(service, "bob-dev", "Engineering")
-        install, uninstall = _always_conflict_for_key(persistence, "agents")
-        install()
-        try:
-            with pytest.raises(VersionConflictError):
-                await service.reorder_agents(
-                    "Engineering",
-                    ReorderAgentsRequest(agent_names=("bob-dev", "alice-dev")),
-                )
-        finally:
-            uninstall()
+        _always_conflict_for_key(monkeypatch, persistence, "agents")
+        with pytest.raises(VersionConflictError):
+            await service.reorder_agents(
+                "Engineering",
+                ReorderAgentsRequest(agent_names=("bob-dev", "alice-dev")),
+            )

--- a/tests/unit/api/services/test_org_mutations_toctou.py
+++ b/tests/unit/api/services/test_org_mutations_toctou.py
@@ -87,6 +87,7 @@ class TestDeleteDepartmentTOCTOU:
         self,
         service: OrgMutationService,
         persistence: FakePersistenceBackend,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """A persistent CAS miss on the agents key aborts the delete.
 
@@ -120,12 +121,9 @@ class TestDeleteDepartmentTOCTOU:
                 ),
             )
 
-        persistence.settings.set_many = always_agents_conflict
-        try:
-            with pytest.raises(VersionConflictError):
-                await service.delete_department("Engineering")
-        finally:
-            persistence.settings.set_many = original_set_many
+        monkeypatch.setattr(persistence.settings, "set_many", always_agents_conflict)
+        with pytest.raises(VersionConflictError):
+            await service.delete_department("Engineering")
 
         # Department still present: every attempt rolled back.
         deps = await service._read_departments()
@@ -137,6 +135,7 @@ class TestDeleteDepartmentTOCTOU:
         self,
         service: OrgMutationService,
         persistence: FakePersistenceBackend,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """delete passes BOTH departments and agents in the CAS map."""
         await _seed_dept(service, "Engineering")
@@ -159,11 +158,8 @@ class TestDeleteDepartmentTOCTOU:
                 ),
             )
 
-        persistence.settings.set_many = capturing_set_many
-        try:
-            await service.delete_department("Engineering")
-        finally:
-            persistence.settings.set_many = original_set_many
+        monkeypatch.setattr(persistence.settings, "set_many", capturing_set_many)
+        await service.delete_department("Engineering")
 
         assert captured, "delete_department must go through set_many"
         cas_keys = captured[-1]


### PR DESCRIPTION
Closes #2117

## Summary

Two test modules (`test_org_mutations_atomic.py`, `test_org_mutations_toctou.py`) were the last unmarked consumers of the bucket-wide `method-assign` lift in the `tests.*` mypy override. They patched repository methods with bare `repo.method = stub` plus `try/finally` blocks. Every other file in `tests/` that touches `method-assign` already carries a per-line `# type: ignore[method-assign]`.

This refactor:

1. Converts each direct method assignment in the two target files to `pytest.MonkeyPatch.setattr(...)`. The patches now auto-revert at test teardown so the `try/finally` boilerplate goes away.
2. Refactors the `_always_conflict_for_key` helper from an `(install, uninstall)` callable pair to a single side-effecting call that takes `monkeypatch`; the six `TestCASRetryCoverage` tests collapse from three setup lines plus `try/finally` to one line each.
3. Removes `"method-assign"` from `tests.*` `disable_error_code` in `pyproject.toml` (plus its matching comment bullet).
4. Drops the now-unused `from collections.abc import Callable` import in `test_org_mutations_atomic.py`.

## Acceptance criteria (with disambiguation)

The issue body's criterion 2 reads "remove `method-assign` once the only consumers are these two files (verify via grep)." Spelling out what "only consumers" means here, since the literal grep returns ~44 hits across `tests/`:

> The `method-assign` bucket lift in `tests.*` `disable_error_code` is the suppression layer for files that do NOT already carry their own per-line `# type: ignore[method-assign]`. Other test files already have explicit per-line ignores and stay green under their own suppression. The two target files were the only files relying solely on the bucket lift. Once they switch to `monkeypatch.setattr`, the bucket bullet has no remaining unmarked consumers and is safe to drop.

This is the standard ratchet pattern documented in the `pyproject.toml` comment block above the override ("Drop the entry from `disable_error_code` when the linked issue closes"), and works in concert with the `unused-ignore` holding pen that intentionally keeps the now-redundant per-line ignores valid across ratchet PRs.

Verification commands:

```bash
# 1. Both target files type-clean under strict++.
uv run mypy --num-workers=4 tests/unit/api/services/test_org_mutations_atomic.py tests/unit/api/services/test_org_mutations_toctou.py

# 2. No direct method-assigns remain in either file.
grep -nE '\bpersistence\.settings\.[a-z_]+\s*=' tests/unit/api/services/test_org_mutations_atomic.py tests/unit/api/services/test_org_mutations_toctou.py
#   expect: zero matches

# 3. Bucket-wide gate stays green project-wide after dropping the entry.
uv run mypy --num-workers=4 src/ tests/
#   actual: Success: no issues found in 4559 source files

# 4. Behaviour unchanged.
uv run python -m pytest tests/unit/api/services/test_org_mutations_atomic.py tests/unit/api/services/test_org_mutations_toctou.py -m unit
#   actual: 14 passed
```

## Test plan

- `mypy src/ tests/`: green (4559 files, exit 0)
- `pytest tests/unit/api/services/test_org_mutations_*.py -m unit`: 14 passed
- All pre-push gates green on the push commit

## Review coverage

Pre-reviewed by `test-quality-reviewer` (no issues) and `issue-resolution-verifier`. The verifier flagged criterion 2 as NOT_RESOLVED on a literal reading of "only consumers"; the disambiguation above is the deliberate response so the criterion's intent is unambiguous on merge.
