### PR TITLE
ci: run the Postgres schema-drift check once, not per integration shard + e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,11 @@ jobs:
     needs: changes
     if: needs.changes.outputs.is_release_please != 'true' # always-run correctness gate (cardinal rule)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # The Postgres drift arm pulls postgres:18-alpine via testcontainers
+    # (cold on this runner, since no start-postgres precedes it), applies
+    # every revision, then runs pg_dump -- heavier than the git-state +
+    # SQLite-drift steps this budget was originally sized for.
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,16 @@ jobs:
       - name: SQLite drift detection
         run: uv run python scripts/check_schema_drift_revisions.py --backend sqlite
 
+      # Schema drift is a global invariant, independent of which tests
+      # run, so it is validated once here rather than on every persistence
+      # test job. The Postgres arm brings its own throwaway database via
+      # testcontainers (Docker on the runner) and dumps it with an
+      # in-container pg_dump, so it needs neither the start-postgres
+      # service nor the postgresql-client package -- only the synced test
+      # dependencies this job already installs.
+      - name: Postgres drift detection
+        run: uv run python scripts/check_schema_drift_revisions.py --backend postgres
+
   # ── Python: Type Check ──
   type-check:
     name: Type Check
@@ -549,9 +559,6 @@ jobs:
 
       - uses: ./.github/actions/warm-tree-sitter-cache
 
-      - name: Postgres drift detection
-        run: uv run python scripts/check_schema_drift_revisions.py --backend postgres
-
       # Mirror test-unit's forensic plumbing -- see the long comment on
       # that step (line ~374) for the full rationale. Without this,
       # SIGABRT from our pytest-timeout monkey-patch (tests/conftest.py)
@@ -702,9 +709,6 @@ jobs:
       - uses: ./.github/actions/install-postgres-18-client
 
       - uses: ./.github/actions/warm-tree-sitter-cache
-
-      - name: Postgres drift detection
-        run: uv run python scripts/check_schema_drift_revisions.py --backend postgres
 
       # See test-unit (line ~374) for the rationale on core dumps.
       - name: Enable core dumps

--- a/scripts/check_schema_drift_revisions.py
+++ b/scripts/check_schema_drift_revisions.py
@@ -76,7 +76,13 @@ _REVISION_PATHS: Final[dict[str, Path]] = {
     ),
 }
 
-_POSTGRES_TESTCONTAINER_IMAGE: Final[str] = "postgres:18-alpine"
+# Digest-pinned for supply-chain integrity; mirrors the pin in the
+# start-postgres composite action so the drift gate and the test
+# suites validate against the same Postgres image bytes.
+_POSTGRES_TESTCONTAINER_IMAGE: Final[str] = (
+    "postgres:18-alpine@sha256:"
+    "96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"
+)
 _POSTGRES_DEFAULT_PORT: Final[int] = 5432
 """Default Postgres listener port inside the testcontainer.
 
@@ -197,9 +203,11 @@ async def _dump_postgres_schema(revisions_path: Path) -> str:
         dbname = pg.dbname
         url = f"postgresql+psycopg://{user}:{password}@{host}:{port}/{dbname}"
         await migrations.migrate_apply(url, revisions_path=revisions_path)
-        dump = await asyncio.to_thread(
-            _run_pg_dump, pg.get_wrapped_container().id, user, dbname
-        )
+        container_id = pg.get_wrapped_container().id
+        if container_id is None:
+            msg = "Postgres testcontainer has no id; cannot run pg_dump."
+            raise SystemExit(msg)
+        dump = await asyncio.to_thread(_run_pg_dump, container_id, user, dbname)
     return _strip_postgres_dump_prelude(dump)
 
 

--- a/scripts/check_schema_drift_revisions.py
+++ b/scripts/check_schema_drift_revisions.py
@@ -203,10 +203,11 @@ async def _dump_postgres_schema(revisions_path: Path) -> str:
         dbname = pg.dbname
         url = f"postgresql+psycopg://{user}:{password}@{host}:{port}/{dbname}"
         await migrations.migrate_apply(url, revisions_path=revisions_path)
-        container_id = pg.get_wrapped_container().id
-        if container_id is None:
+        wrapped_container = pg.get_wrapped_container()
+        if wrapped_container is None or wrapped_container.id is None:
             msg = "Postgres testcontainer has no id; cannot run pg_dump."
             raise SystemExit(msg)
+        container_id = wrapped_container.id
         dump = await asyncio.to_thread(_run_pg_dump, container_id, user, dbname)
     return _strip_postgres_dump_prelude(dump)
 


### PR DESCRIPTION
## Summary

`scripts/check_schema_drift_revisions.py --backend postgres` validates a global invariant (committed revisions match `schema.sql`) that is independent of which tests run. It was executing on all four `test-integration` shards and on `test-e2e` (5x), adding ~12s to each job's critical path.

The script brings its own throwaway Postgres via testcontainers (Docker on the runner) and dumps it with an in-container `pg_dump`, so it needs neither the `start-postgres` service nor the postgresql-client package. This PR runs it **once** in the existing `schema-validate` job (which already runs the SQLite arm) and drops it from the integration shards and e2e.

Drift stays gated: `schema-validate` is already in the `ci-pass` final gate's `needs:` list, so a Postgres schema regression still fails CI.

### Changes
- `schema-validate`: add the `Postgres drift detection` step; widen `timeout-minutes` 10 to 15 (the testcontainers Postgres arm pulls an image + migrates + dumps, heavier than the git-state + SQLite-drift steps this budget was sized for).
- `test-integration` (all 4 shards) and `test-e2e`: remove the now-redundant `Postgres drift detection` step.
- `check_schema_drift_revisions.py`: digest-pin the testcontainers image to mirror the `start-postgres` action's pin (supply-chain integrity); guard the `get_wrapped_container().id` `None` case before `pg_dump`.

### Background
The original ask on this issue (oversubscribe integration xdist workers to `-n 8`) is withdrawn: it was tried in #2351 and measured worse on every shard (long pole 459s to 550s, +20%), because the typeguard-ERROR instrumentation makes these tests CPU-heavy rather than purely I/O-bound. The real speedup shipped in #2355 (Postgres template-clone), nearly halving the job. This drift-check de-dup is a remaining, grounded lever.

A companion rebalance of `.test_durations.integration` (stale since #2261, pre-#2355) is delivered separately by the `Refresh Test Durations` workflow in #2362.

## Test plan
- This PR's own CI is the measurement: confirm the `Postgres drift detection` step now runs only in `Schema Validation`, and no longer in the 4 `Test Integration` shards or `Test E2E`.
- Confirm `schema-validate` still passes (drift gate intact) and the integration/e2e jobs are ~12s shorter on their critical path.

## Review coverage
Pre-reviewed by 4 agents (infra-reviewer, docs-consistency, comment-quality-rot, issue-resolution-verifier). 2 findings, both addressed: schema-validate timeout widened; testcontainers image digest-pinned (plus a latent `None`-guard fix found alongside). No documentation drift; all acceptance criteria verified RESOLVED.

Closes #2350