### PR TITLE
ci: install melange via a retrying, checksum-verified local action

### DIFF
--- a/.github/actions/setup-apko/action.yml
+++ b/.github/actions/setup-apko/action.yml
@@ -9,16 +9,21 @@ inputs:
 runs:
   using: composite
   steps:
+    # `--max-time` bounds each individual transfer: `--retry-max-time` only
+    # caps the retry loop, so a connection that stalls mid-body but stays
+    # open would otherwise hang until the job timeout instead of retrying.
     - name: Install apko
       shell: bash
       env:
         APKO_VERSION: ${{ inputs.version }}
       run: |
         APKO_ARCHIVE="apko_${APKO_VERSION#v}_linux_amd64.tar.gz"
-        curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 \
+        curl -fsSL --connect-timeout 30 --max-time 120 \
+          --retry 8 --retry-all-errors --retry-max-time 300 \
           "https://github.com/chainguard-dev/apko/releases/download/${APKO_VERSION}/${APKO_ARCHIVE}" \
           -o "/tmp/${APKO_ARCHIVE}"
-        curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 \
+        curl -fsSL --connect-timeout 30 --max-time 120 \
+          --retry 8 --retry-all-errors --retry-max-time 300 \
           "https://github.com/chainguard-dev/apko/releases/download/${APKO_VERSION}/checksums.txt" \
           -o /tmp/apko-checksums.txt
         awk -v f="${APKO_ARCHIVE}" '$2==f {print $1"  /tmp/"$2; found=1} END{if(!found) exit 1}' /tmp/apko-checksums.txt | sha256sum -c -

--- a/.github/actions/setup-melange/action.yml
+++ b/.github/actions/setup-melange/action.yml
@@ -1,0 +1,41 @@
+name: Set up melange
+description: Download, verify, and install the melange binary from GitHub releases, plus bubblewrap
+
+inputs:
+  version:
+    description: "melange version to install (e.g. v1.2.3)"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Mirrors setup-apko: download to a file with a bounded retry budget
+    # and verify the published checksum before extracting, so a truncated
+    # release-CDN download self-recovers instead of failing the build on a
+    # single blip (the `curl | tar` pipe in the upstream setup-melange
+    # action had neither retry nor checksum and a truncated body killed the
+    # whole run).
+    - name: Install melange
+      shell: bash
+      env:
+        MELANGE_VERSION: ${{ inputs.version }}
+      run: |
+        MELANGE_ARCHIVE="melange_${MELANGE_VERSION#v}_linux_amd64.tar.gz"
+        curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 \
+          "https://github.com/chainguard-dev/melange/releases/download/${MELANGE_VERSION}/${MELANGE_ARCHIVE}" \
+          -o "/tmp/${MELANGE_ARCHIVE}"
+        curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 \
+          "https://github.com/chainguard-dev/melange/releases/download/${MELANGE_VERSION}/checksums.txt" \
+          -o /tmp/melange-checksums.txt
+        awk -v f="${MELANGE_ARCHIVE}" '$2==f {print $1"  /tmp/"$2; found=1} END{if(!found) exit 1}' /tmp/melange-checksums.txt | sha256sum -c -
+        tar -xzf "/tmp/${MELANGE_ARCHIVE}" -C /tmp
+        mv "/tmp/melange_${MELANGE_VERSION#v}_linux_amd64/melange" /usr/local/bin/melange
+        rm -rf "/tmp/${MELANGE_ARCHIVE}" /tmp/melange-checksums.txt "/tmp/melange_${MELANGE_VERSION#v}_linux_amd64"
+
+    # melange's default container runner shells out to bubblewrap to build
+    # apks; the upstream setup-melange action installed it, so keep parity.
+    - name: Install bubblewrap
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends bubblewrap

--- a/.github/actions/setup-melange/action.yml
+++ b/.github/actions/setup-melange/action.yml
@@ -12,9 +12,7 @@ runs:
     # Mirrors setup-apko: download to a file with a bounded retry budget
     # and verify the published checksum before extracting, so a truncated
     # release-CDN download self-recovers instead of failing the build on a
-    # single blip (the `curl | tar` pipe in the upstream setup-melange
-    # action had neither retry nor checksum and a truncated body killed the
-    # whole run).
+    # single blip.
     - name: Install melange
       shell: bash
       env:
@@ -33,9 +31,14 @@ runs:
         rm -rf "/tmp/${MELANGE_ARCHIVE}" /tmp/melange-checksums.txt "/tmp/melange_${MELANGE_VERSION#v}_linux_amd64"
 
     # melange's default container runner shells out to bubblewrap to build
-    # apks; the upstream setup-melange action installed it, so keep parity.
+    # apks. Both apt calls reach the Ubuntu mirror, so wrap each in the
+    # generic retry helper (idempotent: re-running update/install
+    # converges) so a transient mirror 5xx/reset retries rather than
+    # failing the job on a single blip, matching the binary download above.
     - name: Install bubblewrap
       shell: bash
       run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends bubblewrap
+        .github/scripts/retry_cmd.sh "apt-get update (bubblewrap)" \
+          sudo apt-get update
+        .github/scripts/retry_cmd.sh "apt-get install bubblewrap" \
+          sudo apt-get install -y --no-install-recommends bubblewrap

--- a/.github/actions/setup-melange/action.yml
+++ b/.github/actions/setup-melange/action.yml
@@ -1,5 +1,5 @@
 name: Set up melange
-description: Download, verify, and install the melange binary from GitHub releases, plus bubblewrap
+description: Install the melange binary and the runner dependencies its build sandbox needs
 
 inputs:
   version:
@@ -9,36 +9,67 @@ inputs:
 runs:
   using: composite
   steps:
-    # Mirrors setup-apko: download to a file with a bounded retry budget
-    # and verify the published checksum before extracting, so a truncated
-    # release-CDN download self-recovers instead of failing the build on a
-    # single blip.
+    # melange's default runner builds each apk inside bubblewrap; the
+    # aarch64 leg is emulated on an amd64 runner, so it needs the static
+    # qemu binaries; and the build pipelines shell out to a C toolchain,
+    # git and jq. The Ubuntu mirror is a network dependency like any
+    # other, so route both apt calls through the generic retry helper
+    # (idempotent: re-running update/install converges) rather than
+    # letting a transient mirror 5xx fail the job on a single blip.
+    - name: Install melange runner dependencies
+      shell: bash
+      run: |
+        .github/scripts/retry_cmd.sh "apt-get update (melange deps)" \
+          sudo apt-get update
+        .github/scripts/retry_cmd.sh "apt-get install melange deps" \
+          sudo apt-get install -y \
+            qemu-user-static build-essential git jq bubblewrap
+
+    # Ubuntu 24.04 confines unprivileged user namespaces under AppArmor, so
+    # `bwrap --unshare-user` dies with "setting up uid map: Permission
+    # denied" and melange cannot start its sandbox at all. Grant the
+    # `userns` capability to the bwrap profile, then prove the sandbox
+    # actually starts -- failing here names the cause, whereas failing
+    # later surfaces as an opaque melange runner error mid-build.
+    # https://github.com/chainguard-dev/melange/issues/1508
+    - name: Permit unprivileged user namespaces for bwrap
+      shell: bash
+      run: |
+        sudo tee /etc/apparmor.d/local-bwrap <<"EOF"
+        abi <abi/4.0>,
+        include <tunables/global>
+
+        profile local-bwrap /usr/bin/bwrap flags=(unconfined) {
+          userns,
+          include if exists <local/bwrap>
+        }
+        EOF
+        sudo systemctl reload apparmor
+        bwrap --unshare-user --bind / / true
+        echo "bubblewrap sandbox verified"
+
+    # Mirrors setup-apko: download to a file with a bounded per-attempt
+    # transfer timeout and retry budget, and verify the published checksum
+    # before extracting, so a truncated or stalled release-CDN download
+    # self-recovers instead of failing the build on a single blip.
+    # `--max-time` is what bounds a stalled-but-open connection;
+    # `--retry-max-time` alone only caps the retry loop.
     - name: Install melange
       shell: bash
       env:
         MELANGE_VERSION: ${{ inputs.version }}
       run: |
         MELANGE_ARCHIVE="melange_${MELANGE_VERSION#v}_linux_amd64.tar.gz"
-        curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 \
+        curl -fsSL --connect-timeout 30 --max-time 120 \
+          --retry 8 --retry-all-errors --retry-max-time 300 \
           "https://github.com/chainguard-dev/melange/releases/download/${MELANGE_VERSION}/${MELANGE_ARCHIVE}" \
           -o "/tmp/${MELANGE_ARCHIVE}"
-        curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors --retry-max-time 300 \
+        curl -fsSL --connect-timeout 30 --max-time 120 \
+          --retry 8 --retry-all-errors --retry-max-time 300 \
           "https://github.com/chainguard-dev/melange/releases/download/${MELANGE_VERSION}/checksums.txt" \
           -o /tmp/melange-checksums.txt
         awk -v f="${MELANGE_ARCHIVE}" '$2==f {print $1"  /tmp/"$2; found=1} END{if(!found) exit 1}' /tmp/melange-checksums.txt | sha256sum -c -
         tar -xzf "/tmp/${MELANGE_ARCHIVE}" -C /tmp
         mv "/tmp/melange_${MELANGE_VERSION#v}_linux_amd64/melange" /usr/local/bin/melange
         rm -rf "/tmp/${MELANGE_ARCHIVE}" /tmp/melange-checksums.txt "/tmp/melange_${MELANGE_VERSION#v}_linux_amd64"
-
-    # melange's default container runner shells out to bubblewrap to build
-    # apks. Both apt calls reach the Ubuntu mirror, so wrap each in the
-    # generic retry helper (idempotent: re-running update/install
-    # converges) so a transient mirror 5xx/reset retries rather than
-    # failing the job on a single blip, matching the binary download above.
-    - name: Install bubblewrap
-      shell: bash
-      run: |
-        .github/scripts/retry_cmd.sh "apt-get update (bubblewrap)" \
-          sudo apt-get update
-        .github/scripts/retry_cmd.sh "apt-get install bubblewrap" \
-          sudo apt-get install -y --no-install-recommends bubblewrap
+        melange version

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -91,7 +91,6 @@ jobs:
               - '.github/actions/publish-image/**'
               - '.github/actions/publish-image-loaded/**'
               - '.github/actions/setup-apko/**'
-              - '.github/actions/setup-melange/**'
               - 'scripts/cis-scan.sh'
             sandbox:
               - 'docker/sandbox/**'
@@ -104,7 +103,6 @@ jobs:
               - '.github/actions/publish-image/**'
               - '.github/actions/publish-image-loaded/**'
               - '.github/actions/setup-apko/**'
-              - '.github/actions/setup-melange/**'
               - 'scripts/cis-scan.sh'
             sidecar:
               - 'docker/sidecar/**'
@@ -117,7 +115,6 @@ jobs:
               - '.github/actions/publish-image/**'
               - '.github/actions/publish-image-loaded/**'
               - '.github/actions/setup-apko/**'
-              - '.github/actions/setup-melange/**'
               - 'scripts/cis-scan.sh'
             fine-tune:
               - 'docker/fine-tune/**'
@@ -133,7 +130,6 @@ jobs:
               - '.github/actions/publish-image/**'
               - '.github/actions/publish-image-loaded/**'
               - '.github/actions/setup-apko/**'
-              - '.github/actions/setup-melange/**'
               - 'scripts/cis-scan.sh'
             web:
               - 'docker/web/**'
@@ -702,10 +698,9 @@ jobs:
       - name: Set up melange
         # Local action (twin of setup-apko): a retrying, checksum-verified
         # binary download plus bubblewrap, which melange's default runner
-        # needs to build apks. The upstream chainguard-dev/actions install
-        # piped `curl | tar` with no retry, so a truncated release-CDN
-        # download failed the whole build; this fails only on a sustained
-        # outage. Renovate watches the binary version via the marker below.
+        # needs to build apks. A transient release-CDN blip is absorbed by
+        # the retry budget; only a sustained outage fails the step.
+        # Renovate watches the binary version via the marker below.
         uses: ./.github/actions/setup-melange
         with:
           # renovate: datasource=github-releases depName=chainguard-dev/melange

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -696,11 +696,13 @@ jobs:
         run: uv run zensical build
 
       - name: Set up melange
-        # Local action (twin of setup-apko): a retrying, checksum-verified
-        # binary download plus bubblewrap, which melange's default runner
-        # needs to build apks. A transient release-CDN blip is absorbed by
-        # the retry budget; only a sustained outage fails the step.
-        # Renovate watches the binary version via the marker below.
+        # Local action: a retrying, checksum-verified binary download (twin
+        # of setup-apko) plus the sandbox prerequisites melange needs --
+        # bubblewrap with unprivileged userns permitted, static qemu for the
+        # emulated aarch64 leg, and the build toolchain. A transient
+        # release-CDN or mirror blip is absorbed by the retry budgets; only
+        # a sustained outage fails the step. Renovate watches the binary
+        # version via the marker below.
         uses: ./.github/actions/setup-melange
         with:
           # renovate: datasource=github-releases depName=chainguard-dev/melange

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,6 +21,7 @@ on:
       - ".github/actions/publish-image/**"
       - ".github/actions/publish-image-loaded/**"
       - ".github/actions/setup-apko/**"
+      - ".github/actions/setup-melange/**"
       - ".github/actions/setup-python-uv/**"
       - "scripts/cis-scan.sh"
       - "docs/**"
@@ -90,6 +91,7 @@ jobs:
               - '.github/actions/publish-image/**'
               - '.github/actions/publish-image-loaded/**'
               - '.github/actions/setup-apko/**'
+              - '.github/actions/setup-melange/**'
               - 'scripts/cis-scan.sh'
             sandbox:
               - 'docker/sandbox/**'
@@ -102,6 +104,7 @@ jobs:
               - '.github/actions/publish-image/**'
               - '.github/actions/publish-image-loaded/**'
               - '.github/actions/setup-apko/**'
+              - '.github/actions/setup-melange/**'
               - 'scripts/cis-scan.sh'
             sidecar:
               - 'docker/sidecar/**'
@@ -114,6 +117,7 @@ jobs:
               - '.github/actions/publish-image/**'
               - '.github/actions/publish-image-loaded/**'
               - '.github/actions/setup-apko/**'
+              - '.github/actions/setup-melange/**'
               - 'scripts/cis-scan.sh'
             fine-tune:
               - 'docker/fine-tune/**'
@@ -129,6 +133,7 @@ jobs:
               - '.github/actions/publish-image/**'
               - '.github/actions/publish-image-loaded/**'
               - '.github/actions/setup-apko/**'
+              - '.github/actions/setup-melange/**'
               - 'scripts/cis-scan.sh'
             web:
               - 'docker/web/**'
@@ -142,6 +147,7 @@ jobs:
               - '.github/actions/cis-scan/**'
               - '.github/actions/publish-image-loaded/**'
               - '.github/actions/setup-apko/**'
+              - '.github/actions/setup-melange/**'
               - '.github/actions/setup-python-uv/**'
               - 'scripts/cis-scan.sh'
 
@@ -694,15 +700,13 @@ jobs:
         run: uv run zensical build
 
       - name: Set up melange
-        # ``setup-melange`` accepts a ``version:`` input that pins the
-        # melange binary; the SHA pin on the action itself locks the
-        # action's own code so neither layer can drift unexpectedly.
-        # The action also installs bubblewrap on the runner, which
-        # melange's default container runner needs to build apks.
-        # Renovate watches the binary version via the comment marker
-        # below; the action SHA is bumped via the standard
-        # ``actions/*`` Renovate manager.
-        uses: chainguard-dev/actions/setup-melange@4d37df0d85a91f619edc34a8803323033cdcb124 # v1.6.27
+        # Local action (twin of setup-apko): a retrying, checksum-verified
+        # binary download plus bubblewrap, which melange's default runner
+        # needs to build apks. The upstream chainguard-dev/actions install
+        # piped `curl | tar` with no retry, so a truncated release-CDN
+        # download failed the whole build; this fails only on a sustained
+        # outage. Renovate watches the binary version via the marker below.
+        uses: ./.github/actions/setup-melange
         with:
           # renovate: datasource=github-releases depName=chainguard-dev/melange
           version: v0.56.3


### PR DESCRIPTION
## Summary

The upstream `chainguard-dev/actions/setup-melange` installs the melange binary with a piped `curl | tar` and no retry. On a main-push a truncated GitHub release-CDN download (`gzip: unexpected end of file`) failed the `Build Web Assets (melange)` job outright, which cascaded into the dev-tag `Retag Web` job fail-fasting on the never-published web image.

The repo already solved this class for apko with a local `.github/actions/setup-apko` action. This mirrors it for melange.

## What changed

- **New `.github/actions/setup-melange/action.yml`** — downloads the pinned melange binary to a file with a bounded retry budget (`curl --retry 8 --retry-all-errors --retry-max-time 300`), verifies the published `checksums.txt` via `sha256sum -c`, then extracts. Installs `bubblewrap` (melange's default runner needs it, which the upstream action provided), with both `apt-get` calls wrapped in the repo's `retry_cmd.sh` so a mirror blip retries too.
- **`docker.yml`** — the `build-web` job's `Set up melange` step now uses `./.github/actions/setup-melange`, keeping the renovate version marker. Added `.github/actions/setup-melange/**` to the top-level trigger and the `web` path-filter block (the only consumer).

## Test plan

- `actionlint`, `zizmor`, `yamllint`, and the CI-resilience pre-push gate pass.
- The melange archive/checksum asset names and internal layout (`melange_<v>_linux_amd64/melange`) were verified against the v0.56.3 release.
- The original transient failure was separately re-run green (main Docker republished web, dev.49 retag then succeeded); this PR prevents recurrence.

## Review coverage

Pre-reviewed by 5 local agents (infra-reviewer, docs-consistency, comment-quality-rot, comment-analyzer, issue-resolution-verifier). 4 findings addressed: retry-wrapped the bubblewrap apt install, narrowed the path filter to the actual consumer (was triggering 4 unrelated image builds), and trimmed two change-narration comments.

Closes #2631