### PR TITLE
Repair the weekly unit-shard measurement and the external link check

### DIFF
--- a/.github/workflows/maint-link-rot.yml
+++ b/.github/workflows/maint-link-rot.yml
@@ -2,10 +2,11 @@ name: Maint - Link Rot
 
 # Weekly external-link checker for README, every CLAUDE.md tier, and
 # every Markdown under docs/. Runs lychee ONLINE (no ``--offline``):
-# every remote link is probed and any non-200 is surfaced. This is the
-# counterpart to the blocking gate in ``.github/workflows/verify-links.yml``,
-# which runs ``--offline`` and only validates internal links so a
-# third-party host can never block a merge. External rot is real but is
+# every remote link is probed and any response outside ``lychee.toml``'s
+# ``accept`` list is surfaced. This is the counterpart to the blocking
+# gate in ``.github/workflows/verify-links.yml``, which runs ``--offline``
+# and only validates internal links so a third-party host can never block
+# a merge. External rot is real but is
 # not the committer's to fix, so it is reported here off the critical
 # path: the lychee job goes red for visibility, and on a scheduled
 # failure the report-failure job files (or updates) an ``External link
@@ -70,8 +71,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -o pipefail
-          # No ``--offline``: probe every remote link. A non-200 fails
-          # the step (pipefail propagates lychee's exit through tee), so
+          # No ``--offline``: probe every remote link. An unaccepted status
+          # fails the step (pipefail propagates lychee's exit through tee), so
           # the job goes red and the report-failure job below opens the
           # tracking issue. The markdown report lands in the run summary.
           lychee \

--- a/.github/workflows/unit-shard-balance.yml
+++ b/.github/workflows/unit-shard-balance.yml
@@ -34,7 +34,7 @@ jobs:
           ref: ${{ github.sha }}
           persist-credentials: false
 
-      - name: Measure the newest CI run's unit shards
+      - name: Measure the newest CI run carrying unit shards
         id: measure
         env:
           GH_TOKEN: ${{ github.token }}
@@ -42,6 +42,10 @@ jobs:
           # well clear of that noise and still leaves headroom: at a ~170s
           # balanced shard, a 1.5x spread is ~255s against a 300s cap.
           MAX_SPREAD_RATIO: "1.5"
+          # A release-please bump skips the whole correctness matrix, so the
+          # newest completed run can hold no shards at all. Several runs of
+          # headroom keeps an ordinary bump from costing a week's measurement.
+          RUN_WINDOW: "10"
         run: |
           set -euo pipefail
 
@@ -49,35 +53,47 @@ jobs:
           # already been rewritten once (ci.yml -> verify-backend.yml,
           # "CI" -> "Verify - Backend"), which would silently return no runs
           # and leave this reporting "nothing to measure" forever.
-          run_id=$(gh run list --workflow verify-backend.yml --branch main \
-            --status completed --limit 1 --json databaseId --jq '.[0].databaseId')
-          # `--jq .[0].databaseId` on an empty list prints the string "null",
-          # not nothing, so an empty-string test alone would send that
-          # straight into `actions/runs/null/jobs`.
-          if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+          run_ids=$(gh run list --workflow verify-backend.yml --branch main \
+            --status completed --limit "$RUN_WINDOW" \
+            --json databaseId --jq '.[].databaseId')
+          if [ -z "$run_ids" ]; then
             echo "no completed CI run on main; nothing to measure"
             echo "drifted=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           # `--slurp` folds `--paginate`'s one-document-per-page output into a
-          # single array, which the `--argjson` ratio below needs, but gh
-          # refuses `--slurp` alongside `--jq`, so the selection runs in its
-          # own jq rather than inline.
-          timings=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs" \
-            --paginate --slurp \
-            | jq '[ .[] | .jobs[]
-                    | select(.name | startswith("Test Unit (shard"))
-                    | select(.started_at != null and .completed_at != null)
-                    | { name: .name,
-                        seconds: (((.completed_at | fromdateiso8601)
-                                 - (.started_at | fromdateiso8601))) } ]')
+          # single array so `length` and the `max_by`/`min` spread below read
+          # every job in one pass instead of one page at a time. gh refuses
+          # `--slurp` alongside `--jq`, so the selection runs in its own jq.
+          run_id=""
+          timings=""
+          for candidate in $run_ids; do
+            candidate_timings=$(gh api \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$candidate/jobs" \
+              --paginate --slurp \
+              | jq '[ .[] | .jobs[]
+                      | select(.name | startswith("Test Unit (shard"))
+                      | select(.started_at != null and .completed_at != null)
+                      | { name: .name,
+                          seconds: (((.completed_at | fromdateiso8601)
+                                   - (.started_at | fromdateiso8601))) } ]')
+            if [ "$(jq 'length' <<<"$candidate_timings")" -ge 2 ]; then
+              run_id="$candidate"
+              timings="$candidate_timings"
+              break
+            fi
+          done
 
-          count=$(jq 'length' <<<"$timings")
-          if [ "$count" -lt 2 ]; then
-            echo "run $run_id has $count unit shards; nothing to compare"
-            echo "drifted=false" >> "$GITHUB_OUTPUT"
-            exit 0
+          # Exhausting the window means no run carried the shards this reads.
+          # A bump skipping the matrix explains one run, never the whole
+          # window, so what is left is a selector that stopped matching:
+          # it must fail rather than report a placid "no drift" forever.
+          if [ -z "$run_id" ]; then
+            echo "no run among the newest $RUN_WINDOW on main carries 2+" >&2
+            echo "'Test Unit (shard' jobs; the job name or the workflow that" >&2
+            echo "produces it has probably changed" >&2
+            exit 1
           fi
 
           report=$(jq -r 'sort_by(-.seconds) | .[] | "  \(.name): \(.seconds)s"' <<<"$timings")
@@ -125,8 +141,9 @@ jobs:
     needs: check-balance
     # `== 'failure'` alone: the drift issue above is filed by the job itself
     # on what it measured, so this sink is for the measurement breaking --
-    # a gh API error, or an unparseable timings document. A run that never
-    # finished measured nothing at all and goes to report-stalled.
+    # a gh API error, an unparseable timings document, or a whole window of
+    # runs with no shard job to read. A run that never finished measured
+    # nothing at all and goes to report-stalled.
     if: >-
       always()
       && github.event_name == 'schedule'
@@ -202,8 +219,10 @@ jobs:
           not-measured: 'no shard wall-clock was read, so no spread can have drifted'
           guidance: >-
             Check the run's step timings against the check job's 10-minute
-            budget; `gh api --paginate` over a run with many jobs is the part
-            that grows, so a stall there reads the same as a hung endpoint.
+            budget; `gh api --paginate` over each candidate run's jobs is the
+            part that grows, and a window whose early runs all skipped the
+            matrix pays it repeatedly, so a stall there reads the same as a
+            hung endpoint.
           result: ${{ needs.check-balance.result }}
           run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           gh-token: ${{ github.token }}

--- a/.github/workflows/unit-shard-balance.yml
+++ b/.github/workflows/unit-shard-balance.yml
@@ -51,15 +51,18 @@ jobs:
 
           # By filename, not display name: the display name is prose and has
           # already been rewritten once (ci.yml -> verify-backend.yml,
-          # "CI" -> "Verify - Backend"), which would silently return no runs
-          # and leave this reporting "nothing to measure" forever.
+          # "CI" -> "Verify - Backend"). A filename that no longer resolves is
+          # a 404 that `set -e` turns into a failed step; an empty list is the
+          # different case where the workflow exists but no completed run on
+          # main does. Both are a failure to measure rather than a verdict
+          # about drift, so neither may report one.
           run_ids=$(gh run list --workflow verify-backend.yml --branch main \
             --status completed --limit "$RUN_WINDOW" \
             --json databaseId --jq '.[].databaseId')
           if [ -z "$run_ids" ]; then
-            echo "no completed CI run on main; nothing to measure"
-            echo "drifted=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "no completed verify-backend.yml run on main; nothing to" >&2
+            echo "measure a shard spread from" >&2
+            exit 1
           fi
 
           # `--slurp` folds `--paginate`'s one-document-per-page output into a
@@ -141,9 +144,9 @@ jobs:
     needs: check-balance
     # `== 'failure'` alone: the drift issue above is filed by the job itself
     # on what it measured, so this sink is for the measurement breaking --
-    # a gh API error, an unparseable timings document, or a whole window of
-    # runs with no shard job to read. A run that never finished measured
-    # nothing at all and goes to report-stalled.
+    # a gh API error, an unparseable timings document, no completed run to
+    # read at all, or a whole window of runs with no shard job in them. A run
+    # that never finished measured nothing at all and goes to report-stalled.
     if: >-
       always()
       && github.event_name == 'schedule'

--- a/.github/workflows/unit-shard-balance.yml
+++ b/.github/workflows/unit-shard-balance.yml
@@ -60,19 +60,18 @@ jobs:
             exit 0
           fi
 
-          # Durations come from the job start/finish stamps rather than the
-          # log, so this never has to parse pytest output. `--slurp` because
-          # `--paginate` emits one document per page: a run with more jobs
-          # than one page holds would otherwise produce several arrays, and
-          # the `--argjson` below would reject the resulting ratio.
+          # `--slurp` folds `--paginate`'s one-document-per-page output into a
+          # single array, which the `--argjson` ratio below needs, but gh
+          # refuses `--slurp` alongside `--jq`, so the selection runs in its
+          # own jq rather than inline.
           timings=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs" \
-            --paginate --slurp --jq '
-              [ .[] | .jobs[]
-                | select(.name | startswith("Test Unit (shard"))
-                | select(.started_at != null and .completed_at != null)
-                | { name: .name,
-                    seconds: (((.completed_at | fromdateiso8601)
-                             - (.started_at | fromdateiso8601))) } ]')
+            --paginate --slurp \
+            | jq '[ .[] | .jobs[]
+                    | select(.name | startswith("Test Unit (shard"))
+                    | select(.started_at != null and .completed_at != null)
+                    | { name: .name,
+                        seconds: (((.completed_at | fromdateiso8601)
+                                 - (.started_at | fromdateiso8601))) } ]')
 
           count=$(jq 'length' <<<"$timings")
           if [ "$count" -lt 2 ]; then

--- a/lychee.toml
+++ b/lychee.toml
@@ -29,9 +29,15 @@ max_retries = 1
 retry_wait_time = 1
 timeout = 10
 
-# Treat ONLY 200 OK as success. A non-OK response is a real link-rot
-# signal worth surfacing in the weekly external report.
-accept = ["200"]
+# The success family. 200 is a fetch that reached the target. 202 is an
+# edge accepting the request before it reaches origin, which is how an
+# anti-bot challenge answers (build.nvidia.com serves one via AWS WAF,
+# `x-amzn-waf-action: challenge` with an empty body). Admitting it is a
+# deliberate trade: a 202 shows the host answered but NOT that the target
+# exists, since a path that does not exist gets the same challenge, so a
+# dead link behind such a host reads as healthy here. Every other status
+# is real link rot worth surfacing in the weekly external report.
+accept = ["200", "202"]
 
 # Mail links are not real HTTP targets and lychee SMTP probing is noisy
 # on shared hosts. The schema spells this as `include_mail = false`,

--- a/lychee.toml
+++ b/lychee.toml
@@ -11,10 +11,10 @@
 #
 # Ad-hoc local invocations should also pass `--config lychee.toml`.
 #
-# Strictness preset: STRICT. Every non-200 response counts as link rot.
-# Per-host pacing keeps the strict run polite. These network settings
-# apply to the weekly online run; the offline gate makes no network
-# probes and ignores them.
+# Strictness preset: STRICT. Every response outside `accept` below counts
+# as link rot. Per-host pacing keeps the strict run polite. These network
+# settings apply to the weekly online run; the offline gate makes no
+# network probes and ignores them.
 
 # Local on-disk cache (.lycheecache, gitignored). Only repeated manual
 # local online runs benefit from it: the offline gate makes no requests,
@@ -29,14 +29,11 @@ max_retries = 1
 retry_wait_time = 1
 timeout = 10
 
-# The success family. 200 is a fetch that reached the target. 202 is an
-# edge accepting the request before it reaches origin, which is how an
-# anti-bot challenge answers (build.nvidia.com serves one via AWS WAF,
-# `x-amzn-waf-action: challenge` with an empty body). Admitting it is a
-# deliberate trade: a 202 shows the host answered but NOT that the target
-# exists, since a path that does not exist gets the same challenge, so a
-# dead link behind such a host reads as healthy here. Every other status
-# is real link rot worth surfacing in the weekly external report.
+# 202 joins 200 because it is how an anti-bot edge challenge answers (AWS
+# WAF's Challenge action: empty body, `x-amzn-waf-action: challenge`,
+# returned for every path including ones that do not exist). It therefore
+# shows the host answered, NOT that the target exists, so a dead link
+# behind such a host reads as healthy here.
 accept = ["200", "202"]
 
 # Mail links are not real HTTP targets and lychee SMTP probing is noisy


### PR DESCRIPTION
Both weekly CI-health checks were red and filing tracking issues at themselves. Each is fixed at its root cause, and the shard check additionally gains the ability to notice when it has stopped measuring anything.

Closes #2710
Closes #2189

## Unit shard balance

`gh api ... --paginate --slurp --jq` is rejected outright by gh:

```
the `--slurp` option is not supported with `--jq` or `--template`
```

The command never reached the `Test Unit (shard` filter, so this was neither a job-name-matching nor an auth problem. `--slurp` is kept (it folds `--paginate`'s one-document-per-page output into the single array that `length` and the `max_by`/`min` spread need) and the selection moved into its own `jq`.

**While this was broken the shards went unmeasured, so `.test_durations.unit` could go stale with nothing asking for a refresh.** That is the cost of the outage, and it is also why the second change below matters.

### The check could not tell "measured nothing" from "no drift"

Surfaced during review. `verify-backend.yml` gates `test-unit` on `if: needs.changes.outputs.is_release_please != 'true'`, so a release-please bump merged to main produces a completed run carrying **zero** shard jobs. The check read only the single newest completed run, and its `count -lt 2` branch reported `drifted=false` and exited 0.

A release-please bump and a job rename were therefore indistinguishable, and the display name has already been rewritten once (`ci.yml` to `verify-backend.yml`, "CI" to "Verify - Backend"). A future rename would have produced a placid weekly "no drift" forever.

The step now walks a bounded window of recent completed runs, takes the first that actually carries shards, and **fails** when the whole window yields none, which routes to the existing `report-failure` sink. A bump explains one run, never ten.

## External link rot

Exactly two errors, one URL: `https://build.nvidia.com/` at `docs/research/llm-provider-auth-survey.md` lines 24 and 320, `Rejected status code: 202 Accepted`.

That host answers with `202`, `x-amzn-waf-action: challenge`, `Content-Length: 0`. `https://build.nvidia.com/this-page-does-not-exist-zzz9999` returns the **same** 202, because the AWS WAF challenge fires before the request reaches origin. `accept` now admits 202.

The research citation is unchanged: it is provenance and must stay findable.

### Accepted trade-off, stated plainly

lychee's `accept` list is global; it has no per-host override. Admitting 202 therefore means **any** host behind an AWS-WAF-style challenge now reads as healthy whether or not the linked page exists, with no per-host line in the config to audit it by. This is a deliberate operator decision taken with that consequence on the table, not an oversight, and it is recorded in the config comment itself.

Measured blast radius today is exactly one host: every remote host referenced across README, the CLAUDE.md tiers and `docs/` was probed, and none other returns 202. `integrate.api.nvidia.com` returns 404, so it is not covered by the same pattern.

Both blocking paths are unaffected either way: `verify-links.yml` and the pre-push hook run `--offline`, where `accept` never applies.

## Verification

| Check | Result |
|---|---|
| `unit-shard-balance.yml` dispatched on this branch (run 30883219945) | success, 4 shards, ratio **1.1946** vs the 1.5 ceiling, `drifted=false` |
| `maint-link-rot.yml` dispatched on this branch (run 30883221620) | success, 1445 links, 1397 OK, **0 errors** |
| `lychee --config lychee.toml docs/research/llm-provider-auth-survey.md` (online) | 62 OK, 0 errors, citation unchanged |
| `uv run pre-commit run lychee --hook-stage pre-push --all-files` | Passed |
| actionlint / zizmor / yamllint / check-toml | Passed |

The window-exhaustion path was exercised directly by replaying the step against the live API with a selector matching nothing, standing in for a renamed job: it walks all 10 runs and exits 1, which is what fires the tracking issue.

One honest caveat on the evidence: `uv run pre-commit run lychee --hook-stage pre-push --all-files` runs `--offline`, so it never probes `build.nvidia.com` and would have passed identically on the unfixed config. It is a valid no-regression check but it does **not** exercise the 202 change. What does is the online run on the file and the dispatched weekly workflow, both above.

## Both checks still fail loudly

- The `gh api | jq` pipeline aborts on failure: pipefail takes the rightmost **non-zero** status, so a `gh` error still propagates even though `jq` exits 0 on empty stdin, and `set -e` fires on the bare assignment. Verified by execution, not inspection.
- The window-exhaustion path is a new hard failure where the old code silently succeeded.
- Every status outside `accept` is still link rot; `max_retries`, `timeout` and the exclude list are untouched.
- No `|| true`, no `continue-on-error`, no widened threshold.

## Review coverage

Pre-reviewed by 6 agents (infra-reviewer, silent-failure-hunter, issue-resolution-verifier, docs-consistency, comment-quality-rot, comment-analyzer), 0 failures, 8 findings, 7 addressed. The eighth is the global-`accept` mechanism above, which three agents independently flagged and which was resolved as an explicit operator decision.

Findings fixed included a stale `lychee.toml` strictness claim that contradicted the new accept list, a comment that misattributed which code consumes the folded array, two stale descriptions in `maint-link-rot.yml`, and the run-window hole.
