### PR TITLE
chore: route api-contract-drift on dispersed enums.py after core/enums dissolution

### DIFF
--- a/.claude/skills/aurelio-review-pr/SKILL.md
+++ b/.claude/skills/aurelio-review-pr/SKILL.md
@@ -174,7 +174,7 @@ Based on changed files, launch applicable review agents **in parallel** using th
 | **security-reviewer** | Files in sensitive paths OR any `web_src` changed OR diff contains dangerous patterns | `security-reviewer` |
 | **frontend-reviewer** | Any `web_src` or `web_test` | `frontend-reviewer` |
 | **design-token-audit** | Any `web_src` | `design-token-audit` |
-| **api-contract-drift** | Any file in `src/synthorg/api/` OR `web/src/api/` OR `src/synthorg/core/enums.py` | `api-contract-drift` |
+| **api-contract-drift** | Any file in `src/synthorg/api/` OR `web/src/api/` OR any `src/synthorg/**/enums.py` | `api-contract-drift` |
 | **infra-reviewer** | Any `docker`, `ci`, or `infra_config` file | `infra-reviewer` |
 | **persistence-reviewer** | Any file in `src/synthorg/persistence/` | `persistence-reviewer` |
 | **test-quality-reviewer** | Any `test_py` or `web_test` | `test-quality-reviewer` |
@@ -399,7 +399,7 @@ Read the relevant backend and frontend files, then cross-reference:
 4. Field name mismatches between backend Pydantic response models and frontend TypeScript types (MAJOR)
 5. Field type mismatches (e.g., backend returns `int`, frontend expects `string`) (MAJOR)
 6. Optional/required mismatches: backend field is optional but frontend assumes it's always present, or vice versa (MAJOR)
-7. Enum value drift: backend `core/enums.py` values don't match frontend constants/types (MAJOR)
+7. Enum value drift: backend `**/enums.py` values don't match frontend constants/types (MAJOR)
 
 **Request/response shape (MAJOR):**
 8. Frontend sending request body fields that the backend doesn't accept (silently ignored) (MAJOR)

--- a/.claude/skills/aurelio-review-pr/SKILL.md
+++ b/.claude/skills/aurelio-review-pr/SKILL.md
@@ -174,7 +174,7 @@ Based on changed files, launch applicable review agents **in parallel** using th
 | **security-reviewer** | Files in sensitive paths OR any `web_src` changed OR diff contains dangerous patterns | `security-reviewer` |
 | **frontend-reviewer** | Any `web_src` or `web_test` | `frontend-reviewer` |
 | **design-token-audit** | Any `web_src` | `design-token-audit` |
-| **api-contract-drift** | Any file in `src/synthorg/api/` OR `web/src/api/` OR any `src/synthorg/**/enums.py` | `api-contract-drift` |
+| **api-contract-drift** | Any file in `src/synthorg/api/` OR `web/src/api/` OR any changed `src/synthorg/` `.py` file whose diff defines or modifies a `StrEnum`/`IntEnum`/`Enum` subclass (catches dispersed/domain-named enum modules, e.g. `core/task_enums.py`, `hr/seniority.py`, not just `enums.py`) | `api-contract-drift` |
 | **infra-reviewer** | Any `docker`, `ci`, or `infra_config` file | `infra-reviewer` |
 | **persistence-reviewer** | Any file in `src/synthorg/persistence/` | `persistence-reviewer` |
 | **test-quality-reviewer** | Any `test_py` or `web_test` | `test-quality-reviewer` |
@@ -399,7 +399,7 @@ Read the relevant backend and frontend files, then cross-reference:
 4. Field name mismatches between backend Pydantic response models and frontend TypeScript types (MAJOR)
 5. Field type mismatches (e.g., backend returns `int`, frontend expects `string`) (MAJOR)
 6. Optional/required mismatches: backend field is optional but frontend assumes it's always present, or vice versa (MAJOR)
-7. Enum value drift: backend `**/enums.py` values don't match frontend constants/types (MAJOR)
+7. Enum value drift: backend enum-module values (any `src/synthorg/` module defining an enum, not just `enums.py`) don't match frontend constants/types (MAJOR)
 
 **Request/response shape (MAJOR):**
 8. Frontend sending request body fields that the backend doesn't accept (silently ignored) (MAJOR)

--- a/.claude/skills/pre-pr-review/SKILL.md
+++ b/.claude/skills/pre-pr-review/SKILL.md
@@ -274,7 +274,7 @@ This captures committed-but-unpushed changes AND any uncommitted/untracked work 
 | **security-reviewer** | Files in `src/synthorg/api/`, `src/synthorg/security/`, `src/synthorg/tools/`, `src/synthorg/config/`, `src/synthorg/persistence/`, `src/synthorg/engine/` changed, OR any `web_src` changed, OR diff contains `subprocess`, `eval`, `exec`, `pickle`, `yaml.load`, `sql`, auth/credential patterns | `security-reviewer` |
 | **frontend-reviewer** | Any `web_src` or `web_test` | `frontend-reviewer` |
 | **design-token-audit** | Any `web_src` | `.claude/agents/design-token-audit.md` prompt (scans for density, animation, spacing token violations) |
-| **api-contract-drift** | Any file in `src/synthorg/api/` OR `web/src/api/` OR any `src/synthorg/**/enums.py` | `api-contract-drift` |
+| **api-contract-drift** | Any file in `src/synthorg/api/` OR `web/src/api/` OR any changed `src/synthorg/` `.py` file whose diff defines or modifies a `StrEnum`/`IntEnum`/`Enum` subclass (catches dispersed/domain-named enum modules, e.g. `core/task_enums.py`, `hr/seniority.py`, not just `enums.py`) | `api-contract-drift` |
 | **infra-reviewer** | Any `docker`, `ci`, or `infra_config` file | `infra-reviewer` |
 | **persistence-reviewer** | Any file in `src/synthorg/persistence/` | `persistence-reviewer` |
 | **test-quality-reviewer** | Any `test_py` or `web_test` | `test-quality-reviewer` |
@@ -570,7 +570,7 @@ Read the relevant backend and frontend files, then cross-reference:
 4. Field name mismatches between backend Pydantic response models and frontend TypeScript types (MAJOR)
 5. Field type mismatches (e.g., backend returns `int`, frontend expects `string`) (MAJOR)
 6. Optional/required mismatches: backend field is optional but frontend assumes it's always present, or vice versa (MAJOR)
-7. Enum value drift: backend `**/enums.py` values don't match frontend constants/types (MAJOR)
+7. Enum value drift: backend enum-module values (any `src/synthorg/` module defining an enum, not just `enums.py`) don't match frontend constants/types (MAJOR)
 
 **Request/response shape (MAJOR):**
 8. Frontend sending request body fields that the backend doesn't accept (silently ignored) (MAJOR)

--- a/.claude/skills/pre-pr-review/SKILL.md
+++ b/.claude/skills/pre-pr-review/SKILL.md
@@ -274,7 +274,7 @@ This captures committed-but-unpushed changes AND any uncommitted/untracked work 
 | **security-reviewer** | Files in `src/synthorg/api/`, `src/synthorg/security/`, `src/synthorg/tools/`, `src/synthorg/config/`, `src/synthorg/persistence/`, `src/synthorg/engine/` changed, OR any `web_src` changed, OR diff contains `subprocess`, `eval`, `exec`, `pickle`, `yaml.load`, `sql`, auth/credential patterns | `security-reviewer` |
 | **frontend-reviewer** | Any `web_src` or `web_test` | `frontend-reviewer` |
 | **design-token-audit** | Any `web_src` | `.claude/agents/design-token-audit.md` prompt (scans for density, animation, spacing token violations) |
-| **api-contract-drift** | Any file in `src/synthorg/api/` OR `web/src/api/` OR `src/synthorg/core/enums.py` | `api-contract-drift` |
+| **api-contract-drift** | Any file in `src/synthorg/api/` OR `web/src/api/` OR any `src/synthorg/**/enums.py` | `api-contract-drift` |
 | **infra-reviewer** | Any `docker`, `ci`, or `infra_config` file | `infra-reviewer` |
 | **persistence-reviewer** | Any file in `src/synthorg/persistence/` | `persistence-reviewer` |
 | **test-quality-reviewer** | Any `test_py` or `web_test` | `test-quality-reviewer` |
@@ -570,7 +570,7 @@ Read the relevant backend and frontend files, then cross-reference:
 4. Field name mismatches between backend Pydantic response models and frontend TypeScript types (MAJOR)
 5. Field type mismatches (e.g., backend returns `int`, frontend expects `string`) (MAJOR)
 6. Optional/required mismatches: backend field is optional but frontend assumes it's always present, or vice versa (MAJOR)
-7. Enum value drift: backend `core/enums.py` values don't match frontend constants/types (MAJOR)
+7. Enum value drift: backend `**/enums.py` values don't match frontend constants/types (MAJOR)
 
 **Request/response shape (MAJOR):**
 8. Frontend sending request body fields that the backend doesn't accept (silently ignored) (MAJOR)


### PR DESCRIPTION
## Summary

The dissolution of `core/enums.py` into per-feature `**/enums.py` modules landed via prior PRs, but the review-pipeline skill docs still routed the `api-contract-drift` reviewer at the now-deleted `src/synthorg/core/enums.py` path. As a result, backend/frontend enum-drift no longer auto-routed to that reviewer.

This points the router at the dispersed enum surface instead.

## Changes

- `.claude/skills/pre-pr-review/SKILL.md`: routing table + enum-drift criterion now reference `src/synthorg/**/enums.py` instead of the deleted `core/enums.py`.
- `.claude/skills/aurelio-review-pr/SKILL.md`: same two edits.

Four lines across two files; no `src/`, `tests/`, or runtime changes.

## Verification

This change completes the final residual of the junk-drawer dissolution. Validation against `main` confirmed every acceptance criterion holds: `core/enums.py` deleted (import raises `ModuleNotFoundError`), zero `core.enums` import sites in src/tests, `observability/events/persistence/` is a per-sub-domain package with `__all__ = []` (no re-export bag), all related gates 100% on with zero exemptions (junk-drawer baseline deleted, module-size baseline empty, god-module allowlist empty, no `lint-allow: junk-drawer`), and the full unit suite green (32677 passed, 25 skipped). After this merge, `git grep -rn "core/enums" -- '.claude/**'` returns nothing.

No OpenCode counterpart carries these strings, so no parity edit is needed.

Closes #2051
