### PR TITLE
chore: raise ghcr-cleanup job timeout to 120m to drain large packages per pass

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -55,7 +55,14 @@ jobs:
   cleanup:
     name: Prune ${{ matrix.package }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # GitHub throttles version deletions (the action backs off on each
+    # 429), so a package's drain rate is capped regardless of work left.
+    # At 30 min a large package (thousands of versions) is cut off
+    # mid-delete and must finish over many runs. 120 min lets one pass
+    # clear ~6-7k versions, draining the big packages in a single run
+    # during the historical backfill; steady-state runs finish in
+    # minutes well under the cap.
+    timeout-minutes: 120
     permissions:
       packages: write
     strategy:


### PR DESCRIPTION
## What

Raise the GHCR cleanup job `timeout-minutes` from 30 to 120.

## Why

GitHub throttles container version deletions (the `dataaxiom/ghcr-cleanup-action` backs off on every HTTP 429), so a package's effective drain rate is capped regardless of remaining work. At 30 min a large package only clears ~1,700 versions before being cut off mid-delete, so the big packages need many runs to drain.

Observed during the post-#2386 backfill: one pass deleted ~17k versions, but `backend` / `web` / `sandbox` (each ~6–8k remaining) consistently hit the 30-min cap and were cancelled mid-delete, while the small base packages finished and went green. At the throttled rate, 120 min lets one pass clear ~6–7k — enough to drain the large packages in a single run.

Steady-state runs (keep newest-5 dev + sha < 7 days + orphans) finish in minutes, well under the cap, so the higher ceiling only matters during the backfill. The job stays serialised (`max-parallel: 1`) and off the release-critical path, so the longer wall-clock is a free trade.

Closes #2393