### PR TITLE
feat: complete epic #2490 (per-purpose alerts + end-to-end validation)

### DIFF
--- a/docs/DESIGN_SPEC.md
+++ b/docs/DESIGN_SPEC.md
@@ -39,7 +39,7 @@ The design specification has been split into focused documentation pages for bet
 | [Semantic Ontology](design/ontology.md) | Entity Definitions, Versioning, Drift | Shared vocabulary, decorator, backend, bootstrap, drift detection |
 | [Providers](design/providers.md) | Provider abstraction, routing | LLM provider layer, LiteLLM integration, multi-provider resolution |
 | [Budget & Cost](design/budget.md) | Budget hierarchy, cost tracking, CFO, reporting | Per-agent cost enforcement, quota degradation, risk budget, PTE |
-| [LLM Call Analytics & Coordination Metrics](design/coordination-metrics.md) | Per-call tracking, orchestration ratio, coordination error taxonomy | Call categorisation, the coordination metrics suite, and the multi-agent tuning signals complementing budget controls |
+| [LLM Call Analytics & Coordination Metrics](design/coordination-metrics.md) | Per-call tracking, orchestration ratio, per-purpose cost/latency alerts, coordination error taxonomy | Call categorisation, the coordination metrics suite, and the multi-agent tuning signals complementing budget controls |
 | [Tools & Capabilities](design/tools.md) | Tool categories, sandboxing, MCP, trust | Layered sandbox, progressive disclosure, action types, access levels |
 | [Toolsmith (Self-Extending Toolkit)](design/toolsmith.md) | Runtime MCP tool-surface extension | Capability-gap detection, governed proposal/apply cycle, human-approval gating for new tools |
 | [Integrations](design/integrations.md) | OAuth flows, MCP catalog, webhooks, tunnel, health | External service integrations: OAuth provider connections, MCP server catalog + install, outbound webhooks, ngrok-style tunnel, integration-health rollups |

--- a/docs/design/coordination-metrics.md
+++ b/docs/design/coordination-metrics.md
@@ -106,12 +106,23 @@ The **orchestration ratio** (`coordination / total`) is surfaced in metrics and 
         - per_provider                     # provider reliability and cost comparison
         - orchestration_ratio              # coordination vs productive tokens
       alerts:
-        orchestration_ratio:
+        orchestration_alerts:
           info: 0.30                       # info if coordination > 30% of total
           warn: 0.50                       # warn if coordination > 50% of total
           critical: 0.70                   # critical if coordination > 70% of total
-        retry_rate_warn: 0.1               # warn if > 10% of calls need retries
+        retry_alerts:
+          warn_rate: 0.1                   # warn if > 10% of calls need retries
+        prompt_class_alerts:               # per-prompt-purpose ceilings (opt-in)
+          cost_warn: null                  # budget-currency total-cost ceiling, or null
+          p95_latency_warn_ms: null        # p95 latency ceiling in ms, or null
+          min_seconds_between_alerts: 300  # re-alert throttle window per purpose
     ```
+
+    The `alerts` keys mirror the `CallAnalyticsConfig` sub-models
+    (`orchestration_alerts`, `retry_alerts`, `prompt_class_alerts`). A
+    per-purpose alert is opt-in: with both ceilings `null` no notification
+    fires, and a purpose re-alerts at most once per
+    `min_seconds_between_alerts` so a polled dashboard cannot storm the sinks.
 
     Analytics metadata is append-only and never blocks execution. Failed analytics writes are
     logged and skipped; the agent's task is never delayed by telemetry.

--- a/src/synthorg/budget/_alert_dispatch.py
+++ b/src/synthorg/budget/_alert_dispatch.py
@@ -1,0 +1,62 @@
+# module-kind: code
+"""Shared best-effort dispatch for budget WARNING notifications."""
+
+from synthorg.core.critical_errors import reraise_critical
+from synthorg.notifications.dispatcher import NotificationDispatcher
+from synthorg.observability import get_logger, safe_error_description
+
+logger = get_logger(__name__)
+
+
+async def dispatch_budget_alert(
+    dispatcher: NotificationDispatcher,
+    *,
+    title: str,
+    body: str,
+    on_failure_event: str,
+    **failure_context: object,
+) -> bool:
+    """Dispatch a budget WARNING notification.
+
+    A dispatch failure is logged with ``on_failure_event`` (plus any
+    ``failure_context``) and swallowed so a flaky sink never breaks the caller;
+    ``MemoryError`` / ``RecursionError`` re-raise first. The boolean return lets
+    a rate-limited caller refund its admission slot when the dispatch failed.
+
+    Args:
+        dispatcher: Notification dispatcher.
+        title: Notification title.
+        body: Human-readable alert body.
+        on_failure_event: Event constant logged when dispatch fails.
+        failure_context: Extra structured fields for the failure log.
+
+    Returns:
+        ``True`` when the notification was dispatched; ``False`` on a swallowed
+        failure.
+    """
+    from synthorg.notifications.models import (  # noqa: PLC0415
+        Notification,
+        NotificationCategory,
+        NotificationSeverity,
+    )
+
+    try:
+        await dispatcher.dispatch(
+            Notification(
+                category=NotificationCategory.BUDGET,
+                severity=NotificationSeverity.WARNING,
+                title=title,
+                body=body,
+                source="budget.call_analytics",
+            ),
+        )
+    except Exception as exc:  # noqa: BLE001 -- criticals re-raised
+        reraise_critical(exc)
+        logger.warning(
+            on_failure_event,
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
+            **failure_context,
+        )
+        return False
+    return True

--- a/src/synthorg/budget/call_analytics.py
+++ b/src/synthorg/budget/call_analytics.py
@@ -7,6 +7,7 @@ from collections import Counter, defaultdict
 from datetime import datetime
 from typing import Final, NamedTuple
 
+from synthorg.budget._alert_dispatch import dispatch_budget_alert
 from synthorg.budget.call_analytics_config import (
     CallAnalyticsConfig,
     PromptClassAlertConfig,
@@ -29,13 +30,12 @@ from synthorg.budget.tracker_protocol import (
     CostTrackerProtocol,
     collect_all_records,
 )
-from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.resilience import SlidingWindowEventLimiter
 from synthorg.core.types import NotBlankStr
 from synthorg.llm.model_tier_policy import tier_for_purpose
 from synthorg.llm.prompt_purpose import PromptPurposeId
 from synthorg.notifications.dispatcher import NotificationDispatcher
-from synthorg.observability import get_logger, safe_error_description
+from synthorg.observability import get_logger
 from synthorg.observability.events.analytics import (
     ANALYTICS_AGGREGATION_COMPUTED,
     ANALYTICS_BREAKDOWN_COMPUTED,
@@ -58,6 +58,17 @@ _MIN_RETRY_COUNT: Final[int] = 1
 # 95th-percentile interpolation factor (NIST type-7 / linear-interpolation
 # definition): pick the value at index 0.95 * (n - 1).
 _PERCENTILE_INTERPOLATION_FACTOR: Final[float] = 0.95
+
+
+class _RowBreach(NamedTuple):
+    """A row's breached dimensions: deferred WARNING log specs + alert body.
+
+    Built side-effect free so the caller can throttle both the logs and the
+    dispatch behind a single cooldown admission.
+    """
+
+    logs: tuple[tuple[str, dict[str, object]], ...]
+    body: str
 
 
 class _AdmittedAlert(NamedTuple):
@@ -214,7 +225,7 @@ class CallAnalyticsService:
             )
             if self._dispatcher is not None:
                 warn_rate = self._config.retry_alerts.warn_rate
-                await _dispatch_budget_alert(
+                await dispatch_budget_alert(
                     self._dispatcher,
                     title="High retry rate alert",
                     body=(
@@ -248,20 +259,26 @@ class CallAnalyticsService:
             return
         admitted: list[_AdmittedAlert] = []
         for row in breakdown.rows:
-            body = self._row_alert_body(row, alerts)
-            if body is None:
+            breach = self._row_breach(row, alerts)
+            if breach is None:
                 continue
             handle = await self._alert_limiter.take(row.prompt_class_id)
             if handle is None:
-                # Within this purpose's cooldown window: suppress the repeat
-                # log and dispatch so a polled dashboard does not re-alert.
+                # Within this purpose's cooldown window: emit neither the breach
+                # logs nor a dispatch, so a polled dashboard does not re-alert.
                 continue
+            # Logging is gated by the cooldown admission (not by _row_breach,
+            # which is side-effect free) so the WARNING stream is throttled the
+            # same as the dispatch, including on the dispatcher-is-None path.
+            for event, fields in breach.logs:
+                logger.warning(event, **fields)
             if self._dispatcher is None:
-                # The breach was logged by _row_alert_body; there is no sink to
-                # dispatch to. Hold the admission so the log stays throttled.
+                # Breach logged once per window; there is no sink to dispatch to.
                 continue
             admitted.append(
-                _AdmittedAlert(row.prompt_class_id, body, handle, self._dispatcher)
+                _AdmittedAlert(
+                    row.prompt_class_id, breach.body, handle, self._dispatcher
+                )
             )
         if not admitted:
             return
@@ -269,28 +286,34 @@ class CallAnalyticsService:
             for alert in admitted:
                 _ = tg.create_task(self._dispatch_admitted(alert))
 
-    def _row_alert_body(
+    def _row_breach(
         self,
         row: PromptClassBreakdownRow,
         alerts: PromptClassAlertConfig,
-    ) -> str | None:
-        """Log each breached dimension for a row and return a combined body.
+    ) -> _RowBreach | None:
+        """Build the breach record for a row (side-effect free, no logging).
 
-        The per-dimension WARNING logs stay separate (so spend and latency
+        The per-dimension WARNING log specs stay separate (so spend and latency
         regressions stay queryable), but a single body backs one notification
-        per row.
+        per row. The caller emits the logs only after the cooldown admits the
+        row.
 
         Returns:
-            A combined alert body, or ``None`` when the row breaches neither
+            A :class:`_RowBreach`, or ``None`` when the row breaches neither
             ceiling (so the caller skips it without consuming a cooldown slot).
         """
+        logs: list[tuple[str, dict[str, object]]] = []
         parts: list[str] = []
         if alerts.cost_warn is not None and row.total_cost > alerts.cost_warn:
-            logger.warning(
-                ANALYTICS_PROMPT_CLASS_COST_ALERT,
-                prompt_class_id=row.prompt_class_id,
-                total_cost=row.total_cost,
-                cost_warn=alerts.cost_warn,
+            logs.append(
+                (
+                    ANALYTICS_PROMPT_CLASS_COST_ALERT,
+                    {
+                        "prompt_class_id": row.prompt_class_id,
+                        "total_cost": row.total_cost,
+                        "cost_warn": alerts.cost_warn,
+                    },
+                )
             )
             parts.append(
                 f"cost {row.total_cost:.4f} {row.currency} exceeds the warning "
@@ -302,11 +325,15 @@ class CallAnalyticsService:
             and p95 is not None
             and p95 > alerts.p95_latency_warn_ms
         ):
-            logger.warning(
-                ANALYTICS_PROMPT_CLASS_LATENCY_ALERT,
-                prompt_class_id=row.prompt_class_id,
-                p95_latency_ms=p95,
-                p95_latency_warn_ms=alerts.p95_latency_warn_ms,
+            logs.append(
+                (
+                    ANALYTICS_PROMPT_CLASS_LATENCY_ALERT,
+                    {
+                        "prompt_class_id": row.prompt_class_id,
+                        "p95_latency_ms": p95,
+                        "p95_latency_warn_ms": alerts.p95_latency_warn_ms,
+                    },
+                )
             )
             parts.append(
                 f"p95 latency {p95:.0f}ms exceeds the warning ceiling "
@@ -314,11 +341,12 @@ class CallAnalyticsService:
             )
         if not parts:
             return None
-        return f"Prompt purpose {row.prompt_class_id!r}: {'; '.join(parts)}."
+        body = f"Prompt purpose {row.prompt_class_id!r}: {'; '.join(parts)}."
+        return _RowBreach(logs=tuple(logs), body=body)
 
     async def _dispatch_admitted(self, alert: _AdmittedAlert) -> None:
         """Dispatch one admitted alert; refund its slot on a swallowed failure."""
-        dispatched = await _dispatch_budget_alert(
+        dispatched = await dispatch_budget_alert(
             alert.dispatcher,
             title="High prompt-purpose cost / latency alert",
             body=alert.body,
@@ -517,57 +545,3 @@ def _p95(values: list[float]) -> float:
     if hi >= n:
         return sorted_values[-1]
     return sorted_values[lo] + frac * (sorted_values[hi] - sorted_values[lo])
-
-
-async def _dispatch_budget_alert(
-    dispatcher: NotificationDispatcher,
-    *,
-    title: str,
-    body: str,
-    on_failure_event: str,
-    **failure_context: object,
-) -> bool:
-    """Dispatch a budget WARNING notification.
-
-    A dispatch failure is logged with ``on_failure_event`` (plus any
-    ``failure_context``) and swallowed so a flaky sink never breaks the caller;
-    ``MemoryError`` / ``RecursionError`` re-raise first. The boolean return lets
-    a rate-limited caller refund its admission slot when the dispatch failed.
-
-    Args:
-        dispatcher: Notification dispatcher.
-        title: Notification title.
-        body: Human-readable alert body.
-        on_failure_event: Event constant logged when dispatch fails.
-        failure_context: Extra structured fields for the failure log.
-
-    Returns:
-        ``True`` when the notification was dispatched; ``False`` on a swallowed
-        failure.
-    """
-    from synthorg.notifications.models import (  # noqa: PLC0415
-        Notification,
-        NotificationCategory,
-        NotificationSeverity,
-    )
-
-    try:
-        await dispatcher.dispatch(
-            Notification(
-                category=NotificationCategory.BUDGET,
-                severity=NotificationSeverity.WARNING,
-                title=title,
-                body=body,
-                source="budget.call_analytics",
-            ),
-        )
-    except Exception as exc:  # noqa: BLE001 -- criticals re-raised
-        reraise_critical(exc)
-        logger.warning(
-            on_failure_event,
-            error_type=type(exc).__name__,
-            error=safe_error_description(exc),
-            **failure_context,
-        )
-        return False
-    return True

--- a/src/synthorg/budget/call_analytics.py
+++ b/src/synthorg/budget/call_analytics.py
@@ -6,7 +6,10 @@ from collections import Counter, defaultdict
 from datetime import datetime
 from typing import Final
 
-from synthorg.budget.call_analytics_config import CallAnalyticsConfig
+from synthorg.budget.call_analytics_config import (
+    CallAnalyticsConfig,
+    PromptClassAlertConfig,
+)
 from synthorg.budget.call_analytics_models import (
     AnalyticsAggregation,
     PromptClassBreakdown,
@@ -35,6 +38,9 @@ from synthorg.observability.events.analytics import (
     ANALYTICS_AGGREGATION_COMPUTED,
     ANALYTICS_BREAKDOWN_COMPUTED,
     ANALYTICS_BREAKDOWN_MIXED_CURRENCY,
+    ANALYTICS_PROMPT_CLASS_ALERT_DISPATCH_FAILED,
+    ANALYTICS_PROMPT_CLASS_COST_ALERT,
+    ANALYTICS_PROMPT_CLASS_LATENCY_ALERT,
     ANALYTICS_RETRY_ALERT_DISPATCH_FAILED,
     ANALYTICS_RETRY_RATE_ALERT,
     ANALYTICS_SERVICE_CREATED,
@@ -149,6 +155,10 @@ class CallAnalyticsService:
         records = await collect_all_records(self._tracker, start=start, end=end)
         breakdown = _build_prompt_class_breakdown(records)
         logger.debug(ANALYTICS_BREAKDOWN_COMPUTED, row_count=len(breakdown.rows))
+        # The by-purpose view is the only live read path, so the per-purpose
+        # cost / latency alert thresholds are evaluated here; both default to
+        # off, so an unconfigured deployment dispatches nothing.
+        await self.check_prompt_class_alerts(breakdown)
         return breakdown
 
     async def check_alerts(
@@ -182,6 +192,73 @@ class CallAnalyticsService:
                     self._dispatcher,
                     retry_rate=retry_rate,
                     warn_rate=self._config.retry_alerts.warn_rate,
+                )
+
+    async def check_prompt_class_alerts(
+        self,
+        breakdown: PromptClassBreakdown,
+    ) -> None:
+        """Dispatch per-purpose cost / latency alerts for crossed thresholds.
+
+        Both thresholds are opt-in; a deployment that configures neither
+        dispatches nothing. A row's p95 latency is evaluated only when the
+        purpose reported latency at all.
+
+        Args:
+            breakdown: The per-prompt-class breakdown to evaluate.
+        """
+        if not self._config.enabled:
+            return
+        alerts = self._config.prompt_class_alerts
+        if alerts.cost_warn is None and alerts.p95_latency_warn_ms is None:
+            return
+        for row in breakdown.rows:
+            await self._check_prompt_class_row(row, alerts)
+
+    async def _check_prompt_class_row(
+        self,
+        row: PromptClassBreakdownRow,
+        alerts: PromptClassAlertConfig,
+    ) -> None:
+        """Evaluate one breakdown row against the cost / latency ceilings."""
+        if alerts.cost_warn is not None and row.total_cost > alerts.cost_warn:
+            logger.warning(
+                ANALYTICS_PROMPT_CLASS_COST_ALERT,
+                prompt_class_id=row.prompt_class_id,
+                total_cost=row.total_cost,
+                cost_warn=alerts.cost_warn,
+            )
+            if self._dispatcher is not None:
+                await _dispatch_prompt_class_alert(
+                    self._dispatcher,
+                    title="High prompt-purpose cost alert",
+                    body=(
+                        f"Prompt purpose {row.prompt_class_id!r} cost "
+                        f"{row.total_cost:.4f} {row.currency} exceeds the "
+                        f"warning ceiling {alerts.cost_warn:.4f}."
+                    ),
+                )
+        p95 = row.p95_latency_ms
+        if (
+            alerts.p95_latency_warn_ms is not None
+            and p95 is not None
+            and p95 > alerts.p95_latency_warn_ms
+        ):
+            logger.warning(
+                ANALYTICS_PROMPT_CLASS_LATENCY_ALERT,
+                prompt_class_id=row.prompt_class_id,
+                p95_latency_ms=p95,
+                p95_latency_warn_ms=alerts.p95_latency_warn_ms,
+            )
+            if self._dispatcher is not None:
+                await _dispatch_prompt_class_alert(
+                    self._dispatcher,
+                    title="High prompt-purpose latency alert",
+                    body=(
+                        f"Prompt purpose {row.prompt_class_id!r} p95 latency "
+                        f"{p95:.0f}ms exceeds the warning ceiling "
+                        f"{alerts.p95_latency_warn_ms:.0f}ms."
+                    ),
                 )
 
 
@@ -409,6 +486,44 @@ async def _dispatch_retry_rate_alert(
         reraise_critical(exc)
         logger.warning(
             ANALYTICS_RETRY_ALERT_DISPATCH_FAILED,
+            error_type=type(exc).__name__,
+            error=safe_error_description(exc),
+        )
+
+
+async def _dispatch_prompt_class_alert(
+    dispatcher: NotificationDispatcher,
+    *,
+    title: str,
+    body: str,
+) -> None:
+    """Dispatch a per-prompt-purpose budget / latency warning notification.
+
+    Args:
+        dispatcher: Notification dispatcher.
+        title: Notification title.
+        body: Human-readable alert body.
+    """
+    from synthorg.notifications.models import (  # noqa: PLC0415
+        Notification,
+        NotificationCategory,
+        NotificationSeverity,
+    )
+
+    try:
+        await dispatcher.dispatch(
+            Notification(
+                category=NotificationCategory.BUDGET,
+                severity=NotificationSeverity.WARNING,
+                title=title,
+                body=body,
+                source="budget.call_analytics",
+            ),
+        )
+    except Exception as exc:  # noqa: BLE001 -- criticals re-raised
+        reraise_critical(exc)
+        logger.warning(
+            ANALYTICS_PROMPT_CLASS_ALERT_DISPATCH_FAILED,
             error_type=type(exc).__name__,
             error=safe_error_description(exc),
         )

--- a/src/synthorg/budget/call_analytics.py
+++ b/src/synthorg/budget/call_analytics.py
@@ -1,10 +1,11 @@
 # module-kind: service
 """Per-call analytics aggregation and alerting service."""
 
+import asyncio
 import math
 from collections import Counter, defaultdict
 from datetime import datetime
-from typing import Final
+from typing import Final, NamedTuple
 
 from synthorg.budget.call_analytics_config import (
     CallAnalyticsConfig,
@@ -29,6 +30,7 @@ from synthorg.budget.tracker_protocol import (
     collect_all_records,
 )
 from synthorg.core.critical_errors import reraise_critical
+from synthorg.core.resilience import SlidingWindowEventLimiter
 from synthorg.core.types import NotBlankStr
 from synthorg.llm.model_tier_policy import tier_for_purpose
 from synthorg.llm.prompt_purpose import PromptPurposeId
@@ -58,6 +60,19 @@ _MIN_RETRY_COUNT: Final[int] = 1
 _PERCENTILE_INTERPOLATION_FACTOR: Final[float] = 0.95
 
 
+class _AdmittedAlert(NamedTuple):
+    """A per-purpose alert that passed the cooldown and awaits dispatch.
+
+    ``handle`` is the limiter admission to refund if the dispatch fails;
+    ``dispatcher`` is captured at admit time (only set when one is wired).
+    """
+
+    prompt_class_id: str
+    body: str
+    handle: object
+    dispatcher: NotificationDispatcher
+
+
 class CallAnalyticsService:
     """Aggregates per-call metrics and dispatches threshold alerts.
 
@@ -82,7 +97,17 @@ class CallAnalyticsService:
         self._tracker = cost_tracker
         self._config = config
         self._dispatcher = notification_dispatcher
-        logger.debug(ANALYTICS_SERVICE_CREATED, enabled=config.enabled)
+        # One alert per purpose per window so a frequently-polled dashboard
+        # cannot turn a standing breach into a notification storm.
+        self._alert_limiter = SlidingWindowEventLimiter(
+            max_events=1,
+            window_seconds=config.prompt_class_alerts.min_seconds_between_alerts,
+        )
+        logger.debug(
+            ANALYTICS_SERVICE_CREATED,
+            enabled=config.enabled,
+            has_dispatcher=notification_dispatcher is not None,
+        )
 
     async def get_aggregation(  # noqa: PLR0913 -- orthogonal record filters
         self,
@@ -188,10 +213,15 @@ class CallAnalyticsService:
                 warn_rate=self._config.retry_alerts.warn_rate,
             )
             if self._dispatcher is not None:
-                await _dispatch_retry_rate_alert(
+                warn_rate = self._config.retry_alerts.warn_rate
+                await _dispatch_budget_alert(
                     self._dispatcher,
-                    retry_rate=retry_rate,
-                    warn_rate=self._config.retry_alerts.warn_rate,
+                    title="High retry rate alert",
+                    body=(
+                        f"Retry rate {retry_rate:.1%} exceeds warning "
+                        f"threshold {warn_rate:.1%}."
+                    ),
+                    on_failure_event=ANALYTICS_RETRY_ALERT_DISPATCH_FAILED,
                 )
 
     async def check_prompt_class_alerts(
@@ -202,7 +232,11 @@ class CallAnalyticsService:
 
         Both thresholds are opt-in; a deployment that configures neither
         dispatches nothing. A row's p95 latency is evaluated only when the
-        purpose reported latency at all.
+        purpose reported latency at all. Each purpose re-alerts at most once
+        per ``min_seconds_between_alerts`` window, so repeated dashboard reads
+        cannot storm the notification sinks; a row breaching both dimensions
+        produces a single combined notification dispatched concurrently with
+        the other purposes' alerts.
 
         Args:
             breakdown: The per-prompt-class breakdown to evaluate.
@@ -212,15 +246,45 @@ class CallAnalyticsService:
         alerts = self._config.prompt_class_alerts
         if alerts.cost_warn is None and alerts.p95_latency_warn_ms is None:
             return
+        admitted: list[_AdmittedAlert] = []
         for row in breakdown.rows:
-            await self._check_prompt_class_row(row, alerts)
+            body = self._row_alert_body(row, alerts)
+            if body is None:
+                continue
+            handle = await self._alert_limiter.take(row.prompt_class_id)
+            if handle is None:
+                # Within this purpose's cooldown window: suppress the repeat
+                # log and dispatch so a polled dashboard does not re-alert.
+                continue
+            if self._dispatcher is None:
+                # The breach was logged by _row_alert_body; there is no sink to
+                # dispatch to. Hold the admission so the log stays throttled.
+                continue
+            admitted.append(
+                _AdmittedAlert(row.prompt_class_id, body, handle, self._dispatcher)
+            )
+        if not admitted:
+            return
+        async with asyncio.TaskGroup() as tg:
+            for alert in admitted:
+                _ = tg.create_task(self._dispatch_admitted(alert))
 
-    async def _check_prompt_class_row(
+    def _row_alert_body(
         self,
         row: PromptClassBreakdownRow,
         alerts: PromptClassAlertConfig,
-    ) -> None:
-        """Evaluate one breakdown row against the cost / latency ceilings."""
+    ) -> str | None:
+        """Log each breached dimension for a row and return a combined body.
+
+        The per-dimension WARNING logs stay separate (so spend and latency
+        regressions stay queryable), but a single body backs one notification
+        per row.
+
+        Returns:
+            A combined alert body, or ``None`` when the row breaches neither
+            ceiling (so the caller skips it without consuming a cooldown slot).
+        """
+        parts: list[str] = []
         if alerts.cost_warn is not None and row.total_cost > alerts.cost_warn:
             logger.warning(
                 ANALYTICS_PROMPT_CLASS_COST_ALERT,
@@ -228,16 +292,10 @@ class CallAnalyticsService:
                 total_cost=row.total_cost,
                 cost_warn=alerts.cost_warn,
             )
-            if self._dispatcher is not None:
-                await _dispatch_prompt_class_alert(
-                    self._dispatcher,
-                    title="High prompt-purpose cost alert",
-                    body=(
-                        f"Prompt purpose {row.prompt_class_id!r} cost "
-                        f"{row.total_cost:.4f} {row.currency} exceeds the "
-                        f"warning ceiling {alerts.cost_warn:.4f}."
-                    ),
-                )
+            parts.append(
+                f"cost {row.total_cost:.4f} {row.currency} exceeds the warning "
+                f"ceiling {alerts.cost_warn:.4f}"
+            )
         p95 = row.p95_latency_ms
         if (
             alerts.p95_latency_warn_ms is not None
@@ -250,16 +308,25 @@ class CallAnalyticsService:
                 p95_latency_ms=p95,
                 p95_latency_warn_ms=alerts.p95_latency_warn_ms,
             )
-            if self._dispatcher is not None:
-                await _dispatch_prompt_class_alert(
-                    self._dispatcher,
-                    title="High prompt-purpose latency alert",
-                    body=(
-                        f"Prompt purpose {row.prompt_class_id!r} p95 latency "
-                        f"{p95:.0f}ms exceeds the warning ceiling "
-                        f"{alerts.p95_latency_warn_ms:.0f}ms."
-                    ),
-                )
+            parts.append(
+                f"p95 latency {p95:.0f}ms exceeds the warning ceiling "
+                f"{alerts.p95_latency_warn_ms:.0f}ms"
+            )
+        if not parts:
+            return None
+        return f"Prompt purpose {row.prompt_class_id!r}: {'; '.join(parts)}."
+
+    async def _dispatch_admitted(self, alert: _AdmittedAlert) -> None:
+        """Dispatch one admitted alert; refund its slot on a swallowed failure."""
+        dispatched = await _dispatch_budget_alert(
+            alert.dispatcher,
+            title="High prompt-purpose cost / latency alert",
+            body=alert.body,
+            on_failure_event=ANALYTICS_PROMPT_CLASS_ALERT_DISPATCH_FAILED,
+            prompt_class_id=alert.prompt_class_id,
+        )
+        if not dispatched:
+            await self._alert_limiter.release(alert.prompt_class_id, alert.handle)
 
 
 # ── Pure helpers ─────────────────────────────────────────────────────────────
@@ -452,57 +519,31 @@ def _p95(values: list[float]) -> float:
     return sorted_values[lo] + frac * (sorted_values[hi] - sorted_values[lo])
 
 
-async def _dispatch_retry_rate_alert(
-    dispatcher: NotificationDispatcher,
-    *,
-    retry_rate: float,
-    warn_rate: float,
-) -> None:
-    """Dispatch a retry-rate warning notification.
-
-    Args:
-        dispatcher: Notification dispatcher.
-        retry_rate: Observed retry rate.
-        warn_rate: Configured warn threshold.
-    """
-    from synthorg.notifications.models import (  # noqa: PLC0415
-        Notification,
-        NotificationCategory,
-        NotificationSeverity,
-    )
-
-    body = f"Retry rate {retry_rate:.1%} exceeds warning threshold {warn_rate:.1%}."
-    try:
-        await dispatcher.dispatch(
-            Notification(
-                category=NotificationCategory.BUDGET,
-                severity=NotificationSeverity.WARNING,
-                title="High retry rate alert",
-                body=body,
-                source="budget.call_analytics",
-            ),
-        )
-    except Exception as exc:  # noqa: BLE001 -- criticals re-raised
-        reraise_critical(exc)
-        logger.warning(
-            ANALYTICS_RETRY_ALERT_DISPATCH_FAILED,
-            error_type=type(exc).__name__,
-            error=safe_error_description(exc),
-        )
-
-
-async def _dispatch_prompt_class_alert(
+async def _dispatch_budget_alert(
     dispatcher: NotificationDispatcher,
     *,
     title: str,
     body: str,
-) -> None:
-    """Dispatch a per-prompt-purpose budget / latency warning notification.
+    on_failure_event: str,
+    **failure_context: object,
+) -> bool:
+    """Dispatch a budget WARNING notification.
+
+    A dispatch failure is logged with ``on_failure_event`` (plus any
+    ``failure_context``) and swallowed so a flaky sink never breaks the caller;
+    ``MemoryError`` / ``RecursionError`` re-raise first. The boolean return lets
+    a rate-limited caller refund its admission slot when the dispatch failed.
 
     Args:
         dispatcher: Notification dispatcher.
         title: Notification title.
         body: Human-readable alert body.
+        on_failure_event: Event constant logged when dispatch fails.
+        failure_context: Extra structured fields for the failure log.
+
+    Returns:
+        ``True`` when the notification was dispatched; ``False`` on a swallowed
+        failure.
     """
     from synthorg.notifications.models import (  # noqa: PLC0415
         Notification,
@@ -523,7 +564,10 @@ async def _dispatch_prompt_class_alert(
     except Exception as exc:  # noqa: BLE001 -- criticals re-raised
         reraise_critical(exc)
         logger.warning(
-            ANALYTICS_PROMPT_CLASS_ALERT_DISPATCH_FAILED,
+            on_failure_event,
             error_type=type(exc).__name__,
             error=safe_error_description(exc),
+            **failure_context,
         )
+        return False
+    return True

--- a/src/synthorg/budget/call_analytics_config.py
+++ b/src/synthorg/budget/call_analytics_config.py
@@ -32,6 +32,36 @@ class RetryAlertConfig(BaseModel):
     )
 
 
+class PromptClassAlertConfig(BaseModel):
+    """Per-prompt-purpose cost / latency alert thresholds.
+
+    Both thresholds are opt-in (``None`` disables that dimension) so a
+    deployment alerts only on the bounds it cares about; the cost ceiling is
+    currency-specific and the latency ceiling deployment-specific, so neither
+    carries a privileged default.
+
+    Attributes:
+        cost_warn: A purpose whose total cost over the window exceeds this
+            triggers a warning. ``None`` disables cost alerting.
+        p95_latency_warn_ms: A purpose whose p95 latency exceeds this (in
+            milliseconds) triggers a warning. ``None`` disables latency
+            alerting.
+    """
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False, extra="forbid")
+
+    cost_warn: float | None = Field(
+        default=None,
+        ge=0.0,
+        description="Per-purpose total-cost warning ceiling, or None to disable.",
+    )
+    p95_latency_warn_ms: float | None = Field(
+        default=None,
+        ge=0.0,
+        description="Per-purpose p95-latency warning ceiling in ms, or None.",
+    )
+
+
 class CallAnalyticsConfig(BaseModel):
     """Configuration for the per-call analytics service.
 
@@ -42,6 +72,7 @@ class CallAnalyticsConfig(BaseModel):
         enabled: Whether analytics collection and alerting is active.
         orchestration_alerts: Thresholds for orchestration ratio alerting.
         retry_alerts: Configuration for retry rate alerting.
+        prompt_class_alerts: Per-prompt-purpose cost / latency thresholds.
     """
 
     model_config = ConfigDict(frozen=True, allow_inf_nan=False, extra="forbid")
@@ -57,4 +88,8 @@ class CallAnalyticsConfig(BaseModel):
     retry_alerts: RetryAlertConfig = Field(
         default_factory=RetryAlertConfig,
         description="Configuration for retry rate alerting.",
+    )
+    prompt_class_alerts: PromptClassAlertConfig = Field(
+        default_factory=PromptClassAlertConfig,
+        description="Per-prompt-purpose cost / latency alert thresholds.",
     )

--- a/src/synthorg/budget/call_analytics_config.py
+++ b/src/synthorg/budget/call_analytics_config.py
@@ -11,6 +11,12 @@ from synthorg.budget.coordination_config import OrchestrationAlertThresholds
 # ``RetryAlertConfig(warn_rate=...)`` overrides per deployment.
 _DEFAULT_RETRY_WARN_RATE: Final[float] = 0.10
 
+# A purpose re-alerts at most once per this window, so a dashboard polled
+# every few seconds cannot turn a standing threshold breach into a
+# notification storm. Five minutes balances timely re-notification against
+# operator alert fatigue; override per deployment.
+_DEFAULT_ALERT_WINDOW_SECONDS: Final[float] = 300.0
+
 
 class RetryAlertConfig(BaseModel):
     """Configuration for retry rate alerting.
@@ -36,29 +42,41 @@ class PromptClassAlertConfig(BaseModel):
     """Per-prompt-purpose cost / latency alert thresholds.
 
     Both thresholds are opt-in (``None`` disables that dimension) so a
-    deployment alerts only on the bounds it cares about; the cost ceiling is
-    currency-specific and the latency ceiling deployment-specific, so neither
-    carries a privileged default.
+    deployment alerts only on the bounds it cares about. The cost ceiling is
+    denominated in the deployment's budget currency (the same currency the
+    cost records carry), and the latency ceiling is deployment-specific, so
+    neither carries a privileged default. A set threshold must be strictly
+    positive: ``None`` is the disable switch, so ``0.0`` (which would alert on
+    every non-zero value) is not a meaningful ceiling.
 
     Attributes:
         cost_warn: A purpose whose total cost over the window exceeds this
-            triggers a warning. ``None`` disables cost alerting.
+            (in the deployment's budget currency) triggers a warning. ``None``
+            disables cost alerting.
         p95_latency_warn_ms: A purpose whose p95 latency exceeds this (in
             milliseconds) triggers a warning. ``None`` disables latency
             alerting.
+        min_seconds_between_alerts: A purpose re-alerts at most once per this
+            window, throttling notification volume under frequent dashboard
+            polling.
     """
 
     model_config = ConfigDict(frozen=True, allow_inf_nan=False, extra="forbid")
 
     cost_warn: float | None = Field(
         default=None,
-        ge=0.0,
+        gt=0.0,
         description="Per-purpose total-cost warning ceiling, or None to disable.",
     )
     p95_latency_warn_ms: float | None = Field(
         default=None,
-        ge=0.0,
+        gt=0.0,
         description="Per-purpose p95-latency warning ceiling in ms, or None.",
+    )
+    min_seconds_between_alerts: float = Field(
+        default=_DEFAULT_ALERT_WINDOW_SECONDS,
+        gt=0.0,
+        description="Minimum seconds between re-alerts for the same purpose.",
     )
 
 

--- a/src/synthorg/observability/events/analytics.py
+++ b/src/synthorg/observability/events/analytics.py
@@ -17,6 +17,13 @@ ANALYTICS_RETRY_ALERT_DISPATCH_FAILED: Final[str] = (
     "analytics.retry_alert.dispatch_failed"
 )
 ANALYTICS_ORCHESTRATION_ALERT: Final[str] = "analytics.orchestration_alert"
+ANALYTICS_PROMPT_CLASS_COST_ALERT: Final[str] = "analytics.prompt_class.cost_alert"
+ANALYTICS_PROMPT_CLASS_LATENCY_ALERT: Final[str] = (
+    "analytics.prompt_class.latency_alert"
+)
+ANALYTICS_PROMPT_CLASS_ALERT_DISPATCH_FAILED: Final[str] = (
+    "analytics.prompt_class.alert_dispatch_failed"
+)
 ANALYTICS_TIER_LOOKUP_FAILED: Final[str] = "analytics.tier_lookup_failed"
 ANALYTICS_SERVICE_CREATED: Final[str] = "analytics.service_created"
 

--- a/tests/conformance/persistence/test_cost_attribution_roundtrip.py
+++ b/tests/conformance/persistence/test_cost_attribution_roundtrip.py
@@ -1,12 +1,12 @@
 """Both-backend round-trip: persisted prompt_class_id drives the dashboard DTO.
 
-``test_core_repositories`` proves ``prompt_class_id`` survives a repo round-trip;
-this goes one hop further, across the persistence -> analytics boundary that no
-single test crosses today: it persists attributed cost on each backend, reads it
-back, and feeds it through ``CallAnalyticsService.get_prompt_class_breakdown`` to
-assert the by-purpose dashboard rows reconstruct correctly. It also pins the
-honest fact that latency / cache / success are in-memory telemetry the
-``cost_records`` schema does not persist, so they come back ``None``.
+Persistence round-trips preserve ``prompt_class_id`` as a bare string; this
+crosses the persistence -> analytics boundary: it persists attributed cost on
+each backend, reads it back, and feeds it through
+``CallAnalyticsService.get_prompt_class_breakdown`` to assert the by-purpose
+dashboard rows reconstruct correctly. It also pins the fact that latency /
+cache / success are in-memory telemetry the ``cost_records`` schema does not
+persist, so they come back ``None``.
 """
 
 from datetime import UTC, datetime

--- a/tests/conformance/persistence/test_cost_attribution_roundtrip.py
+++ b/tests/conformance/persistence/test_cost_attribution_roundtrip.py
@@ -1,0 +1,88 @@
+"""Both-backend round-trip: persisted prompt_class_id drives the dashboard DTO.
+
+``test_core_repositories`` proves ``prompt_class_id`` survives a repo round-trip;
+this goes one hop further, across the persistence -> analytics boundary that no
+single test crosses today: it persists attributed cost on each backend, reads it
+back, and feeds it through ``CallAnalyticsService.get_prompt_class_breakdown`` to
+assert the by-purpose dashboard rows reconstruct correctly. It also pins the
+honest fact that latency / cache / success are in-memory telemetry the
+``cost_records`` schema does not persist, so they come back ``None``.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from synthorg.budget.call_analytics import CallAnalyticsService
+from synthorg.budget.call_analytics_config import CallAnalyticsConfig
+from synthorg.budget.call_category import LLMCallCategory
+from synthorg.budget.cost_record import CostRecord
+from synthorg.budget.tracker import CostTracker
+from synthorg.llm.model_tier_policy import tier_for_purpose
+from synthorg.llm.prompt_purpose import PromptPurposeId
+from synthorg.persistence.cost_record_protocol import CostRecordFilterSpec
+from synthorg.persistence.protocol import PersistenceBackend
+from tests._shared import sid
+from tests.unit.persistence.conftest import make_task
+
+
+@pytest.mark.integration
+class TestCostAttributionRoundTrip:
+    async def test_persisted_attribution_drives_breakdown(
+        self, backend: PersistenceBackend
+    ) -> None:
+        await backend.tasks.save(make_task(task_id="t-attr"))
+        timestamp = datetime(2026, 5, 1, 12, tzinfo=UTC)
+
+        def _record(purpose: PromptPurposeId | None, cost: float) -> CostRecord:
+            return CostRecord(
+                agent_id="agent-attr",
+                task_id=sid("t-attr"),
+                provider="test-provider",
+                model="example-small-001",
+                input_tokens=100,
+                output_tokens=50,
+                cost=cost,
+                currency="EUR",
+                timestamp=timestamp,
+                call_category=LLMCallCategory.PRODUCTIVE,
+                prompt_class_id=purpose,
+            )
+
+        await backend.cost_records.append(_record(PromptPurposeId.MEMORY_RERANK, 0.05))
+        await backend.cost_records.append(_record(PromptPurposeId.COS_CHAT, 0.03))
+        await backend.cost_records.append(_record(None, 0.10))
+
+        persisted = await backend.cost_records.query(
+            CostRecordFilterSpec(agent_id="agent-attr")
+        )
+        assert len(persisted) == 3
+
+        # The dashboard read path aggregates the in-memory tracker; seed it from
+        # what each backend persisted to prove persisted attribution reconstructs
+        # into the by-purpose breakdown.
+        tracker = CostTracker()
+        for record in persisted:
+            await tracker.record(record)
+        service = CallAnalyticsService(
+            cost_tracker=tracker, config=CallAnalyticsConfig()
+        )
+        breakdown = await service.get_prompt_class_breakdown()
+
+        ids = [row.prompt_class_id for row in breakdown.rows]
+        # The unattributed record is excluded; rows sort by prompt_class_id value.
+        assert ids == [PromptPurposeId.COS_CHAT, PromptPurposeId.MEMORY_RERANK]
+
+        by_id = {row.prompt_class_id: row for row in breakdown.rows}
+        rerank = by_id[PromptPurposeId.MEMORY_RERANK]
+        assert rerank.tier == tier_for_purpose(PromptPurposeId.MEMORY_RERANK)
+        assert rerank.total_cost == pytest.approx(0.05)
+        assert rerank.currency == "EUR"
+        assert rerank.call_count == 1
+        assert rerank.input_tokens == 100
+        assert rerank.output_tokens == 50
+        # Latency / cache / success are not columns on cost_records, so a repo
+        # round-trip drops them and the breakdown reports them absent.
+        assert rerank.avg_latency_ms is None
+        assert rerank.cache_hit_rate is None
+        assert rerank.success_rate is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -736,6 +736,7 @@ _WALL_CLOCK_GUARD_EXEMPT_FRAGMENTS: Final = (
     "unit/test_cold_import.py",
     "unit/scripts/test_check_completion_config_temperature.py",
     "unit/scripts/test_check_error_code_uniqueness.py::test_real_tree_passes",
+    "unit/scripts/test_epic_2490_gate_live_tree.py",
     "unit/api/test_construction_wiring.py",
     "unit/api/test_app.py",
     "unit/api/test_health.py",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -736,7 +736,7 @@ _WALL_CLOCK_GUARD_EXEMPT_FRAGMENTS: Final = (
     "unit/test_cold_import.py",
     "unit/scripts/test_check_completion_config_temperature.py",
     "unit/scripts/test_check_error_code_uniqueness.py::test_real_tree_passes",
-    "unit/scripts/test_epic_2490_gate_live_tree.py",
+    "unit/scripts/test_gate_live_tree_clean.py",
     "unit/api/test_construction_wiring.py",
     "unit/api/test_app.py",
     "unit/api/test_health.py",

--- a/tests/unit/budget/test_call_analytics_config.py
+++ b/tests/unit/budget/test_call_analytics_config.py
@@ -1,10 +1,58 @@
-"""Tests for CallAnalyticsConfig and RetryAlertConfig."""
+"""Tests for CallAnalyticsConfig, RetryAlertConfig, and PromptClassAlertConfig."""
+
+import math
 
 import pytest
 from pydantic import ValidationError
 
-from synthorg.budget.call_analytics_config import CallAnalyticsConfig, RetryAlertConfig
+from synthorg.budget.call_analytics_config import (
+    CallAnalyticsConfig,
+    PromptClassAlertConfig,
+    RetryAlertConfig,
+)
 from synthorg.budget.coordination_config import OrchestrationAlertThresholds
+
+
+@pytest.mark.unit
+class TestPromptClassAlertConfig:
+    """PromptClassAlertConfig validation and defaults."""
+
+    def test_defaults_disable_both_dimensions(self) -> None:
+        cfg = PromptClassAlertConfig()
+        assert cfg.cost_warn is None
+        assert cfg.p95_latency_warn_ms is None
+        assert cfg.min_seconds_between_alerts == 300.0
+
+    def test_positive_thresholds_accepted(self) -> None:
+        cfg = PromptClassAlertConfig(cost_warn=1.5, p95_latency_warn_ms=250.0)
+        assert cfg.cost_warn == 1.5
+        assert cfg.p95_latency_warn_ms == 250.0
+
+    @pytest.mark.parametrize("field", ["cost_warn", "p95_latency_warn_ms"])
+    def test_zero_threshold_rejected(self, field: str) -> None:
+        # None is the disable switch, so 0.0 (which alerts on any value) is not
+        # a meaningful ceiling and is rejected by gt=0.0.
+        with pytest.raises(ValidationError):
+            PromptClassAlertConfig(**{field: 0.0})
+
+    @pytest.mark.parametrize("field", ["cost_warn", "p95_latency_warn_ms"])
+    def test_negative_threshold_rejected(self, field: str) -> None:
+        with pytest.raises(ValidationError):
+            PromptClassAlertConfig(**{field: -1.0})
+
+    @pytest.mark.parametrize("field", ["cost_warn", "p95_latency_warn_ms"])
+    def test_non_finite_threshold_rejected(self, field: str) -> None:
+        with pytest.raises(ValidationError):
+            PromptClassAlertConfig(**{field: math.inf})
+
+    def test_zero_window_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            PromptClassAlertConfig(min_seconds_between_alerts=0.0)
+
+    def test_frozen(self) -> None:
+        cfg = PromptClassAlertConfig()
+        with pytest.raises(ValidationError):
+            cfg.cost_warn = 1.0  # type: ignore[misc]
 
 
 @pytest.mark.unit
@@ -50,6 +98,9 @@ class TestCallAnalyticsConfig:
         assert cfg.enabled is True
         assert isinstance(cfg.orchestration_alerts, OrchestrationAlertThresholds)
         assert isinstance(cfg.retry_alerts, RetryAlertConfig)
+        assert isinstance(cfg.prompt_class_alerts, PromptClassAlertConfig)
+        assert cfg.prompt_class_alerts.cost_warn is None
+        assert cfg.prompt_class_alerts.p95_latency_warn_ms is None
 
     def test_disabled(self) -> None:
         cfg = CallAnalyticsConfig(enabled=False)

--- a/tests/unit/budget/test_call_analytics_properties.py
+++ b/tests/unit/budget/test_call_analytics_properties.py
@@ -1,7 +1,6 @@
 """Property-based tests for CallAnalyticsService aggregation."""
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock
 
 import pytest
 from hypothesis import given
@@ -12,7 +11,9 @@ from synthorg.budget.call_analytics_config import CallAnalyticsConfig
 from synthorg.budget.call_category import OrchestrationAlertLevel
 from synthorg.budget.category_analytics import OrchestrationRatio
 from synthorg.budget.cost_record import CostRecord
+from synthorg.budget.tracker_protocol import CostTrackerProtocol
 from synthorg.core.completion_enums import FinishReason
+from tests._shared import mock_of
 
 
 def _record(
@@ -42,18 +43,16 @@ def _record(
 
 
 def _make_service(records: tuple[CostRecord, ...]) -> CallAnalyticsService:
-    tracker = AsyncMock()
-    tracker.get_records = AsyncMock(return_value=records)
-    tracker.collect_records = AsyncMock(return_value=records)
-    tracker.get_orchestration_ratio = AsyncMock(
-        return_value=OrchestrationRatio(
-            ratio=0.0,
-            alert_level=OrchestrationAlertLevel.NORMAL,
-            total_tokens=0,
-            productive_tokens=0,
-            coordination_tokens=0,
-            system_tokens=0,
-        )
+    tracker = mock_of[CostTrackerProtocol]()
+    tracker.get_records.return_value = records
+    tracker.collect_records.return_value = records
+    tracker.get_orchestration_ratio.return_value = OrchestrationRatio(
+        ratio=0.0,
+        alert_level=OrchestrationAlertLevel.NORMAL,
+        total_tokens=0,
+        productive_tokens=0,
+        coordination_tokens=0,
+        system_tokens=0,
     )
     return CallAnalyticsService(
         cost_tracker=tracker,

--- a/tests/unit/budget/test_prompt_class_alerts.py
+++ b/tests/unit/budget/test_prompt_class_alerts.py
@@ -1,0 +1,189 @@
+"""Per-prompt-purpose cost / latency alert dispatch (epic #2490, scope J1).
+
+Covers the opt-in thresholds on ``PromptClassAlertConfig`` and the
+``CallAnalyticsService`` evaluation + dispatch path, including the live trigger:
+``get_prompt_class_breakdown`` evaluates the thresholds so the dashboard read
+path fires alerts when a purpose's cost or p95 latency crosses its ceiling.
+"""
+
+from datetime import UTC, datetime
+from typing import Final
+
+import pytest
+
+from synthorg.budget.call_analytics import CallAnalyticsService
+from synthorg.budget.call_analytics_config import (
+    CallAnalyticsConfig,
+    PromptClassAlertConfig,
+)
+from synthorg.budget.call_analytics_models import (
+    PromptClassBreakdown,
+    PromptClassBreakdownRow,
+)
+from synthorg.budget.call_category import LLMCallCategory
+from synthorg.budget.cost_record import CostRecord
+from synthorg.budget.tracker import CostTracker
+from synthorg.budget.tracker_protocol import CostTrackerProtocol
+from synthorg.llm.prompt_purpose import PromptPurposeId
+from synthorg.notifications.dispatcher import NotificationDispatcher
+from tests._shared import mock_of
+
+pytestmark = pytest.mark.unit
+
+_COST_CEILING: Final[float] = 1.0
+_LATENCY_CEILING_MS: Final[float] = 500.0
+
+
+def _row(*, cost: float, p95: float | None) -> PromptClassBreakdownRow:
+    return PromptClassBreakdownRow(
+        prompt_class_id=PromptPurposeId.MEMORY_RERANK.value,
+        total_cost=cost,
+        call_count=1,
+        input_tokens=10,
+        output_tokens=5,
+        p95_latency_ms=p95,
+        retry_rate=0.0,
+    )
+
+
+def _service(
+    config: CallAnalyticsConfig,
+    dispatcher: NotificationDispatcher | None = None,
+) -> CallAnalyticsService:
+    return CallAnalyticsService(
+        cost_tracker=mock_of[CostTrackerProtocol](),
+        config=config,
+        notification_dispatcher=dispatcher,
+    )
+
+
+async def test_no_thresholds_dispatches_nothing() -> None:
+    dispatcher = mock_of[NotificationDispatcher]()
+    service = _service(CallAnalyticsConfig(), dispatcher)
+
+    await service.check_prompt_class_alerts(
+        PromptClassBreakdown(rows=(_row(cost=99.0, p95=9999.0),))
+    )
+
+    assert dispatcher.dispatch.await_count == 0
+
+
+async def test_cost_over_ceiling_dispatches() -> None:
+    dispatcher = mock_of[NotificationDispatcher]()
+    config = CallAnalyticsConfig(
+        prompt_class_alerts=PromptClassAlertConfig(cost_warn=_COST_CEILING)
+    )
+    service = _service(config, dispatcher)
+
+    await service.check_prompt_class_alerts(
+        PromptClassBreakdown(rows=(_row(cost=_COST_CEILING + 0.5, p95=None),))
+    )
+
+    assert dispatcher.dispatch.await_count == 1
+    assert "cost" in dispatcher.dispatch.await_args.args[0].title.lower()
+
+
+async def test_cost_under_ceiling_no_dispatch() -> None:
+    dispatcher = mock_of[NotificationDispatcher]()
+    config = CallAnalyticsConfig(
+        prompt_class_alerts=PromptClassAlertConfig(cost_warn=_COST_CEILING)
+    )
+    service = _service(config, dispatcher)
+
+    await service.check_prompt_class_alerts(
+        PromptClassBreakdown(rows=(_row(cost=_COST_CEILING, p95=None),))
+    )
+
+    assert dispatcher.dispatch.await_count == 0
+
+
+async def test_p95_latency_over_ceiling_dispatches() -> None:
+    dispatcher = mock_of[NotificationDispatcher]()
+    config = CallAnalyticsConfig(
+        prompt_class_alerts=PromptClassAlertConfig(
+            p95_latency_warn_ms=_LATENCY_CEILING_MS
+        )
+    )
+    service = _service(config, dispatcher)
+
+    await service.check_prompt_class_alerts(
+        PromptClassBreakdown(rows=(_row(cost=0.0, p95=_LATENCY_CEILING_MS + 100.0),))
+    )
+
+    assert dispatcher.dispatch.await_count == 1
+    assert "latency" in dispatcher.dispatch.await_args.args[0].title.lower()
+
+
+async def test_latency_threshold_ignores_rows_without_latency() -> None:
+    dispatcher = mock_of[NotificationDispatcher]()
+    config = CallAnalyticsConfig(
+        prompt_class_alerts=PromptClassAlertConfig(
+            p95_latency_warn_ms=_LATENCY_CEILING_MS
+        )
+    )
+    service = _service(config, dispatcher)
+
+    await service.check_prompt_class_alerts(
+        PromptClassBreakdown(rows=(_row(cost=0.0, p95=None),))
+    )
+
+    assert dispatcher.dispatch.await_count == 0
+
+
+async def test_disabled_config_dispatches_nothing() -> None:
+    dispatcher = mock_of[NotificationDispatcher]()
+    config = CallAnalyticsConfig(
+        enabled=False,
+        prompt_class_alerts=PromptClassAlertConfig(cost_warn=_COST_CEILING),
+    )
+    service = _service(config, dispatcher)
+
+    await service.check_prompt_class_alerts(
+        PromptClassBreakdown(rows=(_row(cost=_COST_CEILING + 5.0, p95=None),))
+    )
+
+    assert dispatcher.dispatch.await_count == 0
+
+
+async def test_no_dispatcher_runs_without_error() -> None:
+    config = CallAnalyticsConfig(
+        prompt_class_alerts=PromptClassAlertConfig(cost_warn=_COST_CEILING)
+    )
+    service = _service(config, dispatcher=None)
+
+    # Threshold crossed but no dispatcher wired: logs only, never raises.
+    await service.check_prompt_class_alerts(
+        PromptClassBreakdown(rows=(_row(cost=_COST_CEILING + 1.0, p95=None),))
+    )
+
+
+async def test_breakdown_read_path_fires_alert() -> None:
+    # The live wiring: reading the by-purpose breakdown evaluates the
+    # thresholds, so a configured deployment alerts off the dashboard's call.
+    dispatcher = mock_of[NotificationDispatcher]()
+    tracker = CostTracker()
+    await tracker.record(
+        CostRecord(
+            agent_id="agent-1",
+            task_id="task-1",
+            provider="test-provider",
+            model="example-small-001",
+            input_tokens=10,
+            output_tokens=5,
+            cost=_COST_CEILING + 2.0,
+            currency="EUR",
+            timestamp=datetime(2026, 5, 1, 12, tzinfo=UTC),
+            call_category=LLMCallCategory.PRODUCTIVE,
+            prompt_class_id=PromptPurposeId.MEMORY_RERANK,
+        )
+    )
+    config = CallAnalyticsConfig(
+        prompt_class_alerts=PromptClassAlertConfig(cost_warn=_COST_CEILING)
+    )
+    service = CallAnalyticsService(
+        cost_tracker=tracker, config=config, notification_dispatcher=dispatcher
+    )
+
+    await service.get_prompt_class_breakdown()
+
+    assert dispatcher.dispatch.await_count == 1

--- a/tests/unit/budget/test_prompt_class_alerts.py
+++ b/tests/unit/budget/test_prompt_class_alerts.py
@@ -1,9 +1,10 @@
-"""Per-prompt-purpose cost / latency alert dispatch (epic #2490, scope J1).
+"""Per-prompt-purpose cost / latency alert dispatch.
 
 Covers the opt-in thresholds on ``PromptClassAlertConfig`` and the
-``CallAnalyticsService`` evaluation + dispatch path, including the live trigger:
-``get_prompt_class_breakdown`` evaluates the thresholds so the dashboard read
-path fires alerts when a purpose's cost or p95 latency crosses its ceiling.
+``CallAnalyticsService`` evaluation + dispatch path: the cooldown that throttles
+repeated reads, the single combined notification per row, the
+release-on-failure refund, critical-error propagation, and the live trigger
+(``get_prompt_class_breakdown`` fires alerts on the dashboard read path).
 """
 
 from datetime import UTC, datetime
@@ -26,7 +27,7 @@ from synthorg.budget.tracker import CostTracker
 from synthorg.budget.tracker_protocol import CostTrackerProtocol
 from synthorg.llm.prompt_purpose import PromptPurposeId
 from synthorg.notifications.dispatcher import NotificationDispatcher
-from tests._shared import mock_of
+from tests._shared import mock_of, sid
 
 pytestmark = pytest.mark.unit
 
@@ -34,9 +35,14 @@ _COST_CEILING: Final[float] = 1.0
 _LATENCY_CEILING_MS: Final[float] = 500.0
 
 
-def _row(*, cost: float, p95: float | None) -> PromptClassBreakdownRow:
+def _row(
+    *,
+    cost: float,
+    p95: float | None,
+    purpose: PromptPurposeId = PromptPurposeId.MEMORY_RERANK,
+) -> PromptClassBreakdownRow:
     return PromptClassBreakdownRow(
-        prompt_class_id=PromptPurposeId.MEMORY_RERANK.value,
+        prompt_class_id=purpose.value,
         total_cost=cost,
         call_count=1,
         input_tokens=10,
@@ -57,6 +63,20 @@ def _service(
     )
 
 
+def _cost_config() -> CallAnalyticsConfig:
+    return CallAnalyticsConfig(
+        prompt_class_alerts=PromptClassAlertConfig(cost_warn=_COST_CEILING)
+    )
+
+
+def _latency_config() -> CallAnalyticsConfig:
+    return CallAnalyticsConfig(
+        prompt_class_alerts=PromptClassAlertConfig(
+            p95_latency_warn_ms=_LATENCY_CEILING_MS
+        )
+    )
+
+
 async def test_no_thresholds_dispatches_nothing() -> None:
     dispatcher = mock_of[NotificationDispatcher]()
     service = _service(CallAnalyticsConfig(), dispatcher)
@@ -70,25 +90,19 @@ async def test_no_thresholds_dispatches_nothing() -> None:
 
 async def test_cost_over_ceiling_dispatches() -> None:
     dispatcher = mock_of[NotificationDispatcher]()
-    config = CallAnalyticsConfig(
-        prompt_class_alerts=PromptClassAlertConfig(cost_warn=_COST_CEILING)
-    )
-    service = _service(config, dispatcher)
+    service = _service(_cost_config(), dispatcher)
 
     await service.check_prompt_class_alerts(
         PromptClassBreakdown(rows=(_row(cost=_COST_CEILING + 0.5, p95=None),))
     )
 
     assert dispatcher.dispatch.await_count == 1
-    assert "cost" in dispatcher.dispatch.await_args.args[0].title.lower()
+    assert "cost" in dispatcher.dispatch.await_args.args[0].body.lower()
 
 
 async def test_cost_under_ceiling_no_dispatch() -> None:
     dispatcher = mock_of[NotificationDispatcher]()
-    config = CallAnalyticsConfig(
-        prompt_class_alerts=PromptClassAlertConfig(cost_warn=_COST_CEILING)
-    )
-    service = _service(config, dispatcher)
+    service = _service(_cost_config(), dispatcher)
 
     await service.check_prompt_class_alerts(
         PromptClassBreakdown(rows=(_row(cost=_COST_CEILING, p95=None),))
@@ -99,35 +113,87 @@ async def test_cost_under_ceiling_no_dispatch() -> None:
 
 async def test_p95_latency_over_ceiling_dispatches() -> None:
     dispatcher = mock_of[NotificationDispatcher]()
-    config = CallAnalyticsConfig(
-        prompt_class_alerts=PromptClassAlertConfig(
-            p95_latency_warn_ms=_LATENCY_CEILING_MS
-        )
-    )
-    service = _service(config, dispatcher)
+    service = _service(_latency_config(), dispatcher)
 
     await service.check_prompt_class_alerts(
         PromptClassBreakdown(rows=(_row(cost=0.0, p95=_LATENCY_CEILING_MS + 100.0),))
     )
 
     assert dispatcher.dispatch.await_count == 1
-    assert "latency" in dispatcher.dispatch.await_args.args[0].title.lower()
+    assert "latency" in dispatcher.dispatch.await_args.args[0].body.lower()
+
+
+async def test_p95_latency_at_ceiling_no_dispatch() -> None:
+    dispatcher = mock_of[NotificationDispatcher]()
+    service = _service(_latency_config(), dispatcher)
+
+    # Strict `>`: a p95 exactly at the ceiling does not alert.
+    await service.check_prompt_class_alerts(
+        PromptClassBreakdown(rows=(_row(cost=0.0, p95=_LATENCY_CEILING_MS),))
+    )
+
+    assert dispatcher.dispatch.await_count == 0
 
 
 async def test_latency_threshold_ignores_rows_without_latency() -> None:
     dispatcher = mock_of[NotificationDispatcher]()
-    config = CallAnalyticsConfig(
-        prompt_class_alerts=PromptClassAlertConfig(
-            p95_latency_warn_ms=_LATENCY_CEILING_MS
-        )
-    )
-    service = _service(config, dispatcher)
+    service = _service(_latency_config(), dispatcher)
 
     await service.check_prompt_class_alerts(
         PromptClassBreakdown(rows=(_row(cost=0.0, p95=None),))
     )
 
     assert dispatcher.dispatch.await_count == 0
+
+
+async def test_both_thresholds_breached_dispatches_one_combined() -> None:
+    dispatcher = mock_of[NotificationDispatcher]()
+    config = CallAnalyticsConfig(
+        prompt_class_alerts=PromptClassAlertConfig(
+            cost_warn=_COST_CEILING, p95_latency_warn_ms=_LATENCY_CEILING_MS
+        )
+    )
+    service = _service(config, dispatcher)
+
+    await service.check_prompt_class_alerts(
+        PromptClassBreakdown(
+            rows=(_row(cost=_COST_CEILING + 1.0, p95=_LATENCY_CEILING_MS + 1.0),)
+        )
+    )
+
+    # One row breaching both dimensions yields a single combined notification.
+    assert dispatcher.dispatch.await_count == 1
+    body = dispatcher.dispatch.await_args.args[0].body.lower()
+    assert "cost" in body
+    assert "latency" in body
+
+
+async def test_multiple_rows_alert_only_those_over_ceiling() -> None:
+    dispatcher = mock_of[NotificationDispatcher]()
+    service = _service(_cost_config(), dispatcher)
+
+    await service.check_prompt_class_alerts(
+        PromptClassBreakdown(
+            rows=(
+                _row(
+                    cost=_COST_CEILING + 1.0, p95=None, purpose=PromptPurposeId.COS_CHAT
+                ),
+                _row(
+                    cost=_COST_CEILING - 0.5,
+                    p95=None,
+                    purpose=PromptPurposeId.MEMORY_RERANK,
+                ),
+                _row(
+                    cost=_COST_CEILING + 0.5,
+                    p95=None,
+                    purpose=PromptPurposeId.RESEARCH_TRIAGE,
+                ),
+            )
+        )
+    )
+
+    # Two of three rows breach; each distinct purpose alerts once.
+    assert dispatcher.dispatch.await_count == 2
 
 
 async def test_disabled_config_dispatches_nothing() -> None:
@@ -146,15 +212,51 @@ async def test_disabled_config_dispatches_nothing() -> None:
 
 
 async def test_no_dispatcher_runs_without_error() -> None:
-    config = CallAnalyticsConfig(
-        prompt_class_alerts=PromptClassAlertConfig(cost_warn=_COST_CEILING)
-    )
-    service = _service(config, dispatcher=None)
+    service = _service(_cost_config(), dispatcher=None)
 
     # Threshold crossed but no dispatcher wired: logs only, never raises.
     await service.check_prompt_class_alerts(
         PromptClassBreakdown(rows=(_row(cost=_COST_CEILING + 1.0, p95=None),))
     )
+
+
+async def test_cooldown_suppresses_repeat_alert_for_same_purpose() -> None:
+    dispatcher = mock_of[NotificationDispatcher]()
+    service = _service(_cost_config(), dispatcher)
+    breakdown = PromptClassBreakdown(rows=(_row(cost=_COST_CEILING + 1.0, p95=None),))
+
+    await service.check_prompt_class_alerts(breakdown)
+    await service.check_prompt_class_alerts(breakdown)
+
+    # The second evaluation is inside the purpose's cooldown window.
+    assert dispatcher.dispatch.await_count == 1
+
+
+async def test_failed_dispatch_refunds_slot_so_next_read_retries() -> None:
+    dispatcher = mock_of[NotificationDispatcher]()
+    dispatcher.dispatch.side_effect = [ValueError("sink down"), None]
+    service = _service(_cost_config(), dispatcher)
+    breakdown = PromptClassBreakdown(rows=(_row(cost=_COST_CEILING + 1.0, p95=None),))
+
+    # First dispatch fails (swallowed); the cooldown slot is refunded, so the
+    # next read re-attempts rather than being throttled by a phantom admission.
+    await service.check_prompt_class_alerts(breakdown)
+    await service.check_prompt_class_alerts(breakdown)
+
+    assert dispatcher.dispatch.await_count == 2
+
+
+async def test_critical_error_propagates() -> None:
+    dispatcher = mock_of[NotificationDispatcher]()
+    dispatcher.dispatch.side_effect = MemoryError()
+    service = _service(_cost_config(), dispatcher)
+
+    # A MemoryError must never be swallowed; the TaskGroup surfaces it.
+    with pytest.raises(BaseExceptionGroup) as excinfo:
+        await service.check_prompt_class_alerts(
+            PromptClassBreakdown(rows=(_row(cost=_COST_CEILING + 1.0, p95=None),))
+        )
+    assert any(isinstance(e, MemoryError) for e in excinfo.value.exceptions)
 
 
 async def test_breakdown_read_path_fires_alert() -> None:
@@ -165,7 +267,7 @@ async def test_breakdown_read_path_fires_alert() -> None:
     await tracker.record(
         CostRecord(
             agent_id="agent-1",
-            task_id="task-1",
+            task_id=sid("task-1"),
             provider="test-provider",
             model="example-small-001",
             input_tokens=10,
@@ -177,11 +279,8 @@ async def test_breakdown_read_path_fires_alert() -> None:
             prompt_class_id=PromptPurposeId.MEMORY_RERANK,
         )
     )
-    config = CallAnalyticsConfig(
-        prompt_class_alerts=PromptClassAlertConfig(cost_warn=_COST_CEILING)
-    )
     service = CallAnalyticsService(
-        cost_tracker=tracker, config=config, notification_dispatcher=dispatcher
+        cost_tracker=tracker, config=_cost_config(), notification_dispatcher=dispatcher
     )
 
     await service.get_prompt_class_breakdown()

--- a/tests/unit/budget/test_prompt_class_breakdown_emit_chain.py
+++ b/tests/unit/budget/test_prompt_class_breakdown_emit_chain.py
@@ -4,9 +4,8 @@ Drives the real cost-recording chokepoint: opens a ``cost_recording_scope``
 with a ``purpose``, emits a :class:`CostRecord` through
 ``emit_cost_record_from_context`` exactly as ``BaseCompletionProvider.complete``
 does, drains the tracker, then reads the record back through
-``CallAnalyticsService.get_prompt_class_breakdown``. No existing test crosses
-the whole emit -> tracker -> analytics -> dashboard-DTO span in one chain; the
-per-segment tests each cover only one hop.
+``CallAnalyticsService.get_prompt_class_breakdown``. This proves the full
+emit -> tracker -> analytics -> dashboard-DTO span end-to-end in one chain.
 """
 
 from typing import Final

--- a/tests/unit/budget/test_prompt_class_breakdown_emit_chain.py
+++ b/tests/unit/budget/test_prompt_class_breakdown_emit_chain.py
@@ -1,0 +1,124 @@
+"""End-to-end emit -> analytics chain for prompt-purpose attribution.
+
+Drives the real cost-recording chokepoint: opens a ``cost_recording_scope``
+with a ``purpose``, emits a :class:`CostRecord` through
+``emit_cost_record_from_context`` exactly as ``BaseCompletionProvider.complete``
+does, drains the tracker, then reads the record back through
+``CallAnalyticsService.get_prompt_class_breakdown``. No existing test crosses
+the whole emit -> tracker -> analytics -> dashboard-DTO span in one chain; the
+per-segment tests each cover only one hop.
+"""
+
+from typing import Final
+
+import pytest
+
+from synthorg.budget.call_analytics import CallAnalyticsService
+from synthorg.budget.call_analytics_config import CallAnalyticsConfig
+from synthorg.budget.call_category import LLMCallCategory
+from synthorg.budget.tracker import CostTracker
+from synthorg.core.completion_enums import FinishReason
+from synthorg.llm.model_tier_policy import tier_for_purpose
+from synthorg.llm.prompt_purpose import PromptPurposeId
+from synthorg.providers.cost_recording import (
+    cost_recording_scope,
+    current_cost_context,
+    emit_cost_record_from_context,
+)
+from synthorg.providers.models import CompletionResponse, TokenUsage
+
+pytestmark = pytest.mark.unit
+
+_LATENCY_MS: Final[float] = 123.5
+_INPUT_TOKENS: Final[int] = 1000
+_OUTPUT_TOKENS: Final[int] = 200
+_COST: Final[float] = 0.04
+_CURRENCY: Final[str] = "EUR"
+_MODEL: Final[str] = "example-small-001"
+_PROVIDER: Final[str] = "test-provider"
+
+
+def _response() -> CompletionResponse:
+    """A successful completion carrying usage and ``_synthorg_*`` telemetry."""
+    return CompletionResponse(
+        content="ok",
+        finish_reason=FinishReason.STOP,
+        usage=TokenUsage(
+            input_tokens=_INPUT_TOKENS,
+            output_tokens=_OUTPUT_TOKENS,
+            cost=_COST,
+        ),
+        model=_MODEL,
+        provider_metadata={
+            "_synthorg_latency_ms": _LATENCY_MS,
+            "_synthorg_cache_hit": True,
+            "_synthorg_retry_count": 0,
+        },
+    )
+
+
+async def _emit(tracker: CostTracker, purpose: PromptPurposeId | None) -> None:
+    """Open a scope with ``purpose`` and emit one record, then drain."""
+    async with cost_recording_scope(
+        cost_tracker=tracker,
+        agent_id="agent-1",
+        task_id="task-1",
+        purpose=purpose,
+        call_category=LLMCallCategory.PRODUCTIVE,
+        currency=_CURRENCY,
+    ):
+        ctx = current_cost_context()
+        assert ctx is not None
+        await emit_cost_record_from_context(
+            ctx, _response(), model=_MODEL, provider=_PROVIDER
+        )
+    await tracker.drain_pending_records()
+
+
+async def test_purpose_emit_surfaces_in_breakdown() -> None:
+    tracker = CostTracker()
+    await _emit(tracker, PromptPurposeId.MEMORY_RERANK)
+
+    service = CallAnalyticsService(cost_tracker=tracker, config=CallAnalyticsConfig())
+    breakdown = await service.get_prompt_class_breakdown()
+
+    assert len(breakdown.rows) == 1
+    row = breakdown.rows[0]
+    assert row.prompt_class_id == PromptPurposeId.MEMORY_RERANK
+    # The dashboard tier column is the same design tier the pin records.
+    assert row.tier == tier_for_purpose(PromptPurposeId.MEMORY_RERANK)
+    assert row.total_cost == pytest.approx(_COST)
+    assert row.currency == _CURRENCY
+    assert row.call_count == 1
+    assert row.input_tokens == _INPUT_TOKENS
+    assert row.output_tokens == _OUTPUT_TOKENS
+    assert row.avg_latency_ms == pytest.approx(_LATENCY_MS)
+    assert row.p95_latency_ms == pytest.approx(_LATENCY_MS)
+    assert row.cache_hit_rate == pytest.approx(1.0)
+
+
+async def test_multiple_purposes_grouped_and_unattributed_excluded() -> None:
+    tracker = CostTracker()
+    await _emit(tracker, PromptPurposeId.MEMORY_RERANK)
+    await _emit(tracker, PromptPurposeId.COS_CHAT)
+    # A call with no registered purpose carries no prompt_class_id and must
+    # not appear as a row in the by-purpose breakdown.
+    await _emit(tracker, None)
+
+    service = CallAnalyticsService(cost_tracker=tracker, config=CallAnalyticsConfig())
+    breakdown = await service.get_prompt_class_breakdown()
+
+    ids = [row.prompt_class_id for row in breakdown.rows]
+    # Rows are sorted by prompt_class_id value: 'system:cos:chat' precedes
+    # 'system:memory:rerank'.
+    assert ids == [PromptPurposeId.COS_CHAT, PromptPurposeId.MEMORY_RERANK]
+
+
+async def test_unattributed_only_yields_no_rows() -> None:
+    tracker = CostTracker()
+    await _emit(tracker, None)
+
+    service = CallAnalyticsService(cost_tracker=tracker, config=CallAnalyticsConfig())
+    breakdown = await service.get_prompt_class_breakdown()
+
+    assert breakdown.rows == ()

--- a/tests/unit/hr/evaluation/test_pin_registry_closure.py
+++ b/tests/unit/hr/evaluation/test_pin_registry_closure.py
@@ -1,7 +1,7 @@
 """Closure guard across the three prompt-purpose populations.
 
-The epic keeps three sets in lock-step: the prompt-purpose registry (the source
-of ids), the pin registry (a pin per id), and the committed drift golden (a
+Three sets must stay in lock-step: the prompt-purpose registry (the source of
+ids), the pin registry (a pin per id), and the committed drift golden (a
 fingerprint per id). The freshness canary catches a *changed* fingerprint; this
 guard catches a *missing* one: a new ``PromptPurposeId`` added without a pin or
 a golden refresh, which the per-segment tests would each miss because each only

--- a/tests/unit/hr/evaluation/test_pin_registry_closure.py
+++ b/tests/unit/hr/evaluation/test_pin_registry_closure.py
@@ -1,0 +1,42 @@
+"""Closure guard across the three prompt-purpose populations.
+
+The epic keeps three sets in lock-step: the prompt-purpose registry (the source
+of ids), the pin registry (a pin per id), and the committed drift golden (a
+fingerprint per id). The freshness canary catches a *changed* fingerprint; this
+guard catches a *missing* one: a new ``PromptPurposeId`` added without a pin or
+a golden refresh, which the per-segment tests would each miss because each only
+inspects its own set.
+"""
+
+import pytest
+
+from synthorg.hr.evaluation.pin_fingerprint import GOLDEN_PATH, load_pin_golden
+from synthorg.llm.metadata import ModelPinMetadata
+from synthorg.llm.model_pins import pin_for
+from synthorg.llm.prompt_purpose import PROMPT_PURPOSE_REGISTRY, PromptPurposeId
+
+pytestmark = pytest.mark.unit
+
+
+def test_registry_enumerates_the_enum() -> None:
+    # The registry is the single id source; it must enumerate exactly the enum.
+    registered = {str(purpose.id) for purpose in PROMPT_PURPOSE_REGISTRY.all_purposes()}
+    assert registered == {member.value for member in PromptPurposeId}
+
+
+@pytest.mark.parametrize("purpose", list(PromptPurposeId))
+def test_every_purpose_has_a_pin(purpose: PromptPurposeId) -> None:
+    pin = pin_for(purpose)
+    assert isinstance(pin, ModelPinMetadata)
+    assert pin.prompt_class_id == purpose
+
+
+def test_golden_keys_match_registry_exactly() -> None:
+    golden = load_pin_golden(GOLDEN_PATH)
+    golden_ids = set(golden)
+    registry_ids = {member.value for member in PromptPurposeId}
+
+    missing = registry_ids - golden_ids
+    stale = golden_ids - registry_ids
+    assert not missing, f"purposes absent from the drift golden: {sorted(missing)}"
+    assert not stale, f"stale golden entries with no purpose: {sorted(stale)}"

--- a/tests/unit/llm/test_model_pin_vendor_guard.py
+++ b/tests/unit/llm/test_model_pin_vendor_guard.py
@@ -1,0 +1,63 @@
+"""Guard: model pins record a design tier, never a vendor model name.
+
+The provider-agnostic tenet (epic #2490) requires every pin's ``model`` to be a
+``example-{tier}-001`` archetype id, not a real vendor model. ``test_model_pins``
+checks that ``pin_for`` returns a valid :class:`ModelPinMetadata`; this guard adds
+the explicit negative: no pin's model matches a vendor token, and every model is a
+design-tier archetype. It ratchets against a future vendor name leaking into a pin.
+"""
+
+import re
+from typing import Final
+
+import pytest
+
+from synthorg.llm.model_pins import pin_for
+from synthorg.llm.prompt_purpose import PromptPurposeId
+
+pytestmark = pytest.mark.unit
+
+# A pin model id is the design tier the purpose maps to, per
+# ``model_tier_policy.model_id_for_purpose`` -> ``example-{tier}-001``.
+_ARCHETYPE_RE: Final[re.Pattern[str]] = re.compile(
+    r"^example-(small|medium|large)-001$"
+)
+
+# Substrings that betray a real vendor model name. Lower-cased before the
+# membership test. Not exhaustive, but covers the major families a careless
+# pin edit would reach for.
+_VENDOR_TOKENS: Final[tuple[str, ...]] = (
+    "gpt",
+    "openai",
+    "claude",
+    "anthropic",
+    "sonnet",
+    "opus",
+    "haiku",
+    "gemini",
+    "llama",
+    "mistral",
+    "mixtral",
+    "cohere",
+    "command",
+    "grok",
+    "deepseek",
+    "qwen",
+)
+
+
+@pytest.mark.parametrize("purpose", list(PromptPurposeId))
+def test_pin_model_is_design_tier_archetype(purpose: PromptPurposeId) -> None:
+    model = pin_for(purpose).model
+    assert _ARCHETYPE_RE.match(model), (
+        f"{purpose.value}: pin model {model!r} is not a design-tier archetype"
+    )
+
+
+@pytest.mark.parametrize("purpose", list(PromptPurposeId))
+def test_pin_model_has_no_vendor_token(purpose: PromptPurposeId) -> None:
+    model = pin_for(purpose).model.lower()
+    for token in _VENDOR_TOKENS:
+        assert token not in model, (
+            f"{purpose.value}: pin model {model!r} contains vendor token {token!r}"
+        )

--- a/tests/unit/llm/test_model_pin_vendor_guard.py
+++ b/tests/unit/llm/test_model_pin_vendor_guard.py
@@ -1,10 +1,10 @@
 """Guard: model pins record a design tier, never a vendor model name.
 
-The provider-agnostic tenet (epic #2490) requires every pin's ``model`` to be a
+The provider-agnostic design requires every pin's ``model`` to be an
 ``example-{tier}-001`` archetype id, not a real vendor model. ``test_model_pins``
 checks that ``pin_for`` returns a valid :class:`ModelPinMetadata`; this guard adds
 the explicit negative: no pin's model matches a vendor token, and every model is a
-design-tier archetype. It ratchets against a future vendor name leaking into a pin.
+design-tier archetype. It ratchets against a vendor name leaking into a pin.
 """
 
 import re

--- a/tests/unit/scripts/test_epic_2490_gate_live_tree.py
+++ b/tests/unit/scripts/test_epic_2490_gate_live_tree.py
@@ -1,0 +1,50 @@
+"""Live-tree regression guard for the epic #2490 enforcement gates.
+
+The per-gate unit tests prove each gate flags a *synthetic* violation; this adds
+the complementary clean assertion the F1 gate test was missing (mirroring
+``test_check_completion_config_temperature.test_clean_src_tree``): both the F2
+cost-scope-purpose gate and the F1 prompt-class-metadata gate must return ``0``
+against the real ``src/synthorg`` tree, so a future prompt class that tags spend
+without a purpose / metadata property is caught at unit-test speed, not only at
+pre-push / CI.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+
+
+def _load_gate(name: str) -> ModuleType:
+    # The gates prepend scripts/ to sys.path at import time to resolve their
+    # shared _gate_source sibling; restore sys.path so the load leaves no global
+    # side effect that could shadow an unrelated import.
+    saved = sys.path[:]
+    try:
+        spec = importlib.util.spec_from_file_location(
+            f"_gate_{name}", _SCRIPTS_DIR / f"{name}.py"
+        )
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path[:] = saved
+
+
+def test_cost_scope_purpose_gate_clean_on_live_tree() -> None:
+    gate = _load_gate("check_cost_scope_purpose")
+    assert gate.main(["--repo-root", str(_REPO_ROOT)]) == 0
+
+
+def test_prompt_class_metadata_gate_clean_on_live_tree() -> None:
+    gate = _load_gate("check_prompt_class_metadata")
+    assert gate.cmd_scan_all(_REPO_ROOT) == 0

--- a/tests/unit/scripts/test_gate_live_tree_clean.py
+++ b/tests/unit/scripts/test_gate_live_tree_clean.py
@@ -1,12 +1,12 @@
-"""Live-tree regression guard for the epic #2490 enforcement gates.
+"""Live-tree clean guard for the cost-scope-purpose and prompt-class-metadata gates.
 
-The per-gate unit tests prove each gate flags a *synthetic* violation; this adds
-the complementary clean assertion the F1 gate test was missing (mirroring
-``test_check_completion_config_temperature.test_clean_src_tree``): both the F2
-cost-scope-purpose gate and the F1 prompt-class-metadata gate must return ``0``
-against the real ``src/synthorg`` tree, so a future prompt class that tags spend
-without a purpose / metadata property is caught at unit-test speed, not only at
-pre-push / CI.
+The per-gate unit tests prove each gate flags a *synthetic* violation; this is
+the complementary clean assertion (mirroring
+``test_check_completion_config_temperature.test_clean_src_tree``): both
+``check_cost_scope_purpose`` and ``check_prompt_class_metadata`` must return
+``0`` against the real ``src/synthorg`` tree, so a prompt class that tags spend
+without a purpose or a metadata property is caught at unit-test speed, not only
+at pre-push / CI.
 """
 
 import importlib.util

--- a/web/src/__tests__/pages/BudgetForecastPage.test.tsx
+++ b/web/src/__tests__/pages/BudgetForecastPage.test.tsx
@@ -54,6 +54,7 @@ const mockBudgetConfig: BudgetConfig = {
     enabled: true,
     orchestration_alerts: { critical: 0.7, info: 0.3, warn: 0.5 },
     retry_alerts: { warn_rate: 0.1 },
+    prompt_class_alerts: { cost_warn: null, p95_latency_warn_ms: null, min_seconds_between_alerts: 300 },
   },
   subscriptions: {},
 }

--- a/web/src/__tests__/pages/BudgetPage.test.tsx
+++ b/web/src/__tests__/pages/BudgetPage.test.tsx
@@ -54,6 +54,7 @@ const mockBudgetConfig: BudgetConfig = {
     enabled: true,
     orchestration_alerts: { critical: 0.7, info: 0.3, warn: 0.5 },
     retry_alerts: { warn_rate: 0.1 },
+    prompt_class_alerts: { cost_warn: null, p95_latency_warn_ms: null, min_seconds_between_alerts: 300 },
   },
   subscriptions: {},
 }

--- a/web/src/__tests__/pages/DashboardPage.test.tsx
+++ b/web/src/__tests__/pages/DashboardPage.test.tsx
@@ -61,6 +61,7 @@ const mockBudgetConfig: BudgetConfig = {
     enabled: true,
     orchestration_alerts: { critical: 0.7, info: 0.3, warn: 0.5 },
     retry_alerts: { warn_rate: 0.1 },
+    prompt_class_alerts: { cost_warn: null, p95_latency_warn_ms: null, min_seconds_between_alerts: 300 },
   },
   subscriptions: {},
 }

--- a/web/src/__tests__/pages/budget/ThresholdAlerts.test.tsx
+++ b/web/src/__tests__/pages/budget/ThresholdAlerts.test.tsx
@@ -34,6 +34,7 @@ const mockBudgetConfig: BudgetConfig = {
     enabled: true,
     orchestration_alerts: { critical: 0.7, info: 0.3, warn: 0.5 },
     retry_alerts: { warn_rate: 0.1 },
+    prompt_class_alerts: { cost_warn: null, p95_latency_warn_ms: null, min_seconds_between_alerts: 300 },
   },
   subscriptions: {},
 }

--- a/web/src/__tests__/stores/budget.test.ts
+++ b/web/src/__tests__/stores/budget.test.ts
@@ -56,6 +56,7 @@ const mockBudgetConfig: BudgetConfig = {
     enabled: true,
     orchestration_alerts: { critical: 0.7, info: 0.3, warn: 0.5 },
     retry_alerts: { warn_rate: 0.1 },
+    prompt_class_alerts: { cost_warn: null, p95_latency_warn_ms: null, min_seconds_between_alerts: 300 },
   },
   subscriptions: {},
 }

--- a/web/src/__tests__/utils/budget.test.ts
+++ b/web/src/__tests__/utils/budget.test.ts
@@ -498,6 +498,7 @@ describe('computeBudgetMetricCards', () => {
         enabled: true,
         orchestration_alerts: { critical: 0.7, info: 0.3, warn: 0.5 },
         retry_alerts: { warn_rate: 0.1 },
+        prompt_class_alerts: { cost_warn: null, p95_latency_warn_ms: null, min_seconds_between_alerts: 300 },
       },
       subscriptions: {},
     }

--- a/web/src/__tests__/utils/dashboard.property.test.ts
+++ b/web/src/__tests__/utils/dashboard.property.test.ts
@@ -87,6 +87,7 @@ const arbBudgetConfig: fc.Arbitrary<BudgetConfig> = fc.record({
     enabled: true,
     orchestration_alerts: { critical: 0.7, info: 0.3, warn: 0.5 },
     retry_alerts: { warn_rate: 0.1 },
+    prompt_class_alerts: { cost_warn: null, p95_latency_warn_ms: null, min_seconds_between_alerts: 300 },
   }),
   subscriptions: fc.constant({}),
 })

--- a/web/src/__tests__/utils/dashboard.test.ts
+++ b/web/src/__tests__/utils/dashboard.test.ts
@@ -82,6 +82,7 @@ function makeBudgetConfig(overrides: Partial<BudgetConfig> = {}): BudgetConfig {
       enabled: true,
       orchestration_alerts: { critical: 0.7, info: 0.3, warn: 0.5 },
       retry_alerts: { warn_rate: 0.1 },
+      prompt_class_alerts: { cost_warn: null, p95_latency_warn_ms: null, min_seconds_between_alerts: 300 },
     },
     subscriptions: {},
     ...overrides,

--- a/web/src/api/types/dtos.gen.ts
+++ b/web/src/api/types/dtos.gen.ts
@@ -499,6 +499,7 @@ export type PromotionApplyResultDTO = components['schemas']['PromotionApplyResul
 export type PromotionEvaluationDTO = components['schemas']['PromotionEvaluationDTO']
 export type PromotionRecordDTO = components['schemas']['PromotionRecordDTO']
 export type PromotionRequestDTO = components['schemas']['PromotionRequestDTO']
+export type PromptClassAlertConfig = components['schemas']['PromptClassAlertConfig']
 export type PromptClassBreakdown = components['schemas']['PromptClassBreakdown']
 export type PromptClassBreakdownRow = components['schemas']['PromptClassBreakdownRow']
 export type ProposeResult = components['schemas']['ProposeResult']

--- a/web/src/api/types/openapi.gen.ts
+++ b/web/src/api/types/openapi.gen.ts
@@ -8153,6 +8153,7 @@ export type components = {
              */
             readonly enabled: boolean;
             readonly orchestration_alerts: components["schemas"]["OrchestrationAlertThresholds"];
+            readonly prompt_class_alerts: components["schemas"]["PromptClassAlertConfig"];
             readonly retry_alerts: components["schemas"]["RetryAlertConfig"];
         };
         /** CancelEscalationRequest */
@@ -13725,6 +13726,21 @@ export type components = {
             readonly status: "pending" | "approved" | "rejected" | "expired";
             /** @description Target seniority level */
             readonly target_level: string;
+        };
+        /**
+         * PromptClassAlertConfig
+         * @description Per-prompt-purpose cost / latency alert thresholds.
+         */
+        readonly PromptClassAlertConfig: {
+            /** @description Per-purpose total-cost warning ceiling, or None to disable. */
+            readonly cost_warn: number | null;
+            /**
+             * @description Minimum seconds between re-alerts for the same purpose.
+             * @default 300
+             */
+            readonly min_seconds_between_alerts: number;
+            /** @description Per-purpose p95-latency warning ceiling in ms, or None. */
+            readonly p95_latency_warn_ms: number | null;
         };
         /** PromptClassBreakdown */
         readonly PromptClassBreakdown: {

--- a/web/src/mocks/handlers/budget.ts
+++ b/web/src/mocks/handlers/budget.ts
@@ -110,6 +110,7 @@ function buildBudgetConfig(
       enabled: true,
       orchestration_alerts: { critical: 0.7, info: 0.3, warn: 0.5 },
       retry_alerts: { warn_rate: 0.1 },
+      prompt_class_alerts: { cost_warn: null, p95_latency_warn_ms: null, min_seconds_between_alerts: 300 },
     },
     subscriptions: {},
     ...overrides,

--- a/web/src/pages/budget/BudgetPage.stories.tsx
+++ b/web/src/pages/budget/BudgetPage.stories.tsx
@@ -61,6 +61,7 @@ const mockBudgetConfig: BudgetConfig = {
     enabled: true,
     orchestration_alerts: { critical: 0.7, info: 0.3, warn: 0.5 },
     retry_alerts: { warn_rate: 0.1 },
+    prompt_class_alerts: { cost_warn: null, p95_latency_warn_ms: null, min_seconds_between_alerts: 300 },
   },
   subscriptions: {},
 }

--- a/web/src/pages/budget/ThresholdAlerts.stories.tsx
+++ b/web/src/pages/budget/ThresholdAlerts.stories.tsx
@@ -34,6 +34,7 @@ const baseBudgetConfig: BudgetConfig = {
     enabled: true,
     orchestration_alerts: { critical: 0.7, info: 0.3, warn: 0.5 },
     retry_alerts: { warn_rate: 0.1 },
+    prompt_class_alerts: { cost_warn: null, p95_latency_warn_ms: null, min_seconds_between_alerts: 300 },
   },
   subscriptions: {},
 }

--- a/web/src/pages/dashboard/DashboardPage.stories.tsx
+++ b/web/src/pages/dashboard/DashboardPage.stories.tsx
@@ -60,6 +60,7 @@ const mockBudgetConfig: BudgetConfig = {
     enabled: true,
     orchestration_alerts: { critical: 0.7, info: 0.3, warn: 0.5 },
     retry_alerts: { warn_rate: 0.1 },
+    prompt_class_alerts: { cost_warn: null, p95_latency_warn_ms: null, min_seconds_between_alerts: 300 },
   },
   subscriptions: {},
 }


### PR DESCRIPTION
## Summary

Completes epic **#2490** (prompt-purpose observability + validated model pins). All seven children (#2492-#2498) were already merged; this PR closes the one unmet child acceptance criterion and adds end-to-end verification across the epic.

- **J1 per-purpose cost/latency alerts** (the unmet #2497 criterion): `PromptClassAlertConfig` (opt-in `cost_warn` / `p95_latency_warn_ms`, both default off) + `CallAnalyticsService.check_prompt_class_alerts`, dispatched via `NotificationDispatcher` and evaluated **live** on the `get_prompt_class_breakdown` read path. Storm-safe: a per-purpose cooldown (`SlidingWindowEventLimiter`) re-alerts at most once per `min_seconds_between_alerts`, one combined notification per row, dispatched concurrently via `TaskGroup`, with the cooldown slot refunded on a dispatch failure.
- **#2495 `model_version_pinned_at`**: confirmed resolved-by-design (the validator writes the live last-validated stamp to `ModelPinValidationRow.validated_at`, read by the audit dashboard; the static field is its documented counterpart) -- left unchanged.

## Verification added (new tests only; no shared-logic change beyond J1)

- Full `cost_recording_scope(purpose=)` -> tracker -> `get_prompt_class_breakdown` emit chain.
- Persisted `prompt_class_id` -> breakdown across **SQLite + Postgres** (conformance).
- No-vendor-name pin guard (every pin model is an `example-{tier}-001` archetype).
- Registry / pin / golden closure guard.
- F1 (`check_prompt_class_metadata`) + F2 (`check_cost_scope_purpose`) live-tree clean guard.
- Full J1 coverage: cooldown, combined-breach single dispatch, multi-row selection, release-on-failure retry, critical-error propagation, latency boundary, `PromptClassAlertConfig` validation.

Live gate-failure proofs confirmed each gate exits 1 on a broken fixture and 0 on the real tree; the pin-golden canary reports fresh (39 prompt classes).

## Test plan

- `uv run python -m pytest tests/unit/budget tests/unit/llm/test_model_pin_vendor_guard.py tests/unit/hr/evaluation/test_pin_registry_closure.py tests/unit/scripts/test_gate_live_tree_clean.py -m unit` (1511 passed)
- `uv run python -m pytest tests/conformance/persistence/test_cost_attribution_roundtrip.py` (SQLite + Postgres)
- ruff, mypy (strict), vale: clean. Full pre-push suite + convention gates: green.

## Review coverage

Pre-reviewed by 15 agents (issue-resolution-verifier PASS; ghost-wiring CONFIRMED-WIRED). All valid findings implemented; dispositions recorded in `_audit/pre-pr-review/triage.md`. One follow-up surfaced: strip 3 pre-existing `formerly` migration-framing strings from unrelated modules.

Closes #2490
