### PR TITLE
ci: harden image-publish SBOM steps against timeout cancellation

### DIFF
--- a/.github/actions/publish-image-loaded/action.yml
+++ b/.github/actions/publish-image-loaded/action.yml
@@ -460,45 +460,32 @@ runs:
         subject-digest: ${{ steps.push.outputs.digest }}
         push-to-registry: true
 
-    # SBOM generation pulls the image manifest from GHCR; ride a registry
-    # blip on the same 3-attempt backoff ladder (no downstream step output
-    # consumed, so a straight ladder; the final attempt fails hard).
-    - name: Generate SBOM (attempt 1)
-      id: sbom_image_1
-      continue-on-error: true
-      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+    # SBOM generation pulls the image manifest from GHCR and runs syft
+    # against it. Call syft directly under nick-fields/retry rather than
+    # anchore/sbom-action's own step: `timeout-minutes` is not supported
+    # on composite-action steps, so a slow or hung scan would run until
+    # the JOB timeout and be cancelled -- a cancellation, not a failure,
+    # which skips any retry gated on `outcome == 'failure'`. The retry
+    # wrapper gives each attempt a real wall-clock bound so a stuck scan
+    # becomes a retryable failure, matching the `docker login` step above.
+    # syft is pinned to the sbom-action release via its download-syft
+    # sub-action.
+    - name: Install syft
+      id: download_syft
+      uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+    - name: Generate SBOM
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      env:
+        SYFT_CMD: ${{ steps.download_syft.outputs.cmd }}
+        SBOM_IMAGE: ghcr.io/aureliolo/synthorg-${{ inputs.image-name }}@${{ steps.push.outputs.digest }}
+        SBOM_OUT: sbom-${{ inputs.image-name }}.cdx.json
       with:
-        image: ghcr.io/aureliolo/synthorg-${{ inputs.image-name }}@${{ steps.push.outputs.digest }}
-        format: cyclonedx-json
-        output-file: sbom-${{ inputs.image-name }}.cdx.json
-
-    - name: Back off before SBOM retry 1
-      if: steps.sbom_image_1.outcome == 'failure'
-      shell: bash
-      run: sleep 15
-
-    - name: Generate SBOM (attempt 2)
-      if: steps.sbom_image_1.outcome == 'failure'
-      id: sbom_image_2
-      continue-on-error: true
-      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-      with:
-        image: ghcr.io/aureliolo/synthorg-${{ inputs.image-name }}@${{ steps.push.outputs.digest }}
-        format: cyclonedx-json
-        output-file: sbom-${{ inputs.image-name }}.cdx.json
-
-    - name: Back off before SBOM retry 2
-      if: steps.sbom_image_2.outcome == 'failure'
-      shell: bash
-      run: sleep 30
-
-    - name: Generate SBOM (final attempt)
-      if: steps.sbom_image_2.outcome == 'failure'
-      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-      with:
-        image: ghcr.io/aureliolo/synthorg-${{ inputs.image-name }}@${{ steps.push.outputs.digest }}
-        format: cyclonedx-json
-        output-file: sbom-${{ inputs.image-name }}.cdx.json
+        timeout_minutes: 5
+        max_attempts: 3
+        retry_wait_seconds: 15
+        command: |
+          "$SYFT_CMD" scan "$SBOM_IMAGE" -o "cyclonedx-json=$SBOM_OUT"
 
     - name: Upload SBOM artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/actions/publish-image-retag/action.yml
+++ b/.github/actions/publish-image-retag/action.yml
@@ -234,51 +234,37 @@ runs:
         } >> "$GITHUB_OUTPUT"
 
     # Regenerate the CycloneDX SBOM against the signed digest.
-    # anchore/sbom-action operates on the registry image manifest, so
-    # the same digest produces the same SBOM bytes every run -- but
-    # `update-release` consumes the artifact from THIS workflow run
-    # (cross-run artifact downloads are not supported by
-    # actions/download-artifact), so we re-emit it here on tag-push.
-    # SBOM generation pulls the image manifest from GHCR; ride a registry
-    # blip on the same 3-attempt backoff ladder as the publish-* attest
-    # steps. No downstream step output consumed, so a straight ladder; the
-    # final attempt has no continue-on-error and fails the job.
-    - name: Generate SBOM (attempt 1)
-      id: sbom_retag_1
-      continue-on-error: true
-      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+    # syft operates on the registry image manifest, so the same digest
+    # produces the same SBOM bytes every run -- but `update-release`
+    # consumes the artifact from THIS workflow run (cross-run artifact
+    # downloads are not supported by actions/download-artifact), so we
+    # re-emit it here on tag-push.
+    #
+    # We call syft directly under nick-fields/retry rather than
+    # anchore/sbom-action's own step because `timeout-minutes` is not
+    # supported on composite-action steps: a slow or hung syft scan would
+    # otherwise run until the JOB timeout and be cancelled, which skips
+    # any retry gated on `outcome == 'failure'` (a cancel is not a
+    # failure). nick-fields/retry gives each attempt a real wall-clock
+    # bound, so a stuck scan becomes a retryable failure -- the same
+    # resilience the `docker login` step above already relies on. syft is
+    # pinned to the sbom-action release via its download-syft sub-action.
+    - name: Install syft
+      id: download_syft
+      uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+    - name: Generate SBOM
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      env:
+        SYFT_CMD: ${{ steps.download_syft.outputs.cmd }}
+        SBOM_IMAGE: ghcr.io/aureliolo/synthorg-${{ inputs.image-name }}@${{ steps.resolve.outputs.digest }}
+        SBOM_OUT: sbom-${{ inputs.image-name }}.cdx.json
       with:
-        image: ghcr.io/aureliolo/synthorg-${{ inputs.image-name }}@${{ steps.resolve.outputs.digest }}
-        format: cyclonedx-json
-        output-file: sbom-${{ inputs.image-name }}.cdx.json
-
-    - name: Back off before SBOM retry 1
-      if: steps.sbom_retag_1.outcome == 'failure'
-      shell: bash
-      run: sleep 15
-
-    - name: Generate SBOM (attempt 2)
-      if: steps.sbom_retag_1.outcome == 'failure'
-      id: sbom_retag_2
-      continue-on-error: true
-      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-      with:
-        image: ghcr.io/aureliolo/synthorg-${{ inputs.image-name }}@${{ steps.resolve.outputs.digest }}
-        format: cyclonedx-json
-        output-file: sbom-${{ inputs.image-name }}.cdx.json
-
-    - name: Back off before SBOM retry 2
-      if: steps.sbom_retag_2.outcome == 'failure'
-      shell: bash
-      run: sleep 30
-
-    - name: Generate SBOM (final attempt)
-      if: steps.sbom_retag_2.outcome == 'failure'
-      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-      with:
-        image: ghcr.io/aureliolo/synthorg-${{ inputs.image-name }}@${{ steps.resolve.outputs.digest }}
-        format: cyclonedx-json
-        output-file: sbom-${{ inputs.image-name }}.cdx.json
+        timeout_minutes: 5
+        max_attempts: 3
+        retry_wait_seconds: 15
+        command: |
+          "$SYFT_CMD" scan "$SBOM_IMAGE" -o "cyclonedx-json=$SBOM_OUT"
 
     - name: Upload SBOM artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1338,7 +1338,13 @@ jobs:
       !cancelled() &&
       needs.version.result == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # The `Free disk space` reclaim below is highly variable (56s-9m6s
+    # observed across releases) and the SBOM step runs its own bounded
+    # retry ladder; 10 min left the GPU leg (largest image, slowest syft
+    # scan) no margin and it was cancelled mid-scan. Size to worst-case
+    # cleanup + a full SBOM retry cycle so the timeout is a runaway
+    # backstop, not a starvation trigger.
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -1361,14 +1367,23 @@ jobs:
       # docker-daemon save and the oci-registry cache. A stock runner's
       # ~14 GB free fills up and syft fails with "no space left on device",
       # so mirror the build path's reclaim before the composite action.
+      #
+      # Each `rm -rf` is an independent path, so fan them out in the
+      # background and `wait`: the reclaim's wall-clock becomes the slowest
+      # single tree (typically hostedtoolcache) instead of the sum of all
+      # of them, which is what let this step swing from under a minute to
+      # over nine and starve the SBOM scan.
       - name: Free disk space
         run: |
           df -h /
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache /usr/share/swift /usr/share/miniconda
-          sudo rm -rf /usr/local/share/powershell /usr/local/share/chromium
-          sudo rm -rf /usr/local/lib/node_modules /usr/local/.ghcup
-          sudo docker image prune --all --force
+          for dir in /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                     /opt/hostedtoolcache /usr/share/swift /usr/share/miniconda \
+                     /usr/local/share/powershell /usr/local/share/chromium \
+                     /usr/local/lib/node_modules /usr/local/.ghcup; do
+            sudo rm -rf "$dir" &
+          done
+          sudo docker image prune --all --force &
+          wait
           df -h /
 
       - id: retag

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -892,11 +892,13 @@ jobs:
       needs.build-web.result == 'success' &&
       github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    # Hands off to publish-image-loaded, whose login / cosign / attest /
-    # syft-SBOM steps each carry a bounded retry budget; the job timeout
-    # must clear a full SBOM retry cycle so a transient blip is retried,
-    # not cancelled mid-retry.
-    timeout-minutes: 25
+    # Hands off to publish-image-loaded, whose login / push / cosign /
+    # attest / syft-SBOM steps each carry a bounded retry ladder. The job
+    # timeout must clear the SUM of those ladders (~36m composed worst
+    # case, more than the retag path since it also signs and attests) so
+    # a transient blip that trips several is retried, not cancelled
+    # mid-retry.
+    timeout-minutes: 40
     environment: image-push
     permissions:
       contents: read
@@ -1225,11 +1227,15 @@ jobs:
       !cancelled() &&
       needs.version.result == 'success'
     runs-on: ubuntu-latest
-    # Every retag job shares publish-image-retag, whose GHCR-login and
-    # syft-SBOM steps each carry their own bounded retry budget; the job
-    # timeout must exceed a full retry cycle so a transient registry blip
-    # is retried, not cancelled mid-retry (the failure this family hit).
-    timeout-minutes: 25
+    # Every retag job shares publish-image-retag, whose GHCR-login
+    # (~8m45s worst case), digest-resolve, tag-apply and syft-SBOM
+    # (~15m30s worst case) steps each carry their own bounded retry
+    # ladder. The job timeout must clear the SUM of those ladders, not
+    # just the largest one, so a transient registry blip that trips
+    # several of them in one run is retried rather than cancelled
+    # mid-retry (the failure this family hit). 35 sits above the ~32m
+    # composed worst case with margin for checkout.
+    timeout-minutes: 35
     environment: image-push
     permissions:
       contents: read
@@ -1256,8 +1262,9 @@ jobs:
       !cancelled() &&
       needs.version.result == 'success'
     runs-on: ubuntu-latest
-    # See retag-backend: shared publish-image-retag retry budget.
-    timeout-minutes: 25
+    # See retag-backend: sized above the summed publish-image-retag
+    # retry budget (~32m composed worst case).
+    timeout-minutes: 35
     environment: image-push
     permissions:
       contents: read
@@ -1284,8 +1291,9 @@ jobs:
       !cancelled() &&
       needs.version.result == 'success'
     runs-on: ubuntu-latest
-    # See retag-backend: shared publish-image-retag retry budget.
-    timeout-minutes: 25
+    # See retag-backend: sized above the summed publish-image-retag
+    # retry budget (~32m composed worst case).
+    timeout-minutes: 35
     environment: image-push
     permissions:
       contents: read
@@ -1312,8 +1320,9 @@ jobs:
       !cancelled() &&
       needs.version.result == 'success'
     runs-on: ubuntu-latest
-    # See retag-backend: shared publish-image-retag retry budget.
-    timeout-minutes: 25
+    # See retag-backend: sized above the summed publish-image-retag
+    # retry budget (~32m composed worst case).
+    timeout-minutes: 35
     environment: image-push
     permissions:
       contents: read
@@ -1351,13 +1360,13 @@ jobs:
     runs-on: ubuntu-latest
     # Highest of the retag family: alone among them this job runs the
     # `Free disk space` reclaim (the GPU image is the only one large
-    # enough to fill a stock runner), stacking that on top of the shared
-    # publish-image-retag retry budget (GHCR login + syft SBOM). At 10
+    # enough to fill a stock runner), stacking that on top of the summed
+    # publish-image-retag retry budget (~32m composed worst case). At 10
     # min the GPU leg -- largest image, slowest syft scan -- had no margin
-    # and was cancelled mid-scan. 30 min clears the reclaim plus a full
-    # shared-action retry cycle so the timeout is a runaway backstop, not
-    # a starvation trigger.
-    timeout-minutes: 30
+    # and was cancelled mid-scan. 40 min clears the reclaim plus the full
+    # composed retry budget so the timeout is a runaway backstop, not a
+    # starvation trigger.
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -892,7 +892,11 @@ jobs:
       needs.build-web.result == 'success' &&
       github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Hands off to publish-image-loaded, whose login / cosign / attest /
+    # syft-SBOM steps each carry a bounded retry budget; the job timeout
+    # must clear a full SBOM retry cycle so a transient blip is retried,
+    # not cancelled mid-retry.
+    timeout-minutes: 25
     environment: image-push
     permissions:
       contents: read
@@ -1221,7 +1225,11 @@ jobs:
       !cancelled() &&
       needs.version.result == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Every retag job shares publish-image-retag, whose GHCR-login and
+    # syft-SBOM steps each carry their own bounded retry budget; the job
+    # timeout must exceed a full retry cycle so a transient registry blip
+    # is retried, not cancelled mid-retry (the failure this family hit).
+    timeout-minutes: 25
     environment: image-push
     permissions:
       contents: read
@@ -1248,7 +1256,8 @@ jobs:
       !cancelled() &&
       needs.version.result == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # See retag-backend: shared publish-image-retag retry budget.
+    timeout-minutes: 25
     environment: image-push
     permissions:
       contents: read
@@ -1275,7 +1284,8 @@ jobs:
       !cancelled() &&
       needs.version.result == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # See retag-backend: shared publish-image-retag retry budget.
+    timeout-minutes: 25
     environment: image-push
     permissions:
       contents: read
@@ -1302,7 +1312,8 @@ jobs:
       !cancelled() &&
       needs.version.result == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # See retag-backend: shared publish-image-retag retry budget.
+    timeout-minutes: 25
     environment: image-push
     permissions:
       contents: read
@@ -1338,13 +1349,15 @@ jobs:
       !cancelled() &&
       needs.version.result == 'success'
     runs-on: ubuntu-latest
-    # The `Free disk space` reclaim below is highly variable (56s-9m6s
-    # observed across releases) and the SBOM step runs its own bounded
-    # retry ladder; 10 min left the GPU leg (largest image, slowest syft
-    # scan) no margin and it was cancelled mid-scan. Size to worst-case
-    # cleanup + a full SBOM retry cycle so the timeout is a runaway
-    # backstop, not a starvation trigger.
-    timeout-minutes: 25
+    # Highest of the retag family: alone among them this job runs the
+    # `Free disk space` reclaim (the GPU image is the only one large
+    # enough to fill a stock runner), stacking that on top of the shared
+    # publish-image-retag retry budget (GHCR login + syft SBOM). At 10
+    # min the GPU leg -- largest image, slowest syft scan -- had no margin
+    # and was cancelled mid-scan. 30 min clears the reclaim plus a full
+    # shared-action retry cycle so the timeout is a runaway backstop, not
+    # a starvation trigger.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -1368,23 +1381,34 @@ jobs:
       # ~14 GB free fills up and syft fails with "no space left on device",
       # so mirror the build path's reclaim before the composite action.
       #
-      # Each `rm -rf` is an independent path, so fan them out in the
-      # background and `wait`: the reclaim's wall-clock becomes the slowest
-      # single tree (typically hostedtoolcache) instead of the sum of all
-      # of them, which is what let this step swing from under a minute to
-      # over nine and starve the SBOM scan.
+      # The directories are disjoint, so deleting them sequentially just
+      # sums independent I/O and has been observed to take up to ~9 min --
+      # long enough to starve the SBOM scan out of the job budget. Fan the
+      # deletes out in the background so wall-clock collapses to the
+      # slowest single tree. `wait` with no operands returns 0 regardless
+      # of the jobs' exit status, which under `bash -eo pipefail` would
+      # silently swallow a failed reclaim and let the job continue with
+      # less disk than expected (surfacing later as an opaque ENOSPC in
+      # syft), so wait on each PID and propagate a non-zero status.
       - name: Free disk space
         run: |
           df -h /
+          pids=()
           for dir in /usr/share/dotnet /usr/local/lib/android /opt/ghc \
                      /opt/hostedtoolcache /usr/share/swift /usr/share/miniconda \
                      /usr/local/share/powershell /usr/local/share/chromium \
                      /usr/local/lib/node_modules /usr/local/.ghcup; do
             sudo rm -rf "$dir" &
+            pids+=("$!")
           done
           sudo docker image prune --all --force &
-          wait
+          pids+=("$!")
+          status=0
+          for pid in "${pids[@]}"; do
+            wait "$pid" || status=$?
+          done
           df -h /
+          exit "$status"
 
       - id: retag
         uses: ./.github/actions/publish-image-retag


### PR DESCRIPTION
## Summary

On the `v0.9.4-dev.47` release tag the `Retag Fine-Tune (gpu)` job was cancelled by its own `timeout-minutes: 10` while `syft` was generating the CycloneDX SBOM. Two structural gaps combined:

- The `Free disk space` reclaim swings from ~1 min to over 9 min and shares the single 10-min job budget; on this run it left `syft` under a minute and it was killed mid-scan.
- The SBOM retry ladder gated on `outcome == 'failure'`, but a job-timeout is a **cancellation**, not a failure, so the later attempts were skipped rather than retried.

This makes the timeout a genuine runaway backstop instead of a starvation trigger, across every image-publish path.

## What changed

- **Per-attempt SBOM timeout.** Both `publish-image-retag` and `publish-image-loaded` now install a pinned `syft` (`anchore/sbom-action/download-syft`) and run `syft scan` under `nick-fields/retry` with a real per-attempt `timeout_minutes` (composite-action steps cannot carry `timeout-minutes`). A slow or hung scan becomes a retryable failure instead of riding to the job cap. Mirrors the `docker login` retry already in these actions.
- **Coherent job timeouts.** `publish-image-retag` is shared by all five retag jobs, so raising the SBOM retry budget for one raises it for all: `retag-backend/web/sandbox/sidecar` go 10 -> 25, and `retag-fine-tune` -> 30 (it alone also runs the disk reclaim). `build-web-publish` (the sole `publish-image-loaded` consumer) goes 15 -> 25 to fit the same budget.
- **Parallel, fail-loud reclaim.** The `Free disk space` deletes are backgrounded so wall-clock collapses to the slowest single tree instead of the sum. A bare `wait` returns 0 regardless of a background job's exit, which under `bash -eo pipefail` would silently swallow a failed `rm`/`prune`; the step now waits on each PID and propagates a non-zero status so a partial reclaim fails loud instead of resurfacing later as an opaque `ENOSPC` inside `syft`.

## Test plan

- `actionlint`, `zizmor`, and `yamllint` pass on the workflow + both composite actions.
- The repo's `CI workflow resilience (job timeouts + fail-closed retry ladders)` pre-push gate passes.
- The cancelled dev.47 retag was re-run and completed green (GPU image retagged + signed, signatures verified, release notes updated); this PR prevents the recurrence rather than re-fixing that run.

## Review coverage

Pre-reviewed by 5 local agents (infra-reviewer, docs-consistency, comment-quality-rot, comment-analyzer, issue-resolution-verifier). 6 findings addressed, including the infra-reviewer's catch that the shared action had left four sibling retag jobs under-budgeted.

Closes #2627