### PR TITLE
fix: resolve dev-tag Docker CI failures (retag disk + sig convergence)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1356,6 +1356,22 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
+      # The retag itself is registry-side (no bytes move), but the SBOM
+      # step inside publish-image-retag runs syft against the image, which
+      # pulls the ~4 GB GPU (~1.7 GB CPU) layers to local disk -- both the
+      # docker-daemon save and the oci-registry cache. A stock runner's
+      # ~14 GB free fills up and syft fails with "no space left on device",
+      # so mirror the build path's reclaim before the composite action.
+      - name: Free disk space
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/Python
+          sudo rm -rf /usr/local/share/powershell /usr/local/share/chromium
+          sudo rm -rf /usr/local/lib/node_modules
+          sudo docker image prune --all --force
+          df -h /
+
       - id: retag
         uses: ./.github/actions/publish-image-retag
         with:

--- a/scripts/check_image_signatures.py
+++ b/scripts/check_image_signatures.py
@@ -93,9 +93,15 @@ _TAG_RE = re.compile(r"\A[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}\Z")
 # signature-checked by ``_verify_pair``. Keying on these two fixed naming
 # conventions (rather than enumerating floating names) keeps the rule from
 # drifting if the floating-tag policy grows.
+#
+# The semver pattern tolerates an optional ``v``/``V`` prefix. The current
+# metadata-action ``{{version}}`` policy strips it (image tags are
+# ``0.8.9`` / ``0.8.9-dev.51``, never ``v0.8.9``), but a future tag-policy
+# change emitting a ``v``-prefixed immutable tag would otherwise be
+# misclassified as floating and silently dropped from the convergence check.
 _SHA_TAG_RE = re.compile(r"\Asha-[0-9a-f]{7,}\Z")
 _FULL_SEMVER_TAG_RE = re.compile(
-    r"\A[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?\Z"
+    r"\A[vV]?[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?\Z"
 )
 
 

--- a/scripts/check_image_signatures.py
+++ b/scripts/check_image_signatures.py
@@ -82,6 +82,34 @@ _IMAGE_NAME_RE = re.compile(r"\A[a-z0-9]+(?:[._-][a-z0-9]+)*\Z")
 # not as the first character.
 _TAG_RE = re.compile(r"\A[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}\Z")
 
+# Immutable build-identity tags: a tag that pins to exactly ONE build and
+# must never be repointed. Two metadata-action conventions qualify:
+#   - ``sha-<short>`` (commit-pinned; `type=sha,prefix=sha-`)
+#   - full semver ``X.Y.Z`` / ``X.Y.Z-dev.N`` (`type=semver,pattern={{version}}`)
+# Every OTHER tag the workflow pushes is FLOATING (``dev``, ``latest``,
+# ``X.Y``, ``X``): it advances to the newest build by design, so a
+# concurrent later release legitimately repoints it. Convergence is only an
+# invariant ACROSS immutable tags; floating tags are still individually
+# signature-checked by ``_verify_pair``. Keying on these two fixed naming
+# conventions (rather than enumerating floating names) keeps the rule from
+# drifting if the floating-tag policy grows.
+_SHA_TAG_RE = re.compile(r"\Asha-[0-9a-f]{7,}\Z")
+_FULL_SEMVER_TAG_RE = re.compile(
+    r"\A[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?\Z"
+)
+
+
+def _is_immutable_tag(tag: str) -> bool:
+    """Return True for tags that pin to exactly one build.
+
+    ``sha-<short>`` and full ``X.Y.Z[-pre]`` semver tags identify a single
+    build and must agree on its digest, so the convergence check applies to
+    them. Floating tags (``dev``, ``latest``, ``X.Y``, ``X``) advance to the
+    newest build by design and are excluded; they remain signature-checked
+    individually upstream.
+    """
+    return bool(_SHA_TAG_RE.match(tag) or _FULL_SEMVER_TAG_RE.match(tag))
+
 
 @dataclasses.dataclass(frozen=True)
 class ImageTag:
@@ -301,13 +329,23 @@ def _resolve_token() -> tuple[str | None, str]:
 def _check_per_image_convergence(
     pair_to_digest: dict[ImageTag, str],
 ) -> list[str]:
-    """Return failure messages for any image whose tags diverge.
+    """Return failure messages for any image whose IMMUTABLE tags diverge.
 
-    Order-independent: collects every ``(tag, digest)`` per image, then
-    reports the full set of divergent digests if cardinality > 1.
+    Only immutable build-identity tags (``sha-<short>`` + full semver)
+    participate: they pin to one build and must agree on its digest.
+    Floating tags (``dev``, ``latest``, ``X.Y``) are excluded -- a
+    concurrent later release legitimately repoints them to a newer build,
+    so requiring them to converge produced a false-positive failure
+    whenever two dev builds landed close together. Floating tags stay
+    individually signature-checked upstream in ``_verify_pair``.
+
+    Order-independent: collects every immutable ``(tag, digest)`` per image,
+    then reports the full set of divergent digests if cardinality > 1.
     """
     by_image: dict[str, list[tuple[str, str]]] = {}
     for pair, digest in pair_to_digest.items():
+        if not _is_immutable_tag(pair.tag):
+            continue
         by_image.setdefault(pair.image, []).append((pair.tag, digest))
 
     failures: list[str] = []
@@ -322,8 +360,9 @@ def _check_per_image_convergence(
                 for digest, tags in by_digest.items()
             )
             failures.append(
-                f"{image}: divergent digests across tags (concurrent run "
-                f"overwrote a tag after we signed):\n" + "\n".join(variant_lines)
+                f"{image}: divergent digests across immutable tags "
+                f"(concurrent run overwrote a tag after we signed):\n"
+                + "\n".join(variant_lines)
             )
     return failures
 

--- a/tests/unit/scripts/test_check_image_signatures.py
+++ b/tests/unit/scripts/test_check_image_signatures.py
@@ -88,14 +88,47 @@ class TestImageTagStr:
 
 
 @pytest.mark.unit
+class TestIsImmutableTag:
+    """_is_immutable_tag distinguishes build-identity tags from floating ones."""
+
+    @pytest.mark.parametrize(
+        "tag",
+        [
+            "sha-abc1234",
+            "sha-bb915d8",
+            "0.8.9",
+            "0.8.9-dev.51",
+            "1.0.0-rc.1",
+            "1.2.3+build.4",
+        ],
+    )
+    def test_immutable(self, tag: str) -> None:
+        assert gate._is_immutable_tag(tag) is True
+
+    @pytest.mark.parametrize(
+        "tag",
+        [
+            "dev",
+            "latest",
+            "0.8",  # floating major.minor
+            "0",  # floating major
+            "sha-1",  # too short to be a commit sha
+            "sha-xyz1234",  # non-hex tail
+        ],
+    )
+    def test_floating(self, tag: str) -> None:
+        assert gate._is_immutable_tag(tag) is False
+
+
+@pytest.mark.unit
 class TestPerImageConvergence:
-    """_check_per_image_convergence flags divergent digests order-independently."""
+    """_check_per_image_convergence flags divergence across IMMUTABLE tags only."""
 
     def test_empty_input(self) -> None:
         assert gate._check_per_image_convergence({}) == []
 
-    def test_single_image_single_tag(self) -> None:
-        pairs = {gate.ImageTag(image="backend", tag="dev"): "sha256:aaa"}
+    def test_single_immutable_tag(self) -> None:
+        pairs = {gate.ImageTag(image="backend", tag="sha-abc1234"): "sha256:aaa"}
         assert gate._check_per_image_convergence(pairs) == []
 
     def test_single_image_multiple_tags_same_digest(self) -> None:
@@ -106,10 +139,24 @@ class TestPerImageConvergence:
         }
         assert gate._check_per_image_convergence(pairs) == []
 
-    def test_two_tags_diverge_reports_both_digests(self) -> None:
+    def test_floating_dev_may_diverge_from_immutable_pair(self) -> None:
+        # The dev.51 false positive: the floating `dev` tag advanced to a
+        # newer (signed) build while the immutable version + sha tags stay
+        # converged. This must NOT be reported -- floating tags are allowed
+        # to point elsewhere, and per-pair signature checks still cover them.
         pairs = {
-            gate.ImageTag(image="sandbox", tag="dev"): "sha256:aaa",
-            gate.ImageTag(image="sandbox", tag="0.7.6-dev.9"): "sha256:bbb",
+            gate.ImageTag(image="backend", tag="dev"): "sha256:newer",
+            gate.ImageTag(image="backend", tag="0.8.9-dev.51"): "sha256:aaa",
+            gate.ImageTag(image="backend", tag="sha-bb915d8"): "sha256:aaa",
+        }
+        assert gate._check_per_image_convergence(pairs) == []
+
+    def test_immutable_tags_diverge_reports_both_digests(self) -> None:
+        # The real race the gate exists to catch: the immutable version tag
+        # and its sha tag (both pin THIS build) resolve to different digests.
+        pairs = {
+            gate.ImageTag(image="sandbox", tag="0.7.6-dev.9"): "sha256:aaa",
+            gate.ImageTag(image="sandbox", tag="sha-abc1234"): "sha256:bbb",
         }
         failures = gate._check_per_image_convergence(pairs)
         assert len(failures) == 1
@@ -117,12 +164,14 @@ class TestPerImageConvergence:
         assert "sandbox" in msg
         assert "sha256:aaa" in msg
         assert "sha256:bbb" in msg
-        assert "dev" in msg
         assert "0.7.6-dev.9" in msg
+        assert "sha-abc1234" in msg
 
-    def test_three_tags_two_digests_groups_correctly(self) -> None:
-        # Two tags converge, one diverges; the message should group
-        # the two together and isolate the divergent one.
+    def test_floating_tag_excluded_from_divergent_group(self) -> None:
+        # Two immutable tags converge, a third immutable tag diverges; the
+        # floating `dev` tag is excluded from the report even though it
+        # points at one of the digests. If it were not excluded, the aaa
+        # group would render `[0.7.6-dev.9, dev]` instead of `[0.7.6-dev.9]`.
         pairs = {
             gate.ImageTag(image="sandbox", tag="dev"): "sha256:aaa",
             gate.ImageTag(image="sandbox", tag="0.7.6-dev.9"): "sha256:aaa",
@@ -133,21 +182,19 @@ class TestPerImageConvergence:
         msg = failures[0]
         assert "sha256:aaa" in msg
         assert "sha256:bbb" in msg
-        # The two-tag group must list both tags
-        assert "dev" in msg
-        assert "0.7.6-dev.9" in msg
+        assert "tags [0.7.6-dev.9]" in msg
+        assert "tags [sha-abc1234]" in msg
 
     def test_divergence_is_order_independent(self) -> None:
-        # Construct two dicts with the same content but different
-        # iteration order. Both must produce the same finding count
-        # (1 in either case) and reference both digests.
+        # Same content, different iteration order -> identical result. Use
+        # two immutable tags so the divergence is actually reported.
         first = {
-            gate.ImageTag(image="backend", tag="a"): "sha256:111",
-            gate.ImageTag(image="backend", tag="b"): "sha256:222",
+            gate.ImageTag(image="backend", tag="0.7.6-dev.9"): "sha256:111",
+            gate.ImageTag(image="backend", tag="sha-abc1234"): "sha256:222",
         }
         second = {
-            gate.ImageTag(image="backend", tag="b"): "sha256:222",
-            gate.ImageTag(image="backend", tag="a"): "sha256:111",
+            gate.ImageTag(image="backend", tag="sha-abc1234"): "sha256:222",
+            gate.ImageTag(image="backend", tag="0.7.6-dev.9"): "sha256:111",
         }
         f1 = gate._check_per_image_convergence(first)
         f2 = gate._check_per_image_convergence(second)
@@ -161,10 +208,10 @@ class TestPerImageConvergence:
 
     def test_multiple_images_with_independent_divergence(self) -> None:
         pairs = {
-            gate.ImageTag(image="backend", tag="dev"): "sha256:aaa",
-            gate.ImageTag(image="backend", tag="sha-1"): "sha256:bbb",
-            gate.ImageTag(image="sandbox", tag="dev"): "sha256:ccc",
-            gate.ImageTag(image="sandbox", tag="sha-1"): "sha256:ddd",
+            gate.ImageTag(image="backend", tag="0.7.6-dev.9"): "sha256:aaa",
+            gate.ImageTag(image="backend", tag="sha-abc1234"): "sha256:bbb",
+            gate.ImageTag(image="sandbox", tag="0.7.6-dev.9"): "sha256:ccc",
+            gate.ImageTag(image="sandbox", tag="sha-def5678"): "sha256:ddd",
         }
         failures = gate._check_per_image_convergence(pairs)
         assert len(failures) == 2

--- a/tests/unit/scripts/test_check_image_signatures.py
+++ b/tests/unit/scripts/test_check_image_signatures.py
@@ -100,6 +100,8 @@ class TestIsImmutableTag:
             "0.8.9-dev.51",
             "1.0.0-rc.1",
             "1.2.3+build.4",
+            "v1.0.0",  # optional v-prefix (future tag-policy hardening)
+            "v0.8.9-dev.51",
         ],
     )
     def test_immutable(self, tag: str) -> None:


### PR DESCRIPTION
## Summary

Two recent `main` commits (`164af71`, `bb915d8`) showed a red `finalize-release` commit status. Neither commit's own CI failed — the red is the `always()` status reporter in `finalize-release.yml`, which posts `failure` ("Upstream failure blocked publish") whenever the **Docker** workflow on the dev tag concludes non-success. CLI passed both times; Docker failed at two different jobs, each a distinct root cause. The images were actually retagged and signed correctly in both cases (the retag steps run *before* the failing steps) — the failures are a missing SBOM artifact, a false gate, an unpublished dev-release draft, and the red commit mark.

| Commit | Dev tag | Failed Docker job | Root cause |
|---|---|---|---|
| `164af71` | `v0.8.9-dev.53` | Retag Fine-Tune (gpu) → Generate SBOM | Syft hit `no space left on device` scanning the ~4 GB GPU image |
| `bb915d8` | `v0.8.9-dev.51` | Verify Image Signatures | False positive: floating `dev` tag advanced to a newer (signed) build |

## Fix 1 — disk space on the fine-tune retag path

The build path frees disk before touching the large fine-tune images (`docker.yml` build job), but the **retag path had no such step**. The SBOM step inside `publish-image-retag` runs Syft against the image, which pulls the ~4 GB GPU (~1.7 GB CPU) layers to local disk (both the docker-daemon save *and* the oci-registry cache OOM'd — pinning Syft to a `registry:` source would not have helped). A stock runner's ~14 GB free fills up.

Added a `Free disk space` step to the `retag-fine-tune` job (both matrix legs), mirroring the build path verbatim. Scoped to fine-tune only; the small backend/web/sandbox/sidecar retags are untouched. Removing the Python toolcache there is safe — the retag composite action uses only bash/docker/syft.

## Fix 2 — signature-convergence false positive

**Security framing first: every tag, including `dev`, is still individually cosign-signature-checked. Only the cross-tag digest-*equality* requirement is relaxed, and only for floating tags — which are designed to advance.**

`_check_per_image_convergence` required *every* tag of an image to share one digest. But `dev` is a **floating** tag meant to advance to the newest build, while `0.8.9-dev.51` and `sha-bb915d8` are **immutable** per-build refs. A concurrent later dev build (dev.52/53) moved `dev` forward — every tag was still signed (`OK ... signed` for all), and the immutable `version`+`sha` pair still converged. So this conflated a legitimate floating-tag advance with the real race it exists to catch (an *immutable* tag diverging from its `sha` tag). The dev.51 log confirms: each image showed every tag `OK ... signed`; only `dev` pointed at a different digest.

The fix restricts the convergence invariant to **immutable build-identity tags** (`sha-<hex>` + full semver), keyed on those two fixed naming conventions rather than enumerating floating names so it won't drift if the floating-tag policy grows. The per-pair signature check (`_verify_pair` → `signature_present`) is unchanged and runs for every tag, so the original "unsigned user-facing tag" bug stays covered.

## Tests

The existing convergence tests *encoded the bug* (asserted `dev` diverging from the version tag = failure — literally the dev.51 false positive). Rewritten so:

- floating-tag divergence from a converged immutable pair → **no** failure (regression test for dev.51);
- two immutable tags (`version` vs `sha`) diverging → still fails (the real race);
- floating tag excluded from the divergence report grouping;
- added a `_is_immutable_tag` classifier test (sha-/full-semver immutable; `dev`/`latest`/`X.Y`/`X`/short-or-non-hex-sha floating).

## Verification

`ruff`, `ruff format`, the 71 `test_check_image_signatures.py` unit tests, `actionlint`, `zizmor`, and the full pre-commit + pre-push suites (affected mypy, affected unit tests, persistence-boundary, frozen-model, yamllint, …) all pass.

No tracking issue to close: the `report-failure` lane never fired (the publish *job* succeeded; the red was only the `always()` status reporter), so this PR closes nothing.