### PR TITLE
perf: clone Postgres test DBs from a migrated template instead of per-test migrate

### DIFF
--- a/scripts/check_persistence_boundary.py
+++ b/scripts/check_persistence_boundary.py
@@ -148,6 +148,11 @@ _ALLOWLIST: Final[frozenset[str]] = frozenset(
         "scripts/check_persistence_boundary.py",
         # Shared conftest bootstraps the test database via aiosqlite.
         "tests/conftest.py",
+        # Shared helper that builds a migrated Postgres template database
+        # and clones per-test DBs from it; holds a psycopg driver and
+        # issues CREATE/DROP/ALTER DATABASE DDL for that purpose -- same
+        # test-DB-bootstrap rationale as tests/conftest.py.
+        "tests/_shared/postgres_template.py",
         # Integration / unit tests that legitimately hold driver
         # handles for cross-subsystem fixtures.
         "tests/integration/engine/identity/test_identity_versioning.py",

--- a/tests/_shared/postgres_template.py
+++ b/tests/_shared/postgres_template.py
@@ -120,17 +120,19 @@ def _server_key(proxy: PostgresContainerProxy) -> str:
 
 
 async def _drop_database(proxy: PostgresContainerProxy, db_name: str) -> None:
-    """Terminate remaining sessions on *db_name* and drop it."""
+    """Drop *db_name*, force-terminating any remaining sessions.
+
+    ``WITH (FORCE)`` (PG13+) terminates lingering connections atomically,
+    avoiding the race between a separate ``pg_terminate_backend`` and the
+    drop.
+    """
     async with await psycopg.AsyncConnection.connect(
         _admin_conninfo(proxy), autocommit=True
     ) as admin:
         await admin.execute(
-            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
-            "WHERE datname = %s AND pid != pg_backend_pid()",
-            (db_name,),
-        )
-        await admin.execute(
-            sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(db_name))
+            sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(
+                sql.Identifier(db_name)
+            )
         )
 
 
@@ -149,11 +151,20 @@ async def _build_template(proxy: PostgresContainerProxy) -> None:
     """
     admin = _admin_conninfo(proxy)
     async with await psycopg.AsyncConnection.connect(admin, autocommit=True) as conn:
-        # A sealed template cannot be dropped until datistemplate is cleared.
-        await conn.execute(
-            "UPDATE pg_database SET datistemplate = false WHERE datname = %s",
+        # A sealed template cannot be dropped until IS_TEMPLATE is cleared.
+        # Use the supported DDL (direct pg_database catalog writes need
+        # allow_system_table_mods, off by default); ALTER errors if the DB
+        # is absent, so gate it on an existence check.
+        res = await conn.execute(
+            "SELECT 1 FROM pg_database WHERE datname = %s AND datistemplate = true",
             (TEMPLATE_DB_NAME,),
         )
+        if await res.fetchone() is not None:
+            await conn.execute(
+                sql.SQL("ALTER DATABASE {} WITH IS_TEMPLATE false").format(
+                    sql.Identifier(TEMPLATE_DB_NAME)
+                )
+            )
         await conn.execute(
             sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(
                 sql.Identifier(TEMPLATE_DB_NAME)
@@ -232,9 +243,17 @@ async def clone_from_template(
     try:
         await backend.connect()
     except BaseException:
-        with contextlib.suppress(Exception):
-            await backend.disconnect()
-        with contextlib.suppress(Exception):
+
+        async def _cleanup() -> None:
+            with contextlib.suppress(Exception):
+                await backend.disconnect()
             await _drop_database(proxy, db_name)
+
+        # Shield the best-effort teardown so a cancellation of the calling
+        # task cannot interrupt it mid-way and leak the half-created DB,
+        # and suppress everything (including CancelledError) so the
+        # original connect failure is the exception that propagates.
+        with contextlib.suppress(BaseException):
+            await asyncio.shield(_cleanup())
         raise
     return backend

--- a/tests/_shared/postgres_template.py
+++ b/tests/_shared/postgres_template.py
@@ -1,0 +1,240 @@
+"""Session-shared migrated Postgres template for fast per-test DB cloning.
+
+Per-test Postgres fixtures historically ran ``CREATE DATABASE`` +
+``connect()`` + ``migrate()`` -- a full yoyo migration-chain replay
+costing 7-10s of *setup* per test, across hundreds of ``[postgres]``
+tests. That setup dominated the integration job's wall-clock (adding
+more xdist workers made it worse, because they contend on the one
+shared server replaying migrations concurrently).
+
+This module migrates the schema ONCE per Postgres server (keyed by
+``host:port``, coordinated across xdist workers via a ``FileLock``)
+into a template database, then per test does ``CREATE DATABASE ...
+TEMPLATE <template>`` -- a near-instant file-level copy that preserves
+full per-test isolation. It mirrors the SQLite arm's ``_get_template_db``
+migrated-file template in ``tests/conftest.py``.
+
+The template is marked ``IS_TEMPLATE true`` + ``ALLOW_CONNECTIONS
+false`` after the build so concurrent ``CREATE DATABASE ... TEMPLATE``
+clones from multiple workers never trip "source database is being
+accessed by other users".
+"""
+
+import asyncio
+import contextlib
+import os
+from pathlib import Path
+from typing import Final
+
+import psycopg
+import psycopg.conninfo
+import pytest
+from filelock import FileLock
+from psycopg import sql
+from pydantic import SecretStr
+
+from synthorg.persistence.config import PostgresConfig
+from synthorg.persistence.postgres.backend import PostgresPersistenceBackend
+from tests._shared.postgres_proxy import PostgresContainerProxy
+
+
+def xdist_shared_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Return the xdist run-wide temp dir shared across all workers.
+
+    ``getbasetemp()`` is the worker-local ``popen-gwN`` subdir under
+    xdist; its ``.parent`` is the run-wide base every worker sees. The
+    master (non-xdist) case has no per-worker subdir, so ``getbasetemp()``
+    is already the shared root. Used to key the cross-worker template
+    sentinel + FileLock.
+    """
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    base = tmp_path_factory.getbasetemp()
+    return base if worker_id == "master" else base.parent
+
+
+TEMPLATE_DB_NAME: Final[str] = "synthorg_pg_template"
+
+# Catastrophe ceiling, not the expected wait. A follower blocks in
+# ``acquire()`` only until the leader releases (i.e. the leader's build
+# time, typically one migration replay), then re-checks the sentinel and
+# skips. 600s only fires if the leader genuinely hangs. Aligned with the
+# SQLite ``_get_template_db`` and the conformance container coordinator.
+_LOCK_TIMEOUT_SECONDS: Final[int] = 600
+
+
+def _ipv4(host: str) -> str:
+    """Force IPv4 to dodge Docker Desktop's flaky IPv6 port proxy.
+
+    ``get_container_host_ip()`` returns ``"localhost"`` on Docker Desktop;
+    Go/psycopg may then prefer ``::1`` whose vpnkit port proxy drops the
+    first connection right after container start. Forcing 127.0.0.1
+    sidesteps the race (same fix the conformance conftest applies).
+    """
+    if host in {"localhost", "::1", ""}:
+        return "127.0.0.1"
+    return host
+
+
+def _admin_conninfo(proxy: PostgresContainerProxy) -> str:
+    """Conninfo for the server's default (admin) database."""
+    return psycopg.conninfo.make_conninfo(
+        host=_ipv4(proxy.get_container_host_ip()),
+        port=int(proxy.get_exposed_port(5432)),
+        user=proxy.username,
+        password=proxy.password,
+        dbname=proxy.dbname,
+    )
+
+
+def _config_for(proxy: PostgresContainerProxy, db_name: str) -> PostgresConfig:
+    """Backend config bound to *db_name* on the proxy's server.
+
+    Mirrors the pool/timeout settings the per-test fixtures used before
+    this template path existed, so backend behaviour under test is
+    unchanged -- only the schema-creation route differs.
+    """
+    return PostgresConfig(
+        host=_ipv4(proxy.get_container_host_ip()),
+        port=int(proxy.get_exposed_port(5432)),
+        database=db_name,
+        username=proxy.username,
+        password=SecretStr(proxy.password),
+        ssl_mode="disable",
+        pool_min_size=1,
+        pool_max_size=4,
+        pool_timeout_seconds=10.0,
+        connect_timeout_seconds=5.0,
+    )
+
+
+def _server_key(proxy: PostgresContainerProxy) -> str:
+    """Stable filename-safe key for the proxy's server (host+port).
+
+    CI runs one shared ``services: postgres`` so every worker resolves
+    the same key and builds the template once; local dev gives each
+    worker its own testcontainer on a distinct port, so each builds its
+    own template -- both correct, no cross-server collision.
+    """
+    host = _ipv4(proxy.get_container_host_ip()).replace(".", "-").replace(":", "-")
+    return f"{host}_{int(proxy.get_exposed_port(5432))}"
+
+
+async def _drop_database(proxy: PostgresContainerProxy, db_name: str) -> None:
+    """Terminate remaining sessions on *db_name* and drop it."""
+    async with await psycopg.AsyncConnection.connect(
+        _admin_conninfo(proxy), autocommit=True
+    ) as admin:
+        await admin.execute(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+            "WHERE datname = %s AND pid != pg_backend_pid()",
+            (db_name,),
+        )
+        await admin.execute(
+            sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(db_name))
+        )
+
+
+async def drop_test_database(proxy: PostgresContainerProxy, db_name: str) -> None:
+    """Public teardown helper: drop a per-test database created by a clone."""
+    await _drop_database(proxy, db_name)
+
+
+async def _build_template(proxy: PostgresContainerProxy) -> None:
+    """Create + migrate the template DB, then seal it as a no-connect template.
+
+    Any partial template left by a crashed prior build is cleared first
+    (clearing ``datistemplate`` so a previously-sealed template can be
+    dropped). The backend pool is fully disconnected before sealing so
+    ``ALLOW_CONNECTIONS false`` has no live sessions to refuse.
+    """
+    admin = _admin_conninfo(proxy)
+    async with await psycopg.AsyncConnection.connect(admin, autocommit=True) as conn:
+        # A sealed template cannot be dropped until datistemplate is cleared.
+        await conn.execute(
+            "UPDATE pg_database SET datistemplate = false WHERE datname = %s",
+            (TEMPLATE_DB_NAME,),
+        )
+        await conn.execute(
+            sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(
+                sql.Identifier(TEMPLATE_DB_NAME)
+            )
+        )
+        await conn.execute(
+            sql.SQL("CREATE DATABASE {}").format(sql.Identifier(TEMPLATE_DB_NAME))
+        )
+
+    backend = PostgresPersistenceBackend(_config_for(proxy, TEMPLATE_DB_NAME))
+    try:
+        await backend.connect()
+        await backend.migrate()
+    finally:
+        await backend.disconnect()
+
+    async with await psycopg.AsyncConnection.connect(admin, autocommit=True) as conn:
+        await conn.execute(
+            sql.SQL(
+                "ALTER DATABASE {} WITH IS_TEMPLATE true ALLOW_CONNECTIONS false"
+            ).format(sql.Identifier(TEMPLATE_DB_NAME))
+        )
+
+
+async def ensure_pg_template(proxy: PostgresContainerProxy, shared_dir: Path) -> str:
+    """Ensure the migrated template DB exists on the proxy's server; return its name.
+
+    Idempotent and cross-worker safe: a per-server sentinel file under
+    *shared_dir* (the xdist run-wide temp dir) short-circuits once the
+    template is built; the first worker to take the ``FileLock`` builds
+    it while the rest block on ``acquire()`` until the build completes,
+    then skip via the re-checked sentinel.
+    """
+    key = _server_key(proxy)
+    sentinel = shared_dir / f"pg_template_{key}.ready"
+    lock_path = shared_dir / f"pg_template_{key}.lock"
+    if await asyncio.to_thread(sentinel.exists):
+        return TEMPLATE_DB_NAME
+    await asyncio.to_thread(shared_dir.mkdir, parents=True, exist_ok=True)
+
+    def _acquire() -> FileLock:
+        fl = FileLock(str(lock_path), timeout=_LOCK_TIMEOUT_SECONDS)
+        fl.acquire()
+        return fl
+
+    lock = await asyncio.to_thread(_acquire)
+    try:
+        if not await asyncio.to_thread(sentinel.exists):
+            await _build_template(proxy)
+            await asyncio.to_thread(sentinel.write_text, "ready")
+    finally:
+        await asyncio.to_thread(lock.release)
+    return TEMPLATE_DB_NAME
+
+
+async def clone_from_template(
+    proxy: PostgresContainerProxy, db_name: str
+) -> PostgresPersistenceBackend:
+    """Create *db_name* from the migrated template and return a connected backend.
+
+    Replaces the per-test ``CREATE DATABASE`` + ``connect()`` +
+    ``migrate()`` sequence: the clone copies the already-migrated
+    template's files (near-instant) so no migration chain is replayed.
+    The caller owns teardown (``drop_test_database``). On a failed
+    connect the half-created database is dropped before re-raising.
+    """
+    async with await psycopg.AsyncConnection.connect(
+        _admin_conninfo(proxy), autocommit=True
+    ) as admin:
+        await admin.execute(
+            sql.SQL("CREATE DATABASE {} TEMPLATE {}").format(
+                sql.Identifier(db_name), sql.Identifier(TEMPLATE_DB_NAME)
+            )
+        )
+    backend = PostgresPersistenceBackend(_config_for(proxy, db_name))
+    try:
+        await backend.connect()
+    except BaseException:
+        with contextlib.suppress(Exception):
+            await backend.disconnect()
+        with contextlib.suppress(Exception):
+            await _drop_database(proxy, db_name)
+        raise
+    return backend

--- a/tests/_shared/postgres_template.py
+++ b/tests/_shared/postgres_template.py
@@ -245,7 +245,7 @@ async def clone_from_template(
     except BaseException:
 
         async def _cleanup() -> None:
-            with contextlib.suppress(Exception):
+            with contextlib.suppress(BaseException):
                 await backend.disconnect()
             await _drop_database(proxy, db_name)
 

--- a/tests/conformance/persistence/conftest.py
+++ b/tests/conformance/persistence/conftest.py
@@ -25,7 +25,6 @@ Postgres arm:
 """
 
 import asyncio
-import contextlib
 import json
 import os
 import sys
@@ -34,21 +33,24 @@ from collections.abc import AsyncIterator, Callable, Iterator, Mapping
 from pathlib import Path
 from typing import Any, Final
 
-import psycopg
 import pytest
 from filelock import FileLock
-from psycopg import sql
-from pydantic import SecretStr
 
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.persistence import migrations
-from synthorg.persistence.config import PostgresConfig, SQLiteConfig
+from synthorg.persistence.config import SQLiteConfig
 from synthorg.persistence.postgres.backend import PostgresPersistenceBackend
 from synthorg.persistence.protocol import PersistenceBackend
 from synthorg.persistence.sqlite.backend import SQLitePersistenceBackend
 from tests._shared import JsonDict
 from tests._shared.postgres_proxy import PostgresContainerProxy
 from tests._shared.postgres_proxy import from_env as _proxy_from_env
+from tests._shared.postgres_template import (
+    clone_from_template,
+    drop_test_database,
+    ensure_pg_template,
+    xdist_shared_dir,
+)
 
 logger = get_logger(__name__)
 
@@ -247,6 +249,11 @@ def _release_shared_postgres(state_file: Path) -> None:
 _POSTGRES_CONTAINER_STATE: JsonDict = {}
 
 
+def _xdist_shared_dir(session: pytest.Session) -> Path:
+    """Run-wide xdist temp dir; delegates to the shared helper."""
+    return xdist_shared_dir(session.config._tmp_path_factory)  # type: ignore[attr-defined]
+
+
 def _pre_acquire_postgres_container_state(session: pytest.Session) -> None:
     """Pre-acquire the shared Postgres container BEFORE any per-test timer.
 
@@ -297,7 +304,12 @@ def _pre_acquire_postgres_container_state(session: pytest.Session) -> None:
         f"(worker={_worker}, state_id={id(_POSTGRES_CONTAINER_STATE)})\n"
     )
     sys.stderr.flush()
-    if _proxy_from_env() is not None:
+    env_proxy = _proxy_from_env()
+    if env_proxy is not None:
+        # Build the migrated template once on the shared CI server here
+        # (sessionstart, NOT covered by pytest-timeout) so per-test
+        # setup clones it instead of replaying the migration chain.
+        asyncio.run(ensure_pg_template(env_proxy, _xdist_shared_dir(session)))
         _POSTGRES_CONTAINER_STATE["mode"] = "env"
         return
 
@@ -308,12 +320,7 @@ def _pre_acquire_postgres_container_state(session: pytest.Session) -> None:
         )
         return
 
-    worker_id = os.environ.get("PYTEST_XDIST_WORKER", "master")
-    tmp_path_factory = session.config._tmp_path_factory  # type: ignore[attr-defined]
-    if worker_id == "master":
-        shared_dir = tmp_path_factory.getbasetemp()
-    else:
-        shared_dir = tmp_path_factory.getbasetemp().parent
+    shared_dir = _xdist_shared_dir(session)
     state_file = shared_dir / "postgres_container_state.json"
     lock_path = str(shared_dir / "postgres_container.lock")
     # Catastrophe ceiling, aligned with ``tests/conftest.py``'s
@@ -337,6 +344,17 @@ def _pre_acquire_postgres_container_state(session: pytest.Session) -> None:
     _POSTGRES_CONTAINER_STATE["state_file"] = state_file
     _POSTGRES_CONTAINER_STATE["lock_path"] = lock_path
     _POSTGRES_CONTAINER_STATE["lock_timeout"] = lock_timeout
+    # Build the migrated template on the now-running container (outside
+    # the container FileLock; ensure_pg_template holds its own) so the
+    # per-test backend fixture clones it instead of re-migrating.
+    container_proxy = PostgresContainerProxy(
+        host=data["host"],
+        port=int(data["port"]),
+        username=data["username"],
+        password=data["password"],
+        dbname=data["dbname"],
+    )
+    asyncio.run(ensure_pg_template(container_proxy, shared_dir))
 
 
 @pytest.fixture(scope="session")
@@ -432,79 +450,31 @@ async def _create_postgres_backend(
     container: PostgresContainerProxy,
     db_name: str,
 ) -> PostgresPersistenceBackend:
-    """Create a test database on *container* and return a migrated backend.
+    """Create *db_name* by cloning the session-built migrated template.
 
-    On any failure after ``CREATE DATABASE`` (backend construct,
-    ``connect()``, ``migrate()``) the partially-created database is
-    dropped and the backend is disconnected so the session does not
-    accumulate orphaned databases and dangling pools.  The
-    ``finally``/cleanup in the outer ``backend`` fixture only runs
-    once this helper has returned a successfully-created backend.
+    Clones the template database (built once at session start by
+    :func:`_pre_acquire_postgres_container_state`) instead of replaying
+    the migration chain, so per-test setup is a near-instant file copy
+    rather than a 7-10s ``migrate()``. On a failed connect the
+    half-created database is dropped before re-raising. Kept as a thin
+    wrapper around the shared helper because
+    ``tests/integration/persistence/test_wp1_restart_safety.py`` imports
+    this name directly.
     """
-    host = _container_host_ipv4(container)
-    port = int(container.get_exposed_port(5432))
-    admin_conninfo = psycopg.conninfo.make_conninfo(
-        host=host,
-        port=port,
-        user=container.username,
-        password=container.password,
-        dbname=container.dbname,
-    )
-    async with await psycopg.AsyncConnection.connect(
-        admin_conninfo, autocommit=True
-    ) as admin:
-        await admin.execute(
-            sql.SQL("CREATE DATABASE {}").format(sql.Identifier(db_name))
-        )
-
-    config = PostgresConfig(
-        host=host,
-        port=port,
-        database=db_name,
-        username=container.username,
-        password=SecretStr(container.password),
-        ssl_mode="disable",
-        pool_min_size=1,
-        pool_max_size=4,
-        pool_timeout_seconds=10.0,
-        connect_timeout_seconds=5.0,
-    )
-    backend = PostgresPersistenceBackend(config)
-    try:
-        await backend.connect()
-        await backend.migrate()
-    except BaseException:
-        with contextlib.suppress(Exception):
-            await backend.disconnect()
-        with contextlib.suppress(Exception):
-            await _drop_postgres_database(container, db_name)
-        raise
-    return backend
+    return await clone_from_template(container, db_name)
 
 
 async def _drop_postgres_database(
     container: PostgresContainerProxy,
     db_name: str,
 ) -> None:
-    """Terminate remaining sessions on *db_name* and drop it."""
-    admin_conninfo = psycopg.conninfo.make_conninfo(
-        host=_container_host_ipv4(container),
-        port=int(container.get_exposed_port(5432)),
-        user=container.username,
-        password=container.password,
-        dbname=container.dbname,
-    )
-    async with await psycopg.AsyncConnection.connect(
-        admin_conninfo, autocommit=True
-    ) as admin:
-        await admin.execute(
-            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
-            "WHERE datname = %s AND pid != pg_backend_pid()",
-            (db_name,),
-        )
-        await admin.execute(
-            sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(db_name))
-        )
+    """Terminate remaining sessions on *db_name* and drop it.
+
+    Thin wrapper around the shared helper; kept because
+    ``tests/integration/persistence/test_wp1_restart_safety.py`` imports
+    this name directly.
+    """
+    await drop_test_database(container, db_name)
 
 
 @pytest.fixture(params=["sqlite", "postgres"], ids=["sqlite", "postgres"])

--- a/tests/integration/persistence/conftest.py
+++ b/tests/integration/persistence/conftest.py
@@ -183,8 +183,12 @@ async def postgres_backend(
     try:
         yield backend
     finally:
-        await backend.disconnect()
-        await drop_test_database(postgres_container, db_name)
+        # Drop even if disconnect raises, else a failed disconnect leaks
+        # the per-test database onto the shared server for the session.
+        try:
+            await backend.disconnect()
+        finally:
+            await drop_test_database(postgres_container, db_name)
 
 
 _TIMESCALEDB_IMAGE = "timescale/timescaledb:2.26.2-pg18-oss"

--- a/tests/integration/persistence/conftest.py
+++ b/tests/integration/persistence/conftest.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import psycopg
+import psycopg.conninfo
 import pytest
 from psycopg import sql
 from pydantic import SecretStr

--- a/tests/integration/persistence/conftest.py
+++ b/tests/integration/persistence/conftest.py
@@ -12,6 +12,7 @@ from collections.abc import (
     Iterator,
     Mapping,
 )
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -126,6 +127,24 @@ def _docker_available() -> bool:
     return shutil.which("docker") is not None
 
 
+def _ensure_template_blocking(proxy: PostgresContainerProxy, shared_dir: Path) -> None:
+    """Build the migrated template, tolerating an already-running loop.
+
+    ``postgres_container`` is session-scoped and *sync*, but pytest can
+    first instantiate it while resolving an async test's dependencies, when
+    a plain ``asyncio.run`` raises ``cannot be called from a running event
+    loop``. Detect that case and run the ensure on a dedicated thread with
+    its own loop so the call works however the fixture is first reached.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(ensure_pg_template(proxy, shared_dir))
+        return
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        pool.submit(lambda: asyncio.run(ensure_pg_template(proxy, shared_dir))).result()
+
+
 @pytest.fixture(scope="session")
 def postgres_container(
     tmp_path_factory: pytest.TempPathFactory,
@@ -148,7 +167,7 @@ def postgres_container(
     """
     env_proxy = _proxy_from_env()
     if env_proxy is not None:
-        asyncio.run(ensure_pg_template(env_proxy, xdist_shared_dir(tmp_path_factory)))
+        _ensure_template_blocking(env_proxy, xdist_shared_dir(tmp_path_factory))
         yield env_proxy
         return
 
@@ -161,7 +180,7 @@ def postgres_container(
     container.start()
     try:
         proxy = _proxy_from_testcontainer(container)
-        asyncio.run(ensure_pg_template(proxy, xdist_shared_dir(tmp_path_factory)))
+        _ensure_template_blocking(proxy, xdist_shared_dir(tmp_path_factory))
         yield proxy
     finally:
         container.stop()

--- a/tests/integration/persistence/conftest.py
+++ b/tests/integration/persistence/conftest.py
@@ -27,6 +27,12 @@ from synthorg.persistence.sqlite.backend import SQLitePersistenceBackend
 from tests._shared.postgres_proxy import PostgresContainerProxy
 from tests._shared.postgres_proxy import from_env as _proxy_from_env
 from tests._shared.postgres_proxy import from_testcontainer as _proxy_from_testcontainer
+from tests._shared.postgres_template import (
+    clone_from_template,
+    drop_test_database,
+    ensure_pg_template,
+    xdist_shared_dir,
+)
 
 if TYPE_CHECKING:
     from testcontainers.postgres import PostgresContainer
@@ -120,7 +126,9 @@ def _docker_available() -> bool:
 
 
 @pytest.fixture(scope="session")
-def postgres_container() -> Iterator[PostgresContainerProxy]:
+def postgres_container(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[PostgresContainerProxy]:
     """Start one shared Postgres 18 container per pytest session.
 
     In CI ``services: postgres`` exposes a server-managed instance via
@@ -128,10 +136,18 @@ def postgres_container() -> Iterator[PostgresContainerProxy]:
     / ``DB``; when those env vars are set the testcontainers start-up
     is skipped entirely and a proxy built directly from env is yielded.
     Per-test database isolation still works because ``postgres_backend``
-    creates a unique ``test_<uuid>`` DB on the shared server.
+    clones a unique ``test_<uuid>`` DB on the shared server.
+
+    The migrated template DB is ensured here (idempotent, cross-worker
+    coordinated) so every consumer -- ``postgres_backend`` and the
+    ``test_wp1_restart_safety`` factory -- clones it instead of
+    replaying the migration chain. In CI the conformance suite's
+    ``pytest_sessionstart`` has usually already built it on the same
+    shared server, so this call hits the sentinel and returns instantly.
     """
     env_proxy = _proxy_from_env()
     if env_proxy is not None:
+        asyncio.run(ensure_pg_template(env_proxy, xdist_shared_dir(tmp_path_factory)))
         yield env_proxy
         return
 
@@ -143,7 +159,9 @@ def postgres_container() -> Iterator[PostgresContainerProxy]:
     container = PostgresContainer("postgres:18-alpine")
     container.start()
     try:
-        yield _proxy_from_testcontainer(container)
+        proxy = _proxy_from_testcontainer(container)
+        asyncio.run(ensure_pg_template(proxy, xdist_shared_dir(tmp_path_factory)))
+        yield proxy
     finally:
         container.stop()
 
@@ -152,57 +170,21 @@ def postgres_container() -> Iterator[PostgresContainerProxy]:
 async def postgres_backend(
     postgres_container: PostgresContainerProxy,
 ) -> AsyncIterator[PostgresPersistenceBackend]:
-    """Yield a connected, migrated PostgresPersistenceBackend.
+    """Yield a connected PostgresPersistenceBackend on a fresh cloned DB.
 
-    Creates a unique database on the shared container so tests stay
-    isolated, migrates it via yoyo, hands the backend to the test,
-    then drops the database on teardown.
+    Clones the migrated template (ensured by the ``postgres_container``
+    fixture) into a unique ``test_<uuid>`` database -- a near-instant
+    file copy instead of a per-test ``migrate()`` -- then drops it on
+    teardown. Per-test isolation is unchanged: each test still gets its
+    own database.
     """
     db_name = f"test_{uuid.uuid4().hex}"
-    admin_conninfo = psycopg.conninfo.make_conninfo(
-        host=postgres_container.get_container_host_ip(),
-        port=int(postgres_container.get_exposed_port(5432)),
-        user=postgres_container.username,
-        password=postgres_container.password,
-        dbname=postgres_container.dbname,
-    )
-    async with await psycopg.AsyncConnection.connect(
-        admin_conninfo, autocommit=True
-    ) as admin:
-        await admin.execute(
-            sql.SQL("CREATE DATABASE {}").format(sql.Identifier(db_name))
-        )
-
-    config = PostgresConfig(
-        host=postgres_container.get_container_host_ip(),
-        port=int(postgres_container.get_exposed_port(5432)),
-        database=db_name,
-        username=postgres_container.username,
-        password=SecretStr(postgres_container.password),
-        ssl_mode="disable",
-        pool_min_size=1,
-        pool_max_size=4,
-        pool_timeout_seconds=10.0,
-        connect_timeout_seconds=5.0,
-    )
-    backend = PostgresPersistenceBackend(config)
-    await backend.connect()
+    backend = await clone_from_template(postgres_container, db_name)
     try:
-        await backend.migrate()
         yield backend
     finally:
         await backend.disconnect()
-        async with await psycopg.AsyncConnection.connect(
-            admin_conninfo, autocommit=True
-        ) as admin:
-            await admin.execute(
-                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
-                "WHERE datname = %s AND pid != pg_backend_pid()",
-                (db_name,),
-            )
-            await admin.execute(
-                sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(db_name))
-            )
+        await drop_test_database(postgres_container, db_name)
 
 
 _TIMESCALEDB_IMAGE = "timescale/timescaledb:2.26.2-pg18-oss"


### PR DESCRIPTION
## Summary

The integration job's wall-clock is dominated by **per-test Postgres fixture setup**, not parallelism. On run `27461844049`, shard 4's slowest-20 was almost entirely `setup` entries at 7-10s each, because `tests/conformance/persistence/conftest.py` and `tests/integration/persistence/conftest.py` each did `CREATE DATABASE` + `connect()` + **`migrate()`** (full yoyo migration-chain replay) **per test**, across hundreds of `[postgres]` tests. (An earlier experiment, closed PR #2351, confirmed that *adding* xdist workers makes it worse — they contend replaying migrations on the one shared server.)

The SQLite arm already amortises this via a session-wide migrated template (`tests/conftest.py::_get_template_db`) copied per test. This gives the Postgres arm the same treatment using PG's native template cloning.

## Change

New `tests/_shared/postgres_template.py`:
- `ensure_pg_template(proxy, shared_dir)` — builds **one** migrated template DB per Postgres server (keyed by `host:port`), coordinated across xdist workers by a `FileLock` + per-server sentinel (mirroring the SQLite `_get_template_db` pattern). After migrating it disconnects fully and seals the template `IS_TEMPLATE true ALLOW_CONNECTIONS false`, so concurrent clones never trip "source database is being accessed".
- `clone_from_template(proxy, db_name)` — `CREATE DATABASE … TEMPLATE …` (near-instant file copy), connect, **no `migrate()`**.
- `drop_test_database` / `xdist_shared_dir` helpers.

Wiring:
- **Conformance** builds the template at `pytest_sessionstart` (outside the 30s per-test timeout, the documented constraint); `_create_postgres_backend` / `_drop_postgres_database` now delegate to the shared helpers (signatures kept — `test_wp1_restart_safety` imports them).
- **Integration** `postgres_container` ensures the template (covers `postgres_backend` and the `test_wp1` factory); `postgres_backend` clones instead of migrating.
- In CI both suites share one `services: postgres`, so the conformance session-start build serves both; locally they use separate testcontainers, so the helper builds one per server.
- **`timescaledb_backend` is intentionally left unchanged** (different container + the `timescaledb` extension, only a handful of tests).
- `scripts/check_persistence_boundary.py`: allowlist the new helper (test-only DB bootstrapper holding a psycopg driver + DDL — same rationale as the already-allowlisted `tests/conftest.py`).

## Expected effect

Per-test Postgres setup drops from ~7-10s to a sub-second template clone. Per-test isolation is unchanged — each test still gets its own fresh database. The PR's own integration CI is the validator: it both proves isolation holds under the clone path and re-measures the shard times against the 368/378/387/459s baseline.

## Test plan

- Pre-push gates green locally (ruff, mypy-affected, pytest-unit-affected, persistence-boundary, dual-backend parity, frozen-model).
- Watch this PR's integration shards: expect a materially lower slowest-shard wall-clock and no new isolation/flake failures.

Closes #2353