### PR TITLE
refactor: prompt-class sampling-parameter cleanups

### DIFF
--- a/docs/design/coordination-metrics.md
+++ b/docs/design/coordination-metrics.md
@@ -127,7 +127,7 @@ When coordination metrics collection is enabled, the system classifies coordinat
 | **Logical contradiction** | Agent asserts both "X is true" and "X is false" | Regex assertion matching | LLM reasoning over assistant texts | SAME_TASK |
 | **Numerical drift** | Accumulated errors from cascading rounding (>5% deviation) | Context-labelled number extraction + % drift | LLM cross-verification of numerical claims | SAME_TASK |
 | **Context omission** | Failure to reference previously established entities | Capitalized entity set diff (first-half/second-half) | LLM entity introduction/disposition tracking | SAME_TASK |
-| **Coordination failure** | Message misinterpretation, task allocation conflicts | Tool errors + error finish reasons | LLM classification of coordination breakdowns | SAME_TASK |
+| **Coordination failure** | Message misinterpretation, task allocation conflicts | Tool errors + error finish reasons | LLM classification of coordination breakdowns | TASK_TREE |
 | **Delegation protocol violation** | Broken delegation chains, missing parent linkage | Structural check: parent_task_id, delegation_chain integrity | - | TASK_TREE |
 | **Review pipeline violation** | PASS without stages, PASS contradicting FAIL stage | Structural check: verdict/stage consistency | - | TASK_TREE |
 | **Authority breach attempt** | Execution cost exceeding authority budget limit | Budget comparison: total turn cost vs limit | - | SAME_TASK |

--- a/src/synthorg/engine/classification/_parsing.py
+++ b/src/synthorg/engine/classification/_parsing.py
@@ -66,7 +66,7 @@ def parse_findings(
             category=category.value,
             error_type=type(exc).__name__,
             error=safe_error_description(exc),
-            raw_snippet=raw[:200],
+            raw_length=len(raw),
         )
         return ()
     if not isinstance(items, list):
@@ -109,7 +109,7 @@ def _parse_single_finding(
         )
         return None
     desc = item.get("description", "")
-    if not desc or not isinstance(desc, str):
+    if not isinstance(desc, str) or not desc.strip():
         logger.debug(
             DETECTOR_PARSE_ERROR,
             category=category.value,
@@ -117,6 +117,7 @@ def _parse_single_finding(
             reason="missing or empty description",
         )
         return None
+    desc = desc.strip()
     severity = _SEVERITY_MAP.get(
         str(item.get("severity", "medium")).lower(),
         ErrorSeverity.MEDIUM,
@@ -130,13 +131,15 @@ def _parse_single_finding(
             reason="evidence is not a list, coercing to empty",
         )
         evidence_raw = []
-    evidence = tuple(str(e) for e in evidence_raw if isinstance(e, str) and e.strip())
+    evidence = tuple(e for e in evidence_raw if isinstance(e, str) and e.strip())
     turn_range: tuple[int, int] | None = None
     turn_start = item.get("turn_start")
     turn_end = item.get("turn_end")
     if (
         isinstance(turn_start, int)
+        and not isinstance(turn_start, bool)
         and isinstance(turn_end, int)
+        and not isinstance(turn_end, bool)
         and turn_start >= 0
         and turn_end >= turn_start
     ):

--- a/src/synthorg/engine/classification/_parsing.py
+++ b/src/synthorg/engine/classification/_parsing.py
@@ -1,0 +1,154 @@
+# module-kind: code
+"""JSON-response parsing for the LLM-backed semantic detectors.
+
+Pure, side-effect-free helpers split out of :mod:`semantic_detectors` so
+the detector module stays focused on provider orchestration and budget
+tracking. Malformed JSON or invalid items are logged at DEBUG and
+skipped: a bad response degrades to an empty finding set rather than
+failing the detector.
+"""
+
+import json
+from types import MappingProxyType
+from typing import Final
+
+from synthorg.budget.coordination_config import ErrorCategory
+from synthorg.engine.classification.models import (
+    ErrorFinding,
+    ErrorSeverity,
+)
+from synthorg.observability import get_logger, safe_error_description
+from synthorg.observability.events.classification import DETECTOR_PARSE_ERROR
+
+logger = get_logger(__name__)
+
+_SEVERITY_MAP: Final[MappingProxyType[str, ErrorSeverity]] = MappingProxyType(
+    {
+        "low": ErrorSeverity.LOW,
+        "medium": ErrorSeverity.MEDIUM,
+        "high": ErrorSeverity.HIGH,
+    },
+)
+
+
+def parse_findings(
+    raw: str | None,
+    category: ErrorCategory,
+) -> tuple[ErrorFinding, ...]:
+    """Parse LLM JSON output into ErrorFinding tuples.
+
+    Expected format::
+
+        [
+            {
+                "description": "...",
+                "severity": "high|medium|low",
+                "evidence": ["..."],
+                "turn_start": 0,
+                "turn_end": 2,
+            }
+        ]
+
+    Malformed JSON or invalid items are logged at DEBUG level and
+    skipped -- they do not cause the detector to fail.
+
+    Returns:
+        Tuple of well-formed :class:`ErrorFinding` records; ``()`` on
+        empty input, invalid JSON, or non-list output.
+    """
+    if not raw:
+        return ()
+    try:
+        items = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.debug(
+            DETECTOR_PARSE_ERROR,
+            category=category.value,
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
+            raw_snippet=raw[:200],
+        )
+        return ()
+    if not isinstance(items, list):
+        logger.debug(
+            DETECTOR_PARSE_ERROR,
+            category=category.value,
+            reason="response is not a JSON array",
+            actual_type=type(items).__name__,
+        )
+        return ()
+
+    findings: list[ErrorFinding] = []
+    for idx, item in enumerate(items):
+        finding = _parse_single_finding(item, idx, category)
+        if finding is not None:
+            findings.append(finding)
+    return tuple(findings)
+
+
+def _parse_single_finding(
+    item: object,
+    idx: int,
+    category: ErrorCategory,
+) -> ErrorFinding | None:
+    """Parse a single item from an LLM JSON array.
+
+    Returns ``None`` when the item is malformed -- parse errors
+    are logged at DEBUG level for operator visibility.
+
+    Returns:
+        A well-formed :class:`ErrorFinding`; ``None`` when the JSON
+        object is missing required fields or has the wrong shape.
+    """
+    if not isinstance(item, dict):
+        logger.debug(
+            DETECTOR_PARSE_ERROR,
+            category=category.value,
+            item_index=idx,
+            reason="item is not a JSON object",
+        )
+        return None
+    desc = item.get("description", "")
+    if not desc or not isinstance(desc, str):
+        logger.debug(
+            DETECTOR_PARSE_ERROR,
+            category=category.value,
+            item_index=idx,
+            reason="missing or empty description",
+        )
+        return None
+    severity = _SEVERITY_MAP.get(
+        str(item.get("severity", "medium")).lower(),
+        ErrorSeverity.MEDIUM,
+    )
+    evidence_raw = item.get("evidence", [])
+    if not isinstance(evidence_raw, list):
+        logger.debug(
+            DETECTOR_PARSE_ERROR,
+            category=category.value,
+            item_index=idx,
+            reason="evidence is not a list, coercing to empty",
+        )
+        evidence_raw = []
+    evidence = tuple(str(e) for e in evidence_raw if isinstance(e, str) and e.strip())
+    turn_range: tuple[int, int] | None = None
+    turn_start = item.get("turn_start")
+    turn_end = item.get("turn_end")
+    if (
+        isinstance(turn_start, int)
+        and isinstance(turn_end, int)
+        and turn_start >= 0
+        and turn_end >= turn_start
+    ):
+        turn_range = (turn_start, turn_end)
+
+    return ErrorFinding(
+        category=category,
+        severity=severity,
+        description=desc,
+        evidence=evidence,
+        turn_range=turn_range,
+    )
+
+
+__all__ = ["parse_findings"]

--- a/src/synthorg/engine/classification/pipeline.py
+++ b/src/synthorg/engine/classification/pipeline.py
@@ -251,12 +251,12 @@ def _select_loader(
 ) -> ScopedContextLoader | None:
     """Select a context loader for the requested detection scope.
 
-    TASK_TREE detectors are skipped (``None`` returned) when no task
-    repository is configured -- the previous behaviour silently fell
-    back to :class:`SameTaskLoader`, which produced a context with
-    ``scope=SAME_TASK``, causing TASK_TREE detectors to run against
-    missing delegation/review data.  Skipping them instead keeps
-    every detector aligned with its declared scope.
+    TASK_TREE detectors require a task repository to load delegation and
+    review history; returning ``None`` here signals the caller to skip them
+    rather than run them against the wrong context. A :class:`SameTaskLoader`
+    fallback would expose ``scope=SAME_TASK``, so a TASK_TREE detector would
+    silently check missing delegation/review data instead of its declared
+    scope.
 
     Args:
         scope: Detection scope requested by a detector category.
@@ -295,8 +295,9 @@ async def classify_execution_errors(  # noqa: PLR0913
     dispatches results to registered sinks.
 
     Rate limiting is handled by the ``BaseCompletionProvider``
-    internally -- semantic detectors no longer accept a separate
-    rate limiter to avoid double-throttling.
+    internally; semantic detectors do not take a separate rate limiter
+    because a second limiter on the same shared instance would
+    double-throttle.
 
     Returns ``None`` when the taxonomy is disabled.  Never raises;
     all exceptions except ``MemoryError``/``RecursionError`` are

--- a/src/synthorg/engine/classification/semantic_detectors.py
+++ b/src/synthorg/engine/classification/semantic_detectors.py
@@ -18,6 +18,7 @@ from synthorg.budget.coordination_config import (
 )
 from synthorg.budget.tracker_protocol import CostTrackerProtocol
 from synthorg.core.critical_errors import reraise_critical
+from synthorg.core.types import NotBlankStr
 from synthorg.engine.classification.budget_tracker import (
     ClassificationBudgetTracker,
 )
@@ -225,6 +226,11 @@ class _BaseSemanticDetector(ABC):
 
     @property
     @abstractmethod
+    def prompt_class_id(self) -> NotBlankStr:
+        """Stable per-purpose identifier for this detector's prompt class."""
+
+    @property
+    @abstractmethod
     def supported_scopes(self) -> frozenset[DetectionScope]:
         """Detection scopes this detector can operate on."""
 
@@ -397,6 +403,12 @@ class SemanticContradictionDetector(_BaseSemanticDetector):
 
     @property
     @override
+    def prompt_class_id(self) -> NotBlankStr:
+        """Stable per-purpose identifier for this detector's prompt class."""
+        return NotBlankStr("semantic_detector.logical_contradiction")
+
+    @property
+    @override
     def supported_scopes(self) -> frozenset[DetectionScope]:
         """Detection scopes this detector can operate on."""
         return frozenset({DetectionScope.SAME_TASK})
@@ -425,6 +437,12 @@ class SemanticNumericalVerificationDetector(_BaseSemanticDetector):
     def category(self) -> ErrorCategory:
         """Error category this detector targets."""
         return ErrorCategory.NUMERICAL_DRIFT
+
+    @property
+    @override
+    def prompt_class_id(self) -> NotBlankStr:
+        """Stable per-purpose identifier for this detector's prompt class."""
+        return NotBlankStr("semantic_detector.numerical_drift")
 
     @property
     @override
@@ -461,6 +479,12 @@ class SemanticMissingReferenceDetector(_BaseSemanticDetector):
 
     @property
     @override
+    def prompt_class_id(self) -> NotBlankStr:
+        """Stable per-purpose identifier for this detector's prompt class."""
+        return NotBlankStr("semantic_detector.context_omission")
+
+    @property
+    @override
     def supported_scopes(self) -> frozenset[DetectionScope]:
         """Detection scopes this detector can operate on."""
         return frozenset(
@@ -491,6 +515,12 @@ class SemanticCoordinationDetector(_BaseSemanticDetector):
     def category(self) -> ErrorCategory:
         """Error category this detector targets."""
         return ErrorCategory.COORDINATION_FAILURE
+
+    @property
+    @override
+    def prompt_class_id(self) -> NotBlankStr:
+        """Stable per-purpose identifier for this detector's prompt class."""
+        return NotBlankStr("semantic_detector.coordination_failure")
 
     @property
     @override

--- a/src/synthorg/engine/classification/semantic_detectors.py
+++ b/src/synthorg/engine/classification/semantic_detectors.py
@@ -6,9 +6,7 @@ detectors are disabled by default -- they require explicit opt-in
 via ``DetectorVariant.LLM_SEMANTIC`` in the per-category config.
 """
 
-import json
 from abc import ABC, abstractmethod
-from types import MappingProxyType
 from typing import Final, override
 
 from synthorg.budget.call_category import LLMCallCategory
@@ -19,13 +17,11 @@ from synthorg.budget.coordination_config import (
 from synthorg.budget.tracker_protocol import CostTrackerProtocol
 from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.types import NotBlankStr
+from synthorg.engine.classification._parsing import parse_findings
 from synthorg.engine.classification.budget_tracker import (
     ClassificationBudgetTracker,
 )
-from synthorg.engine.classification.models import (
-    ErrorFinding,
-    ErrorSeverity,
-)
+from synthorg.engine.classification.models import ErrorFinding
 from synthorg.engine.classification.protocol import DetectionContext
 from synthorg.engine.prompt_safety import (
     TAG_TASK_DATA,
@@ -37,7 +33,6 @@ from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.classification import (
     DETECTOR_COMPLETE,
     DETECTOR_ERROR,
-    DETECTOR_PARSE_ERROR,
     DETECTOR_START,
 )
 from synthorg.providers.cost_recording import cost_recording_scope
@@ -48,6 +43,20 @@ from synthorg.providers.protocol import CompletionProvider
 logger = get_logger(__name__)
 _DEFAULT_MAX_TOKENS: Final[int] = 1024
 
+# Stable per-purpose prompt-class identifiers, one per concrete detector.
+_PROMPT_CLASS_ID_CONTRADICTION: Final[NotBlankStr] = NotBlankStr(
+    "semantic_detector.logical_contradiction"
+)
+_PROMPT_CLASS_ID_NUMERICAL: Final[NotBlankStr] = NotBlankStr(
+    "semantic_detector.numerical_drift"
+)
+_PROMPT_CLASS_ID_MISSING_REFERENCE: Final[NotBlankStr] = NotBlankStr(
+    "semantic_detector.context_omission"
+)
+_PROMPT_CLASS_ID_COORDINATION: Final[NotBlankStr] = NotBlankStr(
+    "semantic_detector.coordination_failure"
+)
+
 _SANITIZE_MAX_LENGTH: Final[int] = 2000
 # Cost reserved per LLM semantic detector invocation.  Small enough
 # that the reservation gate admits several concurrent detectors
@@ -55,127 +64,6 @@ _SANITIZE_MAX_LENGTH: Final[int] = 2000
 # provider cannot silently overshoot.  Actual cost is reconciled via
 # ``ClassificationBudgetTracker.settle`` once the call completes.
 _ESTIMATED_LLM_COST: Final[float] = 0.001
-_SEVERITY_MAP: MappingProxyType[str, ErrorSeverity] = MappingProxyType(
-    {
-        "low": ErrorSeverity.LOW,
-        "medium": ErrorSeverity.MEDIUM,
-        "high": ErrorSeverity.HIGH,
-    },
-)
-
-
-def _parse_findings(
-    raw: str | None,
-    category: ErrorCategory,
-) -> tuple[ErrorFinding, ...]:
-    """Parse LLM JSON output into ErrorFinding tuples.
-
-    Expected format::
-
-        [
-            {
-                "description": "...",
-                "severity": "high|medium|low",
-                "evidence": ["..."],
-                "turn_start": 0,
-                "turn_end": 2,
-            }
-        ]
-
-    Malformed JSON or invalid items are logged at DEBUG level and
-    skipped -- they do not cause the detector to fail.
-
-    Returns:
-        Tuple of well-formed :class:`ErrorFinding` records; ``()`` on
-        empty input, invalid JSON, or non-list output.
-    """
-    if not raw:
-        return ()
-    try:
-        items = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        logger.debug(
-            DETECTOR_PARSE_ERROR,
-            category=category.value,
-            error_type=type(exc).__name__,
-            error=safe_error_description(exc),
-            raw_snippet=raw[:200],
-        )
-        return ()
-    if not isinstance(items, list):
-        logger.debug(
-            DETECTOR_PARSE_ERROR,
-            category=category.value,
-            reason="response is not a JSON array",
-            actual_type=type(items).__name__,
-        )
-        return ()
-
-    findings: list[ErrorFinding] = []
-    for idx, item in enumerate(items):
-        finding = _parse_single_finding(item, idx, category)
-        if finding is not None:
-            findings.append(finding)
-    return tuple(findings)
-
-
-def _parse_single_finding(
-    item: object,
-    idx: int,
-    category: ErrorCategory,
-) -> ErrorFinding | None:
-    """Parse a single item from an LLM JSON array.
-
-    Returns ``None`` when the item is malformed -- parse errors
-    are logged at DEBUG level for operator visibility.
-
-    Returns:
-        A well-formed :class:`ErrorFinding`; ``None`` when the JSON
-        object is missing required fields or has the wrong shape.
-    """
-    if not isinstance(item, dict):
-        logger.debug(
-            DETECTOR_PARSE_ERROR,
-            category=category.value,
-            item_index=idx,
-            reason="item is not a JSON object",
-        )
-        return None
-    desc = item.get("description", "")
-    if not desc or not isinstance(desc, str):
-        logger.debug(
-            DETECTOR_PARSE_ERROR,
-            category=category.value,
-            item_index=idx,
-            reason="missing or empty description",
-        )
-        return None
-    severity = _SEVERITY_MAP.get(
-        str(item.get("severity", "medium")).lower(),
-        ErrorSeverity.MEDIUM,
-    )
-    evidence_raw = item.get("evidence", [])
-    if not isinstance(evidence_raw, list):
-        evidence_raw = []
-    evidence = tuple(str(e) for e in evidence_raw if isinstance(e, str) and e.strip())
-    turn_range: tuple[int, int] | None = None
-    turn_start = item.get("turn_start")
-    turn_end = item.get("turn_end")
-    if (
-        isinstance(turn_start, int)
-        and isinstance(turn_end, int)
-        and turn_start >= 0
-        and turn_end >= turn_start
-    ):
-        turn_range = (turn_start, turn_end)
-
-    return ErrorFinding(
-        category=category,
-        severity=severity,
-        description=desc,
-        evidence=evidence,
-        turn_range=turn_range,
-    )
 
 
 def _build_conversation_text(
@@ -203,6 +91,22 @@ def _build_conversation_text(
             )
             parts.append(f"[{i}:{msg.role.value}] {sanitized}")
     return "\n".join(parts)
+
+
+def _build_detector_messages(prompt_text: str) -> list[ChatMessage]:
+    """Build the system + user messages for a semantic-detector call.
+
+    Returns:
+        The detector prompt as the system message plus the fixed
+        return-JSON user instruction.
+    """
+    return [
+        ChatMessage(role=MessageRole.SYSTEM, content=prompt_text),
+        ChatMessage(
+            role=MessageRole.USER,
+            content="Analyze the conversation above and return JSON.",
+        ),
+    ]
 
 
 class _BaseSemanticDetector(ABC):
@@ -238,7 +142,7 @@ class _BaseSemanticDetector(ABC):
         self,
         *,
         provider: CompletionProvider,
-        model_id: str,
+        model_id: NotBlankStr,
         budget_tracker: ClassificationBudgetTracker | None = None,
         temperature: float = 0.0,
         max_tokens: int = _DEFAULT_MAX_TOKENS,
@@ -327,29 +231,54 @@ class _BaseSemanticDetector(ABC):
             Parsed :class:`ErrorFinding` tuple from the LLM response;
             ``()`` when budget is exhausted or the call fails.
         """
-        estimated_cost = _ESTIMATED_LLM_COST
-        if self._budget_tracker is not None:
-            reserved = await self._budget_tracker.try_reserve(estimated_cost)
-            if not reserved:
-                logger.debug(
-                    DETECTOR_COMPLETE,
-                    detector=detector_name,
-                    finding_count=0,
-                    reason="budget exhausted",
-                )
-                return ()
-        else:
-            reserved = False
+        reserved = await self._reserve_budget(detector_name)
+        if reserved is None:
+            return ()
+        messages = _build_detector_messages(self._prompt(conversation_text))
+        return await self._complete_within_budget(
+            messages,
+            context=context,
+            detector_name=detector_name,
+            message_count=message_count,
+            reserved=reserved,
+        )
 
-        prompt_text = self._prompt(conversation_text)
-        messages = [
-            ChatMessage(role=MessageRole.SYSTEM, content=prompt_text),
-            ChatMessage(
-                role=MessageRole.USER,
-                content="Analyze the conversation above and return JSON.",
-            ),
-        ]
+    async def _reserve_budget(self, detector_name: str) -> bool | None:
+        """Reserve the per-call estimated cost against the budget tracker.
 
+        Returns:
+            ``True`` when a reservation was taken, ``False`` when no tracker
+            is wired (nothing to reserve), or ``None`` when the budget is
+            exhausted and the caller must skip the call.
+        """
+        if self._budget_tracker is None:
+            return False
+        reserved = await self._budget_tracker.try_reserve(_ESTIMATED_LLM_COST)
+        if not reserved:
+            logger.debug(
+                DETECTOR_COMPLETE,
+                detector=detector_name,
+                finding_count=0,
+                reason="budget exhausted",
+            )
+            return None
+        return True
+
+    async def _complete_within_budget(
+        self,
+        messages: list[ChatMessage],
+        *,
+        context: DetectionContext,
+        detector_name: str,
+        message_count: int,
+        reserved: bool,
+    ) -> tuple[ErrorFinding, ...]:
+        """Run the provider call, settling or releasing the reservation.
+
+        Returns:
+            Parsed :class:`ErrorFinding` tuple from the LLM response; ``()``
+            on any provider failure.
+        """
         settled = False
         try:
             async with cost_recording_scope(
@@ -370,11 +299,11 @@ class _BaseSemanticDetector(ABC):
             actual_cost = response.usage.cost
             if reserved and self._budget_tracker is not None:
                 await self._budget_tracker.settle(
-                    estimated_cost=estimated_cost,
+                    estimated_cost=_ESTIMATED_LLM_COST,
                     actual_cost=actual_cost,
                 )
                 settled = True
-            return _parse_findings(response.content, self.category)
+            return parse_findings(response.content, self.category)
         except Exception as exc:  # noqa: BLE001 -- criticals re-raised
             reraise_critical(exc)
             logger.warning(
@@ -389,7 +318,7 @@ class _BaseSemanticDetector(ABC):
             return ()
         finally:
             if reserved and not settled and self._budget_tracker is not None:
-                await self._budget_tracker.release(estimated_cost)
+                await self._budget_tracker.release(_ESTIMATED_LLM_COST)
 
 
 class SemanticContradictionDetector(_BaseSemanticDetector):
@@ -405,7 +334,7 @@ class SemanticContradictionDetector(_BaseSemanticDetector):
     @override
     def prompt_class_id(self) -> NotBlankStr:
         """Stable per-purpose identifier for this detector's prompt class."""
-        return NotBlankStr("semantic_detector.logical_contradiction")
+        return _PROMPT_CLASS_ID_CONTRADICTION
 
     @property
     @override
@@ -442,7 +371,7 @@ class SemanticNumericalVerificationDetector(_BaseSemanticDetector):
     @override
     def prompt_class_id(self) -> NotBlankStr:
         """Stable per-purpose identifier for this detector's prompt class."""
-        return NotBlankStr("semantic_detector.numerical_drift")
+        return _PROMPT_CLASS_ID_NUMERICAL
 
     @property
     @override
@@ -481,7 +410,7 @@ class SemanticMissingReferenceDetector(_BaseSemanticDetector):
     @override
     def prompt_class_id(self) -> NotBlankStr:
         """Stable per-purpose identifier for this detector's prompt class."""
-        return NotBlankStr("semantic_detector.context_omission")
+        return _PROMPT_CLASS_ID_MISSING_REFERENCE
 
     @property
     @override
@@ -520,7 +449,7 @@ class SemanticCoordinationDetector(_BaseSemanticDetector):
     @override
     def prompt_class_id(self) -> NotBlankStr:
         """Stable per-purpose identifier for this detector's prompt class."""
-        return NotBlankStr("semantic_detector.coordination_failure")
+        return _PROMPT_CLASS_ID_COORDINATION
 
     @property
     @override

--- a/src/synthorg/engine/compaction/llm_summarizer.py
+++ b/src/synthorg/engine/compaction/llm_summarizer.py
@@ -41,7 +41,7 @@ _SYSTEM_PROMPT = (
 )
 
 # Framework-overhead attribution for the compaction summary call.
-_SUMMARY_AGENT_ID: NotBlankStr = NotBlankStr("system")
+_SUMMARY_AGENT_ID: Final[NotBlankStr] = NotBlankStr("system")
 
 # Mirror ``CompactionConfig.llm_summary_{temperature,max_tokens}`` so a
 # directly-constructed summariser matches the wired path, which sources
@@ -87,7 +87,7 @@ class LLMSummarizer:
         self,
         *,
         provider: CompletionPort,
-        model: str,
+        model: NotBlankStr,
         temperature: float = _DEFAULT_TEMPERATURE,
         max_tokens: int = _DEFAULT_MAX_TOKENS,
         cost_tracker: CostTrackerProtocol | None = None,
@@ -122,6 +122,11 @@ class LLMSummarizer:
         """
         transcript = _build_transcript(archivable)
         if not transcript:
+            logger.debug(
+                CONTEXT_BUDGET_COMPACTION_LLM_FALLBACK,
+                reason="empty_transcript",
+                archived_count=len(archivable),
+            )
             return fallback_text
         identity = current_execution_identity()
         execution_id = (

--- a/src/synthorg/engine/compaction/llm_summarizer.py
+++ b/src/synthorg/engine/compaction/llm_summarizer.py
@@ -9,7 +9,7 @@ the caller passes in, logged as a fallback so the downgrade is never
 silent.
 """
 
-from typing import Protocol, runtime_checkable
+from typing import Final, Protocol, runtime_checkable
 
 from synthorg.budget.call_category import LLMCallCategory
 from synthorg.budget.tracker_protocol import CostTrackerProtocol
@@ -43,6 +43,12 @@ _SYSTEM_PROMPT = (
 # Framework-overhead attribution for the compaction summary call.
 _SUMMARY_AGENT_ID: NotBlankStr = NotBlankStr("system")
 
+# Mirror ``CompactionConfig.llm_summary_{temperature,max_tokens}`` so a
+# directly-constructed summariser matches the wired path, which sources
+# these from the compaction domain config (workers/_engine_assembly.py).
+_DEFAULT_TEMPERATURE: Final[float] = 0.3
+_DEFAULT_MAX_TOKENS: Final[int] = 500
+
 
 @runtime_checkable
 class CompletionPort(Protocol):
@@ -69,8 +75,10 @@ class LLMSummarizer:
     Args:
         provider: Completion port used to generate the summary.
         model: Model id for the summary call.
-        temperature: Sampling temperature (pinned explicitly).
-        max_tokens: Max tokens for the summary response.
+        temperature: Sampling temperature (pinned explicitly); defaults to
+            the compaction domain-config value.
+        max_tokens: Max tokens for the summary response; defaults to the
+            compaction domain-config value.
         cost_tracker: Sink for the per-call cost record (``None`` makes
             recording a no-op).
     """
@@ -80,8 +88,8 @@ class LLMSummarizer:
         *,
         provider: CompletionPort,
         model: str,
-        temperature: float,
-        max_tokens: int,
+        temperature: float = _DEFAULT_TEMPERATURE,
+        max_tokens: int = _DEFAULT_MAX_TOKENS,
         cost_tracker: CostTrackerProtocol | None = None,
     ) -> None:
         self._provider = provider

--- a/src/synthorg/memory/retrieval/hierarchical/default_retriever.py
+++ b/src/synthorg/memory/retrieval/hierarchical/default_retriever.py
@@ -136,6 +136,9 @@ class DefaultHierarchicalRetriever:
         )
         if self._supervisor.reflective_retry_enabled:
             max_retries = self._supervisor.max_retry_count
+            # See docs/reference/retry-patterns.md: Pattern B -- semantic
+            # self-correction, not transient-I/O retry. No sleep; each
+            # iteration changes the query / worker strategy.
             while retries < max_retries:
                 correction = await self._supervisor.evaluate_for_retry(
                     current_query,

--- a/src/synthorg/memory/retrieval/hierarchical/supervisor.py
+++ b/src/synthorg/memory/retrieval/hierarchical/supervisor.py
@@ -431,7 +431,7 @@ class SupervisorRouter:
             logger.debug(
                 MEMORY_HIERARCHICAL_RETRY,
                 action="llm_no_retry",
-                reason=retry.reason,
+                has_reason=bool(retry.reason),
             )
             return None
 
@@ -460,7 +460,7 @@ class SupervisorRouter:
             action="correction",
             has_corrected_query=corrected_query is not None,
             alternative_strategy=retry.alternative_strategy,
-            reason=retry.reason,
+            has_reason=bool(retry.reason),
         )
         return RetrievalRetryCorrection(
             corrected_query=corrected_query,

--- a/src/synthorg/memory/retrieval/hierarchical/supervisor.py
+++ b/src/synthorg/memory/retrieval/hierarchical/supervisor.py
@@ -87,10 +87,18 @@ _DEFAULT_FALLBACK_WORKERS = ("semantic",)
 _DEFAULT_MAX_WORKERS_PER_QUERY: Final[int] = 2
 _DEFAULT_MAX_RETRY_COUNT: Final[int] = 2
 
+# Both calls emit a short JSON object (a worker list + reason, or a
+# retry verdict + corrected query); 256 tokens covers either with
+# headroom while bounding cost regardless of the provider default.
+_ROUTING_MAX_TOKENS: Final[int] = 256
+
 # Routing decisions and retry-evaluation must be deterministic so the
 # same query produces the same worker selection across runs; pin
 # ``temperature=0.0`` regardless of provider defaults.
-_ROUTING_COMPLETION_CONFIG = CompletionConfig(temperature=0.0)
+_ROUTING_COMPLETION_CONFIG = CompletionConfig(
+    temperature=0.0,
+    max_tokens=_ROUTING_MAX_TOKENS,
+)
 
 
 class _LlmRoutingResponse(

--- a/src/synthorg/memory/retrieval/hierarchical/supervisor.py
+++ b/src/synthorg/memory/retrieval/hierarchical/supervisor.py
@@ -87,15 +87,17 @@ _DEFAULT_FALLBACK_WORKERS = ("semantic",)
 _DEFAULT_MAX_WORKERS_PER_QUERY: Final[int] = 2
 _DEFAULT_MAX_RETRY_COUNT: Final[int] = 2
 
-# Both calls emit a short JSON object (a worker list + reason, or a
-# retry verdict + corrected query); 256 tokens covers either with
-# headroom while bounding cost regardless of the provider default.
+# Both calls emit a short JSON object: routing returns a worker list +
+# reason; retry returns a verdict, an optional corrected query, an
+# optional strategy, and a free-text reason. 256 tokens covers the
+# widest of these with headroom while bounding cost regardless of the
+# provider default.
 _ROUTING_MAX_TOKENS: Final[int] = 256
 
 # Routing decisions and retry-evaluation must be deterministic so the
 # same query produces the same worker selection across runs; pin
 # ``temperature=0.0`` regardless of provider defaults.
-_ROUTING_COMPLETION_CONFIG = CompletionConfig(
+_ROUTING_COMPLETION_CONFIG: Final[CompletionConfig] = CompletionConfig(
     temperature=0.0,
     max_tokens=_ROUTING_MAX_TOKENS,
 )
@@ -343,6 +345,11 @@ class SupervisorRouter:
             : self._max_workers
         ]
         if not workers:
+            logger.debug(
+                MEMORY_HIERARCHICAL_ROUTING,
+                action="invalid_workers_filtered",
+                llm_workers=list(routing.workers),
+            )
             workers = _DEFAULT_FALLBACK_WORKERS
         reason = routing.reason
         logger.info(
@@ -377,10 +384,9 @@ class SupervisorRouter:
             count=len(result.candidates),
             avg_score=avg_score,
         )
-        # Wrap the untrusted ``query.text`` so a malicious query
-        # body cannot inject instructions into the retry evaluator.
-        # The candidate-count summary is fixed-format numeric data,
-        # so it stays outside the fence.
+        # Wrap the untrusted ``query.text`` so a malicious query body cannot
+        # inject instructions into the retry evaluator. The candidate-count
+        # summary is fixed-format numeric data, so it stays outside the fence.
         wrapped_query = wrap_untrusted(TAG_TASK_DATA, query.text)
         user_content = (
             f"Original query:\n{wrapped_query}\n"
@@ -403,6 +409,11 @@ class SupervisorRouter:
                 config=_ROUTING_COMPLETION_CONFIG,
             )
         if response.content is None:
+            logger.warning(
+                MEMORY_HIERARCHICAL_RETRY,
+                action="eval_failed",
+                reason="empty_content",
+            )
             return None
         try:
             parsed = json.loads(response.content)
@@ -417,6 +428,11 @@ class SupervisorRouter:
             return None
         retry = parse_typed("memory.retry", parsed, _LlmRetryResponse)
         if not retry.retry:
+            logger.debug(
+                MEMORY_HIERARCHICAL_RETRY,
+                action="llm_no_retry",
+                reason=retry.reason,
+            )
             return None
 
         corrected_query = None
@@ -439,17 +455,15 @@ class SupervisorRouter:
                 )
                 corrected_query = None
 
-        alt_strategy = retry.alternative_strategy
-        reason = retry.reason
         logger.info(
             MEMORY_HIERARCHICAL_RETRY,
             action="correction",
             has_corrected_query=corrected_query is not None,
-            alternative_strategy=alt_strategy,
-            reason=reason,
+            alternative_strategy=retry.alternative_strategy,
+            reason=retry.reason,
         )
         return RetrievalRetryCorrection(
             corrected_query=corrected_query,
-            alternative_strategy=alt_strategy,
-            reason=reason,
+            alternative_strategy=retry.alternative_strategy,
+            reason=retry.reason,
         )

--- a/src/synthorg/memory/retrieval/hierarchical/supervisor.py
+++ b/src/synthorg/memory/retrieval/hierarchical/supervisor.py
@@ -348,7 +348,7 @@ class SupervisorRouter:
             logger.debug(
                 MEMORY_HIERARCHICAL_ROUTING,
                 action="invalid_workers_filtered",
-                llm_workers=list(routing.workers),
+                llm_worker_count=len(routing.workers),
             )
             workers = _DEFAULT_FALLBACK_WORKERS
         reason = routing.reason

--- a/src/synthorg/memory/retrieval/reranking/llm_reranker.py
+++ b/src/synthorg/memory/retrieval/reranking/llm_reranker.py
@@ -21,6 +21,7 @@ from synthorg.engine.prompt_safety import (
 )
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.memory import (
+    MEMORY_RERANK_CACHE_HIT,
     MEMORY_RERANK_CACHE_MISS,
     MEMORY_RERANK_COMPLETE,
     MEMORY_RERANK_FAILED,
@@ -29,15 +30,19 @@ from synthorg.providers.cost_recording import cost_recording_scope
 from synthorg.providers.enums import MessageRole
 from synthorg.providers.models import ChatMessage, CompletionConfig
 
-# The reranker emits only a ranking array of candidate indices, bounded
-# by ``RetrievalQuery.max_results`` (<= 100); 512 tokens fits 100 indices
-# with ample headroom before truncation forces the graceful fallback.
-_RERANK_MAX_TOKENS: Final[int] = 512
+# The reranker emits a ranking array with one index per input candidate.
+# Reranking runs on the full pre-truncation pool (``MemoryRetriever``
+# reranks before the top-k cut), so the array can reach
+# ``MemoryRetrievalConfig.max_memories * candidate_pool_multiplier``
+# (<= 100 * 10 = 1000) entries when the diversity penalty is enabled.
+# 4096 tokens fits a 1000-index array with headroom; truncation past the
+# cap degrades gracefully to the original order.
+_RERANK_MAX_TOKENS: Final[int] = 4096
 
 # Re-ranking must be deterministic across CI shards so cache keys
 # remain stable. Temperature=0.0 also minimises the chance of the
 # LLM returning a malformed ranking array that forces a fallback.
-_RERANK_COMPLETION_CONFIG = CompletionConfig(
+_RERANK_COMPLETION_CONFIG: Final[CompletionConfig] = CompletionConfig(
     temperature=0.0,
     max_tokens=_RERANK_MAX_TOKENS,
 )
@@ -155,6 +160,11 @@ class LLMQuerySpecificReranker:
             RecursionError: If the related operation fails.
         """
         if len(candidates) <= 1:
+            logger.debug(
+                MEMORY_RERANK_COMPLETE,
+                candidate_count=len(candidates),
+                reason="single_candidate",
+            )
             return candidates
 
         candidate_ids = tuple(c.entry.id for c in candidates)
@@ -165,29 +175,14 @@ class LLMQuerySpecificReranker:
             candidate_ids
         )
         by_id = {c.entry.id: c for c in candidates}
-        cache_key = ""
+        cache_key = (
+            _build_cache_key(query.text, candidate_ids) if cache_eligible else ""
+        )
 
-        # Check cache -- returns stored ID ordering, we reapply to
-        # the current candidate set so fresh state always wins.
-        # Cache faults degrade to a cold rerank rather than failing
-        # retrieval; this is an optional optimization.
-        if cache_eligible and self._cache is not None:
-            cache_key = _build_cache_key(query.text, candidate_ids)
-            try:
-                cached_ids = await self._cache.get(cache_key)
-            except builtins.MemoryError, RecursionError:
-                raise
-            except Exception as exc:  # noqa: BLE001 -- criticals re-raised
-                reraise_critical(exc)
-                logger.warning(
-                    MEMORY_RERANK_CACHE_MISS,
-                    error_type=type(exc).__name__,
-                    error=safe_error_description(exc),
-                    reason="cache_get_failed",
-                )
-                cached_ids = None
-            if cached_ids is not None and set(cached_ids) == set(by_id):
-                return tuple(by_id[cid] for cid in cached_ids)
+        if cache_eligible:
+            cached = await self._read_cached_order(cache_key, by_id)
+            if cached is not None:
+                return cached
 
         try:
             reranked = await self._rerank_via_llm(query, candidates)
@@ -217,29 +212,83 @@ class LLMQuerySpecificReranker:
                 query_length=len(query.text),
             )
             return candidates
-        else:
-            if cache_eligible and self._cache is not None and cache_key:
-                try:
-                    await self._cache.put(
-                        cache_key,
-                        tuple(c.entry.id for c in reranked),
-                    )
-                except builtins.MemoryError, RecursionError:
-                    raise
-                except Exception as exc:  # noqa: BLE001 -- criticals re-raised
-                    reraise_critical(exc)
-                    logger.warning(
-                        MEMORY_RERANK_CACHE_MISS,
-                        error_type=type(exc).__name__,
-                        error=safe_error_description(exc),
-                        reason="cache_put_failed",
-                    )
-            logger.info(
-                MEMORY_RERANK_COMPLETE,
-                candidate_count=len(reranked),
-                query_length=len(query.text),
+
+        if cache_eligible and cache_key:
+            await self._write_cached_order(cache_key, reranked)
+        logger.info(
+            MEMORY_RERANK_COMPLETE,
+            candidate_count=len(reranked),
+            query_length=len(query.text),
+        )
+        return reranked
+
+    async def _read_cached_order(
+        self,
+        cache_key: str,
+        by_id: dict[str, RetrievalCandidate],
+    ) -> tuple[RetrievalCandidate, ...] | None:
+        """Return the cached ordering reapplied to the live candidate set.
+
+        Re-applies the stored ID ordering to the current candidates so
+        fresh state always wins. Cache faults degrade to a cold rerank
+        rather than failing retrieval; this is an optional optimization.
+
+        Returns:
+            The cached candidates in stored order, or ``None`` on a miss,
+            a stale ID set, or a cache fault.
+
+        Raises:
+            MemoryError: Propagated; never degraded to a cold rerank.
+            RecursionError: Propagated; never degraded to a cold rerank.
+        """
+        if self._cache is None:
+            return None
+        try:
+            cached_ids = await self._cache.get(cache_key)
+        except builtins.MemoryError, RecursionError:
+            raise
+        except Exception as exc:  # noqa: BLE001 -- criticals re-raised
+            reraise_critical(exc)
+            logger.warning(
+                MEMORY_RERANK_CACHE_MISS,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+                reason="cache_get_failed",
             )
-            return reranked
+            return None
+        if cached_ids is not None and set(cached_ids) == set(by_id):
+            logger.debug(MEMORY_RERANK_CACHE_HIT, candidate_count=len(by_id))
+            return tuple(by_id[cid] for cid in cached_ids)
+        return None
+
+    async def _write_cached_order(
+        self,
+        cache_key: str,
+        reranked: tuple[RetrievalCandidate, ...],
+    ) -> None:
+        """Persist the reranked ID ordering; cache faults are non-fatal.
+
+        Raises:
+            MemoryError: Propagated; never swallowed as a cache fault.
+            RecursionError: Propagated; never swallowed as a cache fault.
+        """
+        if self._cache is None:
+            return
+        try:
+            await self._cache.put(
+                cache_key,
+                tuple(c.entry.id for c in reranked),
+            )
+        except builtins.MemoryError, RecursionError:
+            raise
+        except Exception as exc:  # noqa: BLE001 -- criticals re-raised
+            reraise_critical(exc)
+            logger.warning(
+                MEMORY_RERANK_CACHE_MISS,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+                reason="cache_put_failed",
+            )
 
     async def _rerank_via_llm(
         self,
@@ -296,30 +345,37 @@ class LLMQuerySpecificReranker:
             )
             return candidates
 
+        # A malformed or incomplete ranking is the visible symptom of a
+        # systematic provider regression or an output truncated past
+        # ``_RERANK_MAX_TOKENS``; log at WARNING (matching the supervisor)
+        # so the silent fall-back to original order is operationally
+        # observable rather than buried at DEBUG.
         try:
             parsed = json.loads(response.content)
             ranking = RankingLLMResponse.model_validate(parsed).ranking
         except json.JSONDecodeError as exc:
-            logger.debug(
+            logger.warning(
                 MEMORY_RERANK_FAILED,
                 error="LLM returned non-JSON content",
                 error_type=type(exc).__name__,
                 candidate_count=len(candidates),
+                query_length=len(query.text),
             )
             return candidates
         except ValidationError as exc:
-            logger.debug(
+            logger.warning(
                 MEMORY_RERANK_FAILED,
                 error="Invalid ranking response shape from LLM",
                 error_type=type(exc).__name__,
                 candidate_count=len(candidates),
+                query_length=len(query.text),
             )
             return candidates
 
         # Validate ranking indices
         n = len(candidates)
         if sorted(ranking) != list(range(n)):
-            logger.debug(
+            logger.warning(
                 MEMORY_RERANK_FAILED,
                 error="Invalid ranking indices from LLM",
                 expected_count=n,

--- a/src/synthorg/memory/retrieval/reranking/llm_reranker.py
+++ b/src/synthorg/memory/retrieval/reranking/llm_reranker.py
@@ -29,10 +29,18 @@ from synthorg.providers.cost_recording import cost_recording_scope
 from synthorg.providers.enums import MessageRole
 from synthorg.providers.models import ChatMessage, CompletionConfig
 
+# The reranker emits only a ranking array of candidate indices, bounded
+# by ``RetrievalQuery.max_results`` (<= 100); 512 tokens fits 100 indices
+# with ample headroom before truncation forces the graceful fallback.
+_RERANK_MAX_TOKENS: Final[int] = 512
+
 # Re-ranking must be deterministic across CI shards so cache keys
 # remain stable. Temperature=0.0 also minimises the chance of the
 # LLM returning a malformed ranking array that forces a fallback.
-_RERANK_COMPLETION_CONFIG = CompletionConfig(temperature=0.0)
+_RERANK_COMPLETION_CONFIG = CompletionConfig(
+    temperature=0.0,
+    max_tokens=_RERANK_MAX_TOKENS,
+)
 
 
 class RankingLLMResponse(BaseModel):

--- a/src/synthorg/memory/retrieval/reranking/llm_reranker.py
+++ b/src/synthorg/memory/retrieval/reranking/llm_reranker.py
@@ -256,7 +256,11 @@ class LLMQuerySpecificReranker:
                 reason="cache_get_failed",
             )
             return None
-        if cached_ids is not None and set(cached_ids) == set(by_id):
+        if (
+            cached_ids is not None
+            and len(cached_ids) == len(by_id)
+            and set(cached_ids) == set(by_id)
+        ):
             logger.debug(MEMORY_RERANK_CACHE_HIT, candidate_count=len(by_id))
             return tuple(by_id[cid] for cid in cached_ids)
         return None

--- a/src/synthorg/security/redteam/grounding/_llm.py
+++ b/src/synthorg/security/redteam/grounding/_llm.py
@@ -70,13 +70,15 @@ EXTRACTION_CONFIG: Final[CompletionConfig] = CompletionConfig(
     temperature=LLM_TEMPERATURE,
     max_tokens=EXTRACTION_MAX_TOKENS,
 )
-"""Sampling config for the claim-extraction operation."""
+"""Claim-extraction sampling: temperature ``LLM_TEMPERATURE`` (0.0), capped
+at ``EXTRACTION_MAX_TOKENS`` output tokens."""
 
 ENTAILMENT_CONFIG: Final[CompletionConfig] = CompletionConfig(
     temperature=LLM_TEMPERATURE,
     max_tokens=ENTAILMENT_MAX_TOKENS,
 )
-"""Sampling config for the per-claim entailment operation."""
+"""Per-claim entailment sampling: temperature ``LLM_TEMPERATURE`` (0.0),
+capped at ``ENTAILMENT_MAX_TOKENS`` output tokens."""
 
 _CONFIDENCE_FLOOR: Final[float] = 0.0
 _CONFIDENCE_CEILING: Final[float] = 1.0

--- a/src/synthorg/security/redteam/grounding/_llm.py
+++ b/src/synthorg/security/redteam/grounding/_llm.py
@@ -31,6 +31,7 @@ from synthorg.knowledge.models import KnowledgeHit
 from synthorg.providers.enums import MessageRole
 from synthorg.providers.models import (
     ChatMessage,
+    CompletionConfig,
     CompletionResponse,
     ToolDefinition,
 )
@@ -64,6 +65,18 @@ ENTAILMENT_MAX_TOKENS: Final[int] = 256
 
 LLM_TEMPERATURE: Final[float] = 0.0
 """Pinned temperature for both calls (harness determinism)."""
+
+EXTRACTION_CONFIG: Final[CompletionConfig] = CompletionConfig(
+    temperature=LLM_TEMPERATURE,
+    max_tokens=EXTRACTION_MAX_TOKENS,
+)
+"""Sampling config for the claim-extraction operation."""
+
+ENTAILMENT_CONFIG: Final[CompletionConfig] = CompletionConfig(
+    temperature=LLM_TEMPERATURE,
+    max_tokens=ENTAILMENT_MAX_TOKENS,
+)
+"""Sampling config for the per-claim entailment operation."""
 
 _CONFIDENCE_FLOOR: Final[float] = 0.0
 _CONFIDENCE_CEILING: Final[float] = 1.0

--- a/src/synthorg/security/redteam/grounding/substrate.py
+++ b/src/synthorg/security/redteam/grounding/substrate.py
@@ -29,6 +29,7 @@ from typing import Final
 from synthorg.budget.call_category import LLMCallCategory
 from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.types import NotBlankStr
+from synthorg.knowledge.models import KnowledgeHit
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.red_team import (
     RED_TEAM_GROUNDING_CLAIM_UNSUPPORTED,
@@ -70,7 +71,7 @@ from synthorg.security.redteam.routing import SUBSTRATE_DROP_FLOOR
 
 logger = get_logger(__name__)
 
-_GROUNDING_AGENT_ID: Final[str] = "system:red_team:grounding"
+_GROUNDING_AGENT_ID: Final[NotBlankStr] = NotBlankStr("system:red_team:grounding")
 """Synthetic attribution id for the checker's extraction / entailment calls."""
 
 _DEFAULT_SEARCH_LIMIT: Final[int] = 5
@@ -150,7 +151,28 @@ class KnowledgeSubstrateGroundingChecker:
                 else "knowledge_service_not_wired",
             )
             return await self._delegate(deliverable_content, execution_id, project_id)
+        return await self._check_with_substrate(
+            context, deliverable_content, execution_id, project_id
+        )
 
+    async def _check_with_substrate(
+        self,
+        context: GroundingSubstrateContext,
+        deliverable_content: NotBlankStr,
+        execution_id: NotBlankStr,
+        project_id: NotBlankStr | None,
+    ) -> tuple[UngroundedClaim, ...]:
+        """Extract claims and evaluate each against the wired corpus.
+
+        Degrades to the heuristic fallback when claim-extraction fails.
+
+        Returns:
+            The ungrounded claims; an empty tuple when extraction yields none.
+
+        Raises:
+            asyncio.CancelledError: Propagated when extraction, corpus search,
+                or entailment is cancelled.
+        """
         try:
             claims = await self._extract_claims(
                 context, deliverable_content, execution_id
@@ -174,15 +196,34 @@ class KnowledgeSubstrateGroundingChecker:
                 execution_id=execution_id,
             )
             return ()
+        return await self._evaluate_claims_concurrently(
+            context, claims, execution_id, project_id
+        )
 
-        # Fan the per-claim corpus search + entailment round-trips out
-        # concurrently: each claim costs two LLM calls, so a serial loop
-        # makes worst-case latency scale linearly with claim count (up to
-        # MAX_CLAIMS) and starves later claims under timeout pressure.
-        # ``_evaluate_claim`` is fail-soft (it swallows everything but
-        # critical errors and cancellation), so a single bad claim never
-        # aborts the group. Results are slotted by index to keep output
-        # order deterministic regardless of completion order.
+    async def _evaluate_claims_concurrently(
+        self,
+        context: GroundingSubstrateContext,
+        claims: tuple[str, ...],
+        execution_id: NotBlankStr,
+        project_id: NotBlankStr | None,
+    ) -> tuple[UngroundedClaim, ...]:
+        """Evaluate every extracted claim concurrently, order-preserving.
+
+        Fans the per-claim corpus search + entailment round-trips out
+        concurrently: each claim costs two LLM calls, so a serial loop makes
+        worst-case latency scale linearly with claim count (up to MAX_CLAIMS)
+        and starves later claims under timeout pressure. ``_evaluate_claim``
+        is fail-soft (it swallows everything but critical errors and
+        cancellation), so a single bad claim never aborts the group. Results
+        are slotted by index to keep output order deterministic regardless of
+        completion order.
+
+        Returns:
+            The flagged claims in extracted order.
+
+        Raises:
+            asyncio.CancelledError: Propagated from a cancelled child task.
+        """
         flagged: list[UngroundedClaim | None] = [None] * len(claims)
 
         async def _evaluate_into(index: int, claim: str) -> None:
@@ -286,9 +327,30 @@ class KnowledgeSubstrateGroundingChecker:
             asyncio.CancelledError: Propagated when the corpus search or
                 entailment call is cancelled.
         """
+        hits = await self._search_corpus(context, claim, execution_id, project_id)
+        if not hits:
+            return None
+        return await self._entail_claim(context, claim, hits, execution_id)
+
+    async def _search_corpus(
+        self,
+        context: GroundingSubstrateContext,
+        claim: str,
+        execution_id: NotBlankStr,
+        project_id: NotBlankStr | None,
+    ) -> tuple[KnowledgeHit, ...]:
+        """Retrieve corpus evidence for one claim (fail-soft).
+
+        Returns:
+            The retrieved hits; an empty tuple when the corpus is empty, the
+            knowledge service is unwired, or the search fails transiently.
+
+        Raises:
+            asyncio.CancelledError: Propagated when the search is cancelled.
+        """
         knowledge_service = context.knowledge_service
         if knowledge_service is None:  # pragma: no cover - guarded by caller
-            return None
+            return ()
         try:
             hits = await knowledge_service.search(
                 query=NotBlankStr(claim),
@@ -306,15 +368,32 @@ class KnowledgeSubstrateGroundingChecker:
                 error=safe_error_description(exc),
                 policy="skip_claim",
             )
-            return None
-
+            return ()
         if not hits:
             logger.debug(
                 RED_TEAM_GROUNDING_CORPUS_EMPTY,
                 execution_id=execution_id,
             )
-            return None
+        return hits
 
+    async def _entail_claim(
+        self,
+        context: GroundingSubstrateContext,
+        claim: str,
+        hits: tuple[KnowledgeHit, ...],
+        execution_id: NotBlankStr,
+    ) -> UngroundedClaim | None:
+        """Judge one claim against its evidence; flag it only if unsupported.
+
+        Returns:
+            An :class:`UngroundedClaim` when the verdict is an at-or-above-floor
+            "unsupported"; ``None`` otherwise (transient failure, an unparseable
+            verdict, or a supported / uncertain verdict).
+
+        Raises:
+            asyncio.CancelledError: Propagated when the entailment call is
+                cancelled.
+        """
         try:
             response = await self._complete_entailment(
                 context,
@@ -414,7 +493,7 @@ class KnowledgeSubstrateGroundingChecker:
         """
         async with cost_recording_scope(
             cost_tracker=context.cost_tracker,
-            agent_id=NotBlankStr(_GROUNDING_AGENT_ID),
+            agent_id=_GROUNDING_AGENT_ID,
             task_id=execution_id,
             call_category=LLMCallCategory.SYSTEM,
         ):

--- a/src/synthorg/security/redteam/grounding/substrate.py
+++ b/src/synthorg/security/redteam/grounding/substrate.py
@@ -49,11 +49,10 @@ from synthorg.providers.models import (
     ToolDefinition,
 )
 from synthorg.security.redteam.grounding._llm import (
-    ENTAILMENT_MAX_TOKENS,
+    ENTAILMENT_CONFIG,
     EXTRACT_CLAIMS_TOOL,
-    EXTRACTION_MAX_TOKENS,
+    EXTRACTION_CONFIG,
     GROUNDING_VERDICT_TOOL,
-    LLM_TEMPERATURE,
     MAX_DELIVERABLE_CHARS,
     build_entailment_messages,
     build_extraction_messages,
@@ -258,12 +257,10 @@ class KnowledgeSubstrateGroundingChecker:
                 original_length=len(deliverable_content),
                 cap=MAX_DELIVERABLE_CHARS,
             )
-        response = await self._complete(
+        response = await self._complete_extraction(
             context,
             execution_id,
             messages=build_extraction_messages(deliverable_content),
-            tools=[EXTRACT_CLAIMS_TOOL],
-            max_tokens=EXTRACTION_MAX_TOKENS,
         )
         return parse_extracted_claims(response)
 
@@ -319,12 +316,10 @@ class KnowledgeSubstrateGroundingChecker:
             return None
 
         try:
-            response = await self._complete(
+            response = await self._complete_entailment(
                 context,
                 execution_id,
                 messages=build_entailment_messages(claim, hits),
-                tools=[GROUNDING_VERDICT_TOOL],
-                max_tokens=ENTAILMENT_MAX_TOKENS,
             )
         except asyncio.CancelledError:
             raise
@@ -363,14 +358,54 @@ class KnowledgeSubstrateGroundingChecker:
             expected_source_kind=None,
         )
 
-    async def _complete(
+    async def _complete_extraction(
+        self,
+        context: GroundingSubstrateContext,
+        execution_id: NotBlankStr,
+        *,
+        messages: list[ChatMessage],
+    ) -> CompletionResponse:
+        """Run the claim-extraction completion under a cost-recording scope.
+
+        Returns:
+            The provider's completion response.
+        """
+        return await self._run_completion(
+            context,
+            execution_id,
+            messages=messages,
+            tools=[EXTRACT_CLAIMS_TOOL],
+            config=EXTRACTION_CONFIG,
+        )
+
+    async def _complete_entailment(
+        self,
+        context: GroundingSubstrateContext,
+        execution_id: NotBlankStr,
+        *,
+        messages: list[ChatMessage],
+    ) -> CompletionResponse:
+        """Run the per-claim entailment completion under a cost-recording scope.
+
+        Returns:
+            The provider's completion response.
+        """
+        return await self._run_completion(
+            context,
+            execution_id,
+            messages=messages,
+            tools=[GROUNDING_VERDICT_TOOL],
+            config=ENTAILMENT_CONFIG,
+        )
+
+    async def _run_completion(
         self,
         context: GroundingSubstrateContext,
         execution_id: NotBlankStr,
         *,
         messages: list[ChatMessage],
         tools: list[ToolDefinition],
-        max_tokens: int,
+        config: CompletionConfig,
     ) -> CompletionResponse:
         """Run one structured completion under a cost-recording scope.
 
@@ -387,8 +422,5 @@ class KnowledgeSubstrateGroundingChecker:
                 messages,
                 context.model_id,
                 tools=tools,
-                config=CompletionConfig(
-                    temperature=LLM_TEMPERATURE,
-                    max_tokens=max_tokens,
-                ),
+                config=config,
             )

--- a/tests/unit/engine/classification/test_semantic_detectors.py
+++ b/tests/unit/engine/classification/test_semantic_detectors.py
@@ -176,6 +176,29 @@ class TestParseFindingsHelper:
         findings = parse_findings(raw, ErrorCategory.CONTEXT_OMISSION)
         assert findings[0].turn_range is None
 
+    def test_whitespace_only_description_skipped(self) -> None:
+        raw = json.dumps([{"description": "   ", "severity": "high"}])
+        findings = parse_findings(raw, ErrorCategory.NUMERICAL_DRIFT)
+        assert findings == ()
+
+    def test_description_stripped(self) -> None:
+        raw = json.dumps([{"description": "  padded  "}])
+        findings = parse_findings(raw, ErrorCategory.CONTEXT_OMISSION)
+        assert findings[0].description == "padded"
+
+    def test_boolean_turn_values_ignored(self) -> None:
+        raw = json.dumps(
+            [
+                {
+                    "description": "Issue",
+                    "turn_start": True,
+                    "turn_end": True,
+                },
+            ]
+        )
+        findings = parse_findings(raw, ErrorCategory.CONTEXT_OMISSION)
+        assert findings[0].turn_range is None
+
 
 # ── Protocol compliance ────────────────────────────────────────
 

--- a/tests/unit/engine/classification/test_semantic_detectors.py
+++ b/tests/unit/engine/classification/test_semantic_detectors.py
@@ -13,6 +13,7 @@ from synthorg.budget.coordination_config import (
 )
 from synthorg.core.agent import AgentIdentity, ModelConfig
 from synthorg.core.completion_enums import FinishReason
+from synthorg.engine.classification._parsing import parse_findings
 from synthorg.engine.classification.budget_tracker import (
     ClassificationBudgetTracker,
 )
@@ -26,7 +27,6 @@ from synthorg.engine.classification.semantic_detectors import (
     SemanticCoordinationDetector,
     SemanticMissingReferenceDetector,
     SemanticNumericalVerificationDetector,
-    _parse_findings,
 )
 from synthorg.engine.context import AgentContext
 from synthorg.engine.loop_protocol import (
@@ -99,7 +99,7 @@ def _mock_provider(content: str = "[]") -> AsyncMock:
     return provider
 
 
-# ── _parse_findings ────────────────────────────────────────────
+# ── parse_findings ────────────────────────────────────────────
 
 
 @pytest.mark.unit
@@ -118,7 +118,7 @@ class TestParseFindingsHelper:
                 },
             ]
         )
-        findings = _parse_findings(raw, ErrorCategory.LOGICAL_CONTRADICTION)
+        findings = parse_findings(raw, ErrorCategory.LOGICAL_CONTRADICTION)
         assert len(findings) == 1
         assert findings[0].category == ErrorCategory.LOGICAL_CONTRADICTION
         assert findings[0].severity == ErrorSeverity.HIGH
@@ -126,22 +126,22 @@ class TestParseFindingsHelper:
         assert findings[0].turn_range == (0, 3)
 
     def test_empty_json_array(self) -> None:
-        findings = _parse_findings("[]", ErrorCategory.LOGICAL_CONTRADICTION)
+        findings = parse_findings("[]", ErrorCategory.LOGICAL_CONTRADICTION)
         assert findings == ()
 
     def test_none_input(self) -> None:
-        findings = _parse_findings(None, ErrorCategory.LOGICAL_CONTRADICTION)
+        findings = parse_findings(None, ErrorCategory.LOGICAL_CONTRADICTION)
         assert findings == ()
 
     def test_malformed_json(self) -> None:
-        findings = _parse_findings(
+        findings = parse_findings(
             "not json",
             ErrorCategory.LOGICAL_CONTRADICTION,
         )
         assert findings == ()
 
     def test_non_array_json(self) -> None:
-        findings = _parse_findings(
+        findings = parse_findings(
             '{"key": "value"}',
             ErrorCategory.LOGICAL_CONTRADICTION,
         )
@@ -154,13 +154,13 @@ class TestParseFindingsHelper:
                 {"description": "Valid finding", "severity": "medium"},
             ]
         )
-        findings = _parse_findings(raw, ErrorCategory.NUMERICAL_DRIFT)
+        findings = parse_findings(raw, ErrorCategory.NUMERICAL_DRIFT)
         assert len(findings) == 1
         assert findings[0].description == "Valid finding"
 
     def test_default_severity(self) -> None:
         raw = json.dumps([{"description": "Some issue"}])
-        findings = _parse_findings(raw, ErrorCategory.CONTEXT_OMISSION)
+        findings = parse_findings(raw, ErrorCategory.CONTEXT_OMISSION)
         assert findings[0].severity == ErrorSeverity.MEDIUM
 
     def test_invalid_turn_range_ignored(self) -> None:
@@ -173,7 +173,7 @@ class TestParseFindingsHelper:
                 },
             ]
         )
-        findings = _parse_findings(raw, ErrorCategory.CONTEXT_OMISSION)
+        findings = parse_findings(raw, ErrorCategory.CONTEXT_OMISSION)
         assert findings[0].turn_range is None
 
 
@@ -459,7 +459,7 @@ class TestSemanticDetectorBehavior:
 
 
 @pytest.mark.unit
-class TestSec1SemanticDetectorFences:
+class TestUntrustedContentFences:
     """Each detector wraps conversation text in ``<task-data>`` + directive."""
 
     @pytest.mark.parametrize(

--- a/tests/unit/engine/classification/test_semantic_detectors.py
+++ b/tests/unit/engine/classification/test_semantic_detectors.py
@@ -235,6 +235,49 @@ class TestSemanticDetectorCategories:
         assert d.category == ErrorCategory.COORDINATION_FAILURE
 
 
+@pytest.mark.unit
+class TestSemanticDetectorPromptClassId:
+    """Each detector exposes a distinct, stable prompt-class identifier."""
+
+    @pytest.mark.parametrize(
+        ("cls", "expected"),
+        [
+            (
+                SemanticContradictionDetector,
+                "semantic_detector.logical_contradiction",
+            ),
+            (
+                SemanticNumericalVerificationDetector,
+                "semantic_detector.numerical_drift",
+            ),
+            (
+                SemanticMissingReferenceDetector,
+                "semantic_detector.context_omission",
+            ),
+            (
+                SemanticCoordinationDetector,
+                "semantic_detector.coordination_failure",
+            ),
+        ],
+    )
+    def test_prompt_class_id(self, cls: type, expected: str) -> None:
+        detector = cls(provider=_mock_provider(), model_id="test-small-001")
+        assert detector.prompt_class_id == expected
+
+    def test_prompt_class_ids_are_distinct(self) -> None:
+        classes = (
+            SemanticContradictionDetector,
+            SemanticNumericalVerificationDetector,
+            SemanticMissingReferenceDetector,
+            SemanticCoordinationDetector,
+        )
+        ids = {
+            cls(provider=_mock_provider(), model_id="test-small-001").prompt_class_id
+            for cls in classes
+        }
+        assert len(ids) == len(classes)
+
+
 # ── Detection behavior ─────────────────────────────────────────
 
 

--- a/tests/unit/engine/compaction/test_llm_summarizer.py
+++ b/tests/unit/engine/compaction/test_llm_summarizer.py
@@ -32,7 +32,7 @@ class _FakeProvider:
     ) -> None:
         self._content = content
         self._error = error
-        self.calls: list[tuple[list[ChatMessage], str]] = []
+        self.calls: list[tuple[list[ChatMessage], str, CompletionConfig | None]] = []
 
     async def complete(
         self,
@@ -41,7 +41,7 @@ class _FakeProvider:
         *,
         config: CompletionConfig | None = None,
     ) -> CompletionResponse:
-        self.calls.append((messages, model))
+        self.calls.append((messages, model, config))
         if self._error is not None:
             raise self._error
         return _response(self._content)
@@ -68,6 +68,15 @@ class TestLLMSummarizer:
         )
         assert out == "A concise semantic summary."
         assert provider.calls
+
+    async def test_default_sampling_params_match_compaction_defaults(self) -> None:
+        provider = _FakeProvider(content="summary")
+        summarizer = LLMSummarizer(provider=provider, model="example-small-001")
+        await summarizer.summarize(_archivable(), fallback_text=_FALLBACK)
+        _, _, config = provider.calls[0]
+        assert config is not None
+        assert config.temperature == pytest.approx(0.3)
+        assert config.max_tokens == 500
 
     async def test_empty_content_falls_back(self) -> None:
         provider = _FakeProvider(content="   ")

--- a/tests/unit/engine/compaction/test_llm_summarizer.py
+++ b/tests/unit/engine/compaction/test_llm_summarizer.py
@@ -3,7 +3,12 @@
 import pytest
 
 from synthorg.core.completion_enums import FinishReason
-from synthorg.engine.compaction.llm_summarizer import LLMSummarizer
+from synthorg.engine.compaction.llm_summarizer import (
+    _DEFAULT_MAX_TOKENS,
+    _DEFAULT_TEMPERATURE,
+    LLMSummarizer,
+)
+from synthorg.engine.compaction.models import CompactionConfig
 from synthorg.providers.enums import MessageRole
 from synthorg.providers.models import (
     ChatMessage,
@@ -77,6 +82,28 @@ class TestLLMSummarizer:
         assert config is not None
         assert config.temperature == pytest.approx(0.3)
         assert config.max_tokens == 500
+
+    async def test_explicit_args_override_defaults(self) -> None:
+        provider = _FakeProvider(content="summary")
+        summarizer = LLMSummarizer(
+            provider=provider,
+            model="example-small-001",
+            temperature=0.7,
+            max_tokens=250,
+        )
+        await summarizer.summarize(_archivable(), fallback_text=_FALLBACK)
+        _, _, config = provider.calls[0]
+        assert config is not None
+        assert config.temperature == pytest.approx(0.7)
+        assert config.max_tokens == 250
+
+    def test_module_defaults_mirror_compaction_config(self) -> None:
+        # The module Finals are duplicated from the domain config; guard the
+        # duplication so a CompactionConfig default change cannot silently
+        # diverge a directly-constructed summariser from the wired path.
+        defaults = CompactionConfig()
+        assert defaults.llm_summary_temperature == _DEFAULT_TEMPERATURE
+        assert defaults.llm_summary_max_tokens == _DEFAULT_MAX_TOKENS
 
     async def test_empty_content_falls_back(self) -> None:
         provider = _FakeProvider(content="   ")

--- a/tests/unit/memory/retrieval/hierarchical/test_supervisor.py
+++ b/tests/unit/memory/retrieval/hierarchical/test_supervisor.py
@@ -288,3 +288,28 @@ class TestLlmRetryResponseStrategyValidator:
             {"alternative_strategy": value},
         )
         assert response.alternative_strategy is None
+
+
+@pytest.mark.unit
+class TestSupervisorRouterCompletionBounds:
+    """Both LLM calls carry an explicit, bounded ``max_tokens``."""
+
+    async def test_route_pins_max_tokens(self) -> None:
+        provider = _mock_provider(
+            json.dumps({"workers": ["semantic"], "reason": "broad"}),
+        )
+        supervisor = SupervisorRouter(provider=provider, model="test-small-001")
+        await supervisor.route(_make_query())
+        config = provider.complete.call_args.kwargs["config"]
+        assert config.temperature == 0.0
+        assert config.max_tokens == 256
+
+    async def test_retry_pins_max_tokens(self) -> None:
+        provider = _mock_provider(
+            json.dumps({"retry": True, "reason": "too narrow"}),
+        )
+        supervisor = SupervisorRouter(provider=provider, model="test-small-001")
+        result = FinalRetrievalResult(candidates=(_make_candidate(0.1),))
+        await supervisor.evaluate_for_retry(_make_query(), result)
+        config = provider.complete.call_args.kwargs["config"]
+        assert config.max_tokens == 256

--- a/tests/unit/memory/retrieval/hierarchical/test_supervisor.py
+++ b/tests/unit/memory/retrieval/hierarchical/test_supervisor.py
@@ -300,7 +300,8 @@ class TestSupervisorRouterCompletionBounds:
         )
         supervisor = SupervisorRouter(provider=provider, model="test-small-001")
         await supervisor.route(_make_query())
-        config = provider.complete.call_args.kwargs["config"]
+        config = provider.complete.call_args.kwargs.get("config")
+        assert config is not None
         assert config.temperature == 0.0
         assert config.max_tokens == 256
 
@@ -311,5 +312,7 @@ class TestSupervisorRouterCompletionBounds:
         supervisor = SupervisorRouter(provider=provider, model="test-small-001")
         result = FinalRetrievalResult(candidates=(_make_candidate(0.1),))
         await supervisor.evaluate_for_retry(_make_query(), result)
-        config = provider.complete.call_args.kwargs["config"]
+        config = provider.complete.call_args.kwargs.get("config")
+        assert config is not None
+        assert config.temperature == 0.0
         assert config.max_tokens == 256

--- a/tests/unit/memory/retrieval/reranking/test_llm_reranker.py
+++ b/tests/unit/memory/retrieval/reranking/test_llm_reranker.py
@@ -108,6 +108,20 @@ class TestLLMQuerySpecificReranker:
         assert result[1].combined_score == 0.9
 
     @pytest.mark.unit
+    async def test_rerank_pins_bounded_max_tokens(self) -> None:
+        provider = _mock_provider([1, 0])
+        reranker = LLMQuerySpecificReranker(
+            provider=provider,
+            model="test-small-001",
+        )
+        c1 = _make_candidate("mem-1", 0.9)
+        c2 = _make_candidate("mem-2", 0.7)
+        await reranker.rerank(_make_query(), (c1, c2))
+        config = provider.complete.call_args.kwargs["config"]
+        assert config.temperature == 0.0
+        assert config.max_tokens == 512
+
+    @pytest.mark.unit
     async def test_rerank_single_candidate_passthrough(self) -> None:
         provider = _mock_provider([0])
         reranker = LLMQuerySpecificReranker(

--- a/tests/unit/memory/retrieval/reranking/test_llm_reranker.py
+++ b/tests/unit/memory/retrieval/reranking/test_llm_reranker.py
@@ -117,9 +117,10 @@ class TestLLMQuerySpecificReranker:
         c1 = _make_candidate("mem-1", 0.9)
         c2 = _make_candidate("mem-2", 0.7)
         await reranker.rerank(_make_query(), (c1, c2))
-        config = provider.complete.call_args.kwargs["config"]
+        config = provider.complete.call_args.kwargs.get("config")
+        assert config is not None
         assert config.temperature == 0.0
-        assert config.max_tokens == 512
+        assert config.max_tokens == 4096
 
     @pytest.mark.unit
     async def test_rerank_single_candidate_passthrough(self) -> None:

--- a/tests/unit/memory/retrieval/reranking/test_llm_reranker.py
+++ b/tests/unit/memory/retrieval/reranking/test_llm_reranker.py
@@ -223,6 +223,30 @@ class TestLLMQuerySpecificReranker:
         assert [c.entry.id for c in result2] == ["mem-2", "mem-1"]
 
     @pytest.mark.unit
+    async def test_rerank_duplicate_cached_ids_falls_through(self) -> None:
+        provider = _mock_provider([1, 0])
+        cache = RerankerCache()
+        reranker = LLMQuerySpecificReranker(
+            provider=provider,
+            model="test-small-001",
+            cache=cache,
+        )
+        c1 = _make_candidate("mem-1", 0.9)
+        c2 = _make_candidate("mem-2", 0.7)
+        query = _make_query()
+        # Poison the cache with an ordering whose ID set matches the
+        # live candidates but carries a duplicate (a non-permutation).
+        key = _build_cache_key(query.text, ("mem-1", "mem-2"))
+        await cache.put(key, ("mem-1", "mem-1", "mem-2"))
+
+        result = await reranker.rerank(query, (c1, c2))
+
+        # The duplicate-bearing entry must be ignored: a fresh LLM
+        # rerank runs instead of replaying the non-permutation.
+        provider.complete.assert_awaited_once()
+        assert [c.entry.id for c in result] == ["mem-2", "mem-1"]
+
+    @pytest.mark.unit
     async def test_rerank_empty_returns_empty(self) -> None:
         provider = _mock_provider([])
         reranker = LLMQuerySpecificReranker(

--- a/tests/unit/security/redteam/test_grounding_substrate.py
+++ b/tests/unit/security/redteam/test_grounding_substrate.py
@@ -265,33 +265,6 @@ class TestEscalation:
         assert claim.confidence == pytest.approx(0.95)
         assert "47%" in claim.excerpt
 
-    async def test_extraction_and_entailment_use_purpose_distinct_configs(
-        self,
-    ) -> None:
-        provider = _provider(
-            [
-                _extract_response(["Revenue grew 47% last quarter."]),
-                _verdict_response("unsupported", 0.95),
-            ]
-        )
-        checker = _checker(
-            _context(provider=provider, knowledge_service=_knowledge((_hit(),)))
-        )
-
-        await checker.check(
-            deliverable_content=_NUMERIC_DELIVERABLE,
-            execution_id=_EXEC,
-            project_id=_PROJECT,
-        )
-
-        extraction_call, entailment_call = provider.complete.call_args_list
-        assert extraction_call.kwargs["config"] is EXTRACTION_CONFIG
-        assert extraction_call.kwargs["config"].max_tokens == EXTRACTION_MAX_TOKENS
-        assert extraction_call.kwargs["tools"][0].name == EXTRACT_CLAIMS_TOOL_NAME
-        assert entailment_call.kwargs["config"] is ENTAILMENT_CONFIG
-        assert entailment_call.kwargs["config"].max_tokens == ENTAILMENT_MAX_TOKENS
-        assert entailment_call.kwargs["tools"][0].name == GROUNDING_VERDICT_TOOL_NAME
-
     async def test_search_scoped_to_project(self) -> None:
         knowledge = _knowledge((_hit(),))
         provider = _provider(
@@ -520,3 +493,36 @@ class TestSearchLimitGuard:
     def test_non_positive_search_limit_is_rejected(self) -> None:
         with pytest.raises(ValueError, match="search_limit"):
             KnowledgeSubstrateGroundingChecker(resolver=lambda: None, search_limit=0)
+
+
+class TestSubstrateCompletionRouting:
+    """Extraction and entailment each route through their own sampling config."""
+
+    async def test_extraction_and_entailment_use_purpose_distinct_configs(
+        self,
+    ) -> None:
+        provider = _provider(
+            [
+                _extract_response(["Revenue grew 47% last quarter."]),
+                _verdict_response("unsupported", 0.95),
+            ]
+        )
+        checker = _checker(
+            _context(provider=provider, knowledge_service=_knowledge((_hit(),)))
+        )
+
+        await checker.check(
+            deliverable_content=_NUMERIC_DELIVERABLE,
+            execution_id=_EXEC,
+            project_id=_PROJECT,
+        )
+
+        extraction_call, entailment_call = provider.complete.call_args_list
+        extraction_config = extraction_call.kwargs.get("config")
+        entailment_config = entailment_call.kwargs.get("config")
+        assert extraction_config is EXTRACTION_CONFIG
+        assert extraction_config.max_tokens == EXTRACTION_MAX_TOKENS
+        assert extraction_call.kwargs["tools"][0].name == EXTRACT_CLAIMS_TOOL_NAME
+        assert entailment_config is ENTAILMENT_CONFIG
+        assert entailment_config.max_tokens == ENTAILMENT_MAX_TOKENS
+        assert entailment_call.kwargs["tools"][0].name == GROUNDING_VERDICT_TOOL_NAME

--- a/tests/unit/security/redteam/test_grounding_substrate.py
+++ b/tests/unit/security/redteam/test_grounding_substrate.py
@@ -22,7 +22,14 @@ from synthorg.providers.models import (
     ToolCall,
 )
 from synthorg.providers.protocol import CompletionProvider
-from synthorg.security.redteam.grounding._llm import EXTRACT_CLAIMS_TOOL_NAME
+from synthorg.security.redteam.grounding._llm import (
+    ENTAILMENT_CONFIG,
+    ENTAILMENT_MAX_TOKENS,
+    EXTRACT_CLAIMS_TOOL_NAME,
+    EXTRACTION_CONFIG,
+    EXTRACTION_MAX_TOKENS,
+    GROUNDING_VERDICT_TOOL_NAME,
+)
 from synthorg.security.redteam.grounding.models import UngroundedClaim
 from synthorg.security.redteam.grounding.protocol import GroundingChecker
 from synthorg.security.redteam.grounding.resolver import GroundingSubstrateContext
@@ -257,6 +264,33 @@ class TestEscalation:
         assert claim.source == "knowledge_substrate"
         assert claim.confidence == pytest.approx(0.95)
         assert "47%" in claim.excerpt
+
+    async def test_extraction_and_entailment_use_purpose_distinct_configs(
+        self,
+    ) -> None:
+        provider = _provider(
+            [
+                _extract_response(["Revenue grew 47% last quarter."]),
+                _verdict_response("unsupported", 0.95),
+            ]
+        )
+        checker = _checker(
+            _context(provider=provider, knowledge_service=_knowledge((_hit(),)))
+        )
+
+        await checker.check(
+            deliverable_content=_NUMERIC_DELIVERABLE,
+            execution_id=_EXEC,
+            project_id=_PROJECT,
+        )
+
+        extraction_call, entailment_call = provider.complete.call_args_list
+        assert extraction_call.kwargs["config"] is EXTRACTION_CONFIG
+        assert extraction_call.kwargs["config"].max_tokens == EXTRACTION_MAX_TOKENS
+        assert extraction_call.kwargs["tools"][0].name == EXTRACT_CLAIMS_TOOL_NAME
+        assert entailment_call.kwargs["config"] is ENTAILMENT_CONFIG
+        assert entailment_call.kwargs["config"].max_tokens == ENTAILMENT_MAX_TOKENS
+        assert entailment_call.kwargs["tools"][0].name == GROUNDING_VERDICT_TOOL_NAME
 
     async def test_search_scoped_to_project(self) -> None:
         knowledge = _knowledge((_hit(),))


### PR DESCRIPTION
## Summary

Epic #2490 Wave 0: finalises five prompt-class call-site shapes so the later per-class metadata sweep (#2496) edits clean, consistent surfaces. Each fix is an independent correctness/consistency win.

- **`LLMSummarizer`**: `temperature`/`max_tokens` now derive from module `Final`s (0.3 / 500) mirroring `CompactionConfig`, matching the other 37 prompt classes (a drift-guard test pins the duplication).
- **`SupervisorRouter`**: routing + retry calls carry an explicit `max_tokens=256`.
- **`LLMQuerySpecificReranker`**: explicit `max_tokens=4096`, sized to the full pre-truncation candidate pool (`max_memories x candidate_pool_multiplier`, up to 1000), so reranking is not silently disabled by truncation on large pools.
- **`KnowledgeSubstrateGroundingChecker`**: the two-`max_tokens` `_complete()` helper split into purpose-distinct `_complete_extraction` / `_complete_entailment` over a shared transport, each owning a module-level `CompletionConfig`. Public `check()` shape unchanged.
- **Semantic detectors**: a per-subclass `prompt_class_id` (`NotBlankStr`) on the ABC, distinct per purpose, as the Wave-0 hook #2496 will fill with `ModelPinMetadata`.

No behaviour change to existing successful paths beyond the explicit bounds added.

## Review coverage

Pre-PR review ran 15 specialised agents (correctness, conventions, security, logging, resilience, async, tests, docs, issue-resolution, ghost-wiring, ...). Issue-resolution-verifier confirmed all five acceptance criteria RESOLVED with no later-wave overreach; security APPROVE. All in-scope findings were addressed, including the corrected reranker bound, a JSON-parsing split into a sibling module, `Final[CompletionConfig]` annotations, `NotBlankStr` on `model` params, strengthened tests, and pre-existing observability + comment-accuracy fixes in the surrounding code.

## Test plan

- `ruff check` / `ruff format` clean; `mypy --strict` clean on all changed source + tests.
- Affected unit suites green (compaction, memory/retrieval, security/redteam, engine/classification); new tests assert the forwarded `CompletionConfig` (bounds, temperature, purpose-distinct configs, default/explicit args, drift guard, distinct `prompt_class_id`s).
- Gates green: module-size budget, magic-numbers, completion-config-temperature, architecture-drift, import-layering, migration-framing, review-origin, runtime-stats freshness.

Closes #2492
