### PR TITLE
ci: retry-wrap uv install so a transient blip cannot fail the job

### DIFF
--- a/.github/actions/install-uv/action.yml
+++ b/.github/actions/install-uv/action.yml
@@ -4,17 +4,16 @@ description: |
   retry_cmd.sh's bounded exponential-with-cap backoff, and leave uv + uvx on
   PATH for later steps.
 
-  Why not astral-sh/setup-uv: that action resolves the latest release over
-  the GitHub API and downloads the binary from the CDN as single-attempt
-  network ops, so one transient GitHub-API / CDN blip aborts the step in
-  seconds and takes the whole job -- and every downstream check -- with it.
-  This is the uv analogue of go-mod-download-retry: the house pattern of
-  wrapping every idempotent network fetch in bounded retry rather than
-  trusting a third party's own resilience. The uv dependency cache that
-  setup-uv used to manage is handled by an explicit actions/cache step in
-  the callers that need it (actions/cache treats a cache-service outage as a
-  non-fatal warning, so it cannot fail the job the way setup-uv's bundled
-  cache handling could).
+  Why not astral-sh/setup-uv: that action resolves the latest release over the
+  GitHub API and downloads the binary from the CDN as single-attempt network
+  ops, so one transient GitHub-API / CDN blip aborts the step in seconds and
+  takes the whole job -- and every downstream check -- with it. This is the uv
+  analogue of go-mod-download-retry: the house pattern of wrapping every
+  idempotent network fetch in bounded retry rather than trusting a third
+  party's own resilience. The uv dependency cache that setup-uv used to manage
+  is handled by an explicit actions/cache step in the callers that need it
+  (actions/cache treats a cache-service outage as a non-fatal warning, so it
+  cannot fail the job the way setup-uv's bundled cache handling could).
 
 runs:
   using: composite
@@ -22,21 +21,33 @@ runs:
     - name: Install uv (retry-wrapped)
       shell: bash
       env:
-        # A deterministic install dir removes the runner-env guesswork in the
-        # installer's default-location precedence (XDG_BIN_HOME / CARGO_HOME /
-        # ~/.local/bin); the binary lands directly in UV_INSTALL_DIR, which is
-        # then put on PATH for subsequent steps.
-        UV_INSTALL_DIR: ${{ runner.temp }}/uv-bin
+        # Pinned + Renovate-tracked (mirrors D2_VERSION) so the toolchain is
+        # reproducible instead of silently following whatever uv is latest.
+        # renovate: datasource=github-releases depName=astral-sh/uv
+        UV_VERSION: "0.11.28"
+        # UV_UNMANAGED_INSTALL installs uv to this exact dir AND suppresses the
+        # installer's shell-profile / self-update mutation, the right posture
+        # on an ephemeral CI runner (PATH is threaded via GITHUB_PATH below,
+        # not a profile). The binary lands at $UV_UNMANAGED_INSTALL/uv.
+        UV_UNMANAGED_INSTALL: ${{ runner.temp }}/uv-bin
         # The installer fetches the script AND the binary; a stalled fetch
         # (connection opens, no data) would hang untouched until the job
         # timeout because retry_cmd retries a non-zero EXIT, not a hang. A
         # per-attempt timeout converts that hang into a retryable 124.
         RETRY_CMD_ATTEMPT_TIMEOUT: "120"
-      run: | # zizmor: ignore[github-env] -- UV_INSTALL_DIR is a static runner.temp path, not untrusted input
+      run: | # zizmor: ignore[github-env] -- UV_UNMANAGED_INSTALL / $HOME are static paths, not untrusted input
+        # pipefail so a curl failure (transient blip / DNS) propagates: without
+        # it the pipe's exit is sh's, which exits 0 on empty EOF input, so
+        # retry_cmd would see a false success and never retry. The versioned
+        # URL pins uv to UV_VERSION for a reproducible install.
         .github/scripts/retry_cmd.sh "uv installer" \
-          bash -c 'curl -LsSf https://astral.sh/uv/install.sh | sh'
-        echo "$UV_INSTALL_DIR" >> "$GITHUB_PATH"
+          bash -c 'set -o pipefail; curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh'
+        echo "$UV_UNMANAGED_INSTALL" >> "$GITHUB_PATH"
+        # Pin uv's cache dir to the path setup-python-uv's actions/cache step
+        # restores, so an XDG_CACHE_HOME override on the runner cannot send uv
+        # writes to an uncached location.
+        echo "UV_CACHE_DIR=$HOME/.cache/uv" >> "$GITHUB_ENV"
         # Smoke-test via the absolute path (the GITHUB_PATH addition only
-        # applies to LATER steps, not this one). A wrong UV_INSTALL_DIR fails
+        # applies to LATER steps, not this one). A wrong install dir fails
         # loud here rather than as a confusing "uv: not found" downstream.
-        "$UV_INSTALL_DIR/uv" --version
+        "$UV_UNMANAGED_INSTALL/uv" --version

--- a/.github/actions/install-uv/action.yml
+++ b/.github/actions/install-uv/action.yml
@@ -1,0 +1,42 @@
+name: Install uv (retry-wrapped)
+description: |
+  Install the uv binary via its official standalone installer, wrapped in
+  retry_cmd.sh's bounded exponential-with-cap backoff, and leave uv + uvx on
+  PATH for later steps.
+
+  Why not astral-sh/setup-uv: that action resolves the latest release over
+  the GitHub API and downloads the binary from the CDN as single-attempt
+  network ops, so one transient GitHub-API / CDN blip aborts the step in
+  seconds and takes the whole job -- and every downstream check -- with it.
+  This is the uv analogue of go-mod-download-retry: the house pattern of
+  wrapping every idempotent network fetch in bounded retry rather than
+  trusting a third party's own resilience. The uv dependency cache that
+  setup-uv used to manage is handled by an explicit actions/cache step in
+  the callers that need it (actions/cache treats a cache-service outage as a
+  non-fatal warning, so it cannot fail the job the way setup-uv's bundled
+  cache handling could).
+
+runs:
+  using: composite
+  steps:
+    - name: Install uv (retry-wrapped)
+      shell: bash
+      env:
+        # A deterministic install dir removes the runner-env guesswork in the
+        # installer's default-location precedence (XDG_BIN_HOME / CARGO_HOME /
+        # ~/.local/bin); the binary lands directly in UV_INSTALL_DIR, which is
+        # then put on PATH for subsequent steps.
+        UV_INSTALL_DIR: ${{ runner.temp }}/uv-bin
+        # The installer fetches the script AND the binary; a stalled fetch
+        # (connection opens, no data) would hang untouched until the job
+        # timeout because retry_cmd retries a non-zero EXIT, not a hang. A
+        # per-attempt timeout converts that hang into a retryable 124.
+        RETRY_CMD_ATTEMPT_TIMEOUT: "120"
+      run: | # zizmor: ignore[github-env] -- UV_INSTALL_DIR is a static runner.temp path, not untrusted input
+        .github/scripts/retry_cmd.sh "uv installer" \
+          bash -c 'curl -LsSf https://astral.sh/uv/install.sh | sh'
+        echo "$UV_INSTALL_DIR" >> "$GITHUB_PATH"
+        # Smoke-test via the absolute path (the GITHUB_PATH addition only
+        # applies to LATER steps, not this one). A wrong UV_INSTALL_DIR fails
+        # loud here rather than as a confusing "uv: not found" downstream.
+        "$UV_INSTALL_DIR/uv" --version

--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -10,10 +10,20 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install uv
-      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+    # uv's dependency cache. Replaces astral-sh/setup-uv's bundled cache
+    # handling: actions/cache treats a cache-service outage as a non-fatal
+    # warning, so a restore/save blip never fails the job. Keyed on uv.lock
+    # (the uv project's resolved graph), not the requirements glob setup-uv
+    # defaulted to.
+    - name: Restore uv cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        enable-cache: true
+        path: ~/.cache/uv
+        key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+        restore-keys: |
+          uv-${{ runner.os }}-
+
+    - uses: ./.github/actions/install-uv
 
     # Both installs are wrapped in retry_cmd.sh: a cold run (or evicted
     # uv cache) fetches the CPython standalone tarball and every dependency
@@ -21,10 +31,20 @@ runs:
     # of those would otherwise fail the step on a single attempt. This is
     # the Python analogue of go-mod-download-retry; both wrapped commands
     # are idempotent, so retry-everything is safe. ~3m45s backoff budget.
+    #
+    # ``uv python install`` is a quick, bounded fetch, so it carries a
+    # per-attempt timeout that converts a stalled download into a retry.
+    # ``uv sync`` is deliberately left without one: a cold cross-platform
+    # resolve legitimately runs for minutes, and a per-attempt timeout tight
+    # enough to help within the shorter job budgets would risk killing a
+    # slow-but-progressing sync. Its transient failures already surface as
+    # non-zero exits the retry ladder catches, and the cache above shrinks
+    # the cold-fetch window that a hang could occur in.
     - name: Install Python
       shell: bash
       env:
         PYTHON_VERSION: ${{ inputs.python-version }}
+        RETRY_CMD_ATTEMPT_TIMEOUT: "180"
       run: |
         .github/scripts/retry_cmd.sh "uv python install" \
           uv python install "$PYTHON_VERSION"

--- a/.github/scripts/retry_cmd.sh
+++ b/.github/scripts/retry_cmd.sh
@@ -98,26 +98,34 @@ if ! [[ "$ATTEMPT_TIMEOUT" =~ ^[0-9]+$ ]]; then
   exit 2
 fi
 
+# Resolve the per-attempt timeout wrapper once, before the loop. macOS ships
+# coreutils' `timeout` as `gtimeout` (or not at all); when a timeout was asked
+# for but neither exists, warn ONCE so the unguarded fallback is visible in the
+# log rather than silently skipped -- and warning here, not per attempt, keeps
+# the retry output clean.
+TIMEOUT_CMD=""
+if [ "$ATTEMPT_TIMEOUT" -gt 0 ]; then
+  if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_CMD="timeout"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_CMD="gtimeout"
+  else
+    echo "::warning::retry_cmd.sh: RETRY_CMD_ATTEMPT_TIMEOUT=${ATTEMPT_TIMEOUT} set but neither 'timeout' nor 'gtimeout' is available; attempts run WITHOUT a per-attempt timeout" >&2
+  fi
+fi
+
 attempt=0
 while :; do
   attempt=$((attempt + 1))
   # `|| rc=$?` keeps `set -e`-style aborts away and captures the real exit
   # code, sidestepping the `if cmd; then` idiom that resets $? to 0.
   rc=0
-  if [ "$ATTEMPT_TIMEOUT" -gt 0 ]; then
+  if [ -n "$TIMEOUT_CMD" ]; then
     # --kill-after escalates to SIGKILL if the command ignores the initial
-    # SIGTERM, so a wedged process cannot outlive its attempt. A timeout
-    # exits 124 (or 137 on the SIGKILL escalation), which the loop treats as
-    # any other retryable non-zero exit. macOS runners ship coreutils' timeout
-    # as `gtimeout` (or not at all); fall back rather than fail with a 127
-    # that would burn the whole retry budget on a `command not found`.
-    if command -v timeout >/dev/null 2>&1; then
-      timeout --kill-after=10s "$ATTEMPT_TIMEOUT" "$@" || rc=$?
-    elif command -v gtimeout >/dev/null 2>&1; then
-      gtimeout --kill-after=10s "$ATTEMPT_TIMEOUT" "$@" || rc=$?
-    else
-      "$@" || rc=$?
-    fi
+    # SIGTERM, so a wedged process cannot outlive its attempt. A timeout exits
+    # 124 (or 137 on the SIGKILL escalation), which the loop treats as any
+    # other retryable non-zero exit.
+    "$TIMEOUT_CMD" --kill-after=10s "$ATTEMPT_TIMEOUT" "$@" || rc=$?
   else
     "$@" || rc=$?
   fi

--- a/.github/scripts/retry_cmd.sh
+++ b/.github/scripts/retry_cmd.sh
@@ -108,8 +108,16 @@ while :; do
     # --kill-after escalates to SIGKILL if the command ignores the initial
     # SIGTERM, so a wedged process cannot outlive its attempt. A timeout
     # exits 124 (or 137 on the SIGKILL escalation), which the loop treats as
-    # any other retryable non-zero exit.
-    timeout --kill-after=10s "$ATTEMPT_TIMEOUT" "$@" || rc=$?
+    # any other retryable non-zero exit. macOS runners ship coreutils' timeout
+    # as `gtimeout` (or not at all); fall back rather than fail with a 127
+    # that would burn the whole retry budget on a `command not found`.
+    if command -v timeout >/dev/null 2>&1; then
+      timeout --kill-after=10s "$ATTEMPT_TIMEOUT" "$@" || rc=$?
+    elif command -v gtimeout >/dev/null 2>&1; then
+      gtimeout --kill-after=10s "$ATTEMPT_TIMEOUT" "$@" || rc=$?
+    else
+      "$@" || rc=$?
+    fi
   else
     "$@" || rc=$?
   fi

--- a/.github/scripts/retry_cmd.sh
+++ b/.github/scripts/retry_cmd.sh
@@ -39,6 +39,14 @@
 # Tunable via RETRY_CMD_ATTEMPTS / RETRY_CMD_BASE_DELAY / RETRY_CMD_MAX_DELAY
 # (also the seam the self-test drives with zero backoff).
 #
+# Per-attempt timeout: retry_cmd retries on a non-zero EXIT, so a command
+# that HANGS -- a connection that opens then stalls with no data and no
+# error -- would sit untouched until the job's own timeout-minutes reaps
+# the whole runner, never reaching the retry ladder. RETRY_CMD_ATTEMPT_TIMEOUT
+# (seconds; 0 = off, the default) wraps each attempt in `timeout` so a hang
+# becomes a retryable 124 and the ladder engages. Off by default so existing
+# callers are byte-for-byte unchanged; opt in per-call.
+#
 # Usage:
 #   retry_cmd.sh "label for log" <command> [args...]
 #
@@ -66,6 +74,7 @@ fi
 ATTEMPTS="${RETRY_CMD_ATTEMPTS:-5}"
 DELAY="${RETRY_CMD_BASE_DELAY:-15}"
 MAX_DELAY="${RETRY_CMD_MAX_DELAY:-120}"
+ATTEMPT_TIMEOUT="${RETRY_CMD_ATTEMPT_TIMEOUT:-0}"
 
 # Fail fast on a non-numeric tunable. Without ``-e``, a non-numeric value
 # makes the ``[ "$attempt" -ge "$ATTEMPTS" ]`` exhaustion test error out
@@ -84,6 +93,10 @@ if ! [[ "$MAX_DELAY" =~ ^[0-9]+$ ]]; then
   echo "::error::retry_cmd.sh: RETRY_CMD_MAX_DELAY must be a non-negative integer (got '$MAX_DELAY')" >&2
   exit 2
 fi
+if ! [[ "$ATTEMPT_TIMEOUT" =~ ^[0-9]+$ ]]; then
+  echo "::error::retry_cmd.sh: RETRY_CMD_ATTEMPT_TIMEOUT must be a non-negative integer (got '$ATTEMPT_TIMEOUT')" >&2
+  exit 2
+fi
 
 attempt=0
 while :; do
@@ -91,7 +104,15 @@ while :; do
   # `|| rc=$?` keeps `set -e`-style aborts away and captures the real exit
   # code, sidestepping the `if cmd; then` idiom that resets $? to 0.
   rc=0
-  "$@" || rc=$?
+  if [ "$ATTEMPT_TIMEOUT" -gt 0 ]; then
+    # --kill-after escalates to SIGKILL if the command ignores the initial
+    # SIGTERM, so a wedged process cannot outlive its attempt. A timeout
+    # exits 124 (or 137 on the SIGKILL escalation), which the loop treats as
+    # any other retryable non-zero exit.
+    timeout --kill-after=10s "$ATTEMPT_TIMEOUT" "$@" || rc=$?
+  else
+    "$@" || rc=$?
+  fi
   if [ "$rc" -eq 0 ]; then
     if [ "$attempt" -gt 1 ]; then
       echo "::notice::${LABEL} succeeded on attempt ${attempt}" >&2

--- a/.github/scripts/tests/test_retry_cmd.sh
+++ b/.github/scripts/tests/test_retry_cmd.sh
@@ -134,6 +134,37 @@ else
   printf '%s\n' "$out" | tail -n 3 >&2 || true
 fi
 
+# --- 9. per-attempt timeout: a hang is killed, retried, and (when it never
+# stops hanging) fails closed with timeout's 124 ------------------------
+# `sleep 30` never returns on its own; a 1s attempt timeout kills it, and
+# with 2 attempts + zero backoff the ladder bubbles 124. Guarded on
+# `timeout` being present so an environment without coreutils `timeout`
+# skips the case rather than false-failing.
+if command -v timeout >/dev/null 2>&1; then
+  rc=0
+  out="$(RETRY_CMD_ATTEMPTS=2 RETRY_CMD_BASE_DELAY=0 RETRY_CMD_ATTEMPT_TIMEOUT=1 \
+    bash "$HELPER" "selftest-hang" sleep 30 2>&1)" || rc=$?
+  if [ "$rc" -eq 124 ] && grep -q 'failed after 2 attempts' <<<"$out"; then
+    pass "retry_cmd times out a hanging attempt and fails closed with 124"
+  else
+    fail "retry_cmd did not time out a hang and bubble 124 (rc=${rc}, expected 124)"
+    printf '%s\n' "$out" | tail -n 3 >&2 || true
+  fi
+else
+  printf 'SKIP: timeout(1) unavailable; per-attempt-timeout case not run\n'
+fi
+
+# --- 10. non-numeric attempt timeout: rejected up front with exit 2 -----
+rc=0
+out="$(RETRY_CMD_ATTEMPTS=2 RETRY_CMD_BASE_DELAY=0 RETRY_CMD_ATTEMPT_TIMEOUT=abc \
+  bash "$HELPER" "selftest-badtimeout" bash -c 'exit 1' 2>&1)" || rc=$?
+if [ "$rc" -eq 2 ] && grep -q 'RETRY_CMD_ATTEMPT_TIMEOUT must be a non-negative integer' <<<"$out"; then
+  pass "retry_cmd rejects a non-numeric RETRY_CMD_ATTEMPT_TIMEOUT with exit 2"
+else
+  fail "retry_cmd did not reject a non-numeric attempt timeout (rc=${rc}, expected 2)"
+  printf '%s\n' "$out" | tail -n 3 >&2 || true
+fi
+
 if [ "$FAILED" -ne 0 ]; then
   printf '\nretry_cmd self-test FAILED\n' >&2
   exit 1

--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -133,7 +133,7 @@ jobs:
           allow-prereleases: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: ./.github/actions/install-uv
 
       # D2 binary, required by d2_fence.py at build time.
       # D2 does not publish checksums or signatures in its releases;

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -49,7 +49,7 @@ jobs:
           allow-prereleases: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: ./.github/actions/install-uv
 
       # D2 binary, required by mkdocs-d2-plugin at build time.
       # D2 does not publish checksums or signatures in its releases;


### PR DESCRIPTION
## What

Make uv installation in CI resilient to transient network blips, and give `retry_cmd.sh` a per-attempt hang guard.

## Why

The bare `astral-sh/setup-uv` step was the *only* blip-prone network fetch in the CI critical path with no retry around it. It resolves the latest uv release over the GitHub API and downloads the binary from the CDN as single-attempt operations, so one transient blip aborts the step in seconds and takes the whole job (and every downstream check) with it. Every job that runs `setup-python-uv` starts with this step, so it was a single point of failure across the matrix.

`retry_cmd.sh` (which wraps the later `uv` commands) only retries on a non-zero exit code; it does nothing against a command that hangs. A stalled connection would sit until the job's `timeout-minutes` reaped the runner rather than retrying.

## Changes

- **New `.github/actions/install-uv` composite**: installs uv via its official installer under `retry_cmd.sh` (the uv analogue of the existing `go-mod-download-retry` action), leaving `uv`/`uvx` on `PATH`. Used by `setup-python-uv` and both pages workflows, so no uv install in CI is a single-attempt op any more.
- **`setup-python-uv`**: swaps the bare `setup-uv` step for `install-uv`, and preserves the uv dependency cache via an explicit `actions/cache` step keyed on `uv.lock` (non-fatal on a cache-service outage, unlike setup-uv's bundled cache handling).
- **`pages.yml` / `pages-preview.yml`**: swap their direct `setup-uv` usages for `install-uv` (same latent gap).
- **`retry_cmd.sh`**: opt-in `RETRY_CMD_ATTEMPT_TIMEOUT` wraps each attempt in `timeout`, converting a hang into a retryable `124`. Off by default (existing callers unchanged); the installer and `uv python install` opt in. `uv sync` deliberately stays exit-retry-only, since a cold cross-platform resolve legitimately runs for minutes. Two self-test cases added.

## Validation

- `retry_cmd` self-test: 10/10 pass, including the new hang-timeout and validation cases.
- `actionlint`, `check-yaml`, `yamllint`, `zizmor`, and the CI-resilience gate all pass.
- The install step smoke-tests uv via its absolute path, so a wrong install dir fails loud on this PR rather than downstream.