### PR TITLE
fix: make the docs search and footer usable with a screen reader

### DIFF
--- a/.github/workflows/build-docs-preview.yml
+++ b/.github/workflows/build-docs-preview.yml
@@ -201,6 +201,9 @@ jobs:
       - name: Patch sitemap with static OpenAPI artifacts
         run: uv run python scripts/patch_sitemap.py
 
+      - name: Strip prohibited aria-label from the drawer overlay
+        run: uv run python scripts/patch_docs_a11y.py
+
       # --- Astro (landing page at /) ---
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -162,6 +162,9 @@ jobs:
       - name: Patch sitemap with static OpenAPI artifacts
         run: uv run python scripts/patch_sitemap.py
 
+      - name: Strip prohibited aria-label from the drawer overlay
+        run: uv run python scripts/patch_docs_a11y.py
+
       - name: Generate old-path redirect stubs
         # zensical builds the docs but does NOT run the mkdocs-redirects plugin,
         # so the redirect_maps in mkdocs.yml never materialise as pages and the

--- a/docs/overrides/a11y-search.js
+++ b/docs/overrides/a11y-search.js
@@ -1,0 +1,87 @@
+/* Repair the accessibility of the theme's search widget.
+ *
+ * The widget renders into a shadow root and ships two defects that axe-core
+ * reports (aria-required-attr, button-name):
+ *
+ *   1. Its text input claims role="combobox" but wires up none of the
+ *      contract that role promises: there is no listbox, no aria-expanded,
+ *      no aria-controls and no aria-activedescendant. A role that lies is
+ *      worse for a screen-reader user than no role, because the reader
+ *      announces a control whose advertised state never arrives. Dropping
+ *      the attribute leaves an honest search field, which is what the
+ *      widget actually is. Completing the contract instead would mean
+ *      maintaining listbox/option roles and active-descendant tracking
+ *      against a third-party component that re-renders on every keystroke.
+ *
+ *   2. Its icon-only buttons carry no accessible name, so a screen reader
+ *      announces them as an unlabelled "button". The icon each one holds
+ *      identifies it, so the name is read off that.
+ *
+ * The component re-renders on input, which discards these edits, so a
+ * MutationObserver re-applies them. Every change is idempotent and the
+ * observer only ever adds a name or removes the false role, so it cannot
+ * fight the framework for control of any attribute the widget itself sets.
+ *
+ * Delete this file once the theme wires up its own ARIA and names its own
+ * controls, tracked upstream at https://github.com/zensical/backlog/issues/161.
+ */
+
+(() => {
+  "use strict";
+
+  // Read off the lucide icon each button contains: the widget gives its
+  // buttons no text, no title and no distinguishing class of its own.
+  const BUTTON_NAMES = {
+    "lucide-search": "Search",
+    "lucide-list-filter": "Filter results",
+  };
+
+  const nameButtons = (root) => {
+    for (const button of root.querySelectorAll("button")) {
+      if (button.getAttribute("aria-label")) continue;
+      if (button.textContent.trim()) continue;
+      const icon = button.querySelector("svg[class*='lucide-']");
+      if (!icon) continue;
+      const match = [...icon.classList].find((name) => name in BUTTON_NAMES);
+      if (match) button.setAttribute("aria-label", BUTTON_NAMES[match]);
+    }
+  };
+
+  const dropFalseCombobox = (root) => {
+    for (const input of root.querySelectorAll('input[role="combobox"]')) {
+      if (input.getAttribute("aria-controls")) continue;
+      input.removeAttribute("role");
+    }
+  };
+
+  const repair = (root) => {
+    dropFalseCombobox(root);
+    nameButtons(root);
+  };
+
+  const observed = new WeakSet();
+
+  const attach = (shadowRoot) => {
+    if (observed.has(shadowRoot)) return;
+    observed.add(shadowRoot);
+    repair(shadowRoot);
+    new MutationObserver(() => repair(shadowRoot)).observe(shadowRoot, {
+      childList: true,
+      subtree: true,
+    });
+  };
+
+  const scan = () => {
+    for (const element of document.querySelectorAll("*")) {
+      if (element.shadowRoot) attach(element.shadowRoot);
+    }
+  };
+
+  // The widget mounts its shadow host lazily, when search is first opened,
+  // so a single pass at load time would find nothing to repair.
+  scan();
+  new MutationObserver(scan).observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+})();

--- a/docs/overrides/extra.css
+++ b/docs/overrides/extra.css
@@ -83,3 +83,14 @@ hr,
   background: #0f0f1a;
   border-bottom: 1px solid #1e1e2e;
 }
+
+/* Footer meta bar.
+   The modern theme paints this bar with --md-default-fg-color--lightest and
+   the copyright text with --md-default-fg-color--light. Upstream both are
+   near-transparent tints (#0000000d / #0000008c) layered over the page, but
+   the dark palette above redefines them as opaque slates, which turns a 5%
+   overlay into a solid mid-tone ground and drops the copyright to 2.95:1.
+   Painting the bar explicitly restores the intended dark ground (7.4:1). */
+.md-footer-meta {
+  background-color: #0f0f1a;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -333,6 +333,9 @@ nav:
 extra_css:
   - overrides/extra.css
 
+extra_javascript:
+  - overrides/a11y-search.js
+
 extra:
   homepage: /
   synthorg_version: !ENV [SYNTHORG_VERSION, "dev"]

--- a/scripts/patch_docs_a11y.py
+++ b/scripts/patch_docs_a11y.py
@@ -1,0 +1,91 @@
+"""Strip the prohibited ``aria-label`` from the built docs drawer overlay.
+
+The theme emits ``<label class="md-overlay" for="__drawer" aria-label="...">``
+as a full-page click-catcher that closes the navigation drawer. axe-core 4.13.0
+(``aria-prohibited-attr``) rejects naming a ``<label>``: a label takes its
+accessible name from its content, so an ``aria-label`` on one is invalid ARIA
+and the element is reported as a violation.
+
+Removing the name is the correct resolution rather than adding a role. The
+overlay is a redundant pointer target for a control that already exists in the
+header (the drawer toggle carries its own name), so announcing it a second time
+would add a duplicate control to the accessibility tree rather than remove one.
+
+Only ``md-overlay`` is touched. The header's ``md-header__button`` labels also
+carry ``aria-label``, and there the attribute is load-bearing: those wrap an
+icon with no text, so stripping it would leave two unnamed controls. Widening
+this to every ``<label>`` would trade one violation for two worse ones.
+
+Run after ``zensical build``:
+
+    uv run zensical build
+    uv run python scripts/patch_docs_a11y.py
+
+CI (``build-docs.yml``, ``build-docs-preview.yml``) runs the same sequence
+before deploying the docs site.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_DIR = REPO_ROOT / "_site" / "docs"
+
+# Matches the overlay's opening tag and captures the ``aria-label`` attribute
+# so it can be dropped. Attribute order is not fixed by the template, so the
+# class check and the attribute capture are separate lookaheads rather than one
+# positional pattern.
+OVERLAY_TAG = re.compile(
+    r"<label(?=[^>]*\bclass=[\"'][^\"']*\bmd-overlay\b)[^>]*>",
+    re.IGNORECASE,
+)
+ARIA_LABEL_ATTR = re.compile(r"\s+aria-label=(\"[^\"]*\"|'[^']*')", re.IGNORECASE)
+
+
+def _strip_overlay_label(html: str) -> tuple[str, int]:
+    """Return ``html`` with the overlay's ``aria-label`` removed, and a count."""
+    removed = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal removed
+        tag = match.group(0)
+        cleaned, count = ARIA_LABEL_ATTR.subn("", tag)
+        removed += count
+        return cleaned
+
+    return OVERLAY_TAG.sub(replace, html), removed
+
+
+def main() -> int:
+    """Patch every built docs page, returning 1 if the build output is missing."""
+    if not DOCS_DIR.is_dir():
+        print(f"Error: built docs not found at {DOCS_DIR}", file=sys.stderr)
+        print("Run `uv run zensical build` first.", file=sys.stderr)
+        return 1
+
+    pages = sorted(DOCS_DIR.rglob("*.html"))
+    if not pages:
+        print(f"Error: no HTML pages under {DOCS_DIR}", file=sys.stderr)
+        return 1
+
+    patched_pages = 0
+    total_removed = 0
+    for page in pages:
+        original = page.read_text(encoding="utf-8")
+        patched, removed = _strip_overlay_label(original)
+        if removed == 0:
+            continue
+        page.write_text(patched, encoding="utf-8")
+        patched_pages += 1
+        total_removed += removed
+
+    print(
+        f"Removed {total_removed} prohibited aria-label(s) "
+        f"across {patched_pages}/{len(pages)} page(s)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_patch_docs_a11y.py
+++ b/tests/unit/scripts/test_patch_docs_a11y.py
@@ -1,0 +1,129 @@
+"""Tests for scripts/patch_docs_a11y.py.
+
+Pins the drawer-overlay patcher's contract:
+
+* the overlay's ``aria-label`` is stripped whatever the attribute order
+* the header's ``md-header__button`` labels keep theirs, because there the
+  attribute is the only accessible name those icon-only controls have
+* the rewrite is idempotent, so a rerun over patched output is a no-op
+* ``main()`` walks the built tree and reports how many pages it touched
+"""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _import_script(name: str) -> ModuleType:
+    """Load ``scripts/<name>.py`` as a module, mirroring the sibling tests."""
+    script = Path(__file__).resolve().parents[3] / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, script)
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+patcher = _import_script("patch_docs_a11y")
+
+HEADER_LABEL = (
+    '<label class="md-header__button md-icon" for="__drawer" aria-label="Navigation">'
+)
+OVERLAY = '<label class="md-overlay" for="__drawer" aria-label="Navigation"></label>'
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "tag",
+    [
+        '<label class="md-overlay" for="__drawer" aria-label="Navigation">',
+        '<label aria-label="Navigation" class="md-overlay" for="__drawer">',
+        "<label class='md-overlay' for='__drawer' aria-label='Navigation'>",
+        '<LABEL CLASS="md-overlay" ARIA-LABEL="Navigation">',
+    ],
+)
+def test_strips_overlay_aria_label_whatever_the_attribute_order(tag: str) -> None:
+    patched, removed = patcher._strip_overlay_label(tag)
+
+    assert removed == 1
+    assert "aria-label" not in patched.lower()
+    assert "md-overlay" in patched.lower()
+
+
+@pytest.mark.unit
+def test_leaves_header_button_labels_named() -> None:
+    """The header icons have no text, so their aria-label is load-bearing."""
+    patched, removed = patcher._strip_overlay_label(HEADER_LABEL)
+
+    assert removed == 0
+    assert patched == HEADER_LABEL
+
+
+@pytest.mark.unit
+def test_patches_only_the_overlay_in_a_full_page() -> None:
+    html = (
+        f"<body>{HEADER_LABEL}</label>"
+        '<label class="md-overlay" for="__drawer" aria-label="Navigation"></label>'
+        "</body>"
+    )
+
+    patched, removed = patcher._strip_overlay_label(html)
+
+    assert removed == 1
+    assert patched.count('aria-label="Navigation"') == 1
+    assert 'class="md-overlay" for="__drawer"></label>' in patched
+
+
+@pytest.mark.unit
+def test_rewrite_is_idempotent() -> None:
+    once, first = patcher._strip_overlay_label(
+        '<label class="md-overlay" for="__drawer" aria-label="Navigation">'
+    )
+    twice, second = patcher._strip_overlay_label(once)
+
+    assert first == 1
+    assert second == 0
+    assert twice == once
+
+
+@pytest.mark.unit
+def test_main_walks_the_built_tree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    docs = tmp_path / "_site" / "docs"
+    (docs / "guides").mkdir(parents=True)
+    (docs / "index.html").write_text(OVERLAY, encoding="utf-8")
+    (docs / "guides" / "index.html").write_text(OVERLAY, encoding="utf-8")
+    (docs / "guides" / "untouched.html").write_text(HEADER_LABEL, encoding="utf-8")
+    monkeypatch.setattr(patcher, "DOCS_DIR", docs)
+
+    assert patcher.main() == 0
+
+    nested = docs / "guides" / "index.html"
+    assert "aria-label" not in (docs / "index.html").read_text(encoding="utf-8")
+    assert "aria-label" not in nested.read_text(encoding="utf-8")
+    untouched = docs / "guides" / "untouched.html"
+    assert untouched.read_text(encoding="utf-8") == HEADER_LABEL
+
+
+@pytest.mark.unit
+def test_main_fails_loudly_when_the_build_output_is_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(patcher, "DOCS_DIR", tmp_path / "absent")
+
+    assert patcher.main() == 1
+
+
+@pytest.mark.unit
+def test_main_fails_loudly_when_the_build_output_has_no_pages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    empty = tmp_path / "_site" / "docs"
+    empty.mkdir(parents=True)
+    monkeypatch.setattr(patcher, "DOCS_DIR", empty)
+
+    assert patcher.main() == 1


### PR DESCRIPTION
Fixes four accessibility defects on the documentation site, all of which axe-core reports on every page.

## Why now

`axe-core` 4.12.1 -> 4.13.0 landed in the lockfile-maintenance PR (#2737) and turned `Lighthouse Site` red. Its release notes name the change directly: *"aria-prohibited-attr: allow many elements to be named and disallow label and body from being named"*.

That is a correct new finding, not a regression from the bump. The docs Lighthouse job runs `lhci` from `web/`'s node_modules, so the accessibility engine came along with the refresh. `/docs/` scored **0.86 with three failing audits** before the bump and **0.82 with four** after, against a 0.85 gate. The gate was sitting just above the score three pre-existing defects produce.

#2737 stays red until this lands; it then needs a rebase to pick these up.

## The four defects

**Footer copyright at 2.95:1.** The modern theme paints the meta bar with `--md-default-fg-color--lightest` and the copyright with `--md-default-fg-color--light`. Upstream both are near-transparent tints (`#0000000d` / `#0000008c`) layered over the page, but `docs/overrides/extra.css` redefines them as opaque slates, so a 5% overlay became a solid mid-tone ground. Painting the bar explicitly restores the intended dark ground at **7.4:1**.

**`aria-label` on `label.md-overlay`.** Invalid on a `<label>`, and it names a redundant pointer target for a control the header already exposes. `scripts/patch_docs_a11y.py` strips it post-build. Deliberately scoped to the overlay only: the header's `md-header__button` labels also carry `aria-label`, and there it is the sole accessible name those icon-only controls have, so widening the rule would trade one violation for two worse ones.

**Search input claims `role="combobox"` with none of the contract.** No `aria-expanded`, no `aria-controls`, no listbox, no `aria-activedescendant`. A role that lies is worse than no role: the reader announces a control whose advertised state never arrives. The shim drops it, leaving an honest search field. Completing the contract instead would mean maintaining listbox/option roles and active-descendant tracking against a vendor component that re-renders on every keystroke.

**Two icon-only buttons with no accessible name.** Announced only as "button". Named from the lucide icon each carries.

The last two live in the widget's shadow root, so `docs/overrides/a11y-search.js` repairs them there and reapplies on re-render. Tracked upstream at zensical/backlog#161 so the shim can be deleted rather than carried indefinitely.

## Verification

Built locally and checked in a real browser, before and after:

- overlay `aria-label` gone; both header labels still named
- footer bar `rgb(15,15,26)` behind `rgb(148,163,184)` text
- no `input[role="combobox"]` remains; zero unnamed buttons
- durability: after driving real input and rendering 40 results, the role stayed removed and both buttons stayed named

`tests/unit/scripts/test_patch_docs_a11y.py` pins the patcher's contract (attribute order, quote style, header labels untouched, idempotence, fail-loud on missing build output). It caught a real bug during development: the original regex only matched double-quoted `class`, so a single-quoted attribute would have silently no-opped.

10 tests, ruff, format and mypy all pass; the full pre-push gate set is green.
