### PR TITLE
fix: bump CLI Go toolchain to 1.26.5 to clear stdlib CVEs

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/Aureliolo/synthorg/cli
 
-go 1.26.4
+go 1.26.5
 
 require (
 	charm.land/bubbles/v2 v2.1.0

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,7 +1,5 @@
 charm.land/bubbles/v2 v2.1.0 h1:YSnNh5cPYlYjPxRrzs5VEn3vwhtEn3jVGRBT3M7/I0g=
 charm.land/bubbles/v2 v2.1.0/go.mod h1:l97h4hym2hvWBVfmJDtrEHHCtkIKeTEb3TTJ4ZOB3wY=
-charm.land/bubbletea/v2 v2.0.7 h1:7qw2tTAVar7m7klOPBYfTB0mniv/RuexsYwMRNxSeL0=
-charm.land/bubbletea/v2 v2.0.7/go.mod h1:DGW2q8gvzHnOpMpZTORs0aySVHCox5C+2Svk0fci1qs=
 charm.land/bubbletea/v2 v2.0.8 h1:SxTJMhCAI3lbPmy4SgX5LWZ24AdINr4I6UEqzZvYJuY=
 charm.land/bubbletea/v2 v2.0.8/go.mod h1:2SkdgoTXluXJHOUwAoRlRXF/28vklb1rFl6GcgV1/ss=
 charm.land/huh/v2 v2.0.3 h1:2cJsMqEPwSywGHvdlKsJyQKPtSJLVnFKyFbsYZTlLkU=
@@ -92,8 +90,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
-github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654 h1:FpSYhY28ucg9ZRr+2wj67FAQ0Ey5yiK0072PmRDJNek=
-github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654/go.mod h1:hFpumms29Smx3LStRfku8vcCTBe1Kq8aCXtHUJa3mjY=
 github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7 h1:3FmWoGNWK4STvqg0O0Aeav2T7rodWJAPeF0QpH+8gFw=
 github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7/go.mod h1:f/jRa757WUmaOZrbPspXymbg/GnbF+rwe4OLsG7aXYo=
 github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=


### PR DESCRIPTION
## What

Bumps the CLI Go toolchain from `1.26.4` to `1.26.5` in `cli/go.mod` (with `go mod tidy` pruning two stale `go.sum` entries).

## Why

The `CLI Vulnerability Check` job on `main` is red. `govulncheck ./...` exits 3 against two Go **standard-library** advisories that our code actually calls:

| Advisory | Issue | Found in | Fixed in | Reachable call sites |
|----------|-------|----------|----------|----------------------|
| [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) | Encrypted Client Hello privacy leak in `crypto/tls` | `crypto/tls@go1.26.4` | `crypto/tls@go1.26.5` | `internal/selfupdate/updater.go:728` (`http.Client.Do`); also via `crypto/rand`, `fmt.Fprintf` |
| [GO-2026-4970](https://pkg.go.dev/vuln/GO-2026-4970) | Root escape via symlink + trailing slash in `os` | `os@go1.26.4` | `os@go1.26.5` | `internal/compose/writer.go:99,130` (`os.Root.OpenFile` / `os.Root.Open`) |

`go1.26.5` carries the patched stdlib, so the bump clears both.

## Why it wasn't caught pre-merge

`govulncheck` scans against the live `vuln.go.dev` database at run time, so its verdict is time-dependent, not code-dependent. Both advisories (and their `go1.26.5` fix) were published after the last PR that touched `cli/go.mod` ran its CLI vuln check, so the identical code scanned clean then and fails now. This is precisely the drift a post-merge scan catches that a point-in-time PR scan structurally cannot.

## Verification

Local Go `1.26.5`:

- `govulncheck ./...` -> **No vulnerabilities found** (exit 0), down from 2
- `go build ./...` -> pass
- `go vet ./...` -> pass