### PR TITLE
refactor: reraise_critical adoption + error-path coverage; add filler-docstring gate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -786,6 +786,18 @@ repos:
         pass_filenames: false
         stages: [pre-commit, pre-push]
 
+      - id: no-boilerplate-docstrings
+        name: no machine-generated filler docstrings in src/synthorg/
+        entry: uv run python scripts/check_no_boilerplate_docstrings.py
+        language: system
+        # Trigger on any src file or the gate script itself (so a PR
+        # that reintroduces filler -- or weakens the gate -- cannot
+        # bypass the check). The gate is a fast line-scan, so it stays
+        # on pre-commit. Changed files are passed through; CI runs it
+        # with --scan-all for the whole tree.
+        files: ^(src/synthorg/.*\.py|scripts/check_no_boilerplate_docstrings\.py)$
+        stages: [pre-commit, pre-push]
+
       # ── Codebase modularity gates ─────────────────────────────────
       # Tiered LOC budget per `# module-kind:` header. Baseline-driven.
       - id: module-size-budget

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -788,14 +788,16 @@ repos:
 
       - id: no-boilerplate-docstrings
         name: no machine-generated filler docstrings in src/synthorg/
-        entry: uv run python scripts/check_no_boilerplate_docstrings.py
+        entry: uv run python scripts/check_no_boilerplate_docstrings.py --scan-all
         language: system
-        # Trigger on any src file or the gate script itself (so a PR
-        # that reintroduces filler -- or weakens the gate -- cannot
-        # bypass the check). The gate is a fast line-scan, so it stays
-        # on pre-commit. Changed files are passed through; CI runs it
-        # with --scan-all for the whole tree.
-        files: ^(src/synthorg/.*\.py|scripts/check_no_boilerplate_docstrings\.py)$
+        # Trigger on any src file, the gate script itself, or this
+        # config so a PR that reintroduces filler -- or weakens the gate
+        # by editing the script or its hook wiring -- cannot bypass the
+        # check. The gate is a fast full-tree line-scan, so it runs
+        # --scan-all on every fire (pass_filenames disabled) and stays
+        # on pre-commit.
+        files: ^(src/synthorg/.*\.py|scripts/check_no_boilerplate_docstrings\.py|\.pre-commit-config\.yaml)$
+        pass_filenames: false
         stages: [pre-commit, pre-push]
 
       # ── Codebase modularity gates ─────────────────────────────────

--- a/data/runtime_stats.yaml
+++ b/data/runtime_stats.yaml
@@ -1,27 +1,27 @@
 schema_version: 1
-last_generated_utc: '2026-05-22T06:03:17Z'
-generator_revision: ac5cdc935
+last_generated_utc: '2026-05-26T07:28:18Z'
+generator_revision: '95806446'
 stats:
   tests:
-    raw: 33060
+    raw: 33839
     rounded: 33000
     display: 33,000+
   mem0_stars:
-    raw: 56395
+    raw: 56728
     rounded: 56000
     display: 56k+
   providers_curated:
     raw: 20
     display: '20'
   providers_via_litellm:
-    raw: 2720
+    raw: 2739
     display: 2700+
   subagents:
     raw: 26
     display: '26'
   convention_gates:
-    raw: 61
-    display: '61'
+    raw: 62
+    display: '62'
 sources:
   tests: uv run python -m pytest --collect-only -q
   mem0_stars: gh api repos/mem0ai/mem0 --jq .stargazers_count

--- a/scripts/check_no_boilerplate_docstrings.py
+++ b/scripts/check_no_boilerplate_docstrings.py
@@ -1,29 +1,26 @@
 #!/usr/bin/env python3
 """Gate: forbid machine-generated filler docstrings in src/synthorg/.
 
-A docstring backfill once emitted templated, tautological, or
-implementation-contradicting docstrings across the codebase (e.g.
-``"Internal helper: init"`` stubs with a ``Raises:`` clause that says
-the input "violates a validator", ``Returns:`` sections that read "the
-value captured by the summary above"). An inaccurate docstring is worse
-than no docstring: it actively misleads the reader and the generated
-API docs.
+Blocks a fixed set of templated, tautological, or
+implementation-contradicting docstring phrases (e.g. an
+``"Internal helper:"`` stub, a ``Raises:`` clause asserting the input
+"violates a validator", a ``Returns:`` section reading "the value
+captured by the summary above"). An inaccurate docstring is worse than
+no docstring: it actively misleads the reader and the generated API
+docs.
 
-This gate blocks the exact machine-artifact phrases that backfill
-produced. Each pattern was verified to occur ZERO times in the
-pre-existing ``src/synthorg/`` tree, so the gate has no false positives
-against hand-written docstrings -- it only catches the filler.
-
-A docstring that genuinely needs to describe a helper, a validator, or
-a return value can always do so without these phrases; the fix is to
-state the real intent / contract, per ``CLAUDE.md`` ("Comments WHY
-only").
+Each blocked phrase is a machine-artifact shape that does not occur in
+legitimate hand-written docstrings, so a substring match is a precise
+signal with no false positives. A docstring that genuinely needs to
+describe a helper, a validator, or a return value can always do so
+without these phrases; the fix is to state the real intent / contract,
+per ``CLAUDE.md`` ("Comments WHY only").
 
 Usage
 -----
 
-    python scripts/check_no_boilerplate_docstrings.py <file>...  # pre-commit
-    python scripts/check_no_boilerplate_docstrings.py --scan-all # CI
+    python scripts/check_no_boilerplate_docstrings.py --scan-all  # full tree
+    python scripts/check_no_boilerplate_docstrings.py <file>...   # specific files
 """
 
 import argparse
@@ -37,12 +34,11 @@ if TYPE_CHECKING:
 _REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
 _SRC_ROOT: Final[Path] = _REPO_ROOT / "src" / "synthorg"
 
-# Each phrase is a machine-generated docstring artifact. Verified to
-# appear zero times in the pre-backfill ``src/synthorg/`` tree, so a
-# substring match is a precise signal with no hand-written false
-# positives. Keep this list conservative: only add a phrase after
-# confirming ``git grep -F "<phrase>" <base-ref> -- 'src/**/*.py'``
-# returns nothing.
+# Each phrase is a machine-generated docstring artifact that does not
+# occur in legitimate hand-written docstrings, so a substring match is
+# a precise signal with no false positives. Keep this list
+# conservative: only add a phrase that cannot plausibly appear in a
+# genuine, hand-written docstring.
 _BOILERPLATE_PHRASES: Final[tuple[str, ...]] = (
     "Internal helper:",
     "violates a validator",
@@ -53,11 +49,12 @@ _BOILERPLATE_PHRASES: Final[tuple[str, ...]] = (
 
 
 def _scan_file(path: Path) -> list[tuple[int, str]]:
-    """Return ``(lineno, phrase)`` hits for *path*, sorted by line."""
-    try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-    except UnicodeDecodeError, OSError:
-        return []
+    """Return ``(lineno, phrase)`` hits for *path*, sorted by line.
+
+    Read errors are NOT swallowed: an unreadable / undecodable file in
+    scope propagates and fails the gate rather than passing unscanned.
+    """
+    lines = path.read_text(encoding="utf-8").splitlines()
     return [
         (lineno, phrase)
         for lineno, line in enumerate(lines, start=1)

--- a/scripts/check_no_boilerplate_docstrings.py
+++ b/scripts/check_no_boilerplate_docstrings.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Gate: forbid machine-generated filler docstrings in src/synthorg/.
+
+A docstring backfill once emitted templated, tautological, or
+implementation-contradicting docstrings across the codebase (e.g.
+``"Internal helper: init"`` stubs with a ``Raises:`` clause that says
+the input "violates a validator", ``Returns:`` sections that read "the
+value captured by the summary above"). An inaccurate docstring is worse
+than no docstring: it actively misleads the reader and the generated
+API docs.
+
+This gate blocks the exact machine-artifact phrases that backfill
+produced. Each pattern was verified to occur ZERO times in the
+pre-existing ``src/synthorg/`` tree, so the gate has no false positives
+against hand-written docstrings -- it only catches the filler.
+
+A docstring that genuinely needs to describe a helper, a validator, or
+a return value can always do so without these phrases; the fix is to
+state the real intent / contract, per ``CLAUDE.md`` ("Comments WHY
+only").
+
+Usage
+-----
+
+    python scripts/check_no_boilerplate_docstrings.py <file>...  # pre-commit
+    python scripts/check_no_boilerplate_docstrings.py --scan-all # CI
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+_REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+_SRC_ROOT: Final[Path] = _REPO_ROOT / "src" / "synthorg"
+
+# Each phrase is a machine-generated docstring artifact. Verified to
+# appear zero times in the pre-backfill ``src/synthorg/`` tree, so a
+# substring match is a precise signal with no hand-written false
+# positives. Keep this list conservative: only add a phrase after
+# confirming ``git grep -F "<phrase>" <base-ref> -- 'src/**/*.py'``
+# returns nothing.
+_BOILERPLATE_PHRASES: Final[tuple[str, ...]] = (
+    "Internal helper:",
+    "violates a validator",
+    "captured by the summary above",
+    "As raised by the surrounding logic",
+    "The numeric value captured",
+)
+
+
+def _scan_file(path: Path) -> list[tuple[int, str]]:
+    """Return ``(lineno, phrase)`` hits for *path*, sorted by line."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except UnicodeDecodeError, OSError:
+        return []
+    return [
+        (lineno, phrase)
+        for lineno, line in enumerate(lines, start=1)
+        for phrase in _BOILERPLATE_PHRASES
+        if phrase in line
+    ]
+
+
+def _rel(path: Path) -> str:
+    """Repo-relative POSIX path for stable violation messages."""
+    return path.resolve().relative_to(_REPO_ROOT).as_posix()
+
+
+def _iter_src_files() -> Iterable[Path]:
+    """Walk ``src/synthorg/`` for ``.py`` files."""
+    yield from sorted(_SRC_ROOT.rglob("*.py"))
+
+
+def _scan(path: Path) -> list[str]:
+    """Return violation lines for *path*."""
+    rel = _rel(path)
+    return [
+        f"{rel}:{lineno}: machine-generated filler docstring phrase: {phrase!r}"
+        for lineno, phrase in _scan_file(path)
+    ]
+
+
+def _report(violations: list[str]) -> int:
+    """Print violations and return a pre-commit-friendly exit code."""
+    if not violations:
+        return 0
+    for line in violations:
+        print(line)
+    print(
+        "\nFiller docstrings: a templated / tautological / "
+        "implementation-contradicting docstring is worse than none -- it "
+        "misleads the reader and the generated docs."
+        "\n"
+        "\nReplace the flagged docstring with a concise statement of the "
+        "function's real intent and contract (Returns/Raises that match the "
+        'code), or remove it. See CLAUDE.md ("Comments WHY only").',
+        file=sys.stderr,
+    )
+    return 1
+
+
+def cmd_scan_all() -> int:
+    """Scan every file under ``src/synthorg/`` (CI mode)."""
+    violations: list[str] = []
+    for path in _iter_src_files():
+        violations.extend(_scan(path))
+    return _report(violations)
+
+
+def cmd_scan_paths(paths: Iterable[str]) -> int:
+    """Scan the given files (pre-commit entry point)."""
+    src_root = _SRC_ROOT.resolve()
+    violations: list[str] = []
+    for raw in paths:
+        path = Path(raw).resolve()
+        if not path.is_relative_to(src_root):
+            continue
+        if not path.exists() or path.suffix != ".py":
+            continue
+        violations.extend(_scan(path))
+    return _report(violations)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Gate on machine-generated filler docstrings in src/synthorg/.",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Files to check (pre-commit supplies these).",
+    )
+    parser.add_argument(
+        "--scan-all",
+        action="store_true",
+        help="Scan the full src/synthorg/ tree (CI mode).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.scan_all:
+        return cmd_scan_all()
+    return cmd_scan_paths(args.paths)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/synthorg/communication/async_tasks/service.py
+++ b/src/synthorg/communication/async_tasks/service.py
@@ -14,6 +14,7 @@ from synthorg.communication.async_tasks.models import (
 from synthorg.communication.bus_protocol import MessageBus  # noqa: TC001
 from synthorg.communication.enums import MessagePriority, MessageType
 from synthorg.communication.message import Message, TextPart
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.enums import TaskStatus, TaskType
 from synthorg.core.task import Task  # noqa: TC001
 from synthorg.engine.task_engine import TaskEngine  # noqa: TC001
@@ -120,12 +121,8 @@ class AsyncTaskService:
                 assigned_to=task_spec.agent_id,
                 parent_task_id=task_spec.parent_task_id,
             )
-        except MemoryError, RecursionError:
-            # Process-fatal builtins propagate before any logging /
-            # rollback work runs -- project convention for system-error
-            # propagation.
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             # Include ``task_id`` when the create succeeded so this
             # primary failure log can be correlated with the rollback
             # warning below (which already carries it).  ``None`` when
@@ -186,9 +183,8 @@ class AsyncTaskService:
                     cancelled_task,
                     rollback_prior,
                 )
-        except MemoryError, RecursionError:
-            raise
         except Exception as cancel_exc:
+            reraise_critical(cancel_exc)
             logger.warning(
                 ASYNC_TASK_START_FAILED,
                 task_id=task.id,
@@ -377,9 +373,8 @@ class AsyncTaskService:
                 requested_by=supervisor_id,
                 reason="ASYNC_CANCEL",
             )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 ASYNC_TASK_CANCEL_FAILED,
                 task_id=task_id,

--- a/src/synthorg/communication/bus/_nats_connection.py
+++ b/src/synthorg/communication/bus/_nats_connection.py
@@ -18,6 +18,7 @@ from synthorg.communication.bus.errors import (
     BusStopTimeoutError,
     BusStreamError,
 )
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.communication import (
     COMM_BUS_CONNECTED,
@@ -91,6 +92,7 @@ async def drain_partial_client(state: _NatsState) -> None:
     try:
         await client.drain()
     except Exception as exc:
+        reraise_critical(exc)
         logger.warning(
             COMM_BUS_DISCONNECTED,
             phase="drain_partial",
@@ -212,9 +214,8 @@ async def stop(state: _NatsState) -> None:
         for key, sub in list(state.subscriptions.items()):
             try:
                 await sub.unsubscribe()
-            except MemoryError, RecursionError:
-                raise
             except Exception as exc:
+                reraise_critical(exc)
                 logger.warning(
                     COMM_BUS_DISCONNECTED,
                     phase="stop_unsubscribe",
@@ -250,9 +251,8 @@ async def stop(state: _NatsState) -> None:
                 state.js = None
                 state.kv = None
                 raise BusStopTimeoutError(msg) from exc
-            except MemoryError, RecursionError:
-                raise
             except Exception as exc:
+                reraise_critical(exc)
                 logger.warning(
                     COMM_BUS_DISCONNECTED,
                     phase="stop_drain",

--- a/src/synthorg/communication/bus/_nats_consumers.py
+++ b/src/synthorg/communication/bus/_nats_consumers.py
@@ -22,6 +22,7 @@ from synthorg.communication.bus._nats_utils import (
 from synthorg.communication.bus.errors import BusStreamError
 from synthorg.communication.channel import Channel  # noqa: TC001
 from synthorg.communication.subscription import Subscription
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger
 from synthorg.observability.events.communication import (
     COMM_DUPLICATE_SUBSCRIPTION_DISCARDED,
@@ -185,7 +186,8 @@ async def unsubscribe(
     if sub is not None:
         try:
             await sub.unsubscribe()
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 COMM_SUBSCRIPTION_REMOVED,
                 channel=channel_name,

--- a/src/synthorg/communication/bus/_nats_consumers.py
+++ b/src/synthorg/communication/bus/_nats_consumers.py
@@ -23,7 +23,7 @@ from synthorg.communication.bus.errors import BusStreamError
 from synthorg.communication.channel import Channel  # noqa: TC001
 from synthorg.communication.subscription import Subscription
 from synthorg.core.critical_errors import reraise_critical
-from synthorg.observability import get_logger
+from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.communication import (
     COMM_DUPLICATE_SUBSCRIPTION_DISCARDED,
     COMM_SUBSCRIPTION_CREATED,
@@ -194,6 +194,8 @@ async def unsubscribe(
                 subscriber=subscriber_id,
                 backend="nats",
                 phase="unsubscribe_consumer_failed",
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
             )
 
     logger.info(

--- a/src/synthorg/communication/bus/_nats_consumers.py
+++ b/src/synthorg/communication/bus/_nats_consumers.py
@@ -197,6 +197,11 @@ async def unsubscribe(
                 error_type=type(exc).__name__,
                 error=safe_error_description(exc),
             )
+            # The state-level subscription was already removed above; the
+            # consumer teardown failed. Return after the WARNING so the
+            # same operation does not also emit a success COMM_SUBSCRIPTION_REMOVED
+            # INFO that would mislead telemetry consumers.
+            return
 
     logger.info(
         COMM_SUBSCRIPTION_REMOVED,

--- a/src/synthorg/communication/bus/_nats_history.py
+++ b/src/synthorg/communication/bus/_nats_history.py
@@ -15,6 +15,7 @@ from synthorg.communication.bus._nats_publish import deserialize_message
 from synthorg.communication.bus._nats_state import _NatsState  # noqa: TC001
 from synthorg.communication.bus.errors import BusStreamError
 from synthorg.communication.message import Message  # noqa: TC001
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.communication import (
     COMM_BUS_MESSAGE_DESERIALIZE_FAILED,
@@ -55,6 +56,7 @@ async def create_history_scan_consumer(
     except NotFoundError:
         return None
     except Exception as exc:
+        reraise_critical(exc)
         logger.warning(
             COMM_BUS_STREAM_SCAN_FAILED,
             stream=stream_name,
@@ -96,6 +98,7 @@ async def collect_history_batches(
         except NatsTimeoutError:
             return parsed_messages
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 COMM_BUS_STREAM_SCAN_FAILED,
                 stream=stream_name,
@@ -125,6 +128,7 @@ async def unsubscribe_history_consumer(
     try:
         await psub.unsubscribe()
     except Exception as exc:
+        reraise_critical(exc)
         logger.warning(
             COMM_BUS_STREAM_SCAN_FAILED,
             stream=stream_name,

--- a/src/synthorg/communication/bus/_nats_kv.py
+++ b/src/synthorg/communication/bus/_nats_kv.py
@@ -13,6 +13,7 @@ from synthorg.communication.bus._nats_utils import decode_token, encode_token
 from synthorg.communication.bus.errors import BusStreamError
 from synthorg.communication.channel import Channel
 from synthorg.communication.errors import ChannelAlreadyExistsError
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.communication import (
     COMM_BUS_KV_READ_FAILED,
@@ -62,6 +63,7 @@ async def create_channel_in_kv(
             msg, context={"channel": channel.name}
         ) from None
     except Exception as exc:
+        reraise_critical(exc)
         logger.warning(
             COMM_BUS_KV_WRITE_FAILED,
             channel=channel.name,
@@ -86,6 +88,7 @@ async def write_channel_to_kv(state: _NatsState, channel: Channel) -> None:
     try:
         await state.kv.put(key, value)
     except Exception as exc:
+        reraise_critical(exc)
         logger.warning(
             COMM_BUS_KV_WRITE_FAILED,
             channel=channel.name,
@@ -124,6 +127,7 @@ async def fetch_kv_entry(
     except KeyNotFoundError:
         return None
     except Exception as exc:
+        reraise_critical(exc)
         logger.warning(
             COMM_BUS_KV_READ_FAILED,
             channel=channel_name,
@@ -196,6 +200,7 @@ async def scan_kv_channels(state: _NatsState) -> list[Channel]:
     except NoKeysError:
         return []
     except Exception as exc:
+        reraise_critical(exc)
         logger.warning(
             COMM_BUS_KV_READ_FAILED,
             channel="*",
@@ -211,6 +216,7 @@ async def scan_kv_channels(state: _NatsState) -> list[Channel]:
         try:
             decoded_keys.append((key, decode_token(key)))
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 COMM_BUS_KV_READ_FAILED,
                 channel=key,

--- a/src/synthorg/communication/bus/_nats_publish.py
+++ b/src/synthorg/communication/bus/_nats_publish.py
@@ -25,6 +25,7 @@ from synthorg.communication.bus._nats_utils import (
 )
 from synthorg.communication.errors import MessageBusNotRunningError
 from synthorg.communication.message import Message
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger
 from synthorg.observability.events.communication import (
     COMM_BATCH_PUBLISHED,
@@ -281,6 +282,7 @@ async def publish_batch(
         try:
             future.result()
         except Exception as exc:
+            reraise_critical(exc)
             errors.append(exc)
     if errors:
         msg = "publish_batch: one or more publishes failed"

--- a/src/synthorg/communication/bus/_nats_receive.py
+++ b/src/synthorg/communication/bus/_nats_receive.py
@@ -23,6 +23,7 @@ from synthorg.communication.bus._nats_utils import (
 from synthorg.communication.enums import ChannelType
 from synthorg.communication.errors import CommunicationError
 from synthorg.communication.subscription import DeliveryEnvelope
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.communication import (
     COMM_BUS_MESSAGE_DESERIALIZE_FAILED,
@@ -166,22 +167,19 @@ async def _maybe_log_overflow(
         shutdown_task.cancel()
         raise
     # Clean up the loser (timeout, or the task that didn't finish).
-    # ``contextlib.suppress(BaseException)`` would swallow system
-    # errors; narrow to cancellation + normal Exception so
-    # MemoryError / RecursionError still propagate per the repo
-    # convention for system-error preservation.
+    # The slot must be released on the critical-re-raise path so a
+    # MemoryError / RecursionError does not suppress the next real
+    # overflow warning for ``_OVERFLOW_LOG_INTERVAL_SECONDS``.
     if probe_task not in done:
         probe_task.cancel()
         try:
             await probe_task
         except asyncio.CancelledError:
             pass
-        except MemoryError, RecursionError:
-            # Non-emission path -- release the slot before re-raising.
-            state.last_overflow_log.pop(key, None)
-            raise
-        except Exception:  # noqa: S110  -- probe is best-effort; loser-task result discarded
-            pass
+        except Exception as exc:
+            if isinstance(exc, (MemoryError, RecursionError)):
+                state.last_overflow_log.pop(key, None)
+            reraise_critical(exc)
     if shutdown_task not in done:
         shutdown_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
@@ -194,14 +192,13 @@ async def _maybe_log_overflow(
         return
     try:
         info = probe_task.result()
-    except MemoryError, RecursionError:
-        # Non-emission path -- release the slot before re-raising.
+    except Exception as exc:
+        # Non-emission path: release the slot on both critical re-raise
+        # AND probe-RPC-failure paths so the next empty fetch can retry
+        # without suppressing a real overflow warning for the next
+        # ``_OVERFLOW_LOG_INTERVAL_SECONDS``.
         state.last_overflow_log.pop(key, None)
-        raise
-    except Exception:
-        # Probe RPC failure -- release the slot so the next empty
-        # fetch can retry without suppressing a real overflow warning.
-        state.last_overflow_log.pop(key, None)
+        reraise_critical(exc)
         return
     num_pending = getattr(info, "num_ack_pending", 0)
     if num_pending < cap:
@@ -272,9 +269,8 @@ async def fetch_with_shutdown(
         return []
     except asyncio.CancelledError:
         return None
-    except MemoryError, RecursionError:
-        raise
     except Exception as exc:
+        reraise_critical(exc)
         logger.warning(
             COMM_BUS_RECEIVE_ERROR,
             channel=channel_name,
@@ -298,9 +294,8 @@ async def try_ack(
     """
     try:
         await msg.ack()
-    except MemoryError, RecursionError:
-        raise
     except Exception as exc:
+        reraise_critical(exc)
         logger.warning(
             COMM_BUS_RECEIVE_ERROR,
             channel=channel_name,

--- a/src/synthorg/communication/bus/_nats_utils.py
+++ b/src/synthorg/communication/bus/_nats_utils.py
@@ -20,6 +20,7 @@ from synthorg.communication.errors import (
     MessageBusNotRunningError,
     NotSubscribedError,
 )
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger
 from synthorg.observability.events.communication import (
     COMM_BUS_NOT_RUNNING,
@@ -139,7 +140,8 @@ async def cancel_if_pending(task: asyncio.Task[Any]) -> None:
         await task
     except asyncio.CancelledError:
         pass
-    except Exception:
+    except Exception as exc:
+        reraise_critical(exc)
         logger.warning(
             COMM_BUS_RECEIVE_ERROR,
             phase="cancel_pending_task",

--- a/src/synthorg/communication/bus/nats.py
+++ b/src/synthorg/communication/bus/nats.py
@@ -40,6 +40,7 @@ from synthorg.communication.subscription import (  # noqa: TC001
     DeliveryEnvelope,
     Subscription,
 )
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.communication import (
     COMM_BUS_ALREADY_RUNNING,
@@ -145,9 +146,8 @@ class JetStreamMessageBus:
             await client.flush(
                 timeout=state.nats_config.health_flush_timeout_seconds,  # type: ignore[arg-type]
             )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 COMM_BUS_HEALTH_CHECK_FAILED,
                 phase="flush",
@@ -334,9 +334,8 @@ class JetStreamMessageBus:
             fetch_timeout = await self._config_resolver.get_float(
                 namespace, "nats_history_fetch_timeout_seconds"
             )
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 COMM_BUS_STREAM_SCAN_FAILED,
                 phase="resolve_history_params",

--- a/src/synthorg/communication/conflict_resolution/debate_strategy.py
+++ b/src/synthorg/communication/conflict_resolution/debate_strategy.py
@@ -34,6 +34,7 @@ from synthorg.communication.delegation.hierarchy import (  # noqa: TC001
 )
 from synthorg.communication.enums import ConflictResolutionStrategy
 from synthorg.communication.errors import ConflictHierarchyError
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, log_exception_redacted
 from synthorg.observability.events.conflict import (
     CONFLICT_AUTHORITY_FALLBACK,
@@ -101,9 +102,8 @@ class DebateResolver:
                     conflict,
                     judge_id,
                 )
-            except MemoryError, RecursionError:
-                raise
             except Exception as exc:
+                reraise_critical(exc)
                 log_exception_redacted(
                     logger,
                     CONFLICT_DEBATE_EVALUATOR_FAILED,

--- a/src/synthorg/communication/conflict_resolution/escalation/notify.py
+++ b/src/synthorg/communication/conflict_resolution/escalation/notify.py
@@ -20,6 +20,7 @@ import re
 from typing import TYPE_CHECKING, Final, Protocol, runtime_checkable
 
 from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.background_tasks import log_task_exceptions
 from synthorg.observability.events.conflict import (
@@ -286,13 +287,8 @@ class PostgresEscalationNotifySubscriber:
                     await task
                 except asyncio.CancelledError:
                     pass
-                except MemoryError, RecursionError:
-                    # Catastrophic interpreter-level errors must
-                    # surface to the caller; never log-and-swallow
-                    # because that hides loss-of-process conditions
-                    # behind a "clean shutdown" log line.
-                    raise
                 except Exception as exc:
+                    reraise_critical(exc)
                     logger.warning(
                         CONFLICT_ESCALATION_SUBSCRIBER_FAILED,
                         error_type=type(exc).__name__,
@@ -393,9 +389,8 @@ class PostgresEscalationNotifySubscriber:
             )
         except asyncio.CancelledError:
             raise
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 CONFLICT_ESCALATION_SUBSCRIBER_FAILED,
                 channel=self._channel,
@@ -420,12 +415,8 @@ class PostgresEscalationNotifySubscriber:
                     await self._listen_once()
                 except asyncio.CancelledError:
                     raise
-                except MemoryError, RecursionError:
-                    # Match ``_drain``: surface catastrophic
-                    # interpreter-level errors instead of looping past
-                    # them at WARNING.
-                    raise
                 except Exception as exc:
+                    reraise_critical(exc)
                     logger.warning(
                         CONFLICT_ESCALATION_SUBSCRIBER_FAILED,
                         channel=self._channel,
@@ -513,9 +504,8 @@ class PostgresEscalationNotifySubscriber:
                     status=status,
                     note="unknown_notify_status",
                 )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 CONFLICT_ESCALATION_SUBSCRIBER_FAILED,
                 escalation_id=escalation_id,

--- a/src/synthorg/communication/conflict_resolution/escalation/sweeper.py
+++ b/src/synthorg/communication/conflict_resolution/escalation/sweeper.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Final
 from synthorg.communication.conflict_resolution.escalation.protocol import (
     EscalationQueueStore,  # noqa: TC001
 )
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.conflict import (
     CONFLICT_ESCALATION_EXPIRED,
@@ -214,13 +215,8 @@ class EscalationExpirationSweeper:
                 except asyncio.CancelledError:
                     # Expected: we just cancelled the task.
                     pass
-                except MemoryError, RecursionError:
-                    # Catastrophic interpreter-level errors must
-                    # surface to the caller; never log-and-swallow
-                    # because that hides loss-of-process conditions
-                    # behind a "clean shutdown" log line.
-                    raise
                 except Exception as exc:
+                    reraise_critical(exc)
                     # Best-effort shutdown: never propagate, but elevate
                     # to WARNING so real failures surface in production
                     # logs instead of being lost at DEBUG.
@@ -306,12 +302,8 @@ class EscalationExpirationSweeper:
                     await self._sweep_once()
                 except asyncio.CancelledError:
                     raise
-                except MemoryError, RecursionError:
-                    # Match the ``_drain`` shape: surface catastrophic
-                    # interpreter-level errors instead of looping past
-                    # them at WARNING.
-                    raise
                 except Exception as exc:
+                    reraise_critical(exc)
                     logger.warning(
                         CONFLICT_ESCALATION_SWEEPER_FAILED,
                         error_type=type(exc).__name__,

--- a/src/synthorg/communication/conflict_resolution/human_strategy.py
+++ b/src/synthorg/communication/conflict_resolution/human_strategy.py
@@ -45,6 +45,7 @@ from synthorg.communication.conflict_resolution.models import (
     ConflictResolutionOutcome,
     DissentRecord,
 )
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.notifications.dispatcher import NotificationDispatcher  # noqa: TC001
 from synthorg.notifications.models import (
     Notification,
@@ -155,9 +156,8 @@ class HumanEscalationResolver:
         future = await self._registry.register(escalation.id)
         try:
             await self._store.create(escalation)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             # Reap the future so the registry does not leak, and log
             # the failure so operators see the root cause (a failed
             # ``create`` also surfaces to the caller, but the queue
@@ -282,9 +282,8 @@ class HumanEscalationResolver:
                 note="notification_dispatch_timeout",
             )
             record_escalation_outcome(outcome="notify_failed")
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 CONFLICT_ESCALATION_NOTIFY_FAILED,
                 escalation_id=escalation.id,
@@ -310,9 +309,8 @@ class HumanEscalationResolver:
         """
         try:
             await asyncio.shield(self._registry.cancel(escalation.id))
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 CONFLICT_ESCALATION_TIMEOUT,
                 escalation_id=escalation.id,
@@ -325,9 +323,8 @@ class HumanEscalationResolver:
             await asyncio.shield(
                 self._store.mark_expired(datetime.now(UTC).isoformat()),
             )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 CONFLICT_ESCALATION_TIMEOUT,
                 escalation_id=escalation.id,
@@ -355,9 +352,8 @@ class HumanEscalationResolver:
         """
         try:
             await asyncio.shield(self._registry.cancel(escalation.id))
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 CONFLICT_ESCALATION_CANCELLED,
                 escalation_id=escalation.id,
@@ -373,9 +369,8 @@ class HumanEscalationResolver:
                     cancelled_by="system:resolver_cancelled",
                 ),
             )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 CONFLICT_ESCALATION_CANCELLED,
                 escalation_id=escalation.id,
@@ -409,9 +404,8 @@ class HumanEscalationResolver:
         """
         try:
             row = await self._store.get(escalation.id)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 CONFLICT_ESCALATION_TIMEOUT,
                 escalation_id=escalation.id,
@@ -429,9 +423,8 @@ class HumanEscalationResolver:
         # future completed concurrently.
         try:
             await asyncio.shield(self._registry.cancel(escalation.id))
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 CONFLICT_ESCALATION_RESOLVED,
                 escalation_id=escalation.id,
@@ -466,9 +459,8 @@ class HumanEscalationResolver:
         """
         try:
             row = await self._store.get(escalation_id)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 CONFLICT_ESCALATION_RESOLVED,
                 escalation_id=escalation_id,

--- a/src/synthorg/communication/conflict_resolution/hybrid_strategy.py
+++ b/src/synthorg/communication/conflict_resolution/hybrid_strategy.py
@@ -31,6 +31,7 @@ from synthorg.communication.delegation.hierarchy import (  # noqa: TC001
     HierarchyResolver,
 )
 from synthorg.communication.enums import ConflictResolutionStrategy
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.conflict import (
     CONFLICT_AMBIGUOUS_RESULT,
@@ -110,6 +111,7 @@ class HybridResolver:
                 self._config.review_agent,
             )
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 CONFLICT_STRATEGY_ERROR,
                 conflict_id=conflict.id,

--- a/src/synthorg/communication/conflict_resolution/service.py
+++ b/src/synthorg/communication/conflict_resolution/service.py
@@ -35,6 +35,7 @@ from synthorg.communication.errors import ConflictResolutionError
 from synthorg.communication.event_stream.stream import EventStreamHub  # noqa: TC001
 from synthorg.communication.event_stream.types import AgUiEventType
 from synthorg.communication.message import DataPart, Message
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.types import NotBlankStr  # noqa: TC001
 from synthorg.observability import get_logger, log_exception_redacted
 from synthorg.observability.events.communication import (
@@ -199,9 +200,8 @@ class ConflictResolutionService:
 
         try:
             resolution = await resolver.resolve(conflict)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             log_exception_redacted(
                 logger,
                 CONFLICT_RESOLUTION_FAILED,
@@ -337,9 +337,8 @@ class ConflictResolutionService:
                     transport="bus",
                     note="Message bus missing publish method",
                 )
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 COMM_DISSENT_PUBLISH_FAILED,
                 dissent_id=record.id,
@@ -374,9 +373,8 @@ class ConflictResolutionService:
                 conflict_id=conflict_id,
                 transport="sse",
             )
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 COMM_DISSENT_PUBLISH_FAILED,
                 dissent_id=record.id,

--- a/src/synthorg/communication/delegation/entity_guard.py
+++ b/src/synthorg/communication/delegation/entity_guard.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.types import NotBlankStr  # noqa: TC001
 from synthorg.observability import get_logger
 from synthorg.observability.events.ontology import (
@@ -113,9 +114,8 @@ class EntityAlignmentGuard:
 
         try:
             manifest = await self._ontology.get_version_manifest()
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 ONTOLOGY_GUARD_BLOCKED,
                 delegator=request.delegator_id,

--- a/src/synthorg/communication/delegation/service.py
+++ b/src/synthorg/communication/delegation/service.py
@@ -28,6 +28,7 @@ from synthorg.communication.loop_prevention.guard import (  # noqa: TC001
     DelegationGuard,
 )
 from synthorg.core.agent import AgentIdentity  # noqa: TC001
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.enums import TaskStatus
 from synthorg.core.task import Task
 from synthorg.observability import get_logger, safe_error_description
@@ -237,9 +238,8 @@ class DelegationService:
         if self._record_store is not None:
             try:
                 self._record_store.record_sync(record)
-            except MemoryError, RecursionError:
-                raise
-            except Exception:
+            except Exception as exc:
+                reraise_critical(exc)
                 logger.warning(
                     DELEGATION_RECORD_STORE_FAILED,
                     delegator=request.delegator_id,

--- a/src/synthorg/communication/dispatcher.py
+++ b/src/synthorg/communication/dispatcher.py
@@ -20,6 +20,7 @@ from synthorg.communication.handler import (
 from synthorg.communication.message import (
     Message,  # noqa: TC001 -- required at runtime by Pydantic
 )
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import (
     get_logger,
     log_exception_redacted,
@@ -271,6 +272,7 @@ class MessageDispatcher:
             )
             raise
         except Exception as exc:
+            reraise_critical(exc)
             safe_error = safe_error_description(exc)
             errors[index] = safe_error
             logger.warning(

--- a/src/synthorg/communication/event_stream/stream.py
+++ b/src/synthorg/communication/event_stream/stream.py
@@ -28,6 +28,7 @@ from synthorg.communication.event_stream.types import (
     StreamEvent,
 )
 from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.domain_errors import ConflictError
 from synthorg.core.error_taxonomy import ErrorCategory, ErrorCode
 from synthorg.observability import get_logger, safe_error_description
@@ -352,9 +353,8 @@ class EventStreamHub:
                 await self._prune_idle_subscribers(idle_ttl_seconds)
             except asyncio.CancelledError:
                 raise
-            except MemoryError, RecursionError:
-                raise
             except Exception as exc:
+                reraise_critical(exc)
                 logger.warning(
                     EVENT_STREAM_HUB_JANITOR_FAILED,
                     error_type=type(exc).__name__,

--- a/src/synthorg/communication/loop_prevention/circuit_breaker.py
+++ b/src/synthorg/communication/loop_prevention/circuit_breaker.py
@@ -8,6 +8,7 @@ from enum import StrEnum
 from synthorg.communication.config import CircuitBreakerConfig  # noqa: TC001
 from synthorg.communication.loop_prevention._pair_key import pair_key
 from synthorg.communication.loop_prevention.models import GuardCheckOutcome
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, log_exception_redacted
 from synthorg.observability.events.delegation import (
     DELEGATION_LOOP_CIRCUIT_BACKOFF,
@@ -316,9 +317,8 @@ class DelegationCircuitBreaker:
                     offset=offset,
                 ),
             )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             log_exception_redacted(
                 logger,
                 DELEGATION_LOOP_CIRCUIT_PERSIST_FAILED,
@@ -397,9 +397,8 @@ class DelegationCircuitBreaker:
                     opened_at=opened,
                 )
                 await self._state_repo.save(record)
-            except MemoryError, RecursionError:
-                raise
             except Exception as exc:
+                reraise_critical(exc)
                 # Key stays in _dirty for retry on next persist cycle.
                 log_exception_redacted(
                     logger,

--- a/src/synthorg/communication/meeting/agent_caller.py
+++ b/src/synthorg/communication/meeting/agent_caller.py
@@ -32,6 +32,7 @@ from synthorg.budget.call_category import LLMCallCategory
 from synthorg.budget.tracker import CostTracker  # noqa: TC001
 from synthorg.communication.meeting.models import AgentResponse
 from synthorg.communication.meeting.protocol import AgentCaller  # noqa: TC001
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.domain_errors import DomainError, NotFoundError
 from synthorg.core.error_taxonomy import ErrorCategory, ErrorCode
 from synthorg.core.types import NotBlankStr
@@ -146,9 +147,8 @@ def build_meeting_agent_caller(
                     str(identity.model.model_id),
                     config=config,
                 )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 MEETING_AGENT_CALL_FAILED,
                 agent_id=agent_id,

--- a/src/synthorg/communication/meeting/orchestrator.py
+++ b/src/synthorg/communication/meeting/orchestrator.py
@@ -1,3 +1,4 @@
+# module-kind: orchestrator
 """Meeting orchestrator -- lifecycle manager (see Communication design page).
 
 Manages the full meeting lifecycle: validates inputs, selects the
@@ -31,6 +32,7 @@ from synthorg.communication.meeting.protocol import (  # noqa: TC001
     MeetingProtocol,
     TaskCreator,
 )
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import (
     get_logger,
     log_exception_redacted,
@@ -382,6 +384,7 @@ class MeetingOrchestrator:
                 exc,
             )
         except Exception as exc:
+            reraise_critical(exc)
             status = MeetingStatus.FAILED
             if isinstance(exc, ExceptionGroup):
                 budget_group = exc.subgroup(MeetingBudgetExhaustedError)
@@ -526,9 +529,8 @@ class MeetingOrchestrator:
                     description=action_item.description,
                     assignee=action_item.assignee_id,
                 )
-            except MemoryError, RecursionError:
-                raise
             except Exception as exc:
+                reraise_critical(exc)
                 failures += 1
                 log_exception_redacted(
                     logger,
@@ -562,7 +564,8 @@ class MeetingOrchestrator:
                 participant_ids,
                 lenses,
             )
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 MEETING_LENS_ASSIGNMENT_FAILED,
                 error="Lens assignment failed, proceeding without lenses",

--- a/src/synthorg/communication/meeting/scheduler.py
+++ b/src/synthorg/communication/meeting/scheduler.py
@@ -35,6 +35,7 @@ from synthorg.communication.meeting.orchestrator import (
 from synthorg.communication.meeting.participant import (
     ParticipantResolver,  # noqa: TC001
 )
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import (
     get_logger,
     log_exception_redacted,
@@ -243,9 +244,8 @@ class MeetingScheduler:
             return
         try:
             records = await self._cooldown_repo.load_all()
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 MEETING_SCHEDULER_ERROR,
                 phase="hydrate_cooldown_repo",
@@ -297,9 +297,8 @@ class MeetingScheduler:
         )
         try:
             await self._cooldown_repo.save(record)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 MEETING_SCHEDULER_ERROR,
                 phase="persist_cooldown",
@@ -639,9 +638,8 @@ class MeetingScheduler:
                 )
                 try:
                     await self._execute_meeting(meeting_type)
-                except MemoryError, RecursionError:
-                    raise
                 except Exception as exc:
+                    reraise_critical(exc)
                     logger.warning(
                         MEETING_SCHEDULER_ERROR,
                         meeting_type=meeting_type.name,
@@ -679,9 +677,8 @@ class MeetingScheduler:
 
         try:
             agenda = self._build_default_agenda(meeting_type, context)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 MEETING_SCHEDULER_ERROR,
                 meeting_type=meeting_type.name,
@@ -723,9 +720,8 @@ class MeetingScheduler:
                 meeting_type=meeting_type.name,
             )
             return None
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 MEETING_SCHEDULER_ERROR,
                 meeting_type=meeting_type.name,
@@ -774,9 +770,8 @@ class MeetingScheduler:
                 participant_ids=tuple(participant_ids),
                 token_budget=meeting_type.duration_tokens,
             )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 MEETING_SCHEDULER_ERROR,
                 meeting_type=meeting_type.name,
@@ -811,9 +806,8 @@ class MeetingScheduler:
                     "status": record.status.value,
                 },
             )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 MEETING_SCHEDULER_ERROR,
                 meeting_id=record.meeting_id,
@@ -838,9 +832,8 @@ class MeetingScheduler:
                     "status": "in_progress",
                 },
             )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 MEETING_SCHEDULER_ERROR,
                 meeting_type=meeting_type_name,

--- a/src/synthorg/communication/meeting/scheduler.py
+++ b/src/synthorg/communication/meeting/scheduler.py
@@ -246,13 +246,19 @@ class MeetingScheduler:
             records = await self._cooldown_repo.load_all()
         except Exception as exc:
             reraise_critical(exc)
-            logger.warning(
+            logger.error(
                 MEETING_SCHEDULER_ERROR,
                 phase="hydrate_cooldown_repo",
                 error_type=type(exc).__name__,
                 error=safe_error_description(exc),
             )
-            return
+            # Abort startup rather than continuing with an empty
+            # ``_last_triggered``: a silent hydrate failure drops the
+            # persisted cooldown floor, so an event-triggered meeting
+            # could fire again immediately after a restart. The operator
+            # opted into durable cooldowns by configuring the repo, so a
+            # load failure must surface, not be swallowed.
+            raise
         from datetime import UTC, datetime  # noqa: PLC0415
 
         now_wall = datetime.now(UTC)

--- a/src/synthorg/core/critical_errors.py
+++ b/src/synthorg/core/critical_errors.py
@@ -23,6 +23,18 @@ Call :func:`reraise_critical` as the first statement of every broad
 logging or business logic runs; all other exceptions return silently
 so the caller's recovery logic continues.
 
+The call is deliberately placed BEFORE the ``logger.warning`` /
+``logger.error`` in the handler, which is why the general "log
+WARNING/ERROR before raising" guidance does NOT apply to this helper:
+a fatal out-of-memory / stack-overflow condition must propagate
+immediately, before the handler tries to allocate and emit a
+structured log record (which can itself fail under memory pressure, or
+add frames to an already-overflowing stack). Telemetry for the
+ordinary (non-critical) failures is not lost: ``reraise_critical``
+returns for them, so the WARNING/ERROR on the following line runs as
+normal. The ordering is intentional; do not reorder these blocks to
+log-before-reraise.
+
 ``asyncio.CancelledError`` is **not** routed through this helper because
 it is a subclass of ``BaseException``, not ``Exception`` -- broad
 ``except Exception:`` blocks never catch it in the first place, so no

--- a/src/synthorg/core/json_parsing.py
+++ b/src/synthorg/core/json_parsing.py
@@ -25,6 +25,8 @@ import re
 from collections.abc import Callable  # noqa: TC003
 from typing import Any
 
+from synthorg.core.critical_errors import reraise_critical
+
 # Captures the body of a fenced block, optional ``json`` language tag,
 # tolerant to leading / trailing newlines around the body. Reused by
 # both extractors below.
@@ -58,9 +60,8 @@ def _safe_log(callback: Callable[[str], None] | None, detail: str) -> None:
         return
     try:
         callback(detail)
-    except MemoryError, RecursionError:
-        raise
-    except Exception:
+    except Exception as exc:
+        reraise_critical(exc)
         return
 
 

--- a/src/synthorg/core/registry/strategy.py
+++ b/src/synthorg/core/registry/strategy.py
@@ -13,6 +13,7 @@ import enum
 from types import MappingProxyType
 from typing import TYPE_CHECKING
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.registry.errors import StrategyFactoryNotFoundError
 from synthorg.observability import get_logger
 from synthorg.observability.events.registry import (
@@ -165,6 +166,7 @@ class StrategyRegistry[T]:
         try:
             instance = factory(*args, **kwargs)
         except Exception as exc:
+            reraise_critical(exc)
             # Use ``logger.warning`` + ``safe_error_description``
             # rather than ``logger.exception`` because factory
             # closures used by ``PersistenceBackendRegistry`` may

--- a/src/synthorg/core/resilience/general_retry.py
+++ b/src/synthorg/core/resilience/general_retry.py
@@ -54,6 +54,7 @@ import random
 from typing import TYPE_CHECKING, Final, TypeVar
 
 from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger
 from synthorg.observability.events.resilience import (
     CORE_RESILIENCE_INVALID_CONFIG,
@@ -193,14 +194,8 @@ class GeneralRetryHandler:
         for attempt in range(self._max_attempts):
             try:
                 return await op()
-            except MemoryError, RecursionError:
-                # System-fatal builtins are ``Exception`` subclasses
-                # in Python; re-raise them before the broad retry
-                # handler so process-fatal conditions cannot be run
-                # through the retryable predicate, logged, or slept
-                # on.  Project convention.
-                raise
             except Exception as exc:
+                reraise_critical(exc)
                 if not self._retryable(exc):
                     self._log_attempt(
                         attempt,

--- a/src/synthorg/integrations/connections/_oauth_rotation.py
+++ b/src/synthorg/integrations/connections/_oauth_rotation.py
@@ -16,6 +16,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.types import NotBlankStr
 from synthorg.integrations.connections.models import Connection, SecretRef
 from synthorg.observability import get_logger, safe_error_description
@@ -157,9 +158,8 @@ class OAuthRotationMixin:
         """
         try:
             await self._repo.save(updated)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 OAUTH_TOKEN_EXCHANGE_FAILED,
                 connection_name=name,
@@ -169,9 +169,8 @@ class OAuthRotationMixin:
             )
             try:
                 await self._secret_backend.delete(new_secret_id)
-            except MemoryError, RecursionError:
-                raise
             except Exception as cleanup_exc:
+                reraise_critical(cleanup_exc)
                 logger.warning(
                     OAUTH_TOKEN_EXCHANGE_FAILED,
                     connection_name=name,
@@ -206,9 +205,8 @@ class OAuthRotationMixin:
                         connection_name=name,
                         secret_id=old_ref.secret_id,
                     )
-            except MemoryError, RecursionError:
-                raise
             except Exception as del_exc:
+                reraise_critical(del_exc)
                 logger.warning(
                     SECRET_DELETE_FAILED,
                     connection_name=name,

--- a/src/synthorg/integrations/connections/catalog.py
+++ b/src/synthorg/integrations/connections/catalog.py
@@ -10,6 +10,7 @@ import json
 from datetime import UTC, datetime
 from uuid import uuid4
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.types import NotBlankStr
 from synthorg.integrations.connections._oauth_rotation import OAuthRotationMixin
 from synthorg.integrations.connections.models import (
@@ -218,9 +219,8 @@ class ConnectionCatalog(OAuthRotationMixin):
                 created_at=now,
                 updated_at=now,
             )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             # Surface ``connection_name`` context on model-construction
             # failures.  Without this the resulting 500 carries the
             # exception's raw message but no resource attribution.
@@ -253,9 +253,8 @@ class ConnectionCatalog(OAuthRotationMixin):
                 secret_id,
                 json.dumps(credentials).encode("utf-8"),
             )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 failure_event,
                 connection_name=connection_name,
@@ -280,9 +279,8 @@ class ConnectionCatalog(OAuthRotationMixin):
         """
         try:
             await self._repo.save(connection)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 CONNECTION_CREATE_FAILED,
                 connection_name=connection.name,
@@ -292,9 +290,8 @@ class ConnectionCatalog(OAuthRotationMixin):
             )
             try:
                 await self._secret_backend.delete(secret_id)
-            except MemoryError, RecursionError:
-                raise
             except Exception as cleanup_exc:
+                reraise_critical(cleanup_exc)
                 logger.warning(
                     CONNECTION_CREATE_FAILED,
                     connection_name=connection.name,
@@ -538,9 +535,8 @@ class ConnectionCatalog(OAuthRotationMixin):
                     webhook_receipt_retention_days=webhook_receipt_retention_days,
                     sensitive=sensitive,
                 )
-            except MemoryError, RecursionError:
-                raise
             except Exception as exc:
+                reraise_critical(exc)
                 # ``NotBlankStr`` rejections (e.g. caller passed an
                 # empty ``base_url``) currently bubble with no resource
                 # attribution.  Surface ``connection_name`` + the input
@@ -576,9 +572,8 @@ class ConnectionCatalog(OAuthRotationMixin):
             updated = existing.model_copy(update=real_updates)
             try:
                 await self._repo.save(updated)
-            except MemoryError, RecursionError:
-                raise
             except Exception as exc:
+                reraise_critical(exc)
                 # PATCH persistence failed; surface ``connection_name``
                 # context before re-raising so the failure is
                 # attributable in dashboards (the repo's own exception
@@ -657,6 +652,7 @@ class ConnectionCatalog(OAuthRotationMixin):
                             secret_id=ref.secret_id,
                         )
                 except Exception as exc:
+                    reraise_critical(exc)
                     # The connection delete itself succeeded; a stale
                     # secret cleanup failure is a secret-delete
                     # problem, not a connection-delete problem -- use

--- a/src/synthorg/integrations/health/checks/github.py
+++ b/src/synthorg/integrations/health/checks/github.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 import httpx
 
 from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.integrations.connections.catalog import ConnectionCatalog  # noqa: TC001
 from synthorg.integrations.connections.models import (
     Connection,
@@ -154,9 +155,8 @@ class GitHubHealthCheck:
         # TaskGroup.
         try:
             credentials = await self._catalog.get_credentials(connection.name)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             error_desc = safe_error_description(exc)
             logger.warning(
                 HEALTH_CHECK_FAILED,

--- a/src/synthorg/integrations/health/checks/slack.py
+++ b/src/synthorg/integrations/health/checks/slack.py
@@ -7,6 +7,7 @@ from typing import Final
 import httpx
 
 from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.integrations.connections.catalog import ConnectionCatalog  # noqa: TC001
 from synthorg.integrations.connections.models import (
     Connection,
@@ -83,14 +84,8 @@ class SlackHealthCheck:
         # masked as a single connection's "unhealthy" report.
         try:
             credentials = await self._catalog.get_credentials(connection.name)
-        except MemoryError, RecursionError:
-            # System-level failures must propagate so the surrounding
-            # TaskGroup can unwind cleanly; converting them to an
-            # UNHEALTHY report would mask the real problem and leave
-            # sibling probes running on a doomed process (project
-            # convention).
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             # The secret-backend exception text can carry encrypted
             # token blobs; scrub before logging / surfacing.
             scrubbed = safe_error_description(exc)

--- a/src/synthorg/integrations/health/prober.py
+++ b/src/synthorg/integrations/health/prober.py
@@ -11,6 +11,7 @@ from types import MappingProxyType
 from typing import Final
 
 from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.integrations.connections.catalog import ConnectionCatalog  # noqa: TC001
 from synthorg.integrations.connections.models import (
     ConnectionStatus,
@@ -166,6 +167,7 @@ class HealthProberService:
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
+                reraise_critical(exc)
                 # Routine probe-loop failure: log a redacted
                 # structured warning instead of ``logger.exception``
                 # (full tracebacks are reserved for ``MemoryError``
@@ -216,6 +218,7 @@ class HealthProberService:
         try:
             conn = await self._catalog.get(name)
         except Exception as exc:
+            reraise_critical(exc)
             # Routine catalog-load failure: redacted warning, not
             # full traceback (see _probe_loop comment).
             logger.warning(
@@ -237,6 +240,7 @@ class HealthProberService:
         try:
             report = await checker.check(conn)
         except Exception as exc:
+            reraise_critical(exc)
             # Routine checker failure: redacted warning, not full
             # traceback (see _probe_loop comment).
             logger.warning(
@@ -266,6 +270,7 @@ class HealthProberService:
                 checked_at=now,
             )
         except Exception as exc:
+            reraise_critical(exc)
             # Routine catalog-write failure: redacted warning, not
             # full traceback (see _probe_loop comment).
             logger.warning(

--- a/src/synthorg/integrations/health/service.py
+++ b/src/synthorg/integrations/health/service.py
@@ -74,6 +74,6 @@ async def check_connection_health(
         return HealthReport(
             connection_name=conn.name,
             status=ConnectionStatus.UNHEALTHY,
-            error_detail=str(exc),
+            error_detail=safe_error_description(exc),
             checked_at=now,
         )

--- a/src/synthorg/integrations/health/service.py
+++ b/src/synthorg/integrations/health/service.py
@@ -7,6 +7,7 @@ endpoint on ``ConnectionsController`` and the aggregate endpoint on
 
 from datetime import UTC, datetime
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.integrations.connections.catalog import ConnectionCatalog  # noqa: TC001
 from synthorg.integrations.connections.models import ConnectionStatus
 from synthorg.integrations.health.models import HealthReport
@@ -63,6 +64,7 @@ async def check_connection_health(
     try:
         return await checker.check(conn)
     except Exception as exc:
+        reraise_critical(exc)
         logger.warning(
             HEALTH_CHECK_FAILED,
             connection_name=name,

--- a/src/synthorg/integrations/mcp_catalog/install.py
+++ b/src/synthorg/integrations/mcp_catalog/install.py
@@ -120,8 +120,6 @@ def merge_installed_servers(
                 entry,
                 install.connection_name,
             )
-        except MemoryError, RecursionError:
-            raise
         except ValueError:
             continue
         additions.append(server_cfg)

--- a/src/synthorg/integrations/oauth/callback_handler.py
+++ b/src/synthorg/integrations/oauth/callback_handler.py
@@ -6,6 +6,7 @@ OAuth API controller to process authorization code callbacks.
 
 from typing import TYPE_CHECKING
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.types import NotBlankStr
 from synthorg.integrations.connections.catalog import ConnectionCatalog  # noqa: TC001
 from synthorg.integrations.errors import (
@@ -53,9 +54,8 @@ async def resolve_oauth_http_timeout(
             SettingNamespace.INTEGRATIONS.value,
             "oauth_http_timeout_seconds",
         )
-    except MemoryError, RecursionError:
-        raise
     except Exception as exc:
+        reraise_critical(exc)
         # This is a setting-resolution fallback, not an OAuth flow
         # failure -- logging as OAUTH_FLOW_FAILED would inflate
         # failure metrics and page oncall for a benign condition.

--- a/src/synthorg/integrations/oauth/callback_handler.py
+++ b/src/synthorg/integrations/oauth/callback_handler.py
@@ -42,8 +42,10 @@ async def resolve_oauth_http_timeout(
     Returns ``None`` when no resolver is wired in or the lookup fails;
     callers then fall back to the ``AuthorizationCodeFlow`` default
     (:data:`integrations.oauth.flows.authorization_code._DEFAULT_HTTP_TIMEOUT_SECONDS`).
-    Never propagates -- a settings outage must not break the OAuth
-    callback path.
+    Non-critical exceptions are swallowed so a settings outage cannot
+    break the OAuth callback path; interpreter-critical errors
+    (``MemoryError`` / ``RecursionError``) still propagate via
+    ``reraise_critical``.
     """
     if config_resolver is None:
         return None

--- a/src/synthorg/integrations/oauth/flows/authorization_code.py
+++ b/src/synthorg/integrations/oauth/flows/authorization_code.py
@@ -10,6 +10,7 @@ import httpx
 
 from synthorg.api.auth.token_size import get_auth_token_bytes
 from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.types import NotBlankStr
 from synthorg.integrations.connections.models import (
     OAuthState,
@@ -170,6 +171,7 @@ class AuthorizationCodeFlow:
         try:
             verifier = decrypt_pkce_verifier(state.pkce_verifier)
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 OAUTH_TOKEN_EXCHANGE_FAILED,
                 reason="pkce_verifier_decrypt_failed",

--- a/src/synthorg/integrations/oauth/oidc_verify.py
+++ b/src/synthorg/integrations/oauth/oidc_verify.py
@@ -120,8 +120,6 @@ async def verify_id_token(
             leeway=_LEEWAY_SECONDS,
             options={"require": ["exp", "iat", "nonce"]},
         )
-    except MemoryError, RecursionError:
-        raise
     except (jwt.exceptions.PyJWTError, jwt.exceptions.PyJWKClientError, OSError) as exc:
         # Dedicated forensic event: the caller only logs the generic
         # OAUTH_FLOW_FAILED for the whole callback, which cannot

--- a/src/synthorg/integrations/oauth/state_service.py
+++ b/src/synthorg/integrations/oauth/state_service.py
@@ -19,6 +19,7 @@ a bare repository.
 from datetime import datetime  # noqa: TC003 -- runtime annotation
 from typing import TYPE_CHECKING, Final
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.types import NotBlankStr  # noqa: TC001 -- runtime annotation
 from synthorg.integrations.connections.models import (
     OAuthState,  # noqa: TC001 -- runtime annotation
@@ -72,9 +73,8 @@ class OAuthStateService:
         bound = state.model_copy(update={"connection_name": connection_name})
         try:
             await self._repo.save(bound)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 SECURITY_OAUTH_STATE_PERSIST_FAILED,
                 connection_name=str(connection_name),

--- a/src/synthorg/integrations/oauth/token_manager.py
+++ b/src/synthorg/integrations/oauth/token_manager.py
@@ -9,6 +9,7 @@ import contextlib
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Final
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.integrations.connections.catalog import ConnectionCatalog  # noqa: TC001
 from synthorg.integrations.connections.models import (
     AuthMethod,
@@ -108,9 +109,8 @@ class OAuthTokenManager:
                 SettingNamespace.INTEGRATIONS.value,
                 "oauth_http_timeout_seconds",
             )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             # Logging this as OAUTH_TOKEN_REFRESH_FAILED would
             # falsely mark an OAuth refresh as failed and trip any
             # alerting on that event. Emit on the settings-fetch
@@ -147,9 +147,8 @@ class OAuthTokenManager:
                     SettingNamespace.INTEGRATIONS.value,
                     key,
                 )
-            except MemoryError, RecursionError:
-                raise
             except Exception as exc:
+                reraise_critical(exc)
                 logger.info(
                     SETTINGS_FETCH_FAILED,
                     namespace=SettingNamespace.INTEGRATIONS.value,
@@ -200,9 +199,8 @@ class OAuthTokenManager:
                 await self._check_and_refresh()
             except asyncio.CancelledError:
                 raise
-            except MemoryError, RecursionError:
-                raise
             except Exception as exc:
+                reraise_critical(exc)
                 log_exception_redacted(
                     logger,
                     OAUTH_TOKEN_REFRESH_FAILED,
@@ -277,9 +275,8 @@ class OAuthTokenManager:
         """
         try:
             credentials = await self._catalog.get_credentials(conn.name)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 OAUTH_TOKEN_REFRESH_FAILED,
                 connection_name=conn.name,
@@ -382,9 +379,8 @@ class OAuthTokenManager:
                 meta_updates = dict(conn.metadata)
                 meta_updates["token_expires_at"] = refreshed.expires_at.isoformat()
                 await self._catalog.update(conn.name, metadata=meta_updates)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 OAUTH_TOKEN_REFRESH_FAILED,
                 connection_name=conn.name,
@@ -398,9 +394,8 @@ class OAuthTokenManager:
                     status=ConnectionStatus.DEGRADED,
                     checked_at=now,
                 )
-            except MemoryError, RecursionError:
-                raise
             except Exception as health_exc:
+                reraise_critical(health_exc)
                 logger.warning(
                     OAUTH_TOKEN_REFRESH_FAILED,
                     connection_name=conn.name,

--- a/src/synthorg/integrations/rate_limiting/decorator.py
+++ b/src/synthorg/integrations/rate_limiting/decorator.py
@@ -81,6 +81,7 @@ def with_connection_rate_limit(
     def decorator(
         fn: Callable[..., Coroutine[Any, Any, T]],
     ) -> Callable[..., Coroutine[Any, Any, T]]:
+
         @functools.wraps(fn)
         async def wrapper(*args: Any, **kwargs: Any) -> T:
             from synthorg.integrations.rate_limiting.shared_state import (  # noqa: PLC0415

--- a/src/synthorg/integrations/rate_limiting/shared_state.py
+++ b/src/synthorg/integrations/rate_limiting/shared_state.py
@@ -23,6 +23,7 @@ from synthorg.communication.bus_protocol import MessageBus  # noqa: TC001
 from synthorg.communication.channel import Channel
 from synthorg.communication.enums import ChannelType, MessageType
 from synthorg.communication.message import DataPart, Message
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.integrations.errors import ConnectionRateLimitError
 from synthorg.observability import get_logger
 from synthorg.observability.events.integrations import (
@@ -96,7 +97,8 @@ class SharedRateLimitCoordinator:
                     _RATELIMIT_CHANNEL.name,
                     self._subscriber_id,
                 )
-            except Exception:
+            except Exception as exc:
+                reraise_critical(exc)
                 logger.warning(
                     RATE_LIMIT_COORDINATOR_STARTED,
                     connection_name=self._connection_name,
@@ -137,7 +139,8 @@ class SharedRateLimitCoordinator:
                     _RATELIMIT_CHANNEL.name,
                     self._subscriber_id,
                 )
-            except Exception:
+            except Exception as exc:
+                reraise_critical(exc)
                 logger.warning(
                     RATE_LIMIT_COORDINATOR_STOPPED,
                     connection_name=self._connection_name,
@@ -219,7 +222,8 @@ class SharedRateLimitCoordinator:
                 RATE_LIMIT_ACQUIRE_PUBLISHED,
                 connection_name=self._connection_name,
             )
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             self._distributed = False
             logger.warning(
                 RATE_LIMIT_ACQUIRE_PUBLISHED,
@@ -243,7 +247,8 @@ class SharedRateLimitCoordinator:
                 await envelope.ack()
             except asyncio.CancelledError:
                 break
-            except Exception:
+            except Exception as exc:
+                reraise_critical(exc)
                 # A receive/ingest failure means this worker is no
                 # longer seeing remote acquires. Flip ``_distributed``
                 # to ``False`` so ``acquire()`` stops assuming the
@@ -320,7 +325,8 @@ async def set_coordinator_factory(
     for coordinator in old:
         try:
             await coordinator.stop()
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 RATE_LIMIT_COORDINATOR_STOPPED,
                 connection_name=coordinator._connection_name,  # noqa: SLF001

--- a/src/synthorg/integrations/rate_limiting/shared_state.py
+++ b/src/synthorg/integrations/rate_limiting/shared_state.py
@@ -84,6 +84,11 @@ class SharedRateLimitCoordinator:
         self._subscriber_id = f"{_SUBSCRIBER_PREFIX}{connection_name}_{uuid4().hex[:8]}"
         self._started = False
         self._distributed = True
+        # Tracks whether ``_bus.subscribe`` actually succeeded. A
+        # local-only fallback start (subscribe failed) leaves this
+        # False so ``stop()`` does not call ``unsubscribe`` on a
+        # subscriber the bus never registered.
+        self._subscribed = False
         # Eager init: stop() must be safe before any start() call.
         self._lifecycle_lock = asyncio.Lock()  # lint-allow: loop-bound-init -- see.
 
@@ -107,6 +112,7 @@ class SharedRateLimitCoordinator:
                 self._distributed = False
                 self._started = True
                 return
+            self._subscribed = True
             self._task = asyncio.create_task(
                 self._poll_loop(),
                 name=f"ratelimit-{self._connection_name}",
@@ -122,11 +128,18 @@ class SharedRateLimitCoordinator:
     async def stop(self) -> None:
         """Cancel polling and unsubscribe.
 
-        On unsubscribe failure, the started/distributed flags are
-        left untouched and the exception propagates. Flipping them
-        to ``False`` on a failed unsubscribe would let a later
-        ``start()`` reuse the same subscriber id against a live
-        ghost subscription and corrupt the coordination window.
+        Skips ``unsubscribe`` entirely when the coordinator fell back
+        to local-only mode (subscribe never succeeded): the bus has no
+        registration for this subscriber id, so unsubscribing it would
+        raise ``NotSubscribedError`` and leave the coordinator stuck in
+        a partial-stop state on every shutdown / factory swap.
+
+        On a genuine unsubscribe failure (a subscription that did
+        exist), the started/distributed flags are left untouched and
+        the exception propagates. Flipping them to ``False`` on a
+        failed unsubscribe would let a later ``start()`` reuse the same
+        subscriber id against a live ghost subscription and corrupt the
+        coordination window.
         """
         async with self._lifecycle_lock:
             if self._task is not None:
@@ -134,24 +147,26 @@ class SharedRateLimitCoordinator:
                 with contextlib.suppress(asyncio.CancelledError):
                     await self._task
                 self._task = None
-            try:
-                await self._bus.unsubscribe(
-                    _RATELIMIT_CHANNEL.name,
-                    self._subscriber_id,
-                )
-            except Exception as exc:
-                reraise_critical(exc)
-                logger.warning(
-                    RATE_LIMIT_COORDINATOR_STOPPED,
-                    connection_name=self._connection_name,
-                    subscriber_id=self._subscriber_id,
-                    error=(
-                        "unsubscribe failed -- coordinator remains "
-                        "in partial-stop state; resolve the bus "
-                        "issue before calling stop() again"
-                    ),
-                )
-                raise
+            if self._subscribed:
+                try:
+                    await self._bus.unsubscribe(
+                        _RATELIMIT_CHANNEL.name,
+                        self._subscriber_id,
+                    )
+                except Exception as exc:
+                    reraise_critical(exc)
+                    logger.warning(
+                        RATE_LIMIT_COORDINATOR_STOPPED,
+                        connection_name=self._connection_name,
+                        subscriber_id=self._subscriber_id,
+                        error=(
+                            "unsubscribe failed -- coordinator remains "
+                            "in partial-stop state; resolve the bus "
+                            "issue before calling stop() again"
+                        ),
+                    )
+                    raise
+                self._subscribed = False
             self._started = False
             self._distributed = False
             logger.debug(

--- a/src/synthorg/integrations/rate_limiting/shared_state.py
+++ b/src/synthorg/integrations/rate_limiting/shared_state.py
@@ -25,7 +25,7 @@ from synthorg.communication.enums import ChannelType, MessageType
 from synthorg.communication.message import DataPart, Message
 from synthorg.core.critical_errors import reraise_critical
 from synthorg.integrations.errors import ConnectionRateLimitError
-from synthorg.observability import get_logger
+from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.integrations import (
     RATE_LIMIT_ACQUIRE_PUBLISHED,
     RATE_LIMIT_COORDINATOR_STARTED,
@@ -345,7 +345,9 @@ async def set_coordinator_factory(
             logger.warning(
                 RATE_LIMIT_COORDINATOR_STOPPED,
                 connection_name=coordinator._connection_name,  # noqa: SLF001
-                error="stop failed during factory swap",
+                phase="factory_swap_stop_failed",
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
             )
 
 

--- a/src/synthorg/integrations/tunnel/mcp_service.py
+++ b/src/synthorg/integrations/tunnel/mcp_service.py
@@ -9,6 +9,7 @@ contract (``start`` / ``stop`` / ``get_url``):
 
 from typing import TYPE_CHECKING
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.communication import (
     COMMUNICATION_TUNNEL_CONNECTED,
@@ -52,6 +53,7 @@ class TunnelService:
         try:
             url = await self._provider.get_url()
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 COMMUNICATION_TUNNEL_PROVIDER_ERROR,
                 method="get_url",
@@ -76,6 +78,7 @@ class TunnelService:
         try:
             url = await self._provider.start()
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 COMMUNICATION_TUNNEL_PROVIDER_ERROR,
                 method="start",

--- a/src/synthorg/integrations/tunnel/ngrok_adapter.py
+++ b/src/synthorg/integrations/tunnel/ngrok_adapter.py
@@ -16,6 +16,7 @@ from typing import Any, Final
 
 from pyngrok import conf, ngrok  # type: ignore[import-untyped]
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.integrations.errors import TunnelError
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.integrations import (
@@ -155,6 +156,7 @@ class NgrokAdapter:
                 # never fully owned.
                 public_url = str(tunnel.public_url)
             except Exception as exc:
+                reraise_critical(exc)
                 # ngrok auth token env var may be echoed in exception
                 # messages; scrub + drop traceback.
                 safe_desc = safe_error_description(exc)
@@ -175,6 +177,7 @@ class NgrokAdapter:
                             getattr(tunnel, "public_url", None),
                         )
                     except Exception as cleanup_exc:
+                        reraise_critical(cleanup_exc)
                         logger.warning(
                             TUNNEL_ERROR,
                             phase="cleanup",
@@ -216,6 +219,7 @@ class NgrokAdapter:
             try:
                 await asyncio.to_thread(ngrok.disconnect, self._public_url)
             except Exception as exc:
+                reraise_critical(exc)
                 logger.warning(
                     TUNNEL_ERROR,
                     phase="disconnect",

--- a/src/synthorg/integrations/webhooks/event_bus_bridge.py
+++ b/src/synthorg/integrations/webhooks/event_bus_bridge.py
@@ -13,6 +13,7 @@ from synthorg.communication.bus_protocol import MessageBus  # noqa: TC001
 from synthorg.communication.channel import Channel
 from synthorg.communication.enums import ChannelType, MessageType
 from synthorg.communication.message import DataPart, Message
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, log_exception_redacted
 from synthorg.observability.events.integrations import (
     WEBHOOK_EVENT_PUBLISH_FAILED,
@@ -68,6 +69,7 @@ async def publish_webhook_event(
     try:
         await bus.publish(message)
     except Exception as exc:
+        reraise_critical(exc)
         log_exception_redacted(
             logger,
             WEBHOOK_EVENT_PUBLISH_FAILED,

--- a/src/synthorg/observability/audit_chain/sink.py
+++ b/src/synthorg/observability/audit_chain/sink.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import ValidationError
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, log_exception_redacted
 from synthorg.observability.audit_chain.chain import HashChain
 from synthorg.observability.audit_chain.payloads import AuditChainEventPayload
@@ -370,8 +371,6 @@ class AuditChainSink(logging.Handler):
                 ts_result.timestamp.timestamp(),
             )
 
-        except MemoryError, RecursionError:
-            raise
         except ValidationError as exc:
             # Boundary validation rejected the assembled payload --
             # do NOT fall through to the generic ``except Exception``
@@ -411,7 +410,8 @@ class AuditChainSink(logging.Handler):
                 timeout_seconds=self._signing_timeout_seconds,
             )
             self._invoke_append_callback("error", 0, 0.0)
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             # Use a non-audited event prefix (``audit_chain.*``) so
             # this error log can't loop back through ``emit()`` and
             # recurse on the single-worker signing executor.
@@ -436,9 +436,8 @@ class AuditChainSink(logging.Handler):
             return
         try:
             callback(status, chain_depth, timestamp_unix)
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 AUDIT_CHAIN_CALLBACK_ERROR,
             )

--- a/src/synthorg/observability/audit_chain/timestamping.py
+++ b/src/synthorg/observability/audit_chain/timestamping.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Literal, Protocol
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.audit_chain.tsa_client import (
     TsaError,
@@ -190,9 +191,8 @@ class ResilientTimestampProvider:
                 incident=type(exc).__name__,
             )
             raise
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 SECURITY_TIMESTAMP_FALLBACK,
                 tsa_url=self._client.tsa_url,

--- a/src/synthorg/observability/audit_chain/tsa_client.py
+++ b/src/synthorg/observability/audit_chain/tsa_client.py
@@ -38,6 +38,7 @@ from rfc3161_client import tsp as _rfc_tsp
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.normalization import extract_media_type
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.security import (
@@ -388,9 +389,8 @@ class TsaClient:
 def _decode_response(raw: bytes) -> Any:
     try:
         return rfc3161_client.decode_timestamp_response(raw)
-    except MemoryError, RecursionError:
-        raise
     except Exception as exc:
+        reraise_critical(exc)
         logger.warning(
             SECURITY_TIMESTAMP_PROTOCOL_ERROR,
             reason="decode_failed",
@@ -515,9 +515,8 @@ def _verify_signature(
             builder = builder.add_root_certificate(root_cert)
         verifier = builder.build()
         verifier.verify(response, hashed_message)
-    except MemoryError, RecursionError:
-        raise
     except Exception as exc:
+        reraise_critical(exc)
         logger.warning(
             SECURITY_TIMESTAMP_SIGNATURE_INVALID,
             tsa_url=tsa_url,
@@ -537,9 +536,8 @@ def _load_root_cert(pem_bytes: bytes) -> x509.Certificate:
     """
     try:
         return x509.load_pem_x509_certificate(pem_bytes)
-    except MemoryError, RecursionError:
-        raise
     except Exception as exc:
+        reraise_critical(exc)
         # Log a fingerprint of the rejected PEM so operators can
         # cross-reference the config source without pasting the
         # (potentially large) cert material into logs.

--- a/src/synthorg/observability/audit_chain/verifier.py
+++ b/src/synthorg/observability/audit_chain/verifier.py
@@ -4,6 +4,7 @@ from typing import Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger
 from synthorg.observability.audit_chain.chain import HashChain
 from synthorg.observability.audit_chain.protocol import AuditChainSigner  # noqa: TC001
@@ -79,9 +80,8 @@ class AuditChainVerifier:
         """
         try:
             result = await self._verify_chain_inner(chain)
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             record_audit_chain_verification(
                 outcome="broken",
                 entries_checked=0,

--- a/src/synthorg/observability/http_handler.py
+++ b/src/synthorg/observability/http_handler.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, Final
 import structlog
 from structlog.stdlib import ProcessorFormatter
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability.redaction import safe_error_description
 
 if TYPE_CHECKING:
@@ -96,6 +97,7 @@ class HttpBatchHandler(logging.Handler):
             try:
                 self._drain_and_flush()
             except Exception as exc:
+                reraise_critical(exc)
                 print(  # noqa: T201
                     f"ERROR: log-http-flusher encountered unexpected error: {safe_error_description(exc)}",  # noqa: E501
                     file=sys.stderr,
@@ -178,6 +180,7 @@ class HttpBatchHandler(logging.Handler):
                 ):
                     pass  # Response body not needed
             except Exception as exc:
+                reraise_critical(exc)
                 # HTTPError wraps a response FP -- close to avoid FD leak.
                 if isinstance(exc, urllib.error.HTTPError):
                     exc.close()

--- a/src/synthorg/observability/log_trace_correlation.py
+++ b/src/synthorg/observability/log_trace_correlation.py
@@ -10,6 +10,8 @@ is an opt-in feature and logging must never depend on it.
 
 from typing import Any
 
+from synthorg.core.critical_errors import reraise_critical
+
 
 def inject_trace_context(
     _logger: Any,
@@ -42,9 +44,8 @@ def inject_trace_context(
     try:
         span = _ot_trace.get_current_span()
         context = span.get_span_context() if span is not None else None
-    except MemoryError, RecursionError:
-        raise
-    except Exception:
+    except Exception as exc:
+        reraise_critical(exc)
         return event_dict
     if context is None or not context.is_valid:
         return event_dict

--- a/src/synthorg/observability/metrics_hub.py
+++ b/src/synthorg/observability/metrics_hub.py
@@ -20,6 +20,7 @@ registered so call sites remain safe when metrics are disabled.
 import weakref
 from typing import TYPE_CHECKING, ParamSpec, TypeVar
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.metrics import (
     METRICS_COLLECTOR_ACTIVATED,
@@ -85,11 +86,10 @@ def _safe_record(
     """
 
     def _wrap(fn: Callable[_P, _R]) -> Callable[_P, _R | None]:
+
         def inner(*args: _P.args, **kwargs: _P.kwargs) -> _R | None:
             try:
                 return fn(*args, **kwargs)
-            except MemoryError, RecursionError:
-                raise
             except TypeError:
                 # TypeError from a ``record_*`` call almost always
                 # means the caller passed wrong-shaped arguments,
@@ -98,6 +98,7 @@ def _safe_record(
                 # so the caller sees the wiring mistake.
                 raise
             except Exception as exc:
+                reraise_critical(exc)
                 # ValueError lives under this branch on purpose: it
                 # surfaces both genuine programming bugs (caller
                 # passed an unknown label) AND transient validation

--- a/src/synthorg/observability/otlp_handler.py
+++ b/src/synthorg/observability/otlp_handler.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Final
 import structlog
 from structlog.stdlib import ProcessorFormatter
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.normalization import strip_trailing_slash
 from synthorg.observability import safe_error_description
 from synthorg.observability.enums import OtlpProtocol
@@ -140,9 +141,8 @@ class OtlpHandler(logging.Handler):
                 self._pending_count += 1
                 if self._pending_count >= self._batch_size:
                     self._batch_ready.set()
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             self.handleError(record)
 
     def set_export_callback(
@@ -239,9 +239,8 @@ class OtlpHandler(logging.Handler):
                 break
             try:
                 self._drain_and_flush()
-            except MemoryError, RecursionError:
-                raise
-            except Exception:
+            except Exception as exc:
+                reraise_critical(exc)
                 _internal_logger.error(
                     METRICS_OTLP_FLUSHER_ERROR,
                 )
@@ -270,9 +269,8 @@ class OtlpHandler(logging.Handler):
         for record in records:
             try:
                 log_records.append(self._format_as_otlp_dict(record))
-            except MemoryError, RecursionError:
-                raise
-            except Exception:
+            except Exception as exc:
+                reraise_critical(exc)
                 self.handleError(record)
                 self._increment_dropped(1)
                 format_drops += 1
@@ -314,9 +312,8 @@ class OtlpHandler(logging.Handler):
                 timeout=self._timeout,
             ):
                 pass
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             # urllib.error.HTTPError wraps a file pointer to the response
             # body.  Close it explicitly to avoid leaking file descriptors.
             if isinstance(exc, urllib.error.HTTPError):
@@ -358,9 +355,8 @@ class OtlpHandler(logging.Handler):
             return
         try:
             callback(outcome, dropped)
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             _internal_logger.warning(
                 METRICS_OTLP_CALLBACK_ERROR,
                 outcome=outcome,

--- a/src/synthorg/observability/processors.py
+++ b/src/synthorg/observability/processors.py
@@ -5,6 +5,7 @@ import sys
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability.redaction import scrub_secret_tokens
 
 if TYPE_CHECKING:
@@ -142,13 +143,8 @@ def scrub_event_fields(
     """
     try:
         return {key: _scrub_value(value) for key, value in event_dict.items()}
-    except MemoryError, RecursionError:
-        # Interpreter-fatal errors must propagate per project convention
-        # -- swallowing them here would hide exactly the class of failures
-        # the rest of the codebase relies on for surfacing catastrophic
-        # state.
-        raise
     except Exception as exc:
+        reraise_critical(exc)
         # Fail open: pass the event through unscrubbed rather than drop
         # the log line entirely.  Still safer than crashing the log
         # pipeline -- ``sanitize_sensitive_fields`` (which ran just

--- a/src/synthorg/observability/prometheus_collector.py
+++ b/src/synthorg/observability/prometheus_collector.py
@@ -24,6 +24,7 @@ from prometheus_client import Counter as PromCounter
 
 from synthorg import __version__
 from synthorg.budget.billing import billing_period_start
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, log_exception_redacted
 from synthorg.observability.events.metrics import (
     METRICS_COLLECTOR_INITIALIZED,
@@ -95,9 +96,8 @@ async def _fetch_workflow_definitions(
             page_size=DEFAULT_PAGE_SIZE,
         ):
             definitions.extend(page)
-    except MemoryError, RecursionError:
-        raise
-    except Exception:
+    except Exception as exc:
+        reraise_critical(exc)
         logger.warning(
             METRICS_SCRAPE_FAILED,
             component="workflow_definition_repo",
@@ -119,9 +119,8 @@ async def _fetch_departments(app_state: AppState) -> frozenset[str] | None:
         if dept_service is None:
             return frozenset()
         records, _ = await dept_service.list_departments()
-    except MemoryError, RecursionError:
-        raise
-    except Exception:
+    except Exception as exc:
+        reraise_critical(exc)
         logger.warning(
             METRICS_SCRAPE_FAILED,
             component="department_service",
@@ -146,9 +145,8 @@ async def _fetch_tool_names(app_state: AppState) -> frozenset[str] | None:
         if registry is None:
             return frozenset()
         return frozenset(registry.list_tools())
-    except MemoryError, RecursionError:
-        raise
     except Exception as exc:
+        reraise_critical(exc)
         # ``_fetch_tool_names`` runs inside a ``TaskGroup`` alongside
         # the workflow / department fetchers; an uncaught exception
         # here would cancel its siblings via the structured-concurrency
@@ -347,9 +345,8 @@ class PrometheusCollector(RecordingMixin, StreamRecordingMixin):
                 billing_cost = await tracker.get_total_cost(
                     start=period_start,
                 )
-            except MemoryError, RecursionError:
-                raise
-            except Exception:
+            except Exception as exc:
+                reraise_critical(exc)
                 logger.warning(
                     METRICS_SCRAPE_FAILED,
                     component="cost_tracker",
@@ -393,9 +390,8 @@ class PrometheusCollector(RecordingMixin, StreamRecordingMixin):
             return
         try:
             stats = pool.get_stats()
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.warning(METRICS_SCRAPE_FAILED, component="pg_pool_stats")
             return
         size = stats.get("pool_size")
@@ -526,9 +522,8 @@ class PrometheusCollector(RecordingMixin, StreamRecordingMixin):
                 )
             else:
                 self._budget_used_percent.set(0.0)
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             self._budget_used_percent.set(0.0)
             self._budget_monthly_cost.set(0.0)
             logger.warning(
@@ -589,9 +584,8 @@ class PrometheusCollector(RecordingMixin, StreamRecordingMixin):
             self._budget_daily_used_percent.set(
                 min(100.0, (daily_cost / daily_budget) * 100.0),
             )
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             self._budget_daily_used_percent.set(0.0)
             logger.warning(
                 METRICS_SCRAPE_FAILED,
@@ -634,9 +628,8 @@ class PrometheusCollector(RecordingMixin, StreamRecordingMixin):
             return ()
         try:
             agents = await app_state.agent_registry.list_active()
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             # Keep the prior gauge values intact so the dashboard
             # doesn't drop to "0 active agents" on a transient
             # registry-fetch failure. The snapshot path also
@@ -720,9 +713,8 @@ class PrometheusCollector(RecordingMixin, StreamRecordingMixin):
                     self._agent_budget_used_percent.labels(
                         agent_id=aid,
                     ).set(pct)
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 METRICS_SCRAPE_FAILED,
                 component="agent_cost",
@@ -779,9 +771,8 @@ class PrometheusCollector(RecordingMixin, StreamRecordingMixin):
                     status=status,
                     agent=agent,
                 ).set(count)
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 METRICS_SCRAPE_FAILED,
                 component="task_engine",

--- a/src/synthorg/observability/redaction.py
+++ b/src/synthorg/observability/redaction.py
@@ -44,6 +44,8 @@ chain is still preserved for callers via ``raise ... from exc``.
 import re
 from typing import Any, Final, Protocol
 
+from synthorg.core.critical_errors import reraise_critical
+
 MAX_SCRUBBED_LENGTH: Final[int] = 512
 """Hard cap on the length of the output of :func:`safe_error_description`.
 
@@ -187,11 +189,6 @@ def scrub_secret_tokens(text: str) -> str:
             scrubbed,
         )
         return _FERNET_PATTERN.sub("***FERNET_CIPHERTEXT***", scrubbed)
-    except MemoryError, RecursionError:
-        # Catastrophic interpreter state -- propagate so the process
-        # can surface the failure rather than silently proceeding with
-        # a half-scrubbed or original string.
-        raise
     except re.error:
         # Defensive: regex-level failure (pathological input, engine
         # bug) must not crash the caller's log call.  The
@@ -235,14 +232,12 @@ def safe_error_description(exc: BaseException) -> str:
         # redacted wrapper. ``scrub_secret_tokens`` is applied below.
         # Calling ``safe_error_description`` here would infinitely recurse.
         message = str(exc)
-    except MemoryError, RecursionError:
-        raise
-    except Exception:  # pragma: no cover - defensive
+    except Exception as stringify_exc:
+        reraise_critical(stringify_exc)  # pragma: no cover - defensive
         try:
             message = repr(exc)
-        except MemoryError, RecursionError:
-            raise
-        except Exception:  # pragma: no cover - defensive
+        except Exception as repr_exc:
+            reraise_critical(repr_exc)  # pragma: no cover - defensive
             return type_name
     if not message:
         return type_name

--- a/src/synthorg/observability/tracing/instrumentation.py
+++ b/src/synthorg/observability/tracing/instrumentation.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 from opentelemetry import trace as _ot_trace
 from opentelemetry.trace import Status, StatusCode
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import safe_error_description
 
 if TYPE_CHECKING:
@@ -77,9 +78,8 @@ async def llm_span(
             span.set_attribute("gen_ai.usage.input_tokens", input_tokens)
         try:
             yield span
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             span.set_attribute("exception.type", type(exc).__name__)
             span.set_attribute(
                 "exception.message",
@@ -120,9 +120,8 @@ async def tool_span(
         span.set_attribute("tool.call_id", tool_call_id)
         try:
             yield span
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             span.set_attribute("exception.type", type(exc).__name__)
             span.set_attribute(
                 "exception.message",

--- a/src/synthorg/providers/base.py
+++ b/src/synthorg/providers/base.py
@@ -15,6 +15,7 @@ from opentelemetry.trace import Status, StatusCode
 
 from synthorg.constants import BUDGET_ROUNDING_PRECISION
 from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import (
     get_logger,
     log_exception_redacted,
@@ -180,9 +181,8 @@ class BaseCompletionProvider(ABC):
                     result = retry_info.value
                 else:
                     result = await _attempt()
-            except MemoryError, RecursionError:
-                raise
             except Exception as exc:
+                reraise_critical(exc)
                 latency_ms = (
                     self._clock.monotonic() - t_start
                 ) * _MILLISECONDS_PER_SECOND
@@ -315,9 +315,8 @@ class BaseCompletionProvider(ABC):
 
         try:
             return await self._resilient_execute(_attempt)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             # See the ``complete`` sibling handler; ``logger.error``
             # + scrubbed fields instead of ``logger.exception``
             # prevents traceback frame-locals from leaking provider
@@ -361,9 +360,8 @@ class BaseCompletionProvider(ABC):
 
         try:
             return await self._resilient_execute(_attempt)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             # ``logger.exception`` would attach a traceback whose
             # frame-locals can leak provider credentials; use
             # ``logger.error`` with the structured ``error_type`` +
@@ -418,6 +416,7 @@ class BaseCompletionProvider(ABC):
             except MemoryError, RecursionError, RetryExhaustedError:
                 raise
             except Exception as exc:
+                reraise_critical(exc)
                 logger.warning(
                     PROVIDER_BATCH_CAPABILITIES_PARTIAL,
                     model=m,

--- a/src/synthorg/providers/cassette/provider.py
+++ b/src/synthorg/providers/cassette/provider.py
@@ -170,8 +170,6 @@ class CassetteCompletionProvider(BaseCompletionProvider):
                 tools=tools,
                 config=config,
             )
-        except MemoryError, RecursionError:
-            raise
         except ProviderError as exc:
             await self._session.record_interaction(
                 method=CassetteMethod.COMPLETE,
@@ -201,11 +199,12 @@ class CassetteCompletionProvider(BaseCompletionProvider):
     def _replay_response(self, outcome: CassetteOutcome) -> CompletionResponse:
         """Return the recorded response or re-raise the recorded error."""
         if outcome.kind is CassetteOutcomeKind.ERROR and outcome.error is not None:
-            raise provider_error_for(
+            recorded_error = provider_error_for(
                 outcome.error.error_class,
                 outcome.error.message,
                 context=dict(outcome.error.context),
             )
+            raise recorded_error
         if outcome.kind is CassetteOutcomeKind.RESPONSE and (
             outcome.response is not None
         ):
@@ -304,8 +303,6 @@ class CassetteCompletionProvider(BaseCompletionProvider):
             async for chunk in inner_stream:
                 recorded.append(chunk)
                 yield chunk
-        except MemoryError, RecursionError:
-            raise
         except ProviderError as exc:
             await self._session.record_interaction(
                 method=CassetteMethod.STREAM,
@@ -356,11 +353,12 @@ class CassetteCompletionProvider(BaseCompletionProvider):
                 )
             return list(outcome.stream_chunks), terminal_error
         if outcome.kind is CassetteOutcomeKind.ERROR and outcome.error is not None:
-            raise provider_error_for(
+            recorded_error = provider_error_for(
                 outcome.error.error_class,
                 outcome.error.message,
                 context=dict(outcome.error.context),
             )
+            raise recorded_error
         msg = f"cassette outcome kind {outcome.kind.value!r} is not a stream"
         raise CassetteFormatError(msg, context={"kind": outcome.kind.value})
 
@@ -379,11 +377,12 @@ class CassetteCompletionProvider(BaseCompletionProvider):
             if outcome.kind is CassetteOutcomeKind.ERROR and (
                 outcome.error is not None
             ):
-                raise provider_error_for(
+                provider_error = provider_error_for(
                     outcome.error.error_class,
                     outcome.error.message,
                     context=dict(outcome.error.context),
                 )
+                raise provider_error
             if outcome.kind is CassetteOutcomeKind.CAPABILITIES and (
                 outcome.capabilities is not None
             ):
@@ -399,8 +398,6 @@ class CassetteCompletionProvider(BaseCompletionProvider):
             capabilities = await self._require_inner().get_model_capabilities(
                 model,
             )
-        except MemoryError, RecursionError:
-            raise
         except ProviderError as exc:
             await self._session.record_interaction(
                 method=CassetteMethod.CAPABILITIES,

--- a/src/synthorg/providers/cost_recording.py
+++ b/src/synthorg/providers/cost_recording.py
@@ -35,6 +35,7 @@ from synthorg.budget.currency import DEFAULT_CURRENCY, CurrencyCode
 # ``emit_cost_record_from_context``, so they must resolve at runtime
 # when downstream tooling evaluates type hints.
 from synthorg.budget.tracker import CostTracker  # noqa: TC001
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.types import NotBlankStr
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.provider import (
@@ -351,9 +352,8 @@ async def emit_cost_record_from_context(
 
     try:
         record = _build_cost_record(ctx, response, model=model, provider=provider)
-    except MemoryError, RecursionError:
-        raise
     except Exception as exc:
+        reraise_critical(exc)
         logger.warning(
             PROVIDER_COST_FAILED,
             agent_id=ctx.agent_id,
@@ -410,8 +410,6 @@ async def _record_cost_in_background(
             ctx.cost_tracker.record(record),
             timeout=_COST_RECORD_TIMEOUT_SECONDS,
         )
-    except MemoryError, RecursionError:
-        raise
     except TimeoutError as exc:
         logger.warning(
             PROVIDER_COST_FAILED,
@@ -425,6 +423,7 @@ async def _record_cost_in_background(
         )
         return
     except Exception as exc:
+        reraise_critical(exc)
         logger.warning(
             PROVIDER_COST_FAILED,
             agent_id=ctx.agent_id,

--- a/src/synthorg/providers/discovery.py
+++ b/src/synthorg/providers/discovery.py
@@ -1,3 +1,4 @@
+# module-kind: integration
 """Model auto-discovery for LLM providers.
 
 Two capabilities:
@@ -25,7 +26,7 @@ if TYPE_CHECKING:
 
 from synthorg.config.schema import ProviderModelConfig  # noqa: TC001
 from synthorg.core.critical_errors import reraise_critical
-from synthorg.observability import get_logger
+from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.provider import (
     PROVIDER_DISCOVERY_FAILED,
     PROVIDER_DISCOVERY_SSRF_BYPASSED,
@@ -567,6 +568,8 @@ async def _safe_fetch(
             preset=preset_name,
             reason="unexpected_error",
             url=safe_url,
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
         )
     return None
 

--- a/src/synthorg/providers/discovery.py
+++ b/src/synthorg/providers/discovery.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
 from synthorg.config.schema import ProviderModelConfig  # noqa: TC001
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger
 from synthorg.observability.events.provider import (
     PROVIDER_DISCOVERY_FAILED,
@@ -545,8 +546,6 @@ async def _safe_fetch(
     """
     try:
         return await coro
-    except MemoryError, RecursionError:
-        raise
     except httpx.HTTPStatusError as exc:
         logger.warning(
             PROVIDER_DISCOVERY_FAILED,
@@ -561,7 +560,8 @@ async def _safe_fetch(
         _log_fetch_failure(preset_name, "timeout", safe_url)
     except json.JSONDecodeError:
         _log_fetch_failure(preset_name, "invalid_json_response", safe_url)
-    except Exception:
+    except Exception as exc:
+        reraise_critical(exc)
         logger.warning(
             PROVIDER_DISCOVERY_FAILED,
             preset=preset_name,

--- a/src/synthorg/providers/drivers/litellm_driver.py
+++ b/src/synthorg/providers/drivers/litellm_driver.py
@@ -1,3 +1,4 @@
+# module-kind: adapter
 """LiteLLM-backed completion driver.
 
 Wraps ``litellm.acompletion`` behind the ``BaseCompletionProvider``
@@ -44,6 +45,7 @@ from litellm.exceptions import (
 )
 
 from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.normalization import compare_ci
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.provider import (
@@ -231,6 +233,7 @@ class LiteLLMDriver(BaseCompletionProvider):
         except errors.ProviderError:
             raise
         except Exception as exc:
+            reraise_critical(exc)
             raise self._map_exception(exc, model) from exc
         return self._map_response(response, model_config)
 
@@ -264,6 +267,7 @@ class LiteLLMDriver(BaseCompletionProvider):
         except errors.ProviderError:
             raise
         except Exception as exc:
+            reraise_critical(exc)
             raise self._map_exception(exc, model) from exc
 
     async def _do_get_model_capabilities(
@@ -307,9 +311,8 @@ class LiteLLMDriver(BaseCompletionProvider):
                 continue
             try:
                 results[model] = self._build_capabilities(model_config)
-            except MemoryError, RecursionError:
-                raise
             except Exception as exc:
+                reraise_critical(exc)
                 logger.warning(
                     PROVIDER_BATCH_CAPABILITIES_PARTIAL,
                     provider=self._provider_name,
@@ -581,6 +584,7 @@ class LiteLLMDriver(BaseCompletionProvider):
                     ):
                         yield sc
             except Exception as exc:
+                reraise_critical(exc)
                 logger.error(
                     PROVIDER_CALL_ERROR,
                     provider=provider,
@@ -756,7 +760,8 @@ class LiteLLMDriver(BaseCompletionProvider):
                 model=litellm_model,
             )
             return {}
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 PROVIDER_MODEL_INFO_UNEXPECTED_ERROR,
                 model=litellm_model,

--- a/src/synthorg/providers/health_prober.py
+++ b/src/synthorg/providers/health_prober.py
@@ -16,6 +16,7 @@ from urllib.parse import urlparse
 import httpx
 
 from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.normalization import strip_trailing_slash
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.provider import (
@@ -258,9 +259,8 @@ class ProviderHealthProber:
                     await task
                 except asyncio.CancelledError:
                     pass
-                except MemoryError, RecursionError:
-                    raise
                 except Exception as exc:
+                    reraise_critical(exc)
                     logger.warning(
                         PROVIDER_HEALTH_PROBER_CYCLE_FAILED,
                         error_type=type(exc).__name__,
@@ -324,9 +324,8 @@ class ProviderHealthProber:
             )
         except asyncio.CancelledError:
             raise
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             if not self._resolve_failed_logged:
                 logger.warning(
                     PROVIDER_HEALTH_PROBER_RESOLVE_FAILED,
@@ -362,9 +361,8 @@ class ProviderHealthProber:
                     await self._probe_all()
                 except asyncio.CancelledError:
                     raise
-                except MemoryError, RecursionError:
-                    raise
                 except Exception as exc:
+                    reraise_critical(exc)
                     logger.warning(
                         PROVIDER_HEALTH_PROBER_CYCLE_FAILED,
                         error_type=type(exc).__name__,
@@ -460,9 +458,8 @@ class ProviderHealthProber:
         """
         try:
             await self._probe_one(name, config, ollama_port=ollama_port)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 PROVIDER_HEALTH_PROBE_FAILED,
                 provider=name,
@@ -556,9 +553,8 @@ class ProviderHealthProber:
             error_msg = "timeout"
         except asyncio.CancelledError:
             raise
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             error_msg = _truncate(
                 f"{type(exc).__name__}: {safe_error_description(exc)}"
             )

--- a/src/synthorg/providers/management/_capabilities_mixin.py
+++ b/src/synthorg/providers/management/_capabilities_mixin.py
@@ -14,6 +14,7 @@ from synthorg.config.schema import (  # noqa: TC001 -- runtime use in return typ
     ProviderConfig,
     ProviderModelConfig,
 )
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.provider import (
     PROVIDER_ALREADY_EXISTS,
@@ -157,9 +158,8 @@ class ProviderCapabilitiesMixin:
                 actor=actor or SYSTEM_ACTOR,
                 payload=dict(payload) if payload else {},
             )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 PROVIDER_AUDIT_WRITE_FAILED,
                 provider=provider_name,

--- a/src/synthorg/providers/management/allowlist.py
+++ b/src/synthorg/providers/management/allowlist.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from pydantic import ValidationError
 
 from synthorg.config.schema import ProviderConfig  # noqa: TC001
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger
 from synthorg.observability.events.provider import (
     PROVIDER_DISCOVERY_ALLOWLIST_CORRUPTED,
@@ -130,7 +131,8 @@ class DiscoveryAllowlistManager:
                 host_port=hp,
                 entry_count=len(updated.host_port_allowlist),
             )
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 PROVIDER_DISCOVERY_ALLOWLIST_UPDATED,
                 action="add_failed",
@@ -181,7 +183,8 @@ class DiscoveryAllowlistManager:
                 host_port=hp,
                 entry_count=len(updated.host_port_allowlist),
             )
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 PROVIDER_DISCOVERY_ALLOWLIST_UPDATED,
                 action="remove_failed",
@@ -231,7 +234,8 @@ class DiscoveryAllowlistManager:
                 new_host_port=new_hp,
                 entry_count=len(updated.host_port_allowlist),
             )
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 PROVIDER_DISCOVERY_ALLOWLIST_UPDATED,
                 action="update_failed",

--- a/src/synthorg/providers/management/allowlist.py
+++ b/src/synthorg/providers/management/allowlist.py
@@ -13,7 +13,7 @@ from pydantic import ValidationError
 
 from synthorg.config.schema import ProviderConfig  # noqa: TC001
 from synthorg.core.critical_errors import reraise_critical
-from synthorg.observability import get_logger
+from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.provider import (
     PROVIDER_DISCOVERY_ALLOWLIST_CORRUPTED,
     PROVIDER_DISCOVERY_ALLOWLIST_SEEDED,
@@ -137,6 +137,8 @@ class DiscoveryAllowlistManager:
                 PROVIDER_DISCOVERY_ALLOWLIST_UPDATED,
                 action="add_failed",
                 host_port=hp,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
             )
 
     async def update_for_delete(
@@ -189,6 +191,8 @@ class DiscoveryAllowlistManager:
                 PROVIDER_DISCOVERY_ALLOWLIST_UPDATED,
                 action="remove_failed",
                 host_port=hp,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
             )
 
     async def update_for_update(
@@ -241,6 +245,8 @@ class DiscoveryAllowlistManager:
                 action="update_failed",
                 old_host_port=old_hp,
                 new_host_port=new_hp,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
             )
 
     async def add_entry(

--- a/src/synthorg/providers/management/service.py
+++ b/src/synthorg/providers/management/service.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 from synthorg.budget.call_category import LLMCallCategory
 from synthorg.config.schema import ProviderConfig, ProviderModelConfig
 from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.types import NotBlankStr
 from synthorg.observability import (
     get_logger,
@@ -506,16 +507,10 @@ class ProviderManagementService(ProviderCapabilitiesMixin):
                 error=safe_error_description(exc),
                 model_tested=model_id,
             )
-        except MemoryError, RecursionError:
-            # Process-level failures must propagate, not collapse into
-            # a normal "probe failed" response. Placed before the
-            # ``except asyncio.CancelledError`` and ``except Exception``
-            # branches so the broad catch downstream cannot swallow
-            # them.
-            raise
         except asyncio.CancelledError:
             raise
         except Exception as exc:
+            reraise_critical(exc)
             log_exception_redacted(
                 logger,
                 PROVIDER_CONNECTION_TESTED,
@@ -831,6 +826,7 @@ class ProviderManagementService(ProviderCapabilitiesMixin):
             registry = ProviderRegistry.from_config(new_providers)
             router = self._build_router(new_providers)
         except Exception as exc:
+            reraise_critical(exc)
             msg = f"Provider configuration validation failed: {type(exc).__name__}"
             logger.warning(
                 PROVIDER_VALIDATION_FAILED,
@@ -849,6 +845,7 @@ class ProviderManagementService(ProviderCapabilitiesMixin):
                 json.dumps(serialized),
             )
         except Exception as exc:
+            reraise_critical(exc)
             msg = f"Failed to persist provider configuration: {type(exc).__name__}"
             # ``error=str(exc)`` would leak credential material via
             # exception text, so we redact via
@@ -968,9 +965,8 @@ class ProviderManagementService(ProviderCapabilitiesMixin):
         await manager.delete_model(model_id)
         try:
             await self.discover_models_for_provider(name)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 PROVIDER_DISCOVERY_FAILED,
                 provider=name,

--- a/src/synthorg/providers/probing.py
+++ b/src/synthorg/providers/probing.py
@@ -13,6 +13,7 @@ import httpx
 from pydantic import BaseModel, ConfigDict, Field
 
 from synthorg.config.schema import ProviderModelConfig
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.normalization import strip_trailing_slash
 from synthorg.core.types import NotBlankStr  # noqa: TC001
 from synthorg.observability import get_logger, safe_error_description
@@ -122,8 +123,6 @@ async def _probe_and_fetch(
                 _log_probe_miss(preset_name, "unexpected_json_type", url)
                 return None
             return data
-    except MemoryError, RecursionError:
-        raise
     except httpx.ConnectError:
         _log_probe_miss(preset_name, "connection_refused", url)
     except httpx.TimeoutException:
@@ -131,6 +130,7 @@ async def _probe_and_fetch(
     except json.JSONDecodeError:
         _log_probe_miss(preset_name, "invalid_json", url)
     except Exception as exc:
+        reraise_critical(exc)
         _log_probe_miss(preset_name, "unexpected_error", url, exc=exc)
     return None
 

--- a/src/synthorg/providers/registry.py
+++ b/src/synthorg/providers/registry.py
@@ -8,6 +8,7 @@ provider's ``driver`` field to select the appropriate factory.
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Self
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import (
     get_logger,
     log_exception_redacted,
@@ -286,9 +287,8 @@ def _build_driver(
 
     try:
         driver = factory(name, config)  # type: ignore[operator]
-    except MemoryError, RecursionError:
-        raise
     except Exception as exc:
+        reraise_critical(exc)
         msg = f"Failed to instantiate driver {driver_type!r} for provider {name!r}"
         log_exception_redacted(
             logger,

--- a/src/synthorg/providers/resilience/retry.py
+++ b/src/synthorg/providers/resilience/retry.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 from synthorg.core.critical_errors import reraise_critical
-from synthorg.observability import get_logger
+from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.provider import (
     PROVIDER_CALL_ERROR,
     PROVIDER_RETRY_ATTEMPT,
@@ -110,6 +110,8 @@ class RetryHandler:
                 logger.warning(
                     PROVIDER_CALL_ERROR,
                     reason="unexpected_non_provider_error",
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
                 )
                 raise
 

--- a/src/synthorg/providers/resilience/retry.py
+++ b/src/synthorg/providers/resilience/retry.py
@@ -5,6 +5,7 @@ import random
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generic, TypeVar
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger
 from synthorg.observability.events.provider import (
     PROVIDER_CALL_ERROR,
@@ -104,7 +105,8 @@ class RetryHandler:
                     error_type=type(exc).__name__,
                 )
                 await asyncio.sleep(delay)
-            except Exception:
+            except Exception as exc:
+                reraise_critical(exc)
                 logger.warning(
                     PROVIDER_CALL_ERROR,
                     reason="unexpected_non_provider_error",

--- a/src/synthorg/providers/routing/resolver.py
+++ b/src/synthorg/providers/routing/resolver.py
@@ -14,6 +14,7 @@ immutability after construction.
 from types import MappingProxyType
 from typing import TYPE_CHECKING
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.routing import (
     ROUTING_MODEL_RESOLUTION_FAILED,
@@ -207,9 +208,8 @@ class ModelResolver:
                 error=safe_error_description(exc),
             )
             raise
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 ROUTING_SELECTION_FAILED,
                 ref=ref,
@@ -250,8 +250,6 @@ class ModelResolver:
             return None
         try:
             return self._selector.select(candidates)
-        except MemoryError, RecursionError:
-            raise
         except ModelResolutionError as exc:
             logger.debug(
                 ROUTING_SELECTION_FAILED,
@@ -264,6 +262,7 @@ class ModelResolver:
             )
             return None
         except Exception as exc:
+            reraise_critical(exc)
             # Defensive fallback: any non-domain selector error converts
             # to a "no model found" outcome rather than propagating up
             # the model-resolution stack, where the caller would have
@@ -271,8 +270,9 @@ class ModelResolver:
             # provider-management code path. The WARNING below (with
             # ``reason="unexpected_selector_error"``) is loud enough
             # for operators to see the underlying cause; ``MemoryError``
-            # and ``RecursionError`` are already re-raised above so
-            # interpreter-state failures are not silenced here.
+            # and ``RecursionError`` are re-raised via
+            # :func:`reraise_critical` so interpreter-state failures
+            # are not silenced here.
             logger.warning(
                 ROUTING_SELECTION_FAILED,
                 ref=ref,

--- a/src/synthorg/security/llm_evaluator.py
+++ b/src/synthorg/security/llm_evaluator.py
@@ -36,6 +36,7 @@ from synthorg.budget.call_category import LLMCallCategory
 from synthorg.budget.tracker import CostTracker  # noqa: TC001
 from synthorg.config.schema import ProviderConfig  # noqa: TC001
 from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.enums import ApprovalRiskLevel
 from synthorg.core.types import NotBlankStr
 from synthorg.engine.prompt_safety import (
@@ -289,9 +290,8 @@ class LlmSecurityEvaluator:
                 )
         except TimeoutError:
             return self._on_llm_timeout(context, rule_verdict, start)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             return self._on_llm_error(
                 context,
                 rule_verdict,

--- a/src/synthorg/security/policy_engine/cedar_engine.py
+++ b/src/synthorg/security/policy_engine/cedar_engine.py
@@ -5,6 +5,7 @@ import time
 
 import cedarpy
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import (
     get_logger,
     log_exception_redacted,
@@ -118,9 +119,8 @@ class CedarPolicyEngine:
                 matched_policy="cedar_policy_set",
                 latency_ms=latency_ms,
             )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             latency_ms = (time.perf_counter() - start) * 1000
             log_exception_redacted(
                 logger,
@@ -155,9 +155,8 @@ class CedarPolicyEngine:
         # block a ready policy decision from being returned.
         try:
             record_security_verdict("allow" if decision.allow else "deny")
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 SECURITY_POLICY_ENGINE_ERROR,
                 reason="metrics_mirror_failed",

--- a/src/synthorg/security/redteam/gate.py
+++ b/src/synthorg/security/redteam/gate.py
@@ -22,6 +22,7 @@ import asyncio
 from typing import TYPE_CHECKING, Final
 
 from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.red_team import (
     RED_TEAM_AGENT_FAILED,
@@ -249,9 +250,8 @@ class RedTeamGateService:
             )
         except asyncio.CancelledError:
             raise
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 RED_TEAM_REPORT_MISSING,
                 execution_id=review_input.execution_id,
@@ -305,9 +305,8 @@ class RedTeamGateService:
             )
         except asyncio.CancelledError:
             raise
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 RED_TEAM_GROUNDING_CHECK_FAILED,
                 execution_id=review_input.execution_id,

--- a/src/synthorg/security/redteam/runner.py
+++ b/src/synthorg/security/redteam/runner.py
@@ -13,6 +13,7 @@ import asyncio
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.enums import Complexity, Priority, Stakes, TaskStatus, TaskType
 from synthorg.core.task import AcceptanceCriterion, Task
 from synthorg.core.types import NotBlankStr  # noqa: TC001
@@ -89,9 +90,8 @@ class AgentEngineRunner:
             await self._engine.run(identity=self._identity, task=task)
         except asyncio.CancelledError:
             raise
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 RED_TEAM_AGENT_FAILED,
                 execution_id=review_input.execution_id,

--- a/src/synthorg/security/rules/engine.py
+++ b/src/synthorg/security/rules/engine.py
@@ -3,6 +3,7 @@
 from datetime import UTC, datetime
 
 from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.enums import ApprovalRiskLevel
 from synthorg.observability import get_logger, log_exception_redacted
 from synthorg.observability.events.security import (
@@ -169,9 +170,8 @@ class RuleEngine:
         """Evaluate a single rule, catching exceptions (fail-closed)."""
         try:
             return rule.evaluate(context)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             log_exception_redacted(
                 logger,
                 SECURITY_RULE_ERROR,

--- a/src/synthorg/security/safety_classifier.py
+++ b/src/synthorg/security/safety_classifier.py
@@ -29,6 +29,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from synthorg.budget.call_category import LLMCallCategory
 from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.enums import ApprovalRiskLevel  # noqa: TC001
 from synthorg.core.types import NotBlankStr
 
@@ -431,9 +432,8 @@ class SafetyClassifier:
                 risk_level,
                 start,
             )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             duration_ms = (self._clock.monotonic() - start) * _MILLISECONDS_PER_SECOND
             log_exception_redacted(
                 logger,

--- a/src/synthorg/security/service.py
+++ b/src/synthorg/security/service.py
@@ -12,6 +12,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.enums import ApprovalRiskLevel, ApprovalStatus, AutonomyLevel
 from synthorg.observability import get_logger, log_exception_redacted
 from synthorg.observability.events.autonomy import (
@@ -191,9 +192,8 @@ class SecOpsService(SecOpsServiceSafetyMixin):
         # never be bypassed, regardless of autonomy configuration.
         try:
             verdict = self._rule_engine.evaluate(context)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             log_exception_redacted(
                 logger,
                 SECURITY_INTERCEPTOR_ERROR,
@@ -305,9 +305,8 @@ class SecOpsService(SecOpsServiceSafetyMixin):
             )
             try:
                 self._audit_log.record(entry)
-            except MemoryError, RecursionError:
-                raise
             except Exception as exc:
+                reraise_critical(exc)
                 log_exception_redacted(
                     logger,
                     SECURITY_AUDIT_RECORD_ERROR,
@@ -324,9 +323,8 @@ class SecOpsService(SecOpsServiceSafetyMixin):
         policy_name = getattr(self._output_scan_policy, "name", "<unknown>")
         try:
             result = self._output_scan_policy.apply(result, context)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             log_exception_redacted(
                 logger,
                 SECURITY_INTERCEPTOR_ERROR,
@@ -381,9 +379,8 @@ class SecOpsService(SecOpsServiceSafetyMixin):
 
         try:
             return await self._llm_evaluator.evaluate(context, verdict)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             log_exception_redacted(
                 logger,
                 SECURITY_INTERCEPTOR_ERROR,
@@ -507,9 +504,8 @@ class SecOpsService(SecOpsServiceSafetyMixin):
         )
         try:
             self._audit_log.record(entry)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             log_exception_redacted(
                 logger,
                 SECURITY_AUDIT_RECORD_ERROR,
@@ -617,9 +613,8 @@ class SecOpsService(SecOpsServiceSafetyMixin):
         )
         try:
             await self._approval_store.add(item)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             log_exception_redacted(
                 logger,
                 SECURITY_ESCALATION_STORE_ERROR,

--- a/src/synthorg/security/service_safety.py
+++ b/src/synthorg/security/service_safety.py
@@ -9,6 +9,7 @@ declared on the concrete service.
 
 from typing import TYPE_CHECKING
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, log_exception_redacted
 from synthorg.observability.events.security import (
     SECURITY_SAFETY_CLASSIFY_BLOCKED,
@@ -90,9 +91,8 @@ class SecOpsServiceSafetyMixin:
                 result.reason,
                 metadata,
             )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             log_exception_redacted(
                 logger,
                 SECURITY_SAFETY_CLASSIFY_ERROR,
@@ -210,9 +210,8 @@ class SecOpsServiceSafetyMixin:
                 metadata["embedding_similarity"] = str(
                     result.embedding_similarity,
                 )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             log_exception_redacted(
                 logger,
                 SECURITY_UNCERTAINTY_CHECK_ERROR,

--- a/src/synthorg/security/timeout/scheduler.py
+++ b/src/synthorg/security/timeout/scheduler.py
@@ -13,6 +13,7 @@ from collections.abc import Awaitable, Callable  # noqa: TC003
 from typing import TYPE_CHECKING
 
 from synthorg.core.actor_context import ActorIdentity, actor_scope
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.enums import ApprovalStatus, TimeoutActionType
 from synthorg.notifications.dispatcher import NotificationDispatcher  # noqa: TC001
 from synthorg.observability import get_logger
@@ -298,9 +299,8 @@ class ApprovalTimeoutScheduler:
             logger.debug(TIMEOUT_SCHEDULER_TICK)
             try:
                 await self._check_pending_approvals()
-            except MemoryError, RecursionError:
-                raise
-            except Exception:
+            except Exception as exc:
+                reraise_critical(exc)
                 logger.error(
                     TIMEOUT_SCHEDULER_ERROR,
                     error="Unexpected error in scheduler loop",
@@ -312,9 +312,8 @@ class ApprovalTimeoutScheduler:
             items = await self._store.list_items(
                 status=ApprovalStatus.PENDING,
             )
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.error(
                 TIMEOUT_SCHEDULER_ERROR,
                 error="Failed to list pending approvals",
@@ -337,9 +336,8 @@ class ApprovalTimeoutScheduler:
         with actor_scope(ActorIdentity.system(TIMEOUT_POLICY_DECIDER)):
             try:
                 updated, action = await self._checker.check_and_resolve(item)
-            except MemoryError, RecursionError:
-                raise
-            except Exception:
+            except Exception as exc:
+                reraise_critical(exc)
                 logger.warning(
                     TIMEOUT_SCHEDULER_ERROR,
                     approval_id=item.id,
@@ -378,9 +376,8 @@ class ApprovalTimeoutScheduler:
         """Persist an APPROVE/DENY resolution and invoke callback."""
         try:
             saved = await self._store.save_if_pending(item)
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.error(
                 TIMEOUT_SCHEDULER_ERROR,
                 approval_id=item.id,
@@ -402,9 +399,8 @@ class ApprovalTimeoutScheduler:
         if self._on_resolve is not None:
             try:
                 await self._on_resolve(saved, action)
-            except MemoryError, RecursionError:
-                raise
-            except Exception:
+            except Exception as exc:
+                reraise_critical(exc)
                 logger.error(
                     TIMEOUT_SCHEDULER_ERROR,
                     approval_id=item.id,

--- a/src/synthorg/security/timeout/timeout_checker.py
+++ b/src/synthorg/security/timeout/timeout_checker.py
@@ -8,6 +8,7 @@ and apply the configured ``TimeoutPolicy``.
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.enums import ApprovalStatus, TimeoutActionType
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.timeout import (
@@ -67,9 +68,8 @@ class TimeoutChecker:
 
         try:
             action = await self._policy.determine_action(item, elapsed)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 TIMEOUT_POLICY_EVALUATED,
                 approval_id=item.id,

--- a/src/synthorg/security/uncertainty.py
+++ b/src/synthorg/security/uncertainty.py
@@ -31,6 +31,7 @@ from synthorg.budget.call_category import LLMCallCategory
 # type hints (DI containers, doc generators).
 from synthorg.budget.tracker import CostTracker  # noqa: TC001
 from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.types import NotBlankStr
 from synthorg.engine.prompt_safety import (
     TAG_TASK_DATA,
@@ -428,9 +429,8 @@ class UncertaintyChecker:
                         ),
                         timeout=self._config.timeout_seconds,
                     )
-            except MemoryError, RecursionError:
-                raise
             except Exception as exc:
+                reraise_critical(exc)
                 # ``logger.warning`` + ``safe_error_description``
                 # instead of ``logger.exception`` so the traceback
                 # (which can carry credential-bearing locals from

--- a/src/synthorg/security/visionverify/gate.py
+++ b/src/synthorg/security/visionverify/gate.py
@@ -15,6 +15,7 @@ import asyncio
 from typing import Final
 
 from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.vision_verify import (
     VISION_GATE_BLOCKED,
@@ -129,9 +130,8 @@ class VisionVerifierGateService:
             return await self._verifier.verify(review_input)
         except asyncio.CancelledError:
             raise
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 VISION_VERIFIER_FAILED,
                 execution_id=review_input.execution_id,

--- a/src/synthorg/settings/dispatcher.py
+++ b/src/synthorg/settings/dispatcher.py
@@ -14,6 +14,7 @@ from synthorg.communication.errors import (
     ChannelAlreadyExistsError,
     CommunicationError,
 )
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.normalization import compare_ci
 from synthorg.observability import (
     get_logger,
@@ -183,9 +184,8 @@ class SettingsChangeDispatcher:
                 _SETTINGS_CHANNEL,
                 _SUBSCRIBER_ID,
             )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             # Recovery requires the stale registration to be gone
             # before subscribe() runs further down start(). Continuing
             # past this point on a non-idempotent bus (NATS) would
@@ -272,7 +272,8 @@ class SettingsChangeDispatcher:
                 # not silently skip cleanup (stop() early-returns on
                 # ``_running=False``).
                 await self._bus.subscribe(_SETTINGS_CHANNEL, _SUBSCRIBER_ID)
-            except Exception:
+            except Exception as exc:
+                reraise_critical(exc)
                 logger.warning(
                     SETTINGS_DISPATCHER_START_REJECTED,
                     error="channel ensure/subscribe failed during start()",
@@ -294,7 +295,8 @@ class SettingsChangeDispatcher:
                         _SETTINGS_CHANNEL,
                         _SUBSCRIBER_ID,
                     )
-                except Exception:
+                except Exception as exc:
+                    reraise_critical(exc)
                     # Best-effort rollback -- a failed unsubscribe
                     # during already-failed start() leaves the bus with
                     # a stale ``__settings_dispatcher__`` registration
@@ -404,9 +406,8 @@ class SettingsChangeDispatcher:
             # queue until channel cleanup.
             try:
                 await self._bus.unsubscribe(_SETTINGS_CHANNEL, _SUBSCRIBER_ID)
-            except MemoryError, RecursionError:
-                raise
             except Exception as exc:
+                reraise_critical(exc)
                 # Unsubscribe failure means the bus still holds a
                 # stale ``__settings_dispatcher__`` registration on
                 # ``#settings``. Mark the dispatcher unrestartable so
@@ -529,9 +530,8 @@ class SettingsChangeDispatcher:
             )
         except asyncio.CancelledError:
             raise
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             if not self._resolve_failed_logged:
                 logger.warning(
                     SETTINGS_DISPATCHER_RESOLVE_FAILED,
@@ -569,9 +569,8 @@ class SettingsChangeDispatcher:
             )
         except asyncio.CancelledError:
             raise
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             return bootstrap_default
 
     async def _resolve_stop_drain_timeout(self) -> float:
@@ -599,9 +598,8 @@ class SettingsChangeDispatcher:
             )
         except asyncio.CancelledError:
             raise
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             return bootstrap_default
 
     async def _ensure_channel(self) -> None:
@@ -644,8 +642,6 @@ class SettingsChangeDispatcher:
                 consecutive_errors = 0
             except asyncio.CancelledError:
                 raise
-            except MemoryError, RecursionError:
-                raise
             except (CommunicationError, OSError, TimeoutError) as exc:
                 consecutive_errors += 1
                 max_errors = await self._resolve_max_consecutive_errors()
@@ -665,6 +661,7 @@ class SettingsChangeDispatcher:
                 )
                 await asyncio.sleep(_ERROR_BACKOFF)
             except Exception as exc:
+                reraise_critical(exc)
                 log_exception_redacted(logger, SETTINGS_DISPATCHER_CHANNEL_DEAD, exc)
                 break
 
@@ -695,9 +692,8 @@ class SettingsChangeDispatcher:
                     namespace=namespace,
                     key=key,
                 )
-            except MemoryError, RecursionError:
-                raise
             except Exception as exc:
+                reraise_critical(exc)
                 log_exception_redacted(
                     logger,
                     SETTINGS_SUBSCRIBER_ERROR,

--- a/src/synthorg/settings/kill_switch.py
+++ b/src/synthorg/settings/kill_switch.py
@@ -16,6 +16,7 @@ and consistent across the codebase.
 import asyncio
 from typing import TYPE_CHECKING
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.settings import SETTINGS_FETCH_FAILED
 
@@ -71,6 +72,7 @@ async def resolve_bool_with_fallback(
         # real semantic.
         raise
     except Exception as exc:
+        reraise_critical(exc)
         logger.warning(
             SETTINGS_FETCH_FAILED,
             namespace=namespace,

--- a/src/synthorg/settings/service.py
+++ b/src/synthorg/settings/service.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 
 from synthorg.communication.enums import MessageType
 from synthorg.communication.message import Message, MessageMetadata, TextPart
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.types import NotBlankStr
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.security import SECURITY_SETTINGS_CHANGED
@@ -1017,6 +1018,7 @@ class SettingsService:
         try:
             removed_keys = await self._repository.delete_namespace_returning_keys(ns)
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 SETTINGS_DELETE_FAILED,
                 namespace=namespace,
@@ -1126,9 +1128,8 @@ class SettingsService:
                 namespace=namespace,
                 key=key,
             )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             # Notification failure should not break settings writes.
             # Settings is a credential-bearing path so use the
             # ``safe_error_description`` redactor and do NOT pass

--- a/src/synthorg/settings/subscribers/api_bridge_subscriber.py
+++ b/src/synthorg/settings/subscribers/api_bridge_subscriber.py
@@ -16,6 +16,7 @@ consumers need hot-reload semantics.
 
 from typing import TYPE_CHECKING
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.settings import (
     SETTINGS_SERVICE_SWAP_FAILED,
@@ -113,9 +114,8 @@ class ApiBridgeSettingsSubscriber:
         try:
             value = await self._app_state.config_resolver.get_int(namespace, key)
             self._app_state.mutate_api_bridge_config({key: value})
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 SETTINGS_SERVICE_SWAP_FAILED,
                 service="api_bridge_config",

--- a/src/synthorg/settings/subscribers/backup_subscriber.py
+++ b/src/synthorg/settings/subscribers/backup_subscriber.py
@@ -2,6 +2,7 @@
 
 from typing import TYPE_CHECKING
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.normalization import compare_ci
 from synthorg.observability import get_logger, log_exception_redacted
 from synthorg.observability.events.settings import SETTINGS_SUBSCRIBER_NOTIFIED
@@ -96,9 +97,8 @@ class BackupSettingsSubscriber:
         """Start or stop the scheduler based on the current setting value."""
         try:
             result = await self._settings_service.get("backup", "enabled")
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             log_exception_redacted(
                 logger,
                 SETTINGS_SUBSCRIBER_NOTIFIED,
@@ -116,9 +116,8 @@ class BackupSettingsSubscriber:
         if enabled and not scheduler.is_running:
             try:
                 await scheduler.start()
-            except MemoryError, RecursionError:
-                raise
             except Exception as exc:
+                reraise_critical(exc)
                 # Surface a startup failure here -- without this branch
                 # the exception would propagate from the subscriber
                 # callback with no context tying it back to the
@@ -157,9 +156,8 @@ class BackupSettingsSubscriber:
         """Update the scheduler interval from current settings."""
         try:
             result = await self._settings_service.get("backup", "schedule_hours")
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             log_exception_redacted(
                 logger,
                 SETTINGS_SUBSCRIBER_NOTIFIED,

--- a/src/synthorg/settings/subscribers/memory_bridge_subscriber.py
+++ b/src/synthorg/settings/subscribers/memory_bridge_subscriber.py
@@ -23,6 +23,7 @@ three bridge-backed keys.
 
 from typing import TYPE_CHECKING
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.settings import (
     SETTINGS_SERVICE_SWAP_FAILED,
@@ -107,9 +108,8 @@ class MemoryBridgeSettingsSubscriber:
             resolver = self._app_state.config_resolver
             snapshot = await resolver.get_memory_bridge_config()
             self._app_state.swap_memory_bridge_config(snapshot)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 SETTINGS_SERVICE_SWAP_FAILED,
                 service="memory_bridge_config",

--- a/src/synthorg/settings/subscribers/observability_subscriber.py
+++ b/src/synthorg/settings/subscribers/observability_subscriber.py
@@ -4,6 +4,7 @@ import asyncio
 import sys
 from typing import TYPE_CHECKING, Any
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.normalization import normalize_ascii_lowercase
 from synthorg.observability import get_logger
 from synthorg.observability.enums import LogLevel
@@ -153,9 +154,8 @@ class ObservabilitySettingsSubscriber:
                 custom_sinks_json=cust_result.value,
                 log_dir=self._log_dir,
             )
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.error(
                 SETTINGS_OBSERVABILITY_VALIDATION_FAILED,
                 subscriber=self.subscriber_name,
@@ -176,9 +176,8 @@ class ObservabilitySettingsSubscriber:
                 build_result.config,
                 routing_overrides=routing,
             )
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             # Pipeline may be degraded -- stderr as fallback.
             sys.stderr.write(
                 f"WARNING: configure_logging failed during hot reload "
@@ -208,9 +207,8 @@ class ObservabilitySettingsSubscriber:
         """Full pipeline rebuild: read, parse, build, apply."""
         try:
             results = await self._read_all_settings()
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.error(
                 SETTINGS_OBSERVABILITY_REBUILD_FAILED,
                 subscriber=self.subscriber_name,

--- a/src/synthorg/settings/subscribers/per_op_rate_limit_subscriber.py
+++ b/src/synthorg/settings/subscribers/per_op_rate_limit_subscriber.py
@@ -21,6 +21,7 @@ from synthorg.config.rate_limits import (
     PerOpConcurrencyConfig,
     PerOpRateLimitConfig,
 )
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.normalization import normalize_ascii_lowercase
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.settings import (
@@ -162,9 +163,8 @@ class PerOpRateLimitSettingsSubscriber:
                 backend=backend,
                 overrides=overrides,
             )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 SETTINGS_SERVICE_SWAP_FAILED,
                 service="per_op_rate_limit_config",
@@ -192,9 +192,8 @@ class PerOpRateLimitSettingsSubscriber:
                 backend=backend,
                 overrides=overrides,
             )
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 SETTINGS_SERVICE_SWAP_FAILED,
                 service="per_op_concurrency_config",

--- a/src/synthorg/settings/subscribers/provider_subscriber.py
+++ b/src/synthorg/settings/subscribers/provider_subscriber.py
@@ -3,7 +3,7 @@
 from typing import TYPE_CHECKING
 
 from synthorg.core.critical_errors import reraise_critical
-from synthorg.observability import get_logger
+from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.settings import (
     SETTINGS_SERVICE_SWAP_FAILED,
     SETTINGS_SUBSCRIBER_NOTIFIED,
@@ -123,6 +123,8 @@ class ProviderSettingsSubscriber:
                 SETTINGS_SERVICE_SWAP_FAILED,
                 service="model_router",
                 attempted_strategy=attempted_strategy,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
             )
             raise
         self._app_state.swap_model_router(new_router)

--- a/src/synthorg/settings/subscribers/provider_subscriber.py
+++ b/src/synthorg/settings/subscribers/provider_subscriber.py
@@ -2,6 +2,7 @@
 
 from typing import TYPE_CHECKING
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger
 from synthorg.observability.events.settings import (
     SETTINGS_SERVICE_SWAP_FAILED,
@@ -116,9 +117,8 @@ class ProviderSettingsSubscriber:
                 new_routing,
                 dict(config.providers),
             )
-        except MemoryError, RecursionError:
-            raise
-        except Exception:
+        except Exception as exc:
+            reraise_critical(exc)
             logger.error(
                 SETTINGS_SERVICE_SWAP_FAILED,
                 service="model_router",

--- a/src/synthorg/settings/subscribers/security_subscriber.py
+++ b/src/synthorg/settings/subscribers/security_subscriber.py
@@ -7,6 +7,7 @@ the ``ProviderDiscoveryPolicy`` when it changes.
 import json
 from typing import TYPE_CHECKING
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.security import (
     SECURITY_ALLOWLIST_UPDATE_FAILED,
@@ -111,9 +112,8 @@ class SecuritySubscriber:
 
         try:
             await self._on_changed(allowlist)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 SECURITY_ALLOWLIST_UPDATE_FAILED,
                 namespace=namespace,

--- a/src/synthorg/settings/subscribers/security_timeout_subscriber.py
+++ b/src/synthorg/settings/subscribers/security_timeout_subscriber.py
@@ -9,6 +9,7 @@ startup-time application of the same setting lives in
 
 from typing import TYPE_CHECKING
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import (
     get_logger,
     log_exception_redacted,
@@ -82,9 +83,8 @@ class SecurityTimeoutSettingsSubscriber:
 
         try:
             result = await self._settings_service.get(namespace, key)
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             log_exception_redacted(
                 logger,
                 SETTINGS_SUBSCRIBER_NOTIFIED,

--- a/src/synthorg/settings/subscribers/workers_bridge_subscriber.py
+++ b/src/synthorg/settings/subscribers/workers_bridge_subscriber.py
@@ -10,6 +10,7 @@ invoking subscribers; the three dispatcher retry knobs are mutable
 
 from typing import TYPE_CHECKING
 
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.settings import (
     SETTINGS_SERVICE_SWAP_FAILED,
@@ -102,9 +103,8 @@ class WorkersBridgeSettingsSubscriber:
             else:
                 value = await resolver.get_float(namespace, key)
             self._app_state.mutate_workers_bridge_config({key: value})
-        except MemoryError, RecursionError:
-            raise
         except Exception as exc:
+            reraise_critical(exc)
             logger.warning(
                 SETTINGS_SERVICE_SWAP_FAILED,
                 service="workers_bridge_config",

--- a/tests/unit/communication/bus/test_nats_consumer_unsubscribe.py
+++ b/tests/unit/communication/bus/test_nats_consumer_unsubscribe.py
@@ -79,7 +79,7 @@ async def test_unsubscribe_failure_skips_success_info(
     event, kwargs = recording.warning_events[0]
     assert event == COMM_SUBSCRIPTION_REMOVED
     assert kwargs["phase"] == "unsubscribe_consumer_failed"
-    # Pin the SEC-1 redacted fields so a regression that drops them is caught.
+    # Pin the redacted error fields so a regression that drops them is caught.
     assert kwargs["error_type"] == "RuntimeError"
     assert isinstance(kwargs["error"], str)
     assert kwargs["error"]

--- a/tests/unit/communication/bus/test_nats_consumer_unsubscribe.py
+++ b/tests/unit/communication/bus/test_nats_consumer_unsubscribe.py
@@ -1,0 +1,99 @@
+"""Telemetry correctness for the NATS durable-consumer unsubscribe path.
+
+A failed consumer teardown must log a single WARNING and stop: it must
+not also emit the success ``COMM_SUBSCRIPTION_REMOVED`` INFO for the same
+operation, which would mislead telemetry consumers into seeing both a
+"failed" and a "removed" event for one unsubscribe.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from synthorg.communication.bus import _nats_consumers
+from synthorg.communication.bus._nats_consumers import unsubscribe
+from synthorg.communication.channel import Channel
+from synthorg.communication.enums import ChannelType
+from synthorg.observability.events.communication import COMM_SUBSCRIPTION_REMOVED
+
+pytestmark = pytest.mark.unit
+
+
+class _RecordingLogger:
+    """Records structured-log events without a Mock (mock-spec gate)."""
+
+    def __init__(self) -> None:
+        self.info_events: list[str] = []
+        self.warning_events: list[tuple[str, dict[str, Any]]] = []
+
+    def info(self, event: str, **kwargs: Any) -> None:
+        self.info_events.append(event)
+
+    def warning(self, event: str, **kwargs: Any) -> None:
+        self.warning_events.append((event, kwargs))
+
+    def debug(self, event: str, **kwargs: Any) -> None:
+        pass
+
+    def error(self, event: str, **kwargs: Any) -> None:
+        pass
+
+
+def _state_with_sub(sub: object) -> SimpleNamespace:
+    """A minimal ``_NatsState`` stand-in carrying one subscription.
+
+    ``kv=None`` makes ``write_channel_to_kv`` a no-op so the test does
+    not need a working KV bucket.
+    """
+    channel = Channel(name="#chan", type=ChannelType.TOPIC, subscribers=("sub-1",))
+    return SimpleNamespace(
+        lock=asyncio.Lock(),
+        running=True,
+        channels={"#chan": channel},
+        subscriptions={("#chan", "sub-1"): sub},
+        last_overflow_log={},
+        kv=None,
+    )
+
+
+async def test_unsubscribe_failure_skips_success_info(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recording = _RecordingLogger()
+    monkeypatch.setattr(_nats_consumers, "logger", recording)
+
+    async def _boom_unsubscribe() -> None:
+        msg = "consumer teardown boom"
+        raise RuntimeError(msg)
+
+    state = _state_with_sub(SimpleNamespace(unsubscribe=_boom_unsubscribe))
+
+    await unsubscribe(state, "#chan", "sub-1")  # type: ignore[arg-type]
+
+    # The teardown failure logs exactly one WARNING and returns; the
+    # success COMM_SUBSCRIPTION_REMOVED INFO must NOT also fire.
+    assert recording.info_events == []
+    assert len(recording.warning_events) == 1
+    event, kwargs = recording.warning_events[0]
+    assert event == COMM_SUBSCRIPTION_REMOVED
+    assert kwargs["phase"] == "unsubscribe_consumer_failed"
+
+
+async def test_unsubscribe_success_emits_info(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recording = _RecordingLogger()
+    monkeypatch.setattr(_nats_consumers, "logger", recording)
+
+    async def _ok_unsubscribe() -> None:
+        return None
+
+    state = _state_with_sub(SimpleNamespace(unsubscribe=_ok_unsubscribe))
+
+    await unsubscribe(state, "#chan", "sub-1")  # type: ignore[arg-type]
+
+    # A clean teardown emits the success INFO and no WARNING.
+    assert recording.info_events == [COMM_SUBSCRIPTION_REMOVED]
+    assert recording.warning_events == []

--- a/tests/unit/communication/bus/test_nats_consumer_unsubscribe.py
+++ b/tests/unit/communication/bus/test_nats_consumer_unsubscribe.py
@@ -79,6 +79,10 @@ async def test_unsubscribe_failure_skips_success_info(
     event, kwargs = recording.warning_events[0]
     assert event == COMM_SUBSCRIPTION_REMOVED
     assert kwargs["phase"] == "unsubscribe_consumer_failed"
+    # Pin the SEC-1 redacted fields so a regression that drops them is caught.
+    assert kwargs["error_type"] == "RuntimeError"
+    assert isinstance(kwargs["error"], str)
+    assert kwargs["error"]
 
 
 async def test_unsubscribe_success_emits_info(

--- a/tests/unit/communication/bus/test_nats_kv_error_paths.py
+++ b/tests/unit/communication/bus/test_nats_kv_error_paths.py
@@ -1,0 +1,78 @@
+"""Error-path coverage for the NATS KV channel helpers.
+
+Transport failures while reading / writing the KV bucket must wrap into
+``BusStreamError`` (read/create) or be swallowed (best-effort write),
+and never absorb an interpreter-critical exception.
+"""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from synthorg.communication.bus._nats_kv import (
+    create_channel_in_kv,
+    fetch_kv_entry,
+    scan_kv_channels,
+    write_channel_to_kv,
+)
+from synthorg.communication.bus.errors import BusStreamError
+from synthorg.communication.channel import Channel
+from synthorg.communication.enums import ChannelType
+
+pytestmark = pytest.mark.unit
+
+
+async def _boom(*_args: Any, **_kwargs: Any) -> Any:
+    """Async KV operation that always fails with a non-critical error."""
+    msg = "kv transport boom"
+    raise RuntimeError(msg)
+
+
+def _failing_kv() -> SimpleNamespace:
+    """A KV stand-in whose every operation raises a non-critical error."""
+    return SimpleNamespace(create=_boom, put=_boom, get=_boom, keys=_boom)
+
+
+def _channel() -> Channel:
+    return Channel(name="#kv-error", type=ChannelType.TOPIC)
+
+
+async def test_create_channel_kv_failure_wraps_bus_stream_error() -> None:
+    state = SimpleNamespace(kv=_failing_kv())
+    with pytest.raises(BusStreamError):
+        await create_channel_in_kv(state, _channel())  # type: ignore[arg-type]
+
+
+async def test_write_channel_kv_failure_is_swallowed() -> None:
+    state = SimpleNamespace(kv=_failing_kv())
+    # Best-effort persistence: a put failure is logged, not raised.
+    await write_channel_to_kv(state, _channel())  # type: ignore[arg-type]
+
+
+async def test_fetch_kv_entry_failure_wraps_bus_stream_error() -> None:
+    state = SimpleNamespace(kv=_failing_kv())
+    with pytest.raises(BusStreamError):
+        await fetch_kv_entry(state, "#kv-error")  # type: ignore[arg-type]
+
+
+async def test_scan_kv_keys_failure_wraps_bus_stream_error() -> None:
+    state = SimpleNamespace(kv=_failing_kv())
+    with pytest.raises(BusStreamError):
+        await scan_kv_channels(state)  # type: ignore[arg-type]
+
+
+async def test_scan_kv_skips_undecodable_keys() -> None:
+    async def _keys_with_bad_token(*_args: Any, **_kwargs: Any) -> list[str]:
+        return ["####not-a-valid-token####"]
+
+    kv = _failing_kv()
+    # keys() succeeds but returns an undecodable token; the per-key
+    # decode failure is logged and skipped, and the get() failure for
+    # any decoded key is captured by the gather, so the scan returns [].
+    kv.keys = _keys_with_bad_token
+    state = SimpleNamespace(kv=kv)
+
+    result = await scan_kv_channels(state)  # type: ignore[arg-type]
+
+    assert result == []

--- a/tests/unit/communication/conflict_resolution/escalation/test_notify.py
+++ b/tests/unit/communication/conflict_resolution/escalation/test_notify.py
@@ -272,6 +272,103 @@ class TestPostgresSubscriberLifecycle:
             stuck_task.cancel()
 
 
+class TestPostgresSubscriberErrorPaths:
+    """Resolver / listen / dispatch / drain failures are logged and degrade
+    without swallowing interpreter-critical exceptions."""
+
+    async def test_resolve_enabled_resolver_failure_fails_safe_to_true(
+        self,
+    ) -> None:
+        repo = AsyncMock(spec=InMemoryEscalationStore)
+        registry = AsyncMock(spec=PendingFuturesRegistry)
+        resolver = AsyncMock(spec=ConfigResolver)
+        resolver.get_bool.side_effect = RuntimeError("settings boom")
+        subscriber = PostgresEscalationNotifySubscriber(
+            repo,
+            registry,
+            channel="escalations",
+            reconnect_delay_seconds=1.0,
+            config_resolver=resolver,
+        )
+
+        # Settings outage must not silently pause the subscriber.
+        assert (await subscriber._resolve_subscriber_enabled()) is True
+
+    async def test_dispatch_payload_repo_failure_is_swallowed(self) -> None:
+        repo = AsyncMock(spec=InMemoryEscalationStore)
+        repo.get.side_effect = RuntimeError("repo get boom")
+        registry = AsyncMock(spec=PendingFuturesRegistry)
+        subscriber = PostgresEscalationNotifySubscriber(
+            repo,
+            registry,
+            channel="escalations",
+            reconnect_delay_seconds=1.0,
+        )
+
+        # A backend failure while resolving a NOTIFY must not kill the
+        # subscriber loop -- it is logged and swallowed.
+        await subscriber._dispatch_payload("escalation-1:decided")
+
+    async def test_run_loop_listen_failure_is_logged_and_retries(self) -> None:
+        repo = AsyncMock(spec=InMemoryEscalationStore)
+        registry = AsyncMock(spec=PendingFuturesRegistry)
+        clock = FakeClock()
+        subscriber = PostgresEscalationNotifySubscriber(
+            repo,
+            registry,
+            channel="escalations",
+            reconnect_delay_seconds=1.0,
+            clock=clock,
+        )
+
+        listen_called = asyncio.Event()
+
+        async def _boom_listen() -> None:
+            listen_called.set()
+            msg = "listen boom"
+            raise RuntimeError(msg)
+
+        subscriber._listen_once = _boom_listen  # type: ignore[method-assign]
+
+        task = asyncio.create_task(subscriber._run())
+        try:
+            await asyncio.wait_for(listen_called.wait(), timeout=1.0)
+        finally:
+            # Stop arrives during the post-failure back-off; the loop
+            # exits via the top-of-loop guard.
+            subscriber._stop_event.set()
+        with contextlib.suppress(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=1.0)
+
+    async def test_stop_drain_swallows_noncritical_run_exception(self) -> None:
+        repo = AsyncMock(spec=InMemoryEscalationStore)
+        registry = AsyncMock(spec=PendingFuturesRegistry)
+        clock = FakeClock()
+        subscriber = PostgresEscalationNotifySubscriber(
+            repo,
+            registry,
+            channel="escalations",
+            reconnect_delay_seconds=1.0,
+            clock=clock,
+        )
+
+        async def _boom_run() -> None:
+            msg = "run boom"
+            raise RuntimeError(msg)
+
+        boom_task = asyncio.create_task(_boom_run())
+        # Ensure the task has completed with its RuntimeError so the
+        # drain's ``await task`` re-raises it (hitting the except branch)
+        # rather than seeing a CancelledError.
+        with contextlib.suppress(RuntimeError):
+            await boom_task
+        subscriber._task = boom_task
+
+        # The drain logs the non-critical failure and stop() completes.
+        await subscriber.stop()
+        assert subscriber._task is None
+
+
 class TestPostgresSubscriberDoneCallback:
     """``start()`` registers ``log_task_exceptions`` so MemoryError surfaces."""
 

--- a/tests/unit/communication/conflict_resolution/escalation/test_sweeper.py
+++ b/tests/unit/communication/conflict_resolution/escalation/test_sweeper.py
@@ -175,6 +175,35 @@ class TestSweeperLifecycle:
             stuck_task.cancel()
 
 
+class TestSweeperErrorPaths:
+    async def test_stop_drain_swallows_noncritical_run_exception(self) -> None:
+        store = InMemoryEscalationStore()
+        sweeper = EscalationExpirationSweeper(store, interval_seconds=1.0)
+        await sweeper.start()
+        real_task = sweeper._task
+        assert real_task is not None
+        real_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await real_task
+
+        async def _boom_run() -> None:
+            msg = "run boom"
+            raise RuntimeError(msg)
+
+        boom_task = asyncio.create_task(_boom_run())
+        # Drive the task to its RuntimeError so the drain's ``await task``
+        # re-raises it (hitting the non-critical except branch) instead
+        # of seeing a CancelledError.
+        with contextlib.suppress(RuntimeError):
+            await boom_task
+        sweeper._task = boom_task
+
+        # stop() drains the failed task, logs the non-critical error,
+        # and completes without propagating.
+        await sweeper.stop()
+        assert sweeper._task is None
+
+
 class TestSweeperRunLoop:
     async def test_sweep_expires_stale_rows_on_loop_tick(
         self,

--- a/tests/unit/communication/conflict_resolution/test_human_strategy.py
+++ b/tests/unit/communication/conflict_resolution/test_human_strategy.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -33,6 +34,8 @@ from synthorg.communication.errors import (
     EscalationDecisionAgentError,
     EscalationDecisionShapeError,
 )
+from synthorg.notifications.dispatcher import NotificationDispatcher
+from tests._shared import mock_of
 
 from .conftest import make_conflict
 
@@ -283,3 +286,150 @@ class TestHumanEscalationFullLoop:
         row = await store.get("escalation-stale-0001")
         assert row is not None
         assert row.status == EscalationStatus.EXPIRED
+
+
+@pytest.mark.unit
+class TestHumanEscalationErrorPaths:
+    """Storage / notifier / registry failures degrade without swallowing
+    interpreter-critical exceptions."""
+
+    async def test_store_create_failure_reaps_future_and_reraises(self) -> None:
+        store = InMemoryEscalationStore()
+        store.create = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("create boom"),
+        )
+        registry = PendingFuturesRegistry()
+        resolver = HumanEscalationResolver(
+            store=store,
+            registry=registry,
+            timeout_seconds=0,
+        )
+        conflict = make_conflict()
+
+        with pytest.raises(RuntimeError, match="create boom"):
+            await resolver.resolve(conflict)
+
+    async def test_notification_dispatch_failure_is_swallowed(self) -> None:
+        notifier = mock_of[NotificationDispatcher](
+            dispatch=AsyncMock(
+                spec=NotificationDispatcher.dispatch,
+                side_effect=RuntimeError("dispatch boom"),
+            ),
+        )
+        resolver = HumanEscalationResolver(notifier=notifier, timeout_seconds=0)
+        conflict = make_conflict()
+        escalation = resolver._build_escalation(conflict)
+
+        # Notifier is best-effort: a non-critical dispatch failure is
+        # logged and never propagated to the resolver.
+        await resolver._dispatch_notification(escalation, conflict)
+
+    async def test_timeout_cleanup_tolerates_registry_and_store_failures(
+        self,
+    ) -> None:
+        store = InMemoryEscalationStore()
+        store.mark_expired = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("mark_expired boom"),
+        )
+        registry = PendingFuturesRegistry()
+        registry.cancel = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("cancel boom"),
+        )
+        resolver = HumanEscalationResolver(
+            store=store,
+            registry=registry,
+            timeout_seconds=5,
+        )
+        conflict = make_conflict()
+        escalation = resolver._build_escalation(conflict)
+
+        # Both cleanup awaits fail; the method still completes so
+        # ``resolve`` can return its terminal timeout resolution.
+        await resolver._handle_timeout_cleanup(escalation, conflict)
+
+    async def test_cancelled_cleanup_tolerates_registry_and_store_failures(
+        self,
+    ) -> None:
+        store = InMemoryEscalationStore()
+        store.cancel = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("store cancel boom"),
+        )
+        registry = PendingFuturesRegistry()
+        registry.cancel = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("registry cancel boom"),
+        )
+        resolver = HumanEscalationResolver(
+            store=store,
+            registry=registry,
+            timeout_seconds=5,
+        )
+        conflict = make_conflict()
+        escalation = resolver._build_escalation(conflict)
+
+        await resolver._handle_cancelled_cleanup(escalation, conflict)
+
+    async def test_read_late_decision_lookup_failure_returns_none(self) -> None:
+        store = InMemoryEscalationStore()
+        store.get = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("get boom"),
+        )
+        resolver = HumanEscalationResolver(store=store, timeout_seconds=5)
+        conflict = make_conflict()
+        escalation = resolver._build_escalation(conflict)
+
+        result = await resolver._read_late_decision(escalation, conflict)
+
+        assert result is None
+
+    async def test_read_late_decision_tolerates_registry_cancel_failure(
+        self,
+    ) -> None:
+        store = InMemoryEscalationStore()
+        registry = PendingFuturesRegistry()
+        registry.cancel = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("cancel boom"),
+        )
+        resolver = HumanEscalationResolver(
+            store=store,
+            registry=registry,
+            processor=WinnerOnlyDecisionProcessor(),
+            timeout_seconds=5,
+        )
+        conflict = make_conflict()
+        escalation = resolver._build_escalation(conflict)
+        winning_agent_id = conflict.positions[0].agent_id
+        decided_row = escalation.model_copy(
+            update={
+                "status": EscalationStatus.DECIDED,
+                "decided_at": datetime.now(UTC),
+                "decided_by": "human:op-late",
+                "decision": WinnerDecision(
+                    winning_agent_id=winning_agent_id,
+                    reasoning="late decision",
+                ),
+            },
+        )
+        store.get = AsyncMock(  # type: ignore[method-assign]
+            return_value=decided_row,
+        )
+
+        # Registry cancel fails while reaping the future, but the
+        # durable decision is still honoured.
+        resolution = await resolver._read_late_decision(escalation, conflict)
+
+        assert resolution is not None
+        assert resolution.outcome == ConflictResolutionOutcome.RESOLVED_BY_HUMAN
+        assert resolution.winning_agent_id == winning_agent_id
+
+    async def test_resolve_decided_by_lookup_failure_falls_back_to_human(
+        self,
+    ) -> None:
+        store = InMemoryEscalationStore()
+        store.get = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("get boom"),
+        )
+        resolver = HumanEscalationResolver(store=store, timeout_seconds=5)
+
+        decided_by = await resolver._resolve_decided_by("escalation-missing")
+
+        assert decided_by == "human"

--- a/tests/unit/communication/conflict_resolution/test_hybrid_strategy.py
+++ b/tests/unit/communication/conflict_resolution/test_hybrid_strategy.py
@@ -38,6 +38,47 @@ class FakeReviewEvaluator:
         return JudgeDecision(self._winner_id, self._reasoning)
 
 
+class RaisingReviewEvaluator:
+    """Review evaluator whose evaluate() always raises."""
+
+    async def evaluate(
+        self,
+        conflict: Conflict,
+        judge_agent_id: str,
+    ) -> JudgeDecision:
+        msg = "evaluate boom"
+        raise RuntimeError(msg)
+
+
+@pytest.mark.unit
+class TestHybridResolverEvaluatorError:
+    async def test_evaluator_failure_is_logged_and_reraised(
+        self,
+        hierarchy: HierarchyResolver,
+    ) -> None:
+        resolver = HybridResolver(
+            hierarchy=hierarchy,
+            config=HybridConfig(),
+            human_resolver=HumanEscalationResolver(timeout_seconds=0),
+            review_evaluator=RaisingReviewEvaluator(),
+        )
+        conflict = make_conflict(
+            positions=(
+                make_position(agent_id="sr_dev", level=SeniorityLevel.SENIOR),
+                make_position(
+                    agent_id="jr_dev",
+                    level=SeniorityLevel.JUNIOR,
+                    position="Other",
+                ),
+            ),
+        )
+
+        # A non-critical evaluator failure is logged with context and
+        # re-raised (the hybrid resolver does not silently swallow it).
+        with pytest.raises(RuntimeError, match="evaluate boom"):
+            await resolver.resolve(conflict)
+
+
 @pytest.mark.unit
 class TestHybridResolverAutoResolve:
     async def test_clear_winner_auto_resolves(

--- a/tests/unit/communication/conflict_resolution/test_service.py
+++ b/tests/unit/communication/conflict_resolution/test_service.py
@@ -1,9 +1,11 @@
 """Tests for the conflict resolution service."""
 
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock
 
 import pytest
 
+from synthorg.communication.bus_protocol import MessageBus
 from synthorg.communication.conflict_resolution.authority_strategy import (
     AuthorityResolver,
 )
@@ -27,7 +29,9 @@ from synthorg.communication.enums import (
     ConflictType,
 )
 from synthorg.communication.errors import ConflictResolutionError
+from synthorg.communication.event_stream.stream import EventStreamHub
 from synthorg.core.enums import SeniorityLevel
+from tests._shared import mock_of
 
 from .conftest import make_position
 
@@ -501,3 +505,63 @@ class TestAuditTrail:
         await service.resolve(conflict)
         records = service.get_dissent_records()
         assert isinstance(records, tuple)
+
+
+@pytest.mark.unit
+class TestDissentPublishErrorPaths:
+    """Best-effort dissent publication: bus / SSE failures are logged,
+    never propagated, and never swallow interpreter-critical errors."""
+
+    async def test_bus_and_sse_publish_failures_do_not_propagate(
+        self,
+        hierarchy: HierarchyResolver,
+    ) -> None:
+        bus = mock_of[MessageBus](
+            publish=AsyncMock(
+                spec=MessageBus.publish,
+                side_effect=RuntimeError("bus publish boom"),
+            ),
+        )
+        hub = mock_of[EventStreamHub](
+            publish_raw=AsyncMock(
+                spec=EventStreamHub.publish_raw,
+                side_effect=RuntimeError("sse publish boom"),
+            ),
+        )
+        config = ConflictResolutionConfig(
+            strategy=ConflictResolutionStrategy.AUTHORITY,
+        )
+        service = ConflictResolutionService(
+            config=config,
+            resolvers={
+                ConflictResolutionStrategy.AUTHORITY: AuthorityResolver(
+                    hierarchy=hierarchy,
+                ),
+            },
+            message_bus=bus,
+            event_hub=hub,
+        )
+        # task_id gives the SSE path a session id so it reaches the
+        # publish_raw call (rather than the early-return guard).
+        conflict = service.create_conflict(
+            conflict_type=ConflictType.ARCHITECTURE,
+            subject="Design",
+            positions=[
+                make_position(agent_id="sr_dev", level=SeniorityLevel.SENIOR),
+                make_position(
+                    agent_id="jr_dev",
+                    level=SeniorityLevel.JUNIOR,
+                    position="Other",
+                ),
+            ],
+            task_id="task-dissent-fail",
+        )
+
+        # Both publish paths raise non-critical errors; resolve still
+        # returns its resolution and dissent records.
+        resolution, records = await service.resolve(conflict)
+
+        assert resolution.outcome == ConflictResolutionOutcome.RESOLVED_BY_AUTHORITY
+        assert len(records) == 1
+        bus.publish.assert_awaited()
+        hub.publish_raw.assert_awaited()

--- a/tests/unit/communication/meeting/test_orchestrator.py
+++ b/tests/unit/communication/meeting/test_orchestrator.py
@@ -427,6 +427,43 @@ class TestMeetingOrchestratorBudgetExhaustion:
 class TestMeetingOrchestratorTaskCreation:
     """Tests for task creation from action items."""
 
+    def test_task_creator_failure_is_counted_and_swallowed(self) -> None:
+        """A task_creator that raises is logged per-item; _create_tasks
+        does not propagate (best-effort task fan-out)."""
+
+        def _raising_creator(
+            desc: str,
+            assignee: str | None,
+            priority: Priority,
+        ) -> None:
+            msg = "task create boom"
+            raise RuntimeError(msg)
+
+        orchestrator = _make_orchestrator(task_creator=_raising_creator)
+        now = datetime.now(UTC)
+        agenda = MeetingAgenda(title="Test")
+        minutes = MeetingMinutes(
+            meeting_id="m-fail",
+            protocol_type=MeetingProtocolType.ROUND_ROBIN,
+            leader_id="leader",
+            participant_ids=("agent-a",),
+            agenda=agenda,
+            action_items=(
+                ActionItem(description="Deploy API", priority=Priority.HIGH),
+                ActionItem(description="Write docs"),
+            ),
+            started_at=now,
+            ended_at=now,
+        )
+
+        # Each task_creator call raises; the failures are counted and
+        # logged but never propagate out of _create_tasks.
+        orchestrator._create_tasks(
+            "m-fail",
+            MeetingProtocolConfig(),
+            minutes,
+        )
+
     async def test_task_creator_called_with_correct_args(self) -> None:
         """Task creator receives correct args from action items."""
         created_tasks: list[tuple[str, str | None, Priority]] = []

--- a/tests/unit/communication/meeting/test_scheduler.py
+++ b/tests/unit/communication/meeting/test_scheduler.py
@@ -549,14 +549,19 @@ class _FakeCooldownRepo:
         *,
         initial: tuple[MeetingCooldownRecord, ...] = (),
         fail_save: bool = False,
+        fail_load: bool = False,
     ) -> None:
         self._rows: dict[str, MeetingCooldownRecord] = {
             r.meeting_type_name: r for r in initial
         }
         self._fail_save = fail_save
+        self._fail_load = fail_load
         self.saved: list[MeetingCooldownRecord] = []
 
     async def load_all(self) -> tuple[MeetingCooldownRecord, ...]:
+        if self._fail_load:
+            msg = "cooldown read failed"
+            raise QueryError(msg)
         return tuple(self._rows.values())
 
     async def save(self, entity: MeetingCooldownRecord) -> None:
@@ -640,3 +645,26 @@ class TestMeetingSchedulerCooldownPersistence:
 
         assert "stale_type" not in scheduler._last_triggered
         assert "persisted_type" in scheduler._last_triggered
+
+    async def test_hydrate_failure_aborts_start(
+        self, orchestrator: MagicMock, resolver: MagicMock
+    ) -> None:
+        """A cooldown load failure aborts startup instead of running empty.
+
+        Continuing with an empty ``_last_triggered`` would silently drop
+        the persisted cooldown floor and let an event-triggered meeting
+        re-fire immediately after a restart, so the failure must surface.
+        """
+        config = _make_config(types=(_make_trigger_type(),))
+        scheduler = MeetingScheduler(
+            config=config,
+            orchestrator=orchestrator,
+            participant_resolver=resolver,
+            cooldown_repo=_FakeCooldownRepo(fail_load=True),
+        )
+
+        with pytest.raises(QueryError):
+            await scheduler.start()
+
+        assert scheduler.running is False
+        assert scheduler._last_triggered == {}

--- a/tests/unit/integrations/test_rate_limiter_shared_state_errors.py
+++ b/tests/unit/integrations/test_rate_limiter_shared_state_errors.py
@@ -36,10 +36,12 @@ class TestSharedRateLimitErrorPaths:
         await coord.start()
 
         # Subscribe failure is swallowed: coordinator marks itself
-        # started but degraded to in-process (non-distributed) mode.
+        # started but degraded to in-process (non-distributed) mode,
+        # with no live bus subscription recorded.
         assert coord._started is True
         assert coord._distributed is False
         assert coord._task is None
+        assert coord._subscribed is False
 
     async def test_stop_unsubscribe_failure_reraises_and_preserves_flags(
         self,
@@ -53,6 +55,7 @@ class TestSharedRateLimitErrorPaths:
         coord = SharedRateLimitCoordinator(bus=bus, connection_name="unsub-fail")
         coord._started = True
         coord._distributed = True
+        coord._subscribed = True
 
         with pytest.raises(RuntimeError, match="unsubscribe boom"):
             await coord.stop()
@@ -61,6 +64,31 @@ class TestSharedRateLimitErrorPaths:
         # start() cannot reuse the subscriber id against a ghost sub.
         assert coord._started is True
         assert coord._distributed is True
+        assert coord._subscribed is True
+
+    async def test_stop_after_local_only_fallback_skips_unsubscribe(self) -> None:
+        unsubscribe = AsyncMock(spec=MessageBus.unsubscribe)
+        bus = mock_of[MessageBus](
+            subscribe=AsyncMock(
+                spec=MessageBus.subscribe,
+                side_effect=RuntimeError("subscribe boom"),
+            ),
+            unsubscribe=unsubscribe,
+        )
+        coord = SharedRateLimitCoordinator(bus=bus, connection_name="local-only")
+
+        await coord.start()
+        # Fell back to local-only: no bus registration was created.
+        assert coord._subscribed is False
+
+        # stop() must not try to unsubscribe a never-registered
+        # subscriber (the bus would raise NotSubscribedError); it
+        # cleanly resets the lifecycle flags instead.
+        await coord.stop()
+
+        unsubscribe.assert_not_awaited()
+        assert coord._started is False
+        assert coord._distributed is False
 
     async def test_publish_failure_falls_back_to_local(self) -> None:
         bus = mock_of[MessageBus](
@@ -107,6 +135,7 @@ class TestSharedRateLimitErrorPaths:
             doomed = SharedRateLimitCoordinator(bus=bus, connection_name="doomed")
             doomed._started = True
             doomed._distributed = True
+            doomed._subscribed = True
             shared_state_module._coordinators["doomed"] = doomed
 
             def new_factory(name: str) -> SharedRateLimitCoordinator:

--- a/tests/unit/integrations/test_rate_limiter_shared_state_errors.py
+++ b/tests/unit/integrations/test_rate_limiter_shared_state_errors.py
@@ -1,0 +1,127 @@
+"""Error-handling branches for the shared rate-limit coordinator.
+
+Bus failures (subscribe / unsubscribe / publish / receive) must
+degrade the coordinator gracefully -- falling back to local-only
+coordination or surfacing the failure -- rather than letting a
+broad ``except`` swallow an interpreter-critical exception. These
+exercise the ``reraise_critical`` guard sites with non-critical
+exceptions so the recovery path runs.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from synthorg.communication.bus_protocol import MessageBus
+from synthorg.integrations.rate_limiting import shared_state as shared_state_module
+from synthorg.integrations.rate_limiting.shared_state import (
+    SharedRateLimitCoordinator,
+    set_coordinator_factory,
+)
+from tests._shared import mock_of
+
+
+@pytest.mark.unit
+class TestSharedRateLimitErrorPaths:
+    async def test_start_subscribe_failure_falls_back_to_local(self) -> None:
+        bus = mock_of[MessageBus](
+            subscribe=AsyncMock(
+                spec=MessageBus.subscribe,
+                side_effect=RuntimeError("subscribe boom"),
+            ),
+        )
+        coord = SharedRateLimitCoordinator(bus=bus, connection_name="sub-fail")
+
+        await coord.start()
+
+        # Subscribe failure is swallowed: coordinator marks itself
+        # started but degraded to in-process (non-distributed) mode.
+        assert coord._started is True
+        assert coord._distributed is False
+        assert coord._task is None
+
+    async def test_stop_unsubscribe_failure_reraises_and_preserves_flags(
+        self,
+    ) -> None:
+        bus = mock_of[MessageBus](
+            unsubscribe=AsyncMock(
+                spec=MessageBus.unsubscribe,
+                side_effect=RuntimeError("unsubscribe boom"),
+            ),
+        )
+        coord = SharedRateLimitCoordinator(bus=bus, connection_name="unsub-fail")
+        coord._started = True
+        coord._distributed = True
+
+        with pytest.raises(RuntimeError, match="unsubscribe boom"):
+            await coord.stop()
+
+        # A failed unsubscribe leaves the flags untouched so a later
+        # start() cannot reuse the subscriber id against a ghost sub.
+        assert coord._started is True
+        assert coord._distributed is True
+
+    async def test_publish_failure_falls_back_to_local(self) -> None:
+        bus = mock_of[MessageBus](
+            publish=AsyncMock(
+                spec=MessageBus.publish,
+                side_effect=RuntimeError("publish boom"),
+            ),
+        )
+        coord = SharedRateLimitCoordinator(bus=bus, connection_name="pub-fail")
+        coord._distributed = True
+
+        await coord._publish_acquire(0.0)
+
+        # Publish failure drops the coordinator to local-only mode.
+        assert coord._distributed is False
+
+    async def test_poll_loop_receive_failure_falls_back_and_exits(self) -> None:
+        bus = mock_of[MessageBus](
+            receive=AsyncMock(
+                spec=MessageBus.receive,
+                side_effect=RuntimeError("receive boom"),
+            ),
+        )
+        coord = SharedRateLimitCoordinator(bus=bus, connection_name="poll-fail")
+        coord._distributed = True
+
+        # A non-cancellation error in the poll loop degrades to
+        # local-only and returns (does not spin).
+        await asyncio.wait_for(coord._poll_loop(), timeout=2.0)
+
+        assert coord._distributed is False
+
+    async def test_factory_swap_tolerates_stop_failure(self) -> None:
+        original_factory = shared_state_module._coordinator_factory
+        original_coordinators = dict(shared_state_module._coordinators)
+        try:
+            shared_state_module._coordinators.clear()
+            bus = mock_of[MessageBus](
+                unsubscribe=AsyncMock(
+                    spec=MessageBus.unsubscribe,
+                    side_effect=RuntimeError("stop boom"),
+                ),
+            )
+            doomed = SharedRateLimitCoordinator(bus=bus, connection_name="doomed")
+            doomed._started = True
+            doomed._distributed = True
+            shared_state_module._coordinators["doomed"] = doomed
+
+            def new_factory(name: str) -> SharedRateLimitCoordinator:
+                return SharedRateLimitCoordinator(
+                    bus=mock_of[MessageBus](),
+                    connection_name=name,
+                )
+
+            # The swap stops outgoing coordinators; a stop() failure is
+            # logged, not propagated, so the swap still completes.
+            await set_coordinator_factory(new_factory)
+
+            assert shared_state_module._coordinator_factory is new_factory
+            assert shared_state_module._coordinators == {}
+        finally:
+            shared_state_module._coordinators.clear()
+            shared_state_module._coordinators.update(original_coordinators)
+            shared_state_module._coordinator_factory = original_factory

--- a/tests/unit/observability/test_log_trace_correlation.py
+++ b/tests/unit/observability/test_log_trace_correlation.py
@@ -1,0 +1,25 @@
+"""Error-path coverage for the trace-correlation log processor."""
+
+from unittest.mock import patch
+
+import pytest
+
+from synthorg.observability.log_trace_correlation import inject_trace_context
+
+
+@pytest.mark.unit
+class TestInjectTraceContextErrorPaths:
+    def test_span_lookup_failure_fails_open(self) -> None:
+        event_dict = {"event": "something happened"}
+
+        # A non-critical OTel failure during the current-span lookup
+        # must not drop the log record: the processor returns the dict
+        # unchanged (best-effort enrichment, fail open).
+        with patch(
+            "opentelemetry.trace.get_current_span",
+            side_effect=RuntimeError("otel boom"),
+        ):
+            result = inject_trace_context(None, "info", event_dict)
+
+        assert result is event_dict
+        assert "trace_id" not in result

--- a/tests/unit/observability/test_otlp_handler.py
+++ b/tests/unit/observability/test_otlp_handler.py
@@ -272,3 +272,72 @@ class TestOtlpHandlerExportFailure:
                 handler.close()
         # After close, queue should be empty
         assert handler._queue.empty()
+
+
+@pytest.mark.unit
+class TestOtlpHandlerInternalErrorPaths:
+    """Internal failures route through ``handleError`` / are logged
+    without propagating out of the logging hot path."""
+
+    def test_enqueue_queue_failure_calls_handle_error(self) -> None:
+        handler = _make_handler()
+        try:
+            failing_queue = MagicMock()
+            failing_queue.put_nowait.side_effect = RuntimeError("queue boom")
+            handler._queue = failing_queue  # type: ignore[assignment]
+            handled: list[logging.LogRecord] = []
+            handler.handleError = handled.append  # type: ignore[method-assign,assignment]
+
+            handler._enqueue(_make_record("drop me"))
+
+            assert len(handled) == 1
+        finally:
+            # Restore a real, empty queue so close()'s drain terminates.
+            handler._queue = queue.SimpleQueue()
+            handler.close()
+
+    def test_export_batch_format_failure_increments_dropped(self) -> None:
+        handler = _make_handler(batch_size=1)
+        try:
+            handled: list[logging.LogRecord] = []
+            handler.handleError = handled.append  # type: ignore[method-assign,assignment]
+
+            def _boom_format(_record: logging.LogRecord) -> dict[str, object]:
+                msg = "format boom"
+                raise RuntimeError(msg)
+
+            handler._format_as_otlp_dict = _boom_format  # type: ignore[method-assign,assignment]
+
+            handler._export_batch([_make_record("bad")])
+
+            assert len(handled) == 1
+            with handler._pending_lock:
+                assert handler._dropped_count == 1
+        finally:
+            handler.close()
+
+    def test_flush_loop_drain_failure_is_logged(self) -> None:
+        handler = _make_handler()
+        try:
+            calls = {"n": 0}
+
+            def _boom_drain() -> None:
+                calls["n"] += 1
+                # Stop after one iteration so the loop exits cleanly.
+                handler._shutdown.set()
+                msg = "drain boom"
+                raise RuntimeError(msg)
+
+            handler._drain_and_flush = _boom_drain  # type: ignore[method-assign]
+            handler._batch_ready.set()
+
+            # One iteration: drain raises, the except logs, and the
+            # shutdown flag set above ends the loop.
+            handler._flush_loop()
+
+            assert calls["n"] == 1
+            # Neutralise the raising drain so close()'s own drain is a
+            # no-op rather than re-raising during teardown.
+            handler._drain_and_flush = lambda: None  # type: ignore[method-assign]
+        finally:
+            handler.close()

--- a/tests/unit/observability/test_prometheus_collector.py
+++ b/tests/unit/observability/test_prometheus_collector.py
@@ -6,7 +6,10 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock
 import pytest
 from prometheus_client import generate_latest
 
-from synthorg.observability.prometheus_collector import PrometheusCollector
+from synthorg.observability.prometheus_collector import (
+    PrometheusCollector,
+    _fetch_tool_names,
+)
 
 
 def _mock_app_state(  # noqa: PLR0913
@@ -753,3 +756,51 @@ class TestPrometheusCollectorAgentCost:
             if ln.startswith("synthorg_agent_cost_total{")
         ]
         assert len(cost_lines) == 0
+
+
+@pytest.mark.unit
+class TestPrometheusCollectorErrorPaths:
+    """Each metric fetcher swallows non-critical failures so one broken
+    source does not abort the whole scrape."""
+
+    async def test_fetch_tool_names_registry_failure_returns_none(self) -> None:
+        state = _mock_app_state()
+        state.tool_registry.list_tools.side_effect = RuntimeError("registry boom")
+
+        # A failing tool registry yields ``None`` so the merge step keeps
+        # the prior allowlist instead of cancelling sibling fetchers.
+        assert (await _fetch_tool_names(state)) is None
+
+    def test_pg_pool_stats_failure_is_swallowed(self) -> None:
+        collector = PrometheusCollector()
+        state = MagicMock()
+        type(state).has_persistence = PropertyMock(return_value=True)
+        backend = MagicMock()
+        backend.kind = "postgres"
+        pool = MagicMock()
+        pool.get_stats.side_effect = RuntimeError("pool stats boom")
+        backend._pool = pool
+        type(state).persistence = PropertyMock(return_value=backend)
+
+        # A pool-stats failure logs and returns without raising.
+        collector._refresh_pg_pool_metrics(state)
+
+    def test_budget_metrics_failure_clears_gauges(self) -> None:
+        collector = PrometheusCollector()
+        state = MagicMock()
+        type(state).has_cost_tracker = PropertyMock(return_value=True)
+        type(state).cost_tracker = PropertyMock(
+            side_effect=RuntimeError("tracker boom"),
+        )
+
+        # A cost-tracker failure resets the budget gauges to zero rather
+        # than leaving stale values.
+        collector._refresh_budget_metrics(state, billing_cost=10.0)
+
+    async def test_task_metrics_failure_is_swallowed(self) -> None:
+        collector = PrometheusCollector()
+        state = _mock_app_state(has_task_engine=True)
+        state.task_engine.list_tasks.side_effect = RuntimeError("list boom")
+
+        # A task-engine failure logs and returns without raising.
+        await collector._refresh_task_metrics(state)

--- a/tests/unit/providers/management/test_allowlist_error_paths.py
+++ b/tests/unit/providers/management/test_allowlist_error_paths.py
@@ -1,0 +1,56 @@
+"""Error-path coverage for the discovery allowlist manager.
+
+The ``update_for_*`` hooks are best-effort: a settings-layer failure
+while loading or persisting the allowlist is logged and swallowed
+(never propagated into provider CRUD), and an interpreter-critical
+exception still escapes via ``reraise_critical``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from synthorg.providers.management.allowlist import DiscoveryAllowlistManager
+from synthorg.settings.resolver import ConfigResolver
+from synthorg.settings.service import SettingsService
+from tests._shared import mock_of
+
+
+def _failing_manager() -> DiscoveryAllowlistManager:
+    """Manager whose settings load always raises a non-critical error."""
+    settings = mock_of[SettingsService](
+        get=AsyncMock(
+            spec=SettingsService.get,
+            side_effect=RuntimeError("settings boom"),
+        ),
+    )
+    resolver = mock_of[ConfigResolver]()
+    return DiscoveryAllowlistManager(
+        settings_service=settings,
+        config_resolver=resolver,
+    )
+
+
+@pytest.mark.unit
+class TestAllowlistUpdateErrorPaths:
+    async def test_update_for_create_swallows_load_failure(self) -> None:
+        manager = _failing_manager()
+        config = SimpleNamespace(base_url="http://my-server:9090/v1")
+
+        # Settings failure is logged, not raised, so provider create
+        # is not blocked by an allowlist hiccup.
+        await manager.update_for_create(config)  # type: ignore[arg-type]
+
+    async def test_update_for_delete_swallows_load_failure(self) -> None:
+        manager = _failing_manager()
+        removed = SimpleNamespace(base_url="http://del-server:8080/v1")
+
+        await manager.update_for_delete(removed, {})  # type: ignore[arg-type]
+
+    async def test_update_for_update_swallows_load_failure(self) -> None:
+        manager = _failing_manager()
+        old = SimpleNamespace(base_url="http://old-server:8080/v1")
+        new = SimpleNamespace(base_url="http://new-server:9090/v1")
+
+        await manager.update_for_update(old, new, {})  # type: ignore[arg-type]


### PR DESCRIPTION
Reworked from the original Wave 5 docstring backfill.

## Why this was reworked

The Wave 5 docstring backfill produced machine-generated **filler** docstrings: templated `Internal helper: init` stubs, tautological `Returns:` ("the value captured by the summary above"), and `Returns:`/`Raises:` text that contradicted the implementation. CodeRabbit flagged ~503 such defects across **171 of the ~300** touched files. An inaccurate docstring is worse than none, so rather than hand-patch 500+ filler docstrings, this PR **drops the docstring backfill** and keeps only the sound changes.

## Kept (the sound parts)

- **`reraise_critical` adoption** at broad `except Exception:` sites across `communication/`, `security/`, `observability/`, `integrations/`, `providers/`, `settings/`, `core/`. The premature/duplicated `reraise_critical` ordering bug in `_nats_receive.py` (Gemini-flagged: slot never released on the critical re-raise path) is fixed.
- **Error-path unit tests** covering the new `reraise_critical` except blocks (rate-limit shared-state, conflict-resolution human/service/notify/sweeper/hybrid plus meeting orchestrator, prometheus/OTLP/log-trace handlers, NATS KV, discovery allowlist).

## Added (prevent recurrence)

- **`scripts/check_no_boilerplate_docstrings.py`** gate, wired into pre-commit + CI, blocking the exact machine-artifact phrases the backfill emitted (`Internal helper:`, `violates a validator`, `captured by the summary above`, `As raised by the surrounding logic`, `The numeric value captured`). Each was verified to occur **zero** times in the pre-existing tree, so the gate has no false positives: it only catches filler. Future docstring waves must produce real, intent-focused text.

## Dropped / deferred

- The docstring backfill for the seven packages is **not** in this PR. `pyproject.toml`'s docstring-rule enablement is reverted to match `main`. Issue #2113's docstring goal should be redone with a generation method that produces accurate docstrings (the new gate enforces non-filler).

Part of #2065.
