### PR TITLE
fix: stabilise flaky construction-wiring and NATS distributed-path CI tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -682,12 +682,19 @@ _UNIT_TEST_WALL_CLOCK_LIMIT = 6.0  # seconds
 #    tree (``cmd_scan_all``), inherently near the budget and tipping past
 #    it under ``--dist=loadfile`` contention -- the full scan is the
 #    test's whole point, not a fixture leak.
+#  - ``test_construction_wiring.py``: builds the whole app via
+#    ``create_app`` to assert construction-phase slice wiring. The build is
+#    class-scoped (one build shared across the class), so the one-time cost
+#    lands on whichever assert runs first and is inherently near the budget
+#    under ``--dist=loadfile`` contention -- the full build is the test's
+#    whole point, not a fixture leak.
 # pytest nodeids always use ``/`` separators on every platform, so these
 # fragments match on Windows too.
 _WALL_CLOCK_GUARD_EXEMPT_FRAGMENTS: Final = (
     "unit/architecture/",
     "unit/test_cold_import.py",
     "unit/scripts/test_check_completion_config_temperature.py",
+    "unit/api/test_construction_wiring.py",
 )
 _FUZZ_PROFILE_ACTIVE = os.environ.get("HYPOTHESIS_PROFILE") in ("fuzz", "extreme")
 # pytest-repeat's ``--count`` flag is used exclusively by

--- a/tests/integration/workers/test_distributed_path_nats.py
+++ b/tests/integration/workers/test_distributed_path_nats.py
@@ -15,7 +15,7 @@ shipped defaults (300 / 3 / 30) would make these hang.
 
 import asyncio
 import uuid
-from collections.abc import AsyncIterator, Callable, Iterator
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from typing import Final
 
 import pytest
@@ -105,12 +105,12 @@ async def task_queue(nats_url: str) -> AsyncIterator[JetStreamTaskQueue]:
         nats_config=NatsConfig(url=nats_url, connect_timeout_seconds=10.0),
         durable_name=f"workers_{suffix}",
     )
-    await queue.start()
+    await _bounded_setup(queue.start())
     try:
         yield queue
     finally:
         if queue.is_running:
-            await queue.stop()
+            await _bounded_setup(queue.stop())
 
 
 async def _wait_until(
@@ -150,6 +150,24 @@ async def _shutdown_pool(pool: asyncio.Task[None]) -> None:
         pass
 
 
+async def _bounded_setup(step: Awaitable[object]) -> None:
+    """Run a setup step under ``_HARD_CAP_SECONDS``.
+
+    The happy-path wait and the pool shutdown are already capped, but the
+    fixture's ``queue.start()`` / ``stop()`` and each test's publish and
+    consumer-start were not. Under JetStream-container contention one of those
+    awaits (a publish awaiting an ack, stream/consumer creation, or a drain on
+    stop) can stall indefinitely and run the test to the module-level timeout,
+    which fires ``SIGABRT`` and takes the whole xdist worker down (the
+    observed "node down" failure). Capping setup gives it the same
+    "hang -> fast, legible per-test ``TimeoutError``" contract the wait and
+    shutdown already use, so a stalled broker fails this one test cleanly
+    instead of aborting the shard.
+    """
+    async with asyncio.timeout(_HARD_CAP_SECONDS):
+        await step
+
+
 async def test_synthetic_load_no_loss_no_duplication(
     task_queue: JetStreamTaskQueue,
 ) -> None:
@@ -169,8 +187,10 @@ async def test_synthetic_load_no_loss_no_duplication(
 
     async with make_sqlite_seen_claims() as repo:
         for i in range(claim_count):
-            await task_queue.publish_claim(
-                TaskClaim(task_id=f"task-{i}", new_status="assigned"),
+            await _bounded_setup(
+                task_queue.publish_claim(
+                    TaskClaim(task_id=f"task-{i}", new_status="assigned"),
+                )
             )
         pool = asyncio.create_task(
             run_worker_pool(
@@ -218,8 +238,10 @@ async def test_long_execution_extends_ack_no_duplicate(
         return TaskClaimStatus.SUCCESS
 
     async with make_sqlite_seen_claims() as repo:
-        await task_queue.publish_claim(
-            TaskClaim(task_id="slow-task", new_status="assigned"),
+        await _bounded_setup(
+            task_queue.publish_claim(
+                TaskClaim(task_id="slow-task", new_status="assigned"),
+            )
         )
         pool = asyncio.create_task(
             run_worker_pool(
@@ -267,9 +289,11 @@ async def test_max_deliver_dead_letters_to_failed_no_loss(
             queue_config=task_queue._queue_config,
             seen_claims=repo,
         )
-        await consumer.start()
-        await task_queue.publish_claim(
-            TaskClaim(task_id="doomed-task", new_status="assigned"),
+        await _bounded_setup(consumer.start())
+        await _bounded_setup(
+            task_queue.publish_claim(
+                TaskClaim(task_id="doomed-task", new_status="assigned"),
+            )
         )
         pool = asyncio.create_task(
             run_worker_pool(
@@ -284,6 +308,6 @@ async def test_max_deliver_dead_letters_to_failed_no_loss(
             await _wait_until(changed, lambda: failed.count("doomed-task") >= 1)
         finally:
             await _shutdown_pool(pool)
-            await consumer.stop()
+            await _bounded_setup(consumer.stop())
 
     assert failed == ["doomed-task"], f"task lost or double-failed: {failed}"

--- a/tests/integration/workers/test_distributed_path_nats.py
+++ b/tests/integration/workers/test_distributed_path_nats.py
@@ -294,26 +294,30 @@ async def test_max_deliver_dead_letters_to_failed_no_loss(
             queue_config=task_queue._queue_config,
             seen_claims=repo,
         )
-        # One cap over the whole start+publish phase (not one per step) so
-        # the cumulative setup time is bounded by a single hard cap.
-        async with asyncio.timeout(_HARD_CAP_SECONDS):
-            await consumer.start()
-            await task_queue.publish_claim(
-                TaskClaim(task_id="doomed-task", new_status="assigned"),
-            )
-        pool = asyncio.create_task(
-            run_worker_pool(
-                queue_config=task_queue._queue_config,
-                task_queue=task_queue,
-                executor=always_retry,
-                worker_count=2,
-                seen_claims=repo,
-            ),
-        )
+        # Once the consumer exists, guarantee stop() runs even if the bounded
+        # setup times out after start() succeeds (stop() no-ops when not
+        # running). The start+publish phase shares a single cap so cumulative
+        # setup time stays bounded.
         try:
-            await _wait_until(changed, lambda: failed.count("doomed-task") >= 1)
+            async with asyncio.timeout(_HARD_CAP_SECONDS):
+                await consumer.start()
+                await task_queue.publish_claim(
+                    TaskClaim(task_id="doomed-task", new_status="assigned"),
+                )
+            pool = asyncio.create_task(
+                run_worker_pool(
+                    queue_config=task_queue._queue_config,
+                    task_queue=task_queue,
+                    executor=always_retry,
+                    worker_count=2,
+                    seen_claims=repo,
+                ),
+            )
+            try:
+                await _wait_until(changed, lambda: failed.count("doomed-task") >= 1)
+            finally:
+                await _shutdown_pool(pool)
         finally:
-            await _shutdown_pool(pool)
             await _bounded_setup(consumer.stop())
 
     assert failed == ["doomed-task"], f"task lost or double-failed: {failed}"

--- a/tests/integration/workers/test_distributed_path_nats.py
+++ b/tests/integration/workers/test_distributed_path_nats.py
@@ -151,18 +151,21 @@ async def _shutdown_pool(pool: asyncio.Task[None]) -> None:
 
 
 async def _bounded_setup(step: Awaitable[object]) -> None:
-    """Run a setup step under ``_HARD_CAP_SECONDS``.
+    """Cap a single setup await at ``_HARD_CAP_SECONDS``.
 
     The happy-path wait and the pool shutdown are already capped, but the
-    fixture's ``queue.start()`` / ``stop()`` and each test's publish and
-    consumer-start were not. Under JetStream-container contention one of those
+    fixture's ``queue.start()`` / ``stop()`` and the per-test publish /
+    consumer steps were not. Under JetStream-container contention one of those
     awaits (a publish awaiting an ack, stream/consumer creation, or a drain on
     stop) can stall indefinitely and run the test to the module-level timeout,
-    which fires ``SIGABRT`` and takes the whole xdist worker down (the
-    observed "node down" failure). Capping setup gives it the same
-    "hang -> fast, legible per-test ``TimeoutError``" contract the wait and
-    shutdown already use, so a stalled broker fails this one test cleanly
-    instead of aborting the shard.
+    which fires ``SIGABRT`` and takes the whole xdist worker down (the observed
+    "node down" failure). Capping setup gives it the same "hang -> fast, legible
+    per-test ``TimeoutError``" contract the wait and shutdown already use.
+
+    Use this for a *single* setup await; a sequence (a publish loop, or
+    start-then-publish) is instead wrapped in one ``asyncio.timeout`` block so
+    the whole phase shares a single cap, rather than letting per-step caps sum
+    past the module timeout.
     """
     async with asyncio.timeout(_HARD_CAP_SECONDS):
         await step
@@ -186,12 +189,14 @@ async def test_synthetic_load_no_loss_no_duplication(
         return TaskClaimStatus.SUCCESS
 
     async with make_sqlite_seen_claims() as repo:
-        for i in range(claim_count):
-            await _bounded_setup(
-                task_queue.publish_claim(
+        # One cap over the whole publish phase: a per-call cap would let the
+        # loop's cumulative time exceed the module timeout (and SIGABRT)
+        # without any single publish tripping its own cap.
+        async with asyncio.timeout(_HARD_CAP_SECONDS):
+            for i in range(claim_count):
+                await task_queue.publish_claim(
                     TaskClaim(task_id=f"task-{i}", new_status="assigned"),
                 )
-            )
         pool = asyncio.create_task(
             run_worker_pool(
                 queue_config=task_queue._queue_config,
@@ -289,12 +294,13 @@ async def test_max_deliver_dead_letters_to_failed_no_loss(
             queue_config=task_queue._queue_config,
             seen_claims=repo,
         )
-        await _bounded_setup(consumer.start())
-        await _bounded_setup(
-            task_queue.publish_claim(
+        # One cap over the whole start+publish phase (not one per step) so
+        # the cumulative setup time is bounded by a single hard cap.
+        async with asyncio.timeout(_HARD_CAP_SECONDS):
+            await consumer.start()
+            await task_queue.publish_claim(
                 TaskClaim(task_id="doomed-task", new_status="assigned"),
             )
-        )
         pool = asyncio.create_task(
             run_worker_pool(
                 queue_config=task_queue._queue_config,

--- a/tests/unit/api/test_construction_wiring.py
+++ b/tests/unit/api/test_construction_wiring.py
@@ -27,14 +27,21 @@ from tests.unit.api.fakes import FakeMessageBus, FakePersistenceBackend
 pytestmark = pytest.mark.unit
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def built_app_state(
     fake_persistence: FakePersistenceBackend,
     fake_message_bus: FakeMessageBus,
     cost_tracker: CostTracker,
     root_config: RootConfig,
 ) -> AppState:
-    """Build a full app with fakes injected and return its ``AppState``."""
+    """Build the full app once and share it across the class's read-only asserts.
+
+    Every test here only reads construction-wired slice fields, so the
+    expensive ``create_app`` build is amortised class-wide rather than rebuilt
+    per test (eight builds collapse to one). All four dependencies are
+    session-scoped, so the identity assertions (``is fake_persistence`` etc.)
+    still hold against the single shared build.
+    """
     app = build_test_app(
         config=root_config,
         persistence=fake_persistence,


### PR DESCRIPTION
## What

Fixes two CI tests that flake under heavy runner contention (both surfaced during the post-#2386 storm; both are pre-existing, neither caused by recent merges).

### 1. `test_construction_wiring.py` (unit, timing)

The `built_app_state` fixture was function-scoped, rebuilding the whole app via `create_app` for each of the 8 read-only assertion tests. One build is near the 6s per-test wall-clock guard, so contention tipped a test over (`test_persistence_slice_wired` at 6.3s, ERROR at teardown).

- **Class-scope** the fixture: 8 full-app builds collapse to 1. Identity asserts (`is fake_persistence` etc.) still hold because the deps are session-scoped.
- Add the file to `_WALL_CLOCK_GUARD_EXEMPT_FRAGMENTS`: the `create_app` build is the test's inherent cost that lands on whichever test runs first, exactly like the already-exempt `unit/architecture/` meta-tests (the suite-level timing regression guard still covers real slowdowns).

### 2. `test_distributed_path_nats.py` (integration, SIGABRT)

The test capped its happy-path wait and pool shutdown at `_HARD_CAP_SECONDS` (25s), but the **setup** awaits (`queue.start()`, the `publish_claim` loop, `consumer.start()`/`stop()`) were unbounded. Under JetStream-container contention one stalled, running the test to the 120s module timeout, which fires `SIGABRT` and takes the whole xdist worker down (`Fatal Python error: Aborted` / `node down`). The crash dump confirmed the event loop idle in `selectors.select` awaiting network I/O with no test frame executing, i.e. a stalled unbounded setup await, not the capped wait.

- Bound every previously-unbounded setup await with `_HARD_CAP_SECONDS` via a `_bounded_setup` helper, so a stalled broker fails this one test cleanly (fast `TimeoutError`) instead of `SIGABRT`-ing the worker. Extends the test's own "hang yields a fast legible failure, not a suite-killing abort" contract to the setup path.

## Validation (local)

- construction-wiring: **8 passed**, app builds once, no wall-clock trip.
- NATS distributed-path: **3 passed in 21.9s**, happy path intact.
- `ruff` + `mypy` clean on all three files.

Closes #2395