### PR TITLE
ci: run web CodSpeed benchmarks under simulation instrument only

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -201,9 +201,10 @@ jobs:
     needs: changes
     if: needs.changes.outputs.web == 'true'
     runs-on: ubuntu-24.04
-    # 30 (was 15): headroom for the 3-attempt CodSpeed ladder below, each
-    # attempt running two instruments (simulation + memory); see the
-    # codspeed-python job for the rationale.
+    # 30: headroom for the 3-attempt CodSpeed ladder below. Web runs a
+    # single instrument (simulation only, see the mode-rationale comment
+    # above), so this is budgeted generously relative to the codspeed-python
+    # job, which runs two instruments per attempt.
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -28,12 +28,24 @@ name: CodSpeed
 # Mode rationale: CPU Simulation (cachegrind / valgrind), instruction-count
 # variance under 1% across runners. Walltime would need Macro Runners
 # (CodSpeed's bare-metal pool) to match that variance, which we have
-# explicitly scoped out to keep the gate free-tier. The memory instrument
-# rides alongside simulation in the same invocation (mode: simulation,memory):
-# as of CodSpeed runner 4.17 memtrack runs sudo-less via file capabilities on
-# standard GitHub-hosted runners, so heap-allocation regressions surface next
-# to CPU in the same PR report at no extra job. Both surfaces meet the floor
-# (pytest-codspeed 5.0.3 >= 4.3.0, @codspeed/vitest-plugin 5.6.0 >= 5.2.0).
+# explicitly scoped out to keep the gate free-tier.
+#
+# Python rides the memory instrument alongside simulation (mode:
+# simulation,memory): as of CodSpeed runner 4.17 memtrack runs sudo-less
+# via file capabilities on standard GitHub-hosted runners, and the Python
+# benchmarks touch large enough, deterministic allocations for heap
+# regressions to surface next to CPU in the same report at no extra job
+# (pytest-codspeed 5.0.3 >= 4.3.0).
+#
+# Web runs simulation only. Every dashboard benchmark is a sub-kilobyte
+# pure helper (locale, format, csrf, sanitize, pagination), where memtrack
+# measures a few hundred bytes dominated by V8 allocator internals (Intl
+# temporaries, exception objects on fall-through paths). That figure shifts
+# with the CI runner's CPU vendor on identical source, so the memory
+# instrument produced phantom regressions there with no real signal; the
+# deterministic simulation instruction count (variance under 1% across
+# runners) is the trustworthy guard for these micro helpers
+# (@codspeed/vitest-plugin 5.6.0 >= 5.2.0).
 
 on:
   push:
@@ -225,7 +237,7 @@ jobs:
         continue-on-error: true
         uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286 # v4.18.5
         with:
-          mode: simulation,memory
+          mode: simulation
           run: npm --prefix web run bench
       - name: Backoff before CodSpeed Web attempt 2
         if: ${{ !cancelled() && steps.codspeed-web-1.outcome == 'failure' }}
@@ -238,7 +250,7 @@ jobs:
         continue-on-error: true
         uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286 # v4.18.5
         with:
-          mode: simulation,memory
+          mode: simulation
           run: npm --prefix web run bench
       - name: Backoff before CodSpeed Web attempt 3
         if: ${{ !cancelled() && steps.codspeed-web-1.outcome == 'failure' && steps.codspeed-web-2.outcome == 'failure' }}
@@ -249,7 +261,7 @@ jobs:
         if: ${{ !cancelled() && steps.codspeed-web-1.outcome == 'failure' && steps.codspeed-web-2.outcome == 'failure' }}
         uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286 # v4.18.5
         with:
-          mode: simulation,memory
+          mode: simulation
           run: npm --prefix web run bench
 
   # ── Branch-protection-friendly aggregators ──


### PR DESCRIPTION
## What

Drops the `memory` instrument from the three `codspeed-web` benchmark steps (`mode: simulation,memory` becomes `mode: simulation`). Python benchmarks are unchanged and keep `simulation,memory`. The mode-rationale comment and the `codspeed-web` `timeout-minutes` comment are updated to match.

## Why

Every dashboard benchmark is a sub-kilobyte pure helper (locale, format, csrf, sanitize, pagination). CodSpeed memtrack there measures a few hundred bytes dominated by V8 allocator internals (Intl temporaries, exception objects on fall-through paths), which shifts with the CI runner CPU vendor on identical source.

Concretely, on the lock-file-maintenance PR (#2598, a lockfile-only change touching zero web source), the base run landed on AMD EPYC and the head on Intel Xeon; `resolveLocale x1000 (browser fallback after invalid override)` reported 584 B against 848 B in Memory mode (a phantom 31% regression), while the deterministic Simulation instruction count (variance under 1% across runners) reported it unchanged. The memory instrument produced no real signal for these micro helpers, only recurring false positives.

Simulation (cachegrind instruction count) stays as the trustworthy guard for the web micro helpers. Memory can be re-added selectively if the web suite ever grows an allocation-heavy benchmark where memtrack has signal.

## Scope

`CodSpeed Web Pass` gates on the benchmark job running, not on the analysis verdict, so the required check is unaffected. Python instrumentation is untouched. No source, test, or runtime behaviour change.

## Review coverage

Pre-reviewed by 3 agents (infra-reviewer, docs-consistency, comment-quality-rot). One finding addressed: a stale `codspeed-web` timeout comment still describing two instruments, corrected in the second commit. No doc drift; comment block clean.

## Test plan

- `check yaml` / `yamllint` / actionlint / zizmor / CI-workflow-resilience gate green (pre-commit + pre-push).
- YAML parse verified: `codspeed-python` retains `simulation,memory` (3 steps), `codspeed-web` now `simulation` (3 steps).