### PR TITLE
ci: harden release-download curl retry against transient CDN 504s

### DIFF
--- a/.github/actions/build-apko-base/action.yml
+++ b/.github/actions/build-apko-base/action.yml
@@ -97,8 +97,8 @@ runs:
       env:
         TRIVY_VERSION: ${{ inputs.trivy-version }}
       run: |
-        curl -sfL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
-        curl -sfL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt" -o /tmp/trivy_checksums.txt
+        curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+        curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt" -o /tmp/trivy_checksums.txt
         (cd /tmp && grep "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy_checksums.txt | sha256sum -c -)
         tar -xzf "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -C /tmp trivy
         sudo install -m 0755 /tmp/trivy /usr/local/bin/trivy

--- a/.github/actions/build-apko-base/action.yml
+++ b/.github/actions/build-apko-base/action.yml
@@ -97,8 +97,8 @@ runs:
       env:
         TRIVY_VERSION: ${{ inputs.trivy-version }}
       run: |
-        curl -sfL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
-        curl -sfL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt" -o /tmp/trivy_checksums.txt
+        curl -sfL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+        curl -sfL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt" -o /tmp/trivy_checksums.txt
         (cd /tmp && grep "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy_checksums.txt | sha256sum -c -)
         tar -xzf "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -C /tmp trivy
         sudo install -m 0755 /tmp/trivy /usr/local/bin/trivy

--- a/.github/actions/build-scan-image/action.yml
+++ b/.github/actions/build-scan-image/action.yml
@@ -316,8 +316,8 @@ runs:
       env:
         TRIVY_VERSION: ${{ inputs.trivy-version }}
       run: |
-        curl -sfL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
-        curl -sfL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt" -o /tmp/trivy_checksums.txt
+        curl -sfL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+        curl -sfL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt" -o /tmp/trivy_checksums.txt
         (cd /tmp && grep "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy_checksums.txt | sha256sum -c -)
         tar -xzf "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -C /tmp trivy
         sudo install -m 0755 /tmp/trivy /usr/local/bin/trivy

--- a/.github/actions/build-scan-image/action.yml
+++ b/.github/actions/build-scan-image/action.yml
@@ -316,8 +316,8 @@ runs:
       env:
         TRIVY_VERSION: ${{ inputs.trivy-version }}
       run: |
-        curl -sfL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
-        curl -sfL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt" -o /tmp/trivy_checksums.txt
+        curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+        curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt" -o /tmp/trivy_checksums.txt
         (cd /tmp && grep "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy_checksums.txt | sha256sum -c -)
         tar -xzf "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -C /tmp trivy
         sudo install -m 0755 /tmp/trivy /usr/local/bin/trivy

--- a/.github/actions/setup-apko/action.yml
+++ b/.github/actions/setup-apko/action.yml
@@ -15,10 +15,10 @@ runs:
         APKO_VERSION: ${{ inputs.version }}
       run: |
         APKO_ARCHIVE="apko_${APKO_VERSION#v}_linux_amd64.tar.gz"
-        curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors \
+        curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 \
           "https://github.com/chainguard-dev/apko/releases/download/${APKO_VERSION}/${APKO_ARCHIVE}" \
           -o "/tmp/${APKO_ARCHIVE}"
-        curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors \
+        curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 \
           "https://github.com/chainguard-dev/apko/releases/download/${APKO_VERSION}/checksums.txt" \
           -o /tmp/apko-checksums.txt
         awk -v f="${APKO_ARCHIVE}" '$2==f {print $1"  /tmp/"$2; found=1} END{if(!found) exit 1}' /tmp/apko-checksums.txt | sha256sum -c -

--- a/.github/actions/warm-tree-sitter-cache/action.yml
+++ b/.github/actions/warm-tree-sitter-cache/action.yml
@@ -10,9 +10,10 @@ description: |
   whose only job is downloading the tarball, so the same 502 retries
   cleanly here instead of poisoning a multi-minute test run.
 
-  Matches the project standard for transient downloads documented in
-  the curl ``--retry 5 --retry-delay 5 --retry-all-errors`` pattern
-  (see .github/workflows/pages-preview.yml lines 161-180).
+  Matches the project standard for transient downloads: the curl
+  ``--connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300``
+  pattern (exponential backoff, bounded retry window), as used in
+  .github/actions/setup-apko/action.yml.
 
 runs:
   using: composite

--- a/.github/actions/warm-tree-sitter-cache/action.yml
+++ b/.github/actions/warm-tree-sitter-cache/action.yml
@@ -10,10 +10,12 @@ description: |
   whose only job is downloading the tarball, so the same 502 retries
   cleanly here instead of poisoning a multi-minute test run.
 
-  Matches the project standard for transient downloads: the curl
-  ``--connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300``
-  pattern (exponential backoff, bounded retry window), as used in
-  .github/actions/setup-apko/action.yml.
+  The Rust binding performs the fetch internally, so the project's curl
+  download-retry flags cannot be threaded into it. This step instead
+  wraps the Python call in an explicit bounded-retry loop (3 attempts,
+  10s fixed back-off) that follows the same fail-cleanly intent as the
+  curl standard in .github/actions/setup-apko/action.yml, without being
+  able to share its exact mechanism.
 
 runs:
   using: composite

--- a/.github/workflows/apko-lock.yml
+++ b/.github/workflows/apko-lock.yml
@@ -287,11 +287,20 @@ jobs:
 
           Run: ${RUN_URL}
 
-          Likely cause: a Wolfi package was renamed/removed, an apko CLI
-          breaking change, or the App-token + \`createCommitOnBranch\` +
-          \`gh pr create\` flow could not push (synthorg-repo-bot
-          App token mint failure, GraphQL permission denial, or
-          \`apko-lock\` env branch-policy drift).
+          Read the failing step's logs FIRST before assuming a cause:
+          \`gh run view ${GITHUB_RUN_ID} --log-failed\`. Candidate causes,
+          roughly by likelihood:
+          - Transient GitHub releases-CDN download failure (HTTP 5xx) in
+            the apko binary setup step. These normally clear on a re-run;
+            the download already uses bounded exponential-backoff retry.
+          - A Wolfi package was renamed/removed (the \`apko lock\` step
+            itself fails): update the relevant \`docker/*/apko.yaml\`
+            package list and let the workflow regenerate the lockfiles.
+          - An apko CLI breaking change after a version bump.
+          - The App-token + \`createCommitOnBranch\` + \`gh pr create\` push
+            flow could not push (synthorg-repo-bot token mint failure,
+            GraphQL permission denial, or \`apko-lock\` env branch-policy
+            drift).
           When this stays red for >1 weekly cycle, base images go stale.
           EOF
             echo 'TRACKING_ISSUE_BODY_EOF'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1442,7 +1442,7 @@ jobs:
           set -euo pipefail
           # yq (Mike Farah) -- Go binary, no runtime deps.  Retry on
           # transient GitHub-releases CDN flakes.
-          sudo curl -sSfL --retry 5 --retry-delay 5 --retry-all-errors \
+          sudo curl -sSfL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 \
             https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64 \
             -o /usr/local/bin/yq
           sudo chmod +x /usr/local/bin/yq

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -685,7 +685,7 @@ jobs:
           # renovate: datasource=github-releases depName=terrastruct/d2
           D2_VERSION: v0.7.1
         run: |
-          curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/terrastruct/d2/releases/download/${D2_VERSION}/d2-${D2_VERSION}-linux-amd64.tar.gz" -o /tmp/d2.tar.gz
+          curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/terrastruct/d2/releases/download/${D2_VERSION}/d2-${D2_VERSION}-linux-amd64.tar.gz" -o /tmp/d2.tar.gz
           tar -xzf /tmp/d2.tar.gz -C /tmp
           sudo mv "/tmp/d2-${D2_VERSION}/bin/d2" /usr/local/bin/d2
           rm -rf /tmp/d2.tar.gz "/tmp/d2-${D2_VERSION}"
@@ -835,8 +835,8 @@ jobs:
 
       - name: Install Trivy
         run: |
-          curl -sfL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
-          curl -sfL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt" -o /tmp/trivy_checksums.txt
+          curl -sfL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+          curl -sfL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt" -o /tmp/trivy_checksums.txt
           (cd /tmp && grep "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy_checksums.txt | sha256sum -c -)
           tar -xzf "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -C /tmp trivy
           sudo install -m 0755 /tmp/trivy /usr/local/bin/trivy

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -835,8 +835,8 @@ jobs:
 
       - name: Install Trivy
         run: |
-          curl -sfL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
-          curl -sfL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt" -o /tmp/trivy_checksums.txt
+          curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+          curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt" -o /tmp/trivy_checksums.txt
           (cd /tmp && grep "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy_checksums.txt | sha256sum -c -)
           tar -xzf "/tmp/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -C /tmp trivy
           sudo install -m 0755 /tmp/trivy /usr/local/bin/trivy

--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -128,7 +128,7 @@ jobs:
           # renovate: datasource=github-releases depName=terrastruct/d2
           D2_VERSION: v0.7.1
         run: |
-          curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/terrastruct/d2/releases/download/${D2_VERSION}/d2-${D2_VERSION}-linux-amd64.tar.gz" -o d2.tar.gz
+          curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/terrastruct/d2/releases/download/${D2_VERSION}/d2-${D2_VERSION}-linux-amd64.tar.gz" -o d2.tar.gz
           tar -xzf d2.tar.gz
           sudo mv "d2-${D2_VERSION}/bin/d2" /usr/local/bin/d2
           rm -rf d2.tar.gz "d2-${D2_VERSION}"
@@ -435,7 +435,7 @@ jobs:
           while :; do
             CURL_EXIT=0
             RESPONSE=$(curl -s -w "\n%{http_code}" \
-              --retry 5 --retry-delay 5 --retry-all-errors \
+              --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 \
               "${API_BASE}?per_page=${PER_PAGE}&page=${PAGE}" \
               -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}") || CURL_EXIT=$?
             HTTP_CODE=$(echo "$RESPONSE" | tail -1)
@@ -486,7 +486,7 @@ jobs:
             echo "Deleting deployment ${DEPLOY_ID}..."
             DEL_CURL_EXIT=0
             DEL_RESPONSE=$(curl -s -w "\n%{http_code}" -X DELETE \
-              --retry 5 --retry-delay 5 --retry-all-errors \
+              --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 \
               "${API_BASE}/${DEPLOY_ID}?force=true" \
               -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}") || DEL_CURL_EXIT=$?
             DEL_CODE=$(echo "$DEL_RESPONSE" | tail -1)

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -58,7 +58,7 @@ jobs:
           # renovate: datasource=github-releases depName=terrastruct/d2
           D2_VERSION: v0.7.1
         run: |
-          curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/terrastruct/d2/releases/download/${D2_VERSION}/d2-${D2_VERSION}-linux-amd64.tar.gz" -o d2.tar.gz
+          curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "https://github.com/terrastruct/d2/releases/download/${D2_VERSION}/d2-${D2_VERSION}-linux-amd64.tar.gz" -o d2.tar.gz
           tar -xzf d2.tar.gz
           sudo mv "d2-${D2_VERSION}/bin/d2" /usr/local/bin/d2
           rm -rf d2.tar.gz "d2-${D2_VERSION}"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -29,8 +29,8 @@ jobs:
         run: |
           BASE_URL="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
           ARCHIVE="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
-          curl -fsSLo "${ARCHIVE}" --retry 5 --retry-delay 5 --retry-all-errors "${BASE_URL}/${ARCHIVE}"
-          curl -fsSLo checksums.txt --retry 5 --retry-delay 5 --retry-all-errors "${BASE_URL}/gitleaks_${GITLEAKS_VERSION}_checksums.txt"
+          curl -fsSLo "${ARCHIVE}" --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "${BASE_URL}/${ARCHIVE}"
+          curl -fsSLo checksums.txt --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 "${BASE_URL}/gitleaks_${GITLEAKS_VERSION}_checksums.txt"
           grep " ${ARCHIVE}$" checksums.txt | sha256sum -c -
           tar xzf "${ARCHIVE}" gitleaks
           sudo install -m 0755 gitleaks /usr/local/bin/gitleaks


### PR DESCRIPTION
Closes #2274

## Root cause

The weekly `apko lock` workflow failed on [run 27122829406](https://github.com/Aureliolo/synthorg/actions/runs/27122829406). The failing step was **Set up apko**: `curl` downloading the apko binary got **HTTP 504 (Gateway Timeout)** from GitHub's release-asset CDN on all 6 attempts (1 + 5 retries), exit 22. The lock/commit/PR steps were skipped.

All three candidate causes in the auto-filed issue are ruled out by evidence:
- **Wolfi package rename/removal** — no; the failure was before `apko lock` ran.
- **apko CLI breaking change** — no; `v1.2.15` and asset `apko_1.2.15_linux_amd64.tar.gz` exist, and the 6 prior weekly runs were green on the identical pin.
- **Token / `createCommitOnBranch` / `gh pr create` push failure** — no; the repo-bot App token mint **succeeded**; the push flow was never reached.

It was a **transient CDN outage**. The real defect: the shared retry pattern `--retry 5 --retry-delay 5 --retry-all-errors` gives only a ~25s **fixed-delay** window, too short to ride out a gateway-timeout episode. (`--retry-all-errors` already retries 504; the error class was never the problem — the window was.)

## What changed (`.github/` only)

- **Hardened the shared curl download-retry convention repo-wide** (16 callsites: apko, trivy, d2, gitleaks, yq, plus two Cloudflare API calls). Replaced the token with `--connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300`:
  - Omitting `--retry-delay` enables curl's **exponential backoff** (man page: the flag "changes the default backoff time algorithm"; confirmed on curl 8.x).
  - `--retry-max-time 300` bounds the retry window (only the retry loop, not a slow healthy transfer); safely under every affected job's `timeout-minutes`.
  - `--connect-timeout 30` fails dead connections fast so a retry fires promptly.
- **Updated the documented reference** in `warm-tree-sitter-cache/action.yml` to match (and accurately note that action uses a Python loop, not curl).
- **Reworded the misleading auto-filed tracking-issue body** in `apko-lock.yml` to direct the operator to read the failing step's logs first (`gh run view <id> --log-failed`) and to rank transient CDN failures as the most likely cause.

No apko version bump (renovate owns that; the version was never the cause). No `docker/*/apko.*` lockfile edits (the now-fixed workflow regenerates them). No new third-party actions.

## Verification / test plan

- `actionlint` + `zizmor --offline` clean on all changed workflows/actions; all pre-commit + pre-push gates pass.
- curl exponential-backoff behaviour confirmed against curl 8.x (omitting `--retry-delay` = default exponential backoff).
- **The apko-lock job cannot be tested on this branch** — it is gated to the `apko-lock` environment (main-only branch allowlist). Full verification is a re-run of run 27122829406 (on a main SHA; will go green now the CDN recovered) and/or a `workflow_dispatch` on main after merge.

Honest note: this **lowers recurrence probability** of transient-CDN failures; it does not "turn the failed run green" (that run failed on an external blip that has since cleared).

## Review coverage

Pre-reviewed by 4 agents (infra-reviewer, issue-resolution-verifier, docs-consistency, comment-quality-rot). 1 finding addressed (decoupled the warm-tree-sitter doc comment from the curl pattern, since that action uses a Python retry loop); 1 minor advisory accepted with rationale (kept `--retry-max-time` uniform at 300 rather than reintroducing per-job drift).