### PR TITLE
test: add table-driven tests for zero-coverage CLI command functions

### DIFF
--- a/cli/cmd/cleanup_test.go
+++ b/cli/cmd/cleanup_test.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Aureliolo/synthorg/cli/internal/ui"
+)
+
+// TestIsImageInUse pins the classifier that decides whether a
+// `docker rmi` failure is a benign "image still in use" skip (warn and
+// continue) or a hard failure that must surface as a runtime error. The
+// match is a case-sensitive substring test against the four phrases
+// Docker emits for in-use / dependent images.
+func TestIsImageInUse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		errMsg string
+		want   bool
+	}{
+		{"image being used", "Error response from daemon: image is being used by running container abc123", true},
+		{"conflict", "Error: conflict: unable to delete deadbeef (must be forced)", true},
+		{"dependent child images", "Error: image has dependent child images", true},
+		{"image referenced", "Error: image is referenced in multiple repositories", true},
+
+		{"permission denied is a hard failure", "permission denied while trying to connect to the Docker daemon", false},
+		{"missing image is a hard failure", "Error: no such image: deadbeef", false},
+		{"network error is a hard failure", "network timeout contacting registry", false},
+		{"empty message", "", false},
+
+		// Case-sensitivity boundary: strings.Contains is case-sensitive
+		// and Docker emits lowercase "conflict", so a capitalised variant
+		// must NOT match.
+		{"capitalised conflict does not match", "Conflict: unable to delete", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isImageInUse(errors.New(tt.errMsg)); got != tt.want {
+				t.Errorf("isImageInUse(%q) = %v, want %v", tt.errMsg, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsImageInUseWrappedError confirms the classifier reads through
+// wrapped errors: isImageInUse calls err.Error(), which flattens the
+// wrapped chain, so an in-use sentinel wrapped with %w is still matched.
+func TestIsImageInUseWrappedError(t *testing.T) {
+	t.Parallel()
+	wrapped := fmt.Errorf("rmi failed for deadbeef: %w", errors.New("conflict: in use"))
+	if !isImageInUse(wrapped) {
+		t.Errorf("isImageInUse(%q) = false, want true (wrapped in-use error)", wrapped)
+	}
+}
+
+// TestEmitCleanupSummary pins the post-cleanup output shape across every
+// branch: the freed-vs-removed success line, the skipped-image hint, and
+// the --keep guidance (which only renders in hints=always mode and only
+// when at least one image was removed). It writes to a buffer-bound UI
+// and asserts on substrings, matching the update_walk_test.go pattern.
+func TestEmitCleanupSummary(t *testing.T) {
+	t.Parallel()
+
+	mkImages := func(n int) []oldImage {
+		imgs := make([]oldImage, n)
+		for i := range imgs {
+			imgs[i] = oldImage{id: fmt.Sprintf("img%09d", i), display: "repo", sizeB: 1e6}
+		}
+		return imgs
+	}
+
+	tests := []struct {
+		name        string
+		old         []oldImage
+		removed     int
+		freedB      float64
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name:        "all removed with size freed",
+			old:         mkImages(3),
+			removed:     3,
+			freedB:      1.5e9,
+			wantContain: []string{"Freed", "1.5 GB", "3 image(s) removed", "--keep"},
+			wantAbsent:  []string{"skipped"},
+		},
+		{
+			name:        "removed with zero bytes freed",
+			old:         mkImages(2),
+			removed:     2,
+			freedB:      0,
+			wantContain: []string{"Removed 2 image(s)", "--keep"},
+			wantAbsent:  []string{"Freed", "skipped"},
+		},
+		{
+			name:        "partial removal reports skipped",
+			old:         mkImages(3),
+			removed:     1,
+			freedB:      5e8,
+			wantContain: []string{"Freed", "500.0 MB", "2 image(s) skipped", "--keep"},
+		},
+		{
+			name:        "none removed reports only skipped",
+			old:         mkImages(2),
+			removed:     0,
+			freedB:      0,
+			wantContain: []string{"2 image(s) skipped"},
+			wantAbsent:  []string{"Freed", "Removed", "--keep"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			// Hints: "always" so the HintGuidance --keep line renders;
+			// NoColor strips ANSI so substring assertions are stable.
+			out := ui.NewUIWithOptions(&buf, ui.Options{NoColor: true, Hints: "always"})
+
+			emitCleanupSummary(out, tt.old, tt.removed, tt.freedB)
+
+			got := buf.String()
+			for _, want := range tt.wantContain {
+				if !strings.Contains(got, want) {
+					t.Errorf("summary missing %q\n--- got ---\n%s", want, got)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("summary unexpectedly contains %q\n--- got ---\n%s", absent, got)
+				}
+			}
+		})
+	}
+}

--- a/cli/cmd/flags_test.go
+++ b/cli/cmd/flags_test.go
@@ -71,6 +71,46 @@ func TestValidateCleanupFlags(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
+
+	t.Run("zero keep is valid boundary", func(t *testing.T) {
+		old := cleanupKeep
+		defer func() { cleanupKeep = old }()
+		cleanupKeep = 0
+		if err := validateCleanupFlags(); err != nil {
+			t.Errorf("unexpected error for --keep 0: %v", err)
+		}
+	})
+
+	t.Run("large keep is valid", func(t *testing.T) {
+		old := cleanupKeep
+		defer func() { cleanupKeep = old }()
+		cleanupKeep = 100
+		if err := validateCleanupFlags(); err != nil {
+			t.Errorf("unexpected error for --keep 100: %v", err)
+		}
+	})
+
+	// validateCleanupFlags only checks cleanupKeep; it does not reference
+	// cleanupAll. This guards that contract: --all does not change the
+	// keep-validation verdict (the real --all/--keep interaction lives in
+	// the docker-dependent collectCleanupCandidates and is out of scope
+	// for unit tests). cleanupAll is saved/restored even though unused.
+	t.Run("cleanupAll does not affect keep validation", func(t *testing.T) {
+		oldKeep, oldAll := cleanupKeep, cleanupAll
+		defer func() { cleanupKeep, cleanupAll = oldKeep, oldAll }()
+		cleanupAll = true
+
+		for _, keep := range []int{0, 5} {
+			cleanupKeep = keep
+			if err := validateCleanupFlags(); err != nil {
+				t.Errorf("unexpected error for --all --keep %d: %v", keep, err)
+			}
+		}
+		cleanupKeep = -1
+		if err := validateCleanupFlags(); err == nil {
+			t.Error("expected error for --all --keep -1 (negative keep must still fail)")
+		}
+	})
 }
 
 // --- doctor flag validation ---

--- a/cli/cmd/logs_test.go
+++ b/cli/cmd/logs_test.go
@@ -58,6 +58,13 @@ func TestValidateLogsInput(t *testing.T) {
 		{name: "service with slash rejected", tail: "100", services: []string{"back/end"}, wantErr: true},
 		{name: "service with command substitution rejected", tail: "100", services: []string{"back$(x)"}, wantErr: true},
 		{name: "service with bang rejected", tail: "100", services: []string{"svc!"}, wantErr: true},
+		// Control characters and remaining shell metacharacters. The
+		// pattern is non-multiline, so `$` anchors end-of-string and a
+		// trailing newline cannot smuggle a second token past the gate.
+		{name: "service with newline rejected", tail: "100", services: []string{"back\nend"}, wantErr: true},
+		{name: "service with null byte rejected", tail: "100", services: []string{"back\x00end"}, wantErr: true},
+		{name: "service with backtick rejected", tail: "100", services: []string{"back`cmd`"}, wantErr: true},
+		{name: "service with pipe rejected", tail: "100", services: []string{"back|end"}, wantErr: true},
 		{name: "second service invalid is rejected", tail: "100", services: []string{"backend", "bad;svc"}, wantErr: true},
 
 		// Current-behaviour documentation: a flag-shaped service name

--- a/cli/cmd/logs_test.go
+++ b/cli/cmd/logs_test.go
@@ -1,0 +1,212 @@
+package cmd
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestValidateLogsInput pins the injection-safety gate for `synthorg
+// logs`. The three input families each have their own validator:
+//   - --tail: positive integer or the literal "all" (whitespace-trimmed)
+//   - --since/--until: timeFilterPattern, anchored to a leading
+//     alphanumeric so flag-shaped values (leading '-') are rejected
+//   - service names: serviceNamePattern, restricting to
+//     [a-zA-Z0-9_-]+ so shell metacharacters cannot reach the
+//     `docker compose logs` argv
+//
+// validateLogsInput takes all inputs as parameters (no package
+// globals), so the cases run in parallel.
+func TestValidateLogsInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		tail     string
+		since    string
+		until    string
+		services []string
+		wantErr  bool
+	}{
+		// --- tail ---
+		{name: "default tail accepted", tail: "100"},
+		{name: "tail all accepted", tail: "all"},
+		{name: "tail with surrounding whitespace trimmed", tail: " 50 "},
+		{name: "tail zero rejected", tail: "0", wantErr: true},
+		{name: "tail negative rejected", tail: "-5", wantErr: true},
+		{name: "tail non-numeric rejected", tail: "abc", wantErr: true},
+		{name: "tail empty rejected", tail: "", wantErr: true},
+		{name: "tail fractional rejected", tail: "12.5", wantErr: true},
+
+		// --- since / until accept ---
+		{name: "since relative duration accepted", tail: "100", since: "1h"},
+		{name: "since date accepted", tail: "100", since: "2024-01-01"},
+		{name: "until rfc3339 timestamp accepted", tail: "100", until: "2024-01-01T00:00:00Z"},
+
+		// --- since / until reject (flag-shaped + metacharacters) ---
+		{name: "since flag-shaped rejected", tail: "100", since: "--evil", wantErr: true},
+		{name: "since flag-with-value rejected", tail: "100", since: "--since=x", wantErr: true},
+		{name: "since leading hyphen duration rejected", tail: "100", since: "-1h", wantErr: true},
+		{name: "since with space rejected", tail: "100", since: "1 hour", wantErr: true},
+		{name: "until flag-shaped rejected", tail: "100", until: "--rm", wantErr: true},
+
+		// --- service names ---
+		{name: "service plain accepted", tail: "100", services: []string{"backend"}},
+		{name: "service with underscore accepted", tail: "100", services: []string{"web_1"}},
+		{name: "service with hyphen accepted", tail: "100", services: []string{"synthorg-backend"}},
+		{name: "service with space rejected", tail: "100", services: []string{"back end"}, wantErr: true},
+		{name: "service with semicolon rejected", tail: "100", services: []string{"back;rm"}, wantErr: true},
+		{name: "service with slash rejected", tail: "100", services: []string{"back/end"}, wantErr: true},
+		{name: "service with command substitution rejected", tail: "100", services: []string{"back$(x)"}, wantErr: true},
+		{name: "service with bang rejected", tail: "100", services: []string{"svc!"}, wantErr: true},
+		{name: "second service invalid is rejected", tail: "100", services: []string{"backend", "bad;svc"}, wantErr: true},
+
+		// Current-behaviour documentation: a flag-shaped service name
+		// passes serviceNamePattern because '-' is a member of the
+		// allowed class. It is NOT rejected here; the `--` separator
+		// emitted by buildLogsArgs (asserted in TestBuildLogsArgs) is
+		// what neutralises it for docker compose.
+		{name: "flag-shaped service accepted by name gate", tail: "100", services: []string{"--evil"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateLogsInput(tt.tail, tt.since, tt.until, tt.services)
+			if tt.wantErr && err == nil {
+				t.Errorf("validateLogsInput(%q, %q, %q, %v) = nil, want error",
+					tt.tail, tt.since, tt.until, tt.services)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("validateLogsInput(%q, %q, %q, %v) = %v, want nil",
+					tt.tail, tt.since, tt.until, tt.services, err)
+			}
+		})
+	}
+}
+
+// TestBuildLogsArgs pins the full flag-to-args mapping for `docker
+// compose logs`, including the load-bearing `--` separator that
+// terminates flag parsing immediately before the user-supplied service
+// list. buildLogsArgs reads the logFollow / logSince / logUntil /
+// logTimestamps / logNoPrefix package globals, so cases mutate them in
+// place under a single t.Cleanup and the test does NOT run in parallel.
+func TestBuildLogsArgs(t *testing.T) {
+	origFollow, origSince, origUntil := logFollow, logSince, logUntil
+	origTimestamps, origNoPrefix := logTimestamps, logNoPrefix
+	t.Cleanup(func() {
+		logFollow, logSince, logUntil = origFollow, origSince, origUntil
+		logTimestamps, logNoPrefix = origTimestamps, origNoPrefix
+	})
+
+	tests := []struct {
+		name       string
+		follow     bool
+		since      string
+		until      string
+		timestamps bool
+		noPrefix   bool
+		tail       string
+		services   []string
+		wantArgs   []string
+	}{
+		{
+			name:     "defaults",
+			tail:     "100",
+			wantArgs: []string{"logs", "--tail", "100", "--"},
+		},
+		{
+			name:     "follow",
+			follow:   true,
+			tail:     "100",
+			wantArgs: []string{"logs", "--tail", "100", "-f", "--"},
+		},
+		{
+			name:     "since",
+			since:    "1h",
+			tail:     "100",
+			wantArgs: []string{"logs", "--tail", "100", "--since", "1h", "--"},
+		},
+		{
+			name:     "until",
+			until:    "2024-01-01",
+			tail:     "100",
+			wantArgs: []string{"logs", "--tail", "100", "--until", "2024-01-01", "--"},
+		},
+		{
+			name:       "timestamps",
+			timestamps: true,
+			tail:       "100",
+			wantArgs:   []string{"logs", "--tail", "100", "--timestamps", "--"},
+		},
+		{
+			name:     "no log prefix",
+			noPrefix: true,
+			tail:     "100",
+			wantArgs: []string{"logs", "--tail", "100", "--no-log-prefix", "--"},
+		},
+		{
+			name:     "tail all passthrough",
+			tail:     "all",
+			wantArgs: []string{"logs", "--tail", "all", "--"},
+		},
+		{
+			name:     "single service selection",
+			tail:     "50",
+			services: []string{"backend"},
+			wantArgs: []string{"logs", "--tail", "50", "--", "backend"},
+		},
+		{
+			name:       "all flags with two services preserves order",
+			follow:     true,
+			since:      "2h",
+			until:      "2024-02-02",
+			timestamps: true,
+			noPrefix:   true,
+			tail:       "200",
+			services:   []string{"backend", "web"},
+			wantArgs: []string{
+				"logs", "--tail", "200", "-f",
+				"--since", "2h", "--until", "2024-02-02",
+				"--timestamps", "--no-log-prefix",
+				"--", "backend", "web",
+			},
+		},
+		{
+			name:     "flag-shaped service sits after the separator",
+			tail:     "100",
+			services: []string{"--evil"},
+			wantArgs: []string{"logs", "--tail", "100", "--", "--evil"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Assign all five globals every iteration so no case inherits
+			// leftover state from a prior one.
+			logFollow, logSince, logUntil = tt.follow, tt.since, tt.until
+			logTimestamps, logNoPrefix = tt.timestamps, tt.noPrefix
+
+			got := buildLogsArgs(tt.tail, tt.services)
+			if !slices.Equal(got, tt.wantArgs) {
+				t.Fatalf("buildLogsArgs(%q, %v) = %v, want %v", tt.tail, tt.services, got, tt.wantArgs)
+			}
+
+			// Injection guard: the `--` separator must sit immediately
+			// before the service list and every service token must come
+			// after it, so a hyphen-leading service can never be parsed
+			// as a flag by docker compose.
+			sep := slices.Index(got, "--")
+			if sep == -1 {
+				t.Fatalf("buildLogsArgs() = %v, missing %q separator", got, "--")
+			}
+			if !slices.Equal(got[sep+1:], tt.services) {
+				t.Errorf("tokens after %q separator = %v, want services %v", "--", got[sep+1:], tt.services)
+			}
+			for _, svc := range tt.services {
+				if before := slices.Index(got[:sep], svc); before != -1 {
+					t.Errorf("service %q appears at index %d before the %q separator (index %d)", svc, before, "--", sep)
+				}
+			}
+		})
+	}
+}

--- a/cli/cmd/stop_test.go
+++ b/cli/cmd/stop_test.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestBuildDownArgs locks down the `docker compose down` argument
+// construction. This is the data-destruction path: the --volumes flag
+// permanently removes the named volumes (database, memory), so the
+// table pins exactly when it is emitted, how --timeout is parsed, and
+// the precise argument ordering. buildDownArgs reads the stopTimeout /
+// stopVolumes package globals, so the cases mutate them in place and a
+// single t.Cleanup restores the originals; the test must NOT run in
+// parallel (shared mutable globals).
+func TestBuildDownArgs(t *testing.T) {
+	origTimeout, origVolumes := stopTimeout, stopVolumes
+	t.Cleanup(func() { stopTimeout, stopVolumes = origTimeout, origVolumes })
+
+	tests := []struct {
+		name     string
+		timeout  string
+		volumes  bool
+		wantArgs []string
+		wantErr  bool
+	}{
+		{
+			name:     "no flags",
+			timeout:  "",
+			volumes:  false,
+			wantArgs: []string{"down"},
+		},
+		{
+			name:     "volumes only",
+			timeout:  "",
+			volumes:  true,
+			wantArgs: []string{"down", "--volumes"},
+		},
+		{
+			name:     "timeout 30s",
+			timeout:  "30s",
+			volumes:  false,
+			wantArgs: []string{"down", "--timeout", "30"},
+		},
+		{
+			name:     "timeout 1m converts to 60",
+			timeout:  "1m",
+			volumes:  false,
+			wantArgs: []string{"down", "--timeout", "60"},
+		},
+		{
+			name:     "timeout 2h converts to 7200",
+			timeout:  "2h",
+			volumes:  false,
+			wantArgs: []string{"down", "--timeout", "7200"},
+		},
+		{
+			name:     "zero timeout is valid boundary",
+			timeout:  "0s",
+			volumes:  false,
+			wantArgs: []string{"down", "--timeout", "0"},
+		},
+		{
+			name:     "timeout and volumes preserves order",
+			timeout:  "30s",
+			volumes:  true,
+			wantArgs: []string{"down", "--timeout", "30", "--volumes"},
+		},
+		{
+			name:    "unparseable timeout",
+			timeout: "notaduration",
+			volumes: false,
+			wantErr: true,
+		},
+		{
+			name:    "negative timeout rejected",
+			timeout: "-30s",
+			volumes: false,
+			wantErr: true,
+		},
+		{
+			name:    "sub-second timeout rejected",
+			timeout: "500ms",
+			volumes: false,
+			wantErr: true,
+		},
+		{
+			name:    "fractional second timeout rejected",
+			timeout: "1500ms",
+			volumes: false,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Assign both globals every iteration so no case inherits a
+			// previous case's leftover state.
+			stopTimeout, stopVolumes = tt.timeout, tt.volumes
+
+			got, err := buildDownArgs()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("buildDownArgs() = %v, want error", got)
+				}
+				if got != nil {
+					t.Errorf("buildDownArgs() returned args %v alongside error, want nil", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("buildDownArgs() unexpected error: %v", err)
+			}
+			if !slices.Equal(got, tt.wantArgs) {
+				t.Errorf("buildDownArgs() = %v, want %v", got, tt.wantArgs)
+			}
+			// Explicit data-destruction guard: --volumes appears in the
+			// args if and only if the stopVolumes flag is set.
+			hasVolumes := slices.Contains(got, "--volumes")
+			if hasVolumes != tt.volumes {
+				t.Errorf("--volumes present = %v, want %v (args=%v)", hasVolumes, tt.volumes, got)
+			}
+		})
+	}
+}

--- a/cli/internal/compose/validate.go
+++ b/cli/internal/compose/validate.go
@@ -103,8 +103,9 @@ func validateSandbox(p Params) error {
 		return fmt.Errorf("docker socket path %q contains unsafe characters", p.DockerSock)
 	}
 	// docker_sock_gid is a Linux GID: -1 disables the override, the upper
-	// bound is uint32 max.
-	if p.DockerSockGID < -1 || p.DockerSockGID > 4294967295 {
+	// bound is uint32 max. Widen to int64 first so the untyped 4294967295
+	// constant is representable where int is 32-bit.
+	if gid := int64(p.DockerSockGID); gid < -1 || gid > 4294967295 {
 		return fmt.Errorf("invalid docker socket gid %d: must be -1 to 4294967295", p.DockerSockGID)
 	}
 	return nil

--- a/cli/internal/compose/validate.go
+++ b/cli/internal/compose/validate.go
@@ -102,10 +102,9 @@ func validateSandbox(p Params) error {
 	if strings.ContainsAny(p.DockerSock, "\"'`$\n\r{}[]") {
 		return fmt.Errorf("docker socket path %q contains unsafe characters", p.DockerSock)
 	}
-	// p.DockerSockGID is an int; the upper bound 4294967295 (uint32 max)
-	// is not representable in a 32-bit signed int, so widen the
-	// comparison to int64 to keep the check correct on 32-bit builds.
-	if gid := int64(p.DockerSockGID); gid < -1 || gid > 4294967295 {
+	// docker_sock_gid is a Linux GID: -1 disables the override, the upper
+	// bound is uint32 max.
+	if p.DockerSockGID < -1 || p.DockerSockGID > 4294967295 {
 		return fmt.Errorf("invalid docker socket gid %d: must be -1 to 4294967295", p.DockerSockGID)
 	}
 	return nil

--- a/cli/internal/config/validate.go
+++ b/cli/internal/config/validate.go
@@ -52,10 +52,9 @@ func checkEnumOptional(name, value string, valid func(string) bool, options stri
 }
 
 func validateBackends(s State) error {
-	// State.DockerSockGID is an int; the upper bound 4294967295 (uint32
-	// max) is not representable in a 32-bit signed int, so widen the
-	// comparison to int64 to keep the check correct on 32-bit builds.
-	if gid := int64(s.DockerSockGID); gid < -1 || gid > 4294967295 {
+	// docker_sock_gid is a Linux GID: -1 disables the override, the upper
+	// bound is uint32 max.
+	if s.DockerSockGID < -1 || s.DockerSockGID > 4294967295 {
 		return fmt.Errorf("invalid docker_sock_gid %d: must be -1 to 4294967295", s.DockerSockGID)
 	}
 	if s.ImageTag != "" && !IsValidImageTag(s.ImageTag) {

--- a/cli/internal/config/validate.go
+++ b/cli/internal/config/validate.go
@@ -53,8 +53,9 @@ func checkEnumOptional(name, value string, valid func(string) bool, options stri
 
 func validateBackends(s State) error {
 	// docker_sock_gid is a Linux GID: -1 disables the override, the upper
-	// bound is uint32 max.
-	if s.DockerSockGID < -1 || s.DockerSockGID > 4294967295 {
+	// bound is uint32 max. Widen to int64 first so the untyped 4294967295
+	// constant is representable where int is 32-bit.
+	if gid := int64(s.DockerSockGID); gid < -1 || gid > 4294967295 {
 		return fmt.Errorf("invalid docker_sock_gid %d: must be -1 to 4294967295", s.DockerSockGID)
 	}
 	if s.ImageTag != "" && !IsValidImageTag(s.ImageTag) {

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -29,7 +29,7 @@ Defaults shown below are compiled into the binary; tunable defaults are also rea
 | `start` | `--dry-run` | `false` | Show what would happen without executing |
 | `start` | `--no-detach` | `false` | Run in foreground (stream logs; Ctrl+C to stop) |
 | `start` | `--no-verify` | `false` | Skip image signature verification (also `--skip-verify`) |
-| `stop` | `--timeout` / `-t` | `10s` | Graceful shutdown timeout |
+| `stop` | `--timeout` / `-t` | `10s` (Docker Compose default) | Graceful shutdown timeout (the CLI passes no `--timeout` unless set, deferring to Docker Compose) |
 | `stop` | `--volumes` | `false` | Remove named volumes (destructive) |
 | `update` | `--dry-run` | `false` | Show what would happen without executing |
 | `update` | `--no-restart` | `false` | Pull images but do not restart containers |


### PR DESCRIPTION
## Summary

Adds table-driven tests for previously zero-coverage pure functions in the Go CLI, targeting the two highest-risk paths: data destruction (`stop --volumes`) and command injection (`logs` input validation). A small 64-bit-only cleanup and a doc-precision fix surfaced during review are folded in.

- **`buildDownArgs`** (`stop.go`): pins exactly when `--volumes` is emitted (the data-destruction flag), `--timeout` parsing (non-negative / whole-second bounds), and exact arg ordering.
- **`validateLogsInput`** (`logs.go`): pins the injection-safety gate. Accept + reject cases for `--tail`, flag-shaped `--since`/`--until`, and service names (space, `;`, `/`, `$()`, `!`, newline, null byte, backtick, pipe).
- **`buildLogsArgs`** (`logs.go`): full flag-to-args mapping, plus the load-bearing `--` separator assertion (a flag-shaped service like `--evil` must sit after `--`, never before).
- **`isImageInUse` / `emitCleanupSummary`** (`cleanup.go`): in-use vs hard-failure classification (incl. wrapped errors and the case-sensitivity boundary) and the freed / removed / skipped output branches.
- **`validateCleanupFlags`** (`flags_test.go`): boundary cases (`keep=0`, large keep) and `--all` independence from keep validation.
- **cleanup**: drop the `int64`-widening + 32-bit-build comment on the `docker_sock_gid` validators in `config/validate.go` and `compose/validate.go`. Build targets are 64-bit only (`goarch: [amd64, arm64]`), so the bare comparison compiles on every matrix cell.
- **docs**: clarify in `cli-commands.md` that `stop --timeout` defers to Docker Compose's 10s default (the CLI passes no `--timeout` unless set).

## Test plan

- `go -C cli test ./...` (all packages green)
- `gofmt -l cli/` (clean) and `go -C cli vet ./...` (clean)
- `golangci-lint run` (0 issues)

## Review coverage

Pre-PR review ran 5 agents (go-reviewer, go-conventions-enforcer, go-security-reviewer, docs-consistency, comment-quality-rot). go-reviewer approved; all valid findings addressed. No linked issue (isolated test-hardening).