### PR TITLE
docs: regenerate comparison page timestamp

### DIFF
--- a/docs/reference/comparison.md
+++ b/docs/reference/comparison.md
@@ -11,7 +11,7 @@ description: >-
 
 How SynthOrg compares to agent orchestration frameworks, platforms, and research projects.
 
-Last updated: 2026-07-14
+Last updated: 2026-07-15
 
 **Legend:**
 ✔ Full support | ~ Partial support | - Not supported | ⏲ Planned


### PR DESCRIPTION
## What

Regenerate `docs/reference/comparison.md` so its `Last updated` timestamp (`2026-07-15`) matches the committer date of the last commit that touched `data/competitors.yaml`.

## Why

The `comparison.md matches data/competitors.yaml` gate derives the `Last updated` date from `git log -1 --format=%cs -- data/competitors.yaml`. The committed page on `main` carried a stale `2026-07-14` (the source branch's pre-squash committer date). After the squash-merge of #2578, that last-touch commit's committer date resolved to `2026-07-15`, so the generator and the committed file diverged, failing the gate on `main`.

Regenerating produces the correct, stable `2026-07-15` (tied to the fixed merge commit, not a today-based value), greening the gate.

## Verification

- `uv run python scripts/check_comparison_md_in_sync.py` → OK
- Pre-push `comparison.md matches data/competitors.yaml` gate → Passed
