### PR TITLE
fix: reap dangling untagged manifests in ghcr-cleanup via delete-untagged

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -135,11 +135,22 @@ jobs:
           validate: true
           dry-run: ${{ inputs.dry-run }}
 
-      # Pass 3 -- reap cosign / attestation referrers and untagged
-      # manifests whose parent image was deleted by passes 1-2. Referrers
-      # of kept images (every release, the newest 5 dev builds) have a
-      # live parent and are left untouched. `validate` asserts no surviving
-      # multi-arch image lost a platform child.
+      # Pass 3 -- reap every orphan with no live parent. Two distinct
+      # classes, both needed:
+      #   - delete-orphaned-images: cosign / attestation OCI referrers
+      #     whose subject was deleted, plus children of an index deleted
+      #     earlier in THIS run.
+      #   - delete-untagged: dangling untagged manifests (per-build SLSA
+      #     attestation / SBOM / platform blobs) whose parent index was
+      #     deleted in a PAST run. delete-orphaned-images does NOT catch
+      #     these (they are not subject-bearing referrers and their parent
+      #     is long gone), so without delete-untagged they accumulate
+      #     forever -- the dominant share of stored versions.
+      # `initFilterSet` strips every LIVE image's children/referrers from
+      # the candidate set first, so delete-untagged only ever sees truly
+      # dangling manifests; `validate` then asserts no surviving multi-arch
+      # image lost a platform child. exclude-tags still protects every
+      # release / kept-dev tag (delete-untagged only touches untagged).
       - name: Prune orphaned signatures and untagged manifests
         uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         with:
@@ -148,6 +159,7 @@ jobs:
           token: ${{ secrets.GHCR_CLEANUP_TOKEN || secrets.GITHUB_TOKEN }}
           use-regex: true
           delete-orphaned-images: true
+          delete-untagged: true
           exclude-tags: '^(\d+\.\d+\.\d+|\d+\.\d+|latest|dev|\d+\.\d+\.\d+-dev\.\d+)$'
           validate: true
           dry-run: ${{ inputs.dry-run }}


### PR DESCRIPTION
## What

Adds `delete-untagged: true` to pass 3 of `.github/workflows/ghcr-cleanup.yml`, alongside the existing `delete-orphaned-images: true`.

## Why

`delete-orphaned-images` only reaps OCI subject-bearing referrers (cosign) plus same-run-cascade children. It does **not** catch dangling untagged manifests (per-build SLSA attestation / SBOM / platform blobs) whose parent index was pruned in a *past* run — and those are ~80% of all stored versions.

A dry-run across all 10 packages (run `27689663288`) proves it: pass 3 reports `Finding orphaned images (tags) to delete (0)` on **every** package, while `delete-untagged` would target **13,585** truly-dangling orphans.

## Safety (proven by the same dry-run)

`initFilterSet` strips every live image's children/referrers before `delete-untagged` runs, so it only sees dangling manifests; `validate: true` then asserts no surviving multi-arch image lost a platform child; `exclude-tags` protects all release/kept-dev tags (and `delete-untagged` only touches untagged regardless).

The dry-run shows this working: 13,585 dangling deleted vs **6,347 live-image children protected**.

| package | untagged total | orphaned finds | untagged would delete | protected |
|---|--:|--:|--:|--:|
| backend | 3,313 | 0 | 1,750 | 1,563 |
| web | 3,440 | 0 | 1,844 | 1,596 |
| sandbox | 3,382 | 0 | 1,747 | 1,635 |
| sidecar | 1,397 | 0 | 830 | 567 |
| fine-tune-cpu | 1,062 | 0 | 700 | 362 |
| fine-tune-gpu | 1,006 | 0 | 685 | 321 |
| backend-base | 1,661 | 0 | 1,561 | 100 |
| sandbox-base | 1,627 | 0 | 1,526 | 101 |
| sidecar-base | 1,490 | 0 | 1,488 | 2 |
| fine-tune-base | 1,554 | 0 | 1,454 | 100 |
| **TOTAL** | **19,932** | **0** | **13,585** | **6,347** |

## Rollout (manual backfill, off the release pipeline)

Recommended sequence after merge:

1. Temporarily set `GHCR_CLEANUP_ENABLED=false` so dev-release cleanup runs dry-run (keeps the heavy drain off the release pipeline).
2. Drain the ~13.6k backlog via manual `workflow_dispatch` with `dry-run=false`, repeated until the untagged counts hit steady-state. `max-parallel: 1` + the manifest cache keep reads cheap; a throttled/timed-out big-package run is benign and resumes next run (idempotent + `ghcr-cleanup` concurrency mutex + `fail-fast: false`).
3. Re-enable `GHCR_CLEANUP_ENABLED=true` — steady-state dev-release cleanup is now cheap.

Deletes are irreversible, so the live backfill happens only after this merges and a dry-run looks right.

Closes #2397
