### PR TITLE
fix: make the image-signing pipeline resilient to GHCR flakiness

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash scripts/check_no_repush_after_failure.sh",
+            "timeout": 5000
+          },
+          {
+            "type": "command",
             "command": "bash scripts/check_push_rebased.sh",
             "timeout": 15000
           },

--- a/.github/actions/publish-apko-base/action.yml
+++ b/.github/actions/publish-apko-base/action.yml
@@ -208,13 +208,31 @@ runs:
           exit 1
         fi
 
+        # cosign has just published the signature as an OCI referrer; GHCR
+        # surfaces it as the `sha256-<hex>` referrer tag with EVENTUAL
+        # consistency, so a check issued milliseconds after signing can 404
+        # for a short window. Poll with bounded backoff (5 attempts,
+        # 2s -> 4s -> 8s -> 16s, ~30s budget) so a propagation lag
+        # self-heals while a genuinely-missing signature still fails after
+        # the budget. Mirrors publish-image-loaded's post-sign check.
         SIG_HEX="${SIGNED_DIGEST#sha256:}"
-        SIG_STATUS="$(curl -sSL -o /dev/null -w '%{http_code}' \
-          -H "Authorization: Bearer ${REG_TOKEN}" \
-          -H "Accept: application/vnd.oci.image.index.v1+json" \
-          "https://ghcr.io/v2/${REPO_PATH}/manifests/sha256-${SIG_HEX}")"
+        SIG_ATTEMPTS=5
+        SIG_BACKOFF=2
+        SIG_STATUS=000
+        for ((s = 1; s <= SIG_ATTEMPTS; s++)); do
+          SIG_STATUS="$(curl -sSL -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer ${REG_TOKEN}" \
+            -H "Accept: application/vnd.oci.image.index.v1+json" \
+            "https://ghcr.io/v2/${REPO_PATH}/manifests/sha256-${SIG_HEX}")"
+          [ "${SIG_STATUS}" = "200" ] && break
+          if [ "$s" -lt "$SIG_ATTEMPTS" ]; then
+            echo "::warning::signature referrer sha256-${SIG_HEX} not yet visible (HTTP ${SIG_STATUS}, attempt ${s}/${SIG_ATTEMPTS}); GHCR propagation lag, retrying in ${SIG_BACKOFF}s"
+            sleep "${SIG_BACKOFF}"
+            SIG_BACKOFF=$((SIG_BACKOFF * 2))
+          fi
+        done
         if [ "${SIG_STATUS}" != "200" ]; then
-          echo "::error::cosign signature artifact missing (referrer tag sha256-${SIG_HEX} returned HTTP ${SIG_STATUS})"
+          echo "::error::cosign signature artifact missing (referrer tag sha256-${SIG_HEX} returned HTTP ${SIG_STATUS} after ${SIG_ATTEMPTS} attempts)"
           exit 1
         fi
         echo "✓ ghcr.io/${REPO_PATH}:${TAG} -> ${ACTUAL} (signed)"

--- a/.github/actions/publish-apko-base/action.yml
+++ b/.github/actions/publish-apko-base/action.yml
@@ -122,10 +122,32 @@ runs:
         # fail with "manifest already exists" before the idempotent push below.
         docker manifest create --amend "${REPO}:${TAG}" "${MANIFEST_ARGS[@]}"
         bash "$RETRY" "docker manifest push ${REPO}:${TAG}" docker manifest push "${REPO}:${TAG}"
-        # Read the canonical manifest list digest back from the
-        # registry. Stable across re-runs because the create above pins
-        # source members by digest.
-        DIGEST="$(docker buildx imagetools inspect "${REPO}:${TAG}" --format '{{.Manifest.Digest}}')"
+        # Read the canonical manifest list digest back from the registry.
+        # Stable across re-runs because the create above pins source
+        # members by digest. GHCR is eventually consistent on the write
+        # path: the tag we just pushed can 404 ("not found") for a short
+        # window before it is readable, so retry the read-back with bounded
+        # backoff rather than failing the whole publish (which would leave
+        # the image unsigned). Mirrors the inspect retry in
+        # publish-image-retag and publish-image-loaded.
+        INSPECT_ATTEMPTS=5
+        INSPECT_BACKOFF=2
+        DIGEST=""
+        for ((ia = 1; ia <= INSPECT_ATTEMPTS; ia++)); do
+          if DIGEST="$(docker buildx imagetools inspect "${REPO}:${TAG}" --format '{{.Manifest.Digest}}' 2>/dev/null)" && [ -n "$DIGEST" ]; then
+            break
+          fi
+          DIGEST=""
+          if [ "$ia" -lt "$INSPECT_ATTEMPTS" ]; then
+            echo "::warning::manifest ${REPO}:${TAG} not yet readable after push (attempt ${ia}/${INSPECT_ATTEMPTS}); GHCR read-after-write lag, retrying in ${INSPECT_BACKOFF}s"
+            sleep "${INSPECT_BACKOFF}"
+            INSPECT_BACKOFF=$((INSPECT_BACKOFF * 2))
+          fi
+        done
+        if [ -z "$DIGEST" ]; then
+          echo "::error::manifest ${REPO}:${TAG} not readable after ${INSPECT_ATTEMPTS} attempts -- cannot compute signing digest"
+          exit 1
+        fi
         echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
     # GitHub releases occasionally 5xx; cosign-installer's internal retry (3
@@ -190,7 +212,10 @@ runs:
         set -euo pipefail
         REPO_PATH="aureliolo/synthorg-${IMAGE_NAME}-base"
         # `-L` follows redirects defensively; matches publish-image-loaded.
-        REG_TOKEN="$(curl -sSL -u "x-access-token:${GHCR_TOKEN}" \
+        # `--connect-timeout`/`--max-time` bound every curl (no default
+        # deadline) so a black-holed connection can't stall to the job
+        # timeout.
+        REG_TOKEN="$(curl -sSL --connect-timeout 5 --max-time 15 -u "x-access-token:${GHCR_TOKEN}" \
           "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO_PATH}:pull" \
           | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')"
         if [ -z "${REG_TOKEN}" ]; then
@@ -198,7 +223,7 @@ runs:
           exit 1
         fi
 
-        ACTUAL="$(curl -sSL -I \
+        ACTUAL="$(curl -sSL --connect-timeout 5 --max-time 15 -I \
           -H "Authorization: Bearer ${REG_TOKEN}" \
           -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.index.v1+json" \
           "https://ghcr.io/v2/${REPO_PATH}/manifests/${TAG}" \
@@ -215,12 +240,18 @@ runs:
         # 2s -> 4s -> 8s -> 16s, ~30s budget) so a propagation lag
         # self-heals while a genuinely-missing signature still fails after
         # the budget. Mirrors publish-image-loaded's post-sign check.
+        # Validate the digest shape first so a malformed SIGNED_DIGEST
+        # cannot build a bogus referrer URL.
+        if ! [[ "${SIGNED_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+          echo "::error::SIGNED_DIGEST is not a valid sha256 digest: '${SIGNED_DIGEST}'"
+          exit 1
+        fi
         SIG_HEX="${SIGNED_DIGEST#sha256:}"
         SIG_ATTEMPTS=5
         SIG_BACKOFF=2
         SIG_STATUS=000
         for ((s = 1; s <= SIG_ATTEMPTS; s++)); do
-          SIG_STATUS="$(curl -sSL -o /dev/null -w '%{http_code}' \
+          SIG_STATUS="$(curl -sSL --connect-timeout 5 --max-time 10 -o /dev/null -w '%{http_code}' \
             -H "Authorization: Bearer ${REG_TOKEN}" \
             -H "Accept: application/vnd.oci.image.index.v1+json" \
             "https://ghcr.io/v2/${REPO_PATH}/manifests/sha256-${SIG_HEX}")"
@@ -231,7 +262,10 @@ runs:
             SIG_BACKOFF=$((SIG_BACKOFF * 2))
           fi
         done
-        if [ "${SIG_STATUS}" != "200" ]; then
+        if [ "${SIG_STATUS}" = "000" ]; then
+          echo "::error::cosign signature check could not reach GHCR (curl network error, not a registry response) for sha256-${SIG_HEX} after ${SIG_ATTEMPTS} attempts"
+          exit 1
+        elif [ "${SIG_STATUS}" != "200" ]; then
           echo "::error::cosign signature artifact missing (referrer tag sha256-${SIG_HEX} returned HTTP ${SIG_STATUS} after ${SIG_ATTEMPTS} attempts)"
           exit 1
         fi

--- a/.github/actions/publish-apko-base/action.yml
+++ b/.github/actions/publish-apko-base/action.yml
@@ -251,10 +251,17 @@ runs:
         SIG_BACKOFF=2
         SIG_STATUS=000
         for ((s = 1; s <= SIG_ATTEMPTS; s++)); do
+          # `|| SIG_STATUS=000` on the ASSIGNMENT (not inside the command
+          # substitution) so a curl network failure under `set -e` neither
+          # aborts the step nor double-prints the sentinel: curl already
+          # emits "000" to stdout on a connection failure, so an in-`$()`
+          # `|| echo 000` would capture "000000" and miss the dedicated
+          # network-error branch below. The `||` on the assignment suspends
+          # `set -e` for the left side and overwrites with a clean "000".
           SIG_STATUS="$(curl -sSL --connect-timeout 5 --max-time 10 -o /dev/null -w '%{http_code}' \
             -H "Authorization: Bearer ${REG_TOKEN}" \
             -H "Accept: application/vnd.oci.image.index.v1+json" \
-            "https://ghcr.io/v2/${REPO_PATH}/manifests/sha256-${SIG_HEX}")"
+            "https://ghcr.io/v2/${REPO_PATH}/manifests/sha256-${SIG_HEX}")" || SIG_STATUS=000
           [ "${SIG_STATUS}" = "200" ] && break
           if [ "$s" -lt "$SIG_ATTEMPTS" ]; then
             echo "::warning::signature referrer sha256-${SIG_HEX} not yet visible (HTTP ${SIG_STATUS}, attempt ${s}/${SIG_ATTEMPTS}); GHCR propagation lag, retrying in ${SIG_BACKOFF}s"

--- a/.github/actions/publish-image-loaded/action.yml
+++ b/.github/actions/publish-image-loaded/action.yml
@@ -185,8 +185,29 @@ runs:
           # iteration produces the same bytes, so the digest is the
           # same. Capture once on the sha-<short> iteration to keep the
           # output stable.
+          #
+          # GHCR is eventually consistent on the write path: the tag we
+          # just `docker manifest push`ed can 404 ("not found") for a
+          # short window before it is readable, so a bare inspect here
+          # fails the whole publish (leaving the image unsigned). Retry
+          # the read-back with bounded backoff so a read-after-write lag
+          # self-heals; the `if [ -z "$DIGEST" ]` guard below still fails
+          # loud once the budget is spent. Mirrors the inspect retry in
+          # publish-image-retag.
           if [ "$t" = "sha-${SHORT_SHA}" ]; then
-            DIGEST="$(docker buildx imagetools inspect "${REPO}:${t}" --format '{{.Manifest.Digest}}')"
+            INSPECT_ATTEMPTS=5
+            INSPECT_BACKOFF=2
+            for ((ia = 1; ia <= INSPECT_ATTEMPTS; ia++)); do
+              if DIGEST="$(docker buildx imagetools inspect "${REPO}:${t}" --format '{{.Manifest.Digest}}' 2>/dev/null)" && [ -n "$DIGEST" ]; then
+                break
+              fi
+              DIGEST=""
+              if [ "$ia" -lt "$INSPECT_ATTEMPTS" ]; then
+                echo "::warning::manifest ${REPO}:${t} not yet readable after push (attempt ${ia}/${INSPECT_ATTEMPTS}); GHCR read-after-write lag, retrying in ${INSPECT_BACKOFF}s"
+                sleep "${INSPECT_BACKOFF}"
+                INSPECT_BACKOFF=$((INSPECT_BACKOFF * 2))
+              fi
+            done
           fi
         done <<< "$META_TAGS"
 
@@ -289,7 +310,10 @@ runs:
         # subsequent `curl` with an empty Bearer header.
         # `-L` follows redirects so registry-side rewrites (rare on
         # GHCR but possible in proxy / mirror setups) don't fail.
-        REG_TOKEN="$(curl -sSL -u "x-access-token:${GHCR_TOKEN}" \
+        # `--connect-timeout`/`--max-time` bound every call: curl has no
+        # default deadline, so a silently black-holed connection would
+        # otherwise stall the step until the runner's job timeout.
+        REG_TOKEN="$(curl -sSL --connect-timeout 5 --max-time 15 -u "x-access-token:${GHCR_TOKEN}" \
           "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO_PATH}:pull" \
           | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')"
         if [ -z "${REG_TOKEN}" ]; then
@@ -304,7 +328,7 @@ runs:
         FAILED=0
         while IFS= read -r t; do
           [ -z "${t}" ] && continue
-          ACTUAL="$(curl -sSL -I \
+          ACTUAL="$(curl -sSL --connect-timeout 5 --max-time 15 -I \
             -H "Authorization: Bearer ${REG_TOKEN}" \
             -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.index.v1+json" \
             "https://ghcr.io/v2/${REPO_PATH}/manifests/${t}" \
@@ -317,24 +341,27 @@ runs:
           fi
         done <<< "${PUSHED_TAGS}"
 
-        # Confirm the signed digest is reachable as an OCI referrer
-        # index entry on the registry side. cosign v3 publishes
-        # signatures via the OCI referrer mechanism, surfaced on GHCR
-        # as the `sha256-<hex>` referrer tag.
-        # cosign has just published the signature as an OCI referrer; GHCR
-        # surfaces it as the `sha256-<hex>` referrer tag with EVENTUAL
-        # consistency, so a check issued milliseconds after signing can 404
-        # for a short window before the tag becomes queryable (observed: a
-        # 404 ~270ms after a successful sign). Poll with bounded backoff
-        # (5 attempts, 2s -> 4s -> 8s -> 16s, ~30s budget) so a propagation
-        # lag self-heals, while a genuinely-missing signature still fails
-        # after the budget -- the gate must not mask a real unsigned image.
+        # Confirm the signed digest is reachable as an OCI referrer index
+        # entry. cosign v3 publishes signatures via the OCI referrer
+        # mechanism, surfaced on GHCR as the `sha256-<hex>` referrer tag,
+        # with EVENTUAL consistency: a check issued milliseconds after
+        # signing can 404 for a short window before the tag becomes
+        # queryable (observed: a 404 ~270ms after a successful sign). Poll
+        # with bounded backoff (5 attempts, 2s -> 4s -> 8s -> 16s, ~30s
+        # budget) so a propagation lag self-heals, while a genuinely-missing
+        # signature still fails after the budget -- the gate must not mask a
+        # real unsigned image. Validate the digest shape first so a
+        # malformed SIGNED_DIGEST cannot build a bogus referrer URL.
+        if ! [[ "${SIGNED_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+          echo "::error::SIGNED_DIGEST is not a valid sha256 digest: '${SIGNED_DIGEST}'"
+          exit 1
+        fi
         SIG_HEX="${SIGNED_DIGEST#sha256:}"
         SIG_ATTEMPTS=5
         SIG_BACKOFF=2
         SIG_STATUS=000
         for ((s = 1; s <= SIG_ATTEMPTS; s++)); do
-          SIG_STATUS="$(curl -sSL -o /dev/null -w '%{http_code}' \
+          SIG_STATUS="$(curl -sSL --connect-timeout 5 --max-time 10 -o /dev/null -w '%{http_code}' \
             -H "Authorization: Bearer ${REG_TOKEN}" \
             -H "Accept: application/vnd.oci.image.index.v1+json" \
             "https://ghcr.io/v2/${REPO_PATH}/manifests/sha256-${SIG_HEX}")"
@@ -345,7 +372,10 @@ runs:
             SIG_BACKOFF=$((SIG_BACKOFF * 2))
           fi
         done
-        if [ "${SIG_STATUS}" != "200" ]; then
+        if [ "${SIG_STATUS}" = "000" ]; then
+          echo "::error::cosign signature check could not reach GHCR (curl network error, not a registry response) for ${REPO}:sha256-${SIG_HEX} after ${SIG_ATTEMPTS} attempts"
+          FAILED=1
+        elif [ "${SIG_STATUS}" != "200" ]; then
           echo "::error::cosign signature artifact missing for ${REPO}@${SIGNED_DIGEST} (referrer tag sha256-${SIG_HEX} returned HTTP ${SIG_STATUS} after ${SIG_ATTEMPTS} attempts)"
           FAILED=1
         else

--- a/.github/actions/publish-image-loaded/action.yml
+++ b/.github/actions/publish-image-loaded/action.yml
@@ -361,10 +361,17 @@ runs:
         SIG_BACKOFF=2
         SIG_STATUS=000
         for ((s = 1; s <= SIG_ATTEMPTS; s++)); do
+          # `|| SIG_STATUS=000` on the ASSIGNMENT (not inside the command
+          # substitution) so a curl network failure under `set -e` neither
+          # aborts the step nor double-prints the sentinel: curl already
+          # emits "000" to stdout on a connection failure, so an in-`$()`
+          # `|| echo 000` would capture "000000" and miss the dedicated
+          # network-error branch below. The `||` on the assignment suspends
+          # `set -e` for the left side and overwrites with a clean "000".
           SIG_STATUS="$(curl -sSL --connect-timeout 5 --max-time 10 -o /dev/null -w '%{http_code}' \
             -H "Authorization: Bearer ${REG_TOKEN}" \
             -H "Accept: application/vnd.oci.image.index.v1+json" \
-            "https://ghcr.io/v2/${REPO_PATH}/manifests/sha256-${SIG_HEX}")"
+            "https://ghcr.io/v2/${REPO_PATH}/manifests/sha256-${SIG_HEX}")" || SIG_STATUS=000
           [ "${SIG_STATUS}" = "200" ] && break
           if [ "$s" -lt "$SIG_ATTEMPTS" ]; then
             echo "::warning::signature referrer sha256-${SIG_HEX} not yet visible (HTTP ${SIG_STATUS}, attempt ${s}/${SIG_ATTEMPTS}); GHCR propagation lag, retrying in ${SIG_BACKOFF}s"

--- a/.github/actions/publish-image-loaded/action.yml
+++ b/.github/actions/publish-image-loaded/action.yml
@@ -321,13 +321,32 @@ runs:
         # index entry on the registry side. cosign v3 publishes
         # signatures via the OCI referrer mechanism, surfaced on GHCR
         # as the `sha256-<hex>` referrer tag.
+        # cosign has just published the signature as an OCI referrer; GHCR
+        # surfaces it as the `sha256-<hex>` referrer tag with EVENTUAL
+        # consistency, so a check issued milliseconds after signing can 404
+        # for a short window before the tag becomes queryable (observed: a
+        # 404 ~270ms after a successful sign). Poll with bounded backoff
+        # (5 attempts, 2s -> 4s -> 8s -> 16s, ~30s budget) so a propagation
+        # lag self-heals, while a genuinely-missing signature still fails
+        # after the budget -- the gate must not mask a real unsigned image.
         SIG_HEX="${SIGNED_DIGEST#sha256:}"
-        SIG_STATUS="$(curl -sSL -o /dev/null -w '%{http_code}' \
-          -H "Authorization: Bearer ${REG_TOKEN}" \
-          -H "Accept: application/vnd.oci.image.index.v1+json" \
-          "https://ghcr.io/v2/${REPO_PATH}/manifests/sha256-${SIG_HEX}")"
+        SIG_ATTEMPTS=5
+        SIG_BACKOFF=2
+        SIG_STATUS=000
+        for ((s = 1; s <= SIG_ATTEMPTS; s++)); do
+          SIG_STATUS="$(curl -sSL -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer ${REG_TOKEN}" \
+            -H "Accept: application/vnd.oci.image.index.v1+json" \
+            "https://ghcr.io/v2/${REPO_PATH}/manifests/sha256-${SIG_HEX}")"
+          [ "${SIG_STATUS}" = "200" ] && break
+          if [ "$s" -lt "$SIG_ATTEMPTS" ]; then
+            echo "::warning::signature referrer sha256-${SIG_HEX} not yet visible (HTTP ${SIG_STATUS}, attempt ${s}/${SIG_ATTEMPTS}); GHCR propagation lag, retrying in ${SIG_BACKOFF}s"
+            sleep "${SIG_BACKOFF}"
+            SIG_BACKOFF=$((SIG_BACKOFF * 2))
+          fi
+        done
         if [ "${SIG_STATUS}" != "200" ]; then
-          echo "::error::cosign signature artifact missing for ${REPO}@${SIGNED_DIGEST} (referrer tag sha256-${SIG_HEX} returned HTTP ${SIG_STATUS})"
+          echo "::error::cosign signature artifact missing for ${REPO}@${SIGNED_DIGEST} (referrer tag sha256-${SIG_HEX} returned HTTP ${SIG_STATUS} after ${SIG_ATTEMPTS} attempts)"
           FAILED=1
         else
           echo "✓ signature artifact present at ${REPO}:sha256-${SIG_HEX}"

--- a/.github/actions/publish-image-retag/action.yml
+++ b/.github/actions/publish-image-retag/action.yml
@@ -136,7 +136,15 @@ runs:
           fi
           ERR="$(cat "$ERR_FILE")"
           IS_TRANSIENT=false
-          if printf '%s' "$ERR" | grep -qiE "$TRANSIENT_RE"; then
+          # Grep a here-string, never `printf "$ERR" | grep -qi`: under
+          # `set -o pipefail` a large `$ERR` (a GHCR 5xx HTML error body
+          # overruns the 64 KB pipe buffer) makes the early-exiting
+          # `grep -q` close the pipe while printf is still writing, so
+          # printf takes EPIPE and the pipeline inherits its non-zero
+          # status -- the match is masked and a transient inspect error
+          # is misclassified as terminal. A here-string is not a
+          # pipeline, so the status is purely grep's.
+          if grep -qiE "$TRANSIENT_RE" <<<"$ERR"; then
             IS_TRANSIENT=true
           fi
 

--- a/.github/scripts/cosign_sign_with_retry.sh
+++ b/.github/scripts/cosign_sign_with_retry.sh
@@ -47,9 +47,11 @@ TRANSIENT_RE="$(bash "$SCRIPT_DIR/docker_push_with_retry.sh" --print-transient-r
 # 4 attempts, backoff 15s -> 30s -> 60s = ~1m45s of wait in the worst
 # case before the final attempt. Matches docker_push_with_retry.sh so
 # cosign rides through GHCR's typical 30-90s unicorn windows under the
-# same budget the push step already does.
-ATTEMPTS=4
-BACKOFF=15
+# same budget the push step already does. Overridable via env (mirrors
+# gh_with_retry.sh's GH_RETRY_*) so the regression self-test can drive
+# the classifier with a zero backoff instead of waiting ~1m45s.
+ATTEMPTS="${COSIGN_SIGN_RETRY_ATTEMPTS:-4}"
+BACKOFF="${COSIGN_SIGN_RETRY_BACKOFF:-15}"
 
 for ((i = 1; i <= ATTEMPTS; i++)); do
   out=""

--- a/.github/scripts/cosign_sign_with_retry.sh
+++ b/.github/scripts/cosign_sign_with_retry.sh
@@ -63,7 +63,15 @@ for ((i = 1; i <= ATTEMPTS; i++)); do
   # Idempotency branch: a re-sign that lost the createLogEntry race is
   # success, not a transient error. Check this BEFORE the regex so
   # attempt 1 -> 5xx -> attempt 2 -> conflict resolves cleanly.
-  if printf -- '%s\n' "$out" | grep -q 'createLogEntryConflict'; then
+  #
+  # Grep a here-string, never `printf "$out" | grep -q`: under `set -o
+  # pipefail` a large `$out` (a GHCR 5xx HTML error body easily exceeds
+  # the 64 KB pipe buffer) makes the early-exiting `grep -q` close the
+  # pipe while printf is still writing, so printf takes EPIPE and the
+  # pipeline inherits its non-zero status -- the match is masked and a
+  # transient error is misclassified as terminal. A here-string is not a
+  # pipeline, so the status is purely grep's.
+  if grep -q 'createLogEntryConflict' <<<"$out"; then
     printf '%s\n' "$out"
     echo "::notice::Image ${REF} already signed -- skipping"
     exit 0
@@ -78,7 +86,14 @@ for ((i = 1; i <= ATTEMPTS; i++)); do
   # Guard against an empty `$TRANSIENT_RE` (e.g. sibling helper drift
   # that silently prints nothing) - `grep -E ""` matches every line,
   # which would retry auth failures and other non-transient errors.
-  if [[ -n "$TRANSIENT_RE" ]] && printf -- '%s\n' "$out" | grep -qiE "$TRANSIENT_RE"; then
+  #
+  # Grep a here-string, not `printf "$out" | grep -qi`: see the
+  # idempotency branch above. A GHCR 5xx HTML error body overruns the
+  # 64 KB pipe buffer, so the piped form takes EPIPE on the early
+  # `grep -q` exit and `pipefail` masks the match -- which is exactly
+  # how a transient `502 Bad Gateway` got misclassified as terminal and
+  # left an image unsigned.
+  if [[ -n "$TRANSIENT_RE" ]] && grep -qiE "$TRANSIENT_RE" <<<"$out"; then
     printf '%s\n' "$out" >&2
     echo "::warning::cosign sign ${REF} hit transient error (attempt ${i}/${ATTEMPTS}, rc=${rc}); sleeping ${BACKOFF}s before retry" >&2
     sleep "$BACKOFF"

--- a/.github/scripts/cosign_sign_with_retry.sh
+++ b/.github/scripts/cosign_sign_with_retry.sh
@@ -43,6 +43,13 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 # `bash "$RETRY" ...`; a bare `"$SCRIPT_DIR/..."` would fail
 # "Permission denied" on the Linux runner.
 TRANSIENT_RE="$(bash "$SCRIPT_DIR/docker_push_with_retry.sh" --print-transient-re)"
+# Surface a drift in the sibling helper loudly: an empty regex disables
+# the transient classifier (every error becomes terminal at line ~98),
+# so without this warning a flurry of "non-transient" cosign failures
+# would give no hint that the classifier itself went dark.
+if [[ -z "$TRANSIENT_RE" ]]; then
+  echo "::warning::cosign_sign_with_retry: TRANSIENT_RE is empty (docker_push_with_retry.sh --print-transient-re returned nothing); every error will be treated as non-transient" >&2
+fi
 
 # 4 attempts, backoff 15s -> 30s -> 60s = ~1m45s of wait in the worst
 # case before the final attempt. Matches docker_push_with_retry.sh so
@@ -52,6 +59,17 @@ TRANSIENT_RE="$(bash "$SCRIPT_DIR/docker_push_with_retry.sh" --print-transient-r
 # the classifier with a zero backoff instead of waiting ~1m45s.
 ATTEMPTS="${COSIGN_SIGN_RETRY_ATTEMPTS:-4}"
 BACKOFF="${COSIGN_SIGN_RETRY_BACKOFF:-15}"
+# A zero or non-numeric ATTEMPTS would make the loop body never run and
+# the script exit 0 WITHOUT signing (fail-open). Reject it; a zero
+# BACKOFF is legitimate (tests use it), so only require non-negative.
+if ! [[ "$ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::COSIGN_SIGN_RETRY_ATTEMPTS must be a positive integer; got '${ATTEMPTS}'" >&2
+  exit 2
+fi
+if ! [[ "$BACKOFF" =~ ^[0-9]+$ ]]; then
+  echo "::error::COSIGN_SIGN_RETRY_BACKOFF must be a non-negative integer; got '${BACKOFF}'" >&2
+  exit 2
+fi
 
 for ((i = 1; i <= ATTEMPTS; i++)); do
   out=""

--- a/.github/scripts/docker_push_with_retry.sh
+++ b/.github/scripts/docker_push_with_retry.sh
@@ -69,6 +69,17 @@ fi
 # can drive the classifier with a zero backoff instead of waiting ~1m45s.
 ATTEMPTS="${DOCKER_PUSH_RETRY_ATTEMPTS:-4}"
 BACKOFF="${DOCKER_PUSH_RETRY_BACKOFF:-15}"
+# A zero or non-numeric ATTEMPTS would make the loop body never run and
+# the script exit 0 WITHOUT running the wrapped command (fail-open).
+# Reject it; a zero BACKOFF is legitimate (tests use it).
+if ! [[ "$ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::DOCKER_PUSH_RETRY_ATTEMPTS must be a positive integer; got '${ATTEMPTS}'" >&2
+  exit 2
+fi
+if ! [[ "$BACKOFF" =~ ^[0-9]+$ ]]; then
+  echo "::error::DOCKER_PUSH_RETRY_BACKOFF must be a non-negative integer; got '${BACKOFF}'" >&2
+  exit 2
+fi
 
 for ((i = 1; i <= ATTEMPTS; i++)); do
   out=""

--- a/.github/scripts/docker_push_with_retry.sh
+++ b/.github/scripts/docker_push_with_retry.sh
@@ -64,9 +64,11 @@ fi
 
 # 4 attempts, backoff 15s -> 30s -> 60s = ~1m45s of wait in the worst case
 # before the final attempt. Long enough to ride through GHCR's typical 30-90s
-# unicorn windows; short enough to fail loudly on a real outage.
-ATTEMPTS=4
-BACKOFF=15
+# unicorn windows; short enough to fail loudly on a real outage. Overridable
+# via env (mirrors gh_with_retry.sh's GH_RETRY_*) so the regression self-test
+# can drive the classifier with a zero backoff instead of waiting ~1m45s.
+ATTEMPTS="${DOCKER_PUSH_RETRY_ATTEMPTS:-4}"
+BACKOFF="${DOCKER_PUSH_RETRY_BACKOFF:-15}"
 
 for ((i = 1; i <= ATTEMPTS; i++)); do
   out=""

--- a/.github/scripts/docker_push_with_retry.sh
+++ b/.github/scripts/docker_push_with_retry.sh
@@ -92,7 +92,15 @@ for ((i = 1; i <= ATTEMPTS; i++)); do
   # Mid-loop: only retry if the error looks transient. Echo the captured
   # output to stderr so the build log shows what happened on each attempt
   # without contaminating the caller's captured stdout.
-  if printf '%s' "$out" | grep -qiE "$TRANSIENT_RE"; then
+  #
+  # Grep a here-string, never `printf "$out" | grep -qi`: under `set -o
+  # pipefail` a large `$out` (a GHCR 5xx HTML error body easily exceeds
+  # the 64 KB pipe buffer) makes the early-exiting `grep -q` close the
+  # pipe while printf is still writing, so printf takes EPIPE and the
+  # pipeline inherits its non-zero status -- the match is masked and a
+  # transient push error is misclassified as terminal. A here-string is
+  # not a pipeline, so the status is purely grep's.
+  if grep -qiE "$TRANSIENT_RE" <<<"$out"; then
     printf '%s\n' "$out" >&2
     echo "::warning::${LABEL} hit transient registry error (attempt ${i}/${ATTEMPTS}, rc=${rc}); sleeping ${BACKOFF}s before retry" >&2
     sleep "$BACKOFF"

--- a/.github/scripts/tests/test_retry_classifiers.sh
+++ b/.github/scripts/tests/test_retry_classifiers.sh
@@ -5,7 +5,7 @@
 # The bug: the helpers classified a transient registry error with
 #   printf '%s' "$out" | grep -qiE "$TRANSIENT_RE"
 # under `set -o pipefail`. When `$out` is a GHCR 5xx HTML error body that
-# overruns the 64 KB pipe buffer and the match token sits near the START,
+# overruns the 64 KB pipe buffer and the match token sits at the very START,
 # `grep -q` exits on first match and closes the pipe, `printf` takes EPIPE,
 # and `pipefail` makes the pipeline report the writer's non-zero status --
 # so the match is masked, a genuinely-transient error is misclassified as
@@ -44,7 +44,7 @@ if grep -q 'hit transient registry error' <<<"$out" \
   pass "docker_push retries a large 5xx body"
 else
   fail "docker_push misclassified a large 5xx body (broken-pipe regression)"
-  printf '%s\n' "$out" | tail -n 3 >&2
+  printf '%s\n' "$out" | tail -n 3 >&2 || true
 fi
 
 # --- docker_push_with_retry.sh: a genuine error must NOT be retried -----
@@ -55,7 +55,7 @@ if grep -q 'non-transient error' <<<"$out" && ! grep -q 'hit transient' <<<"$out
   pass "docker_push does not retry a genuine non-transient error"
 else
   fail "docker_push retried a non-transient error (classifier too broad)"
-  printf '%s\n' "$out" | tail -n 3 >&2
+  printf '%s\n' "$out" | tail -n 3 >&2 || true
 fi
 
 # --- cosign_sign_with_retry.sh: a large transient 5xx must be retried ---
@@ -77,7 +77,50 @@ if grep -q 'hit transient error' <<<"$out" && ! grep -q 'non-transient error' <<
   pass "cosign_sign retries a large 5xx body"
 else
   fail "cosign_sign misclassified a large 5xx body (broken-pipe regression)"
-  printf '%s\n' "$out" | tail -n 3 >&2
+  printf '%s\n' "$out" | tail -n 3 >&2 || true
+fi
+
+# --- cosign_sign_with_retry.sh: a genuine error must NOT be retried -----
+# Symmetric to the docker_push negative control: proves the cosign wrapper
+# (which sources TRANSIENT_RE from the sibling helper and guards on it
+# being non-empty) does not retry an auth denial. Catches a future
+# over-broad regex OR a removed empty-regex guard.
+cat >"$STUB_DIR/cosign" <<'STUB'
+#!/usr/bin/env bash
+echo "denied: requested access to the resource is denied"
+exit 1
+STUB
+chmod +x "$STUB_DIR/cosign"
+out="$(PATH="$STUB_DIR:$PATH" \
+  COSIGN_SIGN_RETRY_ATTEMPTS=3 COSIGN_SIGN_RETRY_BACKOFF=0 \
+  bash "$COSIGN_HELPER" "ghcr.io/example/image@${fake_digest}" 2>&1)" || true
+if grep -q 'non-transient error' <<<"$out" && ! grep -q 'hit transient error' <<<"$out"; then
+  pass "cosign_sign does not retry a genuine non-transient error"
+else
+  fail "cosign_sign retried a non-transient error (classifier too broad)"
+  printf '%s\n' "$out" | tail -n 3 >&2 || true
+fi
+
+# --- cosign_sign_with_retry.sh: an already-signed digest is success -----
+# A re-sign that loses the Rekor createLogEntry race returns a
+# `createLogEntryConflict`; the helper treats that as success (exit 0,
+# `::notice::`), not a retry or failure, so a re-run of an already-signed
+# image does not false-red the build.
+cat >"$STUB_DIR/cosign" <<'STUB'
+#!/usr/bin/env bash
+echo "error: ... createLogEntryConflict: ... already exists"
+exit 1
+STUB
+chmod +x "$STUB_DIR/cosign"
+rc=0
+out="$(PATH="$STUB_DIR:$PATH" \
+  COSIGN_SIGN_RETRY_ATTEMPTS=3 COSIGN_SIGN_RETRY_BACKOFF=0 \
+  bash "$COSIGN_HELPER" "ghcr.io/example/image@${fake_digest}" 2>&1)" || rc=$?
+if [ "$rc" -eq 0 ] && grep -q 'already signed' <<<"$out"; then
+  pass "cosign_sign treats createLogEntryConflict as success"
+else
+  fail "cosign_sign did not treat createLogEntryConflict as idempotent success (rc=${rc})"
+  printf '%s\n' "$out" | tail -n 3 >&2 || true
 fi
 
 if [ "$FAILED" -ne 0 ]; then

--- a/.github/scripts/tests/test_retry_classifiers.sh
+++ b/.github/scripts/tests/test_retry_classifiers.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Regression test for the broken-pipe misclassification in the cosign and
+# docker-push retry helpers.
+#
+# The bug: the helpers classified a transient registry error with
+#   printf '%s' "$out" | grep -qiE "$TRANSIENT_RE"
+# under `set -o pipefail`. When `$out` is a GHCR 5xx HTML error body that
+# overruns the 64 KB pipe buffer and the match token sits near the START,
+# `grep -q` exits on first match and closes the pipe, `printf` takes EPIPE,
+# and `pipefail` makes the pipeline report the writer's non-zero status --
+# so the match is masked, a genuinely-transient error is misclassified as
+# terminal, and NOT retried. That is what left a sandbox image
+# pushed-but-unsigned and the Verify Image Signatures gate red.
+#
+# This test feeds exactly that shape (transient token first, >64 KB
+# trailing body) through the REAL helpers and asserts they classify it as
+# transient and retry. On Linux (CI) the old piped form reproduces the
+# EPIPE and fails this test; the here-string form passes. On platforms
+# whose pipe semantics never raise EPIPE the here-string form still
+# passes, so this is a one-way regression guard, never a flake. A negative
+# control proves the classifier did not become match-everything.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)" # .github/scripts
+COSIGN_HELPER="$SCRIPT_DIR/cosign_sign_with_retry.sh"
+PUSH_HELPER="$SCRIPT_DIR/docker_push_with_retry.sh"
+
+FAILED=0
+pass() { printf 'PASS: %s\n' "$*"; }
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  FAILED=1
+}
+
+# Emit a >64 KB body with the transient match token FIRST, then filler --
+# the exact shape that triggers EPIPE under the buggy piped `grep -q`.
+BIG_5XX='printf "502 Bad Gateway: "; head -c 100000 </dev/zero | tr "\0" x; printf "\n"; exit 1'
+
+# --- docker_push_with_retry.sh: a large transient 5xx must be retried ---
+out="$(DOCKER_PUSH_RETRY_ATTEMPTS=2 DOCKER_PUSH_RETRY_BACKOFF=0 \
+  bash "$PUSH_HELPER" "selftest-push" bash -c "$BIG_5XX" 2>&1)" || true
+if grep -q 'hit transient registry error' <<<"$out" \
+  && ! grep -q 'non-transient error' <<<"$out"; then
+  pass "docker_push retries a large 5xx body"
+else
+  fail "docker_push misclassified a large 5xx body (broken-pipe regression)"
+  printf '%s\n' "$out" | tail -n 3 >&2
+fi
+
+# --- docker_push_with_retry.sh: a genuine error must NOT be retried -----
+out="$(DOCKER_PUSH_RETRY_ATTEMPTS=3 DOCKER_PUSH_RETRY_BACKOFF=0 \
+  bash "$PUSH_HELPER" "selftest-neg" \
+  bash -c 'echo "denied: requested access to the resource is denied"; exit 1' 2>&1)" || true
+if grep -q 'non-transient error' <<<"$out" && ! grep -q 'hit transient' <<<"$out"; then
+  pass "docker_push does not retry a genuine non-transient error"
+else
+  fail "docker_push retried a non-transient error (classifier too broad)"
+  printf '%s\n' "$out" | tail -n 3 >&2
+fi
+
+# --- cosign_sign_with_retry.sh: a large transient 5xx must be retried ---
+# The helper hardcodes `cosign sign`, so stub a `cosign` on PATH that emits
+# the same large 5xx body and fails.
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"' EXIT
+cat >"$STUB_DIR/cosign" <<STUB
+#!/usr/bin/env bash
+$BIG_5XX
+STUB
+chmod +x "$STUB_DIR/cosign"
+
+fake_digest="sha256:$(printf 'a%.0s' {1..64})"
+out="$(PATH="$STUB_DIR:$PATH" \
+  COSIGN_SIGN_RETRY_ATTEMPTS=2 COSIGN_SIGN_RETRY_BACKOFF=0 \
+  bash "$COSIGN_HELPER" "ghcr.io/example/image@${fake_digest}" 2>&1)" || true
+if grep -q 'hit transient error' <<<"$out" && ! grep -q 'non-transient error' <<<"$out"; then
+  pass "cosign_sign retries a large 5xx body"
+else
+  fail "cosign_sign misclassified a large 5xx body (broken-pipe regression)"
+  printf '%s\n' "$out" | tail -n 3 >&2
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+  printf '\nretry-helper self-test FAILED\n' >&2
+  exit 1
+fi
+printf '\nretry-helper self-test passed\n'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -372,6 +372,18 @@ repos:
         # actually scanned, letting a weakened gate land unchecked.
         pass_filenames: false
 
+      - id: retry-helper-selftest
+        name: cosign/push retry helpers classify large 5xx output as transient (broken-pipe regression)
+        entry: bash .github/scripts/tests/test_retry_classifiers.sh
+        language: system
+        # Re-run the full self-test whenever a helper or the test itself
+        # changes. pass_filenames: false so an edit to either helper drives
+        # the same assertions (the test feeds a >64 KB early-match 5xx body
+        # through the real scripts; on Linux the old `printf | grep -q` form
+        # reproduces the EPIPE and fails, the here-string form passes).
+        files: ^\.github/scripts/(cosign_sign_with_retry|docker_push_with_retry|tests/test_retry_classifiers)\.sh$
+        pass_filenames: false
+
       - id: doc-drift-counts
         name: doc count floors (event modules)
         entry: uv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -383,6 +383,10 @@ repos:
         # reproduces the EPIPE and fails, the here-string form passes).
         files: ^\.github/scripts/(cosign_sign_with_retry|docker_push_with_retry|tests/test_retry_classifiers)\.sh$
         pass_filenames: false
+        # pre-commit only: the test is fast (three subprocesses, zero
+        # backoff) and gives feedback before a commit message is written;
+        # without an explicit stage it would also run at commit-msg.
+        stages: [pre-commit]
 
       - id: doc-drift-counts
         name: doc count floors (event modules)

--- a/scripts/_module_size_lib.py
+++ b/scripts/_module_size_lib.py
@@ -80,6 +80,28 @@ class UnknownTierError(ValueError):
     """Raised when a ``# module-kind:`` header carries an unknown tier."""
 
 
+def count_loc_text(text: str) -> int:
+    """Count physical lines minus blank and comment-only lines, from text.
+
+    Pure variant of :func:`count_loc` for callers that already hold the
+    file's contents (avoids re-reading the file). One ``str.strip`` per
+    line covers both the blank-line and comment-line tests: ``stripped``
+    has no leading whitespace, so ``stripped[0] == "#"`` is equivalent to
+    ``line.lstrip().startswith("#")``.
+
+    Args:
+        text: Full source text.
+
+    Returns:
+        Non-negative LOC count. Empty text returns 0.
+    """
+    return sum(
+        1
+        for line in text.splitlines()
+        if (stripped := line.strip()) and stripped[0] != "#"
+    )
+
+
 def count_loc(path: Path) -> int:
     """Count physical lines minus blank lines and comment-only lines.
 
@@ -92,12 +114,7 @@ def count_loc(path: Path) -> int:
     Raises:
         OSError: If the file cannot be read.
     """
-    text = path.read_text(encoding="utf-8")
-    return sum(
-        1
-        for line in text.splitlines()
-        if line.strip() and not line.lstrip().startswith("#")
-    )
+    return count_loc_text(path.read_text(encoding="utf-8"))
 
 
 def is_generated(filename: str) -> bool:
@@ -133,7 +150,20 @@ def read_module_kind_header(path: Path) -> str | None:
             :data:`KNOWN_TIERS`.
         OSError: If the file cannot be read.
     """
-    text = path.read_text(encoding="utf-8")
+    return module_kind_from_text(path.read_text(encoding="utf-8"), path)
+
+
+def module_kind_from_text(text: str, path: Path) -> str | None:
+    """Return the ``# module-kind:`` tier from *text*, or ``None``.
+
+    Pure variant of :func:`read_module_kind_header` for callers that
+    already hold the file's contents. *path* is used only for the
+    error message on an unknown tier.
+
+    Raises:
+        UnknownTierError: If the header's tier value is not in
+            :data:`KNOWN_TIERS`.
+    """
     for index, line in enumerate(text.splitlines()):
         if index == 0 and _SHEBANG_RE.match(line):
             continue
@@ -181,4 +211,25 @@ def resolve_tier(path: Path, *, project_root: Path) -> str:
     if rel.startswith("tests/") or rel == "tests":
         return _TESTS_TIER
     header = read_module_kind_header(path)
+    return header if header is not None else _DEFAULT_TIER
+
+
+def resolve_tier_text(path: Path, text: str, *, rel_posix: str) -> str:
+    """Resolve the tier from already-read *text* and a precomputed rel path.
+
+    Pure variant of :func:`resolve_tier` for hot loops (e.g. the
+    codebase-map build) that already hold the file's text and its
+    repo-relative POSIX path, avoiding a second ``read_text`` and the
+    cost of ``Path.relative_to``. ``rel_posix`` must be the file's path
+    relative to the same root :func:`resolve_tier` uses as
+    ``project_root`` (so the ``tests/`` prefix check is identical).
+
+    Raises:
+        UnknownTierError: If the file declares an unknown tier.
+    """
+    if is_generated(path.name):
+        return _GENERATED_TIER
+    if rel_posix.startswith("tests/") or rel_posix == "tests":
+        return _TESTS_TIER
+    header = module_kind_from_text(text, path)
     return header if header is not None else _DEFAULT_TIER

--- a/scripts/check_image_signatures.py
+++ b/scripts/check_image_signatures.py
@@ -56,6 +56,7 @@ MANIFEST_ACCEPT = (
 SIG_ACCEPT = "application/vnd.oci.image.index.v1+json"
 HTTP_TIMEOUT_SECONDS = 30
 HTTP_OK = 200
+HTTP_NOT_FOUND = 404
 USAGE_EXIT_CODE = 2
 FAILURE_EXIT_CODE = 1
 
@@ -319,9 +320,10 @@ def signature_present(
     ``SIG_PROPAGATION_BACKOFF_SECONDS``) to absorb GHCR's
     eventual-consistency window on a freshly-published referrer; a
     genuinely-unsigned digest still returns False once the short budget is
-    spent. A network error that persists past the budget is re-raised (the
-    caller turns it into a "network error" message) rather than being
-    reported as a false "unsigned" verdict.
+    spent. Only a 404 counts as "absent" -- a network error OR a non-404
+    registry error (502/503/429/...) that persists past the budget is
+    re-raised (the caller turns it into a "network error" message) rather
+    than being reported as a false "unsigned" verdict.
 
     ``repo_path`` is pre-validated; ``digest`` is checked to start with
     the literal ``sha256:`` prefix and the hex tail is character-class
@@ -329,8 +331,9 @@ def signature_present(
     the CodeQL ``py/partial-ssrf`` data-flow.
 
     Raises:
-        urllib.error.URLError: a network-level failure that persisted
-            across every attempt (also covers ``OSError`` subclasses).
+        urllib.error.URLError: a network-level failure (also covers
+            ``OSError`` subclasses), OR a non-404 registry error
+            (502/503/429/...), that persisted across every attempt.
     """
     if not digest.startswith("sha256:"):
         return False
@@ -353,6 +356,15 @@ def signature_present(
             raise
         if status == HTTP_OK:
             return True
+        # A 404 is a real "referrer not (yet) present" answer: retry within
+        # the propagation budget, then return False (genuinely unsigned). Any
+        # OTHER non-200 (502/503/429/...) is a registry error, NOT evidence of
+        # a missing signature; if it persists to the final attempt, raise so
+        # the caller reports a network/registry error rather than a false
+        # "unsigned" verdict.
+        if status != HTTP_NOT_FOUND and attempt == SIG_PROPAGATION_ATTEMPTS:
+            msg = f"registry error: HTTP {status} on referrer check for {url}"
+            raise urllib.error.URLError(msg)
         if attempt < SIG_PROPAGATION_ATTEMPTS:
             time.sleep(SIG_PROPAGATION_BACKOFF_SECONDS)
     return False

--- a/scripts/check_image_signatures.py
+++ b/scripts/check_image_signatures.py
@@ -60,11 +60,13 @@ USAGE_EXIT_CODE = 2
 FAILURE_EXIT_CODE = 1
 
 # GHCR surfaces a freshly-published cosign referrer (the `sha256-<hex>`
-# tag) with eventual consistency. This gate runs minutes after the publish
-# jobs, so propagation is normally settled; the short retry only covers the
-# rare case where the gate runs close behind a sign. Kept deliberately
-# short -- the gate's purpose is to FAIL a genuinely-unsigned image, so a
-# persistent 404 must surface quickly rather than be masked by a long wait.
+# tag) with eventual consistency. In the typical workflow topology this
+# gate runs as a separate job minutes after the publish jobs, so
+# propagation is normally settled by the time it runs; the short retry only
+# covers the rare case where the gap between signing and this check is
+# unusually short. Kept deliberately short -- the gate's purpose is to FAIL
+# a genuinely-unsigned image, so a persistent 404 must surface quickly
+# rather than be masked by a long wait.
 SIG_PROPAGATION_ATTEMPTS = 3
 SIG_PROPAGATION_BACKOFF_SECONDS = 3
 
@@ -312,16 +314,23 @@ def signature_present(
 ) -> bool:
     """Return True if a cosign signature referrer artifact exists for this digest.
 
-    Retries a non-200 a few times with a short fixed backoff
-    (``SIG_PROPAGATION_ATTEMPTS`` / ``SIG_PROPAGATION_BACKOFF_SECONDS``) to
-    absorb GHCR's eventual-consistency window on a freshly-published
-    referrer; a genuinely-unsigned digest still returns False once the
-    short budget is spent.
+    Retries a non-200 (and a transient network error) a few times with a
+    short fixed backoff (``SIG_PROPAGATION_ATTEMPTS`` /
+    ``SIG_PROPAGATION_BACKOFF_SECONDS``) to absorb GHCR's
+    eventual-consistency window on a freshly-published referrer; a
+    genuinely-unsigned digest still returns False once the short budget is
+    spent. A network error that persists past the budget is re-raised (the
+    caller turns it into a "network error" message) rather than being
+    reported as a false "unsigned" verdict.
 
     ``repo_path`` is pre-validated; ``digest`` is checked to start with
     the literal ``sha256:`` prefix and the hex tail is character-class
     constrained by definition. The ``urllib.parse.quote`` call closes
     the CodeQL ``py/partial-ssrf`` data-flow.
+
+    Raises:
+        urllib.error.URLError: a network-level failure that persisted
+            across every attempt (also covers ``OSError`` subclasses).
     """
     if not digest.startswith("sha256:"):
         return False
@@ -331,7 +340,17 @@ def signature_present(
     url = f"https://{GHCR_REGISTRY}/v2/{safe_repo}/manifests/{safe_sig_tag}"
     headers = {"Accept": SIG_ACCEPT, **auth_header}
     for attempt in range(1, SIG_PROPAGATION_ATTEMPTS + 1):
-        status, _, _ = _request("HEAD", url, headers)
+        try:
+            status, _, _ = _request("HEAD", url, headers)
+        except urllib.error.URLError, OSError:
+            # A network blip on the referrer check is itself transient:
+            # retry within the same budget. If it persists, re-raise on the
+            # final attempt so the caller reports a network error rather
+            # than a false "unsigned" verdict.
+            if attempt < SIG_PROPAGATION_ATTEMPTS:
+                time.sleep(SIG_PROPAGATION_BACKOFF_SECONDS)
+                continue
+            raise
         if status == HTTP_OK:
             return True
         if attempt < SIG_PROPAGATION_ATTEMPTS:
@@ -454,7 +473,7 @@ def _verify_pair(
                 f"(referrer tag sha256-{sig_hex} returned non-200)"
             )
     except _NetworkExceptions as exc:
-        return None, f"network error ({type(exc).__name__}: {exc})"
+        return None, f"network error ({type(exc).__name__}: {exc!r})"
     return digest, None
 
 
@@ -477,7 +496,7 @@ def _auth_header_for_repo(
     except _NetworkExceptions as exc:
         return (
             None,
-            f"failed to mint pull token ({type(exc).__name__}: {exc})",
+            f"failed to mint pull token ({type(exc).__name__}: {exc!r})",
         )
     header: dict[str, str] = (
         {"Authorization": f"Bearer {reg_token}"} if reg_token else {}

--- a/scripts/check_image_signatures.py
+++ b/scripts/check_image_signatures.py
@@ -40,6 +40,7 @@ import json
 import os
 import re
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -57,6 +58,15 @@ HTTP_TIMEOUT_SECONDS = 30
 HTTP_OK = 200
 USAGE_EXIT_CODE = 2
 FAILURE_EXIT_CODE = 1
+
+# GHCR surfaces a freshly-published cosign referrer (the `sha256-<hex>`
+# tag) with eventual consistency. This gate runs minutes after the publish
+# jobs, so propagation is normally settled; the short retry only covers the
+# rare case where the gate runs close behind a sign. Kept deliberately
+# short -- the gate's purpose is to FAIL a genuinely-unsigned image, so a
+# persistent 404 must surface quickly rather than be masked by a long wait.
+SIG_PROPAGATION_ATTEMPTS = 3
+SIG_PROPAGATION_BACKOFF_SECONDS = 3
 
 # Anchored allowlist patterns, applied to every value that flows into
 # the registry URL path. Closes the partial-SSRF window CodeQL flags
@@ -302,6 +312,12 @@ def signature_present(
 ) -> bool:
     """Return True if a cosign signature referrer artifact exists for this digest.
 
+    Retries a non-200 a few times with a short fixed backoff
+    (``SIG_PROPAGATION_ATTEMPTS`` / ``SIG_PROPAGATION_BACKOFF_SECONDS``) to
+    absorb GHCR's eventual-consistency window on a freshly-published
+    referrer; a genuinely-unsigned digest still returns False once the
+    short budget is spent.
+
     ``repo_path`` is pre-validated; ``digest`` is checked to start with
     the literal ``sha256:`` prefix and the hex tail is character-class
     constrained by definition. The ``urllib.parse.quote`` call closes
@@ -314,8 +330,13 @@ def signature_present(
     safe_sig_tag = urllib.parse.quote(sig_tag, safe="")
     url = f"https://{GHCR_REGISTRY}/v2/{safe_repo}/manifests/{safe_sig_tag}"
     headers = {"Accept": SIG_ACCEPT, **auth_header}
-    status, _, _ = _request("HEAD", url, headers)
-    return status == HTTP_OK
+    for attempt in range(1, SIG_PROPAGATION_ATTEMPTS + 1):
+        status, _, _ = _request("HEAD", url, headers)
+        if status == HTTP_OK:
+            return True
+        if attempt < SIG_PROPAGATION_ATTEMPTS:
+            time.sleep(SIG_PROPAGATION_BACKOFF_SECONDS)
+    return False
 
 
 def _resolve_token() -> tuple[str | None, str]:

--- a/scripts/check_image_signatures.py
+++ b/scripts/check_image_signatures.py
@@ -331,9 +331,10 @@ def signature_present(
     the CodeQL ``py/partial-ssrf`` data-flow.
 
     Raises:
-        urllib.error.URLError: a network-level failure (also covers
-            ``OSError`` subclasses), OR a non-404 registry error
-            (502/503/429/...), that persisted across every attempt.
+        urllib.error.URLError: a network-level failure (a raw ``OSError``
+            is normalised to ``URLError`` with the original kept as
+            ``__cause__``), OR a non-404 registry error (502/503/429/...),
+            that persisted across every attempt.
     """
     if not digest.startswith("sha256:"):
         return False
@@ -345,15 +346,21 @@ def signature_present(
     for attempt in range(1, SIG_PROPAGATION_ATTEMPTS + 1):
         try:
             status, _, _ = _request("HEAD", url, headers)
-        except urllib.error.URLError, OSError:
+        except (urllib.error.URLError, OSError) as exc:
             # A network blip on the referrer check is itself transient:
             # retry within the same budget. If it persists, re-raise on the
             # final attempt so the caller reports a network error rather
-            # than a false "unsigned" verdict.
+            # than a false "unsigned" verdict. URLError is itself an OSError
+            # subclass; a raw (non-URLError) OSError is normalised to URLError
+            # so the raised type matches the documented contract and callers
+            # only need to catch urllib.error.URLError.
             if attempt < SIG_PROPAGATION_ATTEMPTS:
                 time.sleep(SIG_PROPAGATION_BACKOFF_SECONDS)
                 continue
-            raise
+            if isinstance(exc, urllib.error.URLError):
+                raise
+            msg = f"network error on referrer check for {url}"
+            raise urllib.error.URLError(msg) from exc
         if status == HTTP_OK:
             return True
         # A 404 is a real "referrer not (yet) present" answer: retry within

--- a/scripts/check_no_repush_after_failure.sh
+++ b/scripts/check_no_repush_after_failure.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# PreToolUse hook: refuse a reflexive ``git push`` immediately after the
+# previous pre-push hook FAILED, until its log has been read and the
+# failure marker explicitly cleared.
+#
+# Why this exists:
+#   A failed ``git push`` (a red pre-push gate) must be DIAGNOSED, not
+#   retried. Re-pushing without reading the failure:
+#     1. overwrites the failing log in place (``-last.log`` has no
+#        rotation), destroying the only diagnostic of what went wrong; and
+#     2. re-runs an expensive multi-minute gate suite for zero new
+#        information, and usually fails again on the same cause.
+#   The model has done exactly this -- re-pushed a load-induced wall-clock
+#   timeout as "flaky" and destroyed the log. This gate makes that
+#   impossible: after a pre-push failure, the next push is BLOCKED until
+#   the operator has read the preserved log and consciously cleared the
+#   marker.
+#
+# How the marker is set:
+#   ``scripts/git-hooks/_run-hook.sh`` writes
+#   ``<git-dir>/synthorg-hooks/pre-push-FAILED`` on a failed pre-push run
+#   and removes it on a clean run. The failing log is at
+#   ``pre-push-last.log`` and the prior run is preserved at
+#   ``pre-push-prev.log`` (both written by the same runner).
+#
+# Behaviour:
+#   - Non-push commands: exit 0 (allow).
+#   - No marker present: exit 0 (allow) -- the last pre-push was clean
+#     (or there hasn't been one).
+#   - Marker present: deny. The operator must read the log, fix the root
+#     cause, then ``rm`` the marker to authorise the push. Clearing the
+#     marker is the deliberate acknowledgement the gate requires; a clean
+#     pre-push run also clears it automatically.
+
+set -euo pipefail
+
+# Read PreToolUse JSON envelope. No-op when run interactively.
+if [[ -t 0 ]]; then
+    exit 0
+fi
+
+PAYLOAD=$(cat 2>/dev/null || echo "")
+if [[ -z "${PAYLOAD}" ]]; then
+    exit 0
+fi
+
+COMMAND=$(printf '%s' "${PAYLOAD}" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+if [[ -z "${COMMAND}" ]]; then
+    exit 0
+fi
+
+# Robust ``git push`` detection (mirrors check_ci_before_push.sh): the
+# boundary class includes shell-quote characters so nested-shell wrapper
+# forms (``bash -lc 'git push'``) are caught, and ``-m`` / ``--message``
+# argument values are stripped first so a commit-message body mentioning
+# "git push" does not trip the regex.
+PUSH_REGEX=$'(^|[[:space:]|&;(\'"])git[[:space:]]+push([[:space:]]|$|[|&;)\'"])'
+COMMAND_FOR_PUSH_CHECK=$(printf '%s' "${COMMAND}" \
+    | tr '\n\r' '  ' \
+    | sed -E "
+        s/-m[[:space:]]+'[^']*'/-m _MSG_/g
+        s/-m[[:space:]]+\"[^\"]*\"/-m _MSG_/g
+        s/--message=[[:space:]]*'[^']*'/--message=_MSG_/g
+        s/--message=[[:space:]]*\"[^\"]*\"/--message=_MSG_/g
+        s/--message[[:space:]]+'[^']*'/--message _MSG_/g
+        s/--message[[:space:]]+\"[^\"]*\"/--message _MSG_/g
+    ")
+if ! printf '%s\n' "${COMMAND_FOR_PUSH_CHECK}" | grep -qE "${PUSH_REGEX}"; then
+    exit 0
+fi
+
+LOG_DIR=$(git rev-parse --git-path synthorg-hooks 2>/dev/null || echo "")
+if [[ -z "${LOG_DIR}" ]]; then
+    exit 0
+fi
+MARKER="${LOG_DIR}/pre-push-FAILED"
+if [[ ! -f "${MARKER}" ]]; then
+    exit 0
+fi
+
+LOG="${LOG_DIR}/pre-push-last.log"
+PREV="${LOG_DIR}/pre-push-prev.log"
+REASON="git push BLOCKED: the previous pre-push gate FAILED and has not been diagnosed. Re-pushing without reading the log destroys the failing run's output (no log rotation) and re-runs the multi-minute gate suite for nothing -- it almost always fails again on the same cause. Read the full log FIRST: ${LOG} (the run before it is preserved at ${PREV}). Find the FIRST failing gate, root-cause it (a timeout/slow test is a real regression, not 'flaky'; verify in isolation is necessary but NOT sufficient), and FIX it. Only then clear the marker to authorise the push: rm '${MARKER}'. A clean pre-push run also clears it automatically. Do NOT reflexively re-push."
+jq -n --arg reason "${REASON}" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $reason
+  }
+}'
+exit 2

--- a/scripts/check_no_repush_after_failure.sh
+++ b/scripts/check_no_repush_after_failure.sh
@@ -44,7 +44,16 @@ if [[ -z "${PAYLOAD}" ]]; then
     exit 0
 fi
 
-COMMAND=$(printf '%s' "${PAYLOAD}" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+# Fail-open if the payload is not parseable JSON, but SURFACE it: this is a
+# developer-experience guard, not a security boundary, so a broken envelope
+# must not block the user -- yet a silent pass hides a real parse problem
+# (unlike check_bash_no_write.sh, which fails closed). Distinguish a jq parse
+# failure (warn, then allow) from a successfully-parsed non-command tool call
+# (allow silently).
+if ! COMMAND=$(printf '%s' "${PAYLOAD}" | jq -r '.tool_input.command // ""' 2>/dev/null); then
+    echo "check_no_repush_after_failure: could not parse hook payload as JSON; failing open" >&2
+    exit 0
+fi
 if [[ -z "${COMMAND}" ]]; then
     exit 0
 fi

--- a/scripts/generate_feature_index.py
+++ b/scripts/generate_feature_index.py
@@ -26,8 +26,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _module_size_lib import (
     TIER_LIMITS,
-    count_loc,
-    resolve_tier,
+    count_loc_text,
+    resolve_tier_text,
 )
 
 from synthorg._core.features import (
@@ -80,19 +80,29 @@ def _owning_feature(module_rel: str, directories: dict[str, str]) -> str | None:
 
 
 def build_codebase_map() -> list[dict[str, object]]:
-    """Build the per-module codebase map (kind, tier cap, LOC, owning feature)."""
+    """Build the per-module codebase map (kind, tier cap, LOC, owning feature).
+
+    Reads each module ONCE and string-slices the repo-/src-relative paths
+    rather than calling ``Path.relative_to`` (3x per file) and re-opening
+    each file for the tier header and the LOC count: both dominated the
+    profile of this whole-src-tree scan.
+    """
     directories = feature_directories()
+    repo_prefix = f"{_REPO_ROOT.as_posix()}/"
+    src_parent_prefix = f"{_SRC_ROOT.parent.as_posix()}/"
     entries: list[dict[str, object]] = []
     for path in sorted(_SRC_ROOT.rglob("*.py")):
-        rel = path.relative_to(_SRC_ROOT.parent.parent).as_posix()
-        module_rel = path.relative_to(_SRC_ROOT.parent).as_posix()
-        tier = resolve_tier(path, project_root=_REPO_ROOT)
+        posix = path.as_posix()
+        rel = posix.removeprefix(repo_prefix)
+        module_rel = posix.removeprefix(src_parent_prefix)
+        text = path.read_text(encoding="utf-8")
+        tier = resolve_tier_text(path, text, rel_posix=rel)
         entries.append(
             {
                 "module": rel,
                 "kind": tier,
                 "loc_cap": TIER_LIMITS.get(tier),
-                "loc": count_loc(path),
+                "loc": count_loc_text(text),
                 "owning_feature": _owning_feature(module_rel, directories),
             }
         )

--- a/scripts/git-hooks/_run-hook.sh
+++ b/scripts/git-hooks/_run-hook.sh
@@ -55,6 +55,17 @@ export UV_FROZEN=1
 LOG_DIR="$(git rev-parse --git-path synthorg-hooks)"
 mkdir -p "$LOG_DIR"
 LOG="$LOG_DIR/${hook_type}-last.log"
+PREV="$LOG_DIR/${hook_type}-prev.log"
+FAILED_MARKER="$LOG_DIR/${hook_type}-FAILED"
+
+# Rotate the previous run's log to ``-prev.log`` BEFORE this run overwrites
+# ``-last.log``. Without rotation a re-run (e.g. re-pushing after a failure)
+# overwrites the failing log in place, destroying the only diagnostic of
+# what went wrong -- so the prior run's full output is always recoverable
+# for at least one more cycle.
+if [ -f "$LOG" ]; then
+  cp -f "$LOG" "$PREV"
+fi
 
 set +e
 uv run --frozen --project "$ROOT" python -m pre_commit hook-impl \
@@ -69,10 +80,22 @@ if [ "$status" -ne 0 ]; then
     echo "=================================================================="
     echo "git ${hook_type} hook FAILED (exit ${status})."
     echo "Full untruncated output: ${LOG}"
+    echo "Previous run's log preserved at: ${PREV}"
     echo "--- failing tail (last 60 lines; read the full log above if needed) ---"
     tail -n 60 "$LOG"
     echo "=================================================================="
   } >&2
+  # Drop a failure marker so the Claude PreToolUse guard
+  # (check_no_repush_after_failure.sh) blocks a reflexive re-run until the
+  # log has been read and the marker cleared. Best-effort; never fail the
+  # hook on a marker-write error.
+  {
+    printf 'hook=%s\nstatus=%s\nlog=%s\nprev=%s\n' \
+      "$hook_type" "$status" "$LOG" "$PREV"
+  } > "$FAILED_MARKER" 2>/dev/null || true
+else
+  # Clean run: clear any stale failure marker so the guard stops blocking.
+  rm -f "$FAILED_MARKER" 2>/dev/null || true
 fi
 
 exit "$status"

--- a/tests/unit/scripts/test_check_image_signatures.py
+++ b/tests/unit/scripts/test_check_image_signatures.py
@@ -238,7 +238,7 @@ class TestBasicAuth:
 
 @pytest.mark.unit
 class TestSignaturePresent:
-    """signature_present rejects malformed digests up front."""
+    """signature_present validates digests and tolerates propagation lag."""
 
     def test_rejects_non_sha256_digest(self) -> None:
         # No HTTP call should be made; non-sha256 digest fails immediately.
@@ -248,6 +248,61 @@ class TestSignaturePresent:
     def test_rejects_empty_digest(self) -> None:
         repo = "aureliolo/synthorg-backend"
         assert gate.signature_present(repo, "", {}) is False
+
+    def test_present_on_first_check_does_not_sleep(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[str] = []
+
+        def fake_request(
+            _method: str, url: str, _headers: dict[str, str]
+        ) -> tuple[int, dict[str, str], bytes]:
+            calls.append(url)
+            return gate.HTTP_OK, {}, b""
+
+        slept: list[float] = []
+        monkeypatch.setattr(gate, "_request", fake_request)
+        monkeypatch.setattr(gate.time, "sleep", slept.append)
+        digest = "sha256:" + "a" * 64
+        assert gate.signature_present("aureliolo/synthorg-backend", digest, {}) is True
+        assert len(calls) == 1
+        assert slept == []
+
+    def test_retries_propagation_lag_then_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        statuses = iter([404, gate.HTTP_OK])
+
+        def fake_request(
+            _method: str, _url: str, _headers: dict[str, str]
+        ) -> tuple[int, dict[str, str], bytes]:
+            return next(statuses), {}, b""
+
+        slept: list[float] = []
+        monkeypatch.setattr(gate, "_request", fake_request)
+        monkeypatch.setattr(gate.time, "sleep", slept.append)
+        digest = "sha256:" + "b" * 64
+        assert gate.signature_present("aureliolo/synthorg-backend", digest, {}) is True
+        assert len(slept) == 1
+
+    def test_genuine_miss_fails_after_bounded_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[str] = []
+
+        def fake_request(
+            _method: str, url: str, _headers: dict[str, str]
+        ) -> tuple[int, dict[str, str], bytes]:
+            calls.append(url)
+            return 404, {}, b""
+
+        slept: list[float] = []
+        monkeypatch.setattr(gate, "_request", fake_request)
+        monkeypatch.setattr(gate.time, "sleep", slept.append)
+        digest = "sha256:" + "c" * 64
+        assert gate.signature_present("aureliolo/synthorg-backend", digest, {}) is False
+        assert len(calls) == gate.SIG_PROPAGATION_ATTEMPTS
+        assert len(slept) == gate.SIG_PROPAGATION_ATTEMPTS - 1
 
 
 @pytest.mark.unit

--- a/tests/unit/scripts/test_check_image_signatures.py
+++ b/tests/unit/scripts/test_check_image_signatures.py
@@ -1,6 +1,8 @@
+# module-kind: tests
 """Tests for scripts/check_image_signatures.py."""
 
 import importlib.util
+import urllib.error
 from pathlib import Path
 from types import ModuleType
 
@@ -283,7 +285,49 @@ class TestSignaturePresent:
         monkeypatch.setattr(gate.time, "sleep", slept.append)
         digest = "sha256:" + "b" * 64
         assert gate.signature_present("aureliolo/synthorg-backend", digest, {}) is True
+        assert slept == [gate.SIG_PROPAGATION_BACKOFF_SECONDS]
+
+    def test_transient_network_error_is_retried_then_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A network blip on the first attempt must be retried, not fail the
+        # whole check; a subsequent 200 resolves it.
+        results: list[object] = [urllib.error.URLError("blip"), (gate.HTTP_OK, {}, b"")]
+
+        def fake_request(
+            _method: str, _url: str, _headers: dict[str, str]
+        ) -> tuple[int, dict[str, str], bytes]:
+            item = results.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item  # type: ignore[return-value]
+
+        slept: list[float] = []
+        monkeypatch.setattr(gate, "_request", fake_request)
+        monkeypatch.setattr(gate.time, "sleep", slept.append)
+        digest = "sha256:" + "d" * 64
+        assert gate.signature_present("aureliolo/synthorg-backend", digest, {}) is True
         assert len(slept) == 1
+
+    def test_persistent_network_error_reraises_not_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A network error that persists past the budget must re-raise (the
+        # caller reports a network error), not be masked as a False
+        # "unsigned" verdict.
+        def fake_request(
+            _method: str, _url: str, _headers: dict[str, str]
+        ) -> tuple[int, dict[str, str], bytes]:
+            msg = "down"
+            raise urllib.error.URLError(msg)
+
+        slept: list[float] = []
+        monkeypatch.setattr(gate, "_request", fake_request)
+        monkeypatch.setattr(gate.time, "sleep", slept.append)
+        digest = "sha256:" + "e" * 64
+        with pytest.raises(urllib.error.URLError):
+            gate.signature_present("aureliolo/synthorg-backend", digest, {})
+        assert len(slept) == gate.SIG_PROPAGATION_ATTEMPTS - 1
 
     def test_genuine_miss_fails_after_bounded_budget(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/scripts/test_check_image_signatures.py
+++ b/tests/unit/scripts/test_check_image_signatures.py
@@ -329,6 +329,28 @@ class TestSignaturePresent:
             gate.signature_present("aureliolo/synthorg-backend", digest, {})
         assert len(slept) == gate.SIG_PROPAGATION_ATTEMPTS - 1
 
+    def test_persistent_raw_oserror_normalised_to_urlerror(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A raw OSError (not already a URLError) that persists past the budget
+        # is normalised to URLError so callers only need to catch URLError;
+        # the original OSError is preserved as __cause__.
+        original = ConnectionResetError("connection reset by peer")
+
+        def fake_request(
+            _method: str, _url: str, _headers: dict[str, str]
+        ) -> tuple[int, dict[str, str], bytes]:
+            raise original
+
+        slept: list[float] = []
+        monkeypatch.setattr(gate, "_request", fake_request)
+        monkeypatch.setattr(gate.time, "sleep", slept.append)
+        digest = "sha256:" + "a" * 64
+        with pytest.raises(urllib.error.URLError) as excinfo:
+            gate.signature_present("aureliolo/synthorg-backend", digest, {})
+        assert excinfo.value.__cause__ is original
+        assert len(slept) == gate.SIG_PROPAGATION_ATTEMPTS - 1
+
     def test_genuine_miss_fails_after_bounded_budget(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/scripts/test_check_image_signatures.py
+++ b/tests/unit/scripts/test_check_image_signatures.py
@@ -348,6 +348,49 @@ class TestSignaturePresent:
         assert len(calls) == gate.SIG_PROPAGATION_ATTEMPTS
         assert len(slept) == gate.SIG_PROPAGATION_ATTEMPTS - 1
 
+    def test_persistent_registry_error_reraises_not_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A non-404 registry error (e.g. 502) that persists past the budget
+        # is a registry failure, NOT evidence of a missing signature: it must
+        # re-raise (the caller reports a network error) rather than be masked
+        # as a False "unsigned" verdict. Only a 404 means "genuinely absent".
+        calls: list[str] = []
+
+        def fake_request(
+            _method: str, url: str, _headers: dict[str, str]
+        ) -> tuple[int, dict[str, str], bytes]:
+            calls.append(url)
+            return 502, {}, b""
+
+        slept: list[float] = []
+        monkeypatch.setattr(gate, "_request", fake_request)
+        monkeypatch.setattr(gate.time, "sleep", slept.append)
+        digest = "sha256:" + "d" * 64
+        with pytest.raises(urllib.error.URLError):
+            gate.signature_present("aureliolo/synthorg-backend", digest, {})
+        assert len(calls) == gate.SIG_PROPAGATION_ATTEMPTS
+        assert len(slept) == gate.SIG_PROPAGATION_ATTEMPTS - 1
+
+    def test_transient_registry_error_then_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A non-404 registry error on an early attempt is retried within the
+        # budget; a subsequent 200 still resolves to True (signature present).
+        statuses = iter([502, gate.HTTP_OK])
+
+        def fake_request(
+            _method: str, _url: str, _headers: dict[str, str]
+        ) -> tuple[int, dict[str, str], bytes]:
+            return next(statuses), {}, b""
+
+        slept: list[float] = []
+        monkeypatch.setattr(gate, "_request", fake_request)
+        monkeypatch.setattr(gate.time, "sleep", slept.append)
+        digest = "sha256:" + "f" * 64
+        assert gate.signature_present("aureliolo/synthorg-backend", digest, {}) is True
+        assert slept == [gate.SIG_PROPAGATION_BACKOFF_SECONDS]
+
 
 @pytest.mark.unit
 class TestRepoPrefixValidator:

--- a/tests/unit/scripts/test_module_size_lib.py
+++ b/tests/unit/scripts/test_module_size_lib.py
@@ -192,6 +192,67 @@ def test_resolve_tier_default_code(tmp_path: Path) -> None:
     assert _LIB.resolve_tier(src, project_root=project) == "code"
 
 
+# ── Pure (text-based) variants used by the hot codebase-map build ──
+
+
+def test_count_loc_text_matches_count_loc(tmp_path: Path) -> None:
+    source = "import os\n\n# comment\ndef foo() -> int:\n    return 1  # inline\n"
+    path = tmp_path / "m.py"
+    path.write_text(source, encoding="utf-8")
+    assert _LIB.count_loc_text(source) == _LIB.count_loc(path)
+
+
+def test_count_loc_text_empty_is_zero() -> None:
+    assert _LIB.count_loc_text("") == 0
+
+
+def test_module_kind_from_text_matches_read_header(tmp_path: Path) -> None:
+    source = "#!/usr/bin/env python3\n# module-kind: service\nimport x\n"
+    path = tmp_path / "m.py"
+    path.write_text(source, encoding="utf-8")
+    assert _LIB.module_kind_from_text(source, path) == _LIB.read_module_kind_header(
+        path
+    )
+
+
+def test_resolve_tier_text_generated_by_name() -> None:
+    assert (
+        _LIB.resolve_tier_text(
+            Path("src/synthorg/api/types.gen.ts.py"), "", rel_posix="src/.../x.py"
+        )
+        == "generated"
+    )
+
+
+def test_resolve_tier_text_tests_by_rel_posix() -> None:
+    assert (
+        _LIB.resolve_tier_text(
+            Path("tests/unit/test_foo.py"), "", rel_posix="tests/unit/test_foo.py"
+        )
+        == "tests"
+    )
+
+
+def test_resolve_tier_text_header_wins() -> None:
+    assert (
+        _LIB.resolve_tier_text(
+            Path("src/synthorg/foo.py"),
+            "# module-kind: service\n",
+            rel_posix="src/synthorg/foo.py",
+        )
+        == "service"
+    )
+
+
+def test_resolve_tier_text_default_code() -> None:
+    assert (
+        _LIB.resolve_tier_text(
+            Path("src/synthorg/foo.py"), "import os\n", rel_posix="src/synthorg/foo.py"
+        )
+        == "code"
+    )
+
+
 # ── TIER_LIMITS table ───────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

The `Verify Image Signatures` gate has gone red repeatedly on release runs because the signing pipeline had no retry at three distinct GHCR eventual-consistency / flakiness points. Each one left an image pushed-but-unsigned, then the retag carried the unsigned digest forward and the gate failed. This hardens all three, plus an unrelated test-infra optimisation and two tooling guardrails (bundled per request).

### A. Image-signing resilience (the core fix)

1. **Broken-pipe misclassification** (`cosign_sign_with_retry.sh`, `docker_push_with_retry.sh`, `publish-image-retag/action.yml`). The transient-error classifier used `printf "$out" | grep -q` under `set -o pipefail`. When `$out` is a GHCR 5xx HTML body that overruns the 64 KB pipe buffer and the match token is early, `grep -q` closes the pipe, `printf` takes `EPIPE`, and `pipefail` makes the pipeline report failure -- so a genuinely-transient `502 Bad Gateway` was misclassified as terminal and **not retried**. Replaced with a here-string (`grep -q ... <<<"$out"`), which is not a pipeline. This was the original `eb56d22` failure.
2. **Signature-referrer propagation lag** (`publish-image-loaded`, `publish-apko-base`, `check_image_signatures.py`). The post-sign verification queried the `sha256-<hex>` referrer tag ~270 ms after signing and 404'd before GHCR made it queryable. Added bounded propagation-tolerant retry (short in the final gate so a genuine miss still fails fast).
3. **Manifest read-after-write 404** (`publish-image-loaded`, `publish-apko-base`). `docker buildx imagetools inspect <tag>` read the just-pushed digest back with no retry; GHCR's write-path eventual consistency 404'd it (`ERROR: ...: not found`). This was the `b7af50e88` / #2311 `fine-tune-gpu` failure. Added bounded read-after-write retry, mirroring `publish-image-retag`.

Plus pre-PR hardening from 11 review agents: cosign negative-control + idempotency self-tests, `URLError` retried inside the gate loop, `curl --connect-timeout/--max-time` on all verify calls, `*_RETRY_ATTEMPTS` fail-open guard, digest-shape validation, `000`-vs-registry error disambiguation, and a Linux-reproducing broken-pipe regression test wired as a pre-commit hook.

### B. Feature-index build optimisation

`build_codebase_map` (a whole-`src`-tree meta-test) read each of ~2957 modules twice and called `Path.relative_to` 3x per file. Read once + string-slice the rel paths: `check()` **2.23s to 1.03s**, output byte-identical. Keeps the wall-clock-budgeted meta-test well under its limit under xdist contention.

### C. Tooling guardrails

- `_run-hook.sh` rotates `<hook>-last.log` to `-prev.log` before each run (a re-push can no longer destroy the failing log) and drops a `pre-push-FAILED` marker on failure.
- New `check_no_repush_after_failure.sh` PreToolUse hook denies a `git push` while that marker exists, until the log is read and the marker cleared (a clean run clears it automatically).

## Test plan

- New unit coverage: `signature_present` propagation + network-error retry; `_module_size_lib` text-variant helpers; the shell `test_retry_classifiers.sh` self-test (transient retried, genuine error not, idempotency) wired as a pre-commit hook.
- Feature-index gate test verifies byte-identical output after the optimisation.
- Guardrail scripts validated end-to-end (deny on marker incl. shell-wrapper forms, allow otherwise).
- Re-running the failed jobs on `eb56d22` and `b7af50e88` (#2311) with the existing historic actions re-greened both commits, confirming the failures were the flakes diagnosed above.

## Review coverage

Pre-reviewed by 11 agents (infra, security, code, python, silent-failure, test-quality, pr-test-analyzer, conventions, comment-quality-rot, comment-analyzer, docs-consistency); 16 findings implemented.