### PR TITLE
chore(web): add eslint-plugin-react-hooks + promote downgraded @eslint-react rules to error

### DIFF
--- a/.vale/styles/config/vocabularies/SynthOrg/accept.txt
+++ b/.vale/styles/config/vocabularies/SynthOrg/accept.txt
@@ -114,6 +114,10 @@ Dedup
 Deduplicates
 Deduplication
 Denylist
+destructure
+destructured
+destructures
+destructuring
 Deps
 Deserialize
 Dev

--- a/.vale/styles/config/vocabularies/SynthOrg/accept.txt
+++ b/.vale/styles/config/vocabularies/SynthOrg/accept.txt
@@ -114,10 +114,6 @@ Dedup
 Deduplicates
 Deduplication
 Denylist
-destructure
-destructured
-destructures
-destructuring
 Deps
 Deserialize
 Dev
@@ -434,6 +430,10 @@ deserialization
 deserialize
 deserializer
 deserializers
+destructure
+destructured
+destructures
+destructuring
 dev
 devcontainer
 devs

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -97,11 +97,13 @@ See [docs/reference/web-design-system.md](../docs/reference/web-design-system.md
 
 `@eslint-react/eslint-plugin` v5+ via the `recommended-type-checked` preset (requires `parserOptions.projectService: true`, configured in `web/eslint.config.js`). Explicit error-level opt-ins beyond the preset:
 
+- `react-hooks/rules-of-hooks` + `react-hooks/exhaustive-deps` (`eslint-plugin-react-hooks` v7, ESLint-10 compatible): the canonical hooks-dependency rule. `@eslint-react/exhaustive-deps` is turned **off** in favour of it, so any justified suppression uses `// eslint-disable-next-line react-hooks/exhaustive-deps -- <reason>`. The `recommended-latest` preset's `react-hooks/lints` React-Compiler bundle is deliberately NOT enabled (this app does not run the React Compiler; those rules flag compiler-migration constraints, not runtime bugs). Prefer destructuring stable `useCallback`/`useRef` members and listing them over a mount-only `[]` + disable (see the `usePolling` consumers).
 - `@eslint-react/web-api-no-leaked-fetch`: detect `fetch()` in effects without `AbortController` cleanup.
 - `@eslint-react/no-leaked-conditional-rendering`: catch the `{count && <Foo />}` bug where `0` renders verbatim. For `ReactNode | undefined` props use `{value != null && value !== false && <jsx>}`; for compound truthiness use `Boolean(...)`.
 - `@eslint-react/globals`: restrict `window` / `document` / `localStorage` / etc. inside render. Hoist offenders into a `useCallback` event handler, a `useEffect`, or a `useSyncExternalStore`-backed hook.
 - `@typescript-eslint/no-floating-promises`: forbids unawaited promises so async work cannot survive the test that scheduled it and trip the active-handle gate.
 - `@typescript-eslint/no-misused-promises` (with `checksVoidReturn: { attributes: false }`): forbids passing async functions where the callsite ignores the returned promise; React 19 `async` event handlers stay allowed via the `attributes: false` exemption, paired with the global error handler.
+- Promoted from `warn` to `error` (codebase is clean): `@eslint-react/no-unstable-context-value`, `no-unstable-default-props`, `set-state-in-effect` (prop-to-local-state sync is the only sanctioned exception, suppressed per-line with a reason), `jsx-no-useless-fragment` (options pinned), `dom-no-missing-button-type`, and `react-refresh/only-export-components` (`allowConstantExport`; still `off` for the `components/ui/**` shadcn variant co-exports).
 
 Lint runs via `npm --prefix web run lint` with `--max-warnings 0`. To enumerate stale `eslint-disable` directives after a rule reshuffle: `npm --prefix web run lint -- --report-unused-disable-directives-severity=warn`.
 

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -90,8 +90,8 @@ See [docs/reference/web-design-system.md](../docs/reference/web-design-system.md
 
 ### Anti-patterns (lint-enforced)
 
-- **Icon helpers**: NEVER write `getXIcon(value): LucideIcon` factories called inside JSX bodies (`react-x/static-components` flags them). Export a `<XIcon value={...} />` wrapper that does the lookup via `createElement` inside the wrapper body. Wrapper components live in their own file, not alongside utility exports, so `react-refresh/only-export-components` stays clean. Canonical shape: `web/src/utils/activity-event-icon.tsx`.
-- **Viewport-size reads**: use `useViewportSize()` from `@/hooks/useViewportSize`. NEVER read `window.innerWidth` / `window.innerHeight` directly in a render body or `useMemo`; `react-x/globals` flags it and it would be stale across resizes anyway.
+- **Icon helpers**: NEVER write `getXIcon(value): LucideIcon` factories called inside JSX bodies (`@eslint-react/static-components` flags them). Export a `<XIcon value={...} />` wrapper that does the lookup via `createElement` inside the wrapper body. Wrapper components live in their own file, not alongside utility exports, so `react-refresh/only-export-components` stays clean. Canonical shape: `web/src/utils/activity-event-icon.tsx`.
+- **Viewport-size reads**: use `useViewportSize()` from `@/hooks/useViewportSize`. NEVER read `window.innerWidth` / `window.innerHeight` directly in a render body or `useMemo`; `@eslint-react/globals` flags it and it would be stale across resizes anyway.
 
 ## ESLint (MANDATORY)
 

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -3,10 +3,15 @@ import tseslint from 'typescript-eslint'
 import eslintReact from '@eslint-react/eslint-plugin'
 import { reactRefresh } from 'eslint-plugin-react-refresh'
 import pluginSecurity from 'eslint-plugin-security'
+import reactHooks from 'eslint-plugin-react-hooks'
 
-// TODO: Add eslint-plugin-react-hooks when it supports ESLint 10 (v5 caps at ESLint 9).
-// @eslint-react provides hooks analysis via the recommended-type-checked preset
-// in the meantime (rules-of-hooks, exhaustive-deps, set-state-in-effect, etc.).
+// eslint-plugin-react-hooks v7 supports ESLint 10 (peerDeps allow ^10), so the
+// canonical rules-of-hooks + exhaustive-deps rule pair is wired below. We enable
+// only those two (not the recommended-latest preset, which also pulls in the
+// React-Compiler ``react-hooks/lints`` bundle -- this project does not run the
+// compiler, and that bundle flags compiler-migration constraints rather than
+// runtime bugs). ``@eslint-react/exhaustive-deps`` is retired in favour of the
+// canonical rule; ``@eslint-react/rules-of-hooks`` stays on for redundant coverage.
 
 export default tseslint.config(
   // Generated artefacts are never linted. They live alongside the
@@ -35,12 +40,25 @@ export default tseslint.config(
     },
   },
   {
+    files: ['**/*.ts', '**/*.tsx'],
+    plugins: {
+      'react-hooks': reactHooks,
+    },
+    rules: {
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'error',
+      // Retire the @eslint-react port now that the canonical rule is live: keeping
+      // both would double-report and collide with the existing disable directives.
+      '@eslint-react/exhaustive-deps': 'off',
+    },
+  },
+  {
     plugins: {
       'react-refresh': reactRefresh.plugin,
     },
     rules: {
       'react-refresh/only-export-components': [
-        'warn',
+        'error',
         { allowConstantExport: true },
       ],
       'no-useless-assignment': 'error',
@@ -59,18 +77,25 @@ export default tseslint.config(
       // -- eslint-react rules not in recommended-type-checked --
       // Prevent dollar signs from leaking into rendered JSX output
       '@eslint-react/jsx-no-leaked-dollar': 'error',
-      // Remove unnecessary <></> fragment wrappers
-      '@eslint-react/jsx-no-useless-fragment': 'warn',
+      // Remove unnecessary <></> fragment wrappers. Options pinned explicitly so a
+      // future preset default flip cannot start erroring `<>{expr}</>` sites.
+      '@eslint-react/jsx-no-useless-fragment': [
+        'error',
+        { allowEmptyFragment: false, allowExpressions: true },
+      ],
       // Require type attribute on <button> to prevent unintended form submission
-      '@eslint-react/dom-no-missing-button-type': 'warn',
+      '@eslint-react/dom-no-missing-button-type': 'error',
       // Require rel="noopener" with target="_blank" (security)
       '@eslint-react/dom-no-unsafe-target-blank': 'error',
       // Catch duplicate keys in JSX lists
       '@eslint-react/no-duplicate-key': 'error',
       // Catch unstable context values that cause unnecessary re-renders
-      '@eslint-react/no-unstable-context-value': 'warn',
+      '@eslint-react/no-unstable-context-value': 'error',
       // Catch unstable default props that cause unnecessary re-renders
-      '@eslint-react/no-unstable-default-props': 'warn',
+      '@eslint-react/no-unstable-default-props': 'error',
+      // setState synchronously in an effect (derived-state smell). The preset
+      // ships this at warn; promote to error explicitly.
+      '@eslint-react/set-state-in-effect': 'error',
       // -- v5 explicit opt-ins beyond the preset --
       // Detect fetch() in effects without AbortController cleanup. We use
       // axios via apiClient today, but the rule guards future raw fetch

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -76,6 +76,7 @@
         "dpdm": "4.2.0",
         "esbuild": "0.28.0",
         "eslint": "10.4.1",
+        "eslint-plugin-react-hooks": "7.1.1",
         "eslint-plugin-react-refresh": "0.5.2",
         "eslint-plugin-security": "4.0.0",
         "fast-check": "4.8.0",
@@ -7620,6 +7621,26 @@
         "typescript": "*"
       }
     },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
     "node_modules/eslint-plugin-react-jsx": {
       "version": "5.8.7",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-jsx/-/eslint-plugin-react-jsx-5.8.7.tgz",
@@ -8830,6 +8851,23 @@
       "dependencies": {
         "@types/set-cookie-parser": "^2.4.10",
         "set-cookie-parser": "^3.0.1"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -16263,6 +16301,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zustand": {

--- a/web/package.json
+++ b/web/package.json
@@ -93,6 +93,7 @@
     "cross-env": "10.1.0",
     "esbuild": "0.28.0",
     "eslint": "10.4.1",
+    "eslint-plugin-react-hooks": "7.1.1",
     "eslint-plugin-react-refresh": "0.5.2",
     "eslint-plugin-security": "4.0.0",
     "fast-check": "4.8.0",

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -71,8 +71,7 @@ function useNavigationOverlayClose(
     if (prevPathnameRef.current === location.pathname) return
     prevPathnameRef.current = location.pathname
     if (overlayOpen && onOverlayClose) onOverlayClose()
-    // Only trigger on route changes, not on prop changes
-    // eslint-disable-next-line @eslint-react/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- fires on route change only; the prevPathnameRef guard makes re-runs from overlayOpen/onOverlayClose prop changes no-ops, so they are deliberately excluded
   }, [location.pathname])
 }
 

--- a/web/src/components/layout/StatusBar.tsx
+++ b/web/src/components/layout/StatusBar.tsx
@@ -164,12 +164,11 @@ function HealthStatusButton() {
   }, [])
 
   const healthPolling = usePolling(pollHealth, HEALTH_POLL_INTERVAL)
+  const { start: startHealthPolling, stop: stopHealthPolling } = healthPolling
   useEffect(() => {
-    healthPolling.start()
-    return () => healthPolling.stop()
-    // healthPolling.start/stop are stable refs from usePolling.
-    // eslint-disable-next-line @eslint-react/exhaustive-deps
-  }, [])
+    startHealthPolling()
+    return () => stopHealthPolling()
+  }, [startHealthPolling, stopHealthPolling])
 
   const statusCfg = resolveCombinedStatus(healthStatus, wsConnected, wsReconnectExhausted)
   return (

--- a/web/src/components/ui/code-mirror-editor.tsx
+++ b/web/src/components/ui/code-mirror-editor.tsx
@@ -217,8 +217,7 @@ function useEditorMount(
       view.destroy()
       viewRef.current = null
     }
-    // Only run on mount: value/language/readOnly/extensions synced via separate effects.
-    // eslint-disable-next-line @eslint-react/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only: constructs the EditorView once from the initial args; value/language/readOnly/extensions are synced by separate effects, and the refs are stable
   }, [])
 }
 

--- a/web/src/hooks/use-shortcut-registry.ts
+++ b/web/src/hooks/use-shortcut-registry.ts
@@ -47,14 +47,14 @@ export function useRegisterShortcuts(shortcuts: RegisteredShortcut[]) {
   const register = ctx?.register
   const unregister = ctx?.unregister
   const ownerId = useId()
+  // Content-based change key: consumers that build `shortcuts` inline pass a
+  // fresh array identity each render, so we re-register on content change only
+  // (an unmemoised array of the same content does not thrash the registry).
+  const shortcutsKey = JSON.stringify(shortcuts)
   useEffect(() => {
     if (!register || !unregister) return
     register(ownerId, shortcuts)
     return () => unregister(ownerId)
-    // Shortcuts array identity change forces re-registration; consumers
-    // should memoize via useMemo if they construct shortcuts inline. We
-    // keep JSON.stringify for content-based change detection so an
-    // unmemoized array of the same content does not thrash the registry.
-    // eslint-disable-next-line @eslint-react/exhaustive-deps
-  }, [register, unregister, ownerId, JSON.stringify(shortcuts)])
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `shortcuts` is keyed by content via `shortcutsKey`, not identity, to avoid re-registration thrash on inline arrays
+  }, [register, unregister, ownerId, shortcutsKey])
 }

--- a/web/src/hooks/useAgentDetailData.ts
+++ b/web/src/hooks/useAgentDetailData.ts
@@ -93,14 +93,12 @@ function useDetailLifecycle(agentName: string): void {
     await useAgentsStore.getState().fetchAgentDetail(agentName)
   }, [agentName])
   const polling = usePolling(pollFn, DETAIL_POLL_INTERVAL)
+  const { start, stop } = polling
   useEffect(() => {
     if (!agentName) return
-    polling.start()
-    return () => polling.stop()
-    // polling is a new object each render but start/stop are stable;
-    // including it would restart polling on every render
-    // eslint-disable-next-line @eslint-react/exhaustive-deps
-  }, [agentName])
+    start()
+    return () => stop()
+  }, [agentName, start, stop])
 }
 
 interface DetailWsState {

--- a/web/src/hooks/useAgentsData.ts
+++ b/web/src/hooks/useAgentsData.ts
@@ -44,13 +44,11 @@ export function useAgentsData(): UseAgentsDataReturn {
   }, [])
   const polling = usePolling(pollFn, AGENTS_POLL_INTERVAL)
 
+  const { start, stop } = polling
   useEffect(() => {
-    polling.start()
-    return () => polling.stop()
-    // polling is a new object each render but start/stop are stable;
-    // including it would restart polling on every render
-    // eslint-disable-next-line @eslint-react/exhaustive-deps
-  }, [])
+    start()
+    return () => stop()
+  }, [start, stop])
 
   // WebSocket -- debounce to coalesce burst events into a single refetch
   const wsDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)

--- a/web/src/hooks/useApprovalsData.ts
+++ b/web/src/hooks/useApprovalsData.ts
@@ -72,11 +72,11 @@ export function useApprovalsData(): UseApprovalsDataReturn {
 
   const polling = usePolling(pollFn, APPROVAL_POLL_INTERVAL)
 
+  const { start, stop } = polling
   useEffect(() => {
-    polling.start()
-    return () => polling.stop()
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- start/stop are stable useCallback refs; polling object identity is not stable
-  }, [polling.start, polling.stop])
+    start()
+    return () => stop()
+  }, [start, stop])
 
   // WebSocket bindings for real-time updates
   const bindings: ChannelBinding[] = useMemo(

--- a/web/src/hooks/useArtifactsData.ts
+++ b/web/src/hooks/useArtifactsData.ts
@@ -40,11 +40,11 @@ export function useArtifactsData(): UseArtifactsDataReturn {
   }, [])
   const polling = usePolling(pollFn, ARTIFACTS_POLL_INTERVAL)
 
+  const { start, stop } = polling
   useEffect(() => {
-    polling.start()
-    return () => polling.stop()
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- polling object is stable (memoized by usePolling)
-  }, [])
+    start()
+    return () => stop()
+  }, [start, stop])
 
   const wsDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   useEffect(() => () => {

--- a/web/src/hooks/useBudgetData.ts
+++ b/web/src/hooks/useBudgetData.ts
@@ -59,11 +59,11 @@ export function useBudgetData(): UseBudgetDataReturn {
     await useBudgetStore.getState().fetchOverview()
   }, [])
   const polling = usePolling(pollFn, BUDGET_POLL_INTERVAL)
+  const { start, stop } = polling
   useEffect(() => {
-    polling.start()
-    return () => polling.stop()
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- start/stop are stable useCallback refs; polling object identity is not stable
-  }, [polling.start, polling.stop])
+    start()
+    return () => stop()
+  }, [start, stop])
 
   // WebSocket bindings
   const bindings: ChannelBinding[] = useMemo(

--- a/web/src/hooks/useConnectionsData.ts
+++ b/web/src/hooks/useConnectionsData.ts
@@ -107,11 +107,11 @@ export function useConnectionsData(): UseConnectionsDataReturn {
   }, [])
   const polling = usePolling(pollFn, CONNECTIONS_POLL_INTERVAL_MS)
 
+  const { start, stop } = polling
   useEffect(() => {
-    polling.start()
-    return () => polling.stop()
-    // eslint-disable-next-line @eslint-react/exhaustive-deps
-  }, [])
+    start()
+    return () => stop()
+  }, [start, stop])
 
   const filteredConnections = useMemo(() => {
     const filtered = filterConnections(connections, {

--- a/web/src/hooks/useDashboardData.ts
+++ b/web/src/hooks/useDashboardData.ts
@@ -64,12 +64,12 @@ export function useDashboardData(): UseDashboardDataReturn {
   )
   const polling = usePolling(pollFn, DASHBOARD_POLL_INTERVAL, { skipIfFresh })
 
-  // polling.start/stop are stable refs from useCallback inside usePolling
+  // start/stop are stable refs from useCallback inside usePolling
+  const { start, stop } = polling
   useEffect(() => {
-    polling.start()
-    return () => polling.stop()
-    // eslint-disable-next-line @eslint-react/exhaustive-deps
-  }, [])
+    start()
+    return () => stop()
+  }, [start, stop])
 
   // WebSocket bindings for real-time updates
   const bindings: ChannelBinding[] = useMemo(

--- a/web/src/hooks/useMcpCatalogData.ts
+++ b/web/src/hooks/useMcpCatalogData.ts
@@ -30,7 +30,7 @@ export function useMcpCatalogData(): UseMcpCatalogDataReturn {
     // ``installedEntryIds`` Set starts empty and the UI mis-renders
     // already-installed entries as fresh installs.
     void useMcpCatalogStore.getState().fetchInstalled()
-    // eslint-disable-next-line @eslint-react/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only hydration; entries.length / loading are read once to gate the initial fetch, re-running on their change would redundantly refetch
   }, [])
 
   const visibleEntries = useMemo<readonly McpCatalogEntry[]>(() => {

--- a/web/src/hooks/useMeetingsData.ts
+++ b/web/src/hooks/useMeetingsData.ts
@@ -38,11 +38,11 @@ export function useMeetingsData(): UseMeetingsDataReturn {
   }, [])
   const polling = usePolling(pollFn, MEETINGS_POLL_INTERVAL)
 
+  const { start, stop } = polling
   useEffect(() => {
-    polling.start()
-    return () => polling.stop()
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- mount-only effect; polling start/stop are stable useCallback refs
-  }, [])
+    start()
+    return () => stop()
+  }, [start, stop])
 
   // WebSocket bindings for real-time updates
   const bindings: ChannelBinding[] = useMemo(

--- a/web/src/hooks/useMessagesData.ts
+++ b/web/src/hooks/useMessagesData.ts
@@ -88,12 +88,12 @@ export function useMessagesData(activeChannel: string | null): UseMessagesDataRe
 
   const polling = usePolling(pollFn, MESSAGES_POLL_INTERVAL)
 
+  const { start, stop } = polling
   useEffect(() => {
     if (!activeChannel) return
-    polling.start()
-    return () => polling.stop()
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- start/stop are stable useCallback refs
-  }, [activeChannel, polling.start, polling.stop])
+    start()
+    return () => stop()
+  }, [activeChannel, start, stop])
 
   // WebSocket bindings (stable -- reads activeChannel via ref)
   const bindings: ChannelBinding[] = useMemo(

--- a/web/src/hooks/useMissionControlData.ts
+++ b/web/src/hooks/useMissionControlData.ts
@@ -64,11 +64,11 @@ export function useMissionControlData(): UseMissionControlDataReturn {
   )
   const polling = usePolling(pollFn, SNAPSHOT_POLL_INTERVAL, { skipIfFresh })
 
+  const { start, stop } = polling
   useEffect(() => {
-    polling.start()
-    return () => polling.stop()
-    // eslint-disable-next-line @eslint-react/exhaustive-deps
-  }, [])
+    start()
+    return () => stop()
+  }, [start, stop])
 
   const bindings: ChannelBinding[] = useMemo(
     () =>

--- a/web/src/hooks/useOntologyData.ts
+++ b/web/src/hooks/useOntologyData.ts
@@ -48,13 +48,12 @@ export function useOntologyData(): UseOntologyDataReturn {
   }, [])
   const polling = usePolling(pollFn, POLL_INTERVAL)
 
-  // Initial fetch + start polling
+  // Start polling; start() performs the initial fetch
   const { start, stop } = polling
   useEffect(() => {
-    void pollFn()
     start()
     return () => stop()
-  }, [pollFn, start, stop])
+  }, [start, stop])
 
   // Client-side filtering
   const filteredEntities = useMemo(() => {

--- a/web/src/hooks/useOntologyData.ts
+++ b/web/src/hooks/useOntologyData.ts
@@ -49,12 +49,12 @@ export function useOntologyData(): UseOntologyDataReturn {
   const polling = usePolling(pollFn, POLL_INTERVAL)
 
   // Initial fetch + start polling
+  const { start, stop } = polling
   useEffect(() => {
     void pollFn()
-    polling.start()
-    return () => polling.stop()
-    // eslint-disable-next-line @eslint-react/exhaustive-deps
-  }, [])
+    start()
+    return () => stop()
+  }, [pollFn, start, stop])
 
   // Client-side filtering
   const filteredEntities = useMemo(() => {

--- a/web/src/hooks/useOrgChartData.ts
+++ b/web/src/hooks/useOrgChartData.ts
@@ -176,8 +176,7 @@ function useOrgInitialFetch(start: () => void, stop: () => void): void {
       mounted = false
       stop()
     }
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- mount-only effect; start / stop are stable
-  }, [])
+  }, [start, stop])
 }
 
 export function useOrgChartData(

--- a/web/src/hooks/useOrgEditData.ts
+++ b/web/src/hooks/useOrgEditData.ts
@@ -102,8 +102,7 @@ function useCompanyInitialFetch(start: () => void, stop: () => void): void {
       mounted = false
       stop()
     }
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- mount-only effect; start / stop are stable
-  }, [])
+  }, [start, stop])
 }
 
 export function useOrgEditData(): UseOrgEditDataReturn {

--- a/web/src/hooks/usePolling.ts
+++ b/web/src/hooks/usePolling.ts
@@ -173,6 +173,13 @@ function _buildVisibilityHandler(
  * A `visibilitychange` listener re-arms a near-immediate tick when
  * the tab becomes visible again so the user sees fresh data on
  * return.
+ *
+ * `intervalMs` is expected to be a stable value (callers pass a
+ * module-level constant). The returned `start` / `stop` are stable
+ * useCallback identities only while `intervalMs` is stable, so a
+ * caller passing a value that changes between renders would re-create
+ * `start` and restart the loop on every change; route such cases
+ * through a ref instead of changing the argument.
  */
 export function usePolling(
   fn: () => Promise<void>,
@@ -213,7 +220,7 @@ export function usePolling(
       }
       timerRef.current = setTimeout(() => { void tick() }, delayMs)
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- refs / handlers are derived from refs that don't trigger re-render
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refs / handlers are useMemo([])-stabilised bundles of useRef handles; their identities never change, so listing them would add no dep semantics
     [intervalMs],
   )
 
@@ -231,7 +238,7 @@ export function usePolling(
       if (_shouldRunPoll(refs, runId, handlers)) await _invokePoll(refs, handlers)
       scheduleTick(runId)
     })()
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- refs / handlers are derived from refs that don't trigger re-render
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refs / handlers are useMemo([])-stabilised bundles of useRef handles; their identities never change, so listing them would add no dep semantics
   }, [scheduleTick, isValidInterval, intervalMs])
 
   const stop = useCallback(() => {
@@ -243,7 +250,7 @@ export function usePolling(
       clearTimeout(timerRef.current)
       timerRef.current = null
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- ref handles are stable identities; the rule lists them because they were destructured from a non-ref local
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- activeRef / runIdRef / pendingResumeRef / timerRef are stable useRef handles (destructured from the useMemo([])-stabilised refs bundle); the rule lists them as closure free-variables regardless of that stability
   }, [])
 
   useEffect(() => stop, [stop])
@@ -253,7 +260,7 @@ export function usePolling(
     const handler = _buildVisibilityHandler(refs, scheduleTick)
     document.addEventListener('visibilitychange', handler)
     return () => document.removeEventListener('visibilitychange', handler)
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- refs is derived from refs that don't trigger re-render
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refs is a useMemo([])-stabilised bundle; its identity never changes, so listing it would add no dep semantics
   }, [scheduleTick])
 
   return { active, error, isRefetching, start, stop }

--- a/web/src/hooks/usePolling.ts
+++ b/web/src/hooks/usePolling.ts
@@ -118,7 +118,7 @@ function usePollRefs(
   const inFlightRef = useRef(false)
   const pendingResumeRef = useRef(false)
   // Stabilise the refs bundle so consumers can list it in dependency
-  // arrays without forcing an `eslint-disable @eslint-react/exhaustive-deps`
+  // arrays without forcing an `eslint-disable react-hooks/exhaustive-deps`
   // override. Ref identities themselves are stable across renders, but
   // returning a fresh object literal each render would re-trigger any
   // memoised hook that depends on `refs`.
@@ -213,7 +213,7 @@ export function usePolling(
       }
       timerRef.current = setTimeout(() => { void tick() }, delayMs)
     },
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- refs / handlers are derived from refs that don't trigger re-render
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refs / handlers are derived from refs that don't trigger re-render
     [intervalMs],
   )
 
@@ -231,7 +231,7 @@ export function usePolling(
       if (_shouldRunPoll(refs, runId, handlers)) await _invokePoll(refs, handlers)
       scheduleTick(runId)
     })()
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- refs / handlers are derived from refs that don't trigger re-render
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refs / handlers are derived from refs that don't trigger re-render
   }, [scheduleTick, isValidInterval, intervalMs])
 
   const stop = useCallback(() => {
@@ -243,7 +243,7 @@ export function usePolling(
       clearTimeout(timerRef.current)
       timerRef.current = null
     }
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- ref handles are stable identities; the rule lists them because they were destructured from a non-ref local
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- ref handles are stable identities; the rule lists them because they were destructured from a non-ref local
   }, [])
 
   useEffect(() => stop, [stop])
@@ -253,7 +253,7 @@ export function usePolling(
     const handler = _buildVisibilityHandler(refs, scheduleTick)
     document.addEventListener('visibilitychange', handler)
     return () => document.removeEventListener('visibilitychange', handler)
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- refs is derived from refs that don't trigger re-render
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refs is derived from refs that don't trigger re-render
   }, [scheduleTick])
 
   return { active, error, isRefetching, start, stop }

--- a/web/src/hooks/useProjectsData.ts
+++ b/web/src/hooks/useProjectsData.ts
@@ -37,11 +37,11 @@ export function useProjectsData(): UseProjectsDataReturn {
   }, [])
   const polling = usePolling(pollFn, PROJECTS_POLL_INTERVAL)
 
+  const { start, stop } = polling
   useEffect(() => {
-    polling.start()
-    return () => polling.stop()
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- polling object is stable (memoized by usePolling)
-  }, [])
+    start()
+    return () => stop()
+  }, [start, stop])
 
   const wsDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   useEffect(() => () => {

--- a/web/src/hooks/useProviderDetailData.ts
+++ b/web/src/hooks/useProviderDetailData.ts
@@ -50,12 +50,12 @@ export function useProviderDetailData(
   }, [providerName])
   const polling = usePolling(pollFn, DETAIL_POLL_INTERVAL)
 
+  const { start, stop } = polling
   useEffect(() => {
     if (!providerName) return
-    polling.start()
-    return () => polling.stop()
-    // eslint-disable-next-line @eslint-react/exhaustive-deps
-  }, [providerName])
+    start()
+    return () => stop()
+  }, [providerName, start, stop])
 
   if (!providerName) {
     return {

--- a/web/src/hooks/useProvidersData.ts
+++ b/web/src/hooks/useProvidersData.ts
@@ -32,11 +32,11 @@ export function useProvidersData(): UseProvidersDataReturn {
   }, [])
   const polling = usePolling(pollFn, PROVIDERS_POLL_INTERVAL)
 
+  const { start, stop } = polling
   useEffect(() => {
-    polling.start()
-    return () => polling.stop()
-    // eslint-disable-next-line @eslint-react/exhaustive-deps
-  }, [])
+    start()
+    return () => stop()
+  }, [start, stop])
 
   // Client-side filtering + sorting
   const filteredProviders = useMemo(() => {

--- a/web/src/hooks/useScalingData.ts
+++ b/web/src/hooks/useScalingData.ts
@@ -50,11 +50,11 @@ export function useScalingData(): UseScalingDataReturn {
   }, [])
 
   const polling = usePolling(pollFn, SCALING_POLL_INTERVAL)
+  const { start, stop } = polling
   useEffect(() => {
-    polling.start()
-    return () => polling.stop()
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- start/stop are stable useCallback refs; polling object identity is not stable
-  }, [polling.start, polling.stop])
+    start()
+    return () => stop()
+  }, [start, stop])
 
   // WebSocket bindings.
   const bindings: ChannelBinding[] = useMemo(

--- a/web/src/hooks/useSubworkflowsData.ts
+++ b/web/src/hooks/useSubworkflowsData.ts
@@ -23,11 +23,11 @@ export function useSubworkflowsData(): UseSubworkflowsDataReturn {
   }, [])
   const polling = usePolling(pollFn, SUBWORKFLOWS_POLL_INTERVAL)
 
+  const { start, stop } = polling
   useEffect(() => {
-    polling.start()
-    return () => polling.stop()
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- polling object is stable
-  }, [])
+    start()
+    return () => stop()
+  }, [start, stop])
 
   const filteredSubworkflows = useMemo(() => {
     if (!searchQuery) return [...subworkflows]

--- a/web/src/hooks/useTaskBoardData.ts
+++ b/web/src/hooks/useTaskBoardData.ts
@@ -63,10 +63,11 @@ export function useTaskBoardData(): UseTaskBoardDataReturn {
 
   const polling = usePolling(pollFn, TASK_POLL_INTERVAL)
 
+  const { start, stop } = polling
   useEffect(() => {
-    polling.start()
-    return () => polling.stop()
-  }, []) // eslint-disable-line @eslint-react/exhaustive-deps
+    start()
+    return () => stop()
+  }, [start, stop])
 
   // WebSocket bindings for real-time updates
   const bindings: ChannelBinding[] = useMemo(

--- a/web/src/hooks/useWebSocket.ts
+++ b/web/src/hooks/useWebSocket.ts
@@ -127,10 +127,7 @@ export function useWebSocket(options: WebSocketOptions): WebSocketReturn {
         unsubscribe: subscribed,
       })
     }
-    // Bindings and filters are intentionally excluded -- they are captured
-    // once on mount and remain stable for the component's lifetime. Changing
-    // them requires remounting the component (e.g. via a key prop).
-    // eslint-disable-next-line @eslint-react/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- bindings/filters are captured once on mount and remain stable for the component's lifetime; changing them requires remounting (e.g. via a key prop), so they are intentionally excluded
   }, [isEnabled])
 
   return { connected, reconnectExhausted, setupError }

--- a/web/src/hooks/useWorkflowsData.ts
+++ b/web/src/hooks/useWorkflowsData.ts
@@ -30,11 +30,11 @@ export function useWorkflowsData(): UseWorkflowsDataReturn {
   }, [])
   const polling = usePolling(pollFn, WORKFLOWS_POLL_INTERVAL)
 
+  const { start, stop } = polling
   useEffect(() => {
-    polling.start()
-    return () => polling.stop()
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- polling object is stable
-  }, [])
+    start()
+    return () => stop()
+  }, [start, stop])
 
   const filteredWorkflows = useMemo(() => {
     let result = [...workflows]

--- a/web/src/pages/WebhookReceiptsPage.tsx
+++ b/web/src/pages/WebhookReceiptsPage.tsx
@@ -200,11 +200,7 @@ function useWebhookActivity(selected: string, selection: WebhookSelection): Webh
     return () => {
       cancelled = true
     }
-    // The effect intentionally clears state only when ``selected``
-    // changes; ``useBulkSelection`` memoises ``selection`` (it changes
-    // whenever ``selectedIds`` mutates), so listing it here would re-run
-    // the clear loop after every selection toggle.
-    // eslint-disable-next-line @eslint-react/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- clears state only when `selected` changes; `selection` (memoised by useBulkSelection) changes whenever selectedIds mutates, so listing it would re-run the clear loop after every selection toggle
   }, [selected])
 
   useEffect(() => {

--- a/web/src/pages/org/useOrgChartViewMode.ts
+++ b/web/src/pages/org/useOrgChartViewMode.ts
@@ -172,7 +172,7 @@ export function useOrgChartViewMode(nodes: Node[], edges: Edge[], _viewMode: Vie
         animFrameRef.current = null
       }
     }
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- transition.displayNodes is read for starting position only; including it would cause infinite loops
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- transition.displayNodes is read for starting position only; including it would cause infinite loops
   }, [nodes, edges])
 
   useLayoutEffect(() => {

--- a/web/src/pages/personalities/usePersonalitiesAdminController.ts
+++ b/web/src/pages/personalities/usePersonalitiesAdminController.ts
@@ -71,7 +71,7 @@ export function usePersonalitiesAdminController(): PersonalitiesAdminController 
     // effect on every render and reset the page on every keystroke. The
     // ``resetPage`` reference is what we actually need; depending on the
     // search/sort primitives is sufficient.
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- pagination.resetPage identity is unstable; sort/search are the real triggers
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pagination.resetPage identity is unstable; sort/search are the real triggers
   }, [list.searchQuery, list.sortKey])
 
   const handleCreateSubmit = useCallback(

--- a/web/src/pages/settings/NotificationsSection.tsx
+++ b/web/src/pages/settings/NotificationsSection.tsx
@@ -103,8 +103,7 @@ export function NotificationsSection() {
       const actual = Notification.permission
       if (actual !== preferences.browserPermission) setBrowserPermission(actual)
     }
-    // Only run on mount
-    // eslint-disable-next-line @eslint-react/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only: reads preferences.browserPermission once to reconcile against the live Notification.permission; re-running on its change would loop via setBrowserPermission
   }, [])
 
   async function handleRequestPermission() {

--- a/web/src/pages/settings/ceremony-policy/strategies/ExternalTriggerConfig.tsx
+++ b/web/src/pages/settings/ceremony-policy/strategies/ExternalTriggerConfig.tsx
@@ -36,7 +36,7 @@ export function ExternalTriggerConfig({ config, onChange, disabled }: ExternalTr
       // eslint-disable-next-line @eslint-react/set-state-in-effect -- legitimate prop-to-local-state sync
       setJsonError(null)
     }
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- rawJson intentionally excluded
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- rawJson intentionally excluded: this resyncs local state FROM the prop, so depending on rawJson would loop
   }, [config.sources])
 
   return (

--- a/web/src/pages/settings/ceremony-policy/strategies/MilestoneDrivenConfig.tsx
+++ b/web/src/pages/settings/ceremony-policy/strategies/MilestoneDrivenConfig.tsx
@@ -35,7 +35,7 @@ export function MilestoneDrivenConfig({ config, onChange, disabled }: MilestoneD
       // eslint-disable-next-line @eslint-react/set-state-in-effect -- legitimate prop-to-local-state sync
       setJsonError(null)
     }
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- rawJson intentionally excluded
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- rawJson intentionally excluded: this resyncs local state FROM the prop, so depending on rawJson would loop
   }, [config.milestones])
 
   return (

--- a/web/src/pages/workflow-editor/useConditionBuilderState.ts
+++ b/web/src/pages/workflow-editor/useConditionBuilderState.ts
@@ -126,7 +126,7 @@ function useBuilderCoreState(
 ): BuilderCoreState {
   const initialFlat = useMemo(
     () => (value ? parseForBuilderState(value) : null),
-    [], // eslint-disable-line @eslint-react/exhaustive-deps -- intentionally mount-only
+    [], // eslint-disable-line react-hooks/exhaustive-deps -- intentionally mount-only: seeds the builder from the initial `value` once
   )
   const [mode, setMode] = useState<'builder' | 'advanced'>(() =>
     !value ? 'builder' : initialFlat ? 'builder' : 'advanced',
@@ -189,7 +189,8 @@ function useExternalValueSync({
     lastSyncedRef.current = value
     appliedExternalUpdateRef.current = true
     applyExternalValue(value, core, allocKey, toEntries)
-  }, [value]) // eslint-disable-line @eslint-react/exhaustive-deps -- resync only on external change
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- resync only on external `value` change; depending on core/allocKey/toEntries would re-run on every internal edit and loop the external-apply
+  }, [value])
 }
 
 function computeCurrentSerialized(core: BuilderCoreState): string {


### PR DESCRIPTION
Closes #2203

## Summary

The React 19 dashboard shipped without canonical rules-of-hooks / exhaustive-deps enforcement (only a stale `// TODO: Add eslint-plugin-react-hooks when it supports ESLint 10`), with ~36 manual `@eslint-react/exhaustive-deps` disables papering over the gap and five `@eslint-react` correctness rules sitting at `warn`. This PR closes both gaps.

### 1. eslint-plugin-react-hooks (the canonical rule)
- Add `eslint-plugin-react-hooks@7.1.1`. The TODO was stale: v7's `peerDependencies` already declare `eslint: ^10.0.0`, so no ESLint-9 pin / downgrade is needed (repo stays on ESLint 10.4.1).
- Wire `react-hooks/rules-of-hooks` + canonical `react-hooks/exhaustive-deps` at **error**; turn `@eslint-react/exhaustive-deps` **off** in favour of it (keeping `@eslint-react/rules-of-hooks` for redundant coverage).
- The full `recommended-latest` preset's `react-hooks/lints` React-Compiler bundle is **deliberately NOT enabled** (this app does not run the React Compiler; those rules enforce compiler-migration constraints, not runtime bugs).

### 2. exhaustive-deps audit (all ~36 sites resolved)
With the canonical rule live, one lint run surfaced the complete violation list. Every site was either:
- **Fixed** (no papered-over disable): the polling data hooks (`use*Data.ts`, `StatusBar.tsx`) were converted from a mount-only `[]` + inaccurate disable to destructuring the stable `useCallback` members (`const { start, stop } = polling`) and listing `[start, stop]`. `start`/`stop` are provably stable (every caller passes a module-level interval constant), so the effects still run once on mount/cleanup on unmount: behaviourally equivalent to `[]`, but honest. `use-shortcut-registry` extracted its `JSON.stringify(shortcuts)` content-key to a variable.
- **Kept with an accurate per-line reason** where the exclusion is genuinely intentional (mount-only hydration, prop-to-local-state resync that would loop, content-keyed registration, the `usePolling` internal stable-ref bundle).

End state: zero `@eslint-react/exhaustive-deps` references remain in `web/src/`.

### 3. Rule promotions (warn -> error, codebase already clean)
`@eslint-react/no-unstable-context-value`, `no-unstable-default-props`, `set-state-in-effect` (explicit override), `jsx-no-useless-fragment` (options pinned), `dom-no-missing-button-type`, and `react-refresh/only-export-components` (with `allowConstantExport`; still `off` for the `components/ui/**` shadcn variant co-exports).

**Out of scope (untouched, intended-permanent):** the `components/ui/**` shadcn overrides and the test-glob complexity exemptions.

## Test plan
- `npm --prefix web run lint` (--max-warnings 0): clean.
- `npm --prefix web run build` (tsc + vite): green.
- `npm --prefix web run test`: 300 files / 3471 tests pass, active-handle gate reports no leaked handles (the real validator that the dependency changes introduced no leaked timers / re-render storms).
- All pre-push gates (eslint-web, vale, knip, dpdm) green.

## Review coverage
Pre-reviewed by 7 agents (frontend-reviewer, security-reviewer, design-token-audit, issue-resolution-verifier, docs-consistency, comment-quality-rot, tool-parity-checker). Security: APPROVE, 0 findings. Issue-resolution: all 6 acceptance criteria RESOLVED. 3 doc/comment-precision findings applied; 3 (1 false positive, 2 pre-existing/cosmetic) reviewed and skipped with rationale.

## Follow-up (sequenced, not deferred)
A best-in-class hardening series (typescript-eslint `strictTypeChecked` + curated Tier A/B opt-ins + the `react-hooks/lints` React-Compiler bundle) was agreed during planning and will be filed as a separate `scope:web type:tech-debt` tracking issue, sized empirically per the repo's large-refactor PR-sizing rule.