### PR TITLE
Harden charter-to-plan dispatch: exclusive model binding, decomposition resilience, greenlight plan persistence

### DIFF
--- a/data/architecture_report.json
+++ b/data/architecture_report.json
@@ -26,8 +26,8 @@
     },
     "src/synthorg/api/app_builders.py": {
       "cap": 500,
-      "loc": 448,
-      "ratio": 0.896,
+      "loc": 447,
+      "ratio": 0.894,
       "tier": "code"
     },
     "src/synthorg/api/auth/controllers/session.py": {
@@ -66,12 +66,6 @@
       "ratio": 0.91,
       "tier": "code"
     },
-    "src/synthorg/api/controllers/_conversational_resume.py": {
-      "cap": 600,
-      "loc": 600,
-      "ratio": 1.0,
-      "tier": "orchestrator"
-    },
     "src/synthorg/api/controllers/_department_health.py": {
       "cap": 600,
       "loc": 503,
@@ -86,8 +80,8 @@
     },
     "src/synthorg/api/controllers/approvals/decisions.py": {
       "cap": 400,
-      "loc": 344,
-      "ratio": 0.86,
+      "loc": 355,
+      "ratio": 0.887,
       "tier": "controller"
     },
     "src/synthorg/api/controllers/artifacts.py": {
@@ -206,8 +200,8 @@
     },
     "src/synthorg/api/lifecycle_helpers/feature_wiring.py": {
       "cap": 600,
-      "loc": 586,
-      "ratio": 0.977,
+      "loc": 588,
+      "ratio": 0.98,
       "tier": "orchestrator"
     },
     "src/synthorg/api/lifecycle_helpers/persistence_autowire.py": {
@@ -218,8 +212,8 @@
     },
     "src/synthorg/api/lifecycle_helpers/startup_steps.py": {
       "cap": 500,
-      "loc": 499,
-      "ratio": 0.998,
+      "loc": 474,
+      "ratio": 0.948,
       "tier": "code"
     },
     "src/synthorg/api/lifecycle_runner_shutdown.py": {
@@ -482,8 +476,8 @@
     },
     "src/synthorg/engine/feature.py": {
       "cap": 100,
-      "loc": 107,
-      "ratio": 1.07,
+      "loc": 98,
+      "ratio": 0.98,
       "tier": "feature"
     },
     "src/synthorg/engine/hybrid/replan_helpers.py": {
@@ -524,8 +518,8 @@
     },
     "src/synthorg/engine/pipeline/service.py": {
       "cap": 1100,
-      "loc": 901,
-      "ratio": 0.819,
+      "loc": 968,
+      "ratio": 0.88,
       "tier": "complex_service"
     },
     "src/synthorg/engine/plan_execute_loop.py": {
@@ -908,8 +902,8 @@
     },
     "src/synthorg/meta/chief_of_staff/propose.py": {
       "cap": 600,
-      "loc": 546,
-      "ratio": 0.91,
+      "loc": 542,
+      "ratio": 0.903,
       "tier": "service"
     },
     "src/synthorg/meta/chief_of_staff/routing.py": {
@@ -1100,8 +1094,8 @@
     },
     "src/synthorg/persistence/postgres/plan_repo.py": {
       "cap": 500,
-      "loc": 412,
-      "ratio": 0.824,
+      "loc": 413,
+      "ratio": 0.826,
       "tier": "code"
     },
     "src/synthorg/persistence/postgres/project_brain_repo.py": {
@@ -1202,8 +1196,8 @@
     },
     "src/synthorg/persistence/sqlite/plan_repo.py": {
       "cap": 500,
-      "loc": 429,
-      "ratio": 0.858,
+      "loc": 430,
+      "ratio": 0.86,
       "tier": "code"
     },
     "src/synthorg/persistence/sqlite/project_brain_repo.py": {
@@ -1304,8 +1298,8 @@
     },
     "src/synthorg/providers/drivers/litellm_driver.py": {
       "cap": 700,
-      "loc": 700,
-      "ratio": 1.0,
+      "loc": 715,
+      "ratio": 1.021,
       "tier": "adapter"
     },
     "src/synthorg/providers/health_prober.py": {
@@ -1418,8 +1412,8 @@
     },
     "src/synthorg/templates/model_matcher.py": {
       "cap": 500,
-      "loc": 463,
-      "ratio": 0.926,
+      "loc": 466,
+      "ratio": 0.932,
       "tier": "code"
     },
     "src/synthorg/tools/browser/_executor.py": {
@@ -1502,14 +1496,14 @@
     },
     "src/synthorg/workers/execution_service/_agent_engine.py": {
       "cap": 600,
-      "loc": 581,
-      "ratio": 0.968,
+      "loc": 575,
+      "ratio": 0.958,
       "tier": "service"
     },
     "src/synthorg/workers/runtime_builder.py": {
       "cap": 600,
-      "loc": 588,
-      "ratio": 0.98,
+      "loc": 572,
+      "ratio": 0.953,
       "tier": "orchestrator"
     },
     "src/synthorg/workers/worker.py": {
@@ -1521,7 +1515,7 @@
   },
   "description": "Architecture-metrics baseline for the drift gate (scripts/check_architecture_drift.py). fan_in: direct-importer counts for hub modules (>= 20). budget_pressure: source files within 20% of their module-size tier cap. lcom: LCOM4 for service-tier classes >= 400 LOC (1 = cohesive). Regenerate with: uv run python scripts/architecture_report.py",
   "fan_in": {
-    "synthorg._core.features": 145,
+    "synthorg._core.features": 146,
     "synthorg.api.api_core_state": 39,
     "synthorg.api.channels": 23,
     "synthorg.api.construction_wiring": 21,
@@ -1547,7 +1541,6 @@
     "synthorg.budget.tracker_protocol": 103,
     "synthorg.client.models": 41,
     "synthorg.communication.bus_protocol": 32,
-    "synthorg.communication.conversation.enums": 21,
     "synthorg.communication.enums": 33,
     "synthorg.communication.errors": 24,
     "synthorg.communication.mcp_errors": 27,
@@ -1556,36 +1549,37 @@
     "synthorg.config.provider_schema": 29,
     "synthorg.config.schema": 63,
     "synthorg.core.agent": 164,
-    "synthorg.core.approval": 45,
+    "synthorg.core.approval": 46,
     "synthorg.core.auth.models": 34,
     "synthorg.core.auth.roles": 32,
     "synthorg.core.autonomy_enums": 42,
     "synthorg.core.boundary": 66,
-    "synthorg.core.clock": 229,
+    "synthorg.core.clock": 230,
     "synthorg.core.critical_errors": 664,
-    "synthorg.core.domain_errors": 243,
+    "synthorg.core.domain_errors": 247,
     "synthorg.core.effective_autonomy": 24,
     "synthorg.core.error_taxonomy": 63,
     "synthorg.core.iso_datetime": 30,
     "synthorg.core.memory_enums": 49,
     "synthorg.core.normalization": 115,
     "synthorg.core.pagination": 33,
-    "synthorg.core.persistence_errors": 251,
-    "synthorg.core.project_enums": 31,
+    "synthorg.core.persistence_errors": 250,
+    "synthorg.core.plan_enums": 21,
+    "synthorg.core.project_enums": 32,
     "synthorg.core.registry": 28,
     "synthorg.core.role": 22,
-    "synthorg.core.task": 131,
-    "synthorg.core.task_enums": 120,
-    "synthorg.core.types": 1261,
+    "synthorg.core.task": 132,
+    "synthorg.core.task_enums": 122,
+    "synthorg.core.types": 1260,
     "synthorg.engine.context": 44,
     "synthorg.engine.decomposition.models": 38,
     "synthorg.engine.errors": 95,
     "synthorg.engine.loop_protocol": 53,
-    "synthorg.engine.pipeline.models": 27,
+    "synthorg.engine.pipeline.models": 26,
     "synthorg.engine.prompt_safety": 80,
     "synthorg.engine.state": 53,
     "synthorg.engine.strategy.models": 21,
-    "synthorg.engine.task_engine": 41,
+    "synthorg.engine.task_engine": 42,
     "synthorg.engine.task_engine_models": 22,
     "synthorg.engine.workflow.ceremony_policy": 21,
     "synthorg.engine.workflow.definition": 42,
@@ -1612,9 +1606,9 @@
     "synthorg.memory.models": 74,
     "synthorg.memory.protocol": 68,
     "synthorg.meta.chief_of_staff.enums": 20,
-    "synthorg.meta.chief_of_staff.models": 43,
+    "synthorg.meta.chief_of_staff.models": 40,
     "synthorg.meta.config": 28,
-    "synthorg.meta.errors": 21,
+    "synthorg.meta.errors": 20,
     "synthorg.meta.mcp.domains._remaining_args": 25,
     "synthorg.meta.mcp.errors": 56,
     "synthorg.meta.mcp.handler_protocol": 45,
@@ -1626,15 +1620,15 @@
     "synthorg.meta.mcp.tool_builder": 23,
     "synthorg.meta.models": 73,
     "synthorg.meta.signal_models": 24,
-    "synthorg.meta.state": 27,
+    "synthorg.meta.state": 26,
     "synthorg.meta.toolsmith.models": 21,
     "synthorg.notifications.dispatcher": 23,
     "synthorg.notifications.models": 24,
-    "synthorg.observability": 1833,
+    "synthorg.observability": 1832,
     "synthorg.observability.background_tasks": 27,
     "synthorg.observability.events.api": 218,
     "synthorg.observability.events.approval_gate": 26,
-    "synthorg.observability.events.chief_of_staff": 35,
+    "synthorg.observability.events.chief_of_staff": 36,
     "synthorg.observability.events.client": 24,
     "synthorg.observability.events.communication": 26,
     "synthorg.observability.events.config": 22,
@@ -1655,15 +1649,15 @@
     "synthorg.observability.events.workspace": 28,
     "synthorg.observability.metrics_hub": 33,
     "synthorg.ontology.models": 25,
-    "synthorg.persistence._generics": 226,
-    "synthorg.persistence._shared": 169,
-    "synthorg.persistence._shared._filter_clauses": 24,
+    "synthorg.persistence._generics": 223,
+    "synthorg.persistence._shared": 167,
+    "synthorg.persistence._shared._filter_clauses": 22,
     "synthorg.persistence._shared.datetime_marshaller": 27,
     "synthorg.persistence._shared.pagination": 71,
     "synthorg.persistence.ontology_protocol": 21,
     "synthorg.persistence.protocol": 50,
-    "synthorg.persistence.sqlite._shared": 92,
-    "synthorg.persistence.state": 86,
+    "synthorg.persistence.sqlite._shared": 91,
+    "synthorg.persistence.state": 87,
     "synthorg.project_brain.models": 26,
     "synthorg.providers.cost_recording": 44,
     "synthorg.providers.enums": 100,
@@ -1752,7 +1746,7 @@
     },
     "synthorg.engine.pipeline.service:DefaultWorkPipeline": {
       "lcom4": 1,
-      "loc": 795
+      "loc": 859
     },
     "synthorg.engine.review_gate:ReviewGateService": {
       "lcom4": 1,
@@ -1820,7 +1814,7 @@
     },
     "synthorg.meta.chief_of_staff.propose:ChiefOfStaffProposer": {
       "lcom4": 1,
-      "loc": 439
+      "loc": 437
     },
     "synthorg.observability.prometheus_collector:PrometheusCollector": {
       "lcom4": 1,
@@ -1896,7 +1890,7 @@
     },
     "synthorg.workers.execution_service._agent_engine:AgentEngineExecutionService": {
       "lcom4": 1,
-      "loc": 513
+      "loc": 505
     }
   }
 }

--- a/data/architecture_report.json
+++ b/data/architecture_report.json
@@ -518,8 +518,8 @@
     },
     "src/synthorg/engine/pipeline/service.py": {
       "cap": 1100,
-      "loc": 968,
-      "ratio": 0.88,
+      "loc": 993,
+      "ratio": 0.903,
       "tier": "complex_service"
     },
     "src/synthorg/engine/plan_execute_loop.py": {
@@ -1298,8 +1298,8 @@
     },
     "src/synthorg/providers/drivers/litellm_driver.py": {
       "cap": 700,
-      "loc": 715,
-      "ratio": 1.021,
+      "loc": 699,
+      "ratio": 0.999,
       "tier": "adapter"
     },
     "src/synthorg/providers/health_prober.py": {
@@ -1555,15 +1555,15 @@
     "synthorg.core.autonomy_enums": 42,
     "synthorg.core.boundary": 66,
     "synthorg.core.clock": 230,
-    "synthorg.core.critical_errors": 664,
-    "synthorg.core.domain_errors": 247,
+    "synthorg.core.critical_errors": 665,
+    "synthorg.core.domain_errors": 248,
     "synthorg.core.effective_autonomy": 24,
     "synthorg.core.error_taxonomy": 63,
     "synthorg.core.iso_datetime": 30,
     "synthorg.core.memory_enums": 49,
     "synthorg.core.normalization": 115,
     "synthorg.core.pagination": 33,
-    "synthorg.core.persistence_errors": 250,
+    "synthorg.core.persistence_errors": 251,
     "synthorg.core.plan_enums": 21,
     "synthorg.core.project_enums": 32,
     "synthorg.core.registry": 28,
@@ -1746,7 +1746,7 @@
     },
     "synthorg.engine.pipeline.service:DefaultWorkPipeline": {
       "lcom4": 1,
-      "loc": 859
+      "loc": 882
     },
     "synthorg.engine.review_gate:ReviewGateService": {
       "lcom4": 1,

--- a/docs/design/plan-review.md
+++ b/docs/design/plan-review.md
@@ -30,8 +30,8 @@ carries only the plan's `plan_id`.
   objective's acceptance criteria, denormalised for the coverage map),
   `version_history` (snapshots of prior submitted versions), `version`,
   `created_at`, `updated_at`. A model validator rejects an empty item list for
-  every status except the itemless `PLANNING` / `FAILED` shells (which may carry
-  no items), duplicate item ids, an unresolvable dependency, or a dependency
+  every status except the `PLANNING` / `FAILED` shells (which may carry no
+  items), duplicate item ids, an unresolvable dependency, or a dependency
   **cycle** (topological sort); a second validator ties `failure_reason` to the
   `FAILED` status (present iff FAILED). A malformed plan is caught at construction
   rather than as a dispatch failure.

--- a/docs/design/plan-review.md
+++ b/docs/design/plan-review.md
@@ -73,22 +73,38 @@ panel is attached the plan is parked with `review = None`.
 
 ```mermaid
 stateDiagram-v2
-    [*] --> DRAFT
+    [*] --> PLANNING
+    PLANNING --> PENDING_REVIEW: decomposition fills the shell
+    PLANNING --> FAILED: decomposition failed / empty
     DRAFT --> PENDING_REVIEW
     PENDING_REVIEW --> APPROVED
     PENDING_REVIEW --> REJECTED
     PENDING_REVIEW --> DRAFT: edit / request-changes
     APPROVED --> [*]
     REJECTED --> [*]
+    FAILED --> [*]
 ```
 
-An edit or request-changes is accepted only from a non-terminal status.
+**Plan-first-from-greenlight.** When a splittable initiative is greenlit, a
+`PLANNING` **shell** (no items yet) is persisted *before* decomposition runs, so
+every greenlit objective leaves a first-class, visible plan even if decomposition
+never completes. Decomposition fills the shell in place (moving it to
+`PENDING_REVIEW`); a decomposition that fails or produces no items transitions the
+shell to `FAILED`, carrying a `failure_reason` the review surface shows, rather
+than leaving a silent orphan task. The `PLANNING` and `FAILED` statuses are the
+only ones permitted to carry an empty item list (enforced by the model validator
+and the SQLite / Postgres `items` CHECK); every other status requires a non-empty,
+validated item DAG.
 
-`DRAFT` and `PENDING_REVIEW` are the reworkable statuses; `APPROVED`, `REJECTED`,
-and `SUPERSEDED` are terminal. An operator rework or request-changes is accepted
-only from a reworkable status, so a decided plan cannot be revived. Each edit bumps
-`version`, and every write is version-guarded (optimistic concurrency): a stale
-writer is rejected with a conflict rather than silently clobbering a concurrent edit.
+An edit or request-changes is accepted only from a reworkable status.
+
+`DRAFT` and `PENDING_REVIEW` are the reworkable statuses; `PLANNING` is a transient
+shell (not operator-reworkable); `APPROVED`, `REJECTED`, `SUPERSEDED`, and `FAILED`
+are terminal. An operator rework or request-changes is accepted only from a
+reworkable status, so a decided or failed plan cannot be revived (a retry is a
+fresh run). Each edit bumps `version`, and every write is version-guarded
+(optimistic concurrency): a stale writer is rejected with a conflict rather than
+silently clobbering a concurrent edit.
 
 ## Persistence
 

--- a/docs/design/plan-review.md
+++ b/docs/design/plan-review.md
@@ -79,10 +79,14 @@ stateDiagram-v2
     DRAFT --> PENDING_REVIEW
     PENDING_REVIEW --> APPROVED
     PENDING_REVIEW --> REJECTED
+    PENDING_REVIEW --> FAILED: approval-park failed
     PENDING_REVIEW --> DRAFT: edit / request-changes
+    DRAFT --> SUPERSEDED: superseded by a re-plan
+    PENDING_REVIEW --> SUPERSEDED: superseded by a re-plan
     APPROVED --> [*]
     REJECTED --> [*]
     FAILED --> [*]
+    SUPERSEDED --> [*]
 ```
 
 **Plan-first-from-greenlight.** When a splittable initiative is greenlit, a
@@ -91,10 +95,14 @@ every greenlit objective leaves a first-class, visible plan even if decompositio
 never completes. Decomposition fills the shell in place (moving it to
 `PENDING_REVIEW`); a decomposition that fails or produces no items transitions the
 shell to `FAILED`, carrying a `failure_reason` the review surface shows, rather
-than leaving a silent orphan task. The `PLANNING` and `FAILED` statuses are the
-only ones permitted to carry an empty item list (enforced by the model validator
-and the SQLite / Postgres `items` CHECK); every other status requires a non-empty,
-validated item DAG.
+than leaving a silent orphan task. A plan can also reach `FAILED` *after*
+decomposition succeeded, if parking the approval fails: it is then FAILED with its
+items intact, so `FAILED` permits (but does not require) an empty item list. The
+`PLANNING` and `FAILED` statuses are the only ones permitted to carry an empty item
+list (enforced by the model validator and the SQLite / Postgres `items` CHECK);
+every other status requires a non-empty, validated item DAG. A `failure_reason` is
+present iff the status is `FAILED` (a cross-field model validator enforces both
+directions).
 
 An edit or request-changes is accepted only from a reworkable status.
 
@@ -111,7 +119,9 @@ silently clobbering a concurrent edit.
 `PlanRepository` (`persistence/plan_protocol.py`) composes the ADR-0001 generics
 `IdKeyedRepository[Plan, NotBlankStr]` + `FilteredQueryRepository[Plan,
 PlanFilterSpec]`, with SQLite and Postgres implementations kept in parity. The
-`plans` table stores `items` as JSON (a non-empty array, CHECK-enforced), and
+`plans` table stores `items` as JSON (a non-empty array for every status except
+the `PLANNING` / `FAILED` shells, which may carry no items, CHECK-enforced), the
+nullable `failure_reason` (non-blank when present, CHECK-enforced), and
 `review` / `open_questions` / `assumptions` / `objective_criteria` /
 `version_history` as JSON columns; Postgres uses `TIMESTAMPTZ` for the timestamps
 and a composite `(project, status, id)` index for the combined-filter list query.
@@ -192,7 +202,8 @@ Approve/reject route through the existing idempotent `/approvals/{id}` path into
   re-runnable; the plan stays `APPROVED` because the decision stands.
 - On reject, the parent task is cancelled and nothing builds.
 - The gate persists the plan before parking the approval; if the approval write
-  fails, the just-created plan is compensated (deleted) so no orphan remains.
+  fails, the filled plan is marked `FAILED` (carrying the reason) rather than
+  deleted, so the failure stays visible in Plan Review instead of vanishing.
 
 ## Configuration
 
@@ -218,6 +229,9 @@ description, owner, complexity, stakes) or sends the plan back for changes, and
 surfaces a disconnected-updates banner when the WebSocket drops. Beyond the item
 list, it renders review panels derived from the plan (no extra persisted state):
 
+- **Decomposition failure** (`PlanFailureBanner`): shown only for a `FAILED` plan,
+  surfacing its `failure_reason` so the operator can see why the run failed and
+  start a fresh one.
 - **Needs your input** (`PlanOpenQuestionsPanel`): the planner's open questions and
   assumptions to answer or correct before approving.
 - **Cost forecast** (`PlanForecastPanel`): the plan's `forecast_id` hydrated to show

--- a/docs/design/plan-review.md
+++ b/docs/design/plan-review.md
@@ -29,10 +29,12 @@ carries only the plan's `plan_id`.
   `assumptions` (what the planner surfaced for the human), `objective_criteria` (the
   objective's acceptance criteria, denormalised for the coverage map),
   `version_history` (snapshots of prior submitted versions), `version`,
-  `created_at`, `updated_at`. A model validator rejects an empty item list,
-  duplicate item ids, an unresolvable dependency, or a dependency **cycle**
-  (topological sort), so a malformed plan is caught at construction rather than as a
-  dispatch failure.
+  `created_at`, `updated_at`. A model validator rejects an empty item list for
+  every status except the itemless `PLANNING` / `FAILED` shells (which may carry
+  no items), duplicate item ids, an unresolvable dependency, or a dependency
+  **cycle** (topological sort); a second validator ties `failure_reason` to the
+  `FAILED` status (present iff FAILED). A malformed plan is caught at construction
+  rather than as a dispatch failure.
 - **`PlanItem`**: `id` (a canonical UUID string, because dispatch rebuilds each
   child task from it), `title`, `description`, `dependencies`, `owner`,
   `acceptance_criteria`, `expected_artifacts`, `required_skills`, `required_tags`,

--- a/docs/design/plan-review.md
+++ b/docs/design/plan-review.md
@@ -24,7 +24,8 @@ carries only the plan's `plan_id`.
 - **`Plan`**: `id` (UUID), `project`, `objective_id`, `objective_title`
   (denormalised at creation so the surface never resolves, or falls back to, a raw
   id), `parent_task_id`, `items` (ordered tuple forming a dependency DAG),
-  `task_structure`, `coordination_topology`, `status`, `forecast_id`, `review` (the
+  `task_structure`, `coordination_topology`, `status`, `failure_reason` (why a
+  `FAILED` plan failed, `None` otherwise), `forecast_id`, `review` (the
   consolidated stakeholder-panel review, or `None`), `open_questions` and
   `assumptions` (what the planner surfaced for the human), `objective_criteria` (the
   objective's acceptance criteria, denormalised for the coverage map),

--- a/docs/design/providers.md
+++ b/docs/design/providers.md
@@ -287,6 +287,15 @@ Both are hot-reloadable (a change triggers a runtime-services rebuild via the
 settings subscriber, no restart), so the defaults give a sensible allocation
 with no operator input while remaining tunable per deployment.
 
+**Agent-eligible providers.** A provider carries `agent_eligible` (default
+`true`). An `agent_eligible=false` provider stays fully usable for
+explicitly-configured feature calls (the chat / judge / charter / narrative
+models an operator sets), but contributes no models to the seeding pool and is
+excluded from stakes routing, so no agent is ever seeded onto it or routed to it.
+This lets an operator keep a gateway available (added deliberately, e.g. for a
+specific feature model) without any agent silently sourcing from it. The flag is
+a per-provider field on `ProviderConfig`, editable through provider CRUD.
+
 ## Model Routing Strategy
 
 Model routing determines which LLM handles a given request. Five strategies are available,
@@ -379,17 +388,33 @@ pipeline) stay on that default provider in v1.
 
 ### Multi-Provider Model Resolution
 
-When multiple providers register the same model ID or alias, the `ModelResolver`
-stores all variants as a candidate tuple rather than raising a collision error.
-At resolution time, a `ModelCandidateSelector` picks the best candidate from the
-tuple.
+An agent binds an **exclusive `(provider, model)` pair**: `ModelConfig` requires
+both a `provider` and a `model_id`, and the agent's own model always resolves to
+that provider, never re-derived across providers. Two OpenAI-compatible gateways
+can legitimately advertise an overlapping model id (each live-discovers its own
+`/v1/models`), so a bare id can map to more than one provider; the resolver keeps
+all variants as a candidate tuple rather than raising a collision error, and the
+binding decides which one an agent uses.
+
+- **Provider-scoped resolution.** `ModelResolver.resolve_for_pair(provider, ref)`
+  resolves a ref within one provider. Every caller that holds an agent's
+  `identity.model.provider` (the budget downgrade enforcer, the CFO downgrade /
+  routing optimiser) resolves through it, so an overlapping id never silently
+  moves the agent onto a different provider. The run-time client is resolved from
+  `identity.model.provider` directly (`AgentEngine._dispatch_client_for`), so the
+  API called and the `CostRecord.provider` always match the agent's binding.
+- **Eligibility-first selection.** When the provider-agnostic selector *does* run
+  (feature calls, the config-selected routing strategies), it prefers
+  `agent_eligible` candidates: a provider kept out of agent work wins only when it
+  is the sole provider for the ref. Stakes routing (`models_at_or_above_tier`) and
+  agent seeding exclude ineligible providers outright.
 
 Two built-in selectors are provided:
 
 | Selector | Behaviour |
 |----------|----------|
-| `QuotaAwareSelector` (default) | Prefer providers with available quota, then cheapest among those; falls back to cheapest overall when all providers are exhausted |
-| `CheapestSelector` | Always pick the cheapest candidate by total cost per 1k tokens, ignoring quota state |
+| `QuotaAwareSelector` (default) | Prefer agent-eligible providers, then those with available quota, then cheapest; falls back to cheapest overall when all providers are exhausted |
+| `CheapestSelector` | Prefer agent-eligible providers, then pick the cheapest candidate by total cost per 1k tokens, ignoring quota state |
 
 The selector is injected into `ModelResolver` (and transitively into `ModelRouter`)
 at construction time.  `QuotaAwareSelector` is constructed with a snapshot from

--- a/docs/design/providers.md
+++ b/docs/design/providers.md
@@ -292,9 +292,9 @@ with no operator input while remaining tunable per deployment.
 explicitly-configured feature calls (the chat / judge / charter / narrative
 models an operator sets), but contributes no models to the seeding pool and is
 excluded from stakes routing, so no agent is ever *newly* seeded onto it or
-routed to it. It is not an immediate traffic cutover: an agent already pinned to
-the provider keeps running on it because `resolve_for_pair` honours the explicit
-`(provider, model)` binding, until that agent is reassigned. This lets an
+routed to it. It does not immediately cut off existing traffic: an agent already
+pinned to the provider keeps running on it because `resolve_for_pair` honours the
+explicit `(provider, model)` binding, until that agent is reassigned. This lets an
 operator stop new agents sourcing from a gateway (added deliberately, e.g. for a
 specific feature model) without disrupting agents already bound to it. The flag
 is a per-provider field on `ProviderConfig`, editable through provider CRUD.

--- a/docs/design/providers.md
+++ b/docs/design/providers.md
@@ -291,10 +291,13 @@ with no operator input while remaining tunable per deployment.
 `true`). An `agent_eligible=false` provider stays fully usable for
 explicitly-configured feature calls (the chat / judge / charter / narrative
 models an operator sets), but contributes no models to the seeding pool and is
-excluded from stakes routing, so no agent is ever seeded onto it or routed to it.
-This lets an operator keep a gateway available (added deliberately, e.g. for a
-specific feature model) without any agent silently sourcing from it. The flag is
-a per-provider field on `ProviderConfig`, editable through provider CRUD.
+excluded from stakes routing, so no agent is ever *newly* seeded onto it or
+routed to it. It is not an immediate traffic cutover: an agent already pinned to
+the provider keeps running on it because `resolve_for_pair` honours the explicit
+`(provider, model)` binding, until that agent is reassigned. This lets an
+operator stop new agents sourcing from a gateway (added deliberately, e.g. for a
+specific feature model) without disrupting agents already bound to it. The flag
+is a per-provider field on `ProviderConfig`, editable through provider CRUD.
 
 ## Model Routing Strategy
 

--- a/docs/design/providers.md
+++ b/docs/design/providers.md
@@ -413,7 +413,7 @@ Two built-in selectors are provided:
 
 | Selector | Behaviour |
 |----------|----------|
-| `QuotaAwareSelector` (default) | Prefer agent-eligible providers, then those with available quota, then cheapest; falls back to cheapest overall when all providers are exhausted |
+| `QuotaAwareSelector` (default) | Filter to providers with available quota first; within that pool (or all candidates when none have quota), prefer agent-eligible providers, then cheapest |
 | `CheapestSelector` | Prefer agent-eligible providers, then pick the cheapest candidate by total cost per 1k tokens, ignoring quota state |
 
 The selector is injected into `ModelResolver` (and transitively into `ModelRouter`)

--- a/docs/design/providers.md
+++ b/docs/design/providers.md
@@ -344,7 +344,8 @@ Routing maps **stakes to a required model tier** (`StakesTierRequirement`: low t
 not to a benchmark quality floor. The `StakesAwareStrategy` computes the required
 tier, bumps one tier when coordination metrics are unhealthy, holds high/critical
 work at or above the agent's own tier for the red-team gate, then scans every
-configured model at or above that tier (cheapest first) and keeps only the
+agent-eligible model at or above that tier (cheapest first; models on
+`agent_eligible=false` providers are excluded) and keeps only the
 **tool-capable** ones (`is_tool_capable`: `supports_tools` true, or verified, and
 never a model whose `tool_calls_verified` is explicitly `False`). It picks the
 cheapest survivor.
@@ -378,9 +379,10 @@ bulk tier suggestions; it runs on the operator-selected
 picked.
 
 **Per-task multi-provider routing (v1).** The stakes router resolves a tier over
-**all** configured providers with a deterministic `CheapestSelector`, so a tier can
-resolve to the cheapest model serving it across providers rather than being pinned to
-the boot default. After routing, the engine swaps the dispatched client to the routed
+**all agent-eligible** configured providers with a deterministic `CheapestSelector`
+(models on `agent_eligible=false` providers are excluded from candidacy), so a tier
+can resolve to the cheapest model serving it across the eligible providers rather than
+being pinned to the boot default. After routing, the engine swaps the dispatched client to the routed
 model's provider (`AgentEngine._resolve_provider_instance`), so the API actually
 called and the `CostRecord.provider` name are always the same provider (attribution
 parity). If the routed provider cannot be resolved from the registry, the engine keeps

--- a/src/synthorg/api/lifecycle_helpers/plan_review_wiring.py
+++ b/src/synthorg/api/lifecycle_helpers/plan_review_wiring.py
@@ -23,7 +23,11 @@ from synthorg.approval.state import approval_store_of
 from synthorg.budget.tracker_protocol import CostTrackerProtocol
 from synthorg.core.approval import ApprovalItem
 from synthorg.core.clock import Clock
+from synthorg.core.concurrency import CASRetryHandler
 from synthorg.core.critical_errors import reraise_critical
+from synthorg.core.domain_errors import ResourceNotFoundError, VersionConflictError
+from synthorg.core.persistence_errors import PersistenceVersionConflictError
+from synthorg.core.plan import Plan
 from synthorg.core.plan_enums import PlanStatus
 from synthorg.core.plan_review import PlanReview
 from synthorg.core.task import Task
@@ -38,7 +42,10 @@ from synthorg.engine.pipeline.models import PlanReviewHandoff, WorkItem
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.api import API_APP_STARTUP
 from synthorg.observability.events.pipeline import (
-    PIPELINE_PLAN_DECOMPOSITION_FAILED,
+    PIPELINE_PLAN_APPROVAL_PARK_FAILED,
+    PIPELINE_PLAN_FAIL_SHELL_MISSING,
+    PIPELINE_PLAN_FAIL_WRITE_FAILED,
+    PIPELINE_PLAN_MARKED_FAILED,
     PIPELINE_PLAN_SHELL_OPENED,
 )
 from synthorg.persistence.plan_protocol import PlanRepository
@@ -47,6 +54,11 @@ from synthorg.providers.registry import ProviderRegistry
 logger = get_logger(__name__)
 
 _PLAN_ACTION_TYPE = "plan:approve"
+
+# Bounded compare-and-swap retries when the plan is reworked concurrently with
+# its FAILED-compensation write, so a losing CAS re-reads and reapplies rather
+# than aborting the one write meant to make a failure visible.
+_MAX_FAIL_ATTEMPTS: Final[int] = 3
 
 #: ``ApprovalItem.metadata`` keys carrying resume context. The plan itself is
 #: durable (referenced by ``plan_id``); the approval only points at it.
@@ -232,9 +244,7 @@ class PlanReviewApprovalGate:
             # durable plan FAILED (it stays visible in Plan Review, carrying the
             # reason) rather than leaving a PENDING_REVIEW plan with no approval.
             logger.warning(
-                API_APP_STARTUP,
-                service="plan_review_gate",
-                note="approval-store write failed; marking plan FAILED",
+                PIPELINE_PLAN_APPROVAL_PARK_FAILED,
                 plan_id=str(durable_plan.id),
                 error_type=type(exc).__name__,
                 error=safe_error_description(exc),
@@ -251,34 +261,67 @@ class PlanReviewApprovalGate:
         )
 
     async def fail_plan(self, *, plan_id: UUID, reason: str) -> None:
-        """Mark the PLANNING shell FAILED so a failed run leaves a visible plan.
+        """Mark a plan FAILED so a failed run leaves a visible plan, best-effort.
 
-        Idempotent-ish: a missing shell (already pruned) is logged and skipped
-        rather than raised, since the caller is already on a failure path.
+        This is the compensating write on every plan-review failure path, so it
+        is hardened three ways: it is idempotent (a plan already FAILED, or a
+        missing shell, is a no-op), a concurrent rework is retried via CAS, and a
+        persistent write failure is logged, not raised. It must never mask the
+        original failure the caller is surfacing (a re-raised approval error, or
+        the failed handoff `_plan_review` returns) nor turn a handled failure
+        into a 500 -- which is exactly what an unguarded write here would do.
         """
-        plan = await self._plans.get(NotBlankStr(str(plan_id)))
-        if plan is None:
+        key = NotBlankStr(str(plan_id))
+        marked_reason = NotBlankStr(reason or "decomposition failed")
+
+        async def read() -> tuple[Plan, int]:
+            plan = await self._plans.get(key)
+            if plan is None:
+                msg = "plan shell missing"
+                raise ResourceNotFoundError(msg)
+            return plan, plan.version
+
+        async def write(plan: Plan, _version: int) -> None:
+            if plan.status is PlanStatus.FAILED:
+                return  # idempotent: a prior compensation already marked it
+            failed = plan.model_copy(
+                update={
+                    "status": PlanStatus.FAILED,
+                    "failure_reason": marked_reason,
+                    "version": plan.version + 1,
+                    "updated_at": self._clock.now(),
+                }
+            )
+            try:
+                await self._plans.update(failed, expected_version=plan.version)
+            except PersistenceVersionConflictError as exc:
+                # Translate to the domain twin CASRetryHandler retries on.
+                raise VersionConflictError(str(exc)) from exc
+
+        try:
+            await CASRetryHandler(
+                resource="plan_fail", max_attempts=_MAX_FAIL_ATTEMPTS
+            ).execute(read, write)
+        except ResourceNotFoundError:
             logger.warning(
-                PIPELINE_PLAN_DECOMPOSITION_FAILED,
-                plan_id=str(plan_id),
-                note="plan shell missing; cannot mark FAILED",
+                PIPELINE_PLAN_FAIL_SHELL_MISSING, plan_id=str(plan_id), reason=reason
             )
             return
-        now = self._clock.now()
-        failed = plan.model_copy(
-            update={
-                "status": PlanStatus.FAILED,
-                "failure_reason": NotBlankStr(reason or "decomposition failed"),
-                "version": plan.version + 1,
-                "updated_at": now,
-            }
-        )
-        await self._plans.update(failed, expected_version=plan.version)
-        logger.warning(
-            PIPELINE_PLAN_DECOMPOSITION_FAILED,
-            plan_id=str(plan_id),
-            reason=reason,
-        )
+        except Exception as exc:  # noqa: BLE001 -- criticals re-raised
+            # lint-allow: swallow-ok -- the compensating FAILED write is a
+            # best-effort side channel; the caller already surfaces the failure,
+            # so a persistent write error (or exhausted CAS) must not mask it or
+            # escape as a 500 from the greenlit run.
+            reraise_critical(exc)
+            logger.error(
+                PIPELINE_PLAN_FAIL_WRITE_FAILED,
+                plan_id=str(plan_id),
+                reason=reason,
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            return
+        logger.info(PIPELINE_PLAN_MARKED_FAILED, plan_id=str(plan_id), reason=reason)
 
 
 async def wire_plan_review_gate(app_state: AppState) -> None:

--- a/src/synthorg/api/lifecycle_helpers/plan_review_wiring.py
+++ b/src/synthorg/api/lifecycle_helpers/plan_review_wiring.py
@@ -12,6 +12,7 @@ unless an operator opts in.
 """
 
 import uuid
+from datetime import datetime
 from typing import Final
 from uuid import UUID
 
@@ -23,6 +24,7 @@ from synthorg.budget.tracker_protocol import CostTrackerProtocol
 from synthorg.core.approval import ApprovalItem
 from synthorg.core.clock import Clock
 from synthorg.core.critical_errors import reraise_critical
+from synthorg.core.plan_enums import PlanStatus
 from synthorg.core.plan_review import PlanReview
 from synthorg.core.task import Task
 from synthorg.core.types import NotBlankStr
@@ -30,10 +32,15 @@ from synthorg.engine.decomposition.models import DecompositionResult
 from synthorg.engine.decomposition.plan_mapping import (
     PlanProvenance,
     plan_from_decomposition,
+    plan_shell,
 )
 from synthorg.engine.pipeline.models import PlanReviewHandoff, WorkItem
 from synthorg.observability import get_logger, safe_error_description
 from synthorg.observability.events.api import API_APP_STARTUP
+from synthorg.observability.events.pipeline import (
+    PIPELINE_PLAN_DECOMPOSITION_FAILED,
+    PIPELINE_PLAN_SHELL_OPENED,
+)
 from synthorg.persistence.plan_protocol import PlanRepository
 from synthorg.providers.registry import ProviderRegistry
 
@@ -107,19 +114,70 @@ class PlanReviewApprovalGate:
         self._plans = plans
         self._clock = clock
 
+    def _provenance(
+        self,
+        work_item: WorkItem,
+        task: Task,
+        now: datetime,
+        *,
+        status: PlanStatus,
+        review: PlanReview | None,
+    ) -> PlanProvenance:
+        """Build the plan provenance shared by the shell and the filled plan.
+
+        Returns:
+            A :class:`PlanProvenance` stamping the objective / project identity,
+            timing, lifecycle status, and (denormalised) review context.
+        """
+        return PlanProvenance(
+            project=work_item.project,
+            objective_id=work_item.correlation_id,
+            objective_title=NotBlankStr(task.title),
+            parent_task_id=NotBlankStr(str(task.id)),
+            created_at=now,
+            status=status,
+            forecast_id=work_item.forecast_id,
+            review=review,
+            objective_criteria=tuple(
+                NotBlankStr(c.description) for c in task.acceptance_criteria
+            ),
+        )
+
+    async def open_plan(self, *, work_item: WorkItem, task: Task) -> UUID:
+        """Persist a PLANNING plan shell before decomposition runs.
+
+        Returns:
+            The id of the persisted PLANNING shell.
+        """
+        now = self._clock.now()
+        shell = plan_shell(
+            self._provenance(
+                work_item, task, now, status=PlanStatus.PLANNING, review=None
+            )
+        )
+        await self._plans.create(shell)
+        logger.info(
+            PIPELINE_PLAN_SHELL_OPENED,
+            plan_id=str(shell.id),
+            project=work_item.project,
+            task_id=str(task.id),
+        )
+        return shell.id
+
     async def request_plan_approval(
         self,
         *,
+        plan_id: UUID,
         work_item: WorkItem,
         task: Task,
         plan: DecompositionResult,
         review: PlanReview | None = None,
     ) -> PlanReviewHandoff:
-        """Persist *plan* durably and park it as an approval item.
+        """Fill the PLANNING shell with *plan* and park it as an approval item.
 
-        The plan is persisted first so the parked approval always references
-        a durable :class:`~synthorg.core.plan.Plan`; a persistence failure
-        surfaces before any dangling approval is created.
+        The shell (persisted by :meth:`open_plan`) is updated in place to
+        PENDING_REVIEW with the decomposed items, so a plan is first-class from
+        greenlight and the parked approval references the same durable id.
 
         Returns:
             A :class:`PlanReviewHandoff` naming the parked approval item.
@@ -127,22 +185,28 @@ class PlanReviewApprovalGate:
         approval_id = uuid.uuid4()
         detail = _plan_detail(plan)
         now = self._clock.now()
-        durable_plan = plan_from_decomposition(
+        shell = await self._plans.get(NotBlankStr(str(plan_id)))
+        filled = plan_from_decomposition(
             plan,
-            PlanProvenance(
-                project=work_item.project,
-                objective_id=work_item.correlation_id,
-                objective_title=NotBlankStr(task.title),
-                parent_task_id=NotBlankStr(str(task.id)),
-                created_at=now,
-                forecast_id=work_item.forecast_id,
-                review=review,
-                objective_criteria=tuple(
-                    NotBlankStr(c.description) for c in task.acceptance_criteria
-                ),
+            self._provenance(
+                work_item, task, now, status=PlanStatus.PENDING_REVIEW, review=review
             ),
         )
-        await self._plans.create(durable_plan)
+        durable_plan = filled.model_copy(
+            update={
+                "id": plan_id,
+                "created_at": shell.created_at if shell is not None else now,
+                "version": (shell.version + 1) if shell is not None else 1,
+                "updated_at": now,
+            }
+        )
+        if shell is not None:
+            await self._plans.update(durable_plan, expected_version=shell.version)
+        else:
+            # The shell was lost (e.g. opened on a prior boot then pruned);
+            # persist the filled plan fresh so the approval still references a
+            # durable plan rather than dangling.
+            await self._plans.create(durable_plan)
         approval = ApprovalItem(
             id=approval_id,
             action_type=NotBlankStr(_PLAN_ACTION_TYPE),
@@ -163,47 +227,58 @@ class PlanReviewApprovalGate:
             await self._approval_store.add(approval)
         except Exception as exc:
             reraise_critical(exc)
-            # The plan committed but the approval did not: without the
-            # approval there is no route to ever approve or reject this plan,
-            # so the row would be a permanent orphan (a retry mints a fresh
-            # plan id, never colliding). Log the cause, then compensate by
-            # deleting the plan so the failure surfaces cleanly and leaves no
-            # dangling record (the compensating delete's own failure is logged
-            # separately and never masks this error).
+            # The plan is filled but the approval did not park: without an
+            # approval there is no route to approve or reject it, so mark the
+            # durable plan FAILED (it stays visible in Plan Review, carrying the
+            # reason) rather than leaving a PENDING_REVIEW plan with no approval.
             logger.warning(
                 API_APP_STARTUP,
                 service="plan_review_gate",
-                note="approval-store write failed; compensating orphaned plan",
+                note="approval-store write failed; marking plan FAILED",
                 plan_id=str(durable_plan.id),
                 error_type=type(exc).__name__,
                 error=safe_error_description(exc),
             )
-            await self._delete_orphan_plan(durable_plan.id)
+            await self.fail_plan(
+                plan_id=durable_plan.id, reason="approval-store write failed"
+            )
             raise
         return PlanReviewHandoff(
             approval_id=NotBlankStr(str(approval_id)),
+            plan_id=NotBlankStr(str(durable_plan.id)),
             subtask_count=len(plan.plan.subtasks),
             detail=NotBlankStr(detail),
         )
 
-    async def _delete_orphan_plan(self, plan_id: UUID) -> None:
-        """Best-effort delete of a plan orphaned by an approval-write failure.
+    async def fail_plan(self, *, plan_id: UUID, reason: str) -> None:
+        """Mark the PLANNING shell FAILED so a failed run leaves a visible plan.
 
-        A secondary failure here is logged, not raised, so it never masks the
-        original approval-store error the caller is propagating.
+        Idempotent-ish: a missing shell (already pruned) is logged and skipped
+        rather than raised, since the caller is already on a failure path.
         """
-        try:
-            await self._plans.delete(NotBlankStr(str(plan_id)))
-        except Exception as exc:  # noqa: BLE001 -- criticals re-raised
-            reraise_critical(exc)
+        plan = await self._plans.get(NotBlankStr(str(plan_id)))
+        if plan is None:
             logger.warning(
-                API_APP_STARTUP,
-                service="plan_review_gate",
-                note="failed to delete orphaned plan after approval-write failure",
+                PIPELINE_PLAN_DECOMPOSITION_FAILED,
                 plan_id=str(plan_id),
-                error_type=type(exc).__name__,
-                error=safe_error_description(exc),
+                note="plan shell missing; cannot mark FAILED",
             )
+            return
+        now = self._clock.now()
+        failed = plan.model_copy(
+            update={
+                "status": PlanStatus.FAILED,
+                "failure_reason": NotBlankStr(reason or "decomposition failed"),
+                "version": plan.version + 1,
+                "updated_at": now,
+            }
+        )
+        await self._plans.update(failed, expected_version=plan.version)
+        logger.warning(
+            PIPELINE_PLAN_DECOMPOSITION_FAILED,
+            plan_id=str(plan_id),
+            reason=reason,
+        )
 
 
 async def wire_plan_review_gate(app_state: AppState) -> None:

--- a/src/synthorg/budget/_enforcer_helpers.py
+++ b/src/synthorg/budget/_enforcer_helpers.py
@@ -88,7 +88,10 @@ def _apply_downgrade(
     current_model_id = identity.model.model_id
     agent_id_str = str(identity.id)
 
-    resolved = resolver.resolve_safe(current_model_id)
+    # Resolve within the agent's own provider: a budget downgrade must keep the
+    # agent on the (provider, model) pair it was assigned, never let an
+    # overlapping id re-derive to a different provider.
+    resolved = resolver.resolve_for_pair(identity.model.provider, current_model_id)
     if resolved is None:
         logger.debug(
             BUDGET_DOWNGRADE_SKIPPED,
@@ -119,6 +122,11 @@ def _apply_downgrade(
         )
         return identity
 
+    # The downgrade target is a deliberate re-selection, so it may legitimately
+    # land on a different provider (e.g. a cheaper free local model). That is an
+    # explicit new (provider, model) pin, not the overlapping-id ambiguity the
+    # exclusive binding guards against; the eligibility-preferring selector keeps
+    # an agent-ineligible provider (e.g. a gateway) out of the pick.
     target_resolved = resolver.resolve_safe(target_alias)
     if target_resolved is None:
         logger.warning(

--- a/src/synthorg/budget/_enforcer_helpers.py
+++ b/src/synthorg/budget/_enforcer_helpers.py
@@ -138,6 +138,20 @@ def _apply_downgrade(
         )
         return identity
 
+    if not target_resolved.agent_eligible:
+        # When the target alias is served only by an agent-ineligible provider,
+        # the eligibility-preferring selector still returns it (no eligible
+        # alternative exists). Refuse the downgrade rather than move the agent
+        # onto a feature-only gateway; the agent keeps its current model.
+        logger.warning(
+            BUDGET_DOWNGRADE_SKIPPED,
+            agent_id=agent_id_str,
+            source_alias=source_alias,
+            target_alias=target_alias,
+            reason="target_agent_ineligible",
+        )
+        return identity
+
     new_model = _build_downgraded_model_config(
         identity.model,
         target_resolved,

--- a/src/synthorg/budget/_optimizer_helpers.py
+++ b/src/synthorg/budget/_optimizer_helpers.py
@@ -294,23 +294,27 @@ def _compute_global_avg_cost_per_1k(
 
 def _find_most_used_model(
     agent_records: Sequence[CostRecord],
-) -> str | None:
-    """Find the most frequently used model from pre-filtered records.
+) -> tuple[str, str] | None:
+    """Find the most frequently used ``(provider, model)`` pair from records.
 
     Returns:
-        The matching ``str``, or ``None`` when no match is found.
+        The most-used ``(provider, model)`` pair, or ``None`` when there are no
+        records. Keying on the pair (not the bare model id) keeps downstream
+        resolution scoped to the provider the agent actually ran on, so an
+        overlapping model id never re-derives to a different provider.
     """
-    model_counts: dict[str, int] = defaultdict(int)
+    pair_counts: dict[tuple[str, str], int] = defaultdict(int)
     for r in agent_records:
-        model_counts[r.model] += 1
-    if not model_counts:
+        pair_counts[(str(r.provider), str(r.model))] += 1
+    if not pair_counts:
         return None
-    return max(model_counts, key=lambda m: model_counts[m])
+    return max(pair_counts, key=lambda p: pair_counts[p])
 
 
-def _build_downgrade_recommendation(
+def _build_downgrade_recommendation(  # noqa: PLR0913 -- keyword-only; provider scopes resolution to the agent's bound pair
     *,
     agent_id: str,
+    provider: str,
     current_model: str,
     downgrade_map: dict[str, str],
     resolver: ModelResolver,
@@ -318,10 +322,19 @@ def _build_downgrade_recommendation(
 ) -> DowngradeRecommendation | None:
     """Build a downgrade recommendation for a single agent.
 
+    Args:
+        agent_id: The agent the recommendation targets.
+        provider: The provider the agent's current model is bound to, so the
+            current model is resolved within it rather than by a bare id.
+        current_model: The agent's most-used model id.
+        downgrade_map: Alias-to-alias downgrade path map.
+        resolver: The model resolver.
+        currency: Display currency for the recommendation.
+
     Returns:
         The resulting ``DowngradeRecommendation``, or ``None`` when unavailable.
     """
-    current_resolved = resolver.resolve_safe(current_model)
+    current_resolved = resolver.resolve_for_pair(provider, current_model)
     if current_resolved is None:
         logger.debug(
             CFO_DOWNGRADE_SKIPPED,
@@ -414,7 +427,8 @@ def _find_cheaper_model(
     all_models = resolver.all_models_sorted_by_cost()
     for model in all_models:
         if (
-            model.total_cost_per_1k < current_cost_per_1k
+            model.agent_eligible
+            and model.total_cost_per_1k < current_cost_per_1k
             and model.max_context >= min_context
         ):
             return model

--- a/src/synthorg/budget/_optimizer_helpers.py
+++ b/src/synthorg/budget/_optimizer_helpers.py
@@ -372,9 +372,14 @@ def _build_downgrade_recommendation(  # noqa: PLR0913 -- keyword-only; provider 
                 model=current_model,
             )
             return None
+        # Keep the concrete model the selector picked (with its provider). The
+        # same id can exist on multiple providers, so re-resolving by bare id
+        # could silently rebind the recommendation to a different provider.
         target_ref = cheaper.model_id
+        target_resolved: ResolvedModel | None = cheaper
+    else:
+        target_resolved = resolver.resolve_safe(target_ref)
 
-    target_resolved = resolver.resolve_safe(target_ref)
     if target_resolved is None:
         logger.debug(
             CFO_DOWNGRADE_SKIPPED,

--- a/src/synthorg/budget/_optimizer_helpers.py
+++ b/src/synthorg/budget/_optimizer_helpers.py
@@ -384,6 +384,18 @@ def _build_downgrade_recommendation(  # noqa: PLR0913 -- keyword-only; provider 
         )
         return None
 
+    if not target_resolved.agent_eligible:
+        # A downgrade-map target served only by an agent-ineligible provider must
+        # not be recommended (the cheaper-model fallback already filters these);
+        # recommending it would move the agent onto a feature-only gateway.
+        logger.debug(
+            CFO_DOWNGRADE_SKIPPED,
+            agent_id=agent_id,
+            reason="target_agent_ineligible",
+            target=target_ref,
+        )
+        return None
+
     savings = round(
         current_resolved.total_cost_per_1k - target_resolved.total_cost_per_1k,
         BUDGET_ROUNDING_PRECISION,

--- a/src/synthorg/budget/_optimizer_helpers.py
+++ b/src/synthorg/budget/_optimizer_helpers.py
@@ -378,7 +378,9 @@ def _build_downgrade_recommendation(  # noqa: PLR0913 -- keyword-only; provider 
         target_ref = cheaper.model_id
         target_resolved: ResolvedModel | None = cheaper
     else:
-        target_resolved = resolver.resolve_safe(target_ref)
+        # Scope the mapped target to the bound provider so a downgrade never
+        # silently rebinds the agent to a same-alias model on another provider.
+        target_resolved = resolver.resolve_for_pair(provider, target_ref)
 
     if target_resolved is None:
         logger.debug(

--- a/src/synthorg/budget/_optimizer_routing.py
+++ b/src/synthorg/budget/_optimizer_routing.py
@@ -231,8 +231,8 @@ class _CostOptimizerRoutingMixin:
                 continue
 
             agent_records = by_agent.get(agent.agent_id, [])
-            most_used_model = _find_most_used_model(agent_records)
-            if most_used_model is None:
+            most_used = _find_most_used_model(agent_records)
+            if most_used is None:
                 logger.debug(
                     CFO_DOWNGRADE_SKIPPED,
                     agent_id=agent.agent_id,
@@ -240,8 +240,10 @@ class _CostOptimizerRoutingMixin:
                 )
                 continue
 
+            most_used_provider, most_used_model = most_used
             recommendation = _build_downgrade_recommendation(
                 agent_id=agent.agent_id,
+                provider=most_used_provider,
                 current_model=most_used_model,
                 downgrade_map=downgrade_map,
                 resolver=self._model_resolver,
@@ -279,12 +281,19 @@ class _CostOptimizerRoutingMixin:
             if most_used is None:
                 continue
 
-            current_resolved = self._model_resolver.resolve_safe(most_used)
+            most_used_provider, most_used_model = most_used
+            current_resolved = self._model_resolver.resolve_for_pair(
+                most_used_provider, most_used_model
+            )
             if current_resolved is None:
                 continue
 
             # Find cheapest model with sufficient context window
             for candidate in all_models:
+                if not candidate.agent_eligible:
+                    # Never suggest moving an agent onto a provider the operator
+                    # kept out of agent work.
+                    continue
                 if candidate.model_id == current_resolved.model_id:
                     continue
                 if candidate.total_cost_per_1k >= current_resolved.total_cost_per_1k:
@@ -305,7 +314,7 @@ class _CostOptimizerRoutingMixin:
                 suggestions.append(
                     RoutingSuggestion(
                         agent_id=agent_id,
-                        current_model=most_used,
+                        current_model=most_used_model,
                         suggested_model=candidate.model_id,
                         current_cost_per_1k=round(
                             current_resolved.total_cost_per_1k,
@@ -316,7 +325,7 @@ class _CostOptimizerRoutingMixin:
                             BUDGET_ROUNDING_PRECISION,
                         ),
                         reason=(
-                            f"Switch from {most_used!r} "
+                            f"Switch from {most_used_model!r} "
                             f"({cur_fmt}/1k) to "
                             f"{candidate.model_id!r} "
                             f"({cand_fmt}/1k) "

--- a/src/synthorg/config/provider_schema.py
+++ b/src/synthorg/config/provider_schema.py
@@ -234,11 +234,13 @@ class ProviderConfig(BaseModel):
         description=(
             "Whether this provider may back an agent: its models are seeded "
             "onto agents at provisioning and picked by stakes routing. When "
-            "False the provider stays fully usable for explicitly-configured "
-            "feature calls (chat / judge / charter models the operator sets), "
-            "but no agent is ever assigned or routed to it. Lets an operator "
-            "keep a gateway available without any agent silently sourcing from "
-            "it."
+            "False the provider is excluded from new automatic seeding, stakes "
+            "routing, and provider-agnostic reselection, but stays fully usable "
+            "for explicitly-configured feature calls (chat / judge / charter "
+            "models the operator sets). It is NOT an immediate traffic cutover: "
+            "an agent already pinned to this provider keeps running on it (the "
+            "exclusive binding is honoured) until it is reassigned. Lets an "
+            "operator stop new agents sourcing from a gateway."
         ),
     )
 
@@ -307,14 +309,14 @@ class ProviderConfig(BaseModel):
 
     @model_validator(mode="after")
     def _validate_unique_model_identifiers(self) -> Self:
-        """Ensure model IDs and aliases are each unique.
+        """Ensure model IDs and aliases are each unique and non-overlapping.
 
         Returns:
             The validated model instance (``self``), unchanged.
 
         Raises:
-            ValueError: When two models share an id, or two models share
-                a non-null alias.
+            ValueError: When two models share an id, two models share a non-null
+                alias, or one model's alias equals a different model's id.
         """
         ids = [m.id for m in self.models]
         if len(ids) != len(set(ids)):
@@ -330,6 +332,25 @@ class ProviderConfig(BaseModel):
         if len(aliases) != len(set(aliases)):
             dupes = sorted(a for a, c in Counter(aliases).items() if c > 1)
             msg = f"Duplicate model aliases: {dupes}"
+            logger.warning(
+                CONFIG_VALIDATION_FAILED,
+                model="ProviderConfig",
+                error=msg,
+            )
+            raise ValueError(msg)
+        # A ref that is one model's alias AND another model's id is ambiguous:
+        # a provider-scoped resolve (resolve_for_pair) returns the first match
+        # by declaration order, which could silently bind an agent to the wrong
+        # model. The exclusive (provider, model) contract requires every ref to
+        # be unambiguous within a provider.
+        id_set = set(ids)
+        colliding = sorted(
+            m.alias
+            for m in self.models
+            if m.alias is not None and m.alias != m.id and m.alias in id_set
+        )
+        if colliding:
+            msg = f"Model aliases collide with another model's id: {colliding}"
             logger.warning(
                 CONFIG_VALIDATION_FAILED,
                 model="ProviderConfig",

--- a/src/synthorg/config/provider_schema.py
+++ b/src/synthorg/config/provider_schema.py
@@ -229,6 +229,18 @@ class ProviderConfig(BaseModel):
         default=None,
         description="Preset used to create this provider (if any)",
     )
+    agent_eligible: bool = Field(
+        default=True,
+        description=(
+            "Whether this provider may back an agent: its models are seeded "
+            "onto agents at provisioning and picked by stakes routing. When "
+            "False the provider stays fully usable for explicitly-configured "
+            "feature calls (chat / judge / charter models the operator sets), "
+            "but no agent is ever assigned or routed to it. Lets an operator "
+            "keep a gateway available without any agent silently sourcing from "
+            "it."
+        ),
+    )
 
     _AUTH_REQUIRED_FIELDS: ClassVar[dict[AuthType, tuple[str, ...]]] = {
         AuthType.OAUTH: (

--- a/src/synthorg/core/plan.py
+++ b/src/synthorg/core/plan.py
@@ -14,7 +14,7 @@ from uuid import UUID, uuid4
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, model_validator
 
-from synthorg.core.plan_enums import PlanItemKind, PlanStatus
+from synthorg.core.plan_enums import ITEMLESS_STATUSES, PlanItemKind, PlanStatus
 from synthorg.core.plan_review import PlanReview
 from synthorg.core.task_enums import (
     Complexity,
@@ -315,6 +315,11 @@ class Plan(BaseModel):
         default=PlanStatus.DRAFT,
         description="Plan lifecycle status",
     )
+    failure_reason: NotBlankStr | None = Field(
+        default=None,
+        description="Why decomposition failed, set when status is FAILED so the "
+        "review surface shows a visible reason instead of an empty plan",
+    )
     forecast_id: UUID | None = Field(
         default=None,
         description="Cost forecast released alongside the plan",
@@ -366,10 +371,16 @@ class Plan(BaseModel):
             dependency points to a known item, and the graph is acyclic.
 
         Raises:
-            ValueError: When ``items`` is empty, ids duplicate, a dependency
-                references an unknown item id, or the graph contains a cycle.
+            ValueError: When ``items`` is empty for a status that requires a
+                filled plan, ids duplicate, a dependency references an unknown
+                item id, or the graph contains a cycle.
         """
         if not self.items:
+            if self.status in ITEMLESS_STATUSES:
+                # A PLANNING shell (persisted at greenlight, not yet decomposed)
+                # or a FAILED plan (decomposition never produced items) carries
+                # no items yet; there is no DAG to validate.
+                return self
             msg = "a plan must contain at least one item"
             raise ValueError(msg)
         ids = [item.id for item in self.items]

--- a/src/synthorg/core/plan.py
+++ b/src/synthorg/core/plan.py
@@ -378,8 +378,8 @@ class Plan(BaseModel):
         if not self.items:
             if self.status in ITEMLESS_STATUSES:
                 # A PLANNING shell (persisted at greenlight, not yet decomposed)
-                # or a FAILED plan (decomposition never produced items) carries
-                # no items yet; there is no DAG to validate.
+                # or a FAILED plan (which may fail before any items were produced)
+                # is permitted to carry no items; there is no DAG to validate.
                 return self
             msg = "a plan must contain at least one item"
             raise ValueError(msg)
@@ -395,6 +395,36 @@ class Plan(BaseModel):
                 msg = f"plan item {item.id!r} references unknown items: {missing}"
                 raise ValueError(msg)
         self._reject_dependency_cycle()
+        return self
+
+    @model_validator(mode="after")
+    def _validate_failure_reason(self) -> Self:
+        """Tie ``failure_reason`` to the FAILED status, both directions.
+
+        A FAILED plan must carry a reason (so Plan Review always shows why it
+        failed), and only a FAILED plan may carry one (a reason on any live
+        status would be a stale leftover). The ``fail_plan`` compensation always
+        sets both together; this is the entity-level backstop for every other
+        caller of ``save``/``update``.
+
+        Returns:
+            ``self`` when ``failure_reason`` is present iff the status is FAILED.
+
+        Raises:
+            ValueError: When a FAILED plan has no reason, or a non-FAILED plan
+                carries one.
+        """
+        has_reason = self.failure_reason is not None
+        is_failed = self.status is PlanStatus.FAILED
+        if is_failed and not has_reason:
+            msg = "a FAILED plan must carry a failure_reason"
+            raise ValueError(msg)
+        if has_reason and not is_failed:
+            msg = (
+                f"failure_reason is only valid for a FAILED plan, "
+                f"not status={self.status.value}"
+            )
+            raise ValueError(msg)
         return self
 
     def _reject_dependency_cycle(self) -> None:

--- a/src/synthorg/core/plan_enums.py
+++ b/src/synthorg/core/plan_enums.py
@@ -8,33 +8,52 @@ from typing import Final
 class PlanStatus(StrEnum):
     """Lifecycle status of a decomposed plan through CEO review.
 
-    A plan is DRAFT while it is being shaped and PENDING_REVIEW once it is
-    parked for the operator's decision. APPROVED, REJECTED, and SUPERSEDED are
-    terminal: an operator rework or a request-changes is only accepted from a
-    non-terminal status (see :data:`REWORKABLE_STATUSES`). SUPERSEDED is
-    reserved for a plan retired by a fresh re-plan; the current edit path
-    revises a plan in place (bumping :attr:`Plan.version`) rather than
-    retaining prior revisions.
+    A plan is PLANNING while it is a persisted-at-greenlight shell whose items
+    the decomposer has not filled in yet, DRAFT while it is being shaped, and
+    PENDING_REVIEW once it is parked for the operator's decision. APPROVED,
+    REJECTED, SUPERSEDED, and FAILED are terminal: an operator rework or a
+    request-changes is only accepted from a non-terminal status (see
+    :data:`REWORKABLE_STATUSES`). FAILED marks a plan whose decomposition never
+    produced items (the shell failed to fill), so a failed run always leaves a
+    visible plan carrying its :attr:`Plan.failure_reason` rather than a silent
+    orphan; a retry is a fresh plan. SUPERSEDED is reserved for a plan retired
+    by a fresh re-plan; the current edit path revises a plan in place (bumping
+    :attr:`Plan.version`) rather than retaining prior revisions.
     """
 
+    PLANNING = "planning"
     DRAFT = "draft"
     PENDING_REVIEW = "pending_review"
     APPROVED = "approved"
     REJECTED = "rejected"
     SUPERSEDED = "superseded"
+    FAILED = "failed"
 
 
 #: Statuses from which an operator rework / request-changes is accepted. A
-#: terminal plan (APPROVED / REJECTED / SUPERSEDED) cannot be reworked back
-#: into an active status; edits on it are rejected with a conflict.
+#: transient PLANNING shell (no items yet) and every terminal plan (APPROVED /
+#: REJECTED / SUPERSEDED / FAILED) are excluded; edits on them are rejected
+#: with a conflict.
 REWORKABLE_STATUSES: Final[frozenset[PlanStatus]] = frozenset(
     {PlanStatus.DRAFT, PlanStatus.PENDING_REVIEW}
 )
 
-#: Terminal statuses: a decision has been recorded and the plan is closed to
-#: operator rework.
+#: Terminal statuses: a decision has been recorded (or the plan failed to
+#: decompose) and the plan is closed to operator rework.
 TERMINAL_STATUSES: Final[frozenset[PlanStatus]] = frozenset(
-    {PlanStatus.APPROVED, PlanStatus.REJECTED, PlanStatus.SUPERSEDED}
+    {
+        PlanStatus.APPROVED,
+        PlanStatus.REJECTED,
+        PlanStatus.SUPERSEDED,
+        PlanStatus.FAILED,
+    }
+)
+
+#: Statuses whose plan may carry an empty item list: the PLANNING shell has not
+#: been filled yet, and a FAILED plan's decomposition never produced items.
+#: Every other status must carry a non-empty, validated item DAG.
+ITEMLESS_STATUSES: Final[frozenset[PlanStatus]] = frozenset(
+    {PlanStatus.PLANNING, PlanStatus.FAILED}
 )
 
 

--- a/src/synthorg/core/plan_enums.py
+++ b/src/synthorg/core/plan_enums.py
@@ -13,10 +13,11 @@ class PlanStatus(StrEnum):
     PENDING_REVIEW once it is parked for the operator's decision. APPROVED,
     REJECTED, SUPERSEDED, and FAILED are terminal: an operator rework or a
     request-changes is only accepted from a non-terminal status (see
-    :data:`REWORKABLE_STATUSES`). FAILED marks a plan whose decomposition never
-    produced items (the shell failed to fill), so a failed run always leaves a
-    visible plan carrying its :attr:`Plan.failure_reason` rather than a silent
-    orphan; a retry is a fresh plan. SUPERSEDED is reserved for a plan retired
+    :data:`REWORKABLE_STATUSES`). FAILED marks a plan whose run failed to reach
+    review (decomposition failed, or parking the approval failed after it was
+    filled), so a failed run always leaves a visible plan carrying its
+    :attr:`Plan.failure_reason` rather than a silent orphan; a retry is a fresh
+    plan. SUPERSEDED is reserved for a plan retired
     by a fresh re-plan; the current edit path revises a plan in place (bumping
     :attr:`Plan.version`) rather than retaining prior revisions.
     """
@@ -50,8 +51,9 @@ TERMINAL_STATUSES: Final[frozenset[PlanStatus]] = frozenset(
 )
 
 #: Statuses whose plan may carry an empty item list: the PLANNING shell has not
-#: been filled yet, and a FAILED plan's decomposition never produced items.
-#: Every other status must carry a non-empty, validated item DAG.
+#: been filled yet, and a FAILED plan may have failed before any items were
+#: produced. FAILED permits (but does not require) empty items; every other
+#: status must carry a non-empty, validated item DAG.
 ITEMLESS_STATUSES: Final[frozenset[PlanStatus]] = frozenset(
     {PlanStatus.PLANNING, PlanStatus.FAILED}
 )

--- a/src/synthorg/core/task_transitions.py
+++ b/src/synthorg/core/task_transitions.py
@@ -5,7 +5,7 @@ the Engine design page, extended with BLOCKED, CANCELLED,
 FAILED, INTERRUPTED, SUSPENDED, REJECTED, AUTH_REQUIRED, and
 AWAITING_INPUT transitions for completeness::
 
-    CREATED -> ASSIGNED | REJECTED
+    CREATED -> ASSIGNED | REJECTED | FAILED
     ASSIGNED -> IN_PROGRESS | AUTH_REQUIRED | BLOCKED | CANCELLED
                | FAILED | INTERRUPTED | SUSPENDED
     IN_PROGRESS -> IN_REVIEW | AWAITING_INPUT | AUTH_REQUIRED | BLOCKED
@@ -36,7 +36,13 @@ from synthorg.observability.events.task import (
 )
 
 VALID_TRANSITIONS: dict[TaskStatus, frozenset[TaskStatus]] = {
-    TaskStatus.CREATED: frozenset({TaskStatus.ASSIGNED, TaskStatus.REJECTED}),
+    # CREATED -> FAILED: a greenlit objective's root task can fail during the
+    # planning phase (decomposition never produced a plan) before it is ever
+    # assigned; FAILED is re-runnable (-> ASSIGNED), so the failed run stays on
+    # the board and re-runnable rather than becoming a silent orphan.
+    TaskStatus.CREATED: frozenset(
+        {TaskStatus.ASSIGNED, TaskStatus.REJECTED, TaskStatus.FAILED}
+    ),
     TaskStatus.ASSIGNED: frozenset(
         {
             TaskStatus.IN_PROGRESS,

--- a/src/synthorg/engine/decomposition/llm.py
+++ b/src/synthorg/engine/decomposition/llm.py
@@ -15,6 +15,7 @@ from synthorg.budget.call_category import LLMCallCategory
 # must resolve at runtime when downstream tooling evaluates type hints
 # (DI containers, doc generators).
 from synthorg.budget.tracker_protocol import CostTrackerProtocol
+from synthorg.core.critical_errors import reraise_critical
 from synthorg.core.task import Task
 from synthorg.core.types import NotBlankStr
 from synthorg.engine.decomposition.llm_parse import (
@@ -186,20 +187,39 @@ class LlmDecompositionStrategy:
                 attempt=attempt,
             )
 
-            async with cost_recording_scope(
-                cost_tracker=self._cost_tracker,
-                agent_id=NotBlankStr("system"),
-                task_id=str(task.id),
-                # Per-task decomposition, not a system prompt class.
-                purpose=None,
-                call_category=LLMCallCategory.SYSTEM,
-            ):
-                response = await self._provider.complete(
-                    messages,
-                    self._model,
-                    tools=[tool_def],
-                    config=comp_config,
+            try:
+                async with cost_recording_scope(
+                    cost_tracker=self._cost_tracker,
+                    agent_id=NotBlankStr("system"),
+                    task_id=str(task.id),
+                    # Per-task decomposition, not a system prompt class.
+                    purpose=None,
+                    call_category=LLMCallCategory.SYSTEM,
+                ):
+                    response = await self._provider.complete(
+                        messages,
+                        self._model,
+                        tools=[tool_def],
+                        config=comp_config,
+                    )
+            except DecompositionError:
+                raise
+            except Exception as exc:
+                # A provider/infrastructure failure (network error, exhausted
+                # provider retries, malformed response) is not a semantic parse
+                # error the self-correction loop can fix by re-prompting. Surface
+                # it as a typed DecompositionError so decomposition always
+                # terminates inside the domain hierarchy rather than letting a raw
+                # provider exception escape to the caller.
+                reraise_critical(exc)
+                msg = f"LLM decomposition provider call failed for task {task.id!r}"
+                logger.warning(
+                    DECOMPOSITION_FAILED,
+                    task_id=str(task.id),
+                    error_type=type(exc).__name__,
+                    error=safe_error_description(exc),
                 )
+                raise DecompositionError(msg) from exc
             last_response = response
 
             logger.debug(

--- a/src/synthorg/engine/decomposition/plan_mapping.py
+++ b/src/synthorg/engine/decomposition/plan_mapping.py
@@ -136,6 +136,38 @@ def plan_from_decomposition(
     )
 
 
+def plan_shell(provenance: PlanProvenance) -> Plan:
+    """Build a durable ``Plan`` shell persisted at greenlight, before decomposition.
+
+    The shell carries the objective / project identity but no items yet: the
+    decomposer fills them in (via :func:`plan_from_decomposition`, moving the
+    plan to ``PENDING_REVIEW``), or a failed decomposition marks it ``FAILED``.
+    Persisting it up front makes every greenlit objective leave a first-class,
+    visible plan even when decomposition never completes, rather than a silent
+    orphan task.
+
+    Args:
+        provenance: The plan-level identity and timing to stamp; its ``status``
+            is normally :attr:`PlanStatus.PLANNING` for a shell.
+
+    Returns:
+        A validated :class:`Plan` with an empty item list (permitted for the
+        PLANNING / FAILED statuses).
+    """
+    return Plan(
+        project=provenance.project,
+        objective_id=provenance.objective_id,
+        objective_title=provenance.objective_title,
+        parent_task_id=provenance.parent_task_id,
+        items=(),
+        status=provenance.status,
+        forecast_id=provenance.forecast_id,
+        objective_criteria=provenance.objective_criteria,
+        created_at=provenance.created_at,
+        updated_at=provenance.created_at,
+    )
+
+
 def _subtask_from_item(item: PlanItem) -> SubtaskDefinition:
     """Project a durable plan item back onto a decomposition subtask.
 

--- a/src/synthorg/engine/pipeline/models.py
+++ b/src/synthorg/engine/pipeline/models.py
@@ -242,15 +242,26 @@ class PlanReviewHandoff(BaseModel):
     exact approved plan is dispatched (no re-decomposition).
 
     Attributes:
-        approval_id: The parked plan-approval item the human approves.
-        subtask_count: Number of subtasks in the decomposed plan.
-        detail: Human-readable summary of the plan awaiting approval.
+        approval_id: The parked plan-approval item the human approves, or
+            ``None`` when decomposition failed: the durable plan is marked
+            FAILED (and stays visible in Plan Review) but no approval is parked
+            because there is nothing to approve.
+        plan_id: The durable plan this handoff refers to (always set, whether
+            the plan was parked for approval or marked FAILED).
+        subtask_count: Number of subtasks in the decomposed plan (0 on failure).
+        detail: Human-readable summary of the plan (awaiting approval, or the
+            decomposition failure).
     """
 
     model_config = ConfigDict(frozen=True, allow_inf_nan=False, extra="forbid")
 
-    approval_id: NotBlankStr = Field(
-        description="The parked plan-approval item to approve",
+    approval_id: NotBlankStr | None = Field(
+        default=None,
+        description="The parked plan-approval item to approve, or None on a "
+        "failed decomposition (plan marked FAILED, nothing to approve)",
+    )
+    plan_id: NotBlankStr = Field(
+        description="The durable plan this handoff refers to",
     )
     subtask_count: int = Field(
         ge=0,

--- a/src/synthorg/engine/pipeline/plan_review_port.py
+++ b/src/synthorg/engine/pipeline/plan_review_port.py
@@ -72,11 +72,18 @@ class PlanReviewGate(Protocol):
         ...
 
     async def fail_plan(self, *, plan_id: UUID, reason: str) -> None:
-        """Mark the PLANNING shell FAILED when decomposition never completed.
+        """Mark the persisted plan FAILED on any plan-review failure.
+
+        Called for every failure in the plan-review sequence, not only an
+        unfilled ``PLANNING`` shell: a decomposition failure, but also a panel
+        failure or an approval-store write failure on an already-filled
+        ``PENDING_REVIEW`` plan (which is then FAILED with its items intact). A
+        plan already FAILED, or a missing shell, is a no-op.
 
         Args:
-            plan_id: The PLANNING shell returned by :meth:`open_plan`.
-            reason: A scrubbed description of why decomposition failed,
-                surfaced on the durable plan so the failure is visible.
+            plan_id: The plan (a ``PLANNING`` shell or an already-filled
+                ``PENDING_REVIEW`` plan) returned by :meth:`open_plan`.
+            reason: A scrubbed description of why the plan failed, surfaced on
+                the durable plan so the failure is visible in Plan Review.
         """
         ...

--- a/src/synthorg/engine/pipeline/plan_review_port.py
+++ b/src/synthorg/engine/pipeline/plan_review_port.py
@@ -13,6 +13,7 @@ exact approved plan is dispatched (no re-decomposition).
 """
 
 from typing import Protocol, runtime_checkable
+from uuid import UUID
 
 from synthorg.core.plan_review import PlanReview
 from synthorg.core.task import Task
@@ -22,19 +23,41 @@ from synthorg.engine.pipeline.models import PlanReviewHandoff, WorkItem
 
 @runtime_checkable
 class PlanReviewGate(Protocol):
-    """Parks a decomposed plan for human approval before a team builds."""
+    """Parks a decomposed plan for human approval before a team builds.
+
+    The plan is first-class from greenlight: :meth:`open_plan` persists a
+    PLANNING shell before decomposition runs, :meth:`request_plan_approval`
+    fills it and parks the approval on success, and :meth:`fail_plan` marks it
+    FAILED on a decomposition failure, so a failed run always leaves a visible
+    plan rather than a silent orphan.
+    """
+
+    async def open_plan(self, *, work_item: WorkItem, task: Task) -> UUID:
+        """Persist a PLANNING plan shell before decomposition runs.
+
+        Args:
+            work_item: The originating entry envelope.
+            task: The persisted parent (objective) task being planned.
+
+        Returns:
+            The id of the persisted PLANNING shell, threaded back into
+            :meth:`request_plan_approval` / :meth:`fail_plan`.
+        """
+        ...
 
     async def request_plan_approval(
         self,
         *,
+        plan_id: UUID,
         work_item: WorkItem,
         task: Task,
         plan: DecompositionResult,
         review: PlanReview | None = None,
     ) -> PlanReviewHandoff:
-        """Park *plan* for human approval instead of dispatching the team.
+        """Fill the shell with *plan* and park it for human approval.
 
         Args:
+            plan_id: The PLANNING shell returned by :meth:`open_plan` to fill.
             work_item: The originating entry envelope.
             task: The persisted parent task that was decomposed.
             plan: The decomposed subtask tree awaiting approval; the gate
@@ -45,5 +68,15 @@ class PlanReviewGate(Protocol):
         Returns:
             A :class:`PlanReviewHandoff` the caller surfaces so the human
             can approve the plan.
+        """
+        ...
+
+    async def fail_plan(self, *, plan_id: UUID, reason: str) -> None:
+        """Mark the PLANNING shell FAILED when decomposition never completed.
+
+        Args:
+            plan_id: The PLANNING shell returned by :meth:`open_plan`.
+            reason: A scrubbed description of why decomposition failed,
+                surfaced on the durable plan so the failure is visible.
         """
         ...

--- a/src/synthorg/engine/pipeline/service.py
+++ b/src/synthorg/engine/pipeline/service.py
@@ -965,6 +965,9 @@ class DefaultWorkPipeline:
                 reason=f"decomposition failed: {reason}",
             )
         except Exception as exc:  # noqa: BLE001 -- criticals re-raised
+            # lint-allow: swallow-ok -- best-effort FAILED transition; the run is
+            # already reported unsuccessful and the durable plan is FAILED, so a
+            # status-write hiccup must not mask the decomposition failure.
             reraise_critical(exc)
             logger.warning(
                 PIPELINE_PLAN_DECOMPOSITION_FAILED,
@@ -995,9 +998,10 @@ class DefaultWorkPipeline:
         try:
             return await panel.review(task=task, plan=plan, agents=agents, owner=owner)
         except Exception as exc:  # noqa: BLE001 -- criticals re-raised
-            # The plan is already decomposed; a panel failure (e.g. a provider
-            # error mid-review) must not fail the run or 500 the approve. Park
-            # the plan for human approval review-less rather than losing it.
+            # lint-allow: swallow-ok -- the plan is already decomposed; a panel
+            # failure (e.g. a provider error mid-review) must not fail the run or
+            # 500 the approve. Park the plan for human approval review-less
+            # rather than losing it.
             reraise_critical(exc)
             logger.warning(
                 PIPELINE_PLAN_REVIEW_PANEL_FAILED,

--- a/src/synthorg/engine/pipeline/service.py
+++ b/src/synthorg/engine/pipeline/service.py
@@ -12,6 +12,7 @@ the coordinator; the spine records the stage but never re-collects.
 
 from collections.abc import Awaitable
 from typing import TYPE_CHECKING, Final, NamedTuple, TypeVar
+from uuid import UUID
 
 from synthorg.client.models import ClientRequest, TaskRequirement
 from synthorg.core.agent import AgentIdentity
@@ -69,6 +70,7 @@ from synthorg.observability.events.pipeline import (
     PIPELINE_PHASE_COMPLETED,
     PIPELINE_PHASE_FAILED,
     PIPELINE_PLAN_DECOMPOSITION_FAILED,
+    PIPELINE_PLAN_FAIL_TRANSITION_FAILED,
     PIPELINE_PLAN_REVIEW_PANEL_ATTACHED,
     PIPELINE_PLAN_REVIEW_PANEL_FAILED,
     PIPELINE_PLAN_REVIEW_REQUESTED,
@@ -890,9 +892,11 @@ class DefaultWorkPipeline:
 
         Returns:
             The :class:`PlanReviewHandoff` the caller surfaces so the human
-            can approve the plan. On a decomposition failure the handoff carries
-            ``approval_id=None`` (the durable plan is marked FAILED and stays
-            visible in Plan Review); nothing is dispatched and no 500 escapes.
+            can approve the plan. If any step (decomposition, the panel, or
+            parking the approval) fails, the handoff carries ``approval_id=None``,
+            the durable plan is marked FAILED and stays visible in Plan Review,
+            the root task is marked FAILED, and nothing is dispatched: no 500
+            escapes and no orphan is left.
         """
         coordinator = self._coordinator
         gate = self._plan_review_gate
@@ -900,45 +904,32 @@ class DefaultWorkPipeline:
         assert gate is not None  # noqa: S101 -- guarded by _should_gate_plan
         # Persist the plan as a first-class shell at greenlight, so a failed
         # decomposition leaves a visible FAILED plan rather than an orphan task.
+        # Persist the plan as a first-class shell at greenlight, so a failure
+        # anywhere below leaves a visible FAILED plan rather than an orphan task.
         plan_id = await gate.open_plan(work_item=work_item, task=task)
         try:
             plan = await coordinator.plan_preview(
                 self._coordination_context(task, agents, owner)
             )
+            review = await self._phase(
+                phases,
+                _PHASE_REVIEW_PANEL,
+                self._run_review_panel(task, plan, agents, owner),
+            )
+            handoff = await gate.request_plan_approval(
+                plan_id=plan_id,
+                work_item=work_item,
+                task=task,
+                plan=plan,
+                review=review,
+            )
         except Exception as exc:  # noqa: BLE001 -- criticals re-raised
-            # lint-allow: swallow-ok -- not swallowed: a decomposition failure is
-            # surfaced as a FAILED plan + FAILED task + is_success=false result so
-            # the greenlit run never emits a 500 and never leaves a silent orphan.
+            # lint-allow: swallow-ok -- not swallowed: any failure across
+            # decomposition, the review panel, or parking the approval is
+            # surfaced as a FAILED plan + FAILED task + is_success=false result,
+            # so the greenlit run never emits a 500 nor leaves a silent orphan.
             reraise_critical(exc)
-            reason = safe_error_description(exc)
-            logger.warning(
-                PIPELINE_PLAN_DECOMPOSITION_FAILED,
-                correlation_id=work_item.correlation_id,
-                task_id=str(task.id),
-                plan_id=str(plan_id),
-                error_type=type(exc).__name__,
-                error=reason,
-            )
-            await gate.fail_plan(plan_id=plan_id, reason=reason)
-            await self._fail_task(task, work_item, reason=reason)
-            return PlanReviewHandoff(
-                approval_id=None,
-                plan_id=NotBlankStr(str(plan_id)),
-                subtask_count=0,
-                detail=NotBlankStr(f"Decomposition failed: {reason}"),
-            )
-        review = await self._phase(
-            phases,
-            _PHASE_REVIEW_PANEL,
-            self._run_review_panel(task, plan, agents, owner),
-        )
-        handoff = await gate.request_plan_approval(
-            plan_id=plan_id,
-            work_item=work_item,
-            task=task,
-            plan=plan,
-            review=review,
-        )
+            return await self._compensate_plan_failure(plan_id, task, work_item, exc)
         logger.info(
             PIPELINE_PLAN_REVIEW_REQUESTED,
             correlation_id=work_item.correlation_id,
@@ -948,21 +939,61 @@ class DefaultWorkPipeline:
         )
         return handoff
 
+    async def _compensate_plan_failure(
+        self,
+        plan_id: UUID,
+        task: Task,
+        work_item: WorkItem,
+        exc: Exception,
+    ) -> PlanReviewHandoff:
+        """Mark the plan + root task FAILED and return a failed handoff.
+
+        Shared by every failure in the plan-review sequence (decomposition, the
+        stakeholder panel, or parking the approval). Both compensating writes are
+        best-effort (``fail_plan`` / ``_fail_task`` never raise), so the greenlit
+        run always yields a visible FAILED plan instead of an orphan, and never a
+        500.
+
+        Returns:
+            A :class:`PlanReviewHandoff` with ``approval_id=None`` naming the
+            FAILED plan the operator can inspect and re-run.
+        """
+        gate = self._plan_review_gate
+        assert gate is not None  # noqa: S101 -- guarded by _should_gate_plan
+        reason = safe_error_description(exc)
+        logger.warning(
+            PIPELINE_PLAN_DECOMPOSITION_FAILED,
+            correlation_id=work_item.correlation_id,
+            task_id=str(task.id),
+            plan_id=str(plan_id),
+            error_type=type(exc).__name__,
+            error=reason,
+        )
+        await gate.fail_plan(plan_id=plan_id, reason=reason)
+        await self._fail_task(task, work_item, reason=reason)
+        return PlanReviewHandoff(
+            approval_id=None,
+            plan_id=NotBlankStr(str(plan_id)),
+            subtask_count=0,
+            detail=NotBlankStr(f"Plan preparation failed: {reason}"),
+        )
+
     async def _fail_task(self, task: Task, work_item: WorkItem, *, reason: str) -> None:
         """Transition the objective's root task to FAILED, best-effort.
 
-        A decomposition failure marks the root task FAILED so it surfaces on the
-        board and stays re-runnable. A transition hiccup is logged, not raised:
-        the run is already reported unsuccessful (final status FAILED) and the
-        durable plan is FAILED, so a failed status-write must not mask the
-        original decomposition failure or turn it into a 500.
+        A plan-review failure (decomposition, panel, or parking) marks the root
+        task FAILED so it surfaces on the board and stays re-runnable. A
+        transition hiccup is logged, not raised: the run is already reported
+        unsuccessful (final status FAILED) and the durable plan is FAILED, so a
+        failed status-write must not mask the original failure or turn it into a
+        500.
         """
         try:
             await self._task_engine.transition_task(
                 str(task.id),
                 TaskStatus.FAILED,
                 requested_by=work_item.requested_by,
-                reason=f"decomposition failed: {reason}",
+                reason=f"plan preparation failed: {reason}",
             )
         except Exception as exc:  # noqa: BLE001 -- criticals re-raised
             # lint-allow: swallow-ok -- best-effort FAILED transition; the run is
@@ -970,7 +1001,7 @@ class DefaultWorkPipeline:
             # status-write hiccup must not mask the decomposition failure.
             reraise_critical(exc)
             logger.warning(
-                PIPELINE_PLAN_DECOMPOSITION_FAILED,
+                PIPELINE_PLAN_FAIL_TRANSITION_FAILED,
                 correlation_id=work_item.correlation_id,
                 task_id=str(task.id),
                 note="failed to transition root task to FAILED",

--- a/src/synthorg/engine/pipeline/service.py
+++ b/src/synthorg/engine/pipeline/service.py
@@ -1020,19 +1020,20 @@ class DefaultWorkPipeline:
 
         Returns:
             The consolidated :class:`PlanReview`, or ``None`` when no panel is
-            attached or none could be seated (the plan is then parked for
-            approval with no panel review).
+            attached (the plan is then parked for approval with no panel review).
+
+        Raises:
+            Exception: A panel that errors mid-review propagates so the caller's
+                plan-review guard compensates it (FAILED plan + FAILED task),
+                rather than parking a plan whose holistic review silently never
+                ran. Only the "no panel attached" path returns ``None``.
         """
         panel = self._plan_review_panel
         if panel is None:
             return None
         try:
             return await panel.review(task=task, plan=plan, agents=agents, owner=owner)
-        except Exception as exc:  # noqa: BLE001 -- criticals re-raised
-            # lint-allow: swallow-ok -- the plan is already decomposed; a panel
-            # failure (e.g. a provider error mid-review) must not fail the run or
-            # 500 the approve. Park the plan for human approval review-less
-            # rather than losing it.
+        except Exception as exc:
             reraise_critical(exc)
             logger.warning(
                 PIPELINE_PLAN_REVIEW_PANEL_FAILED,
@@ -1040,7 +1041,7 @@ class DefaultWorkPipeline:
                 error_type=type(exc).__name__,
                 error=safe_error_description(exc),
             )
-            return None
+            raise
 
     async def _run_solo(
         self,

--- a/src/synthorg/engine/pipeline/service.py
+++ b/src/synthorg/engine/pipeline/service.py
@@ -902,8 +902,6 @@ class DefaultWorkPipeline:
         gate = self._plan_review_gate
         assert coordinator is not None  # noqa: S101 -- guarded by _should_gate_plan
         assert gate is not None  # noqa: S101 -- guarded by _should_gate_plan
-        # Persist the plan as a first-class shell at greenlight, so a failed
-        # decomposition leaves a visible FAILED plan rather than an orphan task.
         # Persist the plan as a first-class shell at greenlight, so a failure
         # anywhere below leaves a visible FAILED plan rather than an orphan task.
         plan_id = await gate.open_plan(work_item=work_item, task=task)

--- a/src/synthorg/engine/pipeline/service.py
+++ b/src/synthorg/engine/pipeline/service.py
@@ -22,6 +22,7 @@ from synthorg.core.persistence_errors import PersistenceVersionConflictError
 from synthorg.core.plan_review import PlanReview
 from synthorg.core.task import Task
 from synthorg.core.task_enums import TaskStatus
+from synthorg.core.types import NotBlankStr
 from synthorg.engine.assignment.service import TaskAssignmentService
 from synthorg.engine.coordination.models import CoordinationContext
 from synthorg.engine.coordination.service import MultiAgentCoordinator
@@ -67,7 +68,9 @@ from synthorg.observability.events.chief_of_staff import (
 from synthorg.observability.events.pipeline import (
     PIPELINE_PHASE_COMPLETED,
     PIPELINE_PHASE_FAILED,
+    PIPELINE_PLAN_DECOMPOSITION_FAILED,
     PIPELINE_PLAN_REVIEW_PANEL_ATTACHED,
+    PIPELINE_PLAN_REVIEW_PANEL_FAILED,
     PIPELINE_PLAN_REVIEW_REQUESTED,
     PIPELINE_PROJECT_LEAD_CONTENDED,
     PIPELINE_PROJECT_LEAD_ORPHANED,
@@ -420,17 +423,26 @@ class DefaultWorkPipeline:
                 ExecutionPath.REFINEMENT, task.status, refine_handoff, None
             )
         if self._should_gate_plan():
-            # Splittable team work under a human plan-approval gate: decompose
-            # into a plan, park it for approval, and stop. Nothing builds until
-            # the plan is approved, at which point the durable plan (with any
-            # operator edits) is rebuilt and dispatched.
+            # Splittable team work under a human plan-approval gate: persist a
+            # plan shell, decompose to fill it, park it for approval, and stop.
+            # Nothing builds until the plan is approved, at which point the
+            # durable plan (with any operator edits) is rebuilt and dispatched.
+            # A failed decomposition marks the shell FAILED (approval_id=None)
+            # and the run is reported as unsuccessful (final status FAILED)
+            # rather than raising a 500 -- the failure surfaces as a visible
+            # FAILED plan, not a silent orphan.
             plan_handoff = await self._phase(
                 phases,
                 _PHASE_PLAN_REVIEW,
                 self._plan_review(work_item, task, agents, phases, owner),
             )
+            final_status = (
+                task.status
+                if plan_handoff.approval_id is not None
+                else TaskStatus.FAILED
+            )
             return _ExecutionOutcome(
-                ExecutionPath.PLAN_REVIEW, task.status, None, plan_handoff
+                ExecutionPath.PLAN_REVIEW, final_status, None, plan_handoff
             )
         final_status = await self._phase(
             phases, _PHASE_TEAM, self._run_team(work_item, task, agents, owner)
@@ -878,21 +890,50 @@ class DefaultWorkPipeline:
 
         Returns:
             The :class:`PlanReviewHandoff` the caller surfaces so the human
-            can approve the plan.
+            can approve the plan. On a decomposition failure the handoff carries
+            ``approval_id=None`` (the durable plan is marked FAILED and stays
+            visible in Plan Review); nothing is dispatched and no 500 escapes.
         """
         coordinator = self._coordinator
         gate = self._plan_review_gate
         assert coordinator is not None  # noqa: S101 -- guarded by _should_gate_plan
         assert gate is not None  # noqa: S101 -- guarded by _should_gate_plan
-        plan = await coordinator.plan_preview(
-            self._coordination_context(task, agents, owner)
-        )
+        # Persist the plan as a first-class shell at greenlight, so a failed
+        # decomposition leaves a visible FAILED plan rather than an orphan task.
+        plan_id = await gate.open_plan(work_item=work_item, task=task)
+        try:
+            plan = await coordinator.plan_preview(
+                self._coordination_context(task, agents, owner)
+            )
+        except Exception as exc:  # noqa: BLE001 -- criticals re-raised
+            # lint-allow: swallow-ok -- not swallowed: a decomposition failure is
+            # surfaced as a FAILED plan + FAILED task + is_success=false result so
+            # the greenlit run never emits a 500 and never leaves a silent orphan.
+            reraise_critical(exc)
+            reason = safe_error_description(exc)
+            logger.warning(
+                PIPELINE_PLAN_DECOMPOSITION_FAILED,
+                correlation_id=work_item.correlation_id,
+                task_id=str(task.id),
+                plan_id=str(plan_id),
+                error_type=type(exc).__name__,
+                error=reason,
+            )
+            await gate.fail_plan(plan_id=plan_id, reason=reason)
+            await self._fail_task(task, work_item, reason=reason)
+            return PlanReviewHandoff(
+                approval_id=None,
+                plan_id=NotBlankStr(str(plan_id)),
+                subtask_count=0,
+                detail=NotBlankStr(f"Decomposition failed: {reason}"),
+            )
         review = await self._phase(
             phases,
             _PHASE_REVIEW_PANEL,
             self._run_review_panel(task, plan, agents, owner),
         )
         handoff = await gate.request_plan_approval(
+            plan_id=plan_id,
             work_item=work_item,
             task=task,
             plan=plan,
@@ -906,6 +947,33 @@ class DefaultWorkPipeline:
             subtask_count=handoff.subtask_count,
         )
         return handoff
+
+    async def _fail_task(self, task: Task, work_item: WorkItem, *, reason: str) -> None:
+        """Transition the objective's root task to FAILED, best-effort.
+
+        A decomposition failure marks the root task FAILED so it surfaces on the
+        board and stays re-runnable. A transition hiccup is logged, not raised:
+        the run is already reported unsuccessful (final status FAILED) and the
+        durable plan is FAILED, so a failed status-write must not mask the
+        original decomposition failure or turn it into a 500.
+        """
+        try:
+            await self._task_engine.transition_task(
+                str(task.id),
+                TaskStatus.FAILED,
+                requested_by=work_item.requested_by,
+                reason=f"decomposition failed: {reason}",
+            )
+        except Exception as exc:  # noqa: BLE001 -- criticals re-raised
+            reraise_critical(exc)
+            logger.warning(
+                PIPELINE_PLAN_DECOMPOSITION_FAILED,
+                correlation_id=work_item.correlation_id,
+                task_id=str(task.id),
+                note="failed to transition root task to FAILED",
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
 
     async def _run_review_panel(
         self,
@@ -924,7 +992,20 @@ class DefaultWorkPipeline:
         panel = self._plan_review_panel
         if panel is None:
             return None
-        return await panel.review(task=task, plan=plan, agents=agents, owner=owner)
+        try:
+            return await panel.review(task=task, plan=plan, agents=agents, owner=owner)
+        except Exception as exc:  # noqa: BLE001 -- criticals re-raised
+            # The plan is already decomposed; a panel failure (e.g. a provider
+            # error mid-review) must not fail the run or 500 the approve. Park
+            # the plan for human approval review-less rather than losing it.
+            reraise_critical(exc)
+            logger.warning(
+                PIPELINE_PLAN_REVIEW_PANEL_FAILED,
+                task_id=str(task.id),
+                error_type=type(exc).__name__,
+                error=safe_error_description(exc),
+            )
+            return None
 
     async def _run_solo(
         self,

--- a/src/synthorg/observability/events/pipeline.py
+++ b/src/synthorg/observability/events/pipeline.py
@@ -45,11 +45,22 @@ PIPELINE_TASK_MISSING: Final[str] = "pipeline.task.missing"
 PIPELINE_REFINEMENT_REQUESTED: Final[str] = "pipeline.refinement.requested"
 """Team-bound work lacked a definition of done; refinement was opened."""
 
+PIPELINE_PLAN_SHELL_OPENED: Final[str] = "pipeline.plan_review.shell_opened"
+"""A PLANNING plan shell was persisted at greenlight, before decomposition."""
+
 PIPELINE_PLAN_REVIEW_REQUESTED: Final[str] = "pipeline.plan_review.requested"
 """A decomposed plan was parked for human approval before team dispatch."""
 
+PIPELINE_PLAN_DECOMPOSITION_FAILED: Final[str] = (
+    "pipeline.plan_review.decomposition_failed"
+)
+"""Decomposition failed; the plan shell was marked FAILED and the task failed."""
+
 PIPELINE_PLAN_REVIEW_PANEL_ATTACHED: Final[str] = "pipeline.plan_review.panel_attached"
 """The stakeholder plan-review panel was attached to the work pipeline."""
+
+PIPELINE_PLAN_REVIEW_PANEL_FAILED: Final[str] = "pipeline.plan_review.panel_failed"
+"""The stakeholder panel errored; the plan is parked for approval review-less."""
 
 PIPELINE_ENTRY_UNKNOWN_SOURCE: Final[str] = "pipeline.entry.unknown_source"
 """No work-entry adapter is wired for the requested work source."""

--- a/src/synthorg/observability/events/pipeline.py
+++ b/src/synthorg/observability/events/pipeline.py
@@ -54,7 +54,26 @@ PIPELINE_PLAN_REVIEW_REQUESTED: Final[str] = "pipeline.plan_review.requested"
 PIPELINE_PLAN_DECOMPOSITION_FAILED: Final[str] = (
     "pipeline.plan_review.decomposition_failed"
 )
-"""Decomposition failed; the plan shell was marked FAILED and the task failed."""
+"""Decomposition (or plan parking) failed; the plan shell is being marked FAILED."""
+
+PIPELINE_PLAN_MARKED_FAILED: Final[str] = "pipeline.plan_review.marked_failed"
+"""A plan shell was successfully transitioned to FAILED, carrying its reason."""
+
+PIPELINE_PLAN_FAIL_SHELL_MISSING: Final[str] = "pipeline.plan_review.fail_shell_missing"
+"""fail_plan was asked to mark a plan FAILED but its shell was already gone."""
+
+PIPELINE_PLAN_FAIL_WRITE_FAILED: Final[str] = "pipeline.plan_review.fail_write_failed"
+"""The compensating write to mark a plan FAILED itself failed; logged, not raised."""
+
+PIPELINE_PLAN_FAIL_TRANSITION_FAILED: Final[str] = (
+    "pipeline.plan_review.fail_transition_failed"
+)
+"""The best-effort transition of the root task to FAILED could not be written."""
+
+PIPELINE_PLAN_APPROVAL_PARK_FAILED: Final[str] = (
+    "pipeline.plan_review.approval_park_failed"
+)
+"""Parking the plan's approval item failed; the plan is being marked FAILED."""
 
 PIPELINE_PLAN_REVIEW_PANEL_ATTACHED: Final[str] = "pipeline.plan_review.panel_attached"
 """The stakeholder plan-review panel was attached to the work pipeline."""

--- a/src/synthorg/observability/events/provider.py
+++ b/src/synthorg/observability/events/provider.py
@@ -49,6 +49,7 @@ PROVIDER_TOOL_CALL_ARGUMENTS_PARSE_FAILED: Final[str] = (
 )
 PROVIDER_TOOL_CALL_MISSING_FUNCTION: Final[str] = "provider.tool_call.missing_function"
 PROVIDER_FINISH_REASON_UNKNOWN: Final[str] = "provider.finish_reason.unknown"
+PROVIDER_EMPTY_COMPLETION: Final[str] = "provider.completion.empty"
 
 # ── Runtime tool-call failure feedback ───────────────────────
 PROVIDER_TOOL_CALL_FAILURE_OBSERVED: Final[str] = (

--- a/src/synthorg/persistence/postgres/plan_repo.py
+++ b/src/synthorg/persistence/postgres/plan_repo.py
@@ -41,9 +41,9 @@ _MAX_LIST_ROWS: Final[int] = 10_000
 
 _COLUMNS = (
     "id, project, objective_id, objective_title, parent_task_id, items, "
-    "task_structure, coordination_topology, status, forecast_id, review, "
-    "open_questions, assumptions, objective_criteria, version_history, version, "
-    "created_at, updated_at"
+    "task_structure, coordination_topology, status, failure_reason, forecast_id, "
+    "review, open_questions, assumptions, objective_criteria, version_history, "
+    "version, created_at, updated_at"
 )
 _COLUMN_NAMES = tuple(name.strip() for name in _COLUMNS.split(","))
 # Derive placeholders + SET clauses from the single column list so the arity can
@@ -113,6 +113,7 @@ class PostgresPlanRepository:
             plan.task_structure.value,
             plan.coordination_topology.value,
             plan.status.value,
+            plan.failure_reason,
             str(plan.forecast_id) if plan.forecast_id is not None else None,
             Jsonb(plan.review.model_dump(mode="json")) if plan.review else None,
             Jsonb(list(plan.open_questions)),

--- a/src/synthorg/persistence/postgres/revisions/20260717000000_plan_planning_failed_states.sql
+++ b/src/synthorg/persistence/postgres/revisions/20260717000000_plan_planning_failed_states.sql
@@ -6,8 +6,9 @@
 --   1. status CHECK gains 'planning' and 'failed'.
 --   2. the items CHECK permits an empty array for the itemless statuses
 --      ('planning' shell not yet filled, 'failed' never filled).
---   3. a nullable failure_reason column (non-blank when present) surfaces why a
---      FAILED plan failed on the review surface.
+--   3. a nullable failure_reason column (non-blank when present, and set iff the
+--      status is 'failed') surfaces why a FAILED plan failed on the review
+--      surface.
 
 ALTER TABLE plans DROP CONSTRAINT plans_items_check;
 ALTER TABLE plans
@@ -28,3 +29,10 @@ CHECK (status IN (
 ALTER TABLE plans
 ADD COLUMN failure_reason TEXT
 CHECK (failure_reason IS NULL OR CHAR_LENGTH(TRIM(failure_reason)) > 0);
+
+-- failure_reason is present iff the plan is FAILED: a FAILED plan must carry a
+-- reason (so Plan Review always shows why), and no other status may carry one.
+-- Mirrors the Plan model validator as the persistence-level backstop.
+ALTER TABLE plans
+ADD CONSTRAINT plans_failure_reason_status_check
+CHECK ((status = 'failed') = (failure_reason IS NOT NULL));

--- a/src/synthorg/persistence/postgres/revisions/20260717000000_plan_planning_failed_states.sql
+++ b/src/synthorg/persistence/postgres/revisions/20260717000000_plan_planning_failed_states.sql
@@ -1,0 +1,30 @@
+-- Plan first-class from greenlight: a PLANNING shell is persisted the moment an
+-- objective is greenlit (before decomposition fills its items), and a FAILED
+-- plan records a decomposition that never produced items, so a failed run
+-- always leaves a visible plan carrying failure_reason instead of a silent
+-- orphan. Postgres can alter the inline CHECKs in place (no table rebuild):
+--   1. status CHECK gains 'planning' and 'failed'.
+--   2. the items CHECK permits an empty array for the itemless statuses
+--      ('planning' shell not yet filled, 'failed' never filled).
+--   3. a nullable failure_reason column (non-blank when present) surfaces why a
+--      FAILED plan failed on the review surface.
+
+ALTER TABLE plans DROP CONSTRAINT plans_items_check;
+ALTER TABLE plans
+ADD CONSTRAINT plans_items_check
+CHECK (
+    JSONB_TYPEOF(items) = 'array'
+    AND (status IN ('planning', 'failed') OR JSONB_ARRAY_LENGTH(items) > 0)
+);
+
+ALTER TABLE plans DROP CONSTRAINT plans_status_check;
+ALTER TABLE plans
+ADD CONSTRAINT plans_status_check
+CHECK (status IN (
+    'planning', 'draft', 'pending_review', 'approved', 'rejected',
+    'superseded', 'failed'
+));
+
+ALTER TABLE plans
+ADD COLUMN failure_reason TEXT
+CHECK (failure_reason IS NULL OR CHAR_LENGTH(TRIM(failure_reason)) > 0);

--- a/src/synthorg/persistence/postgres/schema.sql
+++ b/src/synthorg/persistence/postgres/schema.sql
@@ -2446,11 +2446,17 @@ CREATE TABLE plans (
     CONSTRAINT plans_objective_title_check CHECK (CHAR_LENGTH(TRIM(objective_title)) > 0),
     parent_task_id TEXT NOT NULL CHECK (CHAR_LENGTH(TRIM(parent_task_id)) > 0),
     items JSONB NOT NULL
-    CHECK (JSONB_TYPEOF(items) = 'array' AND JSONB_ARRAY_LENGTH(items) > 0),
+    CONSTRAINT plans_items_check CHECK (
+        JSONB_TYPEOF(items) = 'array'
+        AND (status IN ('planning', 'failed') OR JSONB_ARRAY_LENGTH(items) > 0)
+    ),
     task_structure TEXT NOT NULL DEFAULT 'sequential',
     coordination_topology TEXT NOT NULL DEFAULT 'auto',
     status TEXT NOT NULL DEFAULT 'draft'
-    CHECK (status IN ('draft', 'pending_review', 'approved', 'rejected', 'superseded')),
+    CONSTRAINT plans_status_check CHECK (status IN (
+        'planning', 'draft', 'pending_review', 'approved', 'rejected',
+        'superseded', 'failed'
+    )),
     forecast_id TEXT,
     review JSONB,
     open_questions JSONB NOT NULL DEFAULT '[]'::JSONB,
@@ -2459,7 +2465,9 @@ CREATE TABLE plans (
     version_history JSONB NOT NULL DEFAULT '[]'::JSONB,
     version INTEGER NOT NULL DEFAULT 1 CHECK (version >= 1),
     created_at TIMESTAMPTZ NOT NULL,
-    updated_at TIMESTAMPTZ NOT NULL
+    updated_at TIMESTAMPTZ NOT NULL,
+    failure_reason TEXT
+    CHECK (failure_reason IS NULL OR CHAR_LENGTH(TRIM(failure_reason)) > 0)
 );
 CREATE INDEX idx_plans_status ON plans (status);
 CREATE INDEX idx_plans_project ON plans (project);

--- a/src/synthorg/persistence/postgres/schema.sql
+++ b/src/synthorg/persistence/postgres/schema.sql
@@ -2467,7 +2467,12 @@ CREATE TABLE plans (
     created_at TIMESTAMPTZ NOT NULL,
     updated_at TIMESTAMPTZ NOT NULL,
     failure_reason TEXT
-    CHECK (failure_reason IS NULL OR CHAR_LENGTH(TRIM(failure_reason)) > 0)
+    CHECK (failure_reason IS NULL OR CHAR_LENGTH(TRIM(failure_reason)) > 0),
+    -- failure_reason is present iff the plan is FAILED: a FAILED plan must carry
+    -- a reason (so Plan Review always shows why), and no other status may carry
+    -- one. Mirrors the Plan model validator as the persistence-level backstop.
+    CONSTRAINT plans_failure_reason_status_check
+    CHECK ((status = 'failed') = (failure_reason IS NOT NULL))
 );
 CREATE INDEX idx_plans_status ON plans (status);
 CREATE INDEX idx_plans_project ON plans (project);

--- a/src/synthorg/persistence/sqlite/plan_repo.py
+++ b/src/synthorg/persistence/sqlite/plan_repo.py
@@ -44,9 +44,9 @@ _MAX_LIST_ROWS: Final[int] = 10_000
 
 _COLUMNS = (
     "id, project, objective_id, objective_title, parent_task_id, items, "
-    "task_structure, coordination_topology, status, forecast_id, review, "
-    "open_questions, assumptions, objective_criteria, version_history, version, "
-    "created_at, updated_at"
+    "task_structure, coordination_topology, status, failure_reason, forecast_id, "
+    "review, open_questions, assumptions, objective_criteria, version_history, "
+    "version, created_at, updated_at"
 )
 
 _COLUMN_NAMES = tuple(_COLUMNS.split(", "))
@@ -124,6 +124,7 @@ class SQLitePlanRepository:
             plan.task_structure.value,
             plan.coordination_topology.value,
             plan.status.value,
+            plan.failure_reason,
             str(plan.forecast_id) if plan.forecast_id is not None else None,
             json.dumps(plan.review.model_dump(mode="json")) if plan.review else None,
             json.dumps(list(plan.open_questions)),

--- a/src/synthorg/persistence/sqlite/revisions/20260717000000_plan_planning_failed_states.sql
+++ b/src/synthorg/persistence/sqlite/revisions/20260717000000_plan_planning_failed_states.sql
@@ -7,8 +7,9 @@
 --   1. status CHECK gains 'planning' and 'failed'.
 --   2. the items CHECK permits an empty array for the itemless statuses
 --      ('planning' shell not yet filled, 'failed' never filled).
---   3. a nullable failure_reason column (non-blank when present) surfaces why a
---      FAILED plan failed on the review surface.
+--   3. a nullable failure_reason column (non-blank when present, and set iff the
+--      status is 'failed') surfaces why a FAILED plan failed on the review
+--      surface.
 
 CREATE TABLE plans_new (
     id TEXT NOT NULL PRIMARY KEY CHECK (LENGTH(TRIM(id)) > 0),
@@ -37,7 +38,11 @@ CREATE TABLE plans_new (
     version_history TEXT NOT NULL DEFAULT '[]',
     version INTEGER NOT NULL DEFAULT 1 CHECK (version >= 1),
     created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL
+    updated_at TEXT NOT NULL,
+    -- failure_reason is present iff the plan is FAILED: a FAILED plan must carry
+    -- a reason (so Plan Review always shows why), and no other status may carry
+    -- one. Mirrors the Plan model validator as the persistence-level backstop.
+    CHECK ((status = 'failed') = (failure_reason IS NOT NULL))
 );
 
 INSERT INTO plans_new (

--- a/src/synthorg/persistence/sqlite/revisions/20260717000000_plan_planning_failed_states.sql
+++ b/src/synthorg/persistence/sqlite/revisions/20260717000000_plan_planning_failed_states.sql
@@ -1,0 +1,77 @@
+-- Plan first-class from greenlight: a PLANNING shell is persisted the moment an
+-- objective is greenlit (before decomposition fills its items), and a FAILED
+-- plan records a decomposition that never produced items, so a failed run
+-- always leaves a visible plan carrying failure_reason instead of a silent
+-- orphan. This requires three changes to the plans table, all CHECK / column
+-- shape changes SQLite cannot ALTER in place, so the table is rebuilt:
+--   1. status CHECK gains 'planning' and 'failed'.
+--   2. the items CHECK permits an empty array for the itemless statuses
+--      ('planning' shell not yet filled, 'failed' never filled).
+--   3. a nullable failure_reason column (non-blank when present) surfaces why a
+--      FAILED plan failed on the review surface.
+
+CREATE TABLE plans_new (
+    id TEXT NOT NULL PRIMARY KEY CHECK (LENGTH(TRIM(id)) > 0),
+    project TEXT NOT NULL CHECK (LENGTH(TRIM(project)) > 0),
+    objective_id TEXT NOT NULL CHECK (LENGTH(TRIM(objective_id)) > 0),
+    objective_title TEXT NOT NULL CHECK (LENGTH(TRIM(objective_title)) > 0),
+    parent_task_id TEXT NOT NULL CHECK (LENGTH(TRIM(parent_task_id)) > 0),
+    items TEXT NOT NULL
+    CHECK (
+        JSON_VALID(items) AND JSON_TYPE(items) = 'array'
+        AND (status IN ('planning', 'failed') OR JSON_ARRAY_LENGTH(items) > 0)
+    ),
+    task_structure TEXT NOT NULL DEFAULT 'sequential',
+    coordination_topology TEXT NOT NULL DEFAULT 'auto',
+    status TEXT NOT NULL DEFAULT 'draft'
+    CHECK (status IN (
+        'planning', 'draft', 'pending_review', 'approved', 'rejected',
+        'superseded', 'failed'
+    )),
+    failure_reason TEXT CHECK (failure_reason IS NULL OR LENGTH(TRIM(failure_reason)) > 0),
+    forecast_id TEXT,
+    review TEXT,
+    open_questions TEXT NOT NULL DEFAULT '[]',
+    assumptions TEXT NOT NULL DEFAULT '[]',
+    objective_criteria TEXT NOT NULL DEFAULT '[]',
+    version_history TEXT NOT NULL DEFAULT '[]',
+    version INTEGER NOT NULL DEFAULT 1 CHECK (version >= 1),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+INSERT INTO plans_new (
+    id, project, objective_id, objective_title, parent_task_id, items,
+    task_structure, coordination_topology, status, failure_reason, forecast_id,
+    review, open_questions, assumptions, objective_criteria, version_history,
+    version, created_at, updated_at
+)
+SELECT
+    id,
+    project,
+    objective_id,
+    objective_title,
+    parent_task_id,
+    items,
+    task_structure,
+    coordination_topology,
+    status,
+    NULL AS failure_reason,
+    forecast_id,
+    review,
+    open_questions,
+    assumptions,
+    objective_criteria,
+    version_history,
+    version,
+    created_at,
+    updated_at
+FROM plans;
+
+DROP TABLE plans;
+ALTER TABLE plans_new RENAME TO plans;
+
+CREATE INDEX idx_plans_status ON plans (status);
+CREATE INDEX idx_plans_project ON plans (project);
+CREATE INDEX idx_plans_objective ON plans (objective_id);
+CREATE INDEX idx_plans_project_status ON plans (project, status, id);

--- a/src/synthorg/persistence/sqlite/schema.sql
+++ b/src/synthorg/persistence/sqlite/schema.sql
@@ -2572,7 +2572,11 @@ CREATE TABLE plans (
     version_history TEXT NOT NULL DEFAULT '[]',
     version INTEGER NOT NULL DEFAULT 1 CHECK (version >= 1),
     created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL
+    updated_at TEXT NOT NULL,
+    -- failure_reason is present iff the plan is FAILED: a FAILED plan must carry
+    -- a reason (so Plan Review always shows why), and no other status may carry
+    -- one. Mirrors the Plan model validator as the persistence-level backstop.
+    CHECK ((status = 'failed') = (failure_reason IS NOT NULL))
 );
 CREATE INDEX idx_plans_status ON plans (status);
 CREATE INDEX idx_plans_project ON plans (project);

--- a/src/synthorg/persistence/sqlite/schema.sql
+++ b/src/synthorg/persistence/sqlite/schema.sql
@@ -2552,11 +2552,18 @@ CREATE TABLE plans (
     objective_title TEXT NOT NULL CHECK (LENGTH(TRIM(objective_title)) > 0),
     parent_task_id TEXT NOT NULL CHECK (LENGTH(TRIM(parent_task_id)) > 0),
     items TEXT NOT NULL
-    CHECK (JSON_VALID(items) AND JSON_TYPE(items) = 'array' AND JSON_ARRAY_LENGTH(items) > 0),
+    CHECK (
+        JSON_VALID(items) AND JSON_TYPE(items) = 'array'
+        AND (status IN ('planning', 'failed') OR JSON_ARRAY_LENGTH(items) > 0)
+    ),
     task_structure TEXT NOT NULL DEFAULT 'sequential',
     coordination_topology TEXT NOT NULL DEFAULT 'auto',
     status TEXT NOT NULL DEFAULT 'draft'
-    CHECK (status IN ('draft', 'pending_review', 'approved', 'rejected', 'superseded')),
+    CHECK (status IN (
+        'planning', 'draft', 'pending_review', 'approved', 'rejected',
+        'superseded', 'failed'
+    )),
+    failure_reason TEXT CHECK (failure_reason IS NULL OR LENGTH(TRIM(failure_reason)) > 0),
     forecast_id TEXT,
     review TEXT,
     open_questions TEXT NOT NULL DEFAULT '[]',

--- a/src/synthorg/providers/_cost.py
+++ b/src/synthorg/providers/_cost.py
@@ -91,6 +91,31 @@ def compute_token_cost(
     )
 
 
+def token_usage_from_response_usage(
+    usage_obj: object,
+    *,
+    cost_per_1k_input: float,
+    cost_per_1k_output: float,
+) -> TokenUsage:
+    """Build a ``TokenUsage`` from a raw provider usage object.
+
+    Reads ``prompt_tokens`` / ``completion_tokens`` off *usage_obj* (an absent
+    or ``None`` attribute counts as 0), then delegates to
+    :func:`compute_token_cost`.
+
+    Returns:
+        A populated ``TokenUsage`` for the usage object's token counts.
+    """
+    input_tok = int(getattr(usage_obj, "prompt_tokens", 0) or 0)
+    output_tok = int(getattr(usage_obj, "completion_tokens", 0) or 0)
+    return compute_token_cost(
+        input_tok,
+        output_tok,
+        cost_per_1k_input=cost_per_1k_input,
+        cost_per_1k_output=cost_per_1k_output,
+    )
+
+
 def compute_image_cost(n: int, *, cost_per_image: float) -> TokenUsage:
     """Build a ``TokenUsage`` for a per-image-priced generation call.
 

--- a/src/synthorg/providers/drivers/litellm_driver.py
+++ b/src/synthorg/providers/drivers/litellm_driver.py
@@ -50,6 +50,7 @@ from pydantic import JsonValue
 
 from synthorg.config.provider_schema import ProviderConfig, ProviderModelConfig
 from synthorg.core.clock import Clock, SystemClock
+from synthorg.core.completion_enums import FinishReason
 from synthorg.core.critical_errors import reraise_critical
 from synthorg.integrations.connections.catalog import ConnectionCatalog
 from synthorg.observability import get_logger, safe_error_description
@@ -58,6 +59,7 @@ from synthorg.observability.events.provider import (
     PROVIDER_BATCH_CAPABILITIES_PARTIAL,
     PROVIDER_CALL_ERROR,
     PROVIDER_CONNECTION_ERROR,
+    PROVIDER_EMPTY_COMPLETION,
     PROVIDER_QUOTA_EXCEEDED,
     PROVIDER_RATE_LIMITED,
     PROVIDER_STREAM_CHUNK_NO_DELTA,
@@ -617,6 +619,30 @@ class LiteLLMDriver(ImageGenerationMixin, BaseCompletionProvider):
         finish = map_finish_reason(
             getattr(choice, "finish_reason", None),
         )
+
+        # A response with neither content nor a surviving tool call is not a
+        # usable completion. ``extract_tool_calls`` drops a malformed tool call
+        # (unparseable arguments), which can leave a TOOL_USE turn empty, and a
+        # provider can also return an empty STOP turn. ``CompletionResponse``
+        # rejects that shape unless the finish reason is already ERROR /
+        # CONTENT_FILTER, so building it here would raise a ValidationError out
+        # of the driver mid-call (surfacing as a 500 up the stack). Normalise
+        # to ERROR: the caller (the decomposition self-correction loop, the
+        # react loop) then receives a well-formed empty completion and applies
+        # its own graceful retry / fail-loud handling instead.
+        if (
+            content is None
+            and not tool_calls
+            and finish not in (FinishReason.CONTENT_FILTER, FinishReason.ERROR)
+        ):
+            logger.warning(
+                PROVIDER_EMPTY_COMPLETION,
+                provider=self._provider_name,
+                model=model_config.id,
+                finish_reason=finish.value,
+                had_raw_tool_calls=bool(raw_tc),
+            )
+            finish = FinishReason.ERROR
 
         usage_obj = getattr(response, "usage", None)
         input_tok = int(getattr(usage_obj, "prompt_tokens", 0) or 0)

--- a/src/synthorg/providers/drivers/litellm_driver.py
+++ b/src/synthorg/providers/drivers/litellm_driver.py
@@ -50,7 +50,6 @@ from pydantic import JsonValue
 
 from synthorg.config.provider_schema import ProviderConfig, ProviderModelConfig
 from synthorg.core.clock import Clock, SystemClock
-from synthorg.core.completion_enums import FinishReason
 from synthorg.core.critical_errors import reraise_critical
 from synthorg.integrations.connections.catalog import ConnectionCatalog
 from synthorg.observability import get_logger, safe_error_description
@@ -59,14 +58,13 @@ from synthorg.observability.events.provider import (
     PROVIDER_BATCH_CAPABILITIES_PARTIAL,
     PROVIDER_CALL_ERROR,
     PROVIDER_CONNECTION_ERROR,
-    PROVIDER_EMPTY_COMPLETION,
     PROVIDER_QUOTA_EXCEEDED,
     PROVIDER_RATE_LIMITED,
     PROVIDER_STREAM_CHUNK_NO_DELTA,
     PROVIDER_STREAM_DONE,
 )
 from synthorg.providers import errors
-from synthorg.providers._cost import compute_token_cost
+from synthorg.providers._cost import token_usage_from_response_usage
 from synthorg.providers.base import BaseCompletionProvider
 from synthorg.providers.capabilities import ModelCapabilities
 from synthorg.providers.drivers.litellm_auth import AuthContext, apply_auth_kwargs
@@ -109,6 +107,7 @@ from .mappers import (
     extract_tool_calls,
     map_finish_reason,
     messages_to_dicts,
+    normalize_empty_finish,
     tools_to_dicts,
 )
 
@@ -616,40 +615,17 @@ class LiteLLMDriver(ImageGenerationMixin, BaseCompletionProvider):
         content: str | None = getattr(message, "content", None)
         raw_tc = getattr(message, "tool_calls", None)
         tool_calls = extract_tool_calls(raw_tc)
-        finish = map_finish_reason(
-            getattr(choice, "finish_reason", None),
+        finish = normalize_empty_finish(
+            content=content,
+            tool_calls=tool_calls,
+            finish=map_finish_reason(getattr(choice, "finish_reason", None)),
+            provider=self._provider_name,
+            model=model_config.id,
+            had_raw_tool_calls=bool(raw_tc),
         )
 
-        # A response with neither content nor a surviving tool call is not a
-        # usable completion. ``extract_tool_calls`` drops a malformed tool call
-        # (unparseable arguments), which can leave a TOOL_USE turn empty, and a
-        # provider can also return an empty STOP turn. ``CompletionResponse``
-        # rejects that shape unless the finish reason is already ERROR /
-        # CONTENT_FILTER, so building it here would raise a ValidationError out
-        # of the driver mid-call (surfacing as a 500 up the stack). Normalise
-        # to ERROR: the caller (the decomposition self-correction loop, the
-        # react loop) then receives a well-formed empty completion and applies
-        # its own graceful retry / fail-loud handling instead.
-        if (
-            content is None
-            and not tool_calls
-            and finish not in (FinishReason.CONTENT_FILTER, FinishReason.ERROR)
-        ):
-            logger.warning(
-                PROVIDER_EMPTY_COMPLETION,
-                provider=self._provider_name,
-                model=model_config.id,
-                finish_reason=finish.value,
-                had_raw_tool_calls=bool(raw_tc),
-            )
-            finish = FinishReason.ERROR
-
-        usage_obj = getattr(response, "usage", None)
-        input_tok = int(getattr(usage_obj, "prompt_tokens", 0) or 0)
-        output_tok = int(getattr(usage_obj, "completion_tokens", 0) or 0)
-        usage = compute_token_cost(
-            input_tok,
-            output_tok,
+        usage = token_usage_from_response_usage(
+            getattr(response, "usage", None),
             cost_per_1k_input=model_config.cost_per_1k_input,
             cost_per_1k_output=model_config.cost_per_1k_output,
         )
@@ -773,11 +749,8 @@ class LiteLLMDriver(ImageGenerationMixin, BaseCompletionProvider):
         Returns:
             A ``StreamChunk`` carrying the token-usage event.
         """
-        input_tok = int(getattr(usage_obj, "prompt_tokens", 0) or 0)
-        output_tok = int(getattr(usage_obj, "completion_tokens", 0) or 0)
-        usage = compute_token_cost(
-            input_tok,
-            output_tok,
+        usage = token_usage_from_response_usage(
+            usage_obj,
             cost_per_1k_input=model_config.cost_per_1k_input,
             cost_per_1k_output=model_config.cost_per_1k_output,
         )

--- a/src/synthorg/providers/drivers/mappers.py
+++ b/src/synthorg/providers/drivers/mappers.py
@@ -19,6 +19,7 @@ from synthorg.core.resilience import (
 )
 from synthorg.observability import get_logger
 from synthorg.observability.events.provider import (
+    PROVIDER_EMPTY_COMPLETION,
     PROVIDER_FINISH_REASON_UNKNOWN,
     PROVIDER_RETRY_AFTER_PARSE_FAILED,
     PROVIDER_TOOL_CALL_ARGUMENTS_PARSE_FAILED,
@@ -209,6 +210,46 @@ def map_finish_reason(reason: str | None) -> FinishReason:
             )
         return FinishReason.ERROR
     return result
+
+
+def normalize_empty_finish(  # noqa: PLR0913 -- keyword-only completion fields
+    *,
+    content: str | None,
+    tool_calls: tuple[ToolCall, ...],
+    finish: FinishReason,
+    provider: str,
+    model: str,
+    had_raw_tool_calls: bool,
+) -> FinishReason:
+    """Force ``ERROR`` when a completion has neither content nor a tool call.
+
+    ``extract_tool_calls`` drops a malformed tool call (unparseable arguments),
+    which can leave a ``TOOL_USE`` turn empty, and a provider can also return an
+    empty ``STOP`` turn. ``CompletionResponse`` rejects that shape unless the
+    finish reason is already ``ERROR`` / ``CONTENT_FILTER``, so building it would
+    raise a ``ValidationError`` out of the driver mid-call (surfacing as a 500).
+    Normalising to ``ERROR`` lets the caller (the decomposition self-correction
+    loop, the react loop) receive a well-formed empty completion and apply its
+    own graceful retry / fail-loud handling instead.
+
+    Returns:
+        ``FinishReason.ERROR`` for an empty, non-error completion; otherwise the
+        original *finish* unchanged.
+    """
+    if (
+        content is None
+        and not tool_calls
+        and finish not in (FinishReason.CONTENT_FILTER, FinishReason.ERROR)
+    ):
+        logger.warning(
+            PROVIDER_EMPTY_COMPLETION,
+            provider=provider,
+            model=model,
+            finish_reason=finish.value,
+            had_raw_tool_calls=had_raw_tool_calls,
+        )
+        return FinishReason.ERROR
+    return finish
 
 
 def extract_tool_calls(raw: list[object] | None) -> tuple[ToolCall, ...]:

--- a/src/synthorg/providers/management/_config_transforms.py
+++ b/src/synthorg/providers/management/_config_transforms.py
@@ -105,6 +105,7 @@ def build_provider_config(
         custom_header_value=_unwrap_secret(request.custom_header_value),
         models=request.models,
         preset_name=request.preset_name,
+        agent_eligible=request.agent_eligible,
     )
 
 
@@ -174,6 +175,12 @@ def apply_update(
             updates[field] = (
                 _unwrap_secret(value) if field in _UPDATE_SECRET_FIELDS else value
             )
+
+    # ``agent_eligible`` is a non-nullable bool on the config, so it is handled
+    # apart from the generic clear-on-None loop: apply it only when the request
+    # carried a concrete True/False (``None`` means "not sent, no change").
+    if request.agent_eligible is not None:
+        updates["agent_eligible"] = request.agent_eligible
 
     # auth_type change: clear all fields NOT owned by the new auth type.
     # ``.get`` (not subscript) tolerates a non-AuthType value that slipped

--- a/src/synthorg/providers/management/_provider_mappers.py
+++ b/src/synthorg/providers/management/_provider_mappers.py
@@ -82,6 +82,7 @@ def to_provider_response(
         oauth_scope=config.oauth_scope,
         custom_header_name=config.custom_header_name,
         preset_name=config.preset_name,
+        agent_eligible=config.agent_eligible,
         supports_model_pull=local_preset.supports_model_pull if local_preset else False,
         supports_model_delete=local_preset.supports_model_delete
         if local_preset

--- a/src/synthorg/providers/management/_provider_requests.py
+++ b/src/synthorg/providers/management/_provider_requests.py
@@ -100,6 +100,13 @@ class CreateProviderRequest(BaseModel):
     custom_header_value: ValidatedCustomHeaderValue = None
     models: tuple[ProviderModelConfig, ...] = ()
     preset_name: NotBlankStr | None = None
+    agent_eligible: bool = Field(
+        default=True,
+        description="Whether this provider may back an agent (seeded onto "
+        "agents and picked by stakes routing). False keeps it usable for "
+        "explicitly-configured feature calls but excludes it from all agent "
+        "assignment.",
+    )
 
 
 class UpdateProviderRequest(BaseModel):
@@ -133,6 +140,7 @@ class UpdateProviderRequest(BaseModel):
     custom_header_name: NotBlankStr | None = None
     custom_header_value: ValidatedCustomHeaderValue = None
     models: tuple[ProviderModelConfig, ...] | None = None
+    agent_eligible: bool | None = None
 
     @model_validator(mode="after")
     def _validate_credential_clear_consistency(self) -> Self:

--- a/src/synthorg/providers/management/_provider_responses.py
+++ b/src/synthorg/providers/management/_provider_responses.py
@@ -250,6 +250,7 @@ class ProviderResponse(BaseModel):
     oauth_scope: NotBlankStr | None = None
     custom_header_name: NotBlankStr | None = None
     preset_name: NotBlankStr | None = None
+    agent_eligible: bool = True
     supports_model_pull: bool = False
     supports_model_delete: bool = False
     supports_model_config: bool = False

--- a/src/synthorg/providers/routing/models.py
+++ b/src/synthorg/providers/routing/models.py
@@ -35,6 +35,14 @@ class ResolvedModel(BaseModel):
         default=True,
         description="Whether the model may execute tool-bearing agentic work",
     )
+    agent_eligible: bool = Field(
+        default=True,
+        description=(
+            "Whether the owning provider may back an agent. False mirrors the "
+            "provider's ``agent_eligible=False``, so stakes routing and agent "
+            "seeding exclude the model while feature calls may still use it."
+        ),
+    )
     cost_per_1k_input: float = Field(
         default=0.0,
         ge=0.0,

--- a/src/synthorg/providers/routing/resolver.py
+++ b/src/synthorg/providers/routing/resolver.py
@@ -175,6 +175,7 @@ class ModelResolver:
                     estimated_latency_ms=model_config.estimated_latency_ms,
                     tier=tier,
                     tool_capable=is_tool_capable(model_config.metadata),
+                    agent_eligible=provider_config.agent_eligible,
                 )
                 for ref in (model_config.id, model_config.alias):
                     if ref is None:
@@ -313,6 +314,36 @@ class ModelResolver:
             )
             return None
 
+    def resolve_for_pair(self, provider_name: str, ref: str) -> ResolvedModel | None:
+        """Resolve a model ref scoped to one provider, without raising.
+
+        An agent binds an exclusive ``(provider, model)`` pair, so its own
+        model must always resolve to that provider rather than being
+        re-derived across providers by the cost / quota selector: with two
+        gateways serving an overlapping id, the bare-ref selector would pick
+        the alphabetically-first (or cheapest) provider and silently move the
+        agent off the provider it was assigned. Callers that hold the agent's
+        ``identity.model.provider`` resolve through here so the pair is honoured.
+
+        Args:
+            provider_name: The provider the agent's model is bound to.
+            ref: The model alias or id to resolve within that provider.
+
+        Returns:
+            The resolved model owned by *provider_name*, or ``None`` when that
+            provider serves no such ref (a config drift the caller handles).
+        """
+        for candidate in self._index.get(ref, ()):
+            if candidate.provider_name == provider_name:
+                return candidate
+        logger.debug(
+            ROUTING_MODEL_RESOLUTION_FAILED,
+            ref=ref,
+            provider=provider_name,
+            reason="ref_not_served_by_bound_provider",
+        )
+        return None
+
     def resolve_all(self, ref: str) -> tuple[ResolvedModel, ...]:
         """Return all provider variants for a model ref.
 
@@ -356,10 +387,13 @@ class ModelResolver:
         self,
         required: ModelTier,
     ) -> tuple[ResolvedModel, ...]:
-        """Return models whose assigned tier meets *required*, cheapest-first.
+        """Return agent-eligible models whose tier meets *required*, cheapest-first.
 
         A model with no assigned tier is excluded: stakes routing must not
-        gamble that an untiered model is strong enough for the requirement.
+        gamble that an untiered model is strong enough for the requirement. A
+        model whose provider is ``agent_eligible=False`` is excluded too, so
+        stakes routing never moves an agent onto a provider the operator kept
+        out of agent work (e.g. a gateway added for feature calls only).
 
         Returns:
             The qualifying models ordered by ascending total cost per 1k, so
@@ -368,7 +402,9 @@ class ModelResolver:
         qualifying = [
             m
             for m in self.all_models()
-            if m.tier is not None and model_tier_meets(m.tier, required)
+            if m.agent_eligible
+            and m.tier is not None
+            and model_tier_meets(m.tier, required)
         ]
         return tuple(sorted(qualifying, key=lambda m: m.total_cost_per_1k))
 

--- a/src/synthorg/providers/routing/selector.py
+++ b/src/synthorg/providers/routing/selector.py
@@ -60,14 +60,16 @@ class ModelCandidateSelector(Protocol):
 
 
 class QuotaAwareSelector:
-    """Prefer providers with available quota, then cheapest.
+    """Prefer providers with quota; within that pool, eligible then cheapest.
 
-    When quota information is available, candidates from providers
-    with remaining quota are preferred.  Among those (or among all
-    candidates when none have quota), the cheapest is returned.
+    Quota is the hard filter: candidates from providers with remaining
+    quota are preferred.  Within that pool (or among all candidates when
+    none have quota), the winner is chosen by ``_cost_key`` -- agent-eligible
+    first, then cheapest, then provider name -- so an ineligible provider is
+    only ever picked when it is the sole remaining candidate.
 
     With an empty quota map (the default), all providers are assumed
-    available and the selector degrades to cheapest-first.
+    available and the selector degrades to eligible-then-cheapest.
 
     The selector is immutable after construction -- reconstruct with
     a fresh quota snapshot to reflect updated quotas.
@@ -97,9 +99,9 @@ class QuotaAwareSelector:
             candidates: Non-empty tuple of resolved models.
 
         Returns:
-            Provider with available quota and lowest cost; if no
-            provider has quota, returns the globally cheapest
-            candidate.
+            The agent-eligible, lowest-cost provider that still has quota;
+            if no provider has quota, the eligible-then-cheapest candidate
+            overall.
 
         Raises:
             ModelResolutionError: If candidates is empty.
@@ -145,21 +147,23 @@ class QuotaAwareSelector:
 
 
 class CheapestSelector:
-    """Always pick the cheapest candidate regardless of quota.
+    """Pick the agent-eligible cheapest candidate, ignoring quota.
 
-    Stateless selector that ignores quota availability and selects
-    purely by ``total_cost_per_1k``.  Use when quota enforcement is
-    handled externally or when cost minimisation is the sole concern.
+    Stateless selector that ignores quota availability and selects by
+    ``_cost_key`` (agent-eligible first, then ``total_cost_per_1k``, then
+    provider name).  Use when quota enforcement is handled externally or
+    when cost minimisation is the sole concern.
     """
 
     def select(
         self,
         candidates: tuple[ResolvedModel, ...],
     ) -> ResolvedModel:
-        """Select the cheapest candidate by total cost per 1k tokens.
+        """Select the agent-eligible cheapest candidate.
 
         Returns:
-            The lowest-cost ``ResolvedModel`` from the candidates.
+            The eligible-then-lowest-cost ``ResolvedModel`` from the
+            candidates.
 
         Raises:
             ModelResolutionError: If the ``candidates`` tuple is empty.

--- a/src/synthorg/providers/routing/selector.py
+++ b/src/synthorg/providers/routing/selector.py
@@ -21,14 +21,19 @@ from .models import ResolvedModel
 logger = get_logger(__name__)
 
 
-def _cost_key(m: ResolvedModel) -> tuple[float, str]:
-    """Sort key: cheapest first, then provider name for stable tie-breaking.
+def _cost_key(m: ResolvedModel) -> tuple[bool, float, str]:
+    """Sort key: agent-eligible first, then cheapest, then provider name.
+
+    Eligibility leads the key so a provider kept out of agent work (e.g. a
+    gateway added for feature calls only) is never picked over an eligible
+    provider that serves the same model; it wins only when it is the sole
+    provider for the ref. Cost then provider name break the remaining ties.
 
     Returns:
-        A ``(total_cost_per_1k, provider_name)`` tuple usable as a sort
-        key (cheapest first, provider name breaking ties).
+        A ``(not agent_eligible, total_cost_per_1k, provider_name)`` tuple
+        usable as a sort key (eligible first, cheapest, then name).
     """
-    return (m.total_cost_per_1k, m.provider_name)
+    return (not m.agent_eligible, m.total_cost_per_1k, m.provider_name)
 
 
 @runtime_checkable

--- a/src/synthorg/templates/model_matcher.py
+++ b/src/synthorg/templates/model_matcher.py
@@ -57,6 +57,7 @@ class _ProviderWithModels(Protocol):
 
     models: tuple[ProviderModelConfig, ...]
     base_url: str | None
+    agent_eligible: bool
 
 
 class ModelMatch(BaseModel):
@@ -482,6 +483,11 @@ def _build_pool(
     owner: dict[int, str] = {}
     local_ids: set[int] = set()
     for pname, pcfg in providers.items():
+        # An agent-ineligible provider (e.g. a gateway kept for feature calls
+        # only) contributes no models to the seeding pool, so no agent is ever
+        # assigned one of its models at provisioning.
+        if not pcfg.agent_eligible:
+            continue
         provider_is_local = is_local_url(pcfg.base_url)
         for model in pcfg.models:
             pool.append(model)

--- a/tests/unit/api/test_plan_review_gate.py
+++ b/tests/unit/api/test_plan_review_gate.py
@@ -52,6 +52,15 @@ class _FailingApprovalStore(ApprovalStore):
         raise QueryError(msg)
 
 
+class _UpdateFailingPlanRepository(FakePlanRepository):
+    """Plan repo whose ``update`` always fails, to exercise the double-fault."""
+
+    @override
+    async def update(self, plan: Plan, *, expected_version: int | None = None) -> None:
+        msg = "update boom"
+        raise QueryError(msg)
+
+
 def _result_task(subtask_id: str) -> Task:
     return Task(
         id=as_uuid(subtask_id),
@@ -209,7 +218,60 @@ class TestPlanReviewApprovalGate:
         persisted = await plans.list_items()
         assert len(persisted) == 1
         assert persisted[0].status is PlanStatus.FAILED
-        assert persisted[0].failure_reason is not None
+        assert persisted[0].failure_reason == "approval-store write failed"
+
+    async def test_fail_plan_write_failure_is_swallowed_not_raised(self) -> None:
+        # The compensating FAILED write is the one on the failure path; if it
+        # itself fails, fail_plan must NOT raise (that would reintroduce the 500
+        # this whole change removes). The plan stays PLANNING and it is logged.
+        plans = _UpdateFailingPlanRepository()
+        gate = PlanReviewApprovalGate(
+            approval_store=ApprovalStore(),
+            plans=plans,
+            clock=FakeClock(),
+        )
+        task = _result_task("root")
+        plan_id = await gate.open_plan(work_item=_work_item(), task=task)
+
+        # No exception escapes.
+        await gate.fail_plan(plan_id=plan_id, reason="decompose boom")
+
+        shell = await plans.get(NotBlankStr(str(plan_id)))
+        assert shell is not None
+        assert shell.status is PlanStatus.PLANNING
+
+    async def test_fail_plan_is_idempotent_on_already_failed(self) -> None:
+        plans = FakePlanRepository()
+        gate = PlanReviewApprovalGate(
+            approval_store=ApprovalStore(),
+            plans=plans,
+            clock=FakeClock(),
+        )
+        task = _result_task("root")
+        plan_id = await gate.open_plan(work_item=_work_item(), task=task)
+
+        await gate.fail_plan(plan_id=plan_id, reason="first")
+        first = await plans.get(NotBlankStr(str(plan_id)))
+        # A second compensation (e.g. the outer pipeline guard after the
+        # approval-store path already failed it) is a no-op, not a re-write.
+        await gate.fail_plan(plan_id=plan_id, reason="second")
+        second = await plans.get(NotBlankStr(str(plan_id)))
+
+        assert first is not None
+        assert second is not None
+        assert second.version == first.version
+        assert second.failure_reason == "first"
+
+    async def test_fail_plan_missing_shell_is_noop(self) -> None:
+        plans = FakePlanRepository()
+        gate = PlanReviewApprovalGate(
+            approval_store=ApprovalStore(),
+            plans=plans,
+            clock=FakeClock(),
+        )
+        # No shell opened; fail_plan on an unknown id must not raise.
+        await gate.fail_plan(plan_id=as_uuid("ghost"), reason="boom")
+        assert await plans.list_items() == ()
 
 
 class TestWirePlanReviewGate:

--- a/tests/unit/api/test_plan_review_gate.py
+++ b/tests/unit/api/test_plan_review_gate.py
@@ -102,7 +102,25 @@ def _work_item() -> WorkItem:
 
 
 class TestPlanReviewApprovalGate:
-    async def test_persists_durable_plan_and_references_id(self) -> None:
+    async def test_open_plan_persists_planning_shell(self) -> None:
+        plans = FakePlanRepository()
+        gate = PlanReviewApprovalGate(
+            approval_store=ApprovalStore(),
+            plans=plans,
+            clock=FakeClock(),
+        )
+        task = _result_task("root")
+
+        plan_id = await gate.open_plan(work_item=_work_item(), task=task)
+
+        # A first-class plan exists at greenlight, PLANNING, with no items yet.
+        shell = await plans.get(NotBlankStr(str(plan_id)))
+        assert shell is not None
+        assert shell.status is PlanStatus.PLANNING
+        assert shell.items == ()
+        assert shell.parent_task_id == str(task.id)
+
+    async def test_fills_shell_and_references_id(self) -> None:
         store = ApprovalStore()
         plans = FakePlanRepository()
         gate = PlanReviewApprovalGate(
@@ -111,65 +129,87 @@ class TestPlanReviewApprovalGate:
             clock=FakeClock(),
         )
         task = _result_task("root")
+        work_item = _work_item()
 
+        plan_id = await gate.open_plan(work_item=work_item, task=task)
         handoff = await gate.request_plan_approval(
-            work_item=_work_item(),
+            plan_id=plan_id,
+            work_item=work_item,
             task=task,
             plan=_decomposition(),
         )
 
         assert handoff.subtask_count == 2
+        assert handoff.approval_id is not None
+        assert handoff.plan_id == str(plan_id)
 
+        # The shell was filled in place (same id), not re-created.
         persisted = await plans.list_items()
         assert len(persisted) == 1
         durable = persisted[0]
+        assert durable.id == plan_id
         assert durable.status is PlanStatus.PENDING_REVIEW
         assert durable.parent_task_id == str(task.id)
         assert len(durable.items) == 2
 
         parked = await store.list_items()
         assert len(parked) == 1
-        metadata = parked[0].metadata
-        assert metadata[PLAN_ID_METADATA_KEY] == str(durable.id)
+        assert parked[0].metadata[PLAN_ID_METADATA_KEY] == str(durable.id)
 
-    async def test_persistence_failure_parks_no_approval(self) -> None:
-        store = ApprovalStore()
+    async def test_fail_plan_marks_failed_with_reason(self) -> None:
+        plans = FakePlanRepository()
         gate = PlanReviewApprovalGate(
-            approval_store=store,
+            approval_store=ApprovalStore(),
+            plans=plans,
+            clock=FakeClock(),
+        )
+        task = _result_task("root")
+        plan_id = await gate.open_plan(work_item=_work_item(), task=task)
+
+        await gate.fail_plan(plan_id=plan_id, reason="decompose boom")
+
+        failed = await plans.get(NotBlankStr(str(plan_id)))
+        assert failed is not None
+        assert failed.status is PlanStatus.FAILED
+        assert failed.failure_reason == "decompose boom"
+        assert failed.items == ()
+
+    async def test_open_plan_persistence_failure_raises(self) -> None:
+        gate = PlanReviewApprovalGate(
+            approval_store=ApprovalStore(),
             plans=_FailingPlanRepository(),
             clock=FakeClock(),
         )
 
         with pytest.raises(QueryError):
-            await gate.request_plan_approval(
-                work_item=_work_item(),
-                task=_result_task("root"),
-                plan=_decomposition(),
-            )
+            await gate.open_plan(work_item=_work_item(), task=_result_task("root"))
 
-        # The plan is persisted before the approval is parked, so a persistence
-        # failure must leave no dangling approval behind.
-        assert await store.list_items() == ()
-
-    async def test_approval_write_failure_deletes_orphan_plan(self) -> None:
-        # The plan commits, then the approval write fails: without the approval
-        # there is no route to ever decide the plan, so the created plan must be
-        # compensated (deleted) rather than left as a permanent orphan.
+    async def test_approval_write_failure_marks_plan_failed(self) -> None:
+        # The plan is filled, then the approval write fails: rather than deleting
+        # the now-first-class plan, it is marked FAILED so the failure stays
+        # visible in Plan Review (a retry is a fresh run, not a resurrected plan).
         plans = FakePlanRepository()
         gate = PlanReviewApprovalGate(
             approval_store=_FailingApprovalStore(),
             plans=plans,
             clock=FakeClock(),
         )
+        task = _result_task("root")
+        work_item = _work_item()
+        plan_id = await gate.open_plan(work_item=work_item, task=task)
 
         with pytest.raises(QueryError):
             await gate.request_plan_approval(
-                work_item=_work_item(),
-                task=_result_task("root"),
+                plan_id=plan_id,
+                work_item=work_item,
+                task=task,
                 plan=_decomposition(),
             )
 
-        assert await plans.list_items() == ()
+        persisted = await plans.list_items()
+        assert len(persisted) == 1
+        assert persisted[0].status is PlanStatus.FAILED
+        assert persisted[0].failure_reason is not None
 
 
 class TestWirePlanReviewGate:

--- a/tests/unit/budget/test_enforcer.py
+++ b/tests/unit/budget/test_enforcer.py
@@ -113,11 +113,13 @@ def _resolved(
     model_id: str,
     provider: str = "test-provider",
     alias: str | None = None,
+    agent_eligible: bool = True,
 ) -> ResolvedModel:
     return ResolvedModel(
         provider_name=provider,
         model_id=model_id,
         alias=alias,
+        agent_eligible=agent_eligible,
     )
 
 
@@ -472,6 +474,54 @@ class TestResolveModel:
         assert result.model.model_id == "test-medium-001"
         assert result.model.provider == "test-provider"
         assert result.model.model_tier == "medium"
+
+    async def test_above_threshold_ineligible_target_unchanged(self) -> None:
+        """An agent-ineligible downgrade target is refused; model stays put."""
+        cfg = _make_budget_config(
+            auto_downgrade=AutoDowngradeConfig(
+                enabled=True,
+                threshold=85,
+                downgrade_map=(("large", "medium"),),
+            ),
+        )
+        tracker = CostTracker(budget_config=cfg)
+        await tracker.record(
+            make_cost_record(
+                cost=90.0,
+                input_tokens=100,
+                output_tokens=50,
+                timestamp=_RECORD_TS,
+            ),
+        )
+        resolver = _make_resolver(
+            {
+                "test-large-001": _resolved(
+                    model_id="test-large-001",
+                    alias="large",
+                ),
+                "large": _resolved(model_id="test-large-001", alias="large"),
+                # The downgrade target resolves only to an agent-ineligible
+                # provider (a feature-only gateway); the downgrade must be
+                # refused rather than move the agent onto it.
+                "medium": _resolved(
+                    model_id="test-medium-001",
+                    provider="test-gateway",
+                    alias="medium",
+                    agent_eligible=False,
+                ),
+            }
+        )
+        enforcer = BudgetEnforcer(
+            budget_config=cfg,
+            cost_tracker=tracker,
+            model_resolver=resolver,
+        )
+        identity = _make_identity(model_id="test-large-001")
+
+        with _patch_periods():
+            result = await enforcer.resolve_model(identity)
+
+        assert result.model.model_id == "test-large-001"
 
     async def test_above_threshold_no_matching_alias_unchanged(self) -> None:
         """Budget above threshold but no matching alias returns unchanged."""

--- a/tests/unit/budget/test_optimizer_decisions.py
+++ b/tests/unit/budget/test_optimizer_decisions.py
@@ -79,6 +79,83 @@ class TestRecommendDowngrades:
         assert rec.recommended_model == "test-small-001"
         assert rec.estimated_savings_per_1k > 0
 
+    async def test_mapped_target_stays_on_bound_provider(self) -> None:
+        """A mapped downgrade target resolves within the agent's bound provider.
+
+        When two providers serve the same downgrade-target alias, the mapped
+        target must resolve to the provider the agent is bound to, never the
+        globally-cheapest variant, so the exclusive ``(provider, model)`` pair
+        is preserved.
+        """
+        resolver = make_resolver(
+            [
+                ResolvedModel(
+                    provider_name="test-provider",
+                    model_id="test-large-001",
+                    alias="large",
+                    cost_per_1k_input=0.03,
+                    cost_per_1k_output=0.06,
+                ),
+                ResolvedModel(
+                    provider_name="test-provider",
+                    model_id="test-small-001",
+                    alias="small",
+                    cost_per_1k_input=0.005,
+                    cost_per_1k_output=0.005,
+                ),
+                ResolvedModel(
+                    provider_name="other-provider",
+                    model_id="other-small-001",
+                    alias="small",
+                    cost_per_1k_input=0.001,
+                    cost_per_1k_output=0.001,
+                ),
+            ]
+        )
+        bc = BudgetConfig(
+            total_monthly=100.0,
+            auto_downgrade=AutoDowngradeConfig(
+                enabled=True,
+                threshold=80,
+                downgrade_map=(("large", "small"),),
+            ),
+        )
+        tracker = CostTracker(budget_config=bc)
+        optimizer = CostOptimizer(
+            cost_tracker=tracker,
+            budget_config=bc,
+            model_resolver=resolver,
+        )
+
+        await tracker.record(
+            make_cost_record(
+                agent_id="alice",
+                provider="test-provider",
+                model="test-large-001",
+                cost=10.0,
+                input_tokens=1000,
+                output_tokens=0,
+                timestamp=OPT_START + timedelta(hours=1),
+            ),
+        )
+        # A cheap peer so alice reads as INEFFICIENT against the global average.
+        await tracker.record(
+            make_cost_record(
+                agent_id="bob",
+                provider="test-provider",
+                model="test-small-001",
+                cost=0.1,
+                input_tokens=1000,
+                output_tokens=0,
+                timestamp=OPT_START + timedelta(hours=1),
+            ),
+        )
+
+        result = await optimizer.recommend_downgrades(start=OPT_START, end=OPT_END)
+        alice_rec = next(r for r in result.recommendations if r.agent_id == "alice")
+        # Bound-provider variant, not the cheaper ``other-provider`` one.
+        assert alice_rec.recommended_model == "test-small-001"
+
     async def test_no_cheaper_model_empty(self) -> None:
         """No recommendation when agent already uses cheapest model."""
         resolver = make_resolver(

--- a/tests/unit/config/test_schema.py
+++ b/tests/unit/config/test_schema.py
@@ -142,6 +142,30 @@ class TestProviderConfig:
                 ),
             )
 
+    def test_alias_colliding_with_another_model_id_rejected(self) -> None:
+        # An alias that equals a DIFFERENT model's id makes a (provider, ref)
+        # binding ambiguous: resolve_for_pair would resolve it by declaration
+        # order. The exclusive (provider, model) contract requires it be rejected.
+        with pytest.raises(
+            ValidationError, match="aliases collide with another model's id"
+        ):
+            ProviderConfig(
+                auth_type=AuthType.NONE,
+                models=(
+                    ProviderModelConfig(id="m1"),
+                    ProviderModelConfig(id="m2", alias="m1"),
+                ),
+            )
+
+    def test_alias_equal_to_own_id_allowed(self) -> None:
+        # A model whose alias equals its OWN id is unambiguous (both refs point
+        # at the same model), so it is permitted.
+        config = ProviderConfig(
+            auth_type=AuthType.NONE,
+            models=(ProviderModelConfig(id="m1", alias="m1"),),
+        )
+        assert config.models[0].alias == "m1"
+
     def test_whitespace_connection_name_rejected(self) -> None:
         with pytest.raises(ValidationError, match="whitespace-only"):
             ProviderConfig(connection_name="   ")

--- a/tests/unit/core/test_plan.py
+++ b/tests/unit/core/test_plan.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 import pytest
 
 from synthorg.core.plan import Plan, PlanItem, PlanOption
-from synthorg.core.plan_enums import PlanItemKind
+from synthorg.core.plan_enums import PlanItemKind, PlanStatus
 from synthorg.core.types import NotBlankStr
 from tests._shared import as_uuid, sid
 
@@ -24,7 +24,12 @@ def _item(label: str, *, dependencies: tuple[str, ...] = ()) -> PlanItem:
     )
 
 
-def _plan(items: tuple[PlanItem, ...]) -> Plan:
+def _plan(
+    items: tuple[PlanItem, ...],
+    *,
+    status: PlanStatus = PlanStatus.DRAFT,
+    failure_reason: str | None = None,
+) -> Plan:
     return Plan(
         id=as_uuid("plan"),
         project=NotBlankStr("beachhead"),
@@ -32,6 +37,8 @@ def _plan(items: tuple[PlanItem, ...]) -> Plan:
         objective_title=NotBlankStr("Ship the game"),
         parent_task_id=NotBlankStr("root"),
         items=items,
+        status=status,
+        failure_reason=NotBlankStr(failure_reason) if failure_reason else None,
         created_at=_CREATED_AT,
         updated_at=_CREATED_AT,
     )
@@ -150,6 +157,44 @@ class TestDecisionItem:
 
     def test_resolved_option_is_none_for_work_item(self) -> None:
         assert _item("a").resolved_option() is None
+
+
+class TestPlanStatusInvariants:
+    """Itemless-status relaxation and the failure_reason cross-field invariant."""
+
+    def test_planning_shell_allows_empty_items(self) -> None:
+        plan = _plan((), status=PlanStatus.PLANNING)
+        assert plan.items == ()
+        assert plan.status is PlanStatus.PLANNING
+
+    def test_failed_allows_empty_items(self) -> None:
+        plan = _plan((), status=PlanStatus.FAILED, failure_reason="decompose boom")
+        assert plan.items == ()
+        assert plan.failure_reason == "decompose boom"
+
+    def test_failed_allows_filled_items(self) -> None:
+        # A plan can fail AFTER decomposition (a failed approval-park), keeping
+        # its items: FAILED permits, but does not require, empty items.
+        plan = _plan(
+            (_item("a"),), status=PlanStatus.FAILED, failure_reason="park boom"
+        )
+        assert len(plan.items) == 1
+
+    def test_approved_still_rejects_empty_items(self) -> None:
+        with pytest.raises(ValueError, match="at least one item"):
+            _plan((), status=PlanStatus.APPROVED)
+
+    def test_failed_requires_a_reason(self) -> None:
+        with pytest.raises(ValueError, match="must carry a failure_reason"):
+            _plan((), status=PlanStatus.FAILED)
+
+    def test_non_failed_plan_rejects_a_reason(self) -> None:
+        with pytest.raises(ValueError, match="only valid for a FAILED plan"):
+            _plan(
+                (_item("a"),),
+                status=PlanStatus.PENDING_REVIEW,
+                failure_reason="stale",
+            )
 
 
 class TestPlanInvariants:

--- a/tests/unit/core/test_task_transitions.py
+++ b/tests/unit/core/test_task_transitions.py
@@ -42,6 +42,9 @@ class TestValidTransitions:
             (TaskStatus.FAILED, TaskStatus.ASSIGNED),
             (TaskStatus.INTERRUPTED, TaskStatus.ASSIGNED),
             (TaskStatus.SUSPENDED, TaskStatus.ASSIGNED),
+            # A greenlit objective's root task can fail during planning,
+            # before it is ever assigned (decomposition / plan-review failure).
+            (TaskStatus.CREATED, TaskStatus.FAILED),
             # REJECTED and AUTH_REQUIRED transitions
             (TaskStatus.CREATED, TaskStatus.REJECTED),
             (TaskStatus.ASSIGNED, TaskStatus.AUTH_REQUIRED),

--- a/tests/unit/core/test_task_transitions.py
+++ b/tests/unit/core/test_task_transitions.py
@@ -262,10 +262,10 @@ class TestTransitionPath:
         )
 
     def test_created_to_failed_is_shortest(self) -> None:
-        # ASSIGNED can fail directly, so the shortest route skips
-        # IN_PROGRESS: CREATED -> ASSIGNED -> FAILED.
+        # CREATED can fail directly (a greenlit objective whose planning-phase
+        # decomposition never produced a plan), so the shortest route is a
+        # single hop CREATED -> FAILED.
         assert transition_path(TaskStatus.CREATED, TaskStatus.FAILED) == (
-            TaskStatus.ASSIGNED,
             TaskStatus.FAILED,
         )
 

--- a/tests/unit/engine/test_decomposition_llm.py
+++ b/tests/unit/engine/test_decomposition_llm.py
@@ -270,16 +270,24 @@ class TestLlmDecompositionStrategy:
             await strategy.decompose(task, ctx)
 
     @pytest.mark.unit
-    async def test_provider_error_propagates(self) -> None:
-        """Provider errors propagate without being caught."""
+    async def test_provider_error_surfaces_as_decomposition_error(self) -> None:
+        """A raw provider/infra failure is wrapped as a typed DecompositionError.
+
+        Decomposition must always terminate inside the domain error hierarchy so
+        the pipeline's plan-review guard can surface it as a FAILED plan rather
+        than an escaping exception (a 500). The non-DomainError raised by the
+        provider is chained as ``__cause__``.
+        """
         provider = MockCompletionProvider([])
         strategy = LlmDecompositionStrategy(provider=provider, model="test-model-001")
         task = _make_task()
         ctx = _make_context()
 
-        # MockCompletionProvider raises IndexError when empty
-        with pytest.raises(IndexError):
+        # MockCompletionProvider raises IndexError when empty; the strategy must
+        # translate that into a DecompositionError rather than let it escape.
+        with pytest.raises(DecompositionError) as exc_info:
             await strategy.decompose(task, ctx)
+        assert isinstance(exc_info.value.__cause__, IndexError)
 
     @pytest.mark.unit
     def test_protocol_conformance(self) -> None:

--- a/tests/unit/engine/test_pipeline_service.py
+++ b/tests/unit/engine/test_pipeline_service.py
@@ -5,7 +5,6 @@ from typing import cast
 from unittest.mock import AsyncMock
 
 import pytest
-from pydantic import ValidationError
 
 from synthorg.core.agent import AgentIdentity
 from synthorg.core.persistence_errors import PersistenceVersionConflictError
@@ -18,7 +17,7 @@ from synthorg.engine.decomposition.models import (
     DecompositionResult,
     SubtaskDefinition,
 )
-from synthorg.engine.errors import ProjectNotFoundError
+from synthorg.engine.errors import DecompositionError, ProjectNotFoundError
 from synthorg.engine.intake.engine import IntakeEngine
 from synthorg.engine.intake.models import IntakeResult
 from synthorg.engine.pipeline.errors import (
@@ -332,6 +331,7 @@ class TestPlanReviewGate:
             request_plan_approval=AsyncMock(
                 return_value=PlanReviewHandoff(
                     approval_id="appr-1",
+                    plan_id="plan-1",
                     subtask_count=3,
                     detail="3 subtasks awaiting approval",
                 )
@@ -349,6 +349,37 @@ class TestPlanReviewGate:
         # builds until the human approves the parked plan.
         coordinator.plan_preview.assert_awaited_once()
         coordinator.coordinate.assert_not_called()
+
+    async def test_decomposition_failure_marks_plan_failed_not_500(self) -> None:
+        # The Tetris dogfood regression: a decomposition failure must degrade to
+        # a visible FAILED plan + FAILED task + is_success=false, never a raw 500
+        # that leaves a project + orphan task behind with no plan.
+        coordinator = mock_of[MultiAgentCoordinator]()
+        coordinator.plan_preview.side_effect = DecompositionError("decompose boom")
+        pipeline, _ = _pipeline(
+            intake_result=IntakeResult.accepted_result(
+                request_id="corr-1", task_id="task-1"
+            ),
+            task=_task(),
+            project=_project(),
+            verdict=RoutingVerdict.SPLITTABLE,
+            coordinator=coordinator,
+            agents=(make_e2e_identity(),),
+        )
+        gate = mock_of[PlanReviewGate]()
+        pipeline.attach_plan_review_gate(gate)
+
+        result = await pipeline.run(_work_item(plan_required=True))
+
+        assert result.is_success is False
+        assert result.final_task_status is TaskStatus.FAILED
+        assert result.execution_path is ExecutionPath.PLAN_REVIEW
+        assert result.plan_review_handoff is not None
+        # No approval is parked: the shell is opened, then marked FAILED.
+        assert result.plan_review_handoff.approval_id is None
+        cast("AsyncMock", gate.open_plan).assert_awaited_once()
+        cast("AsyncMock", gate.fail_plan).assert_awaited_once()
+        cast("AsyncMock", gate.request_plan_approval).assert_not_awaited()
 
     async def test_splittable_dispatches_team_without_gate(self) -> None:
         coordinator = mock_of[MultiAgentCoordinator]()
@@ -399,6 +430,7 @@ class TestPlanRequired:
             request_plan_approval=AsyncMock(
                 return_value=PlanReviewHandoff(
                     approval_id="appr-1",
+                    plan_id="plan-1",
                     subtask_count=3,
                     detail="3 subtasks awaiting approval",
                 )
@@ -458,6 +490,7 @@ class TestOwnerStaffing:
             request_plan_approval=AsyncMock(
                 return_value=PlanReviewHandoff(
                     approval_id="appr-1",
+                    plan_id="plan-1",
                     subtask_count=2,
                     detail="2 subtasks awaiting approval",
                 )
@@ -499,6 +532,7 @@ class TestOwnerStaffing:
             request_plan_approval=AsyncMock(
                 return_value=PlanReviewHandoff(
                     approval_id="appr-1",
+                    plan_id="plan-1",
                     subtask_count=1,
                     detail="1 subtask awaiting approval",
                 )
@@ -534,6 +568,7 @@ class TestOwnerStaffing:
             request_plan_approval=AsyncMock(
                 return_value=PlanReviewHandoff(
                     approval_id="appr-1",
+                    plan_id="plan-1",
                     subtask_count=1,
                     detail="1 subtask awaiting approval",
                 )
@@ -566,6 +601,7 @@ class TestOwnerStaffing:
             request_plan_approval=AsyncMock(
                 return_value=PlanReviewHandoff(
                     approval_id="appr-1",
+                    plan_id="plan-1",
                     subtask_count=1,
                     detail="1 subtask awaiting approval",
                 )
@@ -574,11 +610,19 @@ class TestOwnerStaffing:
         pipeline.attach_plan_review_gate(gate)
 
         # With no agent to staff, owner resolution yields no lead (the
-        # roster-empty path); the run then fails downstream because a team
-        # plan needs at least one agent. The critical invariant is that no
-        # phantom lead is stamped on the way to that failure.
-        with pytest.raises(ValidationError):
-            await pipeline.run(_work_item(plan_required=True))
+        # roster-empty path); the run then fails gracefully because a team plan
+        # needs at least one agent. Rather than raising a 500, the plan shell is
+        # opened then marked FAILED and the run reports failure. The critical
+        # invariant is that no phantom lead is stamped on the way to that failure.
+        result = await pipeline.run(_work_item(plan_required=True))
+        assert result.is_success is False
+        assert result.final_task_status is TaskStatus.FAILED
+        assert result.execution_path is ExecutionPath.PLAN_REVIEW
+        assert result.plan_review_handoff is not None
+        assert result.plan_review_handoff.approval_id is None
+        cast("AsyncMock", gate.open_plan).assert_awaited_once()
+        cast("AsyncMock", gate.fail_plan).assert_awaited_once()
+        cast("AsyncMock", gate.request_plan_approval).assert_not_awaited()
         cast("AsyncMock", handles["project_repo"]).update.assert_not_awaited()
 
     async def test_concurrent_runs_stamp_a_single_lead(self) -> None:
@@ -626,6 +670,7 @@ class TestOwnerStaffing:
             request_plan_approval=AsyncMock(
                 return_value=PlanReviewHandoff(
                     approval_id="appr-1",
+                    plan_id="plan-1",
                     subtask_count=1,
                     detail="1 subtask awaiting approval",
                 )

--- a/tests/unit/engine/test_pipeline_service.py
+++ b/tests/unit/engine/test_pipeline_service.py
@@ -7,7 +7,10 @@ from unittest.mock import AsyncMock
 import pytest
 
 from synthorg.core.agent import AgentIdentity
-from synthorg.core.persistence_errors import PersistenceVersionConflictError
+from synthorg.core.persistence_errors import (
+    PersistenceVersionConflictError,
+    QueryError,
+)
 from synthorg.core.project import Project
 from synthorg.core.task import Task
 from synthorg.core.task_enums import Priority, TaskStatus, TaskType
@@ -379,7 +382,42 @@ class TestPlanReviewGate:
         assert result.plan_review_handoff.approval_id is None
         cast("AsyncMock", gate.open_plan).assert_awaited_once()
         cast("AsyncMock", gate.fail_plan).assert_awaited_once()
+        # The failure reason threads through to the durable plan so Plan Review
+        # shows WHY it failed, not just that it did.
+        fail_call = cast("AsyncMock", gate.fail_plan).await_args
+        assert fail_call is not None
+        assert "decompose boom" in fail_call.kwargs["reason"]
         cast("AsyncMock", gate.request_plan_approval).assert_not_awaited()
+
+    async def test_approval_park_failure_marks_plan_failed_not_500(self) -> None:
+        # A failure AFTER decomposition (parking the approval) is now also
+        # compensated by the pipeline guard: FAILED plan + FAILED task +
+        # is_success=false, never an escaping 500.
+        coordinator = mock_of[MultiAgentCoordinator]()
+        pipeline, _ = _pipeline(
+            intake_result=IntakeResult.accepted_result(
+                request_id="corr-1", task_id="task-1"
+            ),
+            task=_task(),
+            project=_project(),
+            verdict=RoutingVerdict.SPLITTABLE,
+            coordinator=coordinator,
+            agents=(make_e2e_identity(),),
+        )
+        gate = mock_of[PlanReviewGate]()
+        cast("AsyncMock", gate.request_plan_approval).side_effect = QueryError(
+            "park boom"
+        )
+        pipeline.attach_plan_review_gate(gate)
+
+        result = await pipeline.run(_work_item(plan_required=True))
+
+        assert result.is_success is False
+        assert result.final_task_status is TaskStatus.FAILED
+        assert result.plan_review_handoff is not None
+        assert result.plan_review_handoff.approval_id is None
+        cast("AsyncMock", gate.request_plan_approval).assert_awaited_once()
+        cast("AsyncMock", gate.fail_plan).assert_awaited_once()
 
     async def test_splittable_dispatches_team_without_gate(self) -> None:
         coordinator = mock_of[MultiAgentCoordinator]()

--- a/tests/unit/providers/drivers/test_mappers.py
+++ b/tests/unit/providers/drivers/test_mappers.py
@@ -12,6 +12,7 @@ from synthorg.providers.drivers.mappers import (
     extract_tool_calls,
     map_finish_reason,
     messages_to_dicts,
+    normalize_empty_finish,
     tools_to_dicts,
 )
 from synthorg.providers.enums import MessageRole
@@ -451,3 +452,88 @@ class TestExtractRetryAfter:
         future_naive = (now + timedelta(hours=1)).replace(tzinfo=None)
         result = parse_retry_after_seconds(format_datetime(future_naive), now=now)
         assert result == pytest.approx(3600.0)
+
+
+# ── normalize_empty_finish ───────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestNormalizeEmptyFinish:
+    """A content-less, tool-call-less completion is downgraded to ERROR.
+
+    ``CompletionResponse`` rejects an empty non-error completion with a
+    ``ValidationError`` (which would surface as a 500 mid-driver-call), so the
+    mapper normalises that shape to ``ERROR`` -- the codebase's fail-loud signal
+    every downstream loop already handles -- before the response is built.
+    """
+
+    def test_empty_stop_turn_becomes_error(self) -> None:
+        result = normalize_empty_finish(
+            content=None,
+            tool_calls=(),
+            finish=FinishReason.STOP,
+            provider="test-provider",
+            model="test-model-001",
+            had_raw_tool_calls=False,
+        )
+        assert result is FinishReason.ERROR
+
+    def test_empty_tool_use_turn_becomes_error(self) -> None:
+        # A malformed tool call that extract_tool_calls dropped leaves a
+        # TOOL_USE turn with no surviving tool calls: also unusable.
+        result = normalize_empty_finish(
+            content=None,
+            tool_calls=(),
+            finish=FinishReason.TOOL_USE,
+            provider="test-provider",
+            model="test-model-001",
+            had_raw_tool_calls=True,
+        )
+        assert result is FinishReason.ERROR
+
+    def test_content_present_is_unchanged(self) -> None:
+        result = normalize_empty_finish(
+            content="here is the answer",
+            tool_calls=(),
+            finish=FinishReason.STOP,
+            provider="test-provider",
+            model="test-model-001",
+            had_raw_tool_calls=False,
+        )
+        assert result is FinishReason.STOP
+
+    def test_surviving_tool_call_is_unchanged(self) -> None:
+        call = ToolCall(id="call-1", name="do_it", arguments={})
+        result = normalize_empty_finish(
+            content=None,
+            tool_calls=(call,),
+            finish=FinishReason.TOOL_USE,
+            provider="test-provider",
+            model="test-model-001",
+            had_raw_tool_calls=True,
+        )
+        assert result is FinishReason.TOOL_USE
+
+    def test_already_error_is_left_alone(self) -> None:
+        result = normalize_empty_finish(
+            content=None,
+            tool_calls=(),
+            finish=FinishReason.ERROR,
+            provider="test-provider",
+            model="test-model-001",
+            had_raw_tool_calls=False,
+        )
+        assert result is FinishReason.ERROR
+
+    def test_content_filter_is_left_alone(self) -> None:
+        # A content-filtered empty completion is a legitimate terminal shape
+        # CompletionResponse already accepts; do not mask it as ERROR.
+        result = normalize_empty_finish(
+            content=None,
+            tool_calls=(),
+            finish=FinishReason.CONTENT_FILTER,
+            provider="test-provider",
+            model="test-model-001",
+            had_raw_tool_calls=False,
+        )
+        assert result is FinishReason.CONTENT_FILTER

--- a/tests/unit/providers/routing/test_resolver_multi_provider.py
+++ b/tests/unit/providers/routing/test_resolver_multi_provider.py
@@ -380,6 +380,124 @@ class TestSelectorErrorWrapping:
         assert resolver.resolve_safe("shared") is None
 
 
+def _eligibility_config() -> dict[str, ProviderConfig]:
+    """Cheaper provider is agent-INELIGIBLE; the pricier one is eligible."""
+    return {
+        "test-eligible": ProviderConfig(
+            driver="litellm",
+            connection_name="conn-eligible",
+            agent_eligible=True,
+            models=(
+                ProviderModelConfig(
+                    id="test-shared-001",
+                    alias="shared",
+                    cost_per_1k_input=0.010,
+                    cost_per_1k_output=0.050,
+                ),
+            ),
+        ),
+        "test-gateway": ProviderConfig(
+            driver="litellm",
+            connection_name="conn-gateway",
+            agent_eligible=False,
+            models=(
+                ProviderModelConfig(
+                    id="test-shared-001",
+                    alias="shared",
+                    cost_per_1k_input=0.001,
+                    cost_per_1k_output=0.005,
+                ),
+            ),
+        ),
+    }
+
+
+# ── TestResolveForPair ───────────────────────────────────────────
+
+
+class TestResolveForPair:
+    """Provider-scoped resolution honours an agent's bound (provider, model)."""
+
+    def test_scopes_to_the_bound_provider_by_alias(self) -> None:
+        resolver = ModelResolver.from_config(_two_provider_config())
+        a = resolver.resolve_for_pair("test-provider-a", "shared")
+        b = resolver.resolve_for_pair("test-provider-b", "shared")
+        assert a is not None
+        assert a.provider_name == "test-provider-a"
+        assert b is not None
+        assert b.provider_name == "test-provider-b"
+
+    def test_scopes_to_the_bound_provider_by_model_id(self) -> None:
+        resolver = ModelResolver.from_config(_two_provider_config())
+        model = resolver.resolve_for_pair("test-provider-a", "test-shared-001")
+        assert model is not None
+        assert model.provider_name == "test-provider-a"
+        assert model.model_id == "test-shared-001"
+
+    def test_does_not_re_derive_across_providers(self) -> None:
+        # The bare-ref selector would pick the cheaper provider-b; the bound
+        # pair must stay on provider-a regardless of cost.
+        resolver = ModelResolver.from_config(_two_provider_config())
+        cheapest = resolver.resolve("shared")
+        pinned = resolver.resolve_for_pair("test-provider-a", "shared")
+        assert cheapest.provider_name == "test-provider-b"
+        assert pinned is not None
+        assert pinned.provider_name == "test-provider-a"
+
+    def test_unknown_provider_returns_none(self) -> None:
+        resolver = ModelResolver.from_config(_two_provider_config())
+        assert resolver.resolve_for_pair("no-such-provider", "shared") is None
+
+    def test_unknown_ref_returns_none(self) -> None:
+        resolver = ModelResolver.from_config(_two_provider_config())
+        assert resolver.resolve_for_pair("test-provider-a", "no-such-ref") is None
+
+    def test_explicit_pair_honoured_even_when_ineligible(self) -> None:
+        # agent_eligible governs auto-selection, not an explicit bound pair: an
+        # agent already bound to a (now-ineligible) provider still resolves.
+        resolver = ModelResolver.from_config(_eligibility_config())
+        pinned = resolver.resolve_for_pair("test-gateway", "shared")
+        assert pinned is not None
+        assert pinned.provider_name == "test-gateway"
+        assert pinned.agent_eligible is False
+
+
+# ── TestAgentEligibilitySelection ────────────────────────────────
+
+
+class TestAgentEligibilitySelection:
+    """Eligibility-first selection keeps agents off ineligible providers."""
+
+    def test_eligible_provider_beats_cheaper_ineligible(self) -> None:
+        # The cheaper provider is agent-ineligible; the default selector must
+        # still pick the pricier eligible one (never source an agent from a
+        # feature-only gateway when an eligible provider serves the model).
+        resolver = ModelResolver.from_config(_eligibility_config())
+        model = resolver.resolve("shared")
+        assert model.provider_name == "test-eligible"
+        assert model.agent_eligible is True
+
+    def test_ineligible_wins_only_as_sole_candidate(self) -> None:
+        config = {
+            "test-gateway": ProviderConfig(
+                driver="litellm",
+                connection_name="conn-gateway",
+                agent_eligible=False,
+                models=(
+                    ProviderModelConfig(
+                        id="test-shared-001",
+                        alias="shared",
+                        cost_per_1k_input=0.001,
+                        cost_per_1k_output=0.005,
+                    ),
+                ),
+            ),
+        }
+        resolver = ModelResolver.from_config(config)
+        model = resolver.resolve("shared")
+        assert model.provider_name == "test-gateway"
+
+
 # ── TestRouterSelectorPassthrough ────────────────────────────────
 
 

--- a/tests/unit/templates/test_model_matcher.py
+++ b/tests/unit/templates/test_model_matcher.py
@@ -402,6 +402,27 @@ class TestMatchAllAgents:
         assert matches[0].provider_name == "beta"
         assert matches[0].model_id == "beta-1"
 
+    def test_excludes_agent_ineligible_provider_from_the_pool(self) -> None:
+        # An agent-ineligible provider (e.g. a feature-only gateway) is kept out
+        # of the seeding pool: the matcher assigns the eligible provider's model
+        # even though the ineligible one would also match.
+        providers = {
+            "gateway": _Provider((_make_model("gateway-1"),), agent_eligible=False),
+            "eligible": _Provider((_make_model("eligible-1"),), agent_eligible=True),
+        }
+        matches = match_all_agents([{}], providers)
+        assert len(matches) == 1
+        assert matches[0].provider_name == "eligible"
+        assert matches[0].model_id == "eligible-1"
+
+    def test_all_providers_ineligible_omits_agent(self) -> None:
+        # With every provider ineligible for agents, the pool is empty and the
+        # agent is omitted (fail-closed) rather than sourced from a gateway.
+        providers = {
+            "gateway": _Provider((_make_model("gateway-1"),), agent_eligible=False),
+        }
+        assert match_all_agents([{}], providers) == []
+
     def test_no_models_anywhere_omits_agent(self) -> None:
         providers = {"prov": _provider()}
         matches = match_all_agents([{}], providers)

--- a/tests/unit/templates/test_model_matcher.py
+++ b/tests/unit/templates/test_model_matcher.py
@@ -63,10 +63,15 @@ class _Provider:
     """Minimal provider exposing a typed ``models`` tuple."""
 
     def __init__(
-        self, models: tuple[ProviderModelConfig, ...], base_url: str | None = None
+        self,
+        models: tuple[ProviderModelConfig, ...],
+        base_url: str | None = None,
+        *,
+        agent_eligible: bool = True,
     ) -> None:
         self.models = models
         self.base_url = base_url
+        self.agent_eligible = agent_eligible
 
 
 def _provider(*models: ProviderModelConfig) -> _Provider:

--- a/tests/unit/templates/test_model_matcher_tiering.py
+++ b/tests/unit/templates/test_model_matcher_tiering.py
@@ -51,10 +51,14 @@ def _model(  # noqa: PLR0913 -- keyword-only test factory
 
 class _Provider:
     def __init__(
-        self, *models: ProviderModelConfig, base_url: str | None = None
+        self,
+        *models: ProviderModelConfig,
+        base_url: str | None = None,
+        agent_eligible: bool = True,
     ) -> None:
         self.models = models
         self.base_url = base_url
+        self.agent_eligible = agent_eligible
 
 
 _ONE_B: int = 1_000_000_000

--- a/tests/unit/templates/test_ollama_cloud_runnable.py
+++ b/tests/unit/templates/test_ollama_cloud_runnable.py
@@ -26,10 +26,15 @@ class _Provider:
     """Minimal provider exposing a typed ``models`` tuple for the matcher."""
 
     def __init__(
-        self, models: tuple[ProviderModelConfig, ...], base_url: str | None = None
+        self,
+        models: tuple[ProviderModelConfig, ...],
+        base_url: str | None = None,
+        *,
+        agent_eligible: bool = True,
     ) -> None:
         self.models = models
         self.base_url = base_url
+        self.agent_eligible = agent_eligible
 
 
 @pytest.mark.unit

--- a/web/src/__tests__/helpers/factories.ts
+++ b/web/src/__tests__/helpers/factories.ts
@@ -358,6 +358,7 @@ export function makePlan(id: string, overrides?: Partial<Plan>): Plan {
     task_structure: 'sequential',
     coordination_topology: 'auto',
     status: 'pending_review',
+    failure_reason: null,
     forecast_id: null,
     review: null,
     open_questions: [],

--- a/web/src/__tests__/pages/PlanDetailPage.test.tsx
+++ b/web/src/__tests__/pages/PlanDetailPage.test.tsx
@@ -103,4 +103,40 @@ describe('PlanDetailPage', () => {
     ).not.toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Watch it run/ })).toBeInTheDocument()
   })
+
+  it('surfaces the failure banner with its reason for a FAILED plan', () => {
+    hookReturn = {
+      ...defaultHookReturn,
+      plan: makePlan('plan-1', {
+        status: 'failed',
+        failure_reason: 'DecompositionError: model returned no plan',
+        items: [],
+      }),
+    }
+    renderPage()
+    expect(screen.getByText('Decomposition failed')).toBeInTheDocument()
+    expect(
+      screen.getByText(/model returned no plan/),
+    ).toBeInTheDocument()
+    // A failed plan is terminal: no rework affordance.
+    expect(
+      screen.queryByRole('button', { name: /Rework items/ }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('falls back to default copy when a FAILED plan has no reason', () => {
+    hookReturn = {
+      ...defaultHookReturn,
+      plan: makePlan('plan-1', {
+        status: 'failed',
+        failure_reason: null,
+        items: [],
+      }),
+    }
+    renderPage()
+    expect(screen.getByText('Decomposition failed')).toBeInTheDocument()
+    expect(
+      screen.getByText(/could not prepare this objective/),
+    ).toBeInTheDocument()
+  })
 })

--- a/web/src/__tests__/pages/PlanDetailPage.test.tsx
+++ b/web/src/__tests__/pages/PlanDetailPage.test.tsx
@@ -114,7 +114,7 @@ describe('PlanDetailPage', () => {
       }),
     }
     renderPage()
-    expect(screen.getByText('Decomposition failed')).toBeInTheDocument()
+    expect(screen.getByText('Plan processing failed')).toBeInTheDocument()
     expect(
       screen.getByText(/model returned no plan/),
     ).toBeInTheDocument()
@@ -134,9 +134,9 @@ describe('PlanDetailPage', () => {
       }),
     }
     renderPage()
-    expect(screen.getByText('Decomposition failed')).toBeInTheDocument()
+    expect(screen.getByText('Plan processing failed')).toBeInTheDocument()
     expect(
-      screen.getByText(/could not prepare this objective/),
+      screen.getByText(/could not be completed/),
     ).toBeInTheDocument()
   })
 })

--- a/web/src/__tests__/pages/ProviderDetailPage.test.tsx
+++ b/web/src/__tests__/pages/ProviderDetailPage.test.tsx
@@ -65,6 +65,7 @@ function makeProvider(name: string): ProviderWithName {
     preset_name: null,
     supports_model_pull: false,
     supports_model_delete: false,
+    agent_eligible: true,
     supports_model_config: false,
   };
 }

--- a/web/src/__tests__/pages/ProvidersPage.test.tsx
+++ b/web/src/__tests__/pages/ProvidersPage.test.tsx
@@ -37,6 +37,7 @@ function makeProvider(name: string): ProviderWithName {
     preset_name: null,
     supports_model_pull: false,
     supports_model_delete: false,
+    agent_eligible: true,
     supports_model_config: false,
   }
 }

--- a/web/src/__tests__/stores/charter.test.ts
+++ b/web/src/__tests__/stores/charter.test.ts
@@ -125,6 +125,36 @@ describe('useCharterStore', () => {
     expect(useToastStore.getState().toasts[0]!.variant).toBe('success')
   })
 
+  it('approve surfaces an error toast when the run failed (is_success false)', async () => {
+    const charter = buildCharter({
+      id: 'c-1',
+      status: 'approved',
+      approved_by: 'op',
+      approved_at: '2026-05-22T00:00:00Z',
+      correlation_id: 'conv-1',
+      task_id: 'task-1',
+    })
+    const result: CharterApprovalResult = {
+      charter,
+      project_id: 'charter-c-1',
+      task_id: 'task-1',
+      is_success: false,
+    }
+    server.use(
+      http.post('/api/v1/meta/charters/:id/approve', () =>
+        HttpResponse.json(successFor<typeof approveCharterApi>(result)),
+      ),
+    )
+    // The charter was approved (a human decided) but the run produced no
+    // successful work: the store must surface that as an error, not a false
+    // success, so the operator opens Plan Review for the FAILED plan.
+    const out = await useCharterStore.getState().approve('c-1')
+    expect(out?.is_success).toBe(false)
+    const toast = useToastStore.getState().toasts[0]!
+    expect(toast.variant).toBe('error')
+    expect(toast.title).toMatch(/run failed/i)
+  })
+
   it('cancel transitions the draft to cancelled', async () => {
     const ok = await useCharterStore.getState().cancel('charter-default')
     expect(ok).toBe(true)

--- a/web/src/__tests__/stores/setup-wizard.test.ts
+++ b/web/src/__tests__/stores/setup-wizard.test.ts
@@ -990,6 +990,7 @@ describe('setup wizard store', () => {
           auth_type: 'none',
           base_url: 'http://localhost:8000',
           tos_accepted: false,
+          agent_eligible: true,
           models: [],
         })
 
@@ -1013,6 +1014,7 @@ describe('setup wizard store', () => {
           driver: 'litellm',
           auth_type: 'none',
           tos_accepted: false,
+          agent_eligible: true,
           models: [],
         })
 

--- a/web/src/__tests__/utils/providers.test.ts
+++ b/web/src/__tests__/utils/providers.test.ts
@@ -23,6 +23,7 @@ function makeConfig(overrides: Partial<ProviderConfig> = {}): ProviderConfig {
     driver: "litellm",
     litellm_provider: null,
     auth_type: "api_key",
+    agent_eligible: true,
     base_url: null,
     keep_alive: null,
     models: [],

--- a/web/src/__tests__/utils/setup-validation.property.test.ts
+++ b/web/src/__tests__/utils/setup-validation.property.test.ts
@@ -44,6 +44,7 @@ const makeProvider = (
   driver: "test-provider",
   litellm_provider: null,
   auth_type: "api_key",
+  agent_eligible: true,
   base_url: null,
   keep_alive: null,
   models: modelIds.map((id) => ({

--- a/web/src/__tests__/utils/setup-validation.test.ts
+++ b/web/src/__tests__/utils/setup-validation.test.ts
@@ -80,6 +80,7 @@ const makeProvider = (
   driver: "test-provider",
   litellm_provider: null,
   auth_type: "api_key",
+  agent_eligible: true,
   base_url: null,
   keep_alive: null,
   models: [makeModel()],

--- a/web/src/api/types/enum-values.gen.ts
+++ b/web/src/api/types/enum-values.gen.ts
@@ -655,11 +655,13 @@ export const PLAN_REVIEW_VERDICT_VALUES = [
 export type PlanReviewVerdict = (typeof PLAN_REVIEW_VERDICT_VALUES)[number]
 
 export const PLAN_STATUS_VALUES = [
+    'planning',
     'draft',
     'pending_review',
     'approved',
     'rejected',
     'superseded',
+    'failed',
 ] as const
 export type PlanStatus = (typeof PLAN_STATUS_VALUES)[number]
 

--- a/web/src/api/types/openapi.gen.ts
+++ b/web/src/api/types/openapi.gen.ts
@@ -9904,6 +9904,11 @@ export type components = {
         };
         /** CreateProviderRequest */
         readonly CreateProviderRequest: {
+            /**
+             * @description Whether this provider may back an agent (seeded onto agents and picked by stakes routing). False keeps it usable for explicitly-configured feature calls but excludes it from all agent assignment.
+             * @default true
+             */
+            readonly agent_eligible: boolean;
             /** @description API key credential (required for API_KEY auth). */
             readonly api_key?: string | null;
             readonly auth_type?: components["schemas"]["AuthType"];
@@ -13988,6 +13993,8 @@ export type components = {
              * @description datetime with the constraint that the value must have timezone info
              */
             readonly created_at: string;
+            /** @description Why decomposition failed, set when status is FAILED so the review surface shows a visible reason instead of an empty plan */
+            readonly failure_reason: string | null;
             /**
              * Format: uuid
              * @description Cost forecast released alongside the plan
@@ -14259,17 +14266,21 @@ export type components = {
          * PlanStatus
          * @description Lifecycle status of a decomposed plan through CEO review.
          *
-         *     A plan is DRAFT while it is being shaped and PENDING_REVIEW once it is
-         *     parked for the operator's decision. APPROVED, REJECTED, and SUPERSEDED are
-         *     terminal: an operator rework or a request-changes is only accepted from a
-         *     non-terminal status (see :data:`REWORKABLE_STATUSES`). SUPERSEDED is
-         *     reserved for a plan retired by a fresh re-plan; the current edit path
-         *     revises a plan in place (bumping :attr:`Plan.version`) rather than
-         *     retaining prior revisions.
+         *     A plan is PLANNING while it is a persisted-at-greenlight shell whose items
+         *     the decomposer has not filled in yet, DRAFT while it is being shaped, and
+         *     PENDING_REVIEW once it is parked for the operator's decision. APPROVED,
+         *     REJECTED, SUPERSEDED, and FAILED are terminal: an operator rework or a
+         *     request-changes is only accepted from a non-terminal status (see
+         *     :data:`REWORKABLE_STATUSES`). FAILED marks a plan whose decomposition never
+         *     produced items (the shell failed to fill), so a failed run always leaves a
+         *     visible plan carrying its :attr:`Plan.failure_reason` rather than a silent
+         *     orphan; a retry is a fresh plan. SUPERSEDED is reserved for a plan retired
+         *     by a fresh re-plan; the current edit path revises a plan in place (bumping
+         *     :attr:`Plan.version`) rather than retaining prior revisions.
          * @default draft
          * @enum {string}
          */
-        readonly PlanStatus: "draft" | "pending_review" | "approved" | "rejected" | "superseded";
+        readonly PlanStatus: "planning" | "draft" | "pending_review" | "approved" | "rejected" | "superseded" | "failed";
         /** PlanVersionSnapshot */
         readonly PlanVersionSnapshot: {
             /**
@@ -14927,6 +14938,8 @@ export type components = {
         };
         /** ProviderResponse */
         readonly ProviderResponse: {
+            /** @default true */
+            readonly agent_eligible: boolean;
             readonly auth_type: components["schemas"]["AuthType"];
             readonly base_url: string | null;
             readonly custom_header_name: string | null;
@@ -17804,6 +17817,7 @@ export type components = {
         };
         /** UpdateProviderRequest */
         readonly UpdateProviderRequest: {
+            readonly agent_eligible?: boolean | null;
             readonly api_key?: string | null;
             /** @enum {string|null} */
             readonly auth_type?: "api_key" | "oauth" | "custom_header" | "subscription" | "none" | null;

--- a/web/src/api/types/openapi.gen.ts
+++ b/web/src/api/types/openapi.gen.ts
@@ -14271,10 +14271,11 @@ export type components = {
          *     PENDING_REVIEW once it is parked for the operator's decision. APPROVED,
          *     REJECTED, SUPERSEDED, and FAILED are terminal: an operator rework or a
          *     request-changes is only accepted from a non-terminal status (see
-         *     :data:`REWORKABLE_STATUSES`). FAILED marks a plan whose decomposition never
-         *     produced items (the shell failed to fill), so a failed run always leaves a
-         *     visible plan carrying its :attr:`Plan.failure_reason` rather than a silent
-         *     orphan; a retry is a fresh plan. SUPERSEDED is reserved for a plan retired
+         *     :data:`REWORKABLE_STATUSES`). FAILED marks a plan whose run failed to reach
+         *     review (decomposition failed, or parking the approval failed after it was
+         *     filled), so a failed run always leaves a visible plan carrying its
+         *     :attr:`Plan.failure_reason` rather than a silent orphan; a retry is a fresh
+         *     plan. SUPERSEDED is reserved for a plan retired
          *     by a fresh re-plan; the current edit path revises a plan in place (bumping
          *     :attr:`Plan.version`) rather than retaining prior revisions.
          * @default draft

--- a/web/src/components/ui/plan-status-badge.stories.tsx
+++ b/web/src/components/ui/plan-status-badge.stories.tsx
@@ -13,6 +13,10 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
+export const Planning: Story = {
+  args: { status: 'planning' },
+}
+
 export const Draft: Story = {
   args: { status: 'draft' },
 }
@@ -33,17 +37,23 @@ export const Superseded: Story = {
   args: { status: 'superseded' },
 }
 
+export const Failed: Story = {
+  args: { status: 'failed' },
+}
+
 export const AllStatuses: Story = {
   args: { status: 'pending_review' },
   render: () => (
     <div className="flex flex-wrap gap-4">
       {(
         [
+          'planning',
           'draft',
           'pending_review',
           'approved',
           'rejected',
           'superseded',
+          'failed',
         ] satisfies PlanStatus[]
       ).map((s) => (
         <PlanStatusBadge key={s} status={s} />

--- a/web/src/components/ui/plan-status-badge.tsx
+++ b/web/src/components/ui/plan-status-badge.tsx
@@ -3,19 +3,23 @@ import type { PlanStatus } from '@/api/types'
 import { StatusPill, type StatusPillTone } from './status-pill'
 
 const STATUS_LABELS: Record<PlanStatus, string> = {
+  planning: 'Planning',
   draft: 'Draft',
   pending_review: 'Pending review',
   approved: 'Approved',
   rejected: 'Rejected',
   superseded: 'Superseded',
+  failed: 'Failed',
 }
 
 const STATUS_TONES: Record<PlanStatus, StatusPillTone> = {
+  planning: 'text-secondary',
   draft: 'text-secondary',
   pending_review: 'warning',
   approved: 'success',
   rejected: 'danger',
   superseded: 'text-secondary',
+  failed: 'danger',
 }
 
 export interface PlanStatusBadgeProps {

--- a/web/src/mocks/handlers/plans.ts
+++ b/web/src/mocks/handlers/plans.ts
@@ -42,6 +42,7 @@ function buildPlan(overrides: Partial<Plan> = {}): Plan {
     task_structure: 'sequential',
     coordination_topology: 'auto',
     status: 'pending_review',
+    failure_reason: null,
     forecast_id: null,
     review: null,
     open_questions: [],

--- a/web/src/mocks/handlers/providers/crud.ts
+++ b/web/src/mocks/handlers/providers/crud.ts
@@ -85,6 +85,7 @@ export function buildProvider(
     driver: 'litellm',
     litellm_provider: null,
     auth_type: 'api_key',
+    agent_eligible: true,
     base_url: null,
     keep_alive: null,
     models: [],

--- a/web/src/pages/PlanDetailPage.tsx
+++ b/web/src/pages/PlanDetailPage.tsx
@@ -120,16 +120,17 @@ function PlanReviewToolbar({ plan, onEdit, onRequestChanges }: {
   )
 }
 
-/** Visible failure notice for a FAILED plan (decomposition never completed). */
+/** Visible failure notice for a FAILED plan (a plan-review failure, which may
+ * be decomposition OR a later step such as parking the approval). */
 function PlanFailureBanner({ plan }: { plan: Plan }) {
   if (plan.status !== 'failed') return null
   return (
     <ErrorBanner
       severity="error"
-      title="Decomposition failed"
+      title="Plan processing failed"
       description={
         plan.failure_reason ??
-        'The planner could not prepare this objective for review. Start a new project run to try again.'
+        'This plan could not be completed. Start a new project run to try again.'
       }
     />
   )

--- a/web/src/pages/PlanDetailPage.tsx
+++ b/web/src/pages/PlanDetailPage.tsx
@@ -120,6 +120,21 @@ function PlanReviewToolbar({ plan, onEdit, onRequestChanges }: {
   )
 }
 
+/** Visible failure notice for a FAILED plan (decomposition never completed). */
+function PlanFailureBanner({ plan }: { plan: Plan }) {
+  if (plan.status !== 'failed') return null
+  return (
+    <ErrorBanner
+      severity="error"
+      title="Decomposition failed"
+      description={
+        plan.failure_reason ??
+        'The planner could not decompose this objective. Re-run it to try again.'
+      }
+    />
+  )
+}
+
 function PlanReviewView({ plan, setMode }: { plan: Plan; setMode: (mode: Mode) => void }) {
   const criticalPath = useMemo(
     () => criticalPathFor(plan.items, plan.task_structure),
@@ -173,6 +188,7 @@ function PlanReviewView({ plan, setMode }: { plan: Plan; setMode: (mode: Mode) =
         onEdit={() => setMode('edit')}
         onRequestChanges={() => setMode('request-changes')}
       />
+      <PlanFailureBanner plan={plan} />
       <PlanMetricsHeader stats={stats} taskStructure={plan.task_structure} />
       <PlanOpenQuestionsPanel plan={plan} />
       <PlanAttentionPanel items={plan.items} criticalPath={criticalPath} />

--- a/web/src/pages/PlanDetailPage.tsx
+++ b/web/src/pages/PlanDetailPage.tsx
@@ -129,7 +129,7 @@ function PlanFailureBanner({ plan }: { plan: Plan }) {
       title="Decomposition failed"
       description={
         plan.failure_reason ??
-        'The planner could not decompose this objective. Re-run it to try again.'
+        'The planner could not prepare this objective for review. Start a new project run to try again.'
       }
     />
   )

--- a/web/src/pages/PlansPage.tsx
+++ b/web/src/pages/PlansPage.tsx
@@ -13,13 +13,16 @@ import { usePlansData } from '@/hooks/usePlansData'
 import { PlanListItem } from './plans/PlanListItem'
 import { PlansSkeleton } from './plans/PlansSkeleton'
 
-// Plans awaiting a decision surface first; then the rest by recency.
+// Plans awaiting a decision surface first, then failed plans (which need the
+// operator's attention / a re-run), then in-flight and decided plans by recency.
 const STATUS_ORDER: Record<PlanStatus, number> = {
   pending_review: 0,
-  draft: 1,
-  approved: 2,
-  rejected: 3,
-  superseded: 4,
+  failed: 1,
+  planning: 2,
+  draft: 3,
+  approved: 4,
+  rejected: 5,
+  superseded: 6,
 }
 
 function sortForReview(plans: readonly Plan[]): readonly Plan[] {

--- a/web/src/pages/providers/AddManualModelDialog.stories.tsx
+++ b/web/src/pages/providers/AddManualModelDialog.stories.tsx
@@ -33,6 +33,7 @@ const meta = {
           preset_name: null,
           supports_model_pull: false,
           supports_model_delete: false,
+          agent_eligible: true,
           supports_model_config: false,
         }),
       })

--- a/web/src/pages/providers/CredentialsRotateDialog.stories.tsx
+++ b/web/src/pages/providers/CredentialsRotateDialog.stories.tsx
@@ -23,6 +23,7 @@ const apiKeyProvider: ProviderConfig = {
   preset_name: 'cloud-test',
   supports_model_pull: false,
   supports_model_delete: false,
+  agent_eligible: true,
   supports_model_config: false,
 }
 

--- a/web/src/pages/providers/ProviderCard.stories.tsx
+++ b/web/src/pages/providers/ProviderCard.stories.tsx
@@ -76,6 +76,7 @@ const baseProvider: ProviderWithName = {
   preset_name: null,
   supports_model_pull: false,
   supports_model_delete: false,
+  agent_eligible: true,
   supports_model_config: false,
 };
 

--- a/web/src/pages/providers/ProviderCard.tsx
+++ b/web/src/pages/providers/ProviderCard.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react'
 import { ProviderHealthBadge } from '@/components/ui/provider-health-badge'
+import { StatusPill } from '@/components/ui/status-pill'
 import { ProviderLogo } from '@/components/providers/ProviderLogo'
 import { providerLogoName } from '@/components/providers/provider-logos'
 import { cn } from '@/lib/utils'
@@ -11,6 +12,43 @@ interface ProviderCardProps {
   provider: ProviderWithName
   health: ProviderHealthSummary | null
   className?: string
+}
+
+function ProviderCardMetrics({
+  provider,
+  health,
+}: {
+  provider: ProviderWithName
+  health: ProviderHealthSummary | null
+}) {
+  return (
+    <div className="mt-1 flex items-center gap-2">
+      <span className="rounded-md bg-bg-surface px-1.5 py-0.5 text-xs font-mono text-text-secondary">
+        {provider.models.length} model{provider.models.length !== 1 ? 's' : ''}
+      </span>
+      {!provider.agent_eligible && (
+        <StatusPill
+          tone="warning"
+          ariaLabel="This provider is excluded from agent model assignment"
+        >
+          Agents off
+        </StatusPill>
+      )}
+      {health && (
+        <>
+          <span className="text-xs text-text-muted">
+            {health.calls_last_24h} calls/24h
+          </span>
+          <span className="text-xs text-text-muted">
+            {formatTokenCount(health.total_tokens_24h)} tok
+          </span>
+          <span className="text-xs text-text-muted">
+            {formatCost(health.total_cost_24h)}
+          </span>
+        </>
+      )}
+    </div>
+  )
 }
 
 function ProviderCardInner({ provider, health, className }: ProviderCardProps) {
@@ -59,26 +97,7 @@ function ProviderCardInner({ provider, health, className }: ProviderCardProps) {
           </span>
         )}
 
-        <div className="mt-1 flex items-center gap-2">
-          <span className="rounded-md bg-bg-surface px-1.5 py-0.5 text-xs font-mono text-text-secondary">
-            {provider.models.length} model{provider.models.length !== 1 ? 's' : ''}
-          </span>
-          {health && (
-            <span className="text-xs text-text-muted">
-              {health.calls_last_24h} calls/24h
-            </span>
-          )}
-          {health && (
-            <span className="text-xs text-text-muted">
-              {formatTokenCount(health.total_tokens_24h)} tok
-            </span>
-          )}
-          {health && (
-            <span className="text-xs text-text-muted">
-              {formatCost(health.total_cost_24h)}
-            </span>
-          )}
-        </div>
+        <ProviderCardMetrics provider={provider} health={health} />
       </div>
     </div>
   )

--- a/web/src/pages/providers/ProviderDetailHeader.tsx
+++ b/web/src/pages/providers/ProviderDetailHeader.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft, Download, Pencil, RefreshCw, Trash2, Wifi } from 'lucide-react'
 import { Link } from 'react-router'
 import { ProviderHealthBadge } from '@/components/ui/provider-health-badge'
+import { StatusPill } from '@/components/ui/status-pill'
 import { Button } from '@/components/ui/button'
 import { ROUTES } from '@/router/routes'
 import type { ProviderHealthSummary } from '@/api/types/providers'
@@ -39,6 +40,14 @@ function ProviderTitleMeta({
       <div className="flex items-center gap-3">
         <h1 className="truncate text-xl font-semibold text-foreground">{provider.name}</h1>
         {health && <ProviderHealthBadge status={health.health_status} label />}
+        {!provider.agent_eligible && (
+          <StatusPill
+            tone="warning"
+            ariaLabel="This provider is excluded from agent model assignment"
+          >
+            Agents off
+          </StatusPill>
+        )}
       </div>
       <div className="flex items-center gap-2 text-sm text-text-secondary">
         {provider.litellm_provider && (

--- a/web/src/pages/providers/ProviderFormModal.tsx
+++ b/web/src/pages/providers/ProviderFormModal.tsx
@@ -2,6 +2,7 @@ import { Dialog } from '@base-ui/react/dialog'
 import { Loader2, X } from 'lucide-react'
 import { InputField } from '@/components/ui/input-field'
 import { SelectField } from '@/components/ui/select-field'
+import { ToggleField } from '@/components/ui/toggle-field'
 import { Button } from '@/components/ui/button'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { ErrorBanner } from '@/components/ui/error-banner'
@@ -158,6 +159,12 @@ function ProviderAdvancedFields({
         onChange={(e) => fields.setKeepAlive(e.target.value)}
         placeholder="e.g. 5m, 0, -1"
         hint="How long Ollama keeps a model loaded after a request: 5m, 0 unloads immediately, -1 keeps it forever. Empty leaves the server default."
+      />
+      <ToggleField
+        label="Eligible for agents"
+        description="When off, this provider stays usable for explicitly-configured feature calls but is never seeded onto an agent or picked by stakes routing, so no agent silently sources from it."
+        checked={fields.agentEligible}
+        onChange={fields.setAgentEligible}
       />
     </>
   )

--- a/web/src/pages/providers/__tests__/provider-form-helpers.test.ts
+++ b/web/src/pages/providers/__tests__/provider-form-helpers.test.ts
@@ -87,6 +87,14 @@ describe('buildCreateProviderRequest', () => {
     expect(req.oauth_token_url).toBeUndefined()
     expect(req.api_key).toBe('k')
   })
+
+  it('forwards agent_eligible through the create request (default and opted-out)', () => {
+    expect(buildCreateProviderRequest(values({ apiKey: 'k' })).agent_eligible).toBe(true)
+    expect(
+      buildCreateProviderRequest(values({ apiKey: 'k', agentEligible: false }))
+        .agent_eligible,
+    ).toBe(false)
+  })
 })
 
 describe('buildUpdateProviderRequest', () => {
@@ -111,6 +119,12 @@ describe('buildUpdateProviderRequest', () => {
       values({ authType: 'oauth', oauthClientSecret: 'new-secret' }),
     )
     expect(req.oauth_client_secret).toBe('new-secret')
+  })
+
+  it('forwards an opted-out agent_eligible through the update request', () => {
+    expect(
+      buildUpdateProviderRequest(values({ agentEligible: false })).agent_eligible,
+    ).toBe(false)
   })
 })
 

--- a/web/src/pages/providers/__tests__/provider-form-helpers.test.ts
+++ b/web/src/pages/providers/__tests__/provider-form-helpers.test.ts
@@ -51,6 +51,7 @@ function values(overrides: Partial<ProviderFormValues> = {}): ProviderFormValues
     keepAlive: '',
     litellmProvider: '',
     tosAccepted: false,
+    agentEligible: true,
     ...overrides,
   }
 }

--- a/web/src/pages/providers/provider-form-helpers.ts
+++ b/web/src/pages/providers/provider-form-helpers.ts
@@ -60,6 +60,12 @@ export interface ProviderFormValues {
   keepAlive: string
   litellmProvider: string
   tosAccepted: boolean
+  /**
+   * Whether this provider may back an agent. When off the provider stays
+   * usable for explicitly-configured feature calls but is excluded from agent
+   * seeding and stakes routing, so no agent silently sources from it.
+   */
+  agentEligible: boolean
 }
 
 /** Optional store-override props for using this drawer outside the Settings page. */
@@ -327,6 +333,7 @@ export function buildCreateProviderRequest(v: ProviderFormValues): CreateProvide
     tos_accepted: v.authType === 'subscription' && v.tosAccepted,
     base_url: normaliseOptional(v.baseUrl),
     keep_alive: normaliseOptional(v.keepAlive),
+    agent_eligible: v.agentEligible,
     models: [],
   }
 }
@@ -345,6 +352,7 @@ export function buildUpdateProviderRequest(v: ProviderFormValues): UpdateProvide
     tos_accepted: v.authType === 'subscription' && v.tosAccepted,
     base_url: normaliseOptional(v.baseUrl),
     keep_alive: normaliseOptional(v.keepAlive),
+    agent_eligible: v.agentEligible,
   }
 }
 

--- a/web/src/pages/providers/provider-form-helpers.ts
+++ b/web/src/pages/providers/provider-form-helpers.ts
@@ -308,6 +308,11 @@ export function buildCreateFromPresetRequest(
 ): CreateFromPresetRequest {
   const apiKey = normaliseOptional(v.apiKey)
   const subscriptionToken = normaliseOptional(v.subscriptionToken)
+  // agent_eligible is deliberately not forwarded: the backend
+  // CreateFromPresetRequest schema has no such field, so a preset-created
+  // provider always defaults to agent-eligible. The toggle is hidden for the
+  // preset path (only shown for custom-create / edit) and is set afterwards
+  // via an edit, so there is no silent data loss here.
   return {
     preset_name: presetName,
     name: v.name.trim(),

--- a/web/src/pages/providers/useProviderForm.ts
+++ b/web/src/pages/providers/useProviderForm.ts
@@ -66,6 +66,8 @@ export interface ProviderFields {
   setShowTosDialog: Dispatch<SetStateAction<boolean>>
   tosAccepted: boolean
   setTosAccepted: Dispatch<SetStateAction<boolean>>
+  agentEligible: boolean
+  setAgentEligible: Dispatch<SetStateAction<boolean>>
 }
 
 function useProviderFields(): ProviderFields {
@@ -86,6 +88,9 @@ function useProviderFields(): ProviderFields {
   const [submitting, setSubmitting] = useState(false)
   const [showTosDialog, setShowTosDialog] = useState(false)
   const [tosAccepted, setTosAccepted] = useState(false)
+  // Defaults on: a newly-added provider backs agents unless the operator opts
+  // it out (e.g. a gateway kept for feature calls only).
+  const [agentEligible, setAgentEligible] = useState(true)
   // Memoised so the object identity is stable across renders where no
   // field value changed; this keeps the handler useCallbacks (which
   // depend on `fields`) from re-creating on every parent re-render.
@@ -100,12 +105,13 @@ function useProviderFields(): ProviderFields {
       keepAlive, setKeepAlive,
       litellmProvider, setLitellmProvider, submitting, setSubmitting,
       showTosDialog, setShowTosDialog, tosAccepted, setTosAccepted,
+      agentEligible, setAgentEligible,
     }),
     [
       selectedPreset, name, authType, apiKey, subscriptionToken,
       customHeaderName, customHeaderValue, oauthTokenUrl, oauthClientId,
       oauthClientSecret, oauthScope, baseUrl, keepAlive,
-      litellmProvider, submitting, showTosDialog, tosAccepted,
+      litellmProvider, submitting, showTosDialog, tosAccepted, agentEligible,
     ],
   )
 }
@@ -136,6 +142,7 @@ function applyEditPrefill(fields: ProviderFields, provider: ProviderWithName): v
   fields.setKeepAlive(provider.keep_alive ?? '')
   fields.setLitellmProvider(provider.litellm_provider ?? '')
   fields.setTosAccepted(provider.tos_accepted_at !== null)
+  fields.setAgentEligible(provider.agent_eligible)
   // Non-secret credential fields are prefilled so editing an oauth /
   // custom_header provider no longer silently drops them; secrets stay
   // blank (cleared above) and are only re-sent when re-typed.
@@ -152,6 +159,7 @@ function applyCustomPresetSync(fields: ProviderFields): void {
   fields.setKeepAlive('')
   fields.setLitellmProvider('')
   fields.setTosAccepted(false)
+  fields.setAgentEligible(true)
   clearCredentialFields(fields)
 }
 
@@ -162,6 +170,7 @@ function applyPresetSync(fields: ProviderFields, preset: ProviderPreset): void {
   fields.setKeepAlive('')
   fields.setLitellmProvider(preset.litellm_provider)
   fields.setTosAccepted(false)
+  fields.setAgentEligible(true)
   clearCredentialFields(fields)
 }
 
@@ -305,6 +314,7 @@ function valuesOf(fields: ProviderFields): ProviderFormValues {
     keepAlive: fields.keepAlive,
     litellmProvider: fields.litellmProvider,
     tosAccepted: fields.tosAccepted,
+    agentEligible: fields.agentEligible,
   }
 }
 

--- a/web/src/stores/charter.ts
+++ b/web/src/stores/charter.ts
@@ -188,12 +188,12 @@ async function approveImpl(
       // The charter was approved (a human decided) but the run produced no
       // successful work: e.g. decomposition failed. Surface that instead of a
       // false success. The failure is durable and visible as a FAILED plan in
-      // Plan Review, so the operator can inspect the reason and re-run it.
+      // Plan Review, so the operator can inspect the reason and start a new run.
       useToastStore.getState().add({
         variant: 'error',
         title: 'Charter approved, but the run failed',
         description:
-          'The objective could not be decomposed into a plan. Open Plan Review for the failed plan and its reason, then re-run it.',
+          'The objective could not be prepared into a plan. Open Plan Review for the failed plan and its reason, then start a new project run.',
       })
     }
     return result

--- a/web/src/stores/charter.ts
+++ b/web/src/stores/charter.ts
@@ -178,11 +178,24 @@ async function approveImpl(
   try {
     const result = await charterApi.approveCharter(id)
     set({ draftCharter: result.charter, conversationClosed: true })
-    useToastStore.getState().add({
-      variant: 'success',
-      title: 'Charter approved',
-      description: 'The project run has started.',
-    })
+    if (result.is_success) {
+      useToastStore.getState().add({
+        variant: 'success',
+        title: 'Charter approved',
+        description: 'The project run has started.',
+      })
+    } else {
+      // The charter was approved (a human decided) but the run produced no
+      // successful work: e.g. decomposition failed. Surface that instead of a
+      // false success. The failure is durable and visible as a FAILED plan in
+      // Plan Review, so the operator can inspect the reason and re-run it.
+      useToastStore.getState().add({
+        variant: 'error',
+        title: 'Charter approved, but the run failed',
+        description:
+          'The objective could not be decomposed into a plan. Open Plan Review for the failed plan and its reason, then re-run it.',
+      })
+    }
     return result
   } catch (err) {
     log.error('Charter approval failed', sanitizeForLog(err))


### PR DESCRIPTION
## What this does

A live Tetris dogfood run (CEO "New project" charter approve) failed: the project showed a root task stuck in PLANNING, no plan in Plan Review, and agents silently ran on an unintended provider. All symptoms traced to a decomposition 500 that aborted before a plan could park. This bundles the four distinct defects that run surfaced, plus the hardening a 20-agent pre-PR review found in the first cut.

### The four findings

1. **Provider-exclusive model binding.** An agent binds an exclusive `(provider, model)` pair. A new provider-level `agent_eligible` flag, a provider-scoped `resolver.resolve_for_pair(provider, ref)` used wherever an agent's bound provider is known, and an eligibility-first candidate selector keep agent routing on the configured provider and off any feature-only gateway. Two providers can serve the same model without an agent ever being re-derived onto the wrong one.
2. **Decomposition resilience.** The LiteLLM driver maps a content-less, tool-call-less completion to `finish=ERROR` (the codebase's existing fail-loud signal) instead of building an invalid `CompletionResponse` that raised mid-call as a 500. The LLM decomposition strategy also wraps a raw provider/infra failure as a typed `DecompositionError`, so decomposition always terminates in the domain hierarchy.
3. **Failed-run surfacing.** A plan-review failure returns a truthful failed pipeline result (HTTP 200, `is_success:false`) rather than a 500, marks the root task FAILED, and surfaces the failure in the dashboard (a persistent banner + an error toast on approve).
4. **Plan first-party from greenlight.** Charter approval persists a `PLANNING` plan shell before decomposition runs; decomposition fills it in place; a failed or empty decomposition leaves a visible `FAILED` plan carrying its `failure_reason` in Plan Review instead of an orphan. Adds `PlanStatus` PLANNING/FAILED, relaxes the empty-items validator + both DB CHECKs, and surfaces the states in the dashboard.

### Review hardening (from the pre-PR review)

- **The compensating write is now safe.** `fail_plan` (the write that makes a failure visible on every failure path) is idempotent, retries a concurrent rework via the shared `CASRetryHandler`, and logs-rather-than-raises a persistent write failure, so it can never itself reintroduce the 500 it exists to prevent. The pipeline plan-review guard was widened to compensate on any failure across decomposition, the panel, or parking the approval (previously only decomposition was guarded).
- A `Plan` cross-field invariant ties `failure_reason` to the FAILED status. The overloaded plan-failure event constant was split into distinct events, a per-request approval-park failure no longer logs under the startup event, and the successful-FAILED write logs at INFO.
- Docs (plan-review, providers), selector docstrings, provider-card/detail agent-eligibility signal, and copy corrections.

## Test plan

- Full backend unit suite green; new coverage for `normalize_empty_finish`, `resolve_for_pair` scoping, eligibility-first selection, the agent-eligibility seeding exclusion, the `Plan` itemless + failure_reason validators, the `fail_plan` double-fault / idempotency paths, and the `CREATED -> FAILED` transition.
- Dual-backend schema-drift (SQLite + Postgres) + plan conformance green.
- Web: type-check, ESLint, and the full Vitest suite green; new tests for the failed-plan banner, the charter `is_success:false` toast, and the provider `agent_eligible` round-trip.
- Generated data (DTO/enum TS, architecture report) regenerated; all pre-push gates pass.

## Review coverage

Pre-reviewed by 20 specialist agents (correctness, python, security, persistence, resilience, logging, async-concurrency, silent-failure, conventions, comment-quality, docs-consistency, frontend, design-token, api-contract-drift, test-quality, pr-test-analyzer, issue-resolution, diagram-syntax, ghost-wiring, comment-analyzer). Every valid finding was implemented.

## Follow-ups (intentionally out of scope)

- **Project-cancel-on-failure** (an original issue criterion) is deliberately superseded by the plan-first design: leaving a visible FAILED plan is a better end-state than cancelling the project and hiding the failure.
- **Idempotent intake** (dedup a re-dispatch on `correlation_id`) is a cross-cutting intake-engine concern that warrants its own design; tracked separately.
- **Crash-recovery reconciliation sweep** for a PLANNING plan orphaned by a process crash: in-process compensation covers every non-crash path; a comprehensive sweep (plans + tasks + projects) is a larger separate effort.
- **A persisted "review-panel-failed" signal** distinct from "no panel": the failure is already logged; a persisted field needs its own migration.

Closes #2587
