### PR TITLE
Parallelise pre-push gates and trim redundant local checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,11 @@ jobs:
           docker run --rm -v "$PWD:/work" -w /work
           caddy:2.10.2-alpine
           caddy validate --config web/Caddyfile --adapter caddyfile
+      # Spell-check runs as a dedicated step rather than a pre-commit hook so
+      # the ~11s full-tree scan gates every push in CI without sitting on the
+      # local pre-push critical path. Config in .codespellrc.
+      - name: Spell check (codespell)
+        run: uv run codespell --config .codespellrc
 
   # ── Runtime Stats Freshness ──
   # Fails the build when data/runtime_stats.yaml has drifted (any

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,17 +83,18 @@ repos:
         pass_filenames: false
         stages: [pre-commit]
         types: []
-      # Consolidated single-process runner for the pre-push-only Python
-      # gates (scripts/run_prepush_python_gates.py). Folding ~40 individual
-      # `uv run python scripts/check_*.py` hooks into one process collapses
-      # the per-push spawn count -- the desktop-heap / STATUS_DLL_INIT_FAILED
-      # (0xC0000142) pressure on Windows -- and pays the synthorg import once.
-      # The underlying scripts/check_*.py files stay on disk so the
-      # convention-gate-inventory meta-gate still resolves each gate path, and
-      # CI's `pre-commit run --all-files` runs this one hook from the same
-      # config so local<->CI parity holds.
+      # Consolidated runner for the pre-push-only Python gates
+      # (scripts/run_prepush_python_gates.py). Folding ~48 individual
+      # `uv run python scripts/check_*.py` hooks into one runner keeps the
+      # concurrent spawn count bounded -- the desktop-heap / STATUS_DLL_INIT_
+      # FAILED (0xC0000142) pressure on Windows -- while fanning the CPU-bound
+      # whole-tree AST gates across a reused-worker pool. The underlying
+      # scripts/check_*.py files stay on disk so the convention-gate-inventory
+      # meta-gate still resolves each gate path, and CI's `pre-commit run
+      # --all-files` runs this one hook from the same config so local<->CI
+      # parity holds.
       - id: consolidated-python-gates
-        name: consolidated pre-push Python gates (single process)
+        name: consolidated pre-push Python gates
         entry: uv run python scripts/run_prepush_python_gates.py
         language: system
         always_run: true
@@ -779,17 +780,6 @@ repos:
         language: system
         files: ^(src/synthorg/.*\.py|pyproject\.toml|\.pre-commit-config\.yaml)$
         pass_filenames: false
-        stages: [pre-push]
-
-      # Spelling check; configuration in .codespellrc.
-      - id: codespell
-        name: codespell (spelling)
-        entry: uv run codespell --config .codespellrc
-        language: system
-        files: ^(src/synthorg|tests|scripts|docs|README\.md|CLAUDE\.md|\.codespellrc).*$
-        pass_filenames: false
-        # Full-tree spell scan is the slowest pre-commit gate; defer to
-        # pre-push alongside the other prose gates (vale, lychee).
         stages: [pre-push]
 
       # SQL lint for migration revisions and the canonical schema.

--- a/docs/reference/convention-gates.md
+++ b/docs/reference/convention-gates.md
@@ -195,7 +195,7 @@ The justification after `--` is mandatory and must be non-empty. The gate also a
 
 ## Registration procedure
 
-1. Wire each new gate so it runs locally and in CI. A `commit+push` Python gate that must also run at pre-commit gets its own `.pre-commit-config.yaml` hook entry. A **push-only** Python gate is instead appended to the `_GATES` tuple in `scripts/run_prepush_python_gates.py`: the single `consolidated-python-gates` pre-push hook runs every entry in one process (the per-gate failure reporting and exit codes are preserved), so adding a separate per-gate pre-push hook is redundant. `check_local_ci_parity.py` verifies the consolidated hook, not the individual push-only gate ids.
+1. Wire each new gate so it runs locally and in CI. A `commit+push` Python gate that must also run at pre-commit gets its own `.pre-commit-config.yaml` hook entry. A **push-only** Python gate is instead appended to the `_GATES` tuple in `scripts/run_prepush_python_gates.py`: the single `consolidated-python-gates` pre-push hook runs every entry, fanned across a bounded reused-worker pool (the per-gate failure reporting and exit codes are preserved), so adding a separate per-gate pre-push hook is redundant. `check_local_ci_parity.py` verifies the consolidated hook, not the individual push-only gate ids.
 2. Per-line opt-outs use a stable `# lint-allow: <gate-name> -- <reason>` comment; the reason is mandatory non-empty.
 3. Add a corresponding entry in the machine-readable inventory at `scripts/convention_gate_map.yaml`.
 4. Add a row to the gate-inventory table above and bump the `<!--RS:convention_gates-->` count macro.

--- a/scripts/check_docstring_completeness.py
+++ b/scripts/check_docstring_completeness.py
@@ -41,6 +41,8 @@ def main(argv: list[str] | None = None) -> int:
         result = subprocess.run(
             ["ruff", "check", f"--select={_DOC_RULES}", *paths],
             check=False,
+            capture_output=True,
+            text=True,
         )
     except OSError as exc:
         print(
@@ -49,6 +51,15 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 2
+    # Re-emit ruff's report through Python-level stdout/stderr (not the raw file
+    # descriptors a bare subprocess would inherit) so the consolidated pre-push
+    # runner -- which captures each gate's Python-level output to attribute
+    # findings to it under the parallel pool -- surfaces the violations instead
+    # of losing them.
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
     return 1 if result.returncode != 0 else 0
 
 

--- a/scripts/run_affected_tests.py
+++ b/scripts/run_affected_tests.py
@@ -560,9 +560,9 @@ def _run_pytest(paths: list[str], *, run_all: bool = False) -> int:
     that crashes, so a native crash always surfaces as a failed run
     rather than being silently recovered.  ``_classify_isolation_outcome``
     then parses the captured stdout and BLOCKS on any worker crash
-    (native or repeated) alongside real test failures.  There is no
-    advisory pass -- a crashed worker is a real defect to debug from the
-    faulthandler/core dump, not noise to wave through.
+    alongside real test failures.  There is no advisory pass -- a crashed
+    worker is a real defect to debug from the faulthandler/core dump, not
+    noise to wave through.
     """
     cmd = [
         sys.executable,

--- a/scripts/run_affected_tests.py
+++ b/scripts/run_affected_tests.py
@@ -10,14 +10,11 @@ Foundational modules (core, config, observability) are imported by nearly every
 other module, so changes to them trigger a full test run. Same for any
 ``conftest.py`` and top-level source files (``__init__.py``, ``constants.py``).
 
-When the affected-tests run goes green, an isolation regression gate runs
-``pytest --count 2 --max-worker-restart=0`` over the same selection and
-classifies the outcome.  A test that passes the primary run but fails the
-replay points at fixture state leaking process-global state, the exact
-failure mode that splits a green local run from a red xdist push.  Any
+The affected-tests run uses ``--max-worker-restart=0`` (matching CI) so any
 xdist worker crash (commonly the Python 3.14 + Windows ProactorEventLoop
-IOCP teardown race) blocks the gate: a crashed worker is a real defect to
-debug from the faulthandler/core dump, not flakiness to wave through.
+IOCP teardown race) surfaces and blocks the push rather than being silently
+recovered: a crashed worker is a real defect to debug from the
+faulthandler/core dump, not flakiness to wave through.
 
 Exit codes match pytest: 0 (passed/nothing to run), 1 (failures),
 etc.  Git command failures fall back to running the full unit suite.
@@ -842,60 +839,6 @@ def _print_isolation_banner(outcome: IsolationOutcome) -> None:
         return
 
 
-def _run_isolation_gate(paths: list[str]) -> int:
-    """Run ``pytest --count 2`` over the given paths and classify the result.
-
-    Catches module-level-state isolation regressions by re-running each
-    test exactly once.  A test that passes the primary run but fails
-    the replay almost always means a fixture leaked process-global
-    state that polluted the second invocation.
-
-    ``--max-worker-restart=0`` (matching CI) forbids restarting a worker
-    that crashes during the replay, so the Python 3.14 + Windows
-    ProactorEventLoop IOCP teardown race
-    (https://github.com/python/cpython/issues/116773 and family) and any
-    other native crash always surfaces and blocks rather than being
-    silently recovered.  ``_classify_isolation_outcome`` parses the
-    captured stdout; real failures, repeated crashes, and one-off worker
-    crashes all block.
-
-    Skipped only when ``paths`` is empty (nothing affected).  The gate
-    always runs otherwise; root causes are fixed, not bypassed.
-
-    Returns 0 on green / skip; non-zero on any regression or worker crash.
-    """
-    if not paths:
-        return 0
-    print("Isolation gate: re-running affected tests under --count 2...")
-    cmd = [
-        sys.executable,
-        "-m",
-        "pytest",
-        *paths,
-        "-m",
-        "unit",
-        "-n",
-        "8",
-        "--max-worker-restart=0",
-        "--count",
-        "2",
-        "-q",
-    ]
-    # ``--count 2`` runs every affected test twice, so the cap is the
-    # full-suite ceiling regardless of selection size.
-    returncode, captured_stdout = _stream_pytest(
-        cmd, timeout_seconds=_PYTEST_FULL_SUITE_TIMEOUT_SECONDS
-    )
-    if returncode == _PYTEST_HUNG_EXIT_CODE:
-        # Watchdog kill -- same reasoning as in ``_run_pytest``: don't
-        # let ``_classify_isolation_outcome`` misread a killed run's
-        # partial stdout instead of the canonical 124 watchdog signal.
-        return _PYTEST_HUNG_EXIT_CODE
-    outcome = _classify_isolation_outcome(returncode, captured_stdout)
-    _print_isolation_banner(outcome)
-    return outcome.exit_code
-
-
 def _resolve_changed_files() -> list[str] | None:
     """Return changed files, or ``None`` if we should run the full suite.
 
@@ -1028,12 +971,7 @@ def _run_tests() -> int:
         return 0
 
     print(f"Running affected tests: {', '.join(test_dirs)}")
-    primary_returncode = _run_pytest(test_dirs)
-    return (
-        primary_returncode
-        if primary_returncode != 0
-        else _run_isolation_gate(test_dirs)
-    )
+    return _run_pytest(test_dirs)
 
 
 def main() -> int:

--- a/scripts/run_affected_tests.py
+++ b/scripts/run_affected_tests.py
@@ -29,7 +29,6 @@ import subprocess
 import sys
 import threading
 import time
-from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Final, Literal
@@ -224,8 +223,7 @@ _PASSED_COUNT_RE = re.compile(r"(\d+)\s+passed")
 # xdist prints worker-crash lines like
 # ``worker 'gw3' crashed while running 'tests/foo.py::test_bar[2-2]'``
 # when a worker process dies (segfault, abort, OS kill).  Used by the
-# isolation-gate classifier to tell native-level crashes apart from
-# real test failures.
+# run classifier to tell native-level crashes apart from real test failures.
 _WORKER_CRASH_RE = re.compile(
     r"worker '(?P<worker>\w+)' crashed while running '(?P<test>[^']+)'",
 )
@@ -248,22 +246,6 @@ _NODE_DOWN_RE = re.compile(
 # session summary.  ``\S+`` captures up to the first whitespace; valid
 # pytest test ids never contain whitespace, so the boundary is safe.
 _FAILED_RE = re.compile(r"^FAILED (?P<test>\S+)", re.MULTILINE)
-
-# pytest-repeat appends a ``[N-M]`` suffix to each repetition's test id.
-# Stripping it lets the classifier recognise the same logical test
-# crashing on multiple iterations.  Anchored to ``$`` so a parametrize
-# value like ``test_foo[a-b][1-2]`` strips only the trailing repeat
-# suffix.  A naturally-parametrized id of the bare shape ``test_foo[1-2]``
-# is indistinguishable from a pytest-repeat suffix, but the project's
-# parametrize values use descriptive names so the collision is theoretical.
-_REPEAT_SUFFIX_RE = re.compile(r"\[\d+-\d+\]$")
-
-# Minimum crash count for the same logical test to be treated as a real
-# bug rather than transient native-level flakiness.  Two crashes across
-# distinct pytest-repeat iterations of the same test (e.g. ``[1-2]``
-# AND ``[2-2]``) means every replay of the test crashed the worker --
-# very different signal from a single crash that may just be infra noise.
-_MIN_CRASHES_FOR_REAL_BUG = 2
 
 
 def _parse_test_count(pytest_output: str) -> int | None:
@@ -635,22 +617,20 @@ def _run_pytest(paths: list[str], *, run_all: bool = False) -> int:
 
 @dataclass(frozen=True)
 class IsolationOutcome:
-    """Classified result of a single isolation-gate pytest invocation.
+    """Classified result of the affected-test pytest run.
 
-    ``kind`` captures the gate's verdict; ``exit_code`` is what the
-    script should return.  ``crashed_tests`` / ``failed_tests`` /
-    ``repeated_crashes`` carry the supporting evidence so the banner
-    can name names.
+    ``kind`` captures the verdict; ``exit_code`` is what the script should
+    return.  ``crashed_tests`` / ``failed_tests`` carry the supporting evidence
+    so the banner can name names.
 
     Invariants (enforced in ``__post_init__``):
 
     * ``pass`` -- ``exit_code == 0`` and every evidence tuple is empty.
-    * ``regression`` -- ``exit_code >= 1``.  Covers real test failures,
-      repeated crashes, AND one-off worker crashes: a crashed xdist
-      worker is a real defect to debug (teardown race, native deadlock),
-      never an advisory pass. Evidence tuples may all be empty when
-      pytest exits non-zero with degraded output the parser cannot
-      interpret -- we fail closed rather than silently pass.
+    * ``regression`` -- ``exit_code >= 1``.  Covers real test failures AND
+      worker crashes: a crashed xdist worker is a real defect to debug
+      (teardown race, native deadlock), never an advisory pass. Evidence
+      tuples may both be empty when pytest exits non-zero with degraded output
+      the parser cannot interpret -- we fail closed rather than silently pass.
 
     Enforcing these at construction means the banner can rely on the
     invariant without re-checking at the print site.
@@ -660,7 +640,6 @@ class IsolationOutcome:
     exit_code: int
     crashed_tests: tuple[str, ...] = field(default_factory=tuple)
     failed_tests: tuple[str, ...] = field(default_factory=tuple)
-    repeated_crashes: tuple[str, ...] = field(default_factory=tuple)
 
     def __post_init__(self) -> None:
         """Reject illegal ``(kind, exit_code, evidence)`` combinations."""
@@ -668,7 +647,7 @@ class IsolationOutcome:
             if self.exit_code != 0:
                 msg = f"pass outcome must have exit_code=0, got {self.exit_code}"
                 raise ValueError(msg)
-            if self.crashed_tests or self.failed_tests or self.repeated_crashes:
+            if self.crashed_tests or self.failed_tests:
                 msg = "pass outcome must carry no evidence tuples"
                 raise ValueError(msg)
         elif self.kind == "regression" and self.exit_code == 0:
@@ -697,7 +676,7 @@ def _classify_isolation_outcome(
     returncode: int,
     stdout: str,
 ) -> IsolationOutcome:
-    """Decide whether the gate run is a regression or pass.
+    """Decide whether the affected-test run is a regression or pass.
 
     The interesting axis is *real failure* vs *native crash*.  xdist
     marks a crashed test ``FAILED`` as collateral, so a ``FAILED``
@@ -707,9 +686,6 @@ def _classify_isolation_outcome(
     Decision tree:
 
     * Any real failure (``FAILED`` for a non-crashed test) -> regression.
-    * Same logical test crashed on multiple iterations -> regression
-      (a real bug; pytest-repeat ``[N-M]`` suffix is stripped before
-      counting so the two iterations of one test collapse).
     * Any xdist worker crash -- a one-off crash, or a bare ``node down``
       (regardless of returncode) -> regression.  A crashed worker is a
       real defect (Python 3.14 + Windows ProactorEventLoop teardown
@@ -727,24 +703,12 @@ def _classify_isolation_outcome(
     failed_tests_raw = _parse_test_failures(stdout)
     real_failures = tuple(t for t in failed_tests_raw if t not in crashed_set)
 
-    normalized = Counter(_REPEAT_SUFFIX_RE.sub("", t) for t in crashed_tests)
-    repeated = tuple(
-        sorted(t for t, n in normalized.items() if n >= _MIN_CRASHES_FOR_REAL_BUG)
-    )
-
     if real_failures:
         return IsolationOutcome(
             kind="regression",
             exit_code=max(returncode, 1),
             crashed_tests=crashed_tests,
             failed_tests=real_failures,
-        )
-    if repeated:
-        return IsolationOutcome(
-            kind="regression",
-            exit_code=max(returncode, 1),
-            crashed_tests=crashed_tests,
-            repeated_crashes=repeated,
         )
     if crashes:
         return IsolationOutcome(
@@ -754,7 +718,7 @@ def _classify_isolation_outcome(
         )
     # A worker that went ``node down`` is a native-level crash, not a
     # test failure -- and a real defect to debug, never an advisory
-    # pass. The real-failure and repeated-crash checks above already
+    # pass. The real-failure and worker-crash checks above already
     # returned, so the worker death itself is the only adverse signal
     # here, and it blocks regardless of returncode. ``--max-worker-
     # restart=0`` forbids recovery, and a worker killed mid-teardown can
@@ -785,10 +749,9 @@ def _print_isolation_banner(outcome: IsolationOutcome) -> None:
     Two banners:
 
     * ``regression`` -- the operator must investigate; the gate blocks.
-      Distinguishes a module-state leak (real failures), a test that
-      repeatedly crashes the worker, a one-off worker crash (native
-      teardown race / deadlock to debug from the dump), and degraded
-      non-zero output, so the message points at the right cause.
+      Distinguishes a real test failure, a worker crash (native teardown
+      race / deadlock to debug from the dump), and degraded non-zero
+      output, so the message points at the right cause.
     * ``pass`` -- nothing to print.
     """
     if outcome.kind == "pass":
@@ -797,29 +760,16 @@ def _print_isolation_banner(outcome: IsolationOutcome) -> None:
     if outcome.kind == "regression":
         if outcome.failed_tests:
             body = (
-                "ISOLATION REGRESSION: a test passed once but failed on repeat.\n"
-                "Module-level state likely leaked across the two invocations.\n"
-                "Common offenders: module-level dicts/sets that fixtures reset\n"
-                "in only one directory; ``monkeypatch.setattr`` on structlog\n"
-                "lazy-proxy log methods; cached caches that survive teardown.\n"
+                "TEST FAILURE: the affected-test run reported a failing test.\n"
                 f"Failed: {', '.join(outcome.failed_tests)}\n"
-                "Fix the leak. The gate has no bypass."
-            )
-        elif outcome.repeated_crashes:
-            body = (
-                "ISOLATION REGRESSION: a test crashed the xdist worker on\n"
-                "every replay.  This is a real bug in the test or its\n"
-                "fixtures (memory corruption, segfault, native-level\n"
-                "deadlock), not transient infra noise.\n"
-                f"Repeated crashes: {', '.join(outcome.repeated_crashes)}\n"
-                "Fix the bug. The gate has no bypass."
+                "Fix the failure. The gate has no bypass."
             )
         elif outcome.crashed_tests:
             body = (
-                "ISOLATION CRASH: an xdist worker crashed during the replay\n"
-                "run.  A crashed worker is a real defect -- a Python 3.14 +\n"
-                "Windows ProactorEventLoop teardown race, a native deadlock,\n"
-                "or memory corruption -- NOT an advisory to wave through.\n"
+                "WORKER CRASH: an xdist worker crashed during the run.\n"
+                "A crashed worker is a real defect -- a Python 3.14 + Windows\n"
+                "ProactorEventLoop teardown race, a native deadlock, or memory\n"
+                "corruption -- NOT an advisory to wave through.\n"
                 "Read the faulthandler / core dump and inspect the named\n"
                 "test's teardown and fixtures for the root cause.\n"
                 f"Crashed: {', '.join(outcome.crashed_tests)}\n"
@@ -830,7 +780,7 @@ def _print_isolation_banner(outcome: IsolationOutcome) -> None:
             # FAILED or worker-crash signal.  Don't silently pass; surface
             # the raw exit code and ask the operator to inspect the run.
             body = (
-                "ISOLATION REGRESSION: pytest exited non-zero "
+                "TEST-RUN REGRESSION: pytest exited non-zero "
                 f"({outcome.exit_code}) with output the gate could not\n"
                 "parse.  Inspect the captured pytest output above for\n"
                 "the underlying failure.  The gate has no bypass."
@@ -959,11 +909,6 @@ def _run_tests() -> int:
     test_dirs, run_all = _affected_test_dirs(py_changed)
     if run_all:
         print("Foundational module or conftest changed -- running full unit suite.")
-        # Full-suite runs skip the isolation gate: doubling a multi-minute
-        # full-suite run gates a routine push on a 5+ minute extra wait,
-        # and the affected-test gate already covers the realistic delta
-        # surface. The isolation contract is enforced through targeted
-        # runs in active development, not by re-running the world.
         return _run_pytest(["tests/unit/"], run_all=True)
 
     if not test_dirs:

--- a/scripts/run_prepush_python_gates.py
+++ b/scripts/run_prepush_python_gates.py
@@ -35,6 +35,7 @@ monkey-patches a module would silently affect later gates sharing its worker.
 import argparse
 import contextlib
 import io
+import multiprocessing
 import os
 import runpy
 import sys
@@ -262,8 +263,18 @@ def _run_pooled(jobs: int) -> tuple[dict[str, _GateResult], bool]:
                 results[stem] = (code, elapsed, output, detail)
                 _report_gate(stem, code, elapsed)
         except (BrokenProcessPool, TimeoutError) as exc:
-            unfinished = sorted(futures[f] for f in futures if not f.done())
-            pool.shutdown(cancel_futures=True)
+            # A gate whose future raised is already ``done()`` yet never made it
+            # into ``results``, so derive the unreported set from ``results``
+            # membership rather than ``Future.done()`` (which would under-count).
+            unfinished = sorted(stem for stem in _GATES if stem not in results)
+            # A wedged worker never exits on its own, and both
+            # ``shutdown(cancel_futures=True)`` and the context-manager exit
+            # block waiting on it -- which would defeat the batch timeout and
+            # hang the push. Terminate the pool's worker processes (this
+            # runner spawns no other children) so the shutdown returns at once.
+            for child in multiprocessing.active_children():
+                child.terminate()
+            pool.shutdown(wait=False, cancel_futures=True)
             reason = (
                 "a gate worker crashed (BrokenProcessPool)"
                 if isinstance(exc, BrokenProcessPool)

--- a/scripts/run_prepush_python_gates.py
+++ b/scripts/run_prepush_python_gates.py
@@ -1,48 +1,77 @@
 #!/usr/bin/env python3
-"""Single-process runner for the pre-push-only pure-Python gates.
+"""Runner for the pre-push-only pure-Python gates.
 
-Every gate listed here previously ran as its own
-``uv run python scripts/check_*.py`` pre-commit hook. On Windows that meant
-~40 sequential process spawns per push, each re-paying interpreter startup
-and (for the gates that touch ``synthorg``) the multi-second package import,
-and each adding to the desktop-heap pressure that surfaces as
-``STATUS_DLL_INIT_FAILED`` (0xC0000142) once a loaded box can no longer
-initialise a new process.
+The ~48 gates in ``_GATES`` are folded into this one runner rather than ~48
+individual ``uv run python scripts/check_*.py`` pre-commit hooks. Each gate
+is a whole-tree AST analysis costing several seconds -- parsing the ~6k-file
+source tree dominates each gate's runtime -- so the runner fans them out
+across a bounded reused-worker pool (``--jobs``; default ``min(12, cores)``,
+override via ``PREPUSH_GATE_JOBS``). ``--jobs 1`` runs them serially in this
+one process.
 
-This runner executes every gate in ONE process via :func:`runpy.run_path`,
-so the spawn count collapses from ~40 to 1 and the ``synthorg`` import is
-paid once (cached in ``sys.modules`` for every later gate). Each gate runs
-as if ``__main__`` in a fresh module namespace; its ``sys.exit(code)`` is
-caught and aggregated. Every gate ALWAYS runs even if an earlier one fails,
-so one failure never masks the rest -- matching pre-commit's
-run-everything-then-report behaviour. ``sys.argv`` and the working directory
-are saved/restored around each gate so a gate that reads ``sys.argv`` (the
+The pool is BOUNDED -- a handful of workers spawned once and reused for the
+whole batch, not one process per gate -- so the concurrent process count
+stays modest. That is the guard against the desktop-heap / STATUS_DLL_INIT_
+FAILED (0xC0000142) pressure on Windows that a naive one-spawn-per-gate
+fan-out would reintroduce. Each ``scripts/check_*.py`` file stays on disk so
+the convention-gate-inventory meta-gate resolves each gate path, and CI's
+``pre-commit run --all-files`` runs this one hook from the same config, so
+local<->CI parity holds.
+
+Each gate runs as if ``__main__`` in a fresh module namespace via
+:func:`runpy.run_path`; its ``sys.exit(code)`` is caught and aggregated, and
+every gate ALWAYS runs even if another fails, so one failure never masks the
+rest. ``sys.argv``, the working directory, and ``sys.path`` are saved and
+restored around each gate so a gate that reads ``sys.argv`` (the
 ``main(argv=None)`` shape) sees a clean argument list and a stray ``chdir``
-cannot leak into the next gate.
+or path mutation cannot leak into the next gate sharing its worker.
 
-The individual ``scripts/check_*.py`` files stay on disk (the
-convention-gate-inventory meta-gate verifies each gate path exists), and CI's
-``pre-commit run --all-files`` runs this single hook from the same config, so
-local<->CI parity is preserved.
-
-Gate contract: because gates share one process, a gate registered in
-``_GATES`` MUST be stateless with respect to process globals beyond its own
-``runpy`` namespace -- no permanent mutation of ``sys.modules``, logging
-config, or signal handlers. Side-effect-free static analysis (reads only)
-is the required posture; a gate that monkey-patches a module would silently
-affect every later gate.
+Gate contract: a gate registered in ``_GATES`` MUST be stateless with respect
+to process globals beyond its own ``runpy`` namespace -- no permanent mutation
+of ``sys.modules``, logging config, or signal handlers. Side-effect-free
+static analysis (reads only) is the required posture; a gate that
+monkey-patches a module would silently affect later gates sharing its worker.
 """
 
+import argparse
+import contextlib
+import io
 import os
 import runpy
 import sys
 import time
 import traceback
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
+from typing import Final
 
 _SCRIPTS = Path(__file__).resolve().parent
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
+
+# Gate work is CPU-bound whole-tree AST analysis, so the 48 gates fan out
+# across a bounded reused-worker pool. The cap is bounded (not one worker per
+# gate) so the concurrent process count stays modest -- the desktop-heap /
+# STATUS_DLL_INIT_FAILED pressure the single-process consolidation originally
+# dodged. Workers are reused for the whole batch (no maxtasksperchild), so the
+# total distinct spawns equal the pool size, created once at pool startup.
+_DEFAULT_MAX_JOBS: Final[int] = 12
+_FALLBACK_CPU: Final[int] = 8
+
+
+def _default_jobs() -> int:
+    """Return the default worker count.
+
+    ``PREPUSH_GATE_JOBS`` overrides for machines that want to trade memory for
+    speed (a worker per gate is CPU/memory-bound and imports ``synthorg``);
+    otherwise the count is bounded by both the core count and the job cap.
+    """
+    override = os.environ.get("PREPUSH_GATE_JOBS")
+    if override and override.strip().lstrip("-").isdigit():
+        return max(1, int(override))
+    cores = os.cpu_count() or _FALLBACK_CPU
+    return max(1, min(_DEFAULT_MAX_JOBS, cores))
+
 
 # Pre-push-only Python gates, folded from individual pre-commit hooks. Order
 # mirrors .pre-commit-config.yaml for cross-referencing. Each entry is a
@@ -156,26 +185,68 @@ def _run_one(stem: str) -> tuple[int, str]:
             pass
 
 
-def main() -> int:
-    """Run every consolidated gate, then report the aggregate result."""
-    failures: list[tuple[str, int, str]] = []
-    start = time.monotonic()
-    for stem in _GATES:
-        gate_start = time.monotonic()
+def _run_gate(stem: str) -> tuple[str, int, float, str, str]:
+    """Run one gate with output captured and timed; the pool-worker entry point.
+
+    The gate's own ``stdout``/``stderr`` are captured into one buffer so a
+    parallel run can attribute each gate's findings to it and report them in
+    canonical order, rather than interleaving output from concurrent workers.
+    Returns ``(stem, exit_code, elapsed_seconds, captured_output, detail)``.
+    """
+    buffer = io.StringIO()
+    gate_start = time.monotonic()
+    with contextlib.redirect_stdout(buffer), contextlib.redirect_stderr(buffer):
         code, detail = _run_one(stem)
-        elapsed = time.monotonic() - gate_start
+    elapsed = time.monotonic() - gate_start
+    return stem, code, elapsed, buffer.getvalue(), detail
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run every consolidated gate, then report the aggregate result.
+
+    Gates run across a bounded reused-worker pool (``--jobs``); a job count of
+    1 runs them serially in this process. Every gate always runs even if an
+    earlier one fails, and results are reported in ``_GATES`` order regardless
+    of completion order so the output is stable run to run.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--jobs",
+        type=int,
+        default=_default_jobs(),
+        help="worker processes to fan the gates across (1 = serial, in-process)",
+    )
+    args = parser.parse_args(argv)
+    jobs = max(1, args.jobs)
+
+    start = time.monotonic()
+    results: dict[str, tuple[int, float, str, str]] = {}
+    if jobs == 1:
+        for stem in _GATES:
+            _, code, elapsed, output, detail = _run_gate(stem)
+            results[stem] = (code, elapsed, output, detail)
+    else:
+        with ProcessPoolExecutor(max_workers=jobs) as pool:
+            for stem, code, elapsed, output, detail in pool.map(_run_gate, _GATES):
+                results[stem] = (code, elapsed, output, detail)
+
+    failures: list[tuple[str, int, str, str]] = []
+    for stem in _GATES:
+        code, elapsed, output, detail = results[stem]
         status = "ok  " if code == 0 else "FAIL"
         print(f"  [{status}] {elapsed:5.1f}s  {stem}", file=sys.stderr)
         if code != 0:
-            failures.append((stem, code, detail))
+            failures.append((stem, code, output, detail))
     total = time.monotonic() - start
     print(
-        f"\nconsolidated pre-push gates: {len(_GATES)} run in {total:.1f}s, "
-        f"{len(failures)} failed",
+        f"\nconsolidated pre-push gates: {len(_GATES)} run in {total:.1f}s "
+        f"across {jobs} job(s), {len(failures)} failed",
         file=sys.stderr,
     )
-    for stem, code, detail in failures:
+    for stem, code, output, detail in failures:
         print(f"\n=== GATE FAILED: {stem} (exit {code}) ===", file=sys.stderr)
+        if output.strip():
+            print(output, file=sys.stderr)
         if detail.strip():
             print(detail, file=sys.stderr)
     return 1 if failures else 0

--- a/scripts/run_prepush_python_gates.py
+++ b/scripts/run_prepush_python_gates.py
@@ -2,21 +2,20 @@
 """Runner for the pre-push-only pure-Python gates.
 
 The ~48 gates in ``_GATES`` are folded into this one runner rather than ~48
-individual ``uv run python scripts/check_*.py`` pre-commit hooks. Each gate
-is a whole-tree AST analysis costing several seconds -- parsing the ~6k-file
-source tree dominates each gate's runtime -- so the runner fans them out
-across a bounded reused-worker pool (``--jobs``; default ``min(12, cores)``,
-override via ``PREPUSH_GATE_JOBS``). ``--jobs 1`` runs them serially in this
-one process.
+individual ``uv run python scripts/check_*.py`` pre-commit hooks. Each gate is
+a whole-tree static analysis (AST parse, tokenize, or regex over the tracked
+source) costing several seconds -- reading and analysing the tree dominates
+each gate's runtime -- so the runner fans them out across a bounded reused-
+worker pool (``--jobs``; default ``min(12, cores)``, override via
+``PREPUSH_GATE_JOBS``). ``--jobs 1`` runs them serially in this one process.
 
-The pool is BOUNDED -- a handful of workers spawned once and reused for the
-whole batch, not one process per gate -- so the concurrent process count
-stays modest. That is the guard against the desktop-heap / STATUS_DLL_INIT_
-FAILED (0xC0000142) pressure on Windows that a naive one-spawn-per-gate
-fan-out would reintroduce. Each ``scripts/check_*.py`` file stays on disk so
-the convention-gate-inventory meta-gate resolves each gate path, and CI's
-``pre-commit run --all-files`` runs this one hook from the same config, so
-local<->CI parity holds.
+The pool is BOUNDED -- a handful of workers reused across the whole batch, not
+one process per gate -- so the concurrent process count stays modest. That is
+what avoids the desktop-heap / STATUS_DLL_INIT_FAILED (0xC0000142) pressure on
+Windows that an unbounded 48-way fan-out would cause. Each ``scripts/check_*.py``
+file stays on disk so the convention-gate-inventory meta-gate resolves each gate
+path, and CI's ``pre-commit run --all-files`` runs this one hook from the same
+config, so local<->CI parity holds.
 
 Each gate runs as if ``__main__`` in a fresh module namespace via
 :func:`runpy.run_path`; its ``sys.exit(code)`` is caught and aggregated, and
@@ -41,7 +40,8 @@ import runpy
 import sys
 import time
 import traceback
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from concurrent.futures.process import BrokenProcessPool
 from pathlib import Path
 from typing import Final
 
@@ -49,14 +49,21 @@ _SCRIPTS = Path(__file__).resolve().parent
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
-# Gate work is CPU-bound whole-tree AST analysis, so the 48 gates fan out
-# across a bounded reused-worker pool. The cap is bounded (not one worker per
-# gate) so the concurrent process count stays modest -- the desktop-heap /
-# STATUS_DLL_INIT_FAILED pressure the single-process consolidation originally
-# dodged. Workers are reused for the whole batch (no maxtasksperchild), so the
-# total distinct spawns equal the pool size, created once at pool startup.
+# Each gate is a whole-tree static analysis (AST parse, tokenize, or regex over
+# the tracked source) costing several seconds, so the 48 gates fan out across a
+# bounded reused-worker pool. Bounding the pool (rather than one process per
+# gate) keeps the concurrent process count modest, which avoids the desktop-heap
+# / STATUS_DLL_INIT_FAILED (0xC0000142) pressure on Windows that an unbounded
+# 48-way fan-out would cause. Workers are reused for the whole batch
+# (``max_tasks_per_child`` left at its default), so one worker handles many
+# gates over its lifetime rather than respawning per gate.
 _DEFAULT_MAX_JOBS: Final[int] = 12
 _FALLBACK_CPU: Final[int] = 8
+# Wall-clock ceiling for the whole gate batch: gates are static analysis that
+# finishes in seconds, so this is a safety net that fails the push loudly if a
+# gate wedges, rather than hanging every push forever (the sibling pytest
+# runner carries the same watchdog shape).
+_BATCH_TIMEOUT_SECONDS: Final[float] = 600.0
 
 
 def _default_jobs() -> int:
@@ -67,8 +74,15 @@ def _default_jobs() -> int:
     otherwise the count is bounded by both the core count and the job cap.
     """
     override = os.environ.get("PREPUSH_GATE_JOBS")
-    if override and override.strip().lstrip("-").isdigit():
-        return max(1, int(override))
+    if override is not None and override.strip():
+        cleaned = override.strip()
+        if cleaned.lstrip("-").isdigit():
+            return max(1, int(cleaned))
+        print(
+            f"run_prepush_python_gates: ignoring PREPUSH_GATE_JOBS={override!r} "
+            "(not an integer); using the core-count default.",
+            file=sys.stderr,
+        )
     cores = os.cpu_count() or _FALLBACK_CPU
     return max(1, min(_DEFAULT_MAX_JOBS, cores))
 
@@ -131,6 +145,24 @@ _GATES: tuple[str, ...] = (
 )
 
 
+def _recover_cwd(saved_cwd: Path) -> None:
+    """Restore the working directory after a gate ran.
+
+    A gate that chdir'd into a tempdir it then removed leaves ``Path.cwd()``
+    raising and the process in an invalid directory, so the next gate sharing
+    this worker gets broken relative-path reads. Recover to *saved_cwd*, or the
+    repo root when the saved cwd is itself gone, rather than advancing broken.
+    """
+    try:
+        current_cwd: Path | None = Path.cwd()
+    except OSError:
+        current_cwd = None
+    target_cwd = saved_cwd if saved_cwd.is_dir() else _SCRIPTS.parent
+    with contextlib.suppress(OSError):
+        if current_cwd != target_cwd:
+            os.chdir(target_cwd)
+
+
 def _run_one(stem: str) -> tuple[int, str]:
     """Run one gate as ``__main__`` in-process; return ``(exit_code, detail)``.
 
@@ -156,6 +188,12 @@ def _run_one(stem: str) -> tuple[int, str]:
         if isinstance(code, int):
             return code, ""
         return 1, str(code)
+    except MemoryError, RecursionError:
+        # Resource exhaustion is not a gate violation; let it propagate so an
+        # OOM under parallel load surfaces distinctly (crashing the worker,
+        # handled by the pool caller) instead of masquerading as a gate that
+        # "failed" with a traceback.
+        raise
     except Exception:
         return 1, traceback.format_exc()
     else:
@@ -164,25 +202,10 @@ def _run_one(stem: str) -> tuple[int, str]:
     finally:
         sys.argv = saved_argv
         # A gate that mutates ``sys.path`` (directly or via ``runpy.run_path``)
-        # must not leak that change into the next gate; restore the snapshot so
-        # each gate sees the same import path the runner started with.
+        # must not leak that change into the next gate sharing this worker;
+        # restore the snapshot so each gate sees the same import path.
         sys.path = saved_path
-        # Best-effort cwd restore: if a gate chdir'd into a tempdir it then
-        # removed, ``Path.cwd()`` raises and the process is left in an invalid
-        # directory, so the next gate's relative-path reads break. Recover to a
-        # known-good dir -- the saved cwd, or the repo root when the saved cwd
-        # is itself gone -- rather than swallowing the error and advancing with
-        # a broken cwd.
-        try:
-            current_cwd: Path | None = Path.cwd()
-        except OSError:
-            current_cwd = None
-        target_cwd = saved_cwd if saved_cwd.is_dir() else _SCRIPTS.parent
-        try:
-            if current_cwd != target_cwd:
-                os.chdir(target_cwd)
-        except OSError:
-            pass
+        _recover_cwd(saved_cwd)
 
 
 def _run_gate(stem: str) -> tuple[str, int, float, str, str]:
@@ -201,13 +224,71 @@ def _run_gate(stem: str) -> tuple[str, int, float, str, str]:
     return stem, code, elapsed, buffer.getvalue(), detail
 
 
+_GateResult = tuple[int, float, str, str]
+
+
+def _report_gate(stem: str, code: int, elapsed: float) -> None:
+    """Print one gate's live status line as it completes."""
+    status = "ok  " if code == 0 else "FAIL"
+    print(f"  [{status}] {elapsed:5.1f}s  {stem}", file=sys.stderr)
+
+
+def _run_serial() -> dict[str, _GateResult]:
+    """Run every gate in this process, reporting each as it finishes."""
+    results: dict[str, _GateResult] = {}
+    for stem in _GATES:
+        _, code, elapsed, output, detail = _run_gate(stem)
+        results[stem] = (code, elapsed, output, detail)
+        _report_gate(stem, code, elapsed)
+    return results
+
+
+def _run_pooled(jobs: int) -> tuple[dict[str, _GateResult], bool]:
+    """Run gates across a bounded worker pool; report each as it lands.
+
+    Returns ``(results, crashed)``. A worker dying (the STATUS_DLL_INIT_FAILED /
+    OOM class the pool is bounded to avoid) breaks the whole pool, and a wedged
+    gate trips the batch timeout: both are caught here and turned into a loud,
+    attributed failure (naming the gates that never reported) rather than an
+    unhandled ``BrokenProcessPool`` traceback or an indefinite hang. Gates that
+    did report keep their results so their findings still surface.
+    """
+    results: dict[str, _GateResult] = {}
+    with ProcessPoolExecutor(max_workers=jobs) as pool:
+        futures = {pool.submit(_run_gate, stem): stem for stem in _GATES}
+        try:
+            for future in as_completed(futures, timeout=_BATCH_TIMEOUT_SECONDS):
+                stem, code, elapsed, output, detail = future.result()
+                results[stem] = (code, elapsed, output, detail)
+                _report_gate(stem, code, elapsed)
+        except (BrokenProcessPool, TimeoutError) as exc:
+            unfinished = sorted(futures[f] for f in futures if not f.done())
+            pool.shutdown(cancel_futures=True)
+            reason = (
+                "a gate worker crashed (BrokenProcessPool)"
+                if isinstance(exc, BrokenProcessPool)
+                else f"the {_BATCH_TIMEOUT_SECONDS:.0f}s batch timeout fired"
+            )
+            print(
+                f"\nconsolidated pre-push gates: {reason}; "
+                f"{len(unfinished)} gate(s) never reported: "
+                f"{', '.join(unfinished)}.\n"
+                "Re-run with PREPUSH_GATE_JOBS=1 to isolate the offending gate.",
+                file=sys.stderr,
+            )
+            return results, True
+    return results, False
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run every consolidated gate, then report the aggregate result.
 
-    Gates run across a bounded reused-worker pool (``--jobs``); a job count of
-    1 runs them serially in this process. Every gate always runs even if an
-    earlier one fails, and results are reported in ``_GATES`` order regardless
-    of completion order so the output is stable run to run.
+    Gates run across a bounded reused-worker pool (``--jobs``); a job count of 1
+    runs them serially in this process. Each gate's status prints live as it
+    finishes (completion order under the pool, ``_GATES`` order when serial);
+    the final failure detail is reported in ``_GATES`` order for stable output.
+    A worker crash or the batch timeout fails the push loudly (see ``_run_pooled``)
+    rather than masking which gates ran.
     """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -220,27 +301,23 @@ def main(argv: list[str] | None = None) -> int:
     jobs = max(1, args.jobs)
 
     start = time.monotonic()
-    results: dict[str, tuple[int, float, str, str]] = {}
+    crashed = False
     if jobs == 1:
-        for stem in _GATES:
-            _, code, elapsed, output, detail = _run_gate(stem)
-            results[stem] = (code, elapsed, output, detail)
+        results = _run_serial()
     else:
-        with ProcessPoolExecutor(max_workers=jobs) as pool:
-            for stem, code, elapsed, output, detail in pool.map(_run_gate, _GATES):
-                results[stem] = (code, elapsed, output, detail)
+        results, crashed = _run_pooled(jobs)
 
-    failures: list[tuple[str, int, str, str]] = []
-    for stem in _GATES:
-        code, elapsed, output, detail = results[stem]
-        status = "ok  " if code == 0 else "FAIL"
-        print(f"  [{status}] {elapsed:5.1f}s  {stem}", file=sys.stderr)
-        if code != 0:
-            failures.append((stem, code, output, detail))
+    failures = [
+        (stem, results[stem][0], results[stem][2], results[stem][3])
+        for stem in _GATES
+        if stem in results and results[stem][0] != 0
+    ]
+    unreported = [stem for stem in _GATES if stem not in results]
     total = time.monotonic() - start
+    tail = f", {len(unreported)} did not complete" if unreported else ""
     print(
-        f"\nconsolidated pre-push gates: {len(_GATES)} run in {total:.1f}s "
-        f"across {jobs} job(s), {len(failures)} failed",
+        f"\nconsolidated pre-push gates: {len(results)}/{len(_GATES)} reported "
+        f"in {total:.1f}s across {jobs} job(s), {len(failures)} failed{tail}",
         file=sys.stderr,
     )
     for stem, code, output, detail in failures:
@@ -249,7 +326,7 @@ def main(argv: list[str] | None = None) -> int:
             print(output, file=sys.stderr)
         if detail.strip():
             print(detail, file=sys.stderr)
-    return 1 if failures else 0
+    return 1 if (failures or crashed or unreported) else 0
 
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -750,15 +750,13 @@ _WALL_CLOCK_GUARD_EXEMPT_FRAGMENTS: Final = (
     "unit/api/controllers/test_learning.py",
 )
 _FUZZ_PROFILE_ACTIVE = os.environ.get("HYPOTHESIS_PROFILE") in ("fuzz", "extreme")
-# pytest-repeat's ``--count`` flag is used exclusively by
-# ``scripts/run_affected_tests.py``'s isolation regression gate (a
-# ``--count 2`` replay of every affected test to detect fixture
-# state leaks). That replay doubles xdist contention; legitimate
-# unit tests routinely cross the 6s wall-clock guard on Windows
-# under that load even though they run well under it in the primary
-# pass. The primary run (no ``--count``) still enforces the guard;
-# disabling it on the replay keeps the gate focused on its actual
-# purpose (fixture leak detection) rather than re-litigating timing.
+# pytest-repeat's ``--count`` flag is no longer produced by any automated
+# caller; it now appears only when a developer runs ``pytest --count N`` by
+# hand to reproduce a fixture state leak. Such a replay multiplies xdist
+# contention, and legitimate unit tests routinely cross the 6s wall-clock guard
+# on Windows under that load even though they run well under it in a single
+# pass, so the guard is disabled while ``--count`` is present. The single-pass
+# run (no ``--count``) that every push and CI job uses still enforces the guard.
 _COUNT_ISOLATION_RUN = "--count" in sys.argv or any(
     arg.startswith("--count=") for arg in sys.argv
 )

--- a/tests/unit/scripts/test_run_affected_tests.py
+++ b/tests/unit/scripts/test_run_affected_tests.py
@@ -780,81 +780,7 @@ def test_print_isolation_banner_regression_no_evidence_uses_failclosed_text(
     assert "(2)" in err
 
 
-# ── _run_isolation_gate orchestrator ─────────────────────────────
-
-
-def test_run_isolation_gate_skips_when_paths_empty(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Empty path list short-circuits to exit 0 before running pytest."""
-    monkeypatch.setattr(
-        _MODULE,
-        "_stream_pytest",
-        lambda _cmd: pytest.fail("_stream_pytest must not run on empty paths"),
-    )
-    assert _MODULE._run_isolation_gate([]) == 0
-
-
-def test_run_isolation_gate_passes_through_classifier_pass(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Green pytest output -> classifier returns pass -> exit 0."""
-    monkeypatch.setattr(
-        _MODULE,
-        "_stream_pytest",
-        lambda _cmd, **_kwargs: (0, "500 passed in 12.34s\n"),
-    )
-    assert _MODULE._run_isolation_gate(["tests/unit/foo/"]) == 0
-
-
-def test_run_isolation_gate_blocks_on_native_crash(
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """Native worker crashes -> classifier returns regression -> blocks (exit >= 1)."""
-    stdout = _CRASH_LINE + _CRASH_LINE_OTHER_TEST
-    monkeypatch.setattr(
-        _MODULE,
-        "_stream_pytest",
-        lambda _cmd, **_kwargs: (1, stdout),
-    )
-    rc = _MODULE._run_isolation_gate(["tests/unit/api/"])
-    assert rc == 1
-    assert "ISOLATION CRASH" in capsys.readouterr().err
-
-
-def test_run_isolation_gate_returns_nonzero_on_real_regression(
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """Real test failure -> classifier returns regression -> exit non-zero."""
-    monkeypatch.setattr(
-        _MODULE,
-        "_stream_pytest",
-        lambda _cmd, **_kwargs: (1, _FAILED_LINE + "499 passed, 1 failed in 12s\n"),
-    )
-    rc = _MODULE._run_isolation_gate(["tests/unit/api/"])
-    assert rc == 1
-    assert "ISOLATION REGRESSION" in capsys.readouterr().err
-
-
-def test_run_isolation_gate_invokes_pytest_with_correct_flags(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The gate command embeds ``--count 2`` and ``--max-worker-restart=0``."""
-    captured: dict[str, list[str]] = {}
-
-    def _capture(cmd: list[str], **_kwargs: object) -> tuple[int, str]:
-        captured["cmd"] = cmd
-        return 0, "1 passed in 0.1s\n"
-
-    monkeypatch.setattr(_MODULE, "_stream_pytest", _capture)
-    _MODULE._run_isolation_gate(["tests/unit/foo/"])
-    cmd = captured["cmd"]
-    assert "--count" in cmd
-    assert "2" in cmd
-    assert "--max-worker-restart=0" in cmd
-    assert "tests/unit/foo/" in cmd
+# ── _run_pytest orchestrator ─────────────────────────────────────
 
 
 def test_run_pytest_short_circuits_on_hung_exit_code(
@@ -909,36 +835,6 @@ def test_run_pytest_blocks_on_timing_regression_even_when_tests_pass(
     )
     rc = _MODULE._run_pytest(["tests/unit/foo/"], run_all=True)
     assert rc == 1
-
-
-def test_run_isolation_gate_short_circuits_on_hung_exit_code(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Isolation gate also short-circuits on watchdog kill (same reasoning).
-
-    A hung ``--count 2`` replay must NOT be classified from its partial
-    stdout; the watchdog kill returns the canonical 124 so a replay that
-    timed out before finishing blocks cleanly.
-    """
-    monkeypatch.setattr(
-        _MODULE,
-        "_stream_pytest",
-        lambda _cmd, **_kwargs: (
-            _MODULE._PYTEST_HUNG_EXIT_CODE,
-            "[gw0] node down: Not properly terminated\n",
-        ),
-    )
-
-    def _classifier_must_not_run(*_args: object, **_kwargs: object) -> object:
-        msg = "classifier must not run on hung-pytest fast path"
-        raise AssertionError(msg)
-
-    monkeypatch.setattr(
-        _MODULE, "_classify_isolation_outcome", _classifier_must_not_run
-    )
-    rc = _MODULE._run_isolation_gate(["tests/unit/foo/"])
-    assert rc == _MODULE._PYTEST_HUNG_EXIT_CODE
-    assert rc == 124
 
 
 # ── event loop policy fixtures ───────────────────────────────────

--- a/tests/unit/scripts/test_run_affected_tests.py
+++ b/tests/unit/scripts/test_run_affected_tests.py
@@ -2,8 +2,8 @@
 
 Covers ``_check_timing_regression`` and its helpers
 (``_load_baseline_snapshot``, ``_check_per_test_regression``,
-``_check_env_cap``), the isolation-gate output classifier, the banner
-emitter, the ``_run_isolation_gate`` orchestrator, and the
+``_check_env_cap``), the affected-run outcome classifier, the banner
+emitter, the ``_run_pytest`` orchestrator, and the
 ``pytest_asyncio_loop_factories`` hook wired by ``tests/unit/conftest.py``.
 Loads the script as a module so the private helpers are callable.
 """
@@ -343,7 +343,7 @@ def test_load_baseline_snapshot_derives_per_test_ms_when_absent(
     assert snapshot.baseline_test_count == 10_000
 
 
-# ── isolation-gate output classifier ─────────────────────────────
+# ── affected-run outcome classifier ──────────────────────────────
 
 
 _CRASH_LINE = (
@@ -354,11 +354,6 @@ _CRASH_LINE = (
 _CRASH_LINE_OTHER_TEST = (
     "worker 'gw1' crashed while running "
     "'tests/unit/api/controllers/test_meetings.py::test_completed[2-2]'\n"
-)
-_CRASH_LINE_SAME_TEST_OTHER_ITER = (
-    "worker 'gw2' crashed while running "
-    "'tests/unit/api/auth/test_postgres_session_store.py"
-    "::test_enforce_session_limit_revokes_oldest[1-2]'\n"
 )
 _FAILED_LINE = (
     "FAILED tests/unit/api/auth/test_csrf.py::test_revealed_state[2-2]"
@@ -415,7 +410,6 @@ def test_classify_pass_when_returncode_zero_and_no_crashes() -> None:
     assert outcome.exit_code == 0
     assert outcome.crashed_tests == ()
     assert outcome.failed_tests == ()
-    assert outcome.repeated_crashes == ()
 
 
 def test_classify_regression_when_returncode_zero_with_crashes() -> None:
@@ -467,23 +461,6 @@ def test_classify_regression_when_failure_alongside_crash() -> None:
     )
 
 
-def test_classify_regression_when_same_test_crashed_twice() -> None:
-    """Same logical test crashing on both repeat iterations -> real bug."""
-    # Same test, ``[1-2]`` and ``[2-2]`` -- both pytest-repeat iterations crashed.
-    stdout = _CRASH_LINE + _CRASH_LINE_SAME_TEST_OTHER_ITER
-    outcome = _MODULE._classify_isolation_outcome(
-        returncode=1,
-        stdout=stdout,
-    )
-    assert outcome.kind == "regression"
-    assert outcome.exit_code == 1
-    # Repeat suffix stripped before counting.
-    assert outcome.repeated_crashes == (
-        "tests/unit/api/auth/test_postgres_session_store.py"
-        "::test_enforce_session_limit_revokes_oldest",
-    )
-
-
 def test_classify_regression_when_distinct_crashes_only() -> None:
     """Crashes spread across distinct tests, no real failures -> still blocks."""
     stdout = _CRASH_LINE + _CRASH_LINE_OTHER_TEST
@@ -500,7 +477,6 @@ def test_classify_regression_when_distinct_crashes_only() -> None:
         "::test_enforce_session_limit_revokes_oldest[2-2]",
         "tests/unit/api/controllers/test_meetings.py::test_completed[2-2]",
     )
-    assert outcome.repeated_crashes == ()
 
 
 def test_classify_filters_crashed_test_from_failed_line() -> None:
@@ -533,7 +509,6 @@ def test_classify_regression_when_returncode_nonzero_no_signals() -> None:
     assert outcome.kind == "regression"
     assert outcome.exit_code == 2
     assert outcome.failed_tests == ()
-    assert outcome.repeated_crashes == ()
 
 
 def test_classify_regression_when_node_down_with_internal_error() -> None:
@@ -563,7 +538,6 @@ def test_classify_regression_when_node_down_with_internal_error() -> None:
     # lacks a per-test attribution).
     assert outcome.crashed_tests == ("<worker gw5>", "<worker gw0>")
     assert outcome.failed_tests == ()
-    assert outcome.repeated_crashes == ()
 
 
 def test_classify_regression_when_node_down_without_internal_error() -> None:
@@ -586,7 +560,6 @@ def test_classify_regression_when_node_down_without_internal_error() -> None:
     assert outcome.exit_code == 1
     assert outcome.crashed_tests == ("<worker gw5>",)
     assert outcome.failed_tests == ()
-    assert outcome.repeated_crashes == ()
 
 
 def test_classify_node_down_with_zero_returncode_blocks() -> None:
@@ -630,39 +603,22 @@ def test_classify_real_failure_outranks_node_down_signature() -> None:
 
 
 def test_classify_regression_when_single_crash_blocks() -> None:
-    """A single one-off worker crash blocks (regression); repeated_crashes empty.
+    """A single one-off worker crash blocks (regression).
 
-    The repeated-crash threshold (``>= 2``) no longer decides block vs
-    pass -- every worker crash blocks. It only decides which banner the
-    operator sees (repeated-bug vs one-off crash); a one-off crash has
-    empty ``repeated_crashes`` but is still a regression.
+    Every worker crash blocks regardless of how many tests crashed; a
+    lone crash with returncode 1 is still a regression the gate surfaces.
     """
-    stdout = _CRASH_LINE  # Single crash, no repeat iteration.
+    stdout = _CRASH_LINE  # Single crash.
     outcome = _MODULE._classify_isolation_outcome(
         returncode=1,
         stdout=stdout,
     )
     assert outcome.kind == "regression"
     assert outcome.exit_code == 1
-    assert outcome.repeated_crashes == ()
-
-
-def test_classify_regression_when_three_iteration_run_all_crash() -> None:
-    """Pytest-repeat ``--count 3`` -- all three iterations crash on the same test.
-
-    The classifier strips ``[N-3]`` suffixes the same way as ``[N-2]``,
-    so three crashes of the same logical test count as a real bug.
-    """
-    base = "tests/unit/foo.py::test_bar"
-    stdout = "".join(
-        f"worker 'gw{i}' crashed while running '{base}[{i + 1}-3]'\n" for i in range(3)
+    assert outcome.crashed_tests == (
+        "tests/unit/api/auth/test_postgres_session_store.py"
+        "::test_enforce_session_limit_revokes_oldest[2-2]",
     )
-    outcome = _MODULE._classify_isolation_outcome(
-        returncode=1,
-        stdout=stdout,
-    )
-    assert outcome.kind == "regression"
-    assert outcome.repeated_crashes == (base,)
 
 
 def test_parse_worker_crashes_ignores_malformed_line() -> None:
@@ -713,10 +669,10 @@ def test_print_isolation_banner_pass_emits_nothing(
     assert captured.out == ""
 
 
-def test_print_isolation_banner_regression_failed_tests_blames_state_leak(
+def test_print_isolation_banner_regression_failed_tests_names_failure(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Regression with failed_tests names module-level state leak."""
+    """Regression with failed_tests reports a plain test failure."""
     outcome = _MODULE.IsolationOutcome(
         kind="regression",
         exit_code=1,
@@ -724,34 +680,14 @@ def test_print_isolation_banner_regression_failed_tests_blames_state_leak(
     )
     _MODULE._print_isolation_banner(outcome)
     err = capsys.readouterr().err
-    assert "Module-level state likely leaked" in err
-    assert "tests/unit/foo.py::test_bar" in err
-
-
-def test_print_isolation_banner_regression_repeated_crash_blames_real_bug(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """Regression with repeated_crashes blames a real test bug."""
-    outcome = _MODULE.IsolationOutcome(
-        kind="regression",
-        exit_code=1,
-        crashed_tests=(
-            "tests/unit/foo.py::test_bar[1-2]",
-            "tests/unit/foo.py::test_bar[2-2]",
-        ),
-        repeated_crashes=("tests/unit/foo.py::test_bar",),
-    )
-    _MODULE._print_isolation_banner(outcome)
-    err = capsys.readouterr().err
-    assert "crashed the xdist worker on" in err
-    assert "real bug" in err
+    assert "TEST FAILURE" in err
     assert "tests/unit/foo.py::test_bar" in err
 
 
 def test_print_isolation_banner_regression_one_off_crash_demands_dump(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """A one-off worker crash blocks and demands a dump + teardown review."""
+    """A worker crash blocks and demands a dump + teardown review."""
     outcome = _MODULE.IsolationOutcome(
         kind="regression",
         exit_code=1,
@@ -759,7 +695,7 @@ def test_print_isolation_banner_regression_one_off_crash_demands_dump(
     )
     _MODULE._print_isolation_banner(outcome)
     err = capsys.readouterr().err
-    assert "ISOLATION CRASH" in err
+    assert "WORKER CRASH" in err
     assert "dump" in err
     assert "no bypass and no advisory" in err
     assert "tests/unit/foo.py::test_bar[2-2]" in err

--- a/tests/unit/scripts/test_run_prepush_python_gates.py
+++ b/tests/unit/scripts/test_run_prepush_python_gates.py
@@ -1,0 +1,167 @@
+"""Unit tests for ``scripts/run_prepush_python_gates.py``.
+
+Covers the worker-count resolution (``_default_jobs`` + the
+``PREPUSH_GATE_JOBS`` override), the per-gate output capture
+(``_run_gate``), and the serial ``main`` path (pass and failure
+reporting). The parallel pool path is exercised by the real pre-push
+run rather than a nested ``ProcessPoolExecutor`` under xdist. The script
+is loaded as a module so its private helpers are callable.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "run_prepush_python_gates.py"
+
+
+def _load_script_module() -> object:
+    """Import the script as a module so private helpers are callable."""
+    spec = importlib.util.spec_from_file_location(
+        "_run_prepush_python_gates",
+        _SCRIPT_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# Loaded once; isolation preserved because every test mutates module
+# attributes via ``monkeypatch`` (auto-reverted at teardown).
+_MODULE = cast(Any, _load_script_module())  # type: ignore[explicit-any]  # dynamically loaded runner module; attrs resolved by name
+
+
+# ── _default_jobs ────────────────────────────────────────────────
+
+
+def test_default_jobs_bounded_by_cap_when_many_cores(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With more cores than the cap, the cap wins."""
+    monkeypatch.delenv("PREPUSH_GATE_JOBS", raising=False)
+    monkeypatch.setattr(_MODULE.os, "cpu_count", lambda: 64)
+    assert _MODULE._default_jobs() == _MODULE._DEFAULT_MAX_JOBS
+
+
+def test_default_jobs_bounded_by_cores_when_few_cores(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With fewer cores than the cap, the core count wins."""
+    monkeypatch.delenv("PREPUSH_GATE_JOBS", raising=False)
+    monkeypatch.setattr(_MODULE.os, "cpu_count", lambda: 4)
+    assert _MODULE._default_jobs() == 4
+
+
+def test_default_jobs_falls_back_when_cpu_count_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``os.cpu_count()`` returning ``None`` uses the fallback core count."""
+    monkeypatch.delenv("PREPUSH_GATE_JOBS", raising=False)
+    monkeypatch.setattr(_MODULE.os, "cpu_count", lambda: None)
+    expected = min(_MODULE._DEFAULT_MAX_JOBS, _MODULE._FALLBACK_CPU)
+    assert _MODULE._default_jobs() == expected
+
+
+def test_default_jobs_honours_valid_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A valid positive ``PREPUSH_GATE_JOBS`` overrides the core-based default."""
+    monkeypatch.setenv("PREPUSH_GATE_JOBS", "3")
+    monkeypatch.setattr(_MODULE.os, "cpu_count", lambda: 64)
+    assert _MODULE._default_jobs() == 3
+
+
+@pytest.mark.parametrize("value", ["0", "-5"])
+def test_default_jobs_clamps_non_positive_override(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """Zero / negative overrides clamp to a single worker, not error."""
+    monkeypatch.setenv("PREPUSH_GATE_JOBS", value)
+    assert _MODULE._default_jobs() == 1
+
+
+@pytest.mark.parametrize("value", ["fast", "1.5", "   "])
+def test_default_jobs_warns_and_falls_back_on_malformed_override(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    value: str,
+) -> None:
+    """A malformed override falls back to the default; non-blank warns loudly."""
+    monkeypatch.setenv("PREPUSH_GATE_JOBS", value)
+    monkeypatch.setattr(_MODULE.os, "cpu_count", lambda: 4)
+    assert _MODULE._default_jobs() == 4
+    err = capsys.readouterr().err
+    # A blank value is treated as "unset" (no warning); a non-numeric value
+    # warns so a typo in the debug lever is not silently ignored.
+    if value.strip():
+        assert "ignoring PREPUSH_GATE_JOBS" in err
+    else:
+        assert err == ""
+
+
+# ── _run_gate ────────────────────────────────────────────────────
+
+
+def test_run_gate_captures_gate_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A gate's stdout/stderr are captured into the returned output buffer."""
+
+    def _fake_run_one(stem: str) -> tuple[int, str]:
+        # Write through the live sys streams so ``_run_gate``'s redirect
+        # captures them, without tripping the no-``print`` lint in tests.
+        sys.stdout.write(f"stdout from {stem}\n")
+        sys.stderr.write(f"stderr from {stem}\n")
+        return 1, "traceback detail"
+
+    monkeypatch.setattr(_MODULE, "_run_one", _fake_run_one)
+    stem, code, elapsed, output, detail = _MODULE._run_gate("check_example")
+    assert stem == "check_example"
+    assert code == 1
+    assert elapsed >= 0.0
+    assert "stdout from check_example" in output
+    assert "stderr from check_example" in output
+    assert detail == "traceback detail"
+
+
+# ── main (serial path) ───────────────────────────────────────────
+
+
+def test_main_serial_all_pass_returns_zero(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Every gate passing under ``--jobs 1`` returns 0 and reports each gate."""
+    monkeypatch.setattr(_MODULE, "_GATES", ("gate_a", "gate_b"))
+    monkeypatch.setattr(_MODULE, "_run_one", lambda stem: (0, ""))
+    rc = _MODULE.main(["--jobs", "1"])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "gate_a" in err
+    assert "gate_b" in err
+    assert "2/2 reported" in err
+
+
+def test_main_serial_reports_failing_gate(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A failing gate under ``--jobs 1`` returns 1 and names the gate + detail."""
+    monkeypatch.setattr(_MODULE, "_GATES", ("gate_a", "gate_b"))
+
+    def _fake_run_one(stem: str) -> tuple[int, str]:
+        return (1, "why gate_b failed") if stem == "gate_b" else (0, "")
+
+    monkeypatch.setattr(_MODULE, "_run_one", _fake_run_one)
+    rc = _MODULE.main(["--jobs", "1"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "GATE FAILED: gate_b" in err
+    assert "why gate_b failed" in err
+    assert "1 failed" in err


### PR DESCRIPTION
## Summary

Cuts local pre-push time by fanning the consolidated static-analysis gates across a bounded worker pool and removing two redundant local checks, with no loss of CI coverage.

- **Parallelise the 48 consolidated gates** (`scripts/run_prepush_python_gates.py`): they now fan out across a bounded reused-worker `ProcessPoolExecutor` (`--jobs`, default `min(12, cores)`, `PREPUSH_GATE_JOBS` override; `--jobs 1` stays serial). Each gate is a whole-tree static analysis whose parse dominates its runtime, so the block was ~48× redundant tree scans on one core.
- **Drop the pytest `--count 2` isolation replay** (`scripts/run_affected_tests.py`): it doubled affected-test time. The primary run keeps `--max-worker-restart=0` and the worker-crash classifier, so crash detection is retained; CI's full-suite run still exercises the state-leak class.
- **Move `codespell` off the local pre-push hook to a dedicated CI step** (`.pre-commit-config.yaml` + `.github/workflows/ci.yml`): ~11s off every code push, still gated in CI. `vale`/`lychee` deliberately left local (Markdown-scoped, sub-second).

## Measured (same tree)

| Gate block | Time |
|---|---|
| Serial (before) | 136.5s |
| `--jobs 12` (new default) | ~20-27s |
| `--jobs 32` | ~17s |

Verified crash-free at 12, 32, and 24-concurrent-across-3-runs workers — the historical Windows `0xC0000142` desktop-heap failure did not reproduce under stress.

## Robustness (from pre-PR review)

The parallel runner now handles the failure mode it exists to survive: a dead worker (`BrokenProcessPool`) or a wedged gate (batch timeout) fails the push loudly, naming the gates that never reported, instead of an unattributed traceback or an indefinite hang. Per-gate status prints live; `MemoryError`/`RecursionError` propagate rather than masquerading as gate failures; the one gate that shelled out without capturing (`check_docstring_completeness`) now surfaces its findings under the pool. The isolation-gate removal is completed end-to-end (dead repeated-crash branch removed, banner/docstring text reframed for the single run).

## Test plan

- New `tests/unit/scripts/test_run_prepush_python_gates.py` covers `_default_jobs` (env override / clamping / fallback), output capture, and the serial `main` pass/fail paths.
- `tests/unit/scripts/test_run_affected_tests.py` updated to match the single-run classifier.
- Pre-push dogfoods the change: the new parallel runner ran on itself and the replay-dropped runner ran the full unit suite — all gates green on push.

## Review coverage

Pre-reviewed by 11 local agents; 14 findings addressed (2 rejected with rationale: an internal-symbol rename as cosmetic, and the codespell-migration verified clean).
