### PR TITLE
refactor: validate architecture-rework epic and harden auth bootstrap boundary

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -98,6 +98,7 @@ name = controllers reach persistence through services / protocols, never backend
 type = forbidden
 source_modules =
     synthorg.api.controllers
+    synthorg.api.auth.controllers
 forbidden_modules =
     synthorg.persistence._shared
     synthorg.persistence.sqlite

--- a/docs/decisions/0013-layering-dependency-inversion.md
+++ b/docs/decisions/0013-layering-dependency-inversion.md
@@ -65,10 +65,10 @@ move.
 
 The declarative `.importlinter` contracts gained targeted forbidden edges (not
 a blanket `*->api`): business-logic packages may no longer import the moved
-`api` modules, and `api.controllers` may not import `persistence._shared` /
-`sqlite` / `postgres` / constraint-token / jsonb-capability internals
-(protocol-level persistence imports stay legal). The new leaves are pinned in
-the `test_cold_import.py` smoke test.
+`api` modules, and `api.controllers` (and `api.auth.controllers`) may not
+import `persistence._shared` / `sqlite` / `postgres` / constraint-token /
+jsonb-capability internals (protocol-level persistence imports stay legal). The
+new leaves are pinned in the `test_cold_import.py` smoke test.
 
 ### 3. Controller-to-service boundary + DTOs
 

--- a/docs/reference/import-layering.md
+++ b/docs/reference/import-layering.md
@@ -50,11 +50,12 @@ aspirational layering. The current contracts are:
   so business logic names them from `core` and never reaches up into the
   HTTP layer. See [ADR-0013](../decisions/0013-layering-dependency-inversion.md).
 - **controllers-no-persistence-internals** -- `synthorg.api.controllers`
-  does not import `persistence._shared`, `persistence.sqlite`,
-  `persistence.postgres`, `persistence.constraint_tokens`, or
-  `persistence.jsonb_capability`. Controllers reach persistence through a
-  service or the repository protocols; backend internals, raw-SQL helpers,
-  and constraint-token strings stay behind the boundary. See
+  and `synthorg.api.auth.controllers` do not import `persistence._shared`,
+  `persistence.sqlite`, `persistence.postgres`,
+  `persistence.constraint_tokens`, or `persistence.jsonb_capability`.
+  Controllers reach persistence through a service or the repository
+  protocols; backend internals, raw-SQL helpers, and constraint-token
+  strings stay behind the boundary. See
   [ADR-0013](../decisions/0013-layering-dependency-inversion.md).
 
 ### Why direct-only, and the ignore lists

--- a/src/synthorg/api/auth/controllers/bootstrap.py
+++ b/src/synthorg/api/auth/controllers/bootstrap.py
@@ -24,11 +24,7 @@ from synthorg.api.auth.controller_helpers import (
 from synthorg.api.auth.controllers._shared import _AUTH_RATE_LIMIT
 from synthorg.api.auth.service import AuthService
 from synthorg.api.auth.system_user import SYSTEM_USERNAME
-from synthorg.api.auth.user_constraints import (
-    DuplicateUsernameError,
-    SingleCeoConstraintError,
-    raise_for_user_constraint,
-)
+from synthorg.api.auth.user_constraints import raise_for_user_constraint
 from synthorg.api.dto import ApiResponse
 from synthorg.core.auth.models import User
 from synthorg.core.auth.roles import HumanRole
@@ -123,13 +119,20 @@ class AuthBootstrapController(Controller):
         try:
             await persistence.users.save(user)
         except ConstraintViolationError as exc:
+            # raise_for_user_constraint maps a recognised user-constraint token
+            # (single-CEO / username-unique / last-CEO / last-owner) to a typed
+            # ConflictError and re-raises the original error for any unrecognised
+            # token. A recognised conflict means a racer won and setup already
+            # completed; an unrecognised one is not a ConflictError, so it
+            # propagates to the persistence-integrity handler unchanged.
             try:
                 raise_for_user_constraint(exc)
-            except (SingleCeoConstraintError, DuplicateUsernameError) as conflict:
+            except ConflictError as conflict:
                 logger.warning(
                     SECURITY_AUTH_FAILED,
                     reason="setup_race_detected",
                     constraint=exc.constraint,
+                    error_type=type(conflict).__name__,
                 )
                 msg = "Setup already completed"
                 raise ConflictError(msg) from conflict

--- a/src/synthorg/api/auth/controllers/bootstrap.py
+++ b/src/synthorg/api/auth/controllers/bootstrap.py
@@ -24,6 +24,11 @@ from synthorg.api.auth.controller_helpers import (
 from synthorg.api.auth.controllers._shared import _AUTH_RATE_LIMIT
 from synthorg.api.auth.service import AuthService
 from synthorg.api.auth.system_user import SYSTEM_USERNAME
+from synthorg.api.auth.user_constraints import (
+    DuplicateUsernameError,
+    SingleCeoConstraintError,
+    raise_for_user_constraint,
+)
 from synthorg.api.dto import ApiResponse
 from synthorg.core.auth.models import User
 from synthorg.core.auth.roles import HumanRole
@@ -34,10 +39,6 @@ from synthorg.observability.events.security import (
     SECURITY_AUTH_FAILED,
     SECURITY_AUTH_SETUP_COMPLETE,
     SECURITY_SESSION_LIMIT_ENFORCED,
-)
-from synthorg.persistence.constraint_tokens import (
-    IDX_SINGLE_CEO,
-    USERS_USERNAME_UNIQUE,
 )
 from synthorg.persistence.state import persistence_of
 
@@ -122,15 +123,16 @@ class AuthBootstrapController(Controller):
         try:
             await persistence.users.save(user)
         except ConstraintViolationError as exc:
-            if exc.constraint in (IDX_SINGLE_CEO, USERS_USERNAME_UNIQUE):
+            try:
+                raise_for_user_constraint(exc)
+            except (SingleCeoConstraintError, DuplicateUsernameError) as conflict:
                 logger.warning(
                     SECURITY_AUTH_FAILED,
                     reason="setup_race_detected",
                     constraint=exc.constraint,
                 )
                 msg = "Setup already completed"
-                raise ConflictError(msg) from exc
-            raise
+                raise ConflictError(msg) from conflict
 
         token, expires_in, session_id = auth_service.create_token(user)
 

--- a/tests/unit/api/auth/test_controller.py
+++ b/tests/unit/api/auth/test_controller.py
@@ -16,7 +16,7 @@ from synthorg.api.api_core_state import (
 from synthorg.api.state import AppState
 from synthorg.core.auth.roles import HumanRole
 from synthorg.persistence.state import persistence_of
-from tests._shared import LoopAsyncClient
+from tests._shared import LoopAsyncClient, as_uuid
 from tests.unit.api.conftest import _TEST_JWT_SECRET, make_auth_headers
 from tests.unit.api.fakes import FakePersistenceBackend
 
@@ -74,7 +74,6 @@ class TestSetup:
         bare_client: LoopAsyncClient,
     ) -> None:
         # Re-seed a user so the check fails
-        import uuid
         from datetime import UTC, datetime
 
         from synthorg.api.auth.service import AuthService
@@ -85,7 +84,7 @@ class TestSetup:
         svc: AuthService = auth_service_of(app_state)
         now = datetime.now(UTC)
         user = User(
-            id=str(uuid.uuid4()),
+            id=str(as_uuid("existing-ceo")),
             username="existing",
             password_hash=await svc.hash_password_async("test-password-12chars"),
             role=HumanRole.CEO,
@@ -133,7 +132,6 @@ class TestSetup:
         ``constraint=IDX_SINGLE_CEO``). The guard maps it to the uniform
         setup-complete 409 rather than leaking the persistence token.
         """
-        import uuid
         from datetime import UTC, datetime
 
         from synthorg.core.auth.models import User
@@ -145,7 +143,7 @@ class TestSetup:
         now = datetime.now(UTC)
         users_repo.seed(
             User(
-                id=str(uuid.uuid4()),
+                id=str(as_uuid("incumbent-ceo")),
                 username="incumbent-ceo",
                 password_hash="x",
                 role=HumanRole.CEO,
@@ -177,7 +175,6 @@ class TestSetup:
         username-unique constraint, which the guard maps to the uniform
         setup-complete 409 via the typed ``DuplicateUsernameError``.
         """
-        import uuid
         from datetime import UTC, datetime
 
         from synthorg.core.auth.models import User
@@ -188,7 +185,7 @@ class TestSetup:
         now = datetime.now(UTC)
         backend._users.seed(
             User(
-                id=str(uuid.uuid4()),
+                id=str(as_uuid("taken-observer")),
                 username="taken",
                 password_hash="x",
                 role=HumanRole.OBSERVER,

--- a/tests/unit/api/auth/test_controller.py
+++ b/tests/unit/api/auth/test_controller.py
@@ -125,10 +125,13 @@ class TestSetup:
     ) -> None:
         """A losing racer on the single-CEO guard sees 'already completed'.
 
-        The CEO pre-check is forced to observe zero CEOs (the racing window),
-        but ``save`` then hits the single-CEO partial-unique index. The guard
-        maps it to the uniform setup-complete conflict via the typed
-        ``SingleCeoConstraintError`` rather than leaking the persistence token.
+        ``count_by_role`` is monkeypatched to return 0 for any role,
+        simulating the racing window where the incumbent CEO is not yet
+        visible to the pre-check. ``save`` then trips the fake's single-CEO
+        guard (which mirrors the real ``idx_single_ceo`` partial-unique index
+        by raising ``ConstraintViolationError`` with
+        ``constraint=IDX_SINGLE_CEO``). The guard maps it to the uniform
+        setup-complete 409 rather than leaking the persistence token.
         """
         import uuid
         from datetime import UTC, datetime
@@ -169,9 +172,10 @@ class TestSetup:
     ) -> None:
         """A losing racer on the username-unique guard sees 'already completed'.
 
-        The CEO pre-check passes (no CEO yet), but ``save`` raises the
+        An OBSERVER (not a CEO) is seeded under the target username, so the
+        CEO pre-check passes (no CEO yet) but ``save`` raises the
         username-unique constraint, which the guard maps to the uniform
-        setup-complete conflict via the typed ``DuplicateUsernameError``.
+        setup-complete 409 via the typed ``DuplicateUsernameError``.
         """
         import uuid
         from datetime import UTC, datetime
@@ -201,6 +205,40 @@ class TestSetup:
         assert response.status_code == 409
         assert "Setup already completed" in response.text
 
+    async def test_setup_race_last_ceo_constraint_returns_409(
+        self,
+        bare_client: LoopAsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Every recognised user-constraint token maps to 'already completed'.
+
+        The last-CEO trigger cannot fire on a bootstrap INSERT, but the guard
+        must treat every recognised user-constraint token uniformly: ``save``
+        raising ``LAST_CEO_TRIGGER`` is mapped to the setup-complete 409 by
+        ``raise_for_user_constraint`` rather than surfacing the typed
+        ``LastCeoConstraintError`` default message.
+        """
+        from synthorg.core.persistence_errors import ConstraintViolationError
+        from synthorg.persistence.constraint_tokens import LAST_CEO_TRIGGER
+
+        app_state = bare_client.app.state["app_state"]
+        backend = cast(FakePersistenceBackend, persistence_of(app_state))
+        users_repo = backend._users
+        users_repo._users.clear()
+
+        async def _raise_last_ceo(entity: object) -> None:
+            msg = "last ceo"
+            raise ConstraintViolationError(msg, constraint=LAST_CEO_TRIGGER)
+
+        monkeypatch.setattr(users_repo, "save", _raise_last_ceo)
+
+        response = await bare_client.post(
+            "/api/v1/auth/setup",
+            json={"username": "newadmin", "password": "super-secure-password-12"},
+        )
+        assert response.status_code == 409
+        assert "Setup already completed" in response.text
+
     async def test_setup_unrelated_constraint_not_masked(
         self,
         bare_client: LoopAsyncClient,
@@ -208,9 +246,10 @@ class TestSetup:
     ) -> None:
         """An unrelated constraint propagates, not masked as setup-complete.
 
-        The race guard only remaps the single-CEO / username conflicts; any
-        other constraint must surface its own contract instead of a misleading
-        'already completed' response.
+        The race guard only remaps recognised user-constraint conflicts; any
+        other constraint is re-raised as the original ``ConstraintViolationError``
+        and surfaces via the persistence-integrity handler (400) instead of a
+        misleading 'already completed' response.
         """
         from synthorg.core.persistence_errors import ConstraintViolationError
 
@@ -229,8 +268,8 @@ class TestSetup:
             "/api/v1/auth/setup",
             json={"username": "newadmin", "password": "super-secure-password-12"},
         )
+        assert response.status_code == 400
         assert "Setup already completed" not in response.text
-        assert response.status_code >= 400
 
 
 @pytest.mark.unit

--- a/tests/unit/api/auth/test_controller.py
+++ b/tests/unit/api/auth/test_controller.py
@@ -118,6 +118,120 @@ class TestSetup:
         )
         assert response.status_code == 400
 
+    async def test_setup_race_single_ceo_returns_409(
+        self,
+        bare_client: LoopAsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A losing racer on the single-CEO guard sees 'already completed'.
+
+        The CEO pre-check is forced to observe zero CEOs (the racing window),
+        but ``save`` then hits the single-CEO partial-unique index. The guard
+        maps it to the uniform setup-complete conflict via the typed
+        ``SingleCeoConstraintError`` rather than leaking the persistence token.
+        """
+        import uuid
+        from datetime import UTC, datetime
+
+        from synthorg.core.auth.models import User
+
+        app_state = bare_client.app.state["app_state"]
+        backend = cast(FakePersistenceBackend, persistence_of(app_state))
+        users_repo = backend._users
+        users_repo._users.clear()
+        now = datetime.now(UTC)
+        users_repo.seed(
+            User(
+                id=str(uuid.uuid4()),
+                username="incumbent-ceo",
+                password_hash="x",
+                role=HumanRole.CEO,
+                must_change_password=False,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+
+        async def _no_ceos(role: HumanRole) -> int:
+            return 0
+
+        monkeypatch.setattr(users_repo, "count_by_role", _no_ceos)
+
+        response = await bare_client.post(
+            "/api/v1/auth/setup",
+            json={"username": "newadmin", "password": "super-secure-password-12"},
+        )
+        assert response.status_code == 409
+        assert "Setup already completed" in response.text
+
+    async def test_setup_race_duplicate_username_returns_409(
+        self, bare_client: LoopAsyncClient
+    ) -> None:
+        """A losing racer on the username-unique guard sees 'already completed'.
+
+        The CEO pre-check passes (no CEO yet), but ``save`` raises the
+        username-unique constraint, which the guard maps to the uniform
+        setup-complete conflict via the typed ``DuplicateUsernameError``.
+        """
+        import uuid
+        from datetime import UTC, datetime
+
+        from synthorg.core.auth.models import User
+
+        app_state = bare_client.app.state["app_state"]
+        backend = cast(FakePersistenceBackend, persistence_of(app_state))
+        backend._users._users.clear()
+        now = datetime.now(UTC)
+        backend._users.seed(
+            User(
+                id=str(uuid.uuid4()),
+                username="taken",
+                password_hash="x",
+                role=HumanRole.OBSERVER,
+                must_change_password=False,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+
+        response = await bare_client.post(
+            "/api/v1/auth/setup",
+            json={"username": "taken", "password": "super-secure-password-12"},
+        )
+        assert response.status_code == 409
+        assert "Setup already completed" in response.text
+
+    async def test_setup_unrelated_constraint_not_masked(
+        self,
+        bare_client: LoopAsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An unrelated constraint propagates, not masked as setup-complete.
+
+        The race guard only remaps the single-CEO / username conflicts; any
+        other constraint must surface its own contract instead of a misleading
+        'already completed' response.
+        """
+        from synthorg.core.persistence_errors import ConstraintViolationError
+
+        app_state = bare_client.app.state["app_state"]
+        backend = cast(FakePersistenceBackend, persistence_of(app_state))
+        users_repo = backend._users
+        users_repo._users.clear()
+
+        async def _raise_unrelated(entity: object) -> None:
+            msg = "unrelated"
+            raise ConstraintViolationError(msg, constraint="SOME_OTHER_CONSTRAINT")
+
+        monkeypatch.setattr(users_repo, "save", _raise_unrelated)
+
+        response = await bare_client.post(
+            "/api/v1/auth/setup",
+            json={"username": "newadmin", "password": "super-secure-password-12"},
+        )
+        assert "Setup already completed" not in response.text
+        assert response.status_code >= 400
+
 
 @pytest.mark.unit
 class TestLogin:


### PR DESCRIPTION
## Summary

Epic-completion validation for the #2341 architecture-rework + test/CI quality cluster (2026-06-12 audit). All five children were merged into `main`; this is the validation capstone that re-verifies each end-to-end and lands the one root-cause gap found.

**Per-child verdict** (each graded by an `issue-resolution-verifier` against its merged diff, re-confirmed on current `main`):

| Child | Verdict |
|-------|---------|
| #2342 perf+test sweep | RESOLVED (two verifier "partials" investigated and confirmed false: `get_current_many` is a misnomer for the correctly-implemented `list_current_entries` n+1 fix; the `start-postgres` mirror fallback already shipped in #2321) |
| #2343 layering + ADR-0013 | PASS (18/18) |
| #2344 duplication + ADR-0014 | PASS |
| #2366 pluggable seams | PASS (12 seams wired behind config discriminators + safe defaults) |
| #2367 MCP args contracts | PASS (zero residual `lint-allow` markers) |

No child had a NOT_RESOLVED criterion. Full report (local, gitignored under `_audit/`): `_audit/latest/EPIC-2341-VALIDATION.md`.

## What changed (the capstone fix)

Validation surfaced one defence-in-depth gap the epic's own contract should have caught:

- **`api/auth/controllers/bootstrap.py`** imported `persistence.constraint_tokens` directly for its first-run setup race-guard. The `controllers-no-persistence-internals` import-linter contract that #2343 shipped scoped only `synthorg.api.controllers`, so `synthorg.api.auth.controllers` escaped it. The race-guard now routes through the canonical typed helper `raise_for_user_constraint` (from `api/auth/user_constraints.py`, the module that owns the token mapping) and catches the `ConflictError` family, so any recognised user-constraint conflict maps uniformly to the 409 "Setup already completed" and any unrecognised constraint propagates unchanged. No `persistence.constraint_tokens` import remains in the controller.
- **`.importlinter`**: widened `controllers-no-persistence-internals` `source_modules` to also cover `synthorg.api.auth.controllers` (the only offender in that package; `lint-imports` stays green).
- **ADR-0013 + `docs/reference/import-layering.md`**: synced the contract-scope description to match.
- **Tests**: 4 new race-guard tests (single-CEO race, duplicate-username race, last-CEO token mapping, unrelated-constraint propagation) covering a previously-untested branch.

## Test plan

- Full pre-push gate battery green (import-linter incl. the widened contract, error-code-uniqueness, env-read, ghost-wiring, architecture-drift, cold-import, affected mypy + unit, vale, codespell).
- Schema-drift gate green on both SQLite and Postgres.
- Full unit suite: 33392 passed, 25 skipped, 0 failed.
- `tests/unit/api/auth/test_controller.py -k Setup`: 10 passed (incl. the 4 new race-guard tests).

## Review coverage

Pre-PR pipeline ran 16 review agents on the capstone diff (code/security/async/silent-failure/conventions/persistence-boundary/docs/issue-resolution and more). The core refactor was unanimously confirmed correct and security-preserving. 7 valid findings were implemented (widened the conflict catch + test, doc-scope sync, tightened a loose assertion, log/comment/docstring polish); 1 finding was rejected as an inter-agent conflict contradicted by a green gate.

Closes #2341
