### PR TITLE
perf: oversubscribe integration xdist workers to 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -589,7 +589,7 @@ jobs:
           uv run python -m pytest tests/ \
             -m integration \
             -k "not [sqlite-" \
-            -n auto \
+            -n 8 \
             --max-worker-restart=0 \
             --splits 4 \
             --group ${{ matrix.shard }} \


### PR DESCRIPTION
## Summary

The integration test job's critical path is its slowest shard. On the last green run (`27412948559`) the four shards were **368 / 378 / 387 / 459s** — shard 4 the long pole at ~7.6 min. Per-shard breakdown (shard 4): ~46s fixed setup + **407s pytest** at only ~1.9x realised parallelism — `-n auto` gives 4 workers on the 4-vCPU `ubuntu-latest`, and they idle waiting on I/O-bound Postgres/NATS round-trips.

Integration tests are I/O-bound, so running more workers than cores hides that latency. This bumps the integration shards from `-n auto` to **`-n 8`** (2x oversubscribe).

## Change

One line in `.github/workflows/ci.yml` (integration run step): `-n auto` → `-n 8`. Nothing else. `--dist=loadfile` is unchanged, and `.test_durations.integration` is untouched, so the pytest-split groups are identical to the baseline — making this a clean A/B against the 368/378/387/459s numbers above. This PR's own integration CI is the measurement.

Deeper levers (`--dist=loadgroup` with per-module `xdist_group` markers for the ~15 container-touching modules; per-test Postgres schema reuse) need careful per-module classification + their own validation and are tracked separately.

## Test plan

- This PR's integration shards run `-n 8`; compare slowest-shard wall-clock against the `-n auto` baseline (459s long pole).
- Watch for new flakes or container-contention failures from the higher worker count; if any appear, dial back (`-n 6`).

Closes #2350