### PR TITLE
fix(ci): serialize release-please runs to end release-branch 409 race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,9 @@ permissions: {}
 # branch. Two overlapping runs racing the BSL Change Date Contents-API
 # commit on that branch produced HTTP 409 "does not match" conflicts.
 # Queue rather than cancel so an in-flight run always finishes creating
-# the release PR and posting its required-check statuses.
+# the release PR and posting its required-check statuses. GitHub keeps
+# only the newest queued run; dropping older ones is safe because each
+# run reconciles full main state from scratch.
 concurrency:
   group: release-please
   cancel-in-progress: false
@@ -90,10 +92,9 @@ jobs:
           # PUT's optimistic-lock check consults -- the Contents API on the
           # release branch -- so the sha we send always matches the sha the
           # API holds. This is the canonical read-sha-then-conditional-write
-          # pattern and lets the workflow drop a full-branch checkout that
-          # existed only to give this step a working-tree LICENSE.
+          # pattern; no branch checkout is needed.
           api_json=$(gh api "repos/$GITHUB_REPOSITORY/contents/LICENSE?ref=$BRANCH")
-          cur_sha=$(printf '%s' "$api_json" | jq -r '.sha')
+          cur_sha=$(printf '%s' "$api_json" | jq -re '.sha')
           printf '%s' "$api_json" | jq -r '.content' | tr -d '\n' | base64 -d > LICENSE
 
           sed -i "s/^Change Date:          .*/Change Date:          $new_date/" LICENSE
@@ -101,7 +102,7 @@ jobs:
             echo "::error::sed pattern did not match; Change Date was not updated"
             exit 1
           }
-          if [ "$(git hash-object LICENSE)" = "$cur_sha" ]; then
+          if [ "$(git hash-object --no-filters LICENSE)" = "$cur_sha" ]; then
             echo "Change Date already up to date -- skipping commit"
             exit 0
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,15 @@ on:
 
 permissions: {}
 
+# Serialize: every main push updates the SAME sticky release-please PR
+# branch. Two overlapping runs racing the BSL Change Date Contents-API
+# commit on that branch produced HTTP 409 "does not match" conflicts.
+# Queue rather than cancel so an in-flight run always finishes creating
+# the release PR and posting its required-check statuses.
+concurrency:
+  group: release-please
+  cancel-in-progress: false
+
 jobs:
   release-please:
     name: Release Please
@@ -31,8 +40,8 @@ jobs:
       # Minimal checkout of main required so `./.github/actions/...`
       # paths resolve on the runner disk. `fetch-depth: 1` is enough;
       # release-please works via REST API, not the local working tree.
-      # The subsequent BSL-date step does its own checkout of the
-      # release-please PR branch when applicable.
+      # The BSL-date step reads + writes LICENSE on the release branch
+      # entirely through the Contents API, so no branch checkout is needed.
       - uses: Aureliolo/synthorg/.github/actions/checkout@25921183f274c930bf473dc0339376bda0961eaf
         with:
           ref: ${{ github.sha }}
@@ -61,13 +70,6 @@ jobs:
       # When Release Please creates/updates a release PR, update the BSL
       # Change Date to 3 years from today. The date update ships as part
       # of the release PR, so it goes through normal review + merge flow.
-      - name: Checkout Release PR branch
-        if: steps.release.outputs.pr != ''
-        uses: Aureliolo/synthorg/.github/actions/checkout@25921183f274c930bf473dc0339376bda0961eaf
-        with:
-          ref: release-please--branches--main--components--synthorg
-          persist-credentials: false
-
       - name: Update BSL Change Date (release + 3 years)
         if: steps.release.outputs.pr != ''
         env:
@@ -83,12 +85,23 @@ jobs:
           set -euo pipefail
           new_date=$(LC_TIME=C date -d "+3 years" "+%B %-d, %Y")  # GNU date (ubuntu-latest)
           echo "Updating Change Date to: $new_date"
+
+          # Read LICENSE content + its blob sha from the single source the
+          # PUT's optimistic-lock check consults -- the Contents API on the
+          # release branch -- so the sha we send always matches the sha the
+          # API holds. This is the canonical read-sha-then-conditional-write
+          # pattern and lets the workflow drop a full-branch checkout that
+          # existed only to give this step a working-tree LICENSE.
+          api_json=$(gh api "repos/$GITHUB_REPOSITORY/contents/LICENSE?ref=$BRANCH")
+          cur_sha=$(printf '%s' "$api_json" | jq -r '.sha')
+          printf '%s' "$api_json" | jq -r '.content' | tr -d '\n' | base64 -d > LICENSE
+
           sed -i "s/^Change Date:          .*/Change Date:          $new_date/" LICENSE
           grep -q "^Change Date:.*$new_date" LICENSE || {
             echo "::error::sed pattern did not match; Change Date was not updated"
             exit 1
           }
-          if git diff --quiet -- LICENSE; then
+          if [ "$(git hash-object LICENSE)" = "$cur_sha" ]; then
             echo "Change Date already up to date -- skipping commit"
             exit 0
           fi
@@ -98,11 +111,10 @@ jobs:
           # github-actions[bot], appearing as Verified in the release PR
           # UI. (The eventual squash-merge produces a separate GitHub-
           # signed commit on main regardless of this step's signature.)
-          BLOB_SHA=$(git rev-parse HEAD:LICENSE)
           jq -n \
             --arg msg "chore: update BSL Change Date to $new_date" \
             --arg content "$(base64 -w0 LICENSE)" \
-            --arg sha "$BLOB_SHA" \
+            --arg sha "$cur_sha" \
             --arg branch "$BRANCH" \
             '{message: $msg, content: $content, sha: $sha, branch: $branch}' \
           | gh api --method PUT "repos/$GITHUB_REPOSITORY/contents/LICENSE" --input -


### PR DESCRIPTION
Closes #2263.

## Root cause

The Release workflow (`release.yml`) had **no `concurrency:` group**, so every push to `main` started an independent run, and they all write `LICENSE` (BSL Change Date) to the **same sticky release-please PR branch** via the Contents API.

On 2026-06-07 two automated merges landed on `main` 11 seconds apart:

| Time (UTC) | Commit | PR | Release run |
|---|---|---|---|
| 10:13:23 | `f2fd0c3a` | #2261 `ci: refresh .test_durations` | `27089601936` → success (did the PUT) |
| 10:13:34 | `62800a33` | #2260 `chore: Lock file maintenance` (Renovate) | `27089605871` → **HTTP 409** |

The first run rewrote the branch's `LICENSE`; the second had captured the now-stale blob SHA (`git rev-parse HEAD:LICENSE` = main's `1debe8b…`) and its optimistic-lock PUT was rejected (`409 "LICENSE does not match 1debe8b…"`). This is a latent race that has existed since the BSL step was added; it only surfaced now because two bot merges coincided inside the step's execution window.

## Fix

1. **Add `concurrency: { group: release-please, cancel-in-progress: false }`** (the root-cause fix). Release runs now serialise; a second near-simultaneous merge queues, then sees the branch already updated and cleanly skips. Matches the house pattern used by `dev-release.yml`, `auto-rollover.yml`, `graduate.yml`. GitHub keeps only the newest queued run; dropping older ones is safe because each run reconciles full `main` state.
2. **Harden the BSL step** (defense-in-depth): read `LICENSE` content + its blob SHA from the Contents API — the authority the PUT's optimistic lock checks against — instead of a separate full-branch checkout, which is removed. Skip check now uses `git hash-object --no-filters` (raw-byte equality, mirroring the Contents-API PUT's no-normalization behaviour); `jq -re` fails closed on a malformed API response.

## Test plan

- Verified byte-exact against the live release branch: `git hash-object` of the API-decoded `LICENSE` content equals the API's `.sha`.
- `actionlint`, `zizmor`, `yamllint`, and the workflow shell-git / tag-lifecycle gates pass.
- No automated test is possible for a GitHub Actions concurrency setting; CI behaviour is validated on the next `main` push.

## Review coverage

Pre-reviewed by 4 agents (infra-reviewer, issue-resolution-verifier, comment-quality-rot, docs-consistency); 4 findings addressed (migration-framing comment cleanup, `jq -re`, `git hash-object --no-filters`, queued-run-drop comment note). issue-resolution-verifier: RESOLVED (95). docs-consistency: no drift.