### PR TITLE
fix: repoint dead DeepSeek console link and exclude anti-bot host

### DIFF
--- a/docs/research/llm-provider-auth-survey.md
+++ b/docs/research/llm-provider-auth-survey.md
@@ -13,7 +13,7 @@ sources:
   - "https://docs.together.ai"
   - "https://docs.fireworks.ai"
   - "https://platform.moonshot.ai"
-  - "https://platform.deepseek.com"
+  - "https://api-docs.deepseek.com"
   - "https://www.alibabacloud.com/help/en/model-studio"
   - "https://docs.cohere.com"
   - "https://docs.perplexity.ai"
@@ -309,7 +309,7 @@ Primary sources, retrieved 2026-04-27:
 10. [Together AI docs](https://docs.together.ai)
 11. [Fireworks AI docs](https://docs.fireworks.ai)
 12. [Moonshot AI platform](https://platform.moonshot.ai)
-13. [DeepSeek platform](https://platform.deepseek.com)
+13. [DeepSeek API docs](https://api-docs.deepseek.com)
 14. [Alibaba DashScope](https://www.alibabacloud.com/help/en/model-studio)
 15. [Cohere docs](https://docs.cohere.com)
 16. [Perplexity docs](https://docs.perplexity.ai)

--- a/lychee.toml
+++ b/lychee.toml
@@ -59,7 +59,7 @@ exclude = [
     # 403 (a browser GET returns a 202 challenge); the console is real and
     # reachable for any signed-in user. Same anti-bot shape as the platforms
     # above.
-    '^https?://platform\.deepseek\.com/',
+    '^https?://platform\.deepseek\.com(/|$)',
     # Cloudflare dashboard requires login (always 403 to unauthenticated
     # HEAD probes); the URL is real and reachable for any logged-in user
     # following the fork-setup guide.

--- a/lychee.toml
+++ b/lychee.toml
@@ -55,6 +55,11 @@ exclude = [
     # Anti-bot: returns 403 to lychee's UA; live URL works in a browser.
     '^https?://medium\.com/',
     '^https?://platform\.openai\.com/',
+    # DeepSeek's login-gated developer console answers lychee's HEAD/UA with
+    # 403 (a browser GET returns a 202 challenge); the console is real and
+    # reachable for any signed-in user. Same anti-bot shape as the platforms
+    # above.
+    '^https?://platform\.deepseek\.com/',
     # Cloudflare dashboard requires login (always 403 to unauthenticated
     # HEAD probes); the URL is real and reachable for any logged-in user
     # following the fork-setup guide.


### PR DESCRIPTION
## Summary

The weekly external link check (run 26744750696) flagged a single broken
external link, cited twice in `docs/research/llm-provider-auth-survey.md`:
`https://platform.deepseek.com/` returning 403 to lychee's strict probe.

`platform.deepseek.com` is DeepSeek's login-gated developer console. It is
live, not dead: a browser-UA GET returns a 202 anti-bot challenge, a HEAD
returns 405, and lychee's UA gets 403, the same anti-bot shape already
handled for `platform.openai.com/` and the other login-gated `platform.*`
hosts in `lychee.toml`. DeepSeek's canonical API documentation
(`https://api-docs.deepseek.com/`) returns 200.

Both remedies are applied:

- Repoint the two citations (frontmatter `sources:` and the reference
  list) from the console to the live canonical docs at
  `https://api-docs.deepseek.com`, and relabel the reference entry to
  "DeepSeek API docs" so the text matches the target.
- Add a scoped `lychee.toml` exclude for `^https?://platform\.deepseek\.com/`,
  beside the existing `platform.openai.com` entry, with a comment naming the
  host and the anti-bot reason, so the weekly run never re-flags the console.

## Test plan

- `uv run pre-commit run lychee --hook-stage pre-push --all-files` (offline
  internal gate): Passed.
- Strict online lychee against the changed file
  (`lychee --config lychee.toml --no-progress docs/research/llm-provider-auth-survey.md`):
  0 Errors, 2 Excluded.
- `curl -A "Mozilla/5.0" -L https://api-docs.deepseek.com/`: 200.
- `vale docs/research/llm-provider-auth-survey.md`: 0 errors, 0 warnings,
  0 suggestions.
- All pre-commit and pre-push gates passed on commit and push.

## Review coverage

Docs/config-only change (one research doc, one lychee exclude list, no
runtime code). Pre-PR agent review auto-skipped per the no-substantive-code
rule; automated link and prose checks above cover the change.

Closes #2189
