### PR TITLE
fix: dispatch each agent to its own provider and fix chat/streaming cost teardown

### DIFF
--- a/docs/design/agent-execution.md
+++ b/docs/design/agent-execution.md
@@ -253,7 +253,18 @@ async run(
    plan-execute), and `hybrid_loop_config` (for hybrid), along with the
    approval gate and stagnation detector.
 10. **Delegate to loop**: calls `ExecutionLoop.execute()` with context,
-   provider, tool invoker, budget checker, and completion config. If
+   provider, tool invoker, budget checker, and completion config. The
+   provider client is dispatched **per agent**, not fixed to the engine
+   default: `_dispatch_client_for(identity)` resolves the client serving
+   the agent's own `identity.model.provider` from the provider registry, so
+   an agent pinned to a non-default provider runs on its own API and its cost
+   is attributed to that provider. A wired registry that does not know the
+   provider fails closed (`DriverNotRegisteredError`) rather than silently
+   dispatching to the wrong API; only a fully unwired registry falls back to
+   the engine default. Because budget auto-downgrade (`resolve_model`, step 2)
+   and stakes routing can re-point `identity.model.provider` mid-pipeline, the
+   client is re-dispatched after any such change so it stays in lockstep with
+   the resolved model. If
    `timeout_seconds` is set, wraps the call in `asyncio.wait`; on expiry
    the run returns with `TerminationReason.ERROR` but cost recording and
    post-execution processing still occur.

--- a/docs/design/budget.md
+++ b/docs/design/budget.md
@@ -125,12 +125,18 @@ models (`AgentSpending`, `DepartmentSpending`, `PeriodSpending`) extend a shared
 Both paths converge on the same `CostTracker.record()` API and the same
 same-currency invariants apply.
 
-Streaming completions (`BaseCompletionProvider.stream()`) currently bypass the
-chokepoint -- usage arrives as a terminal `StreamEventType.USAGE` chunk that the
-chokepoint would have to consume from the iterator, conflating cost recording
-with the stream-consumption contract. No call site uses `stream()` for paid LLM
-work today; when streaming becomes a mainstream call path the chokepoint will
-be extended.
+Streaming completions (`BaseCompletionProvider.stream()`) route through the
+same chokepoint. Token counts surface only on the terminal
+`StreamEventType.USAGE` chunk, so `stream()` wraps the driver's iterator in a
+lazy pass-through generator (`_cost_recording_stream`) that yields each chunk
+unchanged, captures the usage chunk, and -- once the consumer fully drains the
+stream -- fires the same `record_cost_if_in_scope` chokepoint `complete()` uses.
+Because draining happens in the consumer's scope, the `CostRecord` lands in the
+caller's `cost_recording_scope`, not at connection-setup time. A stream that
+never yields a usage chunk records nothing, matching the no-scope no-op
+contract. The scope's teardown is context-safe (a plain context-var restore, so
+an SSE response body that drives the generator's close in a different `anyio`
+context than its open cannot raise).
 
 The `GET /budget/records` endpoint returns paginated cost records alongside two server-computed
 summaries (aggregated from **all** matching records, not just the current page):

--- a/docs/design/providers.md
+++ b/docs/design/providers.md
@@ -109,7 +109,7 @@ whether the backend is a cloud API, OpenRouter, Ollama, or a custom endpoint.
 
 Every successful **scoped** `provider.complete()` call attributes a `CostRecord` to the agent and task that originated the work. Attribution flows through a `ContextVar` middleware rather than through per-call kwargs, which keeps the provider interface uniform across cloud APIs, OpenRouter, Ollama, and custom adapters. Calls made outside any `cost_recording_scope` -- infrastructure probes, model discovery, the engine turn loop, tests -- read `None` for the active context and are intentionally **not** attributed: the engine's post-execution recorder owns engine turns, and probe / discovery traffic is not user spend.
 
-- **Scope contract**: callers wrap a `provider.complete()` invocation in `cost_recording_scope(cost_tracker, agent_id, task_id, project_id, call_category, currency)` from `synthorg.providers.cost_recording`. The scope is an `@asynccontextmanager` that sets a per-`asyncio.Task` `ContextVar`, yields, and resets on exit. Nested scopes shadow the outer one and are restored on exit; concurrent tasks see independent scopes.
+- **Scope contract**: callers wrap a `provider.complete()` invocation in `cost_recording_scope(cost_tracker, agent_id, task_id, project_id, call_category, currency)` from `synthorg.providers.cost_recording`. The scope is an `@asynccontextmanager` that captures the current `ContextVar` value, sets the new context, yields, and restores the captured value on exit. It restores by plain `set(previous)` rather than `Token.reset` on purpose: a streaming or SSE body can drive the enter and the exit in different `asyncio` contexts, and `Token.reset` raises `ValueError` when the token is reset in a context other than the one that created it, whereas a plain set is always context-safe. Nested scopes shadow the outer one and are restored on exit; concurrent tasks see independent scopes.
 - **Chokepoint**: `BaseCompletionProvider.complete()` reads the scope's context after a successful response, builds a `CostRecord` from `result.usage` + `result.provider_metadata` (`_synthorg_latency_ms`, `_synthorg_cache_hit`, `_synthorg_retry_count`, `_synthorg_retry_reason`) + `result.finish_reason`, and submits it via `cost_tracker.record(record)`. Calls outside any scope (probes, model discovery, tests) are no-ops.
 - **Skip rule**: usage with both zero tokens and zero cost is skipped (matches the engine post-execution recorder). Free-tier providers with non-zero tokens still record.
 - **Failure isolation**: any exception from `cost_tracker.record(...)` other than `MemoryError` / `RecursionError` is logged at WARNING (`PROVIDER_COST_FAILED`) and swallowed -- the user-visible provider response never depends on recording success.
@@ -217,6 +217,20 @@ The recommendation store, scheduler, and service form a both-or-neither paired
 invariant on `ModelRefreshStateSlice`; the controllers 503 when the store is unwired.
 Recommendations only PROPOSE; human approval still gates apply unless a strictly
 in-family upgrade matches the auto-apply flag.
+
+**In-family selection** (`UpgradeRecommender`): models are grouped by
+`(metadata.family, metadata.supports_embeddings)`, not by family alone. A family
+label can span two incompatible classes -- an embedding model (vector output) and
+a chat model are not drop-in replacements -- so grouping on the embedding flag
+prevents a newer-generation chat model from being recommended as the upgrade for
+an embedding model (or vice versa). Within a group, every model older than the
+newest generation is a candidate; the recommendation targets the newest-generation
+sibling with no capability regression (it must not drop a tool / vision / reasoning
+capability the current model has). When several newest-generation candidates
+qualify, the strongest is chosen by upgrade score (capability fit + context
+headroom + generation delta, from the registered matcher weights), with model id
+as a deterministic tie-break, so a larger / more capable variant is preferred over
+an arbitrary alphabetical pick.
 
 ## Model Routing Strategy
 

--- a/src/synthorg/api/services/_org_agent_mutations.py
+++ b/src/synthorg/api/services/_org_agent_mutations.py
@@ -272,11 +272,8 @@ class OrgAgentMutationsMixin:
         at all), so a half-specified pair never reaches here.
         """
         if data.model_provider is not None and data.model_id is not None:
-            providers = await self._read_provider_configs()
-            validate_provider_model_pair(
-                providers,
-                str(data.model_provider),
-                str(data.model_id),
+            await self.validate_model_assignment(
+                str(data.model_provider), str(data.model_id)
             )
 
     async def validate_model_assignment(

--- a/src/synthorg/api/services/_org_agent_mutations.py
+++ b/src/synthorg/api/services/_org_agent_mutations.py
@@ -279,6 +279,23 @@ class OrgAgentMutationsMixin:
                 str(data.model_id),
             )
 
+    async def validate_model_assignment(
+        self, provider_name: str, model_id: str
+    ) -> None:
+        """Validate a provider/model pair against the live catalogue.
+
+        Public pre-flight for callers (e.g. the upgrade-recommendation
+        apply flow) that need to reject a gone provider/model *before*
+        looping over agents, so a removed provider surfaces once as a
+        catalogue error instead of being mistaken for a per-agent skip.
+
+        Raises:
+            NotFoundError: When the provider is not in the catalogue.
+            ValidationError: When the provider does not expose the model.
+        """
+        providers = await self._read_provider_configs()
+        validate_provider_model_pair(providers, provider_name, model_id)
+
     async def update_agent(
         self,
         name: str,

--- a/src/synthorg/api/services/upgrade_recommendation_service.py
+++ b/src/synthorg/api/services/upgrade_recommendation_service.py
@@ -235,10 +235,11 @@ class UpgradeRecommendationService:
 
         Best-effort per agent: a stale agent id (renamed / deleted since
         the recommendation was produced) is logged and skipped so one
-        missing agent never fails the whole apply. The recommended
-        provider/model is pre-validated by ``_preflight_provider``, so a
-        ``NotFoundError`` here is unambiguously a missing agent, never a
-        gone provider.
+        missing agent never fails the whole apply. ``update_agent``
+        revalidates the provider/model on every call, so a gone provider
+        can also raise ``NotFoundError`` mid-loop even after the up-front
+        ``_preflight_provider``; the handler re-validates to tell the two
+        apart and only skips genuine missing-agent cases.
         """
         rec = stored.recommendation
         for agent_name in stored.agent_ids:
@@ -251,9 +252,14 @@ class UpgradeRecommendationService:
                     ),
                 )
             except NotFoundError as exc:
-                # A stale agent id (renamed / deleted since the recommendation
-                # was produced) is the only tolerated per-agent failure; any
-                # other error propagates so it is not silently swallowed.
+                # ``update_agent`` revalidates the provider/model on every
+                # call, so this NotFoundError is either a gone agent (benign
+                # skip) or the recommended provider vanished mid-loop after
+                # the preflight (fatal). Re-validate: a gone provider/model
+                # re-raises so the apply stops instead of partially
+                # completing; a still-present pair means the agent itself is
+                # genuinely stale, which is the only tolerated per-agent skip.
+                await self._preflight_provider(stored)
                 logger.warning(
                     PROVIDER_MODEL_UPGRADE_REASSIGN_FAILED,
                     agent=agent_name,

--- a/src/synthorg/api/services/upgrade_recommendation_service.py
+++ b/src/synthorg/api/services/upgrade_recommendation_service.py
@@ -13,7 +13,7 @@ from uuid import UUID
 
 from synthorg.api.services.org_mutations import OrgMutationService
 from synthorg.core.clock import Clock, SystemClock
-from synthorg.core.critical_errors import reraise_critical
+from synthorg.core.domain_errors import NotFoundError
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.api import (
     API_RESOURCE_CONFLICT,
@@ -222,8 +222,10 @@ class UpgradeRecommendationService:
                         model_id=rec.recommended_model_id,
                     ),
                 )
-            except Exception as exc:  # noqa: BLE001 -- criticals re-raised
-                reraise_critical(exc)
+            except NotFoundError as exc:
+                # A stale agent id (renamed / deleted since the recommendation
+                # was produced) is the only tolerated per-agent failure; any
+                # other error propagates so it is not silently swallowed.
                 logger.warning(
                     PROVIDER_MODEL_UPGRADE_REASSIGN_FAILED,
                     agent=agent_name,

--- a/src/synthorg/api/services/upgrade_recommendation_service.py
+++ b/src/synthorg/api/services/upgrade_recommendation_service.py
@@ -114,6 +114,7 @@ class UpgradeRecommendationService:
             UpgradeRecommendationAlreadyDecidedError: When not pending.
         """
         stored = await self.get_or_404(rec_id)
+        await self._preflight_provider(stored)
         await self._decide(
             stored,
             to_state=RecommendationStatus.APPROVED,
@@ -162,6 +163,7 @@ class UpgradeRecommendationService:
         Transitions ``PENDING -> AUTO_APPLIED`` and reassigns pinned
         agents. A lost CAS (already decided) is a no-op.
         """
+        await self._preflight_provider(stored)
         moved = await self._repo.transition_if(
             stored.id,
             from_state=RecommendationStatus.PENDING,
@@ -205,12 +207,38 @@ class UpgradeRecommendationService:
             logger.warning(API_RESOURCE_CONFLICT, reason=msg, rec_id=str(stored.id))
             raise UpgradeRecommendationAlreadyDecidedError(msg)
 
+    async def _preflight_provider(self, stored: StoredUpgradeRecommendation) -> None:
+        """Validate the recommendation's provider/model before deciding.
+
+        Every pinned agent is reassigned to the *same* recommended
+        provider/model, and ``update_agent`` raises ``NotFoundError`` both
+        when an agent is missing and when the target provider is gone. If
+        the recommended provider was removed since the recommendation was
+        produced, that would surface once per agent inside ``_reassign`` and
+        be silently swallowed as a stale-agent skip, leaving the whole apply
+        a no-op. Validating the pair once up front makes a gone provider a
+        loud failure that keeps the recommendation ``PENDING`` (retryable)
+        rather than decided-but-unapplied, and leaves any ``NotFoundError``
+        inside ``_reassign`` unambiguously an agent-missing skip.
+
+        Raises:
+            NotFoundError: When the recommended provider is gone.
+            ValidationError: When the provider no longer exposes the model.
+        """
+        rec = stored.recommendation
+        await self._org_mutations.validate_model_assignment(
+            rec.provider_name, rec.recommended_model_id
+        )
+
     async def _reassign(self, stored: StoredUpgradeRecommendation) -> None:
         """Re-point each pinned agent at the recommended model.
 
         Best-effort per agent: a stale agent id (renamed / deleted since
         the recommendation was produced) is logged and skipped so one
-        missing agent never fails the whole apply.
+        missing agent never fails the whole apply. The recommended
+        provider/model is pre-validated by ``_preflight_provider``, so a
+        ``NotFoundError`` here is unambiguously a missing agent, never a
+        gone provider.
         """
         rec = stored.recommendation
         for agent_name in stored.agent_ids:

--- a/src/synthorg/engine/agent_engine.py
+++ b/src/synthorg/engine/agent_engine.py
@@ -486,6 +486,11 @@ class AgentEngine(
             provider: CompletionProvider = self._provider
             _project_budget: float = 0.0
             try:
+                # Dispatch to the provider serving this agent's own model
+                # before stakes routing may re-point it; a registry miss
+                # (agent pinned to an unregistered provider) fails the run
+                # here rather than mis-dispatching to the engine default.
+                provider = self._dispatch_client_for(identity, self._provider)
                 loop_mode = (
                     "auto"
                     if self._auto_loop_config is not None
@@ -525,9 +530,11 @@ class AgentEngine(
                         identity,
                         provider,
                     )
-                    identity = await self._budget_enforcer.resolve_model(
-                        identity,
-                    )
+                    identity = await self._budget_enforcer.resolve_model(identity)
+                    # resolve_model may downgrade to a model owned by another
+                    # provider; re-dispatch so the client matches the new
+                    # identity.model.provider for cost/budget attribution.
+                    provider = self._dispatch_client_for(identity, provider)
 
                 if self._project_repo is not None:
                     _project_budget = await self._validate_project(

--- a/src/synthorg/engine/agent_engine.py
+++ b/src/synthorg/engine/agent_engine.py
@@ -522,19 +522,21 @@ class AgentEngine(
 
                 if self._budget_enforcer:
                     preflight = await self._budget_enforcer.check_can_execute(
-                        agent_id,
-                        provider_name=identity.model.provider,
+                        agent_id, provider_name=identity.model.provider
                     )
                     provider, identity = self._apply_degradation(
                         preflight,
                         identity,
                         provider,
                     )
-                    identity = await self._budget_enforcer.resolve_model(identity)
+                    downgraded = await self._budget_enforcer.resolve_model(identity)
                     # resolve_model may downgrade to a model owned by another
-                    # provider; re-dispatch so the client matches the new
-                    # identity.model.provider for cost/budget attribution.
-                    provider = self._dispatch_client_for(identity, provider)
+                    # provider; re-dispatch and only commit the new identity
+                    # once dispatch succeeds, so a registry miss never leaves a
+                    # downgraded identity paired with the pre-downgrade client
+                    # for the fallback / recovery path to reuse.
+                    provider = self._dispatch_client_for(downgraded, provider)
+                    identity = downgraded
 
                 if self._project_repo is not None:
                     _project_budget = await self._validate_project(

--- a/src/synthorg/engine/agent_engine_errors.py
+++ b/src/synthorg/engine/agent_engine_errors.py
@@ -111,6 +111,37 @@ class AgentEngineErrorsMixin:
                 total_tokens=metrics.tokens_per_task,
             )
 
+    def _dispatch_client_for(
+        self,
+        identity: AgentIdentity,
+        fallback_provider: CompletionProvider,
+    ) -> CompletionProvider:
+        """Return the client that serves ``identity.model.provider``.
+
+        The engine holds a single default client, but each agent can be
+        pinned to any registered provider. Cost attribution and the budget
+        preflight both read ``identity.model.provider``, so the dispatched
+        client must be that same provider or a call hits one provider's API
+        while the cost/quota lands on another. Resolving strictly against the
+        registry keeps the client and the identity in lockstep; a miss (an
+        agent pinned to an unregistered provider) raises
+        ``DriverNotRegisteredError`` so the run fails cleanly here instead of
+        silently dispatching a mismatched pair to the engine default. Falls
+        back to ``fallback_provider`` only when no registry is wired at all
+        (a degraded / test context with no catalogue to resolve against).
+
+        Returns:
+            The registry client for ``identity.model.provider``, or
+            ``fallback_provider`` when no provider registry is wired.
+
+        Raises:
+            DriverNotRegisteredError: When a registry is wired but does not
+                know ``identity.model.provider``.
+        """
+        if self._provider_registry is None:
+            return fallback_provider
+        return self._provider_registry.get(identity.model.provider)
+
     def _resolve_provider_instance(
         self,
         routed: AgentIdentity,
@@ -138,6 +169,9 @@ class AgentEngineErrorsMixin:
         """
         target = routed.model.provider
         if target == fallback_identity.model.provider:
+            # Same provider as before routing. ``fallback_provider`` was
+            # resolved for that provider at run start (``_dispatch_client_for``),
+            # so it already serves ``target``; only the model id/tier moved.
             return fallback_provider, routed
         if self._provider_registry is None:
             logger.warning(

--- a/src/synthorg/observability/events/provider.py
+++ b/src/synthorg/observability/events/provider.py
@@ -234,6 +234,9 @@ PROVIDER_MODEL_REFRESH_MODE_RESOLVE_FAILED: Final[str] = (
     "provider.model_refresh.mode_resolve_failed"
 )
 PROVIDER_MODEL_REFRESH_ADD_FAILED: Final[str] = "provider.model_refresh.add_failed"
+PROVIDER_MODEL_REFRESH_RECOMMEND_FAILED: Final[str] = (
+    "provider.model_refresh.recommend_failed"
+)
 PROVIDER_MODEL_FLAGGED_STALE: Final[str] = "provider.model.flagged_stale"
 PROVIDER_MODEL_UPGRADE_RECOMMENDED: Final[str] = "provider.model.upgrade_recommended"
 PROVIDER_MODEL_UPGRADE_AUTO_APPLIED: Final[str] = "provider.model.upgrade_auto_applied"

--- a/src/synthorg/providers/cost_recording.py
+++ b/src/synthorg/providers/cost_recording.py
@@ -200,14 +200,18 @@ async def cost_recording_scope(  # noqa: PLR0913
         # trackerless; it counts these to attribute spend signal by purpose).
         logger.debug(PROVIDER_PROMPT_PURPOSE_INVOKED, prompt_class_id=str(purpose))
     if cost_tracker is None:
-        # Shadow the outer context with ``None`` so nested calls
-        # don't silently inherit a wired outer tracker.  Reset on
-        # exit to restore whatever was active before.
-        token = _cost_context.set(None)
+        # Shadow the outer context with ``None`` so nested calls don't
+        # silently inherit a wired outer tracker; restore the prior value on
+        # exit. A plain ``set(previous)`` is used rather than ``Token.reset``
+        # because streaming scopes wrap an SSE async generator whose enter and
+        # exit can run in different asyncio contexts, where ``Token.reset``
+        # raises; ``set`` is valid in any context.
+        previous = _cost_context.get()
+        _cost_context.set(None)
         try:
             yield
         finally:
-            _cost_context.reset(token)
+            _cost_context.set(previous)
         return
     resolved_currency = (
         currency if currency is not None else resolve_currency(cost_tracker)
@@ -224,11 +228,16 @@ async def cost_recording_scope(  # noqa: PLR0913
         call_category=call_category,
         currency=resolved_currency,
     )
-    token = _cost_context.set(ctx)
+    # Restore the prior value with a plain ``set`` (not ``Token.reset``): a
+    # streaming scope's enter and exit can run in different asyncio contexts
+    # (an SSE body generator's drive step vs its teardown), where
+    # ``Token.reset`` raises ``ValueError``; ``set`` is context-safe.
+    previous = _cost_context.get()
+    _cost_context.set(ctx)
     try:
         yield
     finally:
-        _cost_context.reset(token)
+        _cost_context.set(previous)
 
 
 def resolve_currency(cost_tracker: CostTrackerProtocol) -> CurrencyCode:

--- a/src/synthorg/providers/cost_recording.py
+++ b/src/synthorg/providers/cost_recording.py
@@ -16,12 +16,8 @@ The scope is async-safe: Python :mod:`contextvars` propagate per
 
 import asyncio
 import math
-from collections.abc import (
-    AsyncIterator,
-    Callable,
-    Mapping,
-)
-from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator, Callable, Iterator, Mapping
+from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from datetime import UTC, datetime
 from typing import Final
@@ -149,6 +145,23 @@ def current_cost_context() -> CostRecordingContext | None:
     return _cost_context.get()
 
 
+@contextmanager
+def _bound_cost_context(value: CostRecordingContext | None) -> Iterator[None]:
+    """Bind ``_cost_context`` to *value*, restoring the prior value on exit.
+
+    Restoration is a plain ``set(previous)`` rather than ``Token.reset``:
+    a streaming scope wraps an SSE async generator whose enter and exit can
+    run in different asyncio contexts (a drive step vs its teardown), where
+    ``Token.reset`` raises ``ValueError``; ``set`` is valid in any context.
+    """
+    previous = _cost_context.get()
+    _cost_context.set(value)
+    try:
+        yield
+    finally:
+        _cost_context.set(previous)
+
+
 @asynccontextmanager
 async def cost_recording_scope(  # noqa: PLR0913
     *,
@@ -201,17 +214,9 @@ async def cost_recording_scope(  # noqa: PLR0913
         logger.debug(PROVIDER_PROMPT_PURPOSE_INVOKED, prompt_class_id=str(purpose))
     if cost_tracker is None:
         # Shadow the outer context with ``None`` so nested calls don't
-        # silently inherit a wired outer tracker; restore the prior value on
-        # exit. A plain ``set(previous)`` is used rather than ``Token.reset``
-        # because streaming scopes wrap an SSE async generator whose enter and
-        # exit can run in different asyncio contexts, where ``Token.reset``
-        # raises; ``set`` is valid in any context.
-        previous = _cost_context.get()
-        _cost_context.set(None)
-        try:
+        # silently inherit a wired outer tracker.
+        with _bound_cost_context(None):
             yield
-        finally:
-            _cost_context.set(previous)
         return
     resolved_currency = (
         currency if currency is not None else resolve_currency(cost_tracker)
@@ -228,16 +233,8 @@ async def cost_recording_scope(  # noqa: PLR0913
         call_category=call_category,
         currency=resolved_currency,
     )
-    # Restore the prior value with a plain ``set`` (not ``Token.reset``): a
-    # streaming scope's enter and exit can run in different asyncio contexts
-    # (an SSE body generator's drive step vs its teardown), where
-    # ``Token.reset`` raises ``ValueError``; ``set`` is context-safe.
-    previous = _cost_context.get()
-    _cost_context.set(ctx)
-    try:
+    with _bound_cost_context(ctx):
         yield
-    finally:
-        _cost_context.set(previous)
 
 
 def resolve_currency(cost_tracker: CostTrackerProtocol) -> CurrencyCode:

--- a/src/synthorg/providers/management/refresh_strategy.py
+++ b/src/synthorg/providers/management/refresh_strategy.py
@@ -23,6 +23,7 @@ from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.provider import (
     PROVIDER_MODEL_FLAGGED_STALE,
     PROVIDER_MODEL_REFRESH_ADD_FAILED,
+    PROVIDER_MODEL_REFRESH_RECOMMEND_FAILED,
 )
 from synthorg.providers.management.capability_dtos import AddModelRequest
 from synthorg.providers.management.live_discovery_probe import LiveDiscoveryProbe
@@ -238,9 +239,8 @@ class ReconcileRecommendStrategy:
         except Exception as exc:  # noqa: BLE001 -- criticals re-raised
             reraise_critical(exc)
             logger.warning(
-                PROVIDER_MODEL_REFRESH_ADD_FAILED,
+                PROVIDER_MODEL_REFRESH_RECOMMEND_FAILED,
                 provider=provider_name,
-                note="recommend_reread_failed",
                 error_type=type(exc).__name__,
                 error=safe_error_description(exc),
             )

--- a/src/synthorg/providers/management/upgrade_recommender.py
+++ b/src/synthorg/providers/management/upgrade_recommender.py
@@ -119,6 +119,45 @@ class UpgradeRecommender:
             )
         return UpgradeAnalysis(recommendations=tuple(recommendations))
 
+    def _best_candidate(
+        self,
+        current: ProviderModelConfig,
+        current_generation: float,
+        newest_candidates: list[ProviderModelConfig],
+        newest_gen: float,
+    ) -> tuple[ProviderModelConfig, float] | None:
+        """Pick the strongest newest-gen candidate without a regression.
+
+        Ranks the regression-free candidates by upgrade score (which
+        rewards capability fit and context headroom) so a larger / more
+        capable sibling at the same generation (e.g. a ``-pro`` variant) is
+        preferred over a smaller / cheaper one (e.g. a ``-flash`` variant)
+        rather than an arbitrary alphabetical pick. Id breaks a score tie
+        deterministically.
+
+        Returns:
+            The highest-scoring viable candidate paired with its score, or
+            ``None`` when every newest-gen candidate would drop a capability
+            the current has.
+        """
+        scored = [
+            (
+                c,
+                _score(
+                    current=current,
+                    candidate=c,
+                    current_generation=current_generation,
+                    candidate_generation=newest_gen,
+                    config=self._config,
+                ),
+            )
+            for c in newest_candidates
+            if not _has_capability_regression(current.metadata, c.metadata)
+        ]
+        if not scored:
+            return None
+        return max(scored, key=lambda pair: (pair[1], pair[0].id))
+
     def _recommend_for_provider(
         self,
         provider_name: str,
@@ -129,37 +168,35 @@ class UpgradeRecommender:
         Returns:
             The list of recommendations (possibly empty).
         """
-        by_family: dict[str, list[tuple[ProviderModelConfig, float]]] = {}
+        # Group by (family, embedding-class): a family label alone spans two
+        # incompatible model classes -- an embedding model (vector output)
+        # and a chat model can share one family label yet are not drop-in
+        # replacements for each other, so a newer-generation chat model must
+        # never surface as the upgrade for an embedding model (or vice versa).
+        by_group: dict[tuple[str, bool], list[tuple[ProviderModelConfig, float]]] = {}
         for model in provider.models:
             family = model.metadata.family
             generation = model.metadata.generation
             if family is None or generation is None or model.stale is not None:
                 continue
-            by_family.setdefault(family, []).append((model, generation))
+            key = (family, model.metadata.supports_embeddings)
+            by_group.setdefault(key, []).append((model, generation))
 
         out: list[UpgradeRecommendation] = []
-        for family, entries in by_family.items():
+        for (family, _), entries in by_group.items():
             newest_gen = max(generation for _, generation in entries)
-            # Every model at the newest generation is a candidate (a tie is
-            # broken deterministically by id), so a single regressing pick
-            # never masks a regress-free sibling of the same generation.
-            newest_candidates = sorted(
-                (model for model, generation in entries if generation >= newest_gen),
-                key=lambda model: model.id,
-            )
+            newest_candidates = [
+                model for model, generation in entries if generation >= newest_gen
+            ]
             for model, generation in entries:
                 if generation >= newest_gen:
                     continue
-                candidate = next(
-                    (
-                        c
-                        for c in newest_candidates
-                        if not _has_capability_regression(model.metadata, c.metadata)
-                    ),
-                    None,
+                best = self._best_candidate(
+                    model, generation, newest_candidates, newest_gen
                 )
-                if candidate is None:
+                if best is None:
                     continue
+                candidate, score = best
                 out.append(
                     UpgradeRecommendation(
                         provider_name=provider_name,
@@ -168,13 +205,7 @@ class UpgradeRecommender:
                         family=family,
                         current_generation=generation,
                         recommended_generation=newest_gen,
-                        score=_score(
-                            current=model,
-                            candidate=candidate,
-                            current_generation=generation,
-                            candidate_generation=newest_gen,
-                            config=self._config,
-                        ),
+                        score=score,
                         reason=(
                             f"Newer in-family model "
                             f"{flatten_label(candidate.id)!r} "

--- a/tests/unit/api/services/test_upgrade_recommendation_service.py
+++ b/tests/unit/api/services/test_upgrade_recommendation_service.py
@@ -9,6 +9,7 @@ from synthorg.api.services.org_mutations import OrgMutationService
 from synthorg.api.services.upgrade_recommendation_service import (
     UpgradeRecommendationService,
 )
+from synthorg.core.domain_errors import NotFoundError
 from synthorg.organization.models import UpdateAgentOrgRequest
 from synthorg.persistence.upgrade_recommendation_protocol import (
     UpgradeRecommendationRepository,
@@ -145,17 +146,18 @@ class TestUpgradeRecommendationService:
         await service.apply_auto(stored)
         org.update_agent.assert_not_called()
 
-    async def test_reassign_tolerates_failed_agent(self) -> None:
+    async def test_reassign_tolerates_stale_agent(self) -> None:
         stored = _stored(agents=(sid("a"), sid("b")))
         repo = mock_of[UpgradeRecommendationRepository](
             get=AsyncMock(return_value=stored),
             transition_if=AsyncMock(return_value=True),
         )
         org = mock_of[OrgMutationService](
-            update_agent=AsyncMock(side_effect=[RuntimeError("gone"), None]),
+            update_agent=AsyncMock(side_effect=[NotFoundError("gone"), None]),
         )
         service = _service(repo=repo, org_mutations=org)
-        # One agent fails; the apply still completes for the other.
+        # A stale (renamed / deleted) agent is skipped; the apply still
+        # completes for the other.
         await service.approve(stored.id, decided_by="op")
         assert org.update_agent.await_count == 2
         # Both agents were attempted with the recommended model, in order.
@@ -169,3 +171,18 @@ class TestUpgradeRecommendationService:
         assert all(
             call.args[1] == expected for call in org.update_agent.await_args_list
         )
+
+    async def test_reassign_propagates_non_stale_failure(self) -> None:
+        # Only a stale-agent NotFoundError is tolerated; any other failure
+        # (here a conflict) must surface rather than be swallowed per agent.
+        stored = _stored(agents=(sid("a"), sid("b")))
+        repo = mock_of[UpgradeRecommendationRepository](
+            get=AsyncMock(return_value=stored),
+            transition_if=AsyncMock(return_value=True),
+        )
+        org = mock_of[OrgMutationService](
+            update_agent=AsyncMock(side_effect=RuntimeError("boom")),
+        )
+        service = _service(repo=repo, org_mutations=org)
+        with pytest.raises(RuntimeError, match="boom"):
+            await service.approve(stored.id, decided_by="op")

--- a/tests/unit/api/services/test_upgrade_recommendation_service.py
+++ b/tests/unit/api/services/test_upgrade_recommendation_service.py
@@ -103,6 +103,48 @@ class TestUpgradeRecommendationService:
             await service.approve(stored.id, decided_by="op")
         org.update_agent.assert_not_called()
 
+    async def test_approve_gone_provider_stays_pending(self) -> None:
+        # The recommended provider was removed since the recommendation was
+        # produced. Preflight must fail loudly BEFORE the decide transition,
+        # so the recommendation stays PENDING (retryable) and no agent is
+        # touched, rather than the provider-gone NotFoundError being swallowed
+        # per agent inside _reassign as a benign stale-agent skip.
+        stored = _stored()
+        repo = mock_of[UpgradeRecommendationRepository](
+            get=AsyncMock(return_value=stored),
+            transition_if=AsyncMock(return_value=True),
+        )
+        org = mock_of[OrgMutationService](
+            update_agent=AsyncMock(),
+            validate_model_assignment=AsyncMock(
+                side_effect=NotFoundError("Provider 'example-provider' not found")
+            ),
+        )
+        service = _service(repo=repo, org_mutations=org)
+        with pytest.raises(NotFoundError):
+            await service.approve(stored.id, decided_by="op")
+        repo.transition_if.assert_not_called()
+        org.update_agent.assert_not_called()
+
+    async def test_apply_auto_gone_provider_does_not_decide(self) -> None:
+        # Same guard on the auto-apply path: a gone provider fails preflight
+        # before the CAS transition, so nothing is decided or reassigned.
+        stored = _stored()
+        repo = mock_of[UpgradeRecommendationRepository](
+            transition_if=AsyncMock(return_value=True),
+        )
+        org = mock_of[OrgMutationService](
+            update_agent=AsyncMock(),
+            validate_model_assignment=AsyncMock(
+                side_effect=NotFoundError("Provider 'example-provider' not found")
+            ),
+        )
+        service = _service(repo=repo, org_mutations=org)
+        with pytest.raises(NotFoundError):
+            await service.apply_auto(stored)
+        repo.transition_if.assert_not_called()
+        org.update_agent.assert_not_called()
+
     async def test_reject_transitions_without_reassign(self) -> None:
         stored = _stored()
         repo = mock_of[UpgradeRecommendationRepository](

--- a/tests/unit/api/services/test_upgrade_recommendation_service.py
+++ b/tests/unit/api/services/test_upgrade_recommendation_service.py
@@ -9,7 +9,7 @@ from synthorg.api.services.org_mutations import OrgMutationService
 from synthorg.api.services.upgrade_recommendation_service import (
     UpgradeRecommendationService,
 )
-from synthorg.core.domain_errors import NotFoundError
+from synthorg.core.domain_errors import NotFoundError, ValidationError
 from synthorg.organization.models import UpdateAgentOrgRequest
 from synthorg.persistence.upgrade_recommendation_protocol import (
     UpgradeRecommendationRepository,
@@ -253,4 +253,28 @@ class TestUpgradeRecommendationService:
         with pytest.raises(NotFoundError):
             await service.approve(stored.id, decided_by="op")
         # The apply stopped at the first agent, not silently skipping on.
+        assert org.update_agent.await_count == 1
+
+    async def test_reassign_reraises_when_model_vanishes_mid_loop(self) -> None:
+        # Companion to the provider-vanish case: the recommended model (not
+        # the provider) disappears mid-loop, so the in-except re-validation
+        # raises ValidationError rather than NotFoundError. That must also
+        # propagate and stop the apply, never be swallowed as a stale skip.
+        stored = _stored(agents=(sid("a"), sid("b")))
+        repo = mock_of[UpgradeRecommendationRepository](
+            get=AsyncMock(return_value=stored),
+            transition_if=AsyncMock(return_value=True),
+        )
+        org = mock_of[OrgMutationService](
+            update_agent=AsyncMock(side_effect=NotFoundError("stale?")),
+            validate_model_assignment=AsyncMock(
+                side_effect=[
+                    None,
+                    ValidationError("Model 'new' not found in provider"),
+                ]
+            ),
+        )
+        service = _service(repo=repo, org_mutations=org)
+        with pytest.raises(ValidationError):
+            await service.approve(stored.id, decided_by="op")
         assert org.update_agent.await_count == 1

--- a/tests/unit/api/services/test_upgrade_recommendation_service.py
+++ b/tests/unit/api/services/test_upgrade_recommendation_service.py
@@ -228,3 +228,29 @@ class TestUpgradeRecommendationService:
         service = _service(repo=repo, org_mutations=org)
         with pytest.raises(RuntimeError, match="boom"):
             await service.approve(stored.id, decided_by="op")
+
+    async def test_reassign_reraises_when_provider_vanishes_mid_loop(self) -> None:
+        # The preflight passes at approve() time, then the recommended
+        # provider vanishes. update_agent revalidates the provider/model and
+        # raises NotFoundError; the in-except re-validation confirms the
+        # provider is gone, so the apply must stop rather than swallow it as a
+        # stale-agent skip and partially complete.
+        stored = _stored(agents=(sid("a"), sid("b")))
+        repo = mock_of[UpgradeRecommendationRepository](
+            get=AsyncMock(return_value=stored),
+            transition_if=AsyncMock(return_value=True),
+        )
+        org = mock_of[OrgMutationService](
+            update_agent=AsyncMock(side_effect=NotFoundError("provider gone")),
+            validate_model_assignment=AsyncMock(
+                side_effect=[
+                    None,
+                    NotFoundError("Provider 'example-provider' not found"),
+                ]
+            ),
+        )
+        service = _service(repo=repo, org_mutations=org)
+        with pytest.raises(NotFoundError):
+            await service.approve(stored.id, decided_by="op")
+        # The apply stopped at the first agent, not silently skipping on.
+        assert org.update_agent.await_count == 1

--- a/tests/unit/engine/routing_policy/test_multi_provider_routing.py
+++ b/tests/unit/engine/routing_policy/test_multi_provider_routing.py
@@ -192,3 +192,96 @@ class TestMultiProviderAttributionParity:
         # Parity preserved: keep the prior identity + default client together.
         assert final_identity.model.provider == _DEFAULT_PROVIDER
         assert provider is default_client
+
+
+@pytest.mark.unit
+class TestDispatchClientResolution:
+    """Run-start dispatch resolves the agent's OWN provider, not the default."""
+
+    def _clients(
+        self,
+    ) -> tuple[CompletionProvider, CompletionProvider, ProviderRegistry]:
+        default_client = ScriptedProvider([])
+        cheap_client = ScriptedProvider([])
+        clients = {_DEFAULT_PROVIDER: default_client, _CHEAP_PROVIDER: cheap_client}
+
+        def _get(name: str) -> CompletionProvider:
+            if name not in clients:
+                raise DriverNotRegisteredError(name, context={"name": name})
+            return clients[name]
+
+        return default_client, cheap_client, mock_of[ProviderRegistry](get=_get)
+
+    def test_dispatch_resolves_agent_provider_over_engine_default(self) -> None:
+        """An agent pinned to a non-default provider dispatches to it.
+
+        The engine holds the default provider's client, but the agent's model
+        lives on another provider. Dispatching the default client would hit
+        the wrong API (ModelNotFoundError) while cost attribution names the
+        agent's provider, so dispatch must resolve the agent's own provider.
+        """
+        default_client, cheap_client, registry = self._clients()
+        engine = _engine(default_provider=default_client, registry=registry)
+
+        identity = _identity(
+            provider=_CHEAP_PROVIDER, model_id="cheap-large-001", tier="large"
+        )
+        assert engine._dispatch_client_for(identity, default_client) is cheap_client
+
+    def test_dispatch_no_registry_falls_back_to_default(self) -> None:
+        default_client = ScriptedProvider([])
+        engine = _engine(default_provider=default_client, registry=None)
+
+        identity = _identity(
+            provider=_CHEAP_PROVIDER, model_id="cheap-large-001", tier="large"
+        )
+        assert engine._dispatch_client_for(identity, default_client) is default_client
+
+    def test_dispatch_unknown_provider_raises(self) -> None:
+        # A wired registry that does not know the agent's provider must fail
+        # closed: silently falling back to the default client would dispatch
+        # to the wrong API and misattribute cost.
+        default_client = ScriptedProvider([])
+
+        def _get(name: str) -> CompletionProvider:
+            raise DriverNotRegisteredError(name, context={"name": name})
+
+        registry = mock_of[ProviderRegistry](get=_get)
+        engine = _engine(default_provider=default_client, registry=registry)
+
+        identity = _identity(
+            provider="ghost-provider", model_id="ghost-large-001", tier="large"
+        )
+        with pytest.raises(DriverNotRegisteredError):
+            engine._dispatch_client_for(identity, default_client)
+
+    async def test_noop_route_on_nondefault_provider_dispatches_to_agent(self) -> None:
+        """The exact failing scenario: agent on a non-default provider whose
+        stakes routing cannot resolve a tier (no-op) still runs on its own
+        provider, not the engine default.
+        """
+        default_client, cheap_client, registry = self._clients()
+        # A router whose resolver yields no tiers reproduces the observed
+        # ``no_tier_resolved`` no-op that kept the agent's model unchanged.
+        engine = AgentEngine(
+            provider=default_client,
+            provider_registry=registry,
+            stakes_router=build_stakes_router(
+                StakesRoutingConfig(),
+                benchmark_provider=StubBenchmarkScoreProvider(),
+                resolver=None,
+            ),
+        )
+
+        identity = _identity(
+            provider=_CHEAP_PROVIDER, model_id="cheap-large-001", tier="large"
+        )
+        dispatched = engine._dispatch_client_for(identity, default_client)
+        routed = await engine._route_stakes(identity, _task(Stakes.HIGH))
+        resolved, final_identity = engine._resolve_provider_instance(
+            routed, identity, dispatched
+        )
+
+        assert routed.model == identity.model  # routing was a no-op
+        assert final_identity.model.provider == _CHEAP_PROVIDER
+        assert resolved is cheap_client  # dispatched to the agent's provider

--- a/tests/unit/engine/test_agent_engine_degradation.py
+++ b/tests/unit/engine/test_agent_engine_degradation.py
@@ -233,7 +233,7 @@ class TestEngineDegradation:
         sample_agent_with_personality: AgentIdentity,
         sample_task_with_criteria: Task,
     ) -> None:
-        """Registry.get() raising an error results in BUDGET_EXHAUSTED."""
+        """An unresolvable degradation fallback provider -> BUDGET_EXHAUSTED."""
         from synthorg.providers.errors import DriverNotRegisteredError
 
         enforcer = _make_enforcer()
@@ -241,10 +241,17 @@ class TestEngineDegradation:
             [make_completion_response(content="Done.")],
         )
 
+        # The agent's own provider resolves (per-agent dispatch at run start);
+        # only the degradation *fallback* provider is missing, so the miss
+        # surfaces from ``_apply_degradation`` as the budget-exhausted path.
+        def _get(name: str) -> MockCompletionProvider:
+            if name == "test-provider":
+                return provider
+            msg = f"No driver for {name!r}"
+            raise DriverNotRegisteredError(msg)
+
         mock_registry = AsyncMock(spec=ProviderRegistry)
-        mock_registry.get = lambda name: (_ for _ in ()).throw(
-            DriverNotRegisteredError(f"No driver for {name!r}"),
-        )
+        mock_registry.get = _get
 
         engine = AgentEngine(
             provider=provider,

--- a/tests/unit/providers/management/test_upgrade_recommender.py
+++ b/tests/unit/providers/management/test_upgrade_recommender.py
@@ -20,6 +20,7 @@ def _model(  # noqa: PLR0913 -- model dimensions are intrinsic to the fixture
     tools: bool = False,
     vision: bool = False,
     reasoning: bool = False,
+    embeddings: bool = False,
     max_context: int = 200_000,
     stale: bool = False,
 ) -> ProviderModelConfig:
@@ -32,6 +33,7 @@ def _model(  # noqa: PLR0913 -- model dimensions are intrinsic to the fixture
             supports_tools=tools,
             supports_vision=vision,
             supports_reasoning=reasoning,
+            supports_embeddings=embeddings,
         ),
         stale=(
             ModelStaleness(
@@ -115,3 +117,76 @@ class TestUpgradeRecommender:
     def test_single_model_family_no_recommendation(self) -> None:
         providers = _provider(_model("only", generation=1.0))
         assert UpgradeRecommender().recommend(providers).recommendation_count == 0
+
+    def test_embedding_model_not_upgraded_to_newer_chat_model(self) -> None:
+        # An embedding model has no tool/vision/reasoning caps to "lose", so
+        # the capability-regression guard alone would let a newer-gen chat
+        # model of the same family be recommended as its upgrade. An embedding
+        # model and a chat model are different classes; there must be no
+        # cross-class recommendation.
+        providers = _provider(
+            _model("example-embed", family="example", generation=1.0, embeddings=True),
+            _model("example-chat", family="example", generation=2.0, tools=True),
+        )
+        assert UpgradeRecommender().recommend(providers).recommendation_count == 0
+
+    def test_chat_upgrades_ignore_a_newer_embedding_sibling(self) -> None:
+        # The newer-generation model in the family is an embedding model; a
+        # chat upgrade must route to the newest *chat* model, never the
+        # embedding one.
+        providers = _provider(
+            _model("chat-v1", family="example", generation=1.0, tools=True),
+            _model("chat-v2", family="example", generation=2.0, tools=True),
+            _model("example-embed", family="example", generation=3.0, embeddings=True),
+        )
+        analysis = UpgradeRecommender().recommend(providers)
+        assert analysis.recommendation_count == 1
+        rec = analysis.recommendations[0]
+        assert rec.current_model_id == "chat-v1"
+        assert rec.recommended_model_id == "chat-v2"
+
+    def test_prefers_stronger_variant_over_alphabetically_first(self) -> None:
+        # Two same-generation candidates: a smaller/cheaper 'flash' (sorts
+        # first alphabetically) and a larger/more-capable 'pro'. The
+        # recommender must pick the stronger 'pro', not the first by id.
+        providers = _provider(
+            _model("model-v3", generation=3.0, tools=True, max_context=100_000),
+            _model("model-v4-flash", generation=4.0, tools=True, max_context=100_000),
+            _model(
+                "model-v4-pro",
+                generation=4.0,
+                tools=True,
+                vision=True,
+                max_context=400_000,
+            ),
+        )
+        analysis = UpgradeRecommender().recommend(providers)
+        assert analysis.recommendation_count == 1
+        assert analysis.recommendations[0].recommended_model_id == "model-v4-pro"
+
+    def test_score_tie_broken_deterministically_by_id(self) -> None:
+        # Two newest-gen candidates identical on every scored dimension: the
+        # tiebreak must be the model id (max), never insertion order, so the
+        # recommendation is stable across runs.
+        providers = _provider(
+            _model("model-v1", generation=1.0, tools=True, max_context=100_000),
+            _model("model-v2-aaa", generation=2.0, tools=True, max_context=100_000),
+            _model("model-v2-zzz", generation=2.0, tools=True, max_context=100_000),
+        )
+        analysis = UpgradeRecommender().recommend(providers)
+        assert analysis.recommendation_count == 1
+        assert analysis.recommendations[0].recommended_model_id == "model-v2-zzz"
+
+    def test_regressing_newest_candidate_skipped_for_safe_sibling(self) -> None:
+        # Two newest-generation siblings: the higher-context one drops the
+        # current model's tool capability (a regression) while the other
+        # keeps it. The regression filter is per-candidate, so the safe
+        # sibling wins even though the regressing one would score higher.
+        providers = _provider(
+            _model("current", generation=1.0, tools=True, max_context=100_000),
+            _model("new-drops-tools", generation=2.0, tools=False, max_context=900_000),
+            _model("new-keeps-tools", generation=2.0, tools=True, max_context=100_000),
+        )
+        analysis = UpgradeRecommender().recommend(providers)
+        assert analysis.recommendation_count == 1
+        assert analysis.recommendations[0].recommended_model_id == "new-keeps-tools"

--- a/tests/unit/providers/test_cost_recording_chokepoint.py
+++ b/tests/unit/providers/test_cost_recording_chokepoint.py
@@ -10,6 +10,7 @@ exercised through the chokepoint via the same minimal stub harness.
 """
 
 import asyncio
+import contextvars
 from collections.abc import AsyncIterator
 from typing import override
 
@@ -34,7 +35,7 @@ from synthorg.providers.cost_recording import (
     emit_cost_record_from_usage,
     resolve_currency,
 )
-from synthorg.providers.enums import MessageRole
+from synthorg.providers.enums import MessageRole, StreamEventType
 from synthorg.providers.models import (
     ChatMessage,
     CompletionConfig,
@@ -53,6 +54,7 @@ class _StubProvider(BaseCompletionProvider):
         *,
         usage: TokenUsage | None = None,
         finish_reason: FinishReason = FinishReason.STOP,
+        emit_stream_usage: bool = False,
     ) -> None:
         super().__init__()
         self._usage = usage or TokenUsage(
@@ -61,6 +63,7 @@ class _StubProvider(BaseCompletionProvider):
             cost=0.001,
         )
         self._finish_reason = finish_reason
+        self._emit_stream_usage = emit_stream_usage
 
     @override
     async def _do_complete(
@@ -88,13 +91,16 @@ class _StubProvider(BaseCompletionProvider):
         tools: list[ToolDefinition] | None = None,
         config: CompletionConfig | None = None,
     ) -> AsyncIterator[StreamChunk]:
+        emit_usage = self._emit_stream_usage
+        usage = self._usage
+
         async def _gen() -> AsyncIterator[StreamChunk]:
-            # Empty async generator: the unconditional-False guard
-            # keeps the function's coroutine-shape (so ``async for``
-            # on it works) without producing any chunks.  ``yield``
-            # is unreachable on purpose -- mypy gets the silencer.
-            if False:
-                yield  # type: ignore[unreachable]
+            # Drivers surface token counts only on a terminal USAGE chunk;
+            # emit one when the test opts in so the drain-time chokepoint has
+            # usage to record. Without it the generator yields nothing, which
+            # exercises the no-usage no-op contract.
+            if emit_usage:
+                yield StreamChunk(event_type=StreamEventType.USAGE, usage=usage)
 
         return _gen()
 
@@ -434,24 +440,19 @@ class TestCostRecordingChokepoint:
 
 
 @pytest.mark.unit
-class TestStreamingBypassesChokepoint:
-    """Documented limitation: ``stream()`` does not fire the chokepoint.
+class TestStreamingCostRecording:
+    """``stream()`` records cost on drain, through the same chokepoint.
 
-    Streaming responses surface usage as a terminal
-    ``StreamEventType.USAGE`` chunk, so the chokepoint cannot inspect
-    ``response.usage`` synchronously.  Instead of half-implementing
-    cost recording for streams (which would require consuming the
-    iterator inside the chokepoint and conflating recording with the
-    stream-consumption contract), streaming is explicitly out of scope
-    for cost recording.  This test pins that contract so any later
-    streaming-aware recording must update the assertion.
-
-    No call site in the current codebase uses ``stream()`` for paid
-    LLM work; all 23 cost-attributable LLM call sites use ``complete()``.
+    Streaming responses surface usage only on a terminal
+    ``StreamEventType.USAGE`` chunk, so ``stream()`` wraps the driver's
+    iterator in a lazy pass-through generator that captures that chunk and
+    fires ``record_cost_if_in_scope`` once the consumer fully drains the
+    stream. A stream that never yields a usage chunk records nothing,
+    matching the no-scope / no-usage no-op contract.
     """
 
-    async def test_stream_inside_scope_does_not_record(self) -> None:
-        provider = _StubProvider()
+    async def test_stream_without_usage_chunk_records_nothing(self) -> None:
+        provider = _StubProvider(emit_stream_usage=False)
         tracker = CostTracker()
         async with cost_recording_scope(
             cost_tracker=tracker,
@@ -461,13 +462,29 @@ class TestStreamingBypassesChokepoint:
             currency=CurrencyCode(DEFAULT_CURRENCY),
         ):
             stream = await provider.stream([_msg()], "test-model")
-            # Drain the stream so resilience cleanup runs.
             async for _ in stream:
                 pass
-        # The chokepoint fires only inside complete(), never inside
-        # stream(). When this assertion changes, update the docstring
-        # in BaseCompletionProvider.stream and the migration plan.
         assert await tracker.get_records() == ()
+
+    async def test_stream_with_usage_chunk_records_on_drain(self) -> None:
+        provider = _StubProvider(emit_stream_usage=True)
+        tracker = CostTracker()
+        async with cost_recording_scope(
+            cost_tracker=tracker,
+            agent_id=NotBlankStr("agent-1"),
+            task_id=NotBlankStr("task-1"),
+            call_category=LLMCallCategory.SYSTEM,
+            currency=CurrencyCode(DEFAULT_CURRENCY),
+        ):
+            stream = await provider.stream([_msg()], "test-model")
+            # Nothing is recorded until the terminal USAGE chunk is drained.
+            async for _ in stream:
+                pass
+        await tracker.drain_pending_records()
+        records = await tracker.get_records()
+        assert len(records) == 1
+        assert records[0].agent_id == "agent-1"
+        assert records[0].task_id == "task-1"
 
 
 @pytest.mark.unit
@@ -654,3 +671,51 @@ class TestPendingRecordIsolation:
         assert "budget.pending_record.drain_unexpected" not in events, (
             f"cancelled drain must not WARN-log; got {events}"
         )
+
+
+@pytest.mark.unit
+class TestCostScopeCrossContextTeardown:
+    """The scope enters and exits cleanly across different asyncio contexts.
+
+    A streaming scope wraps an SSE body async generator whose enter (set) and
+    exit (teardown) can run in different asyncio contexts. Restoring via a
+    ``Token`` from ``ContextVar.set`` would raise ``ValueError`` there, so the
+    scope restores with a context-safe ``set(previous)`` and its teardown must
+    neither raise nor leave a wired context bound.
+    """
+
+    async def test_teardown_in_a_foreign_context_does_not_raise(self) -> None:
+        cm = cost_recording_scope(
+            cost_tracker=None,
+            agent_id=NotBlankStr("system"),
+            task_id=NotBlankStr("system:test"),
+            call_category=LLMCallCategory.SYSTEM,
+        )
+        await cm.__aenter__()
+        # Drive __aexit__ from a different context than __aenter__ ran in --
+        # the exact SSE-generator topology that made Token.reset raise.
+        foreign = contextvars.copy_context()
+        suppressed = await asyncio.create_task(
+            cm.__aexit__(None, None, None), context=foreign
+        )
+        assert suppressed is not True  # no exception was raised or suppressed
+
+    async def test_nested_scope_restores_outer_on_exit(self) -> None:
+        outer = CostTracker()
+        async with cost_recording_scope(
+            cost_tracker=outer,
+            agent_id=NotBlankStr("outer-agent"),
+            task_id=NotBlankStr("outer-task"),
+            call_category=LLMCallCategory.SYSTEM,
+            currency=CurrencyCode(DEFAULT_CURRENCY),
+        ):
+            outer_ctx = current_cost_context()
+            async with cost_recording_scope(
+                cost_tracker=None,
+                agent_id=NotBlankStr("inner-agent"),
+                task_id=NotBlankStr("inner-task"),
+                call_category=LLMCallCategory.SYSTEM,
+            ):
+                assert current_cost_context() is None
+            # The outer wired context is restored, not cleared to None.
+            assert current_cost_context() is outer_ctx

--- a/web/src/__tests__/lib/global-error-handlers.test.ts
+++ b/web/src/__tests__/lib/global-error-handlers.test.ts
@@ -41,19 +41,22 @@ describe('installGlobalErrorHandlers', () => {
     // handler uses preventDefault only, never stopImmediatePropagation.
     const later = vi.fn()
     window.addEventListener('error', later)
+    try {
+      const event = new ErrorEvent('error', {
+        message: 'ResizeObserver loop limit exceeded',
+        cancelable: true,
+      })
+      const notCancelled = window.dispatchEvent(event)
 
-    const event = new ErrorEvent('error', {
-      message: 'ResizeObserver loop limit exceeded',
-      cancelable: true,
-    })
-    const notCancelled = window.dispatchEvent(event)
-
-    expect(notCancelled).toBe(false) // preventDefault was called
-    expect(event.defaultPrevented).toBe(true)
-    expect(later).toHaveBeenCalledTimes(1) // propagation was not cut
-
-    window.removeEventListener('error', later)
-    uninstall()
+      expect(notCancelled).toBe(false) // preventDefault was called
+      expect(event.defaultPrevented).toBe(true)
+      expect(later).toHaveBeenCalledTimes(1) // propagation was not cut
+    } finally {
+      // Cleanup in finally so an assertion failure can't leak the listener
+      // or leave the module-level install guard stuck true for later tests.
+      window.removeEventListener('error', later)
+      uninstall()
+    }
   })
 })
 

--- a/web/src/__tests__/lib/global-error-handlers.test.ts
+++ b/web/src/__tests__/lib/global-error-handlers.test.ts
@@ -34,6 +34,27 @@ describe('installGlobalErrorHandlers', () => {
     // The real uninstaller resets the guard so a later install re-arms.
     first()
   })
+
+  it('cancels the default action of a benign error without cutting propagation', () => {
+    const uninstall = installGlobalErrorHandlers()
+    // A listener registered after ours must still receive the event: the
+    // handler uses preventDefault only, never stopImmediatePropagation.
+    const later = vi.fn()
+    window.addEventListener('error', later)
+
+    const event = new ErrorEvent('error', {
+      message: 'ResizeObserver loop limit exceeded',
+      cancelable: true,
+    })
+    const notCancelled = window.dispatchEvent(event)
+
+    expect(notCancelled).toBe(false) // preventDefault was called
+    expect(event.defaultPrevented).toBe(true)
+    expect(later).toHaveBeenCalledTimes(1) // propagation was not cut
+
+    window.removeEventListener('error', later)
+    uninstall()
+  })
 })
 
 describe('isBenignError', () => {

--- a/web/src/lib/global-error-handlers.ts
+++ b/web/src/lib/global-error-handlers.ts
@@ -81,6 +81,14 @@ export function installGlobalErrorHandlers(): () => void {
       ? formatReason(event.error)
       : (event.message || 'Uncaught global error')
     if (isBenignError(event.error ?? event.message)) {
+      // Suppress the browser's default console logging for a benign warning
+      // like the ResizeObserver loop notice, which otherwise floods the
+      // console every layout frame without signalling any real fault.
+      // ``preventDefault`` only, never ``stopImmediatePropagation``: our
+      // listener is registered after Vite's overlay one so it cannot pre-empt
+      // it anyway, and cutting propagation would silently starve any other
+      // legitimate ``error`` listener.
+      event.preventDefault()
       log.debug('Benign global error ignored', {
         reason: sanitizeForLog(reason),
       })


### PR DESCRIPTION
## What

Resolves a set of defects surfaced while tracing a project end-to-end over the CEO/CoS chat (create-over-chat -> charter -> approve -> task dispatch).

### Provider dispatch (per-agent, fail-closed)
Agents pinned to a non-default provider were dispatched to the engine's single default client, causing `ModelNotFoundError` at the API boundary while cost/budget attribution named the agent's own provider. `AgentEngine` now resolves the client for `identity.model.provider` per run (`_dispatch_client_for`) and **re-dispatches** after budget auto-downgrade (`resolve_model`) or stakes routing re-point the model, so client and identity stay in lockstep. A wired registry that does not know the agent's provider now **fails closed** (`DriverNotRegisteredError`) instead of silently mis-dispatching; only a fully unwired registry falls back to the engine default.

### Chat / streaming cost teardown (contextvar bug)
`cost_recording_scope` restored its context var with `Token.reset`, which raises `ValueError: token created in a different Context` when an SSE / streaming response body drives the scope's enter and exit in different `asyncio` contexts (the exact "Provider error" seen in the charter interview and CoS chat). It now restores with a plain, context-safe `set(previous)`. This also brought the module back under its size cap.

### Streaming does record cost
Streaming completions route through the same chokepoint on drain (`_cost_recording_stream`). Corrected `budget.md` / `providers.md`, and replaced the factually-wrong `TestStreamingBypassesChokepoint` (which only passed because the stub emitted no USAGE chunk) with `TestStreamingCostRecording` covering both the no-usage no-op and the positive record-on-drain path.

### Model-recommendation logic
`UpgradeRecommender` now groups by `(family, embedding-class)` so a newer-generation chat model is never recommended as an embedding model's upgrade (or vice versa), and picks the highest-scoring regression-free candidate with a deterministic id tiebreak instead of an arbitrary alphabetical pick.

### Smaller correctness / observability fixes
- Model-refresh re-read failures log a dedicated `PROVIDER_MODEL_REFRESH_RECOMMEND_FAILED` event instead of reusing the "add failed" event.
- Agent reassignment (`_reassign`) narrows its catch to `NotFoundError` (the stale/renamed-agent case) so genuine failures surface rather than being swallowed per agent.
- Benign global browser errors use `preventDefault()` only, never `stopImmediatePropagation()`, so later legitimate `error` listeners are not starved.

## Tests
- New: streaming record-on-drain, recommender class-awareness / score-tie / mixed-regression, reassignment stale-vs-genuine-failure, benign-error propagation-not-cut.
- Updated: routing dispatch-miss now asserts `DriverNotRegisteredError`; degradation-fallback-miss test resolves the agent's own provider so it exercises the intended BUDGET_EXHAUSTED path.

## Surfaced, not built (out of scope for this PR)
- Engine-layer `RetryExhaustedError` provider-fallback **chains** (a new feature, not a bug fix).
- Decomposition of the pre-existing ~230-line `run()` method.
- `chat.py` `wait_for` -> `asyncio.timeout` (pre-existing perf nit).
