### PR TITLE
ci: scope preflight concurrency to sha so main pushes don't self-cancel

### DIFF
--- a/.github/workflows/ci-preflight.yml
+++ b/.github/workflows/ci-preflight.yml
@@ -15,8 +15,8 @@ on:
 permissions: {}
 
 concurrency:
-  group: ci-preflight-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-preflight-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   preflight:


### PR DESCRIPTION
## Problem

The `CI Preflight` workflow's concurrency group was keyed on `github.ref`, which is `refs/heads/main` for **every** push to main, combined with unconditional `cancel-in-progress: true`:

```yaml
concurrency:
  group: ci-preflight-${{ github.ref }}
  cancel-in-progress: true
```

So consecutive pushes to main all share one concurrency group, and each new push cancels the previous push's still-running preflight. When several merges land within minutes, the intermediate commits get a **cancelled** preflight check — which GitHub renders as a red ✗ in the commit/branch status indicator, even though every functional gate (unit/integration shards, lint, type-check, conformance, coverage, security) passed.

Observed on `313946ee` (#2175, test-durations refresh): preflight started at 09:37:46, then #2174 merged at 09:38:21 and cancelled it 35 s in, leaving a red X on a fully-green commit.

## Fix

Key the group on the PR number (PRs) or SHA (pushes) and only cancel in-progress runs for `pull_request` events — matching the existing patterns in `ci.yml` and `docker.yml`:

```yaml
concurrency:
  group: ci-preflight-${{ github.event.pull_request.number || github.sha }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

PR runs still self-cancel on new pushes (the useful behaviour); each main-push preflight now runs to completion under its own SHA-scoped group, so back-to-back merges no longer leave spurious cancelled checks on main history.