### PR TITLE
fix: LLM timeout for Chief-of-Staff chat, direct approval-card reject, and a cancel affordance

### DIFF
--- a/web/e2e/flows/approval.spec.ts
+++ b/web/e2e/flows/approval.spec.ts
@@ -112,7 +112,7 @@ test.describe('Approval critical flow', () => {
     await expect(page.getByText('Approval granted').first()).toBeVisible()
   })
 
-  test('rejects a pending request via the drawer + POST .../reject round-trip', async ({
+  test('rejects a pending request via the per-card reject dialog + POST .../reject round-trip', async ({
     page,
   }) => {
     const pending = {
@@ -150,17 +150,6 @@ test.describe('Approval critical flow', () => {
         },
       })
     })
-    // Detail GET feeds the drawer a single approval (not a list), so its
-    // pending footer (Approve / Reject) renders.
-    await page.route(`**/api/v1/approvals/${pending.id}`, (route) => {
-      if (route.request().method() !== 'GET') {
-        route.fallback()
-        return
-      }
-      route.fulfill({
-        json: { success: true, data: pending, error: null, error_detail: null },
-      })
-    })
     await page.route(`**/api/v1/approvals/${pending.id}/reject`, (route) =>
       route.fulfill({
         json: {
@@ -172,16 +161,12 @@ test.describe('Approval critical flow', () => {
       }),
     )
 
-    // The card's Reject opens the detail drawer (role=dialog); the
-    // drawer's Reject opens an alert-dialog requiring a reason.
+    // The card's Reject opens the reject-reason alert-dialog directly
+    // (no drawer detour), mirroring the one-click Approve affordance.
     await page.goto('/approvals')
     await expect(page.getByText('Deploy to production').first()).toBeVisible()
     await page.getByRole('button', { name: /^reject$/i }).first().click()
 
-    const drawer = page.getByRole('dialog')
-    await expect(drawer).toBeVisible()
-    // Drawer footer Reject -> opens the "Reject Action" alert-dialog.
-    await drawer.getByRole('button', { name: /^reject$/i }).first().click()
     const confirm = page.getByRole('alertdialog')
     await expect(confirm.getByText(/reject action/i)).toBeVisible()
     await confirm.getByRole('textbox').fill('Not authorised for production')

--- a/web/src/__tests__/pages/ApprovalsPage.test.tsx
+++ b/web/src/__tests__/pages/ApprovalsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router'
 import ApprovalsPage from '@/pages/ApprovalsPage'
@@ -131,28 +131,103 @@ describe('ApprovalsPage', () => {
     expect(screen.queryByLabelText('Loading approvals')).not.toBeInTheDocument()
   })
 
-  it('rejects directly from the card via the reason dialog (no drawer detour)', async () => {
-    const user = userEvent.setup()
-    hookReturn = {
-      ...defaultReturn,
-      approvals: [makeApproval('a1', { risk_level: 'high', status: 'pending', title: 'Ship it' })],
-      rejectOne: vi.fn().mockResolvedValue(makeApproval('a1', { status: 'rejected' })),
-      selectedIds: new Set(),
+  describe('per-card reject', () => {
+    function cardRejectButton(title: string) {
+      // ApprovalCard's accessible name is `Approval: <title>` (aria-label).
+      return within(
+        screen.getByRole('article', { name: `Approval: ${title}` }),
+      ).getByRole('button', { name: /reject/i })
     }
-    renderPage()
 
-    // The per-card Reject opens the reject-reason dialog directly, not the
-    // detail drawer: the reason field is reachable in one click.
-    await user.click(screen.getByRole('button', { name: /reject/i }))
-    const dialog = await screen.findByRole('alertdialog')
-    await user.type(
-      within(dialog).getByLabelText(/reason for rejection/i),
-      'Not aligned with the brief',
-    )
-    await user.click(within(dialog).getByRole('button', { name: /^reject$/i }))
+    it('rejects directly from the card via the reason dialog (no drawer detour)', async () => {
+      const user = userEvent.setup()
+      hookReturn = {
+        ...defaultReturn,
+        approvals: [makeApproval('a1', { risk_level: 'high', status: 'pending', title: 'Ship it' })],
+        rejectOne: vi.fn().mockResolvedValue(makeApproval('a1', { status: 'rejected' })),
+        selectedIds: new Set(),
+      }
+      renderPage()
 
-    expect(hookReturn.rejectOne).toHaveBeenCalledWith('a1', {
-      reason: 'Not aligned with the brief',
+      // The per-card Reject opens the reject-reason dialog directly, not the
+      // detail drawer (role="dialog"): the reason field is reachable in one click.
+      await user.click(cardRejectButton('Ship it'))
+      const dialog = await screen.findByRole('alertdialog')
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+      await user.type(
+        within(dialog).getByLabelText(/reason for rejection/i),
+        'Not aligned with the brief',
+      )
+      await user.click(within(dialog).getByRole('button', { name: /^reject$/i }))
+
+      expect(hookReturn.rejectOne).toHaveBeenCalledOnce()
+      expect(hookReturn.rejectOne).toHaveBeenCalledWith('a1', {
+        reason: 'Not aligned with the brief',
+      })
+      // The dialog closes once the reject resolves.
+      await waitFor(() => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument())
+    })
+
+    it('does not reject when the reason is blank', async () => {
+      const user = userEvent.setup()
+      hookReturn = {
+        ...defaultReturn,
+        approvals: [makeApproval('a1', { risk_level: 'high', status: 'pending', title: 'Ship it' })],
+        rejectOne: vi.fn().mockResolvedValue(makeApproval('a1', { status: 'rejected' })),
+        selectedIds: new Set(),
+      }
+      renderPage()
+
+      await user.click(cardRejectButton('Ship it'))
+      const dialog = await screen.findByRole('alertdialog')
+      await user.click(within(dialog).getByRole('button', { name: /^reject$/i }))
+
+      expect(hookReturn.rejectOne).not.toHaveBeenCalled()
+      // Validation keeps the dialog open so the operator can supply a reason.
+      expect(screen.getByRole('alertdialog')).toBeInTheDocument()
+    })
+
+    it('reopens the reject dialog for the same card after cancel', async () => {
+      const user = userEvent.setup()
+      hookReturn = {
+        ...defaultReturn,
+        approvals: [makeApproval('a1', { risk_level: 'high', status: 'pending', title: 'Ship it' })],
+        selectedIds: new Set(),
+      }
+      renderPage()
+
+      await user.click(cardRejectButton('Ship it'))
+      expect(await screen.findByRole('alertdialog')).toBeInTheDocument()
+      await user.click(within(screen.getByRole('alertdialog')).getByRole('button', { name: /cancel/i }))
+      await waitFor(() => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument())
+
+      // Cancelling cleared the target, so the same card can be reopened.
+      await user.click(cardRejectButton('Ship it'))
+      expect(await screen.findByRole('alertdialog')).toBeInTheDocument()
+      expect(hookReturn.rejectOne).not.toHaveBeenCalled()
+    })
+
+    it('targets the correct card when several are pending', async () => {
+      const user = userEvent.setup()
+      hookReturn = {
+        ...defaultReturn,
+        approvals: [
+          makeApproval('a1', { risk_level: 'high', status: 'pending', title: 'Ship it' }),
+          makeApproval('b2', { risk_level: 'high', status: 'pending', title: 'Deploy widget' }),
+        ],
+        rejectOne: vi.fn().mockResolvedValue(makeApproval('b2', { status: 'rejected' })),
+        selectedIds: new Set(),
+      }
+      renderPage()
+
+      await user.click(cardRejectButton('Deploy widget'))
+      const dialog = await screen.findByRole('alertdialog')
+      await user.type(within(dialog).getByLabelText(/reason for rejection/i), 'Wrong target')
+      await user.click(within(dialog).getByRole('button', { name: /^reject$/i }))
+
+      expect(hookReturn.rejectOne).toHaveBeenCalledOnce()
+      expect(hookReturn.rejectOne).toHaveBeenCalledWith('b2', { reason: 'Wrong target' })
     })
   })
 })

--- a/web/src/__tests__/pages/ApprovalsPage.test.tsx
+++ b/web/src/__tests__/pages/ApprovalsPage.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router'
 import ApprovalsPage from '@/pages/ApprovalsPage'
 import { makeApproval } from '../helpers/factories'
@@ -128,5 +129,30 @@ describe('ApprovalsPage', () => {
     }
     renderPage()
     expect(screen.queryByLabelText('Loading approvals')).not.toBeInTheDocument()
+  })
+
+  it('rejects directly from the card via the reason dialog (no drawer detour)', async () => {
+    const user = userEvent.setup()
+    hookReturn = {
+      ...defaultReturn,
+      approvals: [makeApproval('a1', { risk_level: 'high', status: 'pending', title: 'Ship it' })],
+      rejectOne: vi.fn().mockResolvedValue(makeApproval('a1', { status: 'rejected' })),
+      selectedIds: new Set(),
+    }
+    renderPage()
+
+    // The per-card Reject opens the reject-reason dialog directly, not the
+    // detail drawer: the reason field is reachable in one click.
+    await user.click(screen.getByRole('button', { name: /reject/i }))
+    const dialog = await screen.findByRole('alertdialog')
+    await user.type(
+      within(dialog).getByLabelText(/reason for rejection/i),
+      'Not aligned with the brief',
+    )
+    await user.click(within(dialog).getByRole('button', { name: /^reject$/i }))
+
+    expect(hookReturn.rejectOne).toHaveBeenCalledWith('a1', {
+      reason: 'Not aligned with the brief',
+    })
   })
 })

--- a/web/src/__tests__/pages/chat/RequestWorkChat.test.tsx
+++ b/web/src/__tests__/pages/chat/RequestWorkChat.test.tsx
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { apiSuccess } from '@/mocks/handlers'
 import { RequestWorkChat } from '@/pages/chat/RequestWorkChat'
 import { useMetaStore } from '@/stores/meta'
+import { useToastStore } from '@/stores/toast'
 import { server } from '@/test-setup'
 
 function renderChat() {
@@ -20,6 +21,7 @@ function renderChat() {
 
 beforeEach(() => {
   useMetaStore.setState({ proposeLoading: false, error: null })
+  useToastStore.setState({ toasts: [] })
 })
 
 describe('RequestWorkChat', () => {
@@ -116,6 +118,33 @@ describe('RequestWorkChat', () => {
     expect(screen.getByText('Prioritise the launch checklist')).toBeInTheDocument()
     // The closed conversation disables further input.
     expect(screen.getByLabelText('Work request')).toBeDisabled()
+  })
+
+  it('cancels an in-flight propose and shows the cancelled notice (no error toast)', async () => {
+    // Never resolves server-side (a bare pending promise, so no timer / leaked
+    // handle); the request only settles via the client abort the Cancel button
+    // triggers.
+    server.use(
+      http.post('/api/v1/meta/chat/propose', async () => {
+        await new Promise<void>(() => {})
+        return HttpResponse.json(apiSuccess({}))
+      }),
+    )
+    const user = userEvent.setup()
+    renderChat()
+
+    await user.type(screen.getByLabelText('Work request'), 'do a slow thing')
+    await user.click(screen.getByRole('button', { name: 'Send message' }))
+
+    // The Cancel affordance appears while the propose is in flight.
+    await user.click(await screen.findByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/request cancelled/i)).toBeInTheDocument()
+    })
+    // A deliberate cancel is not an error: no failure notice, no error toast.
+    expect(screen.queryByText(/could not respond/i)).not.toBeInTheDocument()
+    expect(useToastStore.getState().toasts).toHaveLength(0)
   })
 
   it('renders a clarifying question without attribution when unrouted', async () => {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -73,6 +73,17 @@ export const apiClient = axios.create({
   xsrfCookieName: '',
 })
 
+/**
+ * Per-request timeout for LLM-bound endpoints (Chief-of-Staff chat, charter
+ * drafting). These block on a synchronous agent session server-side and
+ * routinely exceed the {@link apiClient} 30s default: a propose turn is
+ * regularly 25-35s. An endpoint that waits on a model call MUST override the
+ * default via ``{ timeout: LLM_BOUND_TIMEOUT_MS }``, or a slow-but-successful
+ * turn aborts client-side while the server completes and parks the work,
+ * surfacing a false "could not respond" failure over a real success.
+ */
+export const LLM_BOUND_TIMEOUT_MS = 300_000
+
 
 async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -84,7 +84,6 @@ export const apiClient = axios.create({
  */
 export const LLM_BOUND_TIMEOUT_MS = 300_000
 
-
 async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
     window.setTimeout(resolve, ms)

--- a/web/src/api/endpoints/charter.ts
+++ b/web/src/api/endpoints/charter.ts
@@ -1,4 +1,4 @@
-import { apiClient, unwrap, unwrapPaginated } from '../client'
+import { apiClient, LLM_BOUND_TIMEOUT_MS, unwrap, unwrapPaginated } from '../client'
 import type { PaginatedResult } from '../client'
 import type {
   CharterApprovalResult,
@@ -17,13 +17,6 @@ export interface CharterFilters {
 }
 
 const BASE = '/meta/charters'
-
-// The interview turn (LLM charter drafting) and approval (which synchronously
-// runs solo-vs-team routing + decomposition + kickoff) both make model calls
-// that can exceed the client's 30s default on slower providers (e.g. local
-// Ollama). Give these endpoints a generous ceiling so a slow-but-successful
-// call is not aborted and surfaced as a false "network error".
-const LLM_BOUND_TIMEOUT_MS = 300_000
 
 export async function listCharters(
   filters?: CharterFilters,

--- a/web/src/api/endpoints/meta.ts
+++ b/web/src/api/endpoints/meta.ts
@@ -21,6 +21,7 @@ import type {
 } from '../types/http'
 import {
   apiClient,
+  LLM_BOUND_TIMEOUT_MS,
   paginateAll,
   unwrap,
   unwrapPaginated,
@@ -326,6 +327,10 @@ export async function postChatPropose(
     headers: {
       'Idempotency-Key': idempotencyKey ?? crypto.randomUUID(),
     },
+    // LLM-bound: the CoS propose turn runs a synchronous agent session that
+    // regularly exceeds the 30s client default; without the override a slow-
+    // but-successful turn aborts here while the server parks the work.
+    timeout: LLM_BOUND_TIMEOUT_MS,
   })
   return unwrap(response)
 }
@@ -361,6 +366,9 @@ export async function postChatGroup(
       headers: {
         'Idempotency-Key': idempotencyKey ?? crypto.randomUUID(),
       },
+      // LLM-bound: a group round runs an agent session per participant and can
+      // far exceed the 30s client default.
+      timeout: LLM_BOUND_TIMEOUT_MS,
     },
   )
   return unwrap(response)
@@ -398,6 +406,9 @@ export async function postChatAct(
       headers: {
         'Idempotency-Key': idempotencyKey ?? crypto.randomUUID(),
       },
+      // LLM-bound: the acting agent runs a tool-using session that can exceed
+      // the 30s client default.
+      timeout: LLM_BOUND_TIMEOUT_MS,
     },
   )
   return unwrap(response)
@@ -510,6 +521,9 @@ export async function postChat(
       headers: {
         'Idempotency-Key': idempotencyKey ?? crypto.randomUUID(),
       },
+      // LLM-bound: the explain-chat answer runs an agent session that can
+      // exceed the 30s client default.
+      timeout: LLM_BOUND_TIMEOUT_MS,
     },
   )
   const result = unwrap(response)

--- a/web/src/api/endpoints/meta.ts
+++ b/web/src/api/endpoints/meta.ts
@@ -305,6 +305,7 @@ export async function postChatPropose(
   conversationId?: string,
   project?: string,
   idempotencyKey?: string,
+  signal?: AbortSignal,
 ): Promise<ConversationalProposeResponse> {
   const trimmed = message.trim()
   if (!trimmed) {
@@ -331,6 +332,10 @@ export async function postChatPropose(
     // regularly exceeds the 30s client default; without the override a slow-
     // but-successful turn aborts here while the server parks the work.
     timeout: LLM_BOUND_TIMEOUT_MS,
+    // Caller-supplied signal lets the operator abort a long-pending turn. The
+    // server still completes and parks any work (the request is idempotent),
+    // so aborting only detaches the client's wait.
+    ...(signal && { signal }),
   })
   return unwrap(response)
 }

--- a/web/src/pages/ApprovalsPage.tsx
+++ b/web/src/pages/ApprovalsPage.tsx
@@ -160,11 +160,7 @@ function ApprovalDrawerHost({ ctrl }: { ctrl: ApprovalsPageController }) {
 function ApprovalCardRejectHost({ ctrl }: { ctrl: ApprovalsPageController }) {
   const { cardReject } = ctrl
   return (
-    <ApprovalRejectDialog
-      decision={cardReject.decision}
-      isFailed={cardReject.isFailed}
-      onClosed={cardReject.clearTarget}
-    />
+    <ApprovalRejectDialog decision={cardReject.decision} isFailed={cardReject.isFailed} />
   )
 }
 

--- a/web/src/pages/ApprovalsPage.tsx
+++ b/web/src/pages/ApprovalsPage.tsx
@@ -12,6 +12,7 @@ import type { ApprovalRiskLevel } from '@/api/types/enums'
 import { ApprovalFilterBar } from './approvals/ApprovalFilterBar'
 import { ApprovalRiskGroupSection } from './approvals/ApprovalRiskGroupSection'
 import { ApprovalDetailDrawer } from './approvals/ApprovalDetailDrawer'
+import { ApprovalRejectDialog } from './approvals/ApprovalRejectDialog'
 import { BatchActionBar } from './approvals/BatchActionBar'
 import { ApprovalsSkeleton } from './approvals/ApprovalsSkeleton'
 import {
@@ -156,6 +157,17 @@ function ApprovalDrawerHost({ ctrl }: { ctrl: ApprovalsPageController }) {
   )
 }
 
+function ApprovalCardRejectHost({ ctrl }: { ctrl: ApprovalsPageController }) {
+  const { cardReject } = ctrl
+  return (
+    <ApprovalRejectDialog
+      decision={cardReject.decision}
+      isFailed={cardReject.isFailed}
+      onClosed={cardReject.clearTarget}
+    />
+  )
+}
+
 function ApprovalBatchSection({ ctrl }: { ctrl: ApprovalsPageController }) {
   const { batch, data } = ctrl
   const count = data.selectedIds.size
@@ -277,6 +289,7 @@ export default function ApprovalsPage() {
 
       <ApprovalGroups ctrl={ctrl} />
       <ApprovalDrawerHost ctrl={ctrl} />
+      <ApprovalCardRejectHost ctrl={ctrl} />
       <ApprovalBatchSection ctrl={ctrl} />
     </div>
   )

--- a/web/src/pages/approvals/ApprovalDetailDrawer.tsx
+++ b/web/src/pages/approvals/ApprovalDetailDrawer.tsx
@@ -20,6 +20,7 @@ import type {
 } from '@/api/types/approvals'
 import { ApprovalDecisionButtons } from './ApprovalDecisionButtons'
 import { ApprovalDetailContent } from './ApprovalDetailContent'
+import { ApprovalRejectDialog } from './ApprovalRejectDialog'
 import { type ApprovalDecision, useApprovalDecision } from './useApprovalDrawer'
 
 export interface ApprovalDetailDrawerProps {
@@ -103,43 +104,7 @@ function ApprovalDecisionDialogs({
         />
       </ConfirmDialog>
 
-      <ConfirmDialog
-        open={decision.rejectOpen}
-        onOpenChange={(o) => {
-          decision.setRejectOpen(o)
-          if (!o) {
-            decision.setReason('')
-            decision.setReasonError(null)
-          }
-        }}
-        title={isFailed ? 'Retry task' : 'Reject Action'}
-        description={
-          isFailed
-            ? 'Send this task back for rework. Explain what to change.'
-            : 'Please provide a reason for rejection.'
-        }
-        confirmLabel={isFailed ? 'Retry' : 'Reject'}
-        variant="destructive"
-        onConfirm={decision.handleReject}
-        loading={decision.submitting}
-      >
-        <InputField
-          multiline
-          label={isFailed ? 'Reason for rework' : 'Reason for rejection'}
-          value={decision.reason}
-          onValueChange={(value) => {
-            decision.setReason(value)
-            if (decision.reasonError && value.trim()) decision.setReasonError(null)
-          }}
-          placeholder="Give the requester enough context to iterate."
-          rows={3}
-          maxLength={2000}
-          required
-          autoFocus
-          error={decision.reasonError}
-          className="mt-2"
-        />
-      </ConfirmDialog>
+      <ApprovalRejectDialog decision={decision} isFailed={isFailed} />
     </>
   )
 }

--- a/web/src/pages/approvals/ApprovalRejectDialog.tsx
+++ b/web/src/pages/approvals/ApprovalRejectDialog.tsx
@@ -1,0 +1,63 @@
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { InputField } from '@/components/ui/input-field'
+import type { ApprovalDecision } from './useApprovalDrawer'
+
+export interface ApprovalRejectDialogProps {
+  decision: ApprovalDecision
+  isFailed: boolean
+  /**
+   * Called after the dialog fully closes (cancel or successful reject), on top
+   * of the decision's own state reset. The list-level card-reject flow uses it
+   * to clear the target approval so the same card can be reopened; the drawer
+   * leaves it unset because its own approval selection owns that lifecycle.
+   */
+  onClosed?: () => void
+}
+
+/**
+ * The reject-with-reason confirmation, shared by the detail drawer and the
+ * list-level per-card Reject button so both collect a mandatory reason through
+ * the same dialog rather than two divergent copies.
+ */
+export function ApprovalRejectDialog({ decision, isFailed, onClosed }: ApprovalRejectDialogProps) {
+  return (
+    <ConfirmDialog
+      open={decision.rejectOpen}
+      onOpenChange={(o) => {
+        decision.setRejectOpen(o)
+        if (!o) {
+          decision.setReason('')
+          decision.setReasonError(null)
+          onClosed?.()
+        }
+      }}
+      title={isFailed ? 'Retry task' : 'Reject Action'}
+      description={
+        isFailed
+          ? 'Send this task back for rework. Explain what to change.'
+          : 'Please provide a reason for rejection.'
+      }
+      confirmLabel={isFailed ? 'Retry' : 'Reject'}
+      variant="destructive"
+      onConfirm={decision.handleReject}
+      loading={decision.submitting}
+    >
+      <InputField
+        multiline
+        label={isFailed ? 'Reason for rework' : 'Reason for rejection'}
+        value={decision.reason}
+        onValueChange={(value) => {
+          decision.setReason(value)
+          if (decision.reasonError && value.trim()) decision.setReasonError(null)
+        }}
+        placeholder="Give the requester enough context to iterate."
+        rows={3}
+        maxLength={2000}
+        required
+        autoFocus
+        error={decision.reasonError}
+        className="mt-2"
+      />
+    </ConfirmDialog>
+  )
+}

--- a/web/src/pages/approvals/ApprovalRejectDialog.tsx
+++ b/web/src/pages/approvals/ApprovalRejectDialog.tsx
@@ -5,13 +5,6 @@ import type { ApprovalDecision } from './useApprovalDrawer'
 export interface ApprovalRejectDialogProps {
   decision: ApprovalDecision
   isFailed: boolean
-  /**
-   * Called after the dialog fully closes (cancel or successful reject), on top
-   * of the decision's own state reset. The list-level card-reject flow uses it
-   * to clear the target approval so the same card can be reopened; the drawer
-   * leaves it unset because its own approval selection owns that lifecycle.
-   */
-  onClosed?: () => void
 }
 
 /**
@@ -19,7 +12,7 @@ export interface ApprovalRejectDialogProps {
  * list-level per-card Reject button so both collect a mandatory reason through
  * the same dialog rather than two divergent copies.
  */
-export function ApprovalRejectDialog({ decision, isFailed, onClosed }: ApprovalRejectDialogProps) {
+export function ApprovalRejectDialog({ decision, isFailed }: ApprovalRejectDialogProps) {
   return (
     <ConfirmDialog
       open={decision.rejectOpen}
@@ -28,7 +21,6 @@ export function ApprovalRejectDialog({ decision, isFailed, onClosed }: ApprovalR
         if (!o) {
           decision.setReason('')
           decision.setReasonError(null)
-          onClosed?.()
         }
       }}
       title={isFailed ? 'Retry task' : 'Reject Action'}

--- a/web/src/pages/approvals/useApprovalDrawer.ts
+++ b/web/src/pages/approvals/useApprovalDrawer.ts
@@ -103,6 +103,11 @@ export function useApprovalDecision(
   approval: ApprovalResponse | null,
   onApprove: (id: string, data?: ApproveRequest) => Promise<boolean>,
   onReject: (id: string, data: RejectRequest) => Promise<boolean>,
+  // When true, a fresh non-null target opens the reject dialog in the same
+  // render pass the target changes. The card-reject flow sets this so its
+  // "click Reject -> dialog" step needs no post-commit effect racing this
+  // reset; the drawer leaves it false (a target switch closes the dialog).
+  openRejectOnTargetChange = false,
 ): ApprovalDecision {
   const [approveOpen, setApproveOpen] = useState(false)
   const [rejectOpen, setRejectOpen] = useState(false)
@@ -116,7 +121,7 @@ export function useApprovalDecision(
   // Reset dialog/input state when the displayed approval changes.
   useResetOnChange(approval?.id, () => {
     setApproveOpen(false)
-    setRejectOpen(false)
+    setRejectOpen(openRejectOnTargetChange && approval != null)
     setComment('')
     setReason('')
     setReasonError(null)

--- a/web/src/pages/approvals/useApprovalDrawer.ts
+++ b/web/src/pages/approvals/useApprovalDrawer.ts
@@ -6,7 +6,7 @@ import { useToastStore } from '@/stores/toast'
 import type { ApprovalResponse, ApproveRequest, RejectRequest } from '@/api/types/approvals'
 
 /** Run `onChange` during render whenever `value`'s identity changes. */
-function useResetOnChange(value: unknown, onChange: () => void): void {
+export function useResetOnChange(value: unknown, onChange: () => void): void {
   const prevRef = useRef(value)
   if (value !== prevRef.current) {
     prevRef.current = value

--- a/web/src/pages/approvals/useApprovalsPage.ts
+++ b/web/src/pages/approvals/useApprovalsPage.ts
@@ -6,7 +6,9 @@ import { useEmptyStateProps } from '@/hooks/use-empty-state-props'
 import { useToastStore } from '@/stores/toast'
 import { filterApprovals, groupByRiskLevel, type ApprovalPageFilters } from '@/utils/approvals'
 import type { ApprovalRiskLevel } from '@/api/types/enums'
+import type { RejectRequest } from '@/api/types/approvals'
 import { REJECTION_REASON_REQUIRED } from './errors'
+import { type CardReject, useCardReject } from './useCardReject'
 
 const VALID_STATUSES: ReadonlySet<string> = new Set(['pending', 'approved', 'rejected', 'expired'])
 const VALID_RISK_LEVELS: ReadonlySet<string> = new Set(['critical', 'high', 'medium', 'low'])
@@ -199,6 +201,7 @@ export interface ApprovalsPageController {
   derived: ApprovalsDerived
   wasConnectedRef: React.RefObject<boolean>
   emptyStateProps: ReturnType<typeof useEmptyStateProps>
+  cardReject: CardReject
   handleApproveOne: (id: string) => Promise<void>
   handleRejectOne: (id: string) => void
   handleRiskToggle: (level: ApprovalRiskLevel) => void
@@ -210,8 +213,8 @@ export function useApprovalsPageController(): ApprovalsPageController {
   const batch = useApprovalBatch(data)
   const derived = useApprovalsDerived(data.approvals, url.filters)
   const wasConnectedRef = useWasConnected(data.wsConnected)
-  const { fetchApproval, approveOne, optimisticApprove } = data
-  const { selectedId, filters, handleSelectApproval, handleFiltersChange } = url
+  const { fetchApproval, approveOne, optimisticApprove, rejectOne } = data
+  const { selectedId, filters, handleFiltersChange } = url
 
   useEffect(() => {
     if (selectedId) void fetchApproval(selectedId)
@@ -225,7 +228,16 @@ export function useApprovalsPageController(): ApprovalsPageController {
     },
     [approveOne, optimisticApprove],
   )
-  const handleRejectOne = useCallback((id: string) => handleSelectApproval(id), [handleSelectApproval])
+
+  // The per-card Reject opens a reject-with-reason dialog directly (symmetric
+  // with one-click Approve) rather than detouring through the detail drawer.
+  const rejectOneBool = useCallback(
+    async (id: string, payload: RejectRequest): Promise<boolean> =>
+      (await rejectOne(id, payload)) !== null,
+    [rejectOne],
+  )
+  const cardReject = useCardReject(data.approvals, rejectOneBool)
+  const handleRejectOne = cardReject.openReject
 
   const handleRiskToggle = useCallback(
     (level: ApprovalRiskLevel) => {
@@ -257,6 +269,7 @@ export function useApprovalsPageController(): ApprovalsPageController {
     derived,
     wasConnectedRef,
     emptyStateProps,
+    cardReject,
     handleApproveOne,
     handleRejectOne,
     handleRiskToggle,

--- a/web/src/pages/approvals/useCardReject.ts
+++ b/web/src/pages/approvals/useCardReject.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import type { ApprovalResponse, RejectRequest } from '@/api/types/approvals'
+import { isFailedApproval } from '@/utils/approvals'
+
+import { type ApprovalDecision, useApprovalDecision } from './useApprovalDrawer'
+
+// Approving from a card is a one-click action that never opens this dialog, so
+// the decision hook's approve path is wired to a stable no-op here.
+const NOOP_APPROVE = (): Promise<boolean> => Promise.resolve(false)
+
+export interface CardReject {
+  /** The approval whose reject dialog is open, or null when closed. */
+  target: ApprovalResponse | null
+  decision: ApprovalDecision
+  isFailed: boolean
+  /** Open the reject-with-reason dialog for the given approval id. */
+  openReject: (id: string) => void
+  /** Clear the target once the dialog fully closes. */
+  clearTarget: () => void
+}
+
+/**
+ * Drives the list-level per-card Reject dialog. The card's Reject button opens
+ * a reject-with-reason dialog directly (mirroring one-click Approve) instead of
+ * detouring through the detail drawer. Reuses {@link useApprovalDecision} so
+ * the reason field, validation, and submit state match the drawer exactly.
+ */
+export function useCardReject(
+  approvals: readonly ApprovalResponse[],
+  onReject: (id: string, data: RejectRequest) => Promise<boolean>,
+): CardReject {
+  const [targetId, setTargetId] = useState<string | null>(null)
+  const target =
+    targetId != null ? (approvals.find((a) => a.id === targetId) ?? null) : null
+
+  // Clear the target on a successful reject so the decision hook's id-change
+  // reset closes the dialog and the same card can be reopened later.
+  const rejectAndClear = useCallback(
+    async (id: string, data: RejectRequest): Promise<boolean> => {
+      const ok = await onReject(id, data)
+      if (ok) setTargetId(null)
+      return ok
+    },
+    [onReject],
+  )
+
+  const decision = useApprovalDecision(target, NOOP_APPROVE, rejectAndClear)
+  const { setRejectOpen } = decision
+
+  // Open the dialog once a fresh target is set. This runs after commit, so it
+  // wins over the in-render id-change reset inside useApprovalDecision that
+  // would otherwise leave the newly-targeted dialog closed.
+  useEffect(() => {
+    if (targetId !== null) setRejectOpen(true)
+  }, [targetId, setRejectOpen])
+
+  const openReject = useCallback((id: string) => setTargetId(id), [])
+  const clearTarget = useCallback(() => setTargetId(null), [])
+
+  return {
+    target,
+    decision,
+    isFailed: target !== null && isFailedApproval(target),
+    openReject,
+    clearTarget,
+  }
+}

--- a/web/src/pages/approvals/useCardReject.ts
+++ b/web/src/pages/approvals/useCardReject.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 
 import type { ApprovalResponse, RejectRequest } from '@/api/types/approvals'
 import { isFailedApproval } from '@/utils/approvals'
@@ -24,7 +24,10 @@ export interface CardReject {
  * Drives the list-level per-card Reject dialog. The card's Reject button opens
  * a reject-with-reason dialog directly (mirroring one-click Approve) instead of
  * detouring through the detail drawer. Reuses {@link useApprovalDecision} so
- * the reason field, validation, and submit state match the drawer exactly.
+ * the reason field, validation, and submit state match the drawer exactly; the
+ * `openRejectOnTargetChange` flag makes a fresh target open the dialog
+ * synchronously. The dialog's close (cancel or successful reject, both routed
+ * through ConfirmDialog -> onClosed) is the sole owner of clearing the target.
  */
 export function useCardReject(
   approvals: readonly ApprovalResponse[],
@@ -34,26 +37,7 @@ export function useCardReject(
   const target =
     targetId != null ? (approvals.find((a) => a.id === targetId) ?? null) : null
 
-  // Clear the target on a successful reject so the decision hook's id-change
-  // reset closes the dialog and the same card can be reopened later.
-  const rejectAndClear = useCallback(
-    async (id: string, data: RejectRequest): Promise<boolean> => {
-      const ok = await onReject(id, data)
-      if (ok) setTargetId(null)
-      return ok
-    },
-    [onReject],
-  )
-
-  const decision = useApprovalDecision(target, NOOP_APPROVE, rejectAndClear)
-  const { setRejectOpen } = decision
-
-  // Open the dialog once a fresh target is set. This runs after commit, so it
-  // wins over the in-render id-change reset inside useApprovalDecision that
-  // would otherwise leave the newly-targeted dialog closed.
-  useEffect(() => {
-    if (targetId !== null) setRejectOpen(true)
-  }, [targetId, setRejectOpen])
+  const decision = useApprovalDecision(target, NOOP_APPROVE, onReject, true)
 
   const openReject = useCallback((id: string) => setTargetId(id), [])
   const clearTarget = useCallback(() => setTargetId(null), [])

--- a/web/src/pages/approvals/useCardReject.ts
+++ b/web/src/pages/approvals/useCardReject.ts
@@ -3,7 +3,11 @@ import { useCallback, useState } from 'react'
 import type { ApprovalResponse, RejectRequest } from '@/api/types/approvals'
 import { isFailedApproval } from '@/utils/approvals'
 
-import { type ApprovalDecision, useApprovalDecision } from './useApprovalDrawer'
+import {
+  type ApprovalDecision,
+  useApprovalDecision,
+  useResetOnChange,
+} from './useApprovalDrawer'
 
 // Approving from a card is a one-click action that never opens this dialog, so
 // the decision hook's approve path is wired to a stable no-op here.
@@ -16,8 +20,6 @@ export interface CardReject {
   isFailed: boolean
   /** Open the reject-with-reason dialog for the given approval id. */
   openReject: (id: string) => void
-  /** Clear the target once the dialog fully closes. */
-  clearTarget: () => void
 }
 
 /**
@@ -26,8 +28,7 @@ export interface CardReject {
  * detouring through the detail drawer. Reuses {@link useApprovalDecision} so
  * the reason field, validation, and submit state match the drawer exactly; the
  * `openRejectOnTargetChange` flag makes a fresh target open the dialog
- * synchronously. The dialog's close (cancel or successful reject, both routed
- * through ConfirmDialog -> onClosed) is the sole owner of clearing the target.
+ * synchronously.
  */
 export function useCardReject(
   approvals: readonly ApprovalResponse[],
@@ -39,14 +40,22 @@ export function useCardReject(
 
   const decision = useApprovalDecision(target, NOOP_APPROVE, onReject, true)
 
+  // Clear the target whenever the reject dialog closes, however it closed. A
+  // user cancel or a successful reject routes through ConfirmDialog, but a
+  // programmatic close (the approval leaves `pending` or drops off the list via
+  // a WebSocket update) flips `rejectOpen` inside useApprovalDecision with no
+  // onOpenChange. This render-phase sync is the single owner that keeps
+  // `targetId` from going stale and blocking a later reopen of the same card.
+  useResetOnChange(decision.rejectOpen, () => {
+    if (!decision.rejectOpen) setTargetId(null)
+  })
+
   const openReject = useCallback((id: string) => setTargetId(id), [])
-  const clearTarget = useCallback(() => setTargetId(null), [])
 
   return {
     target,
     decision,
     isFailed: target !== null && isFailedApproval(target),
     openReject,
-    clearTarget,
   }
 }

--- a/web/src/pages/chat/RequestWorkChat.tsx
+++ b/web/src/pages/chat/RequestWorkChat.tsx
@@ -155,7 +155,14 @@ export function RequestWorkChat() {
             }}
           />
         ))}
-        {ctrl.proposeLoading && <ChatThinkingIndicator label="Working on it" />}
+        {ctrl.proposeLoading && (
+          <div className="flex items-center justify-between gap-3">
+            <ChatThinkingIndicator label="Working on it" />
+            <Button variant="ghost" size="sm" onClick={ctrl.cancel}>
+              Cancel
+            </Button>
+          </div>
+        )}
       </div>
 
       {ctrl.conversationClosed && (

--- a/web/src/pages/chat/useRequestWorkState.ts
+++ b/web/src/pages/chat/useRequestWorkState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 
 import type { ConversationalProposeResponse } from '@/api/endpoints/meta'
 import { useConversationsStore } from '@/stores/conversations'
@@ -36,6 +36,8 @@ export interface RequestWorkState {
   setInput: (value: string) => void
   triggerSend: () => void
   retryBefore: (beforeMsgId: number) => void
+  /** Abort the in-flight propose turn (renders a cancelled bubble, no error). */
+  cancel: () => void
   /** Clear a closed conversation so the next send opens a fresh one. */
   startNew: () => void
 }
@@ -48,6 +50,7 @@ export function useRequestWorkState(): RequestWorkState {
   const proposeLoading = useMetaStore((s) => s.proposeLoading)
   const propose = useMetaStore((s) => s.proposeConversation)
   const scrollRef = useScrollToBottom(messages)
+  const abortRef = useRef<AbortController | null>(null)
 
   const sendMessage = useCallback(
     async (message: string, idempotencyKey?: string) => {
@@ -55,31 +58,27 @@ export function useRequestWorkState(): RequestWorkState {
       // Mint the key once per logical turn; a manual retry reuses it so a
       // parked proposal that actually succeeded is deduped, not re-parked.
       const key = idempotencyKey ?? crypto.randomUUID()
-      setWork((s) => ({
-        messages: [
-          ...s.messages,
-          {
-            id: nextMessageId(),
-            role: 'user',
-            content: message,
-            idempotencyKey: key,
-          },
-        ],
-      }))
+      setWork((s) => ({ messages: [...s.messages, buildUserMessage(message, key)] }))
       const conversationId = useConversationsStore.getState().work.conversationId
-      const result = await propose(message, conversationId, key)
+      const controller = new AbortController()
+      abortRef.current = controller
+      const result = await propose(message, conversationId, key, controller.signal)
+      abortRef.current = null
       if (result) {
         setWork({
           conversationId: result.conversation_id,
           closed: result.conversation_closed,
         })
       }
-      setWork((s) => ({
-        messages: [...s.messages, buildAssistantMessage(result)],
-      }))
+      const reply = buildReplyMessage(result, controller.signal.aborted)
+      setWork((s) => ({ messages: [...s.messages, reply] }))
     },
     [propose, setWork],
   )
+
+  const cancel = useCallback(() => {
+    abortRef.current?.abort()
+  }, [])
 
   const triggerSend = useCallback(() => {
     const message = input.trim()
@@ -120,6 +119,7 @@ export function useRequestWorkState(): RequestWorkState {
     setInput,
     triggerSend,
     retryBefore,
+    cancel,
     startNew,
   }
 }
@@ -137,12 +137,35 @@ function toAttribution(result: ConversationalProposeResponse): Attribution {
   }
 }
 
+function buildUserMessage(content: string, idempotencyKey: string): RequestWorkMessage {
+  return { id: nextMessageId(), role: 'user', content, idempotencyKey }
+}
+
+// A user abort resolves to null with the signal marked aborted; render a
+// distinct cancelled bubble rather than the failure notice.
+function buildReplyMessage(
+  result: ConversationalProposeResponse | null,
+  aborted: boolean,
+): RequestWorkMessage {
+  if (result === null && aborted) return buildCancelledMessage()
+  return buildAssistantMessage(result)
+}
+
 function buildFailureMessage(): RequestWorkMessage {
   return {
     id: nextMessageId(),
     role: 'assistant',
     content: 'The assistant could not respond. Please try again.',
     isError: true,
+  }
+}
+
+function buildCancelledMessage(): RequestWorkMessage {
+  return {
+    id: nextMessageId(),
+    role: 'assistant',
+    content:
+      'Request cancelled. Any work the organisation had already queued still appears in Approvals.',
   }
 }
 

--- a/web/src/stores/meta.ts
+++ b/web/src/stores/meta.ts
@@ -32,7 +32,7 @@ import type {
 import { ErrorCode } from '@/api/types/errors'
 import { createLogger } from '@/lib/logger'
 import { useToastStore } from '@/stores/toast'
-import { getErrorDetail, getErrorMessage, unavailableMessage } from '@/utils/errors'
+import { getErrorDetail, getErrorMessage, isAbortError, unavailableMessage } from '@/utils/errors'
 import { sanitizeForLog } from '@/utils/logging'
 
 const log = createLogger('meta')
@@ -79,11 +79,19 @@ async function runProposeConversation(
   message: string,
   conversationId?: string,
   idempotencyKey?: string,
+  signal?: AbortSignal,
 ): Promise<ConversationalProposeResponse | null> {
   set({ proposeLoading: true })
   try {
-    return await postChatPropose(message, conversationId, undefined, idempotencyKey)
+    return await postChatPropose(message, conversationId, undefined, idempotencyKey, signal)
   } catch (err) {
+    // A deliberate operator abort is not a failure: no error toast, no
+    // log.error. The caller sees the null sentinel and renders a cancelled
+    // state; the server still completes and parks any work idempotently.
+    if (isAbortError(err)) {
+      log.debug('Propose request cancelled by user')
+      return null
+    }
     const { title, description } = describeConversationalError(
       err,
       'Propose request failed',
@@ -310,6 +318,7 @@ interface MetaState {
     message: string,
     conversationId?: string,
     idempotencyKey?: string,
+    signal?: AbortSignal,
   ) => Promise<ConversationalProposeResponse | null>
   converseGroup: (
     message: string,
@@ -353,7 +362,8 @@ export const useMetaStore = create<MetaState>((set) => ({
     message: string,
     conversationId?: string,
     idempotencyKey?: string,
-  ) => runProposeConversation(set, message, conversationId, idempotencyKey),
+    signal?: AbortSignal,
+  ) => runProposeConversation(set, message, conversationId, idempotencyKey, signal),
   converseGroup: (
     message: string,
     agentIds: readonly string[],

--- a/web/src/utils/errors.ts
+++ b/web/src/utils/errors.ts
@@ -46,6 +46,18 @@ const STATUS_FALLBACK_MESSAGES: Readonly<Record<number, string>> = {
   504: 'Temporary connectivity issue. Please retry shortly.',
 }
 
+/**
+ * True when a rejected request was aborted by the caller (an
+ * `AbortController.abort()`), not a server or network failure. axios surfaces
+ * this as a `CanceledError`; a raw fetch/`AbortSignal` path surfaces a DOM
+ * `AbortError`. Callers use it to suppress error toasts for a deliberate
+ * user cancel and render a distinct "cancelled" state instead.
+ */
+export function isAbortError(err: unknown): boolean {
+  if (axios.isCancel(err)) return true
+  return err instanceof Error && err.name === 'AbortError'
+}
+
 /** Pydantic v1 / v2 leak patterns; see `_isPydanticishMessage` for use. */
 const PYDANTIC_PHRASE_PATTERN =
   /(field required|value is not a valid|string too (short|long)|input should|string should|list should|dict should)/i


### PR DESCRIPTION
## Summary

Two dashboard bugs surfaced while dogfooding the conversational org interface, plus an operator cancel affordance.

- **Chief-of-Staff chat endpoints falsely timed out.** The shared axios client defaults to a 30s timeout, but the CoS chat turns (`propose` / `group` / `act` / `explain`) run synchronous agent sessions server-side that regularly take 25-35s. A slow-but-successful `propose` aborted client-side and showed "The assistant could not respond" **while the server completed and parked the work**. Promoted `LLM_BOUND_TIMEOUT_MS` (300s) to a shared export in `api/client.ts` (previously a private copy in `charter.ts`) and applied it to the four LLM-bound `meta.ts` chat endpoints.
- **Per-card approval Reject did not reject.** The list-level "Reject" button only opened the detail drawer (asymmetric with one-click Approve). It now opens the reject-with-reason dialog directly, via a shared `ApprovalRejectDialog` (extracted from the drawer, reused by both) and a `useCardReject` hook that reuses the existing `useApprovalDecision`. `useApprovalDecision` gained an `openRejectOnTargetChange` flag so a fresh target opens the dialog synchronously; `ConfirmDialog`'s close is the single owner of clearing the target.
- **Cancel affordance for long-running propose.** Added an `AbortController`-backed Cancel button to the Request-work flow. A deliberate abort renders a distinct "cancelled" bubble with no error toast (`isAbortError` distinguishes it from a failure); `postChatPropose` / `proposeConversation` thread the signal. The server still completes idempotently, so any already-queued work still appears in Approvals.

Two other findings from the dogfood session were investigated and are **not** code defects: the Chat page "renderer freeze" was a CDP screenshot-capture artifact (the page stayed fully interactive), and the health pill "checking..." was the deliberate hidden-tab poll skip (`/readyz` responds in ~5ms for a foreground user).

## Test plan

- `npm --prefix web run type-check` and `run lint` clean.
- Full web unit suite: **3905 passing**.
- New coverage: per-card reject happy path + no-drawer-detour, blank-reason validation, reopen-after-cancel, cross-card targeting, dialog-close-on-success; and the propose cancel flow (abort renders the cancelled bubble, no error toast).

## Review coverage

Pre-reviewed by 7 agents (frontend, security, api-contract-drift, test-quality, design-token, docs-consistency, comment-quality-rot). 10 findings (all in the new code) addressed; `code-simplifier` polish pass found nothing to change. Security, api-drift, design-token, docs, and comment-rot came back clean.

No linked issue (dogfood-found).