### PR TITLE
Co-locate the agent model tier as a muted suffix on the model row

### DIFF
--- a/web/src/__tests__/components/ui/agent-card.test.tsx
+++ b/web/src/__tests__/components/ui/agent-card.test.tsx
@@ -56,7 +56,9 @@ describe('AgentCard', () => {
     render(<AgentCard {...defaultProps} model="example-large-001" tier="large" />)
 
     expect(screen.getByText('example-large-001')).toBeInTheDocument()
-    expect(screen.getByText('· large')).toBeInTheDocument()
+    expect(screen.getByText('large')).toBeInTheDocument()
+    // The separator dot is decorative and hidden from assistive tech.
+    expect(screen.getByText('·')).toHaveAttribute('aria-hidden', 'true')
     expect(screen.queryByText('Tier:')).not.toBeInTheDocument()
   })
 

--- a/web/src/__tests__/components/ui/agent-card.test.tsx
+++ b/web/src/__tests__/components/ui/agent-card.test.tsx
@@ -52,6 +52,21 @@ describe('AgentCard', () => {
     expect(screen.queryByText(/Task:/)).not.toBeInTheDocument()
   })
 
+  it('renders the model with its capability tier as a suffix', () => {
+    render(<AgentCard {...defaultProps} model="example-large-001" tier="large" />)
+
+    expect(screen.getByText('example-large-001')).toBeInTheDocument()
+    expect(screen.getByText('· large')).toBeInTheDocument()
+    expect(screen.queryByText('Tier:')).not.toBeInTheDocument()
+  })
+
+  it('renders a standalone tier row when a tier has no model', () => {
+    render(<AgentCard {...defaultProps} tier="medium" />)
+
+    expect(screen.getByText('Tier:')).toBeInTheDocument()
+    expect(screen.getByText('medium')).toBeInTheDocument()
+  })
+
   it('renders timestamp when provided', () => {
     render(<AgentCard {...defaultProps} timestamp="2m ago" />)
 

--- a/web/src/__tests__/components/ui/agent-card.test.tsx
+++ b/web/src/__tests__/components/ui/agent-card.test.tsx
@@ -67,6 +67,14 @@ describe('AgentCard', () => {
     expect(screen.getByText('medium')).toBeInTheDocument()
   })
 
+  it('renders the model with no tier suffix when the tier is absent', () => {
+    render(<AgentCard {...defaultProps} model="example-large-001" />)
+
+    expect(screen.getByText('example-large-001')).toBeInTheDocument()
+    expect(screen.queryByText(/·/)).not.toBeInTheDocument()
+    expect(screen.queryByText('Tier:')).not.toBeInTheDocument()
+  })
+
   it('renders timestamp when provided', () => {
     render(<AgentCard {...defaultProps} timestamp="2m ago" />)
 

--- a/web/src/components/ui/agent-card.stories.tsx
+++ b/web/src/components/ui/agent-card.stories.tsx
@@ -95,6 +95,17 @@ export const FullProfile: Story = {
   },
 }
 
+export const TierWithoutModel: Story = {
+  args: {
+    name: 'Grace Hopper',
+    role: 'Principal Engineer',
+    department: 'Engineering',
+    status: 'active',
+    tier: 'medium',
+    timestamp: '4m ago',
+  },
+}
+
 export const AgentGrid: Story = {
   args: { name: 'Alice Smith', role: 'Engineer', department: 'Engineering', status: 'active' },
   render: () => (

--- a/web/src/components/ui/agent-card.tsx
+++ b/web/src/components/ui/agent-card.tsx
@@ -42,12 +42,27 @@ interface MetaItemData {
   mono?: boolean
   /** Span both grid columns (long values like traits / current task). */
   span?: boolean
+  /** Muted qualifier shown after the value (e.g. the model's capability tier). */
+  suffix?: string | undefined
+}
+
+/**
+ * The model row, with the capability tier co-located as a muted suffix. Falls
+ * back to a standalone tier row when the model id is absent.
+ */
+function modelMetaItem(props: AgentCardProps): MetaItemData | null {
+  if (props.model) {
+    return { label: 'Model', value: props.model, mono: true, suffix: props.tier ?? undefined }
+  }
+  if (props.tier) return { label: 'Tier', value: props.tier }
+  return null
 }
 
 /** Assemble the metadata items present for this agent, in display order. */
 function buildMetaItems(props: AgentCardProps): MetaItemData[] {
   const items: MetaItemData[] = [{ label: 'Dept', value: props.department }]
-  if (props.model) items.push({ label: 'Model', value: props.model, mono: true })
+  const model = modelMetaItem(props)
+  if (model) items.push(model)
   if (props.personality) items.push({ label: 'Personality', value: props.personality })
   if (props.capabilities?.length) {
     items.push({ label: 'Capabilities', value: props.capabilities.join(', ') })
@@ -59,20 +74,13 @@ function buildMetaItems(props: AgentCardProps): MetaItemData[] {
   return items
 }
 
-function MetaItem({ label, value, mono = false, span = false }: MetaItemData) {
+function MetaItem({ label, value, mono = false, span = false, suffix }: MetaItemData) {
   return (
     <div className={cn('flex min-w-0 items-baseline gap-1 text-xs', span && 'col-span-2')}>
       <span className="shrink-0 text-muted-foreground">{label}:</span>
       <span className={cn('truncate text-text-secondary', mono && 'font-mono')}>{value}</span>
+      {suffix && <span className="shrink-0 text-muted-foreground">· {suffix}</span>}
     </div>
-  )
-}
-
-function TierBadge({ tier }: { tier: 'large' | 'medium' | 'small' }) {
-  return (
-    <span className="shrink-0 self-start rounded-md border border-border bg-surface px-1.5 py-0.5 text-micro uppercase tracking-wide text-text-secondary">
-      {tier}
-    </span>
   )
 }
 
@@ -98,7 +106,7 @@ function CardFooterTime({
 }
 
 export function AgentCard(props: AgentCardProps) {
-  const { name, role, status, tier, timestamp, timestampIso, className, flashStyle } = props
+  const { name, role, status, timestamp, timestampIso, className, flashStyle } = props
   const nameId = useId()
   const roleId = useId()
   const metaItems = buildMetaItems(props)
@@ -113,7 +121,7 @@ export function AgentCard(props: AgentCardProps) {
       )}
       style={flashStyle}
     >
-      {/* Header: avatar + name + status + tier */}
+      {/* Header: avatar + name + status */}
       <div className="flex items-start gap-2.5">
         <Avatar name={name} size="md" />
         <div className="min-w-0 flex-1">
@@ -125,7 +133,6 @@ export function AgentCard(props: AgentCardProps) {
           </div>
           <span id={roleId} className="text-xs text-text-secondary">{role}</span>
         </div>
-        {tier && <TierBadge tier={tier} />}
       </div>
 
       {/* Body: two-column metadata grid */}

--- a/web/src/components/ui/agent-card.tsx
+++ b/web/src/components/ui/agent-card.tsx
@@ -78,8 +78,13 @@ function MetaItem({ label, value, mono = false, span = false, suffix }: MetaItem
   return (
     <div className={cn('flex min-w-0 items-baseline gap-1 text-xs', span && 'col-span-2')}>
       <span className="shrink-0 text-muted-foreground">{label}:</span>
-      <span className={cn('truncate text-text-secondary', mono && 'font-mono')}>{value}</span>
-      {suffix && <span className="shrink-0 text-muted-foreground">· {suffix}</span>}
+      <span className={cn('min-w-0 truncate text-text-secondary', mono && 'font-mono')}>{value}</span>
+      {suffix && (
+        <span className="shrink-0 text-muted-foreground">
+          <span aria-hidden="true">· </span>
+          {suffix}
+        </span>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

On the Agents screen, the capability tier (`large` / `medium` / `small`) was shown as a prominent bordered badge in the card header, giving a low-information label more visual weight than the actual model. This co-locates the tier with the model it qualifies:

- Removes the header `TierBadge` pill.
- Renders the tier as a muted `· <tier>` suffix on the **Model** metadata row (via a new optional `suffix` field on `MetaItemData` + a `modelMetaItem` helper).
- Falls back to a standalone **Tier** row when an agent has a tier but no resolved model id, so the information is never lost.

The tier now reads as a qualifier of the model rather than competing with it, and is conveyed as plain text (more accessible than the colour-oriented badge).

## Test plan

- `web/src/__tests__/components/ui/agent-card.test.tsx` covers all three `modelMetaItem` branches: model+tier (suffix shown, no Tier row), tier-only (standalone Tier row), and model-only (no dangling suffix).
- Added a `TierWithoutModel` Storybook story for the fallback state.
- `tsc -b` clean; full agent-card vitest suite (14 tests) green; ESLint / knip / dpdm pass on push.

## Review coverage

Pre-reviewed by 2 agents (frontend-reviewer, design-token-audit). design-token-audit clean; frontend-reviewer surfaced 2 medium coverage gaps (missing story + missing model-only test), both fixed in this branch before the PR was opened.
