### PR TITLE
Show the update changelog without blocking on it, and scrub what it renders

### DIFF
--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -85,7 +85,7 @@ Supported keys:
   auto_pull             Auto-accept container image pulls
   auto_restart          Auto-restart containers after update
   auto_start_after_wipe Auto-start containers after wipe
-  auto_update_cli       Auto-accept CLI self-updates
+  auto_update_cli       Auto-accept CLI self-updates (changelog shown, not paged)
   backend_port          Backend API port
   changelog_view        Default changelog view for 'synthorg update' walk: "highlights" or "commits"
   channel               Update channel
@@ -130,7 +130,8 @@ Supported keys:
   auto_pull              Auto-accept container image pulls: "true" or "false"
   auto_restart           Auto-restart containers after update: "true" or "false"
   auto_start_after_wipe  Auto-start containers after wipe: "true" or "false"
-  auto_update_cli        Auto-accept CLI self-updates: "true" or "false"
+  auto_update_cli        Auto-accept CLI self-updates, printing the changelog
+                         instead of paging it: "true" or "false"
   backend_port           Backend API port: 1-65535
   changelog_view         Default 'synthorg update' walk view: "highlights" or "commits"
   channel                Update channel: "stable" or "dev"

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -323,7 +320,12 @@ func isDevChannelMismatch(channel, ver string) bool {
 // jump contains (the changelog, or its terse offline notice when that could
 // not be fetched), so this function goes straight to the install confirm.
 func downloadAndApplyCLI(ctx context.Context, out *ui.UI, result selfupdate.CheckResult, autoAccept bool) error {
-	ok, err := confirmUpdate(ctx, fmt.Sprintf("Update CLI from %s to %s?", result.CurrentVersion, result.LatestVersion), autoAccept)
+	// The confirm prompt renders through huh, which applies none of the
+	// UI's own scrubbing, and the target version is a remote tag name: this
+	// is the one string the operator reads before consenting.
+	ok, err := confirmUpdate(ctx, fmt.Sprintf("Update CLI from %s to %s?",
+		ui.SanitizeUntrustedLine(result.CurrentVersion),
+		ui.SanitizeUntrustedLine(result.LatestVersion)), autoAccept)
 	if err != nil {
 		return fmt.Errorf("confirming CLI update: %w", err)
 	}
@@ -332,8 +334,11 @@ func downloadAndApplyCLI(ctx context.Context, out *ui.UI, result selfupdate.Chec
 	}
 	if autoAccept {
 		// Name the setting that answered, or an install nobody confirmed
-		// looks like the confirm prompt went missing.
-		out.Step(fmt.Sprintf("auto_update_cli is set: installing %s without confirmation.", result.LatestVersion))
+		// looks like the confirm prompt went missing. StepAlways because
+		// --quiet is precisely how an unattended install is invoked, and
+		// this line is the only record that it was unattended.
+		out.StepAlways(fmt.Sprintf("auto_update_cli is set: installing %s without confirmation.",
+			ui.SanitizeUntrustedLine(result.LatestVersion)))
 	}
 
 	// Surface a permission error in the install directory before the
@@ -371,9 +376,10 @@ func downloadAndApplyCLI(ctx context.Context, out *ui.UI, result selfupdate.Chec
 	if err := selfupdate.Replace(binary); err != nil {
 		return fmt.Errorf("replacing binary: %w", err)
 	}
-	out.Success(fmt.Sprintf("CLI updated to %s", result.LatestVersion))
+	installed := ui.SanitizeUntrustedLine(result.LatestVersion)
+	out.Success(fmt.Sprintf("CLI updated to %s", installed))
 	out.HintNextStep(fmt.Sprintf("Release notes: %s/releases/tag/v%s",
-		version.RepoURL, strings.TrimPrefix(result.LatestVersion, "v")))
+		version.RepoURL, strings.TrimPrefix(installed, "v")))
 	if !autoAccept {
 		out.HintTip("Run 'synthorg config set auto_update_cli true' to auto-accept CLI updates.")
 	}
@@ -455,114 +461,6 @@ func resolveUpdateChannel(ctx context.Context) string {
 		return state.Channel
 	}
 	return "stable"
-}
-
-// ChildExitError and ChildExitCode are defined in exitcodes.go.
-
-// reexecUpdate spawns the new binary with the same arguments so the rest
-// of the update (compose refresh, image pull) uses the new embedded template.
-// The CLI update step already ran, so the new binary will see "up to date"
-// and proceed directly to compose + images.
-//
-// Arguments are reconstructed from known flag values rather than forwarding
-// raw os.Args to avoid silently propagating unexpected flags.
-//
-// Returns a *ChildExitError if the child exits non-zero, so the caller
-// can propagate the exit code rather than printing a generic error.
-func reexecUpdate(cmd *cobra.Command, recovered bool) error {
-	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Re-launching updated CLI to continue...")
-	execPath, err := resolveCurrentExecutable(cmd)
-	if err != nil {
-		return err
-	}
-	c := exec.CommandContext(cmd.Context(), execPath, buildReexecArgs(cmd, recovered)...) //nolint:gosec // G204: execPath is the CLI's own resolved binary, args reconstructed from known flags (not raw os.Args)
-	c.Stdin = os.Stdin
-	c.Stdout = cmd.OutOrStdout()
-	c.Stderr = cmd.ErrOrStderr()
-	if runErr := c.Run(); runErr != nil {
-		// Preserve the child's exit code so the parent can propagate it.
-		if exitErr, ok := errors.AsType[*exec.ExitError](runErr); ok {
-			return &ChildExitError{Code: exitErr.ExitCode()}
-		}
-		return fmt.Errorf("re-launching updated CLI: %w", runErr)
-	}
-	return nil
-}
-
-// resolveCurrentExecutable returns the absolute, symlink-resolved path
-// to the running binary. Failure to resolve symlinks is non-fatal and
-// produces a warning (selfupdate.Replace writes to the resolved path,
-// so a mismatch surfaces as a stale-binary re-exec).
-func resolveCurrentExecutable(cmd *cobra.Command) (string, error) {
-	execPath, err := os.Executable()
-	if err != nil {
-		return "", fmt.Errorf("finding executable path: %w", err)
-	}
-	resolved, resolveErr := filepath.EvalSymlinks(execPath)
-	if resolveErr != nil {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not resolve executable symlink: %v\n", resolveErr)
-		return execPath, nil
-	}
-	return resolved, nil
-}
-
-// buildReexecArgs reconstructs the argv for the re-exec'd child from
-// the known flag set. Forwarding os.Args would silently propagate
-// unexpected flags; rebuilding from typed values keeps the contract
-// explicit.
-func buildReexecArgs(cmd *cobra.Command, recovered bool) []string {
-	reArgs := []string{"update", "--skip-cli-update"}
-	if recovered {
-		// Carry the parent's installation-health verdict so the child
-		// forces the image pull without re-running the interactive
-		// corruption check.
-		reArgs = append(reArgs, "--health-recovered")
-	}
-	if flagDataDir != "" {
-		reArgs = append(reArgs, "--data-dir", flagDataDir)
-	}
-	if flagSkipVerify {
-		reArgs = append(reArgs, "--skip-verify")
-		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Warning: --skip-verify is being carried forward to the re-launched CLI.")
-	}
-	if flagQuiet {
-		reArgs = append(reArgs, "--quiet")
-	}
-	for range flagVerbose {
-		reArgs = append(reArgs, "-v")
-	}
-	reArgs = appendBoolFlags(reArgs, []boolFlag{
-		{"--no-color", flagNoColor},
-		{"--plain", flagPlain},
-		{"--json", flagJSON},
-		{"--yes", flagYes},
-		{"--no-restart", updateNoRestart},
-		{"--images-only", updateImagesOnly},
-		{"--cli-only", updateCLIOnly},
-	})
-	if cmd.Flags().Changed("timeout") {
-		reArgs = append(reArgs, "--timeout", updateTimeout)
-	}
-	if cmd.Flags().Changed("verify-timeout") {
-		reArgs = append(reArgs, "--verify-timeout", updateVerifyTimeout)
-	}
-	return reArgs
-}
-
-type boolFlag struct {
-	name string
-	set  bool
-}
-
-// appendBoolFlags appends every flag whose set field is true. Keeps
-// buildReexecArgs flat instead of carrying a long if-chain.
-func appendBoolFlags(args []string, flags []boolFlag) []string {
-	for _, f := range flags {
-		if f.set {
-			args = append(args, f.name)
-		}
-	}
-	return args
 }
 
 // targetImageTag converts a CLI version string to a Docker image tag.

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -376,10 +376,9 @@ func downloadAndApplyCLI(ctx context.Context, out *ui.UI, result selfupdate.Chec
 	if err := selfupdate.Replace(binary); err != nil {
 		return fmt.Errorf("replacing binary: %w", err)
 	}
-	installed := ui.SanitizeUntrustedLine(result.LatestVersion)
-	out.Success(fmt.Sprintf("CLI updated to %s", installed))
-	out.HintNextStep(fmt.Sprintf("Release notes: %s/releases/tag/v%s",
-		version.RepoURL, strings.TrimPrefix(installed, "v")))
+	out.Success(fmt.Sprintf("CLI updated to %s", versionLabel(result.LatestVersion)))
+	out.HintNextStep(fmt.Sprintf("Release notes: %s/releases/tag/%s",
+		version.RepoURL, versionURLRef(result.LatestVersion)))
 	if !autoAccept {
 		out.HintTip("Run 'synthorg config set auto_update_cli true' to auto-accept CLI updates.")
 	}

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -319,9 +319,9 @@ func isDevChannelMismatch(channel, ver string) bool {
 
 // downloadAndApplyCLI downloads, verifies, and replaces the current binary
 // with the new version. Returns errReexec on success so the caller can
-// re-exec the updated binary. runChangelogWalk (or its offline fallback)
-// prints the "New version available" notice before this is called, so this
-// function goes straight to the install confirm prompt.
+// re-exec the updated binary. runChangelogWalk has already shown what the
+// jump contains (the changelog, or its terse offline notice when that could
+// not be fetched), so this function goes straight to the install confirm.
 func downloadAndApplyCLI(ctx context.Context, out *ui.UI, result selfupdate.CheckResult, autoAccept bool) error {
 	ok, err := confirmUpdate(ctx, fmt.Sprintf("Update CLI from %s to %s?", result.CurrentVersion, result.LatestVersion), autoAccept)
 	if err != nil {
@@ -329,6 +329,11 @@ func downloadAndApplyCLI(ctx context.Context, out *ui.UI, result selfupdate.Chec
 	}
 	if !ok {
 		return nil
+	}
+	if autoAccept {
+		// Name the setting that answered, or an install nobody confirmed
+		// looks like the confirm prompt went missing.
+		out.Step(fmt.Sprintf("auto_update_cli is set: installing %s without confirmation.", result.LatestVersion))
 	}
 
 	// Surface a permission error in the install directory before the
@@ -438,7 +443,7 @@ func updateCLI(cmd *cobra.Command, autoAcceptCLI bool) error {
 	// Failure is non-fatal here: an unreadable config only degrades the
 	// changelog walk to its offline fallback, and the update proceeds.
 	state, _ := config.Load(opts.DataDir)
-	runChangelogWalk(ctx, cmd, result, state)
+	runChangelogWalk(ctx, cmd, result, state, autoAcceptCLI)
 
 	return downloadAndApplyCLI(ctx, out, result, autoAcceptCLI)
 }

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -254,16 +254,20 @@ func runUpdateCheck(cmd *cobra.Command, state config.State) error {
 	if channel == "" {
 		channel = "stable"
 	}
-	result, err := selfupdate.CheckForChannel(ctx, channel)
+	result, err := checkForChannel(ctx, channel)
 	if err != nil {
 		return fmt.Errorf("checking for updates: %w", err)
 	}
 	if result.UpdateAvail {
-		out.Step(fmt.Sprintf("Update available: %s (current: %s)", result.LatestVersion, result.CurrentVersion))
+		// LatestVersion is a remote tag name, and this is the line `update
+		// --check` exists to print: on the terse path it is the ONLY thing an
+		// operator sees before deciding to run the install.
+		out.Step(fmt.Sprintf("Update available: %s (current: %s)",
+			versionLabel(result.LatestVersion), versionLabel(result.CurrentVersion)))
 		out.HintNextStep("Run 'synthorg update' to apply")
 		return NewExitError(ExitUpdateAvail, nil)
 	}
-	out.Success(fmt.Sprintf("Up to date (%s)", result.CurrentVersion))
+	out.Success(fmt.Sprintf("Up to date (%s)", versionLabel(result.CurrentVersion)))
 	out.HintGuidance("Exit code 0 means up to date; exit code 10 means an update is available.")
 	return nil
 }
@@ -324,8 +328,8 @@ func downloadAndApplyCLI(ctx context.Context, out *ui.UI, result selfupdate.Chec
 	// UI's own scrubbing, and the target version is a remote tag name: this
 	// is the one string the operator reads before consenting.
 	ok, err := confirmUpdate(ctx, fmt.Sprintf("Update CLI from %s to %s?",
-		ui.SanitizeUntrustedLine(result.CurrentVersion),
-		ui.SanitizeUntrustedLine(result.LatestVersion)), autoAccept)
+		versionLabel(result.CurrentVersion),
+		versionLabel(result.LatestVersion)), autoAccept)
 	if err != nil {
 		return fmt.Errorf("confirming CLI update: %w", err)
 	}
@@ -338,7 +342,7 @@ func downloadAndApplyCLI(ctx context.Context, out *ui.UI, result selfupdate.Chec
 		// --quiet is precisely how an unattended install is invoked, and
 		// this line is the only record that it was unattended.
 		out.StepAlways(fmt.Sprintf("auto_update_cli is set: installing %s without confirmation.",
-			ui.SanitizeUntrustedLine(result.LatestVersion)))
+			versionLabel(result.LatestVersion)))
 	}
 
 	// Surface a permission error in the install directory before the
@@ -441,7 +445,7 @@ func updateCLI(cmd *cobra.Command, autoAcceptCLI bool) error {
 	}
 
 	if !result.UpdateAvail {
-		out.Success(fmt.Sprintf("CLI is up to date (%s)", result.CurrentVersion))
+		out.Success(fmt.Sprintf("CLI is up to date (%s)", versionLabel(result.CurrentVersion)))
 		return nil
 	}
 

--- a/cli/cmd/update_reexec.go
+++ b/cli/cmd/update_reexec.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+// ChildExitError and ChildExitCode are defined in exitcodes.go.
+
+// reexecUpdate spawns the new binary with the same arguments so the rest
+// of the update (compose refresh, image pull) uses the new embedded template.
+// The CLI update step already ran, so the new binary will see "up to date"
+// and proceed directly to compose + images.
+//
+// Arguments are reconstructed from known flag values rather than forwarding
+// raw os.Args to avoid silently propagating unexpected flags.
+//
+// Returns a *ChildExitError if the child exits non-zero, so the caller
+// can propagate the exit code rather than printing a generic error.
+func reexecUpdate(cmd *cobra.Command, recovered bool) error {
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Re-launching updated CLI to continue...")
+	execPath, err := resolveCurrentExecutable(cmd)
+	if err != nil {
+		return err
+	}
+	c := exec.CommandContext(cmd.Context(), execPath, buildReexecArgs(cmd, recovered)...) //nolint:gosec // G204: execPath is the CLI's own resolved binary, args reconstructed from known flags (not raw os.Args)
+	c.Stdin = os.Stdin
+	c.Stdout = cmd.OutOrStdout()
+	c.Stderr = cmd.ErrOrStderr()
+	if runErr := c.Run(); runErr != nil {
+		// Preserve the child's exit code so the parent can propagate it.
+		if exitErr, ok := errors.AsType[*exec.ExitError](runErr); ok {
+			return &ChildExitError{Code: exitErr.ExitCode()}
+		}
+		return fmt.Errorf("re-launching updated CLI: %w", runErr)
+	}
+	return nil
+}
+
+// resolveCurrentExecutable returns the absolute, symlink-resolved path
+// to the running binary. Failure to resolve symlinks is non-fatal and
+// produces a warning (selfupdate.Replace writes to the resolved path,
+// so a mismatch surfaces as a stale-binary re-exec).
+func resolveCurrentExecutable(cmd *cobra.Command) (string, error) {
+	execPath, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("finding executable path: %w", err)
+	}
+	resolved, resolveErr := filepath.EvalSymlinks(execPath)
+	if resolveErr != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not resolve executable symlink: %v\n", resolveErr)
+		return execPath, nil
+	}
+	return resolved, nil
+}
+
+// buildReexecArgs reconstructs the argv for the re-exec'd child from
+// the known flag set. Forwarding os.Args would silently propagate
+// unexpected flags; rebuilding from typed values keeps the contract
+// explicit.
+func buildReexecArgs(cmd *cobra.Command, recovered bool) []string {
+	reArgs := []string{"update", "--skip-cli-update"}
+	if recovered {
+		// Carry the parent's installation-health verdict so the child
+		// forces the image pull without re-running the interactive
+		// corruption check.
+		reArgs = append(reArgs, "--health-recovered")
+	}
+	if flagDataDir != "" {
+		reArgs = append(reArgs, "--data-dir", flagDataDir)
+	}
+	if flagSkipVerify {
+		reArgs = append(reArgs, "--skip-verify")
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Warning: --skip-verify is being carried forward to the re-launched CLI.")
+	}
+	if flagQuiet {
+		reArgs = append(reArgs, "--quiet")
+	}
+	for range flagVerbose {
+		reArgs = append(reArgs, "-v")
+	}
+	reArgs = appendBoolFlags(reArgs, []boolFlag{
+		{"--no-color", flagNoColor},
+		{"--plain", flagPlain},
+		{"--json", flagJSON},
+		{"--yes", flagYes},
+		{"--no-restart", updateNoRestart},
+		{"--images-only", updateImagesOnly},
+		{"--cli-only", updateCLIOnly},
+	})
+	if cmd.Flags().Changed("timeout") {
+		reArgs = append(reArgs, "--timeout", updateTimeout)
+	}
+	if cmd.Flags().Changed("verify-timeout") {
+		reArgs = append(reArgs, "--verify-timeout", updateVerifyTimeout)
+	}
+	return reArgs
+}
+
+type boolFlag struct {
+	name string
+	set  bool
+}
+
+// appendBoolFlags appends every flag whose set field is true. Keeps
+// buildReexecArgs flat instead of carrying a long if-chain.
+func appendBoolFlags(args []string, flags []boolFlag) []string {
+	for _, f := range flags {
+		if f.set {
+			args = append(args, f.name)
+		}
+	}
+	return args
+}

--- a/cli/cmd/update_reexec.go
+++ b/cli/cmd/update_reexec.go
@@ -35,11 +35,27 @@ func reexecUpdate(cmd *cobra.Command, recovered bool) error {
 	if runErr := c.Run(); runErr != nil {
 		// Preserve the child's exit code so the parent can propagate it.
 		if exitErr, ok := errors.AsType[*exec.ExitError](runErr); ok {
-			return &ChildExitError{Code: exitErr.ExitCode()}
+			return &ChildExitError{Code: normalizeChildExitCode(exitErr.ExitCode())}
 		}
 		return fmt.Errorf("re-launching updated CLI: %w", runErr)
 	}
 	return nil
+}
+
+// normalizeChildExitCode maps a child's reported exit code onto one the CLI
+// actually defines.
+//
+// A signal-terminated child never carried an exit status, and os/exec says
+// so by reporting -1. Propagating that verbatim would reach os.Exit, which
+// takes the low byte, so the shell would report 255: a code this CLI does
+// not document and no caller can key on. ExitRuntime is the honest answer,
+// because a child killed mid-update did fail at runtime. A genuine status
+// from the child is passed through untouched.
+func normalizeChildExitCode(code int) int {
+	if code < 0 {
+		return ExitRuntime
+	}
+	return code
 }
 
 // resolveCurrentExecutable returns the absolute, symlink-resolved path

--- a/cli/cmd/update_reexec_test.go
+++ b/cli/cmd/update_reexec_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import "testing"
+
+// A re-exec'd child that dies to a signal reports no exit status at all, and
+// os/exec surfaces that as -1. The parent hands whatever it gets to os.Exit,
+// which takes the low byte, so -1 would reach the shell as 255: a code the
+// CLI never documents and a caller cannot distinguish from a real failure
+// mode. Every non-negative status is the child's own and stays untouched.
+func TestNormalizeChildExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		code int
+		want int
+	}{
+		{"signal_terminated_becomes_runtime", -1, ExitRuntime},
+		{"success_passes_through", ExitSuccess, ExitSuccess},
+		{"runtime_passes_through", ExitRuntime, ExitRuntime},
+		{"usage_passes_through", ExitUsage, ExitUsage},
+		{"unhealthy_passes_through", ExitUnhealthy, ExitUnhealthy},
+		{"update_available_passes_through", ExitUpdateAvail, ExitUpdateAvail},
+		// A shell reports a signal death as 128+signum; a child that chose
+		// to exit with that number is still reporting a status, so it is
+		// the child's to keep.
+		{"sigint_shell_convention_passes_through", 130, 130},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeChildExitCode(tt.code); got != tt.want {
+				t.Errorf("normalizeChildExitCode(%d) = %d, want %d", tt.code, got, tt.want)
+			}
+		})
+	}
+}
+
+// The mapped code is what the entrypoint reads back out, so the guard is
+// only worth anything if it survives the ChildExitError round trip.
+func TestNormalizeChildExitCode_survivesChildExitError(t *testing.T) {
+	err := &ChildExitError{Code: normalizeChildExitCode(-1)}
+	got, ok := ChildExitCode(err)
+	if !ok {
+		t.Fatalf("ChildExitCode did not recognise %T", err)
+	}
+	if got != ExitRuntime {
+		t.Errorf("ChildExitCode = %d, want ExitRuntime (%d)", got, ExitRuntime)
+	}
+}

--- a/cli/cmd/update_test.go
+++ b/cli/cmd/update_test.go
@@ -770,6 +770,40 @@ func TestIsDevChannelMismatch(t *testing.T) {
 	}
 }
 
+// `update --check` prints one line and exits, so that line is the whole of
+// what an operator sees before deciding to install: the terse path never
+// reaches the changelog walk that scrubs everything else. The target is a
+// remote tag name, so it takes the same scrub the walk's labels do.
+func TestRunUpdateCheck_scrubsSpoofedTargetVersion(t *testing.T) {
+	prev := checkForChannel
+	checkForChannel = func(_ context.Context, _ string) (selfupdate.CheckResult, error) {
+		return selfupdate.CheckResult{
+			UpdateAvail:    true,
+			CurrentVersion: "0.7.4",
+			LatestVersion:  spoofedTargetTag,
+		}, nil
+	}
+	t.Cleanup(func() { checkForChannel = prev })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(SetGlobalOpts(context.Background(), &GlobalOpts{Hints: "always"}))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	err := runUpdateCheck(cmd, config.State{Channel: "stable"})
+
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != ExitUpdateAvail {
+		t.Fatalf("expected ExitUpdateAvail, got %v", err)
+	}
+	got := buf.String()
+	requireContains(t, got, spoofedTargetSaf)
+	requireLacks(t, got, rloRune, zwspRune, wordJoinerRune)
+	// The installed version is stamped without the "v" by GoReleaser, so the
+	// two halves of this line would otherwise disagree about the prefix.
+	requireContains(t, got, "(current: v0.7.4)")
+}
+
 // TestUpdateCLI_checkFailureAborts verifies that a failed update-check
 // aborts with an ExitRuntime-wrapped ExitError (so Execute does not
 // re-print it) and surfaces the recovery hint on stderr, rather than

--- a/cli/cmd/update_walk.go
+++ b/cli/cmd/update_walk.go
@@ -42,27 +42,39 @@ var currentBuildCommit = func() string { return version.Commit }
 // prompt in updateCLI. The walk is informational and never blocks the
 // update; any failure falls back to a terse "Update available" notice.
 //
-// Gating: walk is skipped entirely in non-interactive contexts (--yes,
-// --quiet, --json, non-TTY stdin or stdout). The single-line fallback is
-// printed in those cases so the user still sees the version jump.
-func runChangelogWalk(ctx context.Context, cmd *cobra.Command, result selfupdate.CheckResult, state config.State) {
-	if !shouldShowWalk(cmd) {
-		printOfflineNotice(cmd, result)
+// autoAccept is the auto_update_cli verdict updateCLI already resolved, and
+// decides whether the walk waits for keys -- not whether it renders.
+func runChangelogWalk(
+	ctx context.Context,
+	cmd *cobra.Command,
+	result selfupdate.CheckResult,
+	state config.State,
+	autoAccept bool,
+) {
+	mode := resolveWalkMode(cmd, autoAccept)
+	if mode == walkModeSuppressed {
 		return
 	}
 
 	if state.Channel == "dev" {
-		runDevCommitWalk(ctx, cmd, result)
+		runDevCommitWalk(ctx, cmd, result, mode)
 		return
 	}
 
-	runStableHighlightsWalk(ctx, cmd, result, state)
+	runStableHighlightsWalk(ctx, cmd, result, state, mode)
 }
 
 // runStableHighlightsWalk fetches every release in (installed, target] and
-// renders them oldest-to-newest in batches of walkBatchSize using the
-// per-release Highlights walk Model.
-func runStableHighlightsWalk(ctx context.Context, cmd *cobra.Command, result selfupdate.CheckResult, state config.State) {
+// renders them oldest-to-newest: in batches of walkBatchSize through the
+// per-release Highlights walk Model when interactive, or as one printed
+// block when static.
+func runStableHighlightsWalk(
+	ctx context.Context,
+	cmd *cobra.Command,
+	result selfupdate.CheckResult,
+	state config.State,
+	mode walkMode,
+) {
 	opts := GetGlobalOpts(ctx)
 	out := ui.NewUIWithOptions(cmd.OutOrStdout(), opts.UIOptions())
 
@@ -90,12 +102,32 @@ func runStableHighlightsWalk(ctx context.Context, cmd *cobra.Command, result sel
 	}
 
 	printWalkSummary(out, releases, result)
-	if !confirmStartWalk(opts) {
-		return
-	}
 
 	width, height := terminalSize(cmd)
 	view := state.ChangelogViewOrDefault()
+	if mode == walkModeStatic {
+		printStaticBlock(cmd, ui.RenderWalkStatic(ui.WalkBatchInput{
+			Versions:    releases,
+			InitialView: view,
+			Width:       width,
+			Options:     opts.UIOptions(),
+		}))
+		return
+	}
+	runStableWalkBatches(ctx, cmd, out, releases, view, width, height)
+}
+
+// runStableWalkBatches drives the interactive per-release walk, carrying the
+// operator's `c` view toggle across batch boundaries.
+func runStableWalkBatches(
+	ctx context.Context,
+	cmd *cobra.Command,
+	out *ui.UI,
+	releases []selfupdate.Release,
+	view string,
+	width, height int,
+) {
+	opts := GetGlobalOpts(ctx)
 	batches := batchReleases(releases, walkBatchSize)
 	for batchIdx, batch := range batches {
 		isFinal := batchIdx == len(batches)-1
@@ -122,6 +154,15 @@ func runStableHighlightsWalk(ctx context.Context, cmd *cobra.Command, result sel
 	}
 }
 
+// printStaticBlock writes a pre-rendered changelog block verbatim.
+//
+// Deliberately not ui.UI.Plain: that runs stripControl, which drops ESC and
+// would strip every colour out of the block. Writing raw is safe because
+// both renderers ANSI-scrub the untrusted release/commit text they format.
+func printStaticBlock(cmd *cobra.Command, block string) {
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), block)
+}
+
 // runDevCommitWalk fetches all commits between the installed and target dev
 // (or stable) tag via the GitHub compare API and renders them in a single
 // scrollable bubbletea program. Dev pre-releases have no Highlights blocks,
@@ -142,7 +183,7 @@ func runStableHighlightsWalk(ctx context.Context, cmd *cobra.Command, result sel
 // explaining why the rich walk did not render -- silent fallbacks have
 // repeatedly bitten users who could not tell whether the changelog was
 // missing because of an empty range or a real error.
-func runDevCommitWalk(ctx context.Context, cmd *cobra.Command, result selfupdate.CheckResult) {
+func runDevCommitWalk(ctx context.Context, cmd *cobra.Command, result selfupdate.CheckResult, mode walkMode) {
 	opts := GetGlobalOpts(ctx)
 	out := ui.NewUIWithOptions(cmd.OutOrStdout(), opts.UIOptions())
 
@@ -171,7 +212,7 @@ func runDevCommitWalk(ctx context.Context, cmd *cobra.Command, result selfupdate
 		return
 	}
 	width, height := terminalSize(cmd)
-	if _, err := ui.RunCommitWalk(ctx, ui.CommitWalkInput{
+	in := ui.CommitWalkInput{
 		Installed: base,
 		Target:    head,
 		Commits:   commitRange,
@@ -179,7 +220,12 @@ func runDevCommitWalk(ctx context.Context, cmd *cobra.Command, result selfupdate
 		Height:    height,
 		Options:   opts.UIOptions(),
 		Output:    cmd.OutOrStdout(),
-	}); err != nil {
+	}
+	if mode == walkModeStatic {
+		printStaticBlock(cmd, ui.RenderCommitWalkStatic(in))
+		return
+	}
+	if _, err := ui.RunCommitWalk(ctx, in); err != nil {
 		out.Warn(fmt.Sprintf("commit walk failed: %v", err))
 		printOfflineNotice(cmd, result)
 	}
@@ -268,18 +314,39 @@ func devCommitWalkErrorHint(usedCommitSHA bool) string {
 		"commit SHA. Showing terse update notice instead."
 }
 
-// shouldShowWalk reports whether the walk UI should run for this invocation.
-// Bubbletea requires both stdin and stdout to be a TTY; --yes / --quiet /
-// --json all suppress the walk.
-func shouldShowWalk(cmd *cobra.Command) bool {
+// walkMode is how the changelog is presented for one invocation.
+type walkMode int
+
+const (
+	// walkModeInteractive runs the bubbletea pager and waits for keys.
+	walkModeInteractive walkMode = iota
+	// walkModeStatic prints the whole changelog and returns immediately.
+	walkModeStatic
+	// walkModeSuppressed renders nothing.
+	walkModeSuppressed
+)
+
+// resolveWalkMode decides how this invocation presents the changelog.
+//
+// Only --json suppresses it: what somebody is about to install is worth
+// seeing even when nothing is going to ask them about it, so every other
+// non-interactive context downgrades to the static render rather than
+// losing the content. That deliberately includes --quiet, the one place
+// this outranks a flag's usual meaning: an unattended install is exactly
+// where the record of what landed is worth most.
+//
+// Interactive needs what bubbletea needs (a TTY on both stdin and stdout)
+// plus an operator who has not already said yes, via --yes or
+// auto_update_cli.
+func resolveWalkMode(cmd *cobra.Command, autoAccept bool) walkMode {
 	opts := GetGlobalOpts(cmd.Context())
-	if opts.Quiet || opts.JSON || opts.Yes {
-		return false
+	if opts.JSON {
+		return walkModeSuppressed
 	}
-	if !opts.ShouldPrompt() {
-		return false
+	if autoAccept || opts.Quiet || !opts.ShouldPrompt() || !writerIsTTY(cmd.OutOrStdout()) {
+		return walkModeStatic
 	}
-	return writerIsTTY(cmd.OutOrStdout())
+	return walkModeInteractive
 }
 
 // writerIsTTY reports whether w is a terminal file descriptor.
@@ -302,11 +369,11 @@ func terminalSize(cmd *cobra.Command) (int, int) {
 	return 80, 24
 }
 
-// printWalkSummary prints a one-line summary above the walk so the user
-// sees what they are about to walk through. The bubbletea Model handles
-// the per-version layout; this is plain UI output.
+// printWalkSummary prints an index of what the changelog covers above the
+// releases themselves. Worded for both presentations: the interactive walk
+// and the static block show the same list underneath it.
 func printWalkSummary(out *ui.UI, releases []selfupdate.Release, result selfupdate.CheckResult) {
-	out.Section(fmt.Sprintf("Walking %d release%s: %s -> %s",
+	out.Section(fmt.Sprintf("%d release%s: %s -> %s",
 		len(releases), pluralS(len(releases)),
 		normalizeVersionRef(result.CurrentVersion),
 		normalizeVersionRef(result.LatestVersion),
@@ -320,21 +387,6 @@ func printWalkSummary(out *ui.UI, releases []selfupdate.Release, result selfupda
 		out.KeyValue(r.TagName, fmt.Sprintf("%s   %s", formatPublishedDate(r.PublishedAt), marker))
 	}
 	out.Blank()
-}
-
-// confirmStartWalk asks the user (interactively) to start the walk. Returns
-// false to abort; non-interactive paths (Yes, no TTY) never reach this code.
-func confirmStartWalk(opts *GlobalOpts) bool {
-	// In non-prompting modes (Yes, no TTY) shouldShowWalk would have already
-	// returned false before reaching here. Belt-and-braces: skip the prompt
-	// if for some reason we got here without a TTY.
-	if !opts.ShouldPrompt() {
-		return false
-	}
-	// We could prompt here, but the issue's UX explicitly opens the walk
-	// directly after the summary table. Returning true preserves that flow.
-	// Users can still abort via `q` once inside the bubbletea program.
-	return true
 }
 
 // pluralS returns "s" when n != 1, "" otherwise.

--- a/cli/cmd/update_walk.go
+++ b/cli/cmd/update_walk.go
@@ -103,9 +103,15 @@ func runStableHighlightsWalk(
 	// not silently regress.
 	base := normalizeVersionRef(result.CurrentVersion)
 	head := normalizeVersionRef(result.LatestVersion)
+	// Display-only copies. The raw values keep going to the API, which needs
+	// the ref as published; the labels below are read by an operator, and
+	// UI.Warn strips control bytes but leaves the bidi and zero-width runes
+	// a remote tag can carry to spoof the range being offered.
+	baseLabel := ui.SanitizeUntrustedLine(base)
+	headLabel := ui.SanitizeUntrustedLine(head)
 	releases, err := releasesBetween(ctx, base, head, false)
 	if err != nil {
-		out.Warn(fmt.Sprintf("Could not load release list (%s..%s): %v", base, head, err))
+		out.Warn(fmt.Sprintf("Could not load release list (%s..%s): %v", baseLabel, headLabel, err))
 		out.HintError("Showing terse update notice instead. Re-run later or check release notes manually.")
 		printOfflineNotice(out, result)
 		return
@@ -113,7 +119,7 @@ func runStableHighlightsWalk(
 	if len(releases) == 0 {
 		out.Warn(fmt.Sprintf(
 			"No releases found strictly between %s and %s -- the walk has nothing to show.",
-			base, head))
+			baseLabel, headLabel))
 		out.HintError("This is unusual on the stable channel; check the GitHub releases page if a release was pruned.")
 		printOfflineNotice(out, result)
 		return
@@ -213,6 +219,10 @@ func runDevCommitWalk(
 
 	base := normalizeVersionRef(result.CurrentVersion)
 	head := normalizeVersionRef(result.LatestVersion)
+	// Display-only copies; see runStableHighlightsWalk. The raw values still
+	// go to the compare API below.
+	baseLabel := ui.SanitizeUntrustedLine(base)
+	headLabel := ui.SanitizeUntrustedLine(head)
 	apiBase := effectiveBaseRef(base, currentBuildCommit())
 	commitRange, err := commitsBetween(ctx, apiBase, head)
 	if err != nil {
@@ -223,15 +233,18 @@ func runDevCommitWalk(
 		// label before formatting. The inner cause (rate-limit, 404,
 		// etc.) is preserved because it is genuinely useful for
 		// self-diagnosis and contains no secret data.
-		errMsg := scrubAPIBase(err.Error(), apiBase, base)
-		out.Warn(fmt.Sprintf("Could not fetch commit list for %s..%s: %s", base, head, errMsg))
+		//
+		// The wrapper embeds the head ref verbatim, so the message is
+		// itself remote-influenced and gets the same scrub as the labels.
+		errMsg := ui.SanitizeUntrustedLine(scrubAPIBase(err.Error(), apiBase, base))
+		out.Warn(fmt.Sprintf("Could not fetch commit list for %s..%s: %s", baseLabel, headLabel, errMsg))
 		out.HintError(devCommitWalkErrorHint(apiBase != base))
 		printOfflineNotice(out, result)
 		return
 	}
 	if len(commitRange.Commits) == 0 {
 		out.Warn(fmt.Sprintf(
-			"GitHub returned 0 commits between %s and %s -- range looks empty.", base, head))
+			"GitHub returned 0 commits between %s and %s -- range looks empty.", baseLabel, headLabel))
 		printOfflineNotice(out, result)
 		return
 	}

--- a/cli/cmd/update_walk.go
+++ b/cli/cmd/update_walk.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -289,6 +290,17 @@ func versionLabel(v string) string {
 	return ui.SanitizeUntrustedLine(normalizeVersionRef(v))
 }
 
+// versionURLRef is the link form of the same ref, and it deliberately is not
+// versionLabel. The scrub DELETES runes git permits in a tag name, so a label
+// pasted into a URL addresses a tag that does not exist, and the one hostile
+// character the scrub does pass through, "#", truncates the link at a
+// fragment. Percent-encoding answers both at once, and answers what the scrub
+// was for as well: every byte it emits is printable ASCII, so nothing that
+// acts on a terminal survives into a line the operator reads.
+func versionURLRef(v string) string {
+	return url.PathEscape(normalizeVersionRef(v))
+}
+
 // effectiveBaseRef chooses which ref to pass to the GitHub compare API for
 // the "installed" side of the dev-channel commit walk. Prefers the embedded
 // build commit SHA (permanent on the remote) over the installed tag (which
@@ -502,5 +514,5 @@ func printOfflineNotice(out *ui.UI, result selfupdate.CheckResult) {
 	latest := versionLabel(result.LatestVersion)
 	out.Step(fmt.Sprintf("New version available: %s (current: %s)", latest, current))
 	out.HintNextStep(fmt.Sprintf("Release notes: %s/releases/tag/%s",
-		version.RepoURL, latest))
+		version.RepoURL, versionURLRef(result.LatestVersion)))
 }

--- a/cli/cmd/update_walk.go
+++ b/cli/cmd/update_walk.go
@@ -107,8 +107,8 @@ func runStableHighlightsWalk(
 	// the ref as published; the labels below are read by an operator, and
 	// UI.Warn strips control bytes but leaves the bidi and zero-width runes
 	// a remote tag can carry to spoof the range being offered.
-	baseLabel := ui.SanitizeUntrustedLine(base)
-	headLabel := ui.SanitizeUntrustedLine(head)
+	baseLabel := versionLabel(result.CurrentVersion)
+	headLabel := versionLabel(result.LatestVersion)
 	releases, err := releasesBetween(ctx, base, head, false)
 	if err != nil {
 		out.Warn(fmt.Sprintf("Could not load release list (%s..%s): %v", baseLabel, headLabel, err))
@@ -221,8 +221,8 @@ func runDevCommitWalk(
 	head := normalizeVersionRef(result.LatestVersion)
 	// Display-only copies; see runStableHighlightsWalk. The raw values still
 	// go to the compare API below.
-	baseLabel := ui.SanitizeUntrustedLine(base)
-	headLabel := ui.SanitizeUntrustedLine(head)
+	baseLabel := versionLabel(result.CurrentVersion)
+	headLabel := versionLabel(result.LatestVersion)
 	apiBase := effectiveBaseRef(base, currentBuildCommit())
 	commitRange, err := commitsBetween(ctx, apiBase, head)
 	if err != nil {
@@ -278,6 +278,15 @@ func normalizeVersionRef(v string) string {
 		return v
 	}
 	return "v" + v
+}
+
+// versionLabel is the display form of a remote version ref: normalised to the
+// leading "v", then scrubbed of the control and spoofing runes git permits in
+// a tag name. The two steps travel together in one helper because every
+// rendered version is read by an operator deciding whether to install it, and
+// a call site that takes only the first is the defect this closes.
+func versionLabel(v string) string {
+	return ui.SanitizeUntrustedLine(normalizeVersionRef(v))
 }
 
 // effectiveBaseRef chooses which ref to pass to the GitHub compare API for
@@ -377,10 +386,20 @@ const (
 // auto_update_cli.
 func resolveWalkMode(cmd *cobra.Command, autoAccept bool) walkMode {
 	opts := GetGlobalOpts(cmd.Context())
+	return walkModeFor(opts, autoAccept, opts.ShouldPrompt(), writerIsTTY(cmd.OutOrStdout()))
+}
+
+// walkModeFor is the decision above with both terminal probes lifted out to
+// parameters. They have to leave together: ShouldPrompt stats the process's
+// own stdin and writerIsTTY needs a real *os.File, so under `go test` each is
+// independently false and the static verdict is unconditional. A table that
+// cannot vary them proves only that some term fired, never which, and the
+// interactive verdict is unreachable altogether.
+func walkModeFor(opts *GlobalOpts, autoAccept, canPrompt, outIsTTY bool) walkMode {
 	if opts.JSON {
 		return walkModeSuppressed
 	}
-	if autoAccept || opts.Quiet || !opts.ShouldPrompt() || !writerIsTTY(cmd.OutOrStdout()) {
+	if autoAccept || opts.Quiet || !canPrompt || !outIsTTY {
 		return walkModeStatic
 	}
 	return walkModeInteractive
@@ -415,8 +434,8 @@ func terminalSize(cmd *cobra.Command) (int, int) {
 func printWalkSummary(out *ui.UI, releases []selfupdate.Release, result selfupdate.CheckResult) {
 	out.Section(fmt.Sprintf("%d release%s: %s -> %s",
 		len(releases), pluralS(len(releases)),
-		ui.SanitizeUntrustedLine(normalizeVersionRef(result.CurrentVersion)),
-		ui.SanitizeUntrustedLine(normalizeVersionRef(result.LatestVersion)),
+		versionLabel(result.CurrentVersion),
+		versionLabel(result.LatestVersion),
 	))
 	for _, r := range releases {
 		_, hasHighlights := selfupdate.ExtractHighlights(r.Body)
@@ -479,8 +498,8 @@ func batchReleases(releases []selfupdate.Release, size int) [][]selfupdate.Relea
 // installed version is stamped without the "v" prefix at build time, but
 // the user-facing notice should match the GitHub release tag style.
 func printOfflineNotice(out *ui.UI, result selfupdate.CheckResult) {
-	current := ui.SanitizeUntrustedLine(normalizeVersionRef(result.CurrentVersion))
-	latest := ui.SanitizeUntrustedLine(normalizeVersionRef(result.LatestVersion))
+	current := versionLabel(result.CurrentVersion)
+	latest := versionLabel(result.LatestVersion)
 	out.Step(fmt.Sprintf("New version available: %s (current: %s)", latest, current))
 	out.HintNextStep(fmt.Sprintf("Release notes: %s/releases/tag/%s",
 		version.RepoURL, latest))

--- a/cli/cmd/update_walk.go
+++ b/cli/cmd/update_walk.go
@@ -55,13 +55,31 @@ func runChangelogWalk(
 	if mode == walkModeSuppressed {
 		return
 	}
+	out := changelogUI(cmd, mode)
 
 	if state.Channel == "dev" {
-		runDevCommitWalk(ctx, cmd, result, mode)
+		runDevCommitWalk(ctx, cmd, out, result, mode)
 		return
 	}
 
-	runStableHighlightsWalk(ctx, cmd, result, state, mode)
+	runStableHighlightsWalk(ctx, cmd, out, result, state, mode)
+}
+
+// changelogUI builds the UI the whole changelog presentation writes through.
+//
+// Static mode outranks --quiet, and it has to do so for every part of the
+// presentation rather than just the body: the summary index carries the
+// publish dates and the Highlights markers that appear nowhere else, and the
+// fallback notice is the only output at all when the fetch fails. Printing
+// the body raw while letting the flag eat those leaves a record that reads
+// complete and is not. --json still suppresses everything, and never reaches
+// static mode.
+func changelogUI(cmd *cobra.Command, mode walkMode) *ui.UI {
+	opts := GetGlobalOpts(cmd.Context()).UIOptions()
+	if mode == walkModeStatic {
+		opts.Quiet = false
+	}
+	return ui.NewUIWithOptions(cmd.OutOrStdout(), opts)
 }
 
 // runStableHighlightsWalk fetches every release in (installed, target] and
@@ -71,12 +89,12 @@ func runChangelogWalk(
 func runStableHighlightsWalk(
 	ctx context.Context,
 	cmd *cobra.Command,
+	out *ui.UI,
 	result selfupdate.CheckResult,
 	state config.State,
 	mode walkMode,
 ) {
 	opts := GetGlobalOpts(ctx)
-	out := ui.NewUIWithOptions(cmd.OutOrStdout(), opts.UIOptions())
 
 	// Normalise to vX.Y.Z[-dev.N] so release/compare API failures and the
 	// user-facing range labels stay consistent with the dev-channel path.
@@ -89,7 +107,7 @@ func runStableHighlightsWalk(
 	if err != nil {
 		out.Warn(fmt.Sprintf("Could not load release list (%s..%s): %v", base, head, err))
 		out.HintError("Showing terse update notice instead. Re-run later or check release notes manually.")
-		printOfflineNotice(cmd, result)
+		printOfflineNotice(out, result)
 		return
 	}
 	if len(releases) == 0 {
@@ -97,7 +115,7 @@ func runStableHighlightsWalk(
 			"No releases found strictly between %s and %s -- the walk has nothing to show.",
 			base, head))
 		out.HintError("This is unusual on the stable channel; check the GitHub releases page if a release was pruned.")
-		printOfflineNotice(cmd, result)
+		printOfflineNotice(out, result)
 		return
 	}
 
@@ -164,8 +182,9 @@ func printStaticBlock(cmd *cobra.Command, block string) {
 }
 
 // runDevCommitWalk fetches all commits between the installed and target dev
-// (or stable) tag via the GitHub compare API and renders them in a single
-// scrollable bubbletea program. Dev pre-releases have no Highlights blocks,
+// (or stable) tag via the GitHub compare API and renders them as a single
+// combined list: a scrollable bubbletea program when interactive, one
+// printed block when static. Dev pre-releases have no Highlights blocks,
 // so a per-release walk is uninformative -- a flat commit list is what the
 // user actually wants to see.
 //
@@ -183,9 +202,14 @@ func printStaticBlock(cmd *cobra.Command, block string) {
 // explaining why the rich walk did not render -- silent fallbacks have
 // repeatedly bitten users who could not tell whether the changelog was
 // missing because of an empty range or a real error.
-func runDevCommitWalk(ctx context.Context, cmd *cobra.Command, result selfupdate.CheckResult, mode walkMode) {
+func runDevCommitWalk(
+	ctx context.Context,
+	cmd *cobra.Command,
+	out *ui.UI,
+	result selfupdate.CheckResult,
+	mode walkMode,
+) {
 	opts := GetGlobalOpts(ctx)
-	out := ui.NewUIWithOptions(cmd.OutOrStdout(), opts.UIOptions())
 
 	base := normalizeVersionRef(result.CurrentVersion)
 	head := normalizeVersionRef(result.LatestVersion)
@@ -202,13 +226,13 @@ func runDevCommitWalk(ctx context.Context, cmd *cobra.Command, result selfupdate
 		errMsg := scrubAPIBase(err.Error(), apiBase, base)
 		out.Warn(fmt.Sprintf("Could not fetch commit list for %s..%s: %s", base, head, errMsg))
 		out.HintError(devCommitWalkErrorHint(apiBase != base))
-		printOfflineNotice(cmd, result)
+		printOfflineNotice(out, result)
 		return
 	}
 	if len(commitRange.Commits) == 0 {
 		out.Warn(fmt.Sprintf(
 			"GitHub returned 0 commits between %s and %s -- range looks empty.", base, head))
-		printOfflineNotice(cmd, result)
+		printOfflineNotice(out, result)
 		return
 	}
 	width, height := terminalSize(cmd)
@@ -227,7 +251,7 @@ func runDevCommitWalk(ctx context.Context, cmd *cobra.Command, result selfupdate
 	}
 	if _, err := ui.RunCommitWalk(ctx, in); err != nil {
 		out.Warn(fmt.Sprintf("commit walk failed: %v", err))
-		printOfflineNotice(cmd, result)
+		printOfflineNotice(out, result)
 	}
 }
 
@@ -370,13 +394,16 @@ func terminalSize(cmd *cobra.Command) (int, int) {
 }
 
 // printWalkSummary prints an index of what the changelog covers above the
-// releases themselves. Worded for both presentations: the interactive walk
-// and the static block show the same list underneath it.
+// releases themselves, carrying the publish date and the Highlights marker
+// that appear nowhere in the releases underneath it. Worded for both
+// presentations, and written through the caller's UI, which clears the
+// quiet flag for the static one so this index cannot go missing from the
+// only record an unattended run leaves.
 func printWalkSummary(out *ui.UI, releases []selfupdate.Release, result selfupdate.CheckResult) {
 	out.Section(fmt.Sprintf("%d release%s: %s -> %s",
 		len(releases), pluralS(len(releases)),
-		normalizeVersionRef(result.CurrentVersion),
-		normalizeVersionRef(result.LatestVersion),
+		ui.SanitizeUntrustedLine(normalizeVersionRef(result.CurrentVersion)),
+		ui.SanitizeUntrustedLine(normalizeVersionRef(result.LatestVersion)),
 	))
 	for _, r := range releases {
 		_, hasHighlights := selfupdate.ExtractHighlights(r.Body)
@@ -384,7 +411,10 @@ func printWalkSummary(out *ui.UI, releases []selfupdate.Release, result selfupda
 		if hasHighlights {
 			marker = "Highlights"
 		}
-		out.KeyValue(r.TagName, fmt.Sprintf("%s   %s", formatPublishedDate(r.PublishedAt), marker))
+		// Same remote tag the renderers scrub: this index prints it too,
+		// so it needs the same treatment or the spoof just moves up a line.
+		out.KeyValue(ui.SanitizeUntrustedLine(r.TagName), fmt.Sprintf("%s   %s",
+			ui.SanitizeUntrustedLine(formatPublishedDate(r.PublishedAt)), marker))
 	}
 	out.Blank()
 }
@@ -435,11 +465,9 @@ func batchReleases(releases []selfupdate.Release, size int) [][]selfupdate.Relea
 // the line never reads "v0.7.3-dev.19 (current: 0.7.3-dev.11)" -- the
 // installed version is stamped without the "v" prefix at build time, but
 // the user-facing notice should match the GitHub release tag style.
-func printOfflineNotice(cmd *cobra.Command, result selfupdate.CheckResult) {
-	opts := GetGlobalOpts(cmd.Context())
-	out := ui.NewUIWithOptions(cmd.OutOrStdout(), opts.UIOptions())
-	current := normalizeVersionRef(result.CurrentVersion)
-	latest := normalizeVersionRef(result.LatestVersion)
+func printOfflineNotice(out *ui.UI, result selfupdate.CheckResult) {
+	current := ui.SanitizeUntrustedLine(normalizeVersionRef(result.CurrentVersion))
+	latest := ui.SanitizeUntrustedLine(normalizeVersionRef(result.LatestVersion))
 	out.Step(fmt.Sprintf("New version available: %s (current: %s)", latest, current))
 	out.HintNextStep(fmt.Sprintf("Release notes: %s/releases/tag/%s",
 		version.RepoURL, latest))

--- a/cli/cmd/update_walk_test.go
+++ b/cli/cmd/update_walk_test.go
@@ -279,6 +279,94 @@ func TestRunStableHighlightsWalk_warnsOnEmptyRange(t *testing.T) {
 	)
 }
 
+// A tag name is remote-controlled and git permits the whole invisible
+// format class in one, so a target label reaching a warning carries the
+// same spoofing surface as the release bodies below it. UI.Warn strips
+// control bytes and nothing else, which leaves exactly these runes free to
+// reorder or pad the version range an operator is being shown.
+// Written as UTF-8 byte escapes: the literal characters are invisible in a
+// diff and staticcheck rejects them in a string literal (ST1018).
+const (
+	rloRune        = "\xe2\x80\xae" // U+202E RIGHT-TO-LEFT OVERRIDE
+	zwspRune       = "\xe2\x80\x8b" // U+200B ZERO WIDTH SPACE
+	wordJoinerRune = "\xe2\x81\xa0" // U+2060 WORD JOINER
+
+	spoofedTargetTag = "v0.7.5" + rloRune + zwspRune + "evil" + wordJoinerRune
+	spoofedTargetSaf = "v0.7.5evil"
+)
+
+// requireLacks is the negative half of requireContains: proof that a rune
+// was dropped, not merely that the visible text survived.
+func requireLacks(t *testing.T, got string, unwanted ...string) {
+	t.Helper()
+	for _, u := range unwanted {
+		if strings.Contains(got, u) {
+			t.Errorf("expected output NOT to contain %q\n--- got ---\n%s", u, got)
+		}
+	}
+}
+
+func TestRunStableHighlightsWalk_scrubsSpoofedLabelOnLoadFailure(t *testing.T) {
+	withReleasesBetween(t, func(_ context.Context, _, _ string, _ bool) ([]selfupdate.Release, error) {
+		return nil, errors.New("simulated GitHub 503")
+	})
+	cmd, buf := newWalkTestCmd(t)
+	result := selfupdate.CheckResult{CurrentVersion: "v0.7.1", LatestVersion: spoofedTargetTag}
+	state := config.DefaultState()
+
+	runStableHighlightsWalk(cmd.Context(), cmd, changelogUI(cmd, walkModeStatic), result, state, walkModeStatic)
+
+	got := buf.String()
+	requireContains(t, got, "Could not load release list", "v0.7.1..", spoofedTargetSaf)
+	requireLacks(t, got, rloRune, zwspRune, wordJoinerRune)
+}
+
+func TestRunStableHighlightsWalk_scrubsSpoofedLabelOnEmptyRange(t *testing.T) {
+	withReleasesBetween(t, func(_ context.Context, _, _ string, _ bool) ([]selfupdate.Release, error) {
+		return nil, nil
+	})
+	cmd, buf := newWalkTestCmd(t)
+	result := selfupdate.CheckResult{CurrentVersion: "v0.7.4", LatestVersion: spoofedTargetTag}
+	state := config.DefaultState()
+
+	runStableHighlightsWalk(cmd.Context(), cmd, changelogUI(cmd, walkModeStatic), result, state, walkModeStatic)
+
+	got := buf.String()
+	requireContains(t, got, "No releases found strictly between", spoofedTargetSaf)
+	requireLacks(t, got, rloRune, zwspRune, wordJoinerRune)
+}
+
+// The compare wrapper embeds the head ref verbatim ("comparing a...b: ..."),
+// so the error text is remote-influenced even once the labels beside it are
+// clean, and it gets scrubbed too.
+func TestRunDevCommitWalk_scrubsSpoofedLabelOnCompareError(t *testing.T) {
+	withCommitsBetween(t, func(_ context.Context, base, head string) (selfupdate.CommitRange, error) {
+		return selfupdate.CommitRange{}, fmt.Errorf("comparing %s...%s: simulated 502", base, head)
+	})
+	cmd, buf := newWalkTestCmd(t)
+	result := selfupdate.CheckResult{CurrentVersion: "v0.7.4", LatestVersion: spoofedTargetTag}
+
+	runDevCommitWalk(cmd.Context(), cmd, changelogUI(cmd, walkModeStatic), result, walkModeStatic)
+
+	got := buf.String()
+	requireContains(t, got, "Could not fetch commit list for", spoofedTargetSaf, "simulated 502")
+	requireLacks(t, got, rloRune, zwspRune, wordJoinerRune)
+}
+
+func TestRunDevCommitWalk_scrubsSpoofedLabelOnEmptyRange(t *testing.T) {
+	withCommitsBetween(t, func(_ context.Context, _, _ string) (selfupdate.CommitRange, error) {
+		return selfupdate.CommitRange{}, nil
+	})
+	cmd, buf := newWalkTestCmd(t)
+	result := selfupdate.CheckResult{CurrentVersion: "v0.7.4", LatestVersion: spoofedTargetTag}
+
+	runDevCommitWalk(cmd.Context(), cmd, changelogUI(cmd, walkModeStatic), result, walkModeStatic)
+
+	got := buf.String()
+	requireContains(t, got, "GitHub returned 0 commits between", spoofedTargetSaf)
+	requireLacks(t, got, rloRune, zwspRune, wordJoinerRune)
+}
+
 // The static path is what every non-interactive invocation takes, so the
 // whole changelog has to survive the trip to stdout: the summary index AND
 // every release body, with nothing waiting on a key press.

--- a/cli/cmd/update_walk_test.go
+++ b/cli/cmd/update_walk_test.go
@@ -54,8 +54,10 @@ func newWalkTestCmd(t *testing.T) (*cobra.Command, *bytes.Buffer) {
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 	cmd.SetErr(&buf)
-	// Yes:true skips bubbletea (the real walk would deadlock without a TTY)
-	// while still letting Warn / HintError render to the captured writer.
+	// Yes:true keeps these tests off any prompting path while still letting
+	// Warn / HintError render to the captured writer. Callers pass
+	// walkModeStatic explicitly, which is what keeps bubbletea out of it:
+	// the real program would deadlock against a bytes.Buffer.
 	cmd.SetContext(SetGlobalOpts(context.Background(), &GlobalOpts{Yes: true, Hints: "always"}))
 	return cmd, &buf
 }
@@ -175,38 +177,35 @@ func TestPrintOfflineNotice(t *testing.T) {
 	}
 }
 
-func TestShouldShowWalk_quietSuppresses(t *testing.T) {
-	cmd := &cobra.Command{}
-	cmd.SetContext(SetGlobalOpts(context.Background(), &GlobalOpts{Quiet: true}))
-	if shouldShowWalk(cmd) {
-		t.Error("--quiet should suppress walk")
+// TestResolveWalkMode covers the whole gate: only --json loses the
+// changelog, everything else that cannot (or must not) run a pager
+// downgrades to the static render rather than dropping the content.
+// A bytes.Buffer is not an *os.File, so every case here has a non-TTY
+// stdout; the interactive verdict is unreachable from a test writer,
+// which is exactly the property the last case asserts.
+func TestResolveWalkMode(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       GlobalOpts
+		autoAccept bool
+		want       walkMode
+	}{
+		{"json suppresses", GlobalOpts{JSON: true}, false, walkModeSuppressed},
+		{"json wins over auto-accept", GlobalOpts{JSON: true}, true, walkModeSuppressed},
+		{"quiet renders static", GlobalOpts{Quiet: true}, false, walkModeStatic},
+		{"yes renders static", GlobalOpts{Yes: true}, false, walkModeStatic},
+		{"auto-accept renders static", GlobalOpts{}, true, walkModeStatic},
+		{"non-TTY renders static", GlobalOpts{}, false, walkModeStatic},
 	}
-}
-
-func TestShouldShowWalk_jsonSuppresses(t *testing.T) {
-	cmd := &cobra.Command{}
-	cmd.SetContext(SetGlobalOpts(context.Background(), &GlobalOpts{JSON: true}))
-	if shouldShowWalk(cmd) {
-		t.Error("--json should suppress walk")
-	}
-}
-
-func TestShouldShowWalk_yesSuppresses(t *testing.T) {
-	cmd := &cobra.Command{}
-	cmd.SetContext(SetGlobalOpts(context.Background(), &GlobalOpts{Yes: true}))
-	if shouldShowWalk(cmd) {
-		t.Error("--yes should suppress walk")
-	}
-}
-
-func TestShouldShowWalk_nonTTYSuppresses(t *testing.T) {
-	cmd := &cobra.Command{}
-	// Set a non-TTY writer (bytes.Buffer is not a *os.File). Even if stdin
-	// is a TTY in the test runner, stdout is not, so the walk must not run.
-	cmd.SetOut(&bytes.Buffer{})
-	cmd.SetContext(SetGlobalOpts(context.Background(), &GlobalOpts{}))
-	if shouldShowWalk(cmd) {
-		t.Error("non-TTY stdout should suppress walk")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetContext(SetGlobalOpts(context.Background(), &tt.opts))
+			if got := resolveWalkMode(cmd, tt.autoAccept); got != tt.want {
+				t.Errorf("resolveWalkMode = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -225,7 +224,7 @@ func TestPrintWalkSummary_listsAllVersions(t *testing.T) {
 	printWalkSummary(out2, releases, result)
 	got := buf.String()
 	for _, want := range []string{
-		"Walking 2 releases",
+		"2 releases",
 		"v0.7.1",
 		"v0.7.3",
 		"v0.7.2",
@@ -248,7 +247,7 @@ func TestRunStableHighlightsWalk_warnsOnReleasesBetweenError(t *testing.T) {
 	result := selfupdate.CheckResult{CurrentVersion: "v0.7.1", LatestVersion: "v0.7.5"}
 	state := config.DefaultState()
 
-	runStableHighlightsWalk(cmd.Context(), cmd, result, state)
+	runStableHighlightsWalk(cmd.Context(), cmd, result, state, walkModeStatic)
 
 	got := buf.String()
 	requireContains(t, got,
@@ -268,7 +267,7 @@ func TestRunStableHighlightsWalk_warnsOnEmptyRange(t *testing.T) {
 	result := selfupdate.CheckResult{CurrentVersion: "v0.7.4", LatestVersion: "v0.7.5"}
 	state := config.DefaultState()
 
-	runStableHighlightsWalk(cmd.Context(), cmd, result, state)
+	runStableHighlightsWalk(cmd.Context(), cmd, result, state, walkModeStatic)
 
 	got := buf.String()
 	requireContains(t, got,
@@ -277,6 +276,54 @@ func TestRunStableHighlightsWalk_warnsOnEmptyRange(t *testing.T) {
 		"v0.7.5",
 		"check the GitHub releases page",
 		"New version available: v0.7.5",
+	)
+}
+
+// The static path is what every non-interactive invocation now takes, so
+// the whole changelog has to survive the trip to stdout: the summary index
+// AND every release body, with nothing waiting on a keypress.
+func TestRunStableHighlightsWalk_staticPrintsEveryRelease(t *testing.T) {
+	withReleasesBetween(t, func(_ context.Context, _, _ string, _ bool) ([]selfupdate.Release, error) {
+		return []selfupdate.Release{
+			{TagName: "v0.7.2", PublishedAt: "2026-04-22T10:00:00Z", Body: "## [0.7.2]\n### Features\n* older thing\n---\n"},
+			{TagName: "v0.7.3", PublishedAt: "2026-04-25T12:00:00Z", Body: "<!-- HIGHLIGHTS_START -->\n## Highlights\n\n### What's new\n- Newer thing\n\n<!-- HIGHLIGHTS_END -->\n## [0.7.3]\n### Features\n* commit line\n---\n"},
+		}, nil
+	})
+	cmd, buf := newWalkTestCmd(t)
+	result := selfupdate.CheckResult{CurrentVersion: "v0.7.1", LatestVersion: "v0.7.3"}
+
+	runStableHighlightsWalk(cmd.Context(), cmd, result, config.DefaultState(), walkModeStatic)
+
+	requireContains(t, buf.String(),
+		"2 releases",
+		"v0.7.2",
+		"v0.7.3",
+		"older thing", // commit log for the release with no Highlights block
+		"No AI highlights",
+		"Newer thing", // Highlights block for the release that has one
+	)
+}
+
+func TestRunDevCommitWalk_staticPrintsEveryCommit(t *testing.T) {
+	withCommitsBetween(t, func(_ context.Context, _, _ string) (selfupdate.CommitRange, error) {
+		return selfupdate.CommitRange{
+			TotalCommits: 2,
+			Commits: []selfupdate.Commit{
+				{SHA: "abc1234567890abcdef0123456789abcdef01234", Subject: "first change", Author: "Ada", Date: "2026-04-25"},
+				{SHA: "def4567890abcdef1234567890abcdef12345678", Subject: "second change", Author: "Grace", Date: "2026-04-26"},
+			},
+		}, nil
+	})
+	cmd, buf := newWalkTestCmd(t)
+	result := selfupdate.CheckResult{CurrentVersion: "v0.7.3-dev.18", LatestVersion: "v0.7.3-dev.19"}
+
+	runDevCommitWalk(cmd.Context(), cmd, result, walkModeStatic)
+
+	requireContains(t, buf.String(),
+		"dev channel: v0.7.3-dev.18 -> v0.7.3-dev.19",
+		"2 commits",
+		"first change",
+		"second change",
 	)
 }
 
@@ -297,7 +344,7 @@ func TestRunDevCommitWalk_warnsOnCompareError(t *testing.T) {
 	// "v0.7.3-dev.11..v0.7.3-dev.19" before passing to commitsBetween.
 	result := selfupdate.CheckResult{CurrentVersion: "0.7.3-dev.11", LatestVersion: "v0.7.3-dev.19"}
 
-	runDevCommitWalk(cmd.Context(), cmd, result)
+	runDevCommitWalk(cmd.Context(), cmd, result, walkModeStatic)
 
 	got := buf.String()
 	requireContains(t, got,
@@ -316,7 +363,7 @@ func TestRunDevCommitWalk_warnsOnEmptyRange(t *testing.T) {
 	cmd, buf := newWalkTestCmd(t)
 	result := selfupdate.CheckResult{CurrentVersion: "v0.7.3-dev.18", LatestVersion: "v0.7.3-dev.19"}
 
-	runDevCommitWalk(cmd.Context(), cmd, result)
+	runDevCommitWalk(cmd.Context(), cmd, result, walkModeStatic)
 
 	got := buf.String()
 	requireContains(t, got,
@@ -343,7 +390,7 @@ func TestRunDevCommitWalk_normalisesVersionRefs(t *testing.T) {
 	cmd, _ := newWalkTestCmd(t)
 	result := selfupdate.CheckResult{CurrentVersion: "0.7.3-dev.11", LatestVersion: "0.7.3-dev.19"}
 
-	runDevCommitWalk(cmd.Context(), cmd, result)
+	runDevCommitWalk(cmd.Context(), cmd, result, walkModeStatic)
 
 	if seenBase != "v0.7.3-dev.11" {
 		t.Errorf("base passed to commitsBetween = %q, want %q", seenBase, "v0.7.3-dev.11")
@@ -377,7 +424,7 @@ func TestRunDevCommitWalk_usesEmbeddedCommitSHA(t *testing.T) {
 	cmd, buf := newWalkTestCmd(t)
 	result := selfupdate.CheckResult{CurrentVersion: "0.7.3-dev.20", LatestVersion: "0.7.3-dev.24"}
 
-	runDevCommitWalk(cmd.Context(), cmd, result)
+	runDevCommitWalk(cmd.Context(), cmd, result, walkModeStatic)
 
 	if seenBase != buildSHA {
 		t.Errorf("base passed to commitsBetween = %q, want embedded SHA %q", seenBase, buildSHA)
@@ -544,7 +591,7 @@ func TestRunChangelogWalk_jsonSuppressesOutput(t *testing.T) {
 	result := selfupdate.CheckResult{CurrentVersion: "v0.7.1", LatestVersion: "v0.7.5"}
 	state := config.DefaultState()
 
-	runChangelogWalk(cmd.Context(), cmd, result, state)
+	runChangelogWalk(cmd.Context(), cmd, result, state, false)
 	got := buf.String()
 	// JSON mode suppresses the walk and any human-readable offline notice.
 	// Asserting "no output" -- not just "no panic" -- is what guards against

--- a/cli/cmd/update_walk_test.go
+++ b/cli/cmd/update_walk_test.go
@@ -177,32 +177,60 @@ func TestPrintOfflineNotice(t *testing.T) {
 	}
 }
 
-// TestResolveWalkMode covers the whole gate: only --json loses the
-// changelog, everything else that cannot (or must not) run a pager
-// downgrades to the static render rather than dropping the content.
-// A bytes.Buffer is not an *os.File, so every case here has a non-TTY
-// stdout; the interactive verdict is unreachable from a test writer,
-// which is exactly the property the last case asserts.
-func TestResolveWalkMode(t *testing.T) {
+// TestWalkModeFor covers the whole gate: only --json loses the changelog,
+// everything else that cannot (or must not) run a pager downgrades to the
+// static render rather than dropping the content.
+//
+// Every static case leaves all terms but its own permissive, so deleting that
+// term from walkModeFor flips the case to interactive and the case fails.
+// That isolation is the reason the terminal probes are parameters: with
+// either read inside, all four static cases pass for the same reason and none
+// of them is testing what it claims to.
+func TestWalkModeFor(t *testing.T) {
 	tests := []struct {
 		name       string
 		opts       GlobalOpts
 		autoAccept bool
+		canPrompt  bool
+		outIsTTY   bool
 		want       walkMode
 	}{
-		{"json suppresses", GlobalOpts{JSON: true}, false, walkModeSuppressed},
-		{"json wins over auto-accept", GlobalOpts{JSON: true}, true, walkModeSuppressed},
-		{"quiet renders static", GlobalOpts{Quiet: true}, false, walkModeStatic},
-		{"yes renders static", GlobalOpts{Yes: true}, false, walkModeStatic},
-		{"auto-accept renders static", GlobalOpts{}, true, walkModeStatic},
-		{"non-TTY renders static", GlobalOpts{}, false, walkModeStatic},
+		{"json suppresses", GlobalOpts{JSON: true}, false, true, true, walkModeSuppressed},
+		{"json wins over auto-accept", GlobalOpts{JSON: true}, true, true, true, walkModeSuppressed},
+		{"quiet renders static", GlobalOpts{Quiet: true}, false, true, true, walkModeStatic},
+		{"auto-accept renders static", GlobalOpts{}, true, true, true, walkModeStatic},
+		{"no prompting renders static", GlobalOpts{}, false, false, true, walkModeStatic},
+		{"non-TTY stdout renders static", GlobalOpts{}, false, true, false, walkModeStatic},
+		{"interactive when nothing forbids it", GlobalOpts{}, false, true, true, walkModeInteractive},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := walkModeFor(&tt.opts, tt.autoAccept, tt.canPrompt, tt.outIsTTY); got != tt.want {
+				t.Errorf("walkModeFor = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolveWalkMode covers only what walkModeFor cannot: that the wrapper
+// reads the flags from the command's context and supplies the two probes. A
+// bytes.Buffer is not an *os.File, so outIsTTY is false for both cases, which
+// is why the permissive one still expects the static render.
+func TestResolveWalkMode(t *testing.T) {
+	tests := []struct {
+		name string
+		opts GlobalOpts
+		want walkMode
+	}{
+		{"json from context suppresses", GlobalOpts{JSON: true}, walkModeSuppressed},
+		{"non-TTY stdout renders static", GlobalOpts{}, walkModeStatic},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := &cobra.Command{}
 			cmd.SetOut(&bytes.Buffer{})
 			cmd.SetContext(SetGlobalOpts(context.Background(), &tt.opts))
-			if got := resolveWalkMode(cmd, tt.autoAccept); got != tt.want {
+			if got := resolveWalkMode(cmd, false); got != tt.want {
 				t.Errorf("resolveWalkMode = %v, want %v", got, tt.want)
 			}
 		})

--- a/cli/cmd/update_walk_test.go
+++ b/cli/cmd/update_walk_test.go
@@ -164,7 +164,7 @@ func TestPrintOfflineNotice(t *testing.T) {
 		CurrentVersion: "v0.7.1",
 		LatestVersion:  "v0.7.5",
 	}
-	printOfflineNotice(cmd, result)
+	printOfflineNotice(changelogUI(cmd, walkModeStatic), result)
 	out := buf.String()
 	if !strings.Contains(out, "v0.7.5") {
 		t.Errorf("offline notice should contain target version\n--- got ---\n%s", out)
@@ -247,7 +247,7 @@ func TestRunStableHighlightsWalk_warnsOnReleasesBetweenError(t *testing.T) {
 	result := selfupdate.CheckResult{CurrentVersion: "v0.7.1", LatestVersion: "v0.7.5"}
 	state := config.DefaultState()
 
-	runStableHighlightsWalk(cmd.Context(), cmd, result, state, walkModeStatic)
+	runStableHighlightsWalk(cmd.Context(), cmd, changelogUI(cmd, walkModeStatic), result, state, walkModeStatic)
 
 	got := buf.String()
 	requireContains(t, got,
@@ -267,7 +267,7 @@ func TestRunStableHighlightsWalk_warnsOnEmptyRange(t *testing.T) {
 	result := selfupdate.CheckResult{CurrentVersion: "v0.7.4", LatestVersion: "v0.7.5"}
 	state := config.DefaultState()
 
-	runStableHighlightsWalk(cmd.Context(), cmd, result, state, walkModeStatic)
+	runStableHighlightsWalk(cmd.Context(), cmd, changelogUI(cmd, walkModeStatic), result, state, walkModeStatic)
 
 	got := buf.String()
 	requireContains(t, got,
@@ -279,9 +279,9 @@ func TestRunStableHighlightsWalk_warnsOnEmptyRange(t *testing.T) {
 	)
 }
 
-// The static path is what every non-interactive invocation now takes, so
-// the whole changelog has to survive the trip to stdout: the summary index
-// AND every release body, with nothing waiting on a keypress.
+// The static path is what every non-interactive invocation takes, so the
+// whole changelog has to survive the trip to stdout: the summary index AND
+// every release body, with nothing waiting on a key press.
 func TestRunStableHighlightsWalk_staticPrintsEveryRelease(t *testing.T) {
 	withReleasesBetween(t, func(_ context.Context, _, _ string, _ bool) ([]selfupdate.Release, error) {
 		return []selfupdate.Release{
@@ -292,7 +292,7 @@ func TestRunStableHighlightsWalk_staticPrintsEveryRelease(t *testing.T) {
 	cmd, buf := newWalkTestCmd(t)
 	result := selfupdate.CheckResult{CurrentVersion: "v0.7.1", LatestVersion: "v0.7.3"}
 
-	runStableHighlightsWalk(cmd.Context(), cmd, result, config.DefaultState(), walkModeStatic)
+	runStableHighlightsWalk(cmd.Context(), cmd, changelogUI(cmd, walkModeStatic), result, config.DefaultState(), walkModeStatic)
 
 	requireContains(t, buf.String(),
 		"2 releases",
@@ -302,6 +302,108 @@ func TestRunStableHighlightsWalk_staticPrintsEveryRelease(t *testing.T) {
 		"No AI highlights",
 		"Newer thing", // Highlights block for the release that has one
 	)
+}
+
+// newQuietWalkTestCmd is newWalkTestCmd with --quiet, the mode an unattended
+// run is actually invoked in.
+func newQuietWalkTestCmd(t *testing.T) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetContext(SetGlobalOpts(context.Background(), &GlobalOpts{Quiet: true, Hints: "always"}))
+	return cmd, &buf
+}
+
+// Static mode outranks --quiet, and it has to do so for the whole
+// presentation: printing the release bodies while the flag eats the index
+// above them leaves a record that reads complete and is missing the publish
+// dates and Highlights markers that appear nowhere else.
+func TestRunStableHighlightsWalk_quietStaticKeepsTheSummary(t *testing.T) {
+	withReleasesBetween(t, func(_ context.Context, _, _ string, _ bool) ([]selfupdate.Release, error) {
+		return []selfupdate.Release{
+			{TagName: "v0.7.2", PublishedAt: "2026-04-22T10:00:00Z", Body: "## [0.7.2]\n### Features\n* older thing\n---\n"},
+		}, nil
+	})
+	cmd, buf := newQuietWalkTestCmd(t)
+	result := selfupdate.CheckResult{CurrentVersion: "v0.7.1", LatestVersion: "v0.7.2"}
+
+	runStableHighlightsWalk(cmd.Context(), cmd, changelogUI(cmd, walkModeStatic), result, config.DefaultState(), walkModeStatic)
+
+	requireContains(t, buf.String(),
+		"1 release:",   // the summary heading
+		"2026-04-22",   // the publish date, which the bodies never carry
+		"commit-based", // the per-release marker, likewise
+		"older thing",  // and the body itself
+	)
+}
+
+// The fallback notice is the only output there is when the fetch fails, so
+// letting --quiet eat it means the changelog step prints nothing at all and
+// an operator cannot tell a silent success from a silent failure.
+func TestRunStableHighlightsWalk_quietStaticKeepsTheFallbackNotice(t *testing.T) {
+	withReleasesBetween(t, func(_ context.Context, _, _ string, _ bool) ([]selfupdate.Release, error) {
+		return nil, errors.New("simulated GitHub 503")
+	})
+	cmd, buf := newQuietWalkTestCmd(t)
+	result := selfupdate.CheckResult{CurrentVersion: "v0.7.1", LatestVersion: "v0.7.5"}
+
+	runStableHighlightsWalk(cmd.Context(), cmd, changelogUI(cmd, walkModeStatic), result, config.DefaultState(), walkModeStatic)
+
+	requireContains(t, buf.String(), "New version available: v0.7.5")
+}
+
+func TestRunDevCommitWalk_quietStaticPrintsTheChangelog(t *testing.T) {
+	withCommitsBetween(t, func(_ context.Context, _, _ string) (selfupdate.CommitRange, error) {
+		return selfupdate.CommitRange{
+			TotalCommits: 1,
+			Commits: []selfupdate.Commit{
+				{SHA: "abc1234567890abcdef0123456789abcdef01234", Subject: "only change", Author: "Ada", Date: "2026-04-25"},
+			},
+		}, nil
+	})
+	cmd, buf := newQuietWalkTestCmd(t)
+	result := selfupdate.CheckResult{CurrentVersion: "v0.7.3-dev.18", LatestVersion: "v0.7.3-dev.19"}
+
+	runDevCommitWalk(cmd.Context(), cmd, changelogUI(cmd, walkModeStatic), result, walkModeStatic)
+
+	requireContains(t, buf.String(), "dev channel: v0.7.3-dev.18 -> v0.7.3-dev.19", "only change")
+}
+
+// Driving runChangelogWalk itself rather than the walk beneath it, so the
+// wiring is covered too: the walks receive whatever UI the entry point
+// hands them, and a quiet one there would put the summary back out of reach.
+func TestRunChangelogWalk_quietStillRendersTheWholePresentation(t *testing.T) {
+	withReleasesBetween(t, func(_ context.Context, _, _ string, _ bool) ([]selfupdate.Release, error) {
+		return []selfupdate.Release{
+			{TagName: "v0.7.2", PublishedAt: "2026-04-22T10:00:00Z", Body: "## [0.7.2]\n### Features\n* older thing\n---\n"},
+		}, nil
+	})
+	cmd, buf := newQuietWalkTestCmd(t)
+	result := selfupdate.CheckResult{CurrentVersion: "v0.7.1", LatestVersion: "v0.7.2"}
+
+	runChangelogWalk(cmd.Context(), cmd, result, config.DefaultState(), false)
+
+	requireContains(t, buf.String(), "1 release:", "2026-04-22", "older thing")
+}
+
+// --json is the one mode that suppresses the changelog, and it must keep
+// doing so through changelogUI, which clears the quiet flag static mode
+// would otherwise inherit.
+func TestChangelogUI_jsonStillSuppresses(t *testing.T) {
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetContext(SetGlobalOpts(context.Background(), &GlobalOpts{JSON: true}))
+
+	printOfflineNotice(changelogUI(cmd, walkModeStatic), selfupdate.CheckResult{
+		CurrentVersion: "v0.7.1", LatestVersion: "v0.7.5",
+	})
+
+	if strings.TrimSpace(buf.String()) != "" {
+		t.Errorf("JSON mode must emit no human output\n--- got ---\n%s", buf.String())
+	}
 }
 
 func TestRunDevCommitWalk_staticPrintsEveryCommit(t *testing.T) {
@@ -317,7 +419,7 @@ func TestRunDevCommitWalk_staticPrintsEveryCommit(t *testing.T) {
 	cmd, buf := newWalkTestCmd(t)
 	result := selfupdate.CheckResult{CurrentVersion: "v0.7.3-dev.18", LatestVersion: "v0.7.3-dev.19"}
 
-	runDevCommitWalk(cmd.Context(), cmd, result, walkModeStatic)
+	runDevCommitWalk(cmd.Context(), cmd, changelogUI(cmd, walkModeStatic), result, walkModeStatic)
 
 	requireContains(t, buf.String(),
 		"dev channel: v0.7.3-dev.18 -> v0.7.3-dev.19",
@@ -344,7 +446,7 @@ func TestRunDevCommitWalk_warnsOnCompareError(t *testing.T) {
 	// "v0.7.3-dev.11..v0.7.3-dev.19" before passing to commitsBetween.
 	result := selfupdate.CheckResult{CurrentVersion: "0.7.3-dev.11", LatestVersion: "v0.7.3-dev.19"}
 
-	runDevCommitWalk(cmd.Context(), cmd, result, walkModeStatic)
+	runDevCommitWalk(cmd.Context(), cmd, changelogUI(cmd, walkModeStatic), result, walkModeStatic)
 
 	got := buf.String()
 	requireContains(t, got,
@@ -363,7 +465,7 @@ func TestRunDevCommitWalk_warnsOnEmptyRange(t *testing.T) {
 	cmd, buf := newWalkTestCmd(t)
 	result := selfupdate.CheckResult{CurrentVersion: "v0.7.3-dev.18", LatestVersion: "v0.7.3-dev.19"}
 
-	runDevCommitWalk(cmd.Context(), cmd, result, walkModeStatic)
+	runDevCommitWalk(cmd.Context(), cmd, changelogUI(cmd, walkModeStatic), result, walkModeStatic)
 
 	got := buf.String()
 	requireContains(t, got,
@@ -390,7 +492,7 @@ func TestRunDevCommitWalk_normalisesVersionRefs(t *testing.T) {
 	cmd, _ := newWalkTestCmd(t)
 	result := selfupdate.CheckResult{CurrentVersion: "0.7.3-dev.11", LatestVersion: "0.7.3-dev.19"}
 
-	runDevCommitWalk(cmd.Context(), cmd, result, walkModeStatic)
+	runDevCommitWalk(cmd.Context(), cmd, changelogUI(cmd, walkModeStatic), result, walkModeStatic)
 
 	if seenBase != "v0.7.3-dev.11" {
 		t.Errorf("base passed to commitsBetween = %q, want %q", seenBase, "v0.7.3-dev.11")
@@ -424,7 +526,7 @@ func TestRunDevCommitWalk_usesEmbeddedCommitSHA(t *testing.T) {
 	cmd, buf := newWalkTestCmd(t)
 	result := selfupdate.CheckResult{CurrentVersion: "0.7.3-dev.20", LatestVersion: "0.7.3-dev.24"}
 
-	runDevCommitWalk(cmd.Context(), cmd, result, walkModeStatic)
+	runDevCommitWalk(cmd.Context(), cmd, changelogUI(cmd, walkModeStatic), result, walkModeStatic)
 
 	if seenBase != buildSHA {
 		t.Errorf("base passed to commitsBetween = %q, want embedded SHA %q", seenBase, buildSHA)

--- a/cli/cmd/update_walk_test.go
+++ b/cli/cmd/update_walk_test.go
@@ -177,6 +177,55 @@ func TestPrintOfflineNotice(t *testing.T) {
 	}
 }
 
+// The label and the link are different answers to the same ref, and the
+// notice prints both on adjacent lines. The label is scrubbed, so it must not
+// carry the spoofing runes; the link is escaped, so it must still address the
+// tag that actually exists, which the scrubbed form no longer names.
+func TestPrintOfflineNotice_linkAddressesTheRealTag(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(SetGlobalOpts(context.Background(), &GlobalOpts{Hints: "always"}))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	result := selfupdate.CheckResult{CurrentVersion: "v0.7.4", LatestVersion: spoofedTargetTag}
+	printOfflineNotice(changelogUI(cmd, walkModeStatic), result)
+	got := buf.String()
+
+	requireContains(t, got, spoofedTargetSaf,
+		"/releases/tag/v0.7.5%E2%80%AE%E2%80%8Bevil%E2%81%A0")
+	requireLacks(t, got, rloRune, zwspRune, wordJoinerRune)
+}
+
+// versionURLRef exists because versionLabel is wrong in a URL twice over: it
+// deletes runes git allows in a tag, and it passes "#" through to start a
+// fragment. Both are exercised here because both silently produce a link to
+// the wrong place rather than an error anybody would notice.
+func TestVersionURLRef(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain tag unchanged", "v0.7.5", "v0.7.5"},
+		{"missing prefix normalised", "0.7.5", "v0.7.5"},
+		{"dev tag unchanged", "v0.7.5-dev.11", "v0.7.5-dev.11"},
+		// The scrub deletes this rune outright, so the label names a tag the
+		// remote does not have; percent-encoding keeps the ref addressable.
+		{"line separator encoded", "v1.2.3" + lineSepRune + "build", "v1.2.3%E2%80%A8build"},
+		// The one hostile character the scrub passes through: unescaped it
+		// truncates the URL at a fragment, so the link opens the releases
+		// index rather than the tag.
+		{"hash encoded", "v1.2.3#build", "v1.2.3%23build"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := versionURLRef(tt.in); got != tt.want {
+				t.Errorf("versionURLRef(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestWalkModeFor covers the whole gate: only --json loses the changelog,
 // everything else that cannot (or must not) run a pager downgrades to the
 // static render rather than dropping the content.
@@ -318,6 +367,7 @@ const (
 	rloRune        = "\xe2\x80\xae" // U+202E RIGHT-TO-LEFT OVERRIDE
 	zwspRune       = "\xe2\x80\x8b" // U+200B ZERO WIDTH SPACE
 	wordJoinerRune = "\xe2\x81\xa0" // U+2060 WORD JOINER
+	lineSepRune    = "\xe2\x80\xa8" // U+2028 LINE SEPARATOR
 
 	spoofedTargetTag = "v0.7.5" + rloRune + zwspRune + "evil" + wordJoinerRune
 	spoofedTargetSaf = "v0.7.5evil"

--- a/cli/internal/ui/changelog.go
+++ b/cli/internal/ui/changelog.go
@@ -69,14 +69,71 @@ var ansiEscapeRe = regexp.MustCompile(`\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\x07\x1b]*
 // H2 sections in the release body (e.g. "## Migration notes") are kept.
 var releaseHeadingRe = regexp.MustCompile(`^##\s+\[[^\]]+\](?:\([^)]+\))?(?:\s+\([^)]+\))?\s*$`)
 
-// stripANSI removes ANSI escape sequences from s. Applied at every renderer
-// boundary so user-controlled release-body content cannot inject styling /
-// cursor-movement / clear-screen escapes into the operator's terminal.
-func stripANSI(s string) string {
+// stripEscapes removes the CSI / OSC sequences ansiEscapeRe matches. It is
+// only ever half the job: see sanitizeUntrusted.
+func stripEscapes(s string) string {
 	if !strings.ContainsRune(s, '\x1b') {
 		return s
 	}
 	return ansiEscapeRe.ReplaceAllString(s, "")
+}
+
+// isSpoofingRune reports whether r can visually reorder or hide neighbouring
+// text without being a control character: the bidirectional overrides and
+// isolates behind Trojan-Source spoofing, the zero-width joiners and marks,
+// and the BOM. Git restricts none of them in a ref name, so they survive
+// into the version string an operator reads immediately before consenting
+// to an install.
+func isSpoofingRune(r rune) bool {
+	switch {
+	case r >= 0x200B && r <= 0x200F: // ZWSP, ZWNJ, ZWJ, LRM, RLM
+		return true
+	case r >= 0x202A && r <= 0x202E: // LRE, RLE, PDF, LRO, RLO
+		return true
+	case r >= 0x2066 && r <= 0x2069: // LRI, RLI, FSI, PDI
+		return true
+	case r == 0xFEFF: // zero-width no-break space / BOM
+		return true
+	}
+	return false
+}
+
+func stripSpoofingRunes(s string) string {
+	return strings.Map(func(r rune) rune {
+		if isSpoofingRune(r) {
+			return -1
+		}
+		return r
+	}, s)
+}
+
+// sanitizeUntrusted scrubs remote-sourced multi-line text (a release body)
+// of everything that can act on a terminal rather than print in it, keeping
+// the newlines and tabs the layout needs. Escape sequences go first so their
+// printable payload (the "[0;31m" of a CSI) leaves with them instead of
+// surviving as text.
+//
+// The escape regex alone is not enough: it matches CSI and OSC, leaving bare
+// CR, backspace, BEL and the non-CSI introducers (DCS, APC, and the two-byte
+// RIS full-terminal-reset) free to overwrite or hide what the operator is
+// reading. Git constrains none of those in a commit subject or an author
+// name, and the static renderers write their output raw, where it lands in
+// log files and captured CI output that somebody later cats back to a real
+// terminal.
+func sanitizeUntrusted(s string) string {
+	return stripSpoofingRunes(stripControl(stripEscapes(s)))
+}
+
+// SanitizeUntrustedLine is sanitizeUntrusted for a value that must occupy a
+// single line: a tag name, a version label, a commit subject. It drops the
+// newlines and tabs the multi-line form keeps, so a hostile value cannot
+// break out of the row it is rendered into.
+//
+// Exported because the same remote values are printed by the surrounding
+// command (the release index above the changelog), not only by the
+// renderers in this package.
+func SanitizeUntrustedLine(s string) string {
+	return stripSpoofingRunes(stripControlStrict(stripEscapes(s)))
 }
 
 // RenderHighlights formats the styled-block content of a release Highlights
@@ -86,7 +143,7 @@ func stripANSI(s string) string {
 // release body cannot inject terminal styling / cursor moves into the walk.
 func RenderHighlights(body string, opts Options) string {
 	st := newChangelogStyle(opts)
-	body = stripANSI(strings.ReplaceAll(body, "\r\n", "\n"))
+	body = sanitizeUntrusted(strings.ReplaceAll(body, "\r\n", "\n"))
 	lines := strings.Split(body, "\n")
 	var out strings.Builder
 	for _, line := range lines {
@@ -120,10 +177,10 @@ func formatHighlightLine(line string, st changelogStyle) string {
 // RenderCommits formats the commit-based changelog of a release. body is
 // expected to be the output of selfupdate.ExtractCommits. ANSI escape
 // sequences embedded in the input are stripped before rendering -- see
-// stripANSI for the threat model.
+// sanitizeUntrusted for the threat model.
 func RenderCommits(body string, opts Options) string {
 	st := newChangelogStyle(opts)
-	body = stripANSI(strings.ReplaceAll(body, "\r\n", "\n"))
+	body = sanitizeUntrusted(strings.ReplaceAll(body, "\r\n", "\n"))
 	lines := strings.Split(body, "\n")
 	var out strings.Builder
 	for _, line := range lines {

--- a/cli/internal/ui/changelog.go
+++ b/cli/internal/ui/changelog.go
@@ -132,12 +132,28 @@ func isControlRune(r rune, keepLayout bool) bool {
 	return r < 0x20 || r == 0x7F || (r >= 0x80 && r <= 0x9F)
 }
 
-// scrubDrops is the whole removal predicate: the control characters and the
-// spoofing runes, behind an ASCII-printable fast exit because that is what
-// almost every byte of a release body is.
+// isLineSeparatorRune reports whether r is one of the two Unicode separators
+// that carry no control-character encoding: U+2028 LINE SEPARATOR and U+2029
+// PARAGRAPH SEPARATOR. No common terminal moves the cursor on either, so the
+// multi-line form leaves them be, but a Unicode-aware consumer of the same
+// output -- a log processor splitting on line boundaries -- does treat them as
+// breaks. Git constrains neither in a ref name, so the single-line form drops
+// them for the reason it drops '\n': its whole promise is that the value
+// cannot leave the row it was rendered into.
+func isLineSeparatorRune(r rune) bool {
+	return r == 0x2028 || r == 0x2029
+}
+
+// scrubDrops is the whole removal predicate: the control characters, the
+// Unicode line separators the single-line form cannot keep, and the spoofing
+// runes, behind an ASCII-printable fast exit because that is what almost
+// every byte of a release body is.
 func scrubDrops(r rune, keepLayout bool) bool {
 	if r >= 0x20 && r < 0x7F {
 		return false
+	}
+	if !keepLayout && isLineSeparatorRune(r) {
+		return true
 	}
 	return isControlRune(r, keepLayout) || isSpoofingRune(r)
 }
@@ -182,11 +198,16 @@ func scrubIndex(s string, keepLayout bool) int {
 			continue
 		}
 		r, size := utf8.DecodeRuneInString(s[i:])
-		// RuneError covers two cases that both have to stop the scan: a
-		// byte that is not valid UTF-8, which must not reach a terminal as
-		// though it were text, and a genuine U+FFFD, which the rebuild
-		// simply writes back.
-		if r == utf8.RuneError || isControlRune(r, keepLayout) || isSpoofingRune(r) {
+		// Deferring to scrubDrops rather than restating its classes is what
+		// keeps this scan and the rebuild below answering the same question:
+		// a class listed in one and not the other would leave the rune in
+		// the output whenever it was the only thing wrong with the string.
+		//
+		// RuneError is the one case that belongs here alone, and it covers
+		// two: a byte that is not valid UTF-8, which must not reach a
+		// terminal as though it were text, and a genuine U+FFFD, which the
+		// rebuild simply writes back.
+		if r == utf8.RuneError || scrubDrops(r, keepLayout) {
 			return i
 		}
 		i += size
@@ -237,8 +258,9 @@ func sanitizeUntrusted(s string) string {
 
 // SanitizeUntrustedLine is sanitizeUntrusted for a value that must occupy a
 // single line: a tag name, a version label, a commit subject. It drops the
-// newlines and tabs the multi-line form keeps, so a hostile value cannot
-// break out of the row it is rendered into.
+// newlines and tabs the multi-line form keeps, and the Unicode line
+// separators that are breaks to everything downstream of the terminal, so a
+// hostile value cannot break out of the row it is rendered into.
 //
 // Exported because the same remote values are printed by the surrounding
 // command (the release index above the changelog), not only by the
@@ -249,9 +271,12 @@ func SanitizeUntrustedLine(s string) string {
 
 // RenderHighlights formats the styled-block content of a release Highlights
 // section. body is expected to be the output of selfupdate.ExtractHighlights,
-// already stripped of markers / "## Highlights" / attribution. The renderer
-// also strips any embedded ANSI escape sequences from the input so a hostile
-// release body cannot inject terminal styling / cursor moves into the walk.
+// already stripped of markers / "## Highlights" / attribution. The body is
+// remote-controlled, so it passes through sanitizeUntrusted first: not only
+// the embedded ANSI escapes, but the bare control characters, the invalid
+// UTF-8 and the spoofing runes a hostile release body can otherwise use to
+// rewrite what the operator reads. See sanitizeUntrusted for the threat
+// model.
 func RenderHighlights(body string, opts Options) string {
 	st := newChangelogStyle(opts)
 	body = sanitizeUntrusted(strings.ReplaceAll(body, "\r\n", "\n"))
@@ -286,9 +311,9 @@ func formatHighlightLine(line string, st changelogStyle) string {
 }
 
 // RenderCommits formats the commit-based changelog of a release. body is
-// expected to be the output of selfupdate.ExtractCommits. ANSI escape
-// sequences embedded in the input are stripped before rendering -- see
-// sanitizeUntrusted for the threat model.
+// expected to be the output of selfupdate.ExtractCommits, and takes the same
+// sanitizeUntrusted sweep as RenderHighlights before it is rendered -- see
+// there for the threat model.
 func RenderCommits(body string, opts Options) string {
 	st := newChangelogStyle(opts)
 	body = sanitizeUntrusted(strings.ReplaceAll(body, "\r\n", "\n"))

--- a/cli/internal/ui/changelog.go
+++ b/cli/internal/ui/changelog.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"charm.land/lipgloss/v2"
 )
@@ -78,33 +79,143 @@ func stripEscapes(s string) string {
 	return ansiEscapeRe.ReplaceAllString(s, "")
 }
 
+// spoofingRanges is the isSpoofingRune vocabulary as inclusive codepoint
+// spans, ascending and non-overlapping, which is what lets the lookup stop
+// at the first span starting above r rather than reading the whole table.
+var spoofingRanges = [...][2]rune{
+	{0x00AD, 0x00AD},   // SOFT HYPHEN
+	{0x061C, 0x061C},   // ARABIC LETTER MARK
+	{0x180E, 0x180E},   // MONGOLIAN VOWEL SEPARATOR
+	{0x200B, 0x200F},   // ZWSP, ZWNJ, ZWJ, LRM, RLM
+	{0x202A, 0x202E},   // LRE, RLE, PDF, LRO, RLO
+	{0x2060, 0x2064},   // WORD JOINER, invisible operators
+	{0x2066, 0x2069},   // LRI, RLI, FSI, PDI
+	{0xFEFF, 0xFEFF},   // zero-width no-break space / BOM
+	{0xFFF9, 0xFFFB},   // interlinear annotation
+	{0xE0000, 0xE007F}, // tag block
+}
+
 // isSpoofingRune reports whether r can visually reorder or hide neighbouring
-// text without being a control character: the bidirectional overrides and
-// isolates behind Trojan-Source spoofing, the zero-width joiners and marks,
-// and the BOM. Git restricts none of them in a ref name, so they survive
-// into the version string an operator reads immediately before consenting
-// to an install.
+// text without being a control character: the bidirectional overrides, marks
+// and isolates behind Trojan-Source spoofing, the zero-width joiners and the
+// invisible format runes, the interlinear annotation controls, and the tag
+// block, which carries a whole hidden string past a reader one codepoint at
+// a time. Git restricts none of them in a ref name, so they survive into the
+// version string an operator reads immediately before consenting to an
+// install. None of them carries meaning in a version label, a commit subject
+// or a release body, so dropping the class outright costs nothing legible.
 func isSpoofingRune(r rune) bool {
-	switch {
-	case r >= 0x200B && r <= 0x200F: // ZWSP, ZWNJ, ZWJ, LRM, RLM
-		return true
-	case r >= 0x202A && r <= 0x202E: // LRE, RLE, PDF, LRO, RLO
-		return true
-	case r >= 0x2066 && r <= 0x2069: // LRI, RLI, FSI, PDI
-		return true
-	case r == 0xFEFF: // zero-width no-break space / BOM
-		return true
+	// Every span sits above ASCII, so the printable majority of a release
+	// body is answered without reaching the table at all.
+	if r < spoofingRanges[0][0] {
+		return false
+	}
+	for _, span := range spoofingRanges {
+		if r < span[0] {
+			return false
+		}
+		if r <= span[1] {
+			return true
+		}
 	}
 	return false
 }
 
-func stripSpoofingRunes(s string) string {
-	return strings.Map(func(r rune) rune {
-		if isSpoofingRune(r) {
-			return -1
+// isControlRune reports whether r acts on a terminal rather than printing in
+// it. keepLayout spares the tab and newline a multi-line block is laid out
+// with; a value that must occupy a single line keeps neither, so a hostile
+// string cannot break out of the row it is rendered into.
+func isControlRune(r rune, keepLayout bool) bool {
+	if keepLayout && (r == '\t' || r == '\n') {
+		return false
+	}
+	return r < 0x20 || r == 0x7F || (r >= 0x80 && r <= 0x9F)
+}
+
+// scrubDrops is the whole removal predicate: the control characters and the
+// spoofing runes, behind an ASCII-printable fast exit because that is what
+// almost every byte of a release body is.
+func scrubDrops(r rune, keepLayout bool) bool {
+	if r >= 0x20 && r < 0x7F {
+		return false
+	}
+	return isControlRune(r, keepLayout) || isSpoofingRune(r)
+}
+
+// scrubDropsASCII is scrubDrops for a byte already known to be ASCII, which
+// narrows the question to the C0 controls and DEL: no spoofing rune is
+// encoded in one byte, so the table lookup cannot apply. Splitting it out
+// keeps the single-byte case, the one that decides almost every byte of a
+// release body, down to two comparisons.
+func scrubDropsASCII(c byte, keepLayout bool) bool {
+	if c >= 0x20 && c != 0x7F {
+		return false
+	}
+	return !keepLayout || (c != '\t' && c != '\n')
+}
+
+// scrubIndex returns the index of the first rune scrubUntrusted has to drop
+// or replace, or -1 when s is already clean.
+//
+// The scan is byte-oriented and decodes only at or above utf8.RuneSelf. That
+// is the whole performance story here: a release body is almost entirely
+// printable ASCII, the walk scrubs one on every "synthorg update", and
+// decoding every rune to ask a per-class predicate about it measured 2.15ns
+// per byte against the 0.01ns the escape strip costs for the same string.
+// Settling the ASCII majority in two comparisons keeps the sweep off the
+// render path's critical cost.
+func scrubIndex(s string, keepLayout bool) int {
+	for i := 0; i < len(s); {
+		c := s[i]
+		// Printable ASCII first and on its own: it is almost every byte of
+		// a release body, and putting any other test ahead of it puts that
+		// test on every byte too.
+		if c >= 0x20 && c < 0x7F {
+			i++
+			continue
 		}
-		return r
-	}, s)
+		if c < utf8.RuneSelf {
+			if scrubDropsASCII(c, keepLayout) {
+				return i
+			}
+			i++
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(s[i:])
+		// RuneError covers two cases that both have to stop the scan: a
+		// byte that is not valid UTF-8, which must not reach a terminal as
+		// though it were text, and a genuine U+FFFD, which the rebuild
+		// simply writes back.
+		if r == utf8.RuneError || isControlRune(r, keepLayout) || isSpoofingRune(r) {
+			return i
+		}
+		i += size
+	}
+	return -1
+}
+
+// scrubUntrusted removes every control and spoofing rune in a single pass.
+//
+// One pass rather than one per class: each class costs a rune decode and an
+// indirect call per rune, and layering two of them behind the escape strip
+// measured 76% slower on the release-body render than the escape strip
+// alone. A clean body is returned as itself, so the common case neither
+// copies nor allocates.
+func scrubUntrusted(s string, keepLayout bool) string {
+	cut := scrubIndex(s, keepLayout)
+	if cut < 0 {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	b.WriteString(s[:cut])
+	for _, r := range s[cut:] {
+		if scrubDrops(r, keepLayout) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }
 
 // sanitizeUntrusted scrubs remote-sourced multi-line text (a release body)
@@ -121,7 +232,7 @@ func stripSpoofingRunes(s string) string {
 // log files and captured CI output that somebody later cats back to a real
 // terminal.
 func sanitizeUntrusted(s string) string {
-	return stripSpoofingRunes(stripControl(stripEscapes(s)))
+	return scrubUntrusted(stripEscapes(s), true)
 }
 
 // SanitizeUntrustedLine is sanitizeUntrusted for a value that must occupy a
@@ -133,7 +244,7 @@ func sanitizeUntrusted(s string) string {
 // command (the release index above the changelog), not only by the
 // renderers in this package.
 func SanitizeUntrustedLine(s string) string {
-	return stripSpoofingRunes(stripControlStrict(stripEscapes(s)))
+	return scrubUntrusted(stripEscapes(s), false)
 }
 
 // RenderHighlights formats the styled-block content of a release Highlights

--- a/cli/internal/ui/changelog_bench_test.go
+++ b/cli/internal/ui/changelog_bench_test.go
@@ -86,3 +86,25 @@ func BenchmarkRenderCommitsStyled(b *testing.B) {
 		_ = RenderCommits(sampleCommitsBody, opts)
 	}
 }
+
+// BenchmarkSanitizeUntrustedBody isolates the scrub every renderer above
+// runs before it formats anything. It is measured on its own because the
+// renderers' cost is dominated by lipgloss, which hid a sanitizer that had
+// become the larger half of the render: a sweep per removal class decoded
+// every rune of the body once per class, and only the A/B against the
+// merge-base caught it. A dedicated number makes the next such change
+// visible in the benchmark that owns it.
+func BenchmarkSanitizeUntrustedBody(b *testing.B) {
+	for b.Loop() {
+		_ = sanitizeUntrusted(sampleCommitsBody)
+	}
+}
+
+// BenchmarkSanitizeUntrustedLineLabel measures the single-line form on a
+// version label, which the walk calls once per rendered release row rather
+// than once per body.
+func BenchmarkSanitizeUntrustedLineLabel(b *testing.B) {
+	for b.Loop() {
+		_ = SanitizeUntrustedLine("v0.7.3-dev.42")
+	}
+}

--- a/cli/internal/ui/changelog_test.go
+++ b/cli/internal/ui/changelog_test.go
@@ -198,6 +198,18 @@ const (
 	zwjRune  = "\xe2\x80\x8d" // U+200D ZERO WIDTH JOINER
 	bomRune  = "\xef\xbb\xbf" // U+FEFF BYTE ORDER MARK
 	nelRune  = "\xc2\x90"     // U+0090 DEVICE CONTROL STRING (C1)
+
+	// Invisible format runes outside the bidi and zero-width blocks above.
+	// Each renders as nothing, so each can pad a version label into looking
+	// like a different one.
+	wordJoinerRune  = "\xe2\x81\xa0"     // U+2060 WORD JOINER
+	invisiblePlus   = "\xe2\x81\xa4"     // U+2064 INVISIBLE PLUS
+	softHyphenRune  = "\xc2\xad"         // U+00AD SOFT HYPHEN
+	arabicLetterMar = "\xd8\x9c"         // U+061C ARABIC LETTER MARK
+	mongolianVowel  = "\xe1\xa0\x8e"     // U+180E MONGOLIAN VOWEL SEPARATOR
+	interlinearAnch = "\xef\xbf\xb9"     // U+FFF9 INTERLINEAR ANNOTATION ANCHOR
+	langTagRune     = "\xf3\xa0\x80\x81" // U+E0001 LANGUAGE TAG
+	tagLetterARune  = "\xf3\xa0\x81\x81" // U+E0041 TAG LATIN CAPITAL LETTER A
 )
 
 func TestSanitizeUntrusted(t *testing.T) {
@@ -229,6 +241,26 @@ func TestSanitizeUntrusted(t *testing.T) {
 		{"strip_bidi_override", "v1.0.0" + rloRune + "gnitset" + pdfRune, "v1.0.0gnitset"},
 		{"strip_bidi_isolate", "v1" + lriRune + ".0" + pdiRune + ".0", "v1.0.0"},
 		{"strip_zero_width", "v1." + zwspRune + "0." + zwjRune + "0" + bomRune, "v1.0.0"},
+		// The rest of the invisible-format class. None is a control
+		// character or a bidi control, so only the spoofing sweep sees them.
+		{"strip_word_joiner", "v1." + wordJoinerRune + "0.0", "v1.0.0"},
+		{"strip_invisible_operator", "v1.0" + invisiblePlus + ".0", "v1.0.0"},
+		{"strip_soft_hyphen", "v1." + softHyphenRune + "0.0", "v1.0.0"},
+		{"strip_arabic_letter_mark", "v1.0" + arabicLetterMar + ".0", "v1.0.0"},
+		{"strip_mongolian_vowel_separator", "v1" + mongolianVowel + ".0.0", "v1.0.0"},
+		{"strip_interlinear_anchor", "v1.0." + interlinearAnch + "0", "v1.0.0"},
+		// The tag block smuggles a whole hidden string one codepoint at a
+		// time, which is why it goes with its opener rather than alone.
+		{"strip_tag_block", "v1.0.0" + langTagRune + tagLetterARune, "v1.0.0"},
+		// Visible text either side of a dropped rune must survive, or the
+		// sweep would be eating the label it exists to keep readable.
+		{"keep_neighbours_of_dropped_rune", "a" + wordJoinerRune + "b", "ab"},
+		// Bytes that are not text at all: they decode to U+FFFD and the
+		// rebuild writes the replacement rather than passing them through.
+		{"replace_invalid_utf8", "v1\xff.0", "v1\xef\xbf\xbd.0"},
+		// Printable multi-byte text survives, including the bullet, which
+		// shares its leading byte with the zero-width block above.
+		{"keep_multibyte_text", "café • release", "café • release"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cli/internal/ui/changelog_test.go
+++ b/cli/internal/ui/changelog_test.go
@@ -197,7 +197,7 @@ const (
 	zwspRune = "\xe2\x80\x8b" // U+200B ZERO WIDTH SPACE
 	zwjRune  = "\xe2\x80\x8d" // U+200D ZERO WIDTH JOINER
 	bomRune  = "\xef\xbb\xbf" // U+FEFF BYTE ORDER MARK
-	nelRune  = "\xc2\x90"     // U+0090 DEVICE CONTROL STRING (C1)
+	dcsRune  = "\xc2\x90"     // U+0090 DEVICE CONTROL STRING (C1)
 
 	// Invisible format runes outside the bidi and zero-width blocks above.
 	// Each renders as nothing, so each can pad a version label into looking
@@ -210,6 +210,11 @@ const (
 	interlinearAnch = "\xef\xbf\xb9"     // U+FFF9 INTERLINEAR ANNOTATION ANCHOR
 	langTagRune     = "\xf3\xa0\x80\x81" // U+E0001 LANGUAGE TAG
 	tagLetterARune  = "\xf3\xa0\x81\x81" // U+E0041 TAG LATIN CAPITAL LETTER A
+
+	// Line breaks to a Unicode-aware reader, inert to a terminal, which is
+	// why they are the one class the two sanitize forms disagree about.
+	lineSepRune = "\xe2\x80\xa8" // U+2028 LINE SEPARATOR
+	paraSepRune = "\xe2\x80\xa9" // U+2029 PARAGRAPH SEPARATOR
 )
 
 func TestSanitizeUntrusted(t *testing.T) {
@@ -234,7 +239,7 @@ func TestSanitizeUntrusted(t *testing.T) {
 		{"strip_bel", "ring\x07ring", "ringring"},
 		{"strip_vertical_tab_and_formfeed", "a\x0bb\x0cc", "abc"},
 		{"strip_bare_ris_reset", "before\x1bcafter", "beforecafter"},
-		{"strip_c1_control", "a" + nelRune + "b", "ab"},
+		{"strip_c1_control", "a" + dcsRune + "b", "ab"},
 		{"keep_newline_and_tab", "line one\nline\ttwo", "line one\nline\ttwo"},
 		// Trojan-Source shapes: not control characters, so no control
 		// sweep catches them, and git permits them in a ref name.
@@ -261,6 +266,10 @@ func TestSanitizeUntrusted(t *testing.T) {
 		// Printable multi-byte text survives, including the bullet, which
 		// shares its leading byte with the zero-width block above.
 		{"keep_multibyte_text", "café • release", "café • release"},
+		// The body form keeps the Unicode separators for the same reason it
+		// keeps '\n': it already carries line structure, so one more
+		// boundary changes nothing about what the text can do.
+		{"keep_line_separators_in_body", "a" + lineSepRune + "b" + paraSepRune + "c", "a" + lineSepRune + "b" + paraSepRune + "c"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -282,6 +291,17 @@ func TestSanitizeUntrustedLine_dropsLayoutBreakingWhitespace(t *testing.T) {
 	}
 	if strings.ContainsAny(got, "\n\t") {
 		t.Errorf("result still carries layout-breaking whitespace: %q", got)
+	}
+}
+
+// The Unicode separators are the case a terminal-only reading misses: neither
+// moves a cursor, so both survive every control sweep, and both are still a
+// line boundary to whatever later parses the captured output.
+func TestSanitizeUntrustedLine_dropsUnicodeLineSeparators(t *testing.T) {
+	got := SanitizeUntrustedLine("v1.0.0" + lineSepRune + "spoofed" + paraSepRune + "row")
+	want := "v1.0.0spoofedrow"
+	if got != want {
+		t.Errorf("SanitizeUntrustedLine = %q, want %q", got, want)
 	}
 }
 

--- a/cli/internal/ui/changelog_test.go
+++ b/cli/internal/ui/changelog_test.go
@@ -186,7 +186,21 @@ func TestRenderFallbackNote_plainNoANSI(t *testing.T) {
 	}
 }
 
-func TestStripANSI(t *testing.T) {
+// Trojan-Source code points, written as UTF-8 byte escapes. The literal
+// characters are invisible in a diff, staticcheck rejects them in a string
+// literal (ST1018), and a literal BOM is not legal Go source at all.
+const (
+	rloRune  = "\xe2\x80\xae" // U+202E RIGHT-TO-LEFT OVERRIDE
+	pdfRune  = "\xe2\x80\xac" // U+202C POP DIRECTIONAL FORMATTING
+	lriRune  = "\xe2\x81\xa6" // U+2066 LEFT-TO-RIGHT ISOLATE
+	pdiRune  = "\xe2\x81\xa9" // U+2069 POP DIRECTIONAL ISOLATE
+	zwspRune = "\xe2\x80\x8b" // U+200B ZERO WIDTH SPACE
+	zwjRune  = "\xe2\x80\x8d" // U+200D ZERO WIDTH JOINER
+	bomRune  = "\xef\xbb\xbf" // U+FEFF BYTE ORDER MARK
+	nelRune  = "\xc2\x90"     // U+0090 DEVICE CONTROL STRING (C1)
+)
+
+func TestSanitizeUntrusted(t *testing.T) {
 	tests := []struct {
 		name string
 		in   string
@@ -200,13 +214,42 @@ func TestStripANSI(t *testing.T) {
 		{"strip_osc_hyperlink", "click \x1b]8;;https://evil.com\x07here\x1b]8;;\x07!", "click here!"},
 		{"empty_unchanged", "", ""},
 		{"no_escape_unchanged", "no escapes here \\x1b not literal", "no escapes here \\x1b not literal"},
+		// The CSI/OSC regex passes all of these; only the control-character
+		// sweep behind it catches them, and each one can overwrite or hide
+		// what the operator is reading.
+		{"strip_bare_cr", "real subject\rspoofed subject", "real subjectspoofed subject"},
+		{"strip_backspace", "safe\x08\x08\x08\x08evil", "safeevil"},
+		{"strip_bel", "ring\x07ring", "ringring"},
+		{"strip_vertical_tab_and_formfeed", "a\x0bb\x0cc", "abc"},
+		{"strip_bare_ris_reset", "before\x1bcafter", "beforecafter"},
+		{"strip_c1_control", "a" + nelRune + "b", "ab"},
+		{"keep_newline_and_tab", "line one\nline\ttwo", "line one\nline\ttwo"},
+		// Trojan-Source shapes: not control characters, so no control
+		// sweep catches them, and git permits them in a ref name.
+		{"strip_bidi_override", "v1.0.0" + rloRune + "gnitset" + pdfRune, "v1.0.0gnitset"},
+		{"strip_bidi_isolate", "v1" + lriRune + ".0" + pdiRune + ".0", "v1.0.0"},
+		{"strip_zero_width", "v1." + zwspRune + "0." + zwjRune + "0" + bomRune, "v1.0.0"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := stripANSI(tt.in); got != tt.want {
-				t.Errorf("stripANSI(%q) = %q, want %q", tt.in, got, tt.want)
+			if got := sanitizeUntrusted(tt.in); got != tt.want {
+				t.Errorf("sanitizeUntrusted(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+// SanitizeUntrustedLine is for values rendered into a single row, so unlike
+// its multi-line sibling it must also drop the newlines and tabs that would
+// let a hostile value break out of that row.
+func TestSanitizeUntrustedLine_dropsLayoutBreakingWhitespace(t *testing.T) {
+	got := SanitizeUntrustedLine("v1.0.0\nfake release line\tpadded")
+	want := "v1.0.0fake release linepadded"
+	if got != want {
+		t.Errorf("SanitizeUntrustedLine = %q, want %q", got, want)
+	}
+	if strings.ContainsAny(got, "\n\t") {
+		t.Errorf("result still carries layout-breaking whitespace: %q", got)
 	}
 }
 

--- a/cli/internal/ui/commitlist.go
+++ b/cli/internal/ui/commitlist.go
@@ -71,13 +71,13 @@ func RenderCommitList(r selfupdate.CommitRange, width int, opts Options) string 
 	}
 	rows := make([]prepared, len(r.Commits))
 	for i, c := range r.Commits {
-		// Strip ANSI escapes from every operator-visible field so a
-		// hostile commit subject / author / SHA cannot inject terminal
-		// control sequences into the walk. See stripANSI in changelog.go.
+		// Scrub every operator-visible field so a hostile commit subject /
+		// author / SHA cannot act on the terminal instead of printing in
+		// it. See sanitizeUntrusted in changelog.go for the threat model.
 		// Sanitize once per commit and reuse the cleaned values; passing
 		// a still-dirty `c` into formatMeta would re-do the work and risk
 		// drift if a future field is added without the helper coverage.
-		clean := stripANSIInCommit(c)
+		clean := sanitizeCommit(c)
 		rows[i] = prepared{
 			shortSHA: shortSHA(clean.SHA),
 			subject:  strings.TrimSpace(clean.Subject),
@@ -139,14 +139,14 @@ func formatMeta(c selfupdate.Commit) string {
 	return "(" + strings.Join(parts, ", ") + ")"
 }
 
-// stripANSIInCommit returns a copy of c with ANSI escape sequences scrubbed
+// sanitizeCommit returns a copy of c with terminal-acting sequences scrubbed
 // from every operator-visible field. Used by the commit-list renderer at the
 // boundary between attacker-controllable git data and the operator's terminal.
-func stripANSIInCommit(c selfupdate.Commit) selfupdate.Commit {
-	c.Author = stripANSI(c.Author)
-	c.Date = stripANSI(c.Date)
-	c.Subject = stripANSI(c.Subject)
-	c.SHA = stripANSI(c.SHA)
+func sanitizeCommit(c selfupdate.Commit) selfupdate.Commit {
+	c.Author = SanitizeUntrustedLine(c.Author)
+	c.Date = SanitizeUntrustedLine(c.Date)
+	c.Subject = SanitizeUntrustedLine(c.Subject)
+	c.SHA = SanitizeUntrustedLine(c.SHA)
 	return c
 }
 

--- a/cli/internal/ui/commitlist_walk.go
+++ b/cli/internal/ui/commitlist_walk.go
@@ -209,6 +209,9 @@ func (m commitWalkModel) renderView() string {
 // commitWalkTitle renders the "── dev channel: v1 -> v2  N commits" line that
 // heads both the interactive walk and its static render, so the two cannot
 // drift apart.
+//
+// The target label is a remote tag name; see versionHeader for why that
+// needs scrubbing even though git rejects control bytes in a ref.
 func commitWalkTitle(installed, target string, total int, opts Options) string {
 	plain := opts.NoColor || opts.Plain
 	muted := lipgloss.NewStyle()
@@ -224,6 +227,7 @@ func commitWalkTitle(installed, target string, total int, opts Options) string {
 	}
 
 	return muted.Render(prefix) +
-		header.Render(fmt.Sprintf("dev channel: %s -> %s", installed, target)) +
+		header.Render(fmt.Sprintf("dev channel: %s -> %s",
+			SanitizeUntrustedLine(installed), SanitizeUntrustedLine(target))) +
 		"  " + muted.Render(fmt.Sprintf("%d commits", total))
 }

--- a/cli/internal/ui/commitlist_walk.go
+++ b/cli/internal/ui/commitlist_walk.go
@@ -39,6 +39,16 @@ type CommitWalkInput struct {
 	Output io.Writer
 }
 
+// RenderCommitWalkStatic renders the same commit list as RunCommitWalk into a
+// plain string: title line plus the full listing, no viewport and no key
+// footer. Nothing here is height-bounded -- the caller prints the block and
+// the terminal's scrollback holds it.
+func RenderCommitWalkStatic(in CommitWalkInput) string {
+	w, _ := initialDimensions(in.Width, in.Height)
+	return commitWalkTitle(in.Installed, in.Target, in.Commits.TotalCommits, in.Options) +
+		"\n" + RenderCommitList(in.Commits, w, in.Options)
+}
+
 // RunCommitWalk runs the dev-channel commit list view in a single bubbletea
 // program and returns the outcome.
 func RunCommitWalk(ctx context.Context, in CommitWalkInput) (CommitWalkOutcome, error) {
@@ -80,13 +90,7 @@ const commitWalkFooterText = "[j/k] scroll  [g/G] top/bottom  [enter] continue  
 // `<prefix><title>  <count>` so the viewportHeight chrome calculation can
 // detect when the title wraps on narrow terminals.
 func (m commitWalkModel) titleVisibleWidth() int {
-	prefix := "── "
-	if m.opts.Plain {
-		prefix = "-- "
-	}
-	title := fmt.Sprintf("dev channel: %s -> %s", m.installed, m.target)
-	count := fmt.Sprintf("%d commits", m.commits.TotalCommits)
-	return lipgloss.Width(prefix) + lipgloss.Width(title) + 2 + lipgloss.Width(count)
+	return lipgloss.Width(commitWalkTitle(m.installed, m.target, m.commits.TotalCommits, m.opts))
 }
 
 // viewportHeight reserves chrome for the dev-channel walk layout: the
@@ -189,6 +193,25 @@ func (m commitWalkModel) View() tea.View {
 func (m commitWalkModel) renderView() string {
 	plain := m.opts.NoColor || m.opts.Plain
 	muted := lipgloss.NewStyle()
+	if !plain {
+		muted = muted.Foreground(colorMuted)
+	}
+
+	var sb strings.Builder
+	sb.WriteString(commitWalkTitle(m.installed, m.target, m.commits.TotalCommits, m.opts))
+	sb.WriteByte('\n')
+	sb.WriteString(m.viewport.View())
+	sb.WriteByte('\n')
+	sb.WriteString(muted.Render(commitWalkFooterText))
+	return sb.String()
+}
+
+// commitWalkTitle renders the "── dev channel: v1 -> v2  N commits" line that
+// heads both the interactive walk and its static render, so the two cannot
+// drift apart.
+func commitWalkTitle(installed, target string, total int, opts Options) string {
+	plain := opts.NoColor || opts.Plain
+	muted := lipgloss.NewStyle()
 	header := lipgloss.NewStyle()
 	if !plain {
 		muted = muted.Foreground(colorMuted)
@@ -196,21 +219,11 @@ func (m commitWalkModel) renderView() string {
 	}
 
 	prefix := "── "
-	if m.opts.Plain {
+	if opts.Plain {
 		prefix = "-- "
 	}
 
-	title := fmt.Sprintf("dev channel: %s -> %s", m.installed, m.target)
-	count := fmt.Sprintf("%d commits", m.commits.TotalCommits)
-
-	var sb strings.Builder
-	sb.WriteString(muted.Render(prefix))
-	sb.WriteString(header.Render(title))
-	sb.WriteString("  ")
-	sb.WriteString(muted.Render(count))
-	sb.WriteByte('\n')
-	sb.WriteString(m.viewport.View())
-	sb.WriteByte('\n')
-	sb.WriteString(muted.Render(commitWalkFooterText))
-	return sb.String()
+	return muted.Render(prefix) +
+		header.Render(fmt.Sprintf("dev channel: %s -> %s", installed, target)) +
+		"  " + muted.Render(fmt.Sprintf("%d commits", total))
 }

--- a/cli/internal/ui/commitlist_walk_test.go
+++ b/cli/internal/ui/commitlist_walk_test.go
@@ -79,6 +79,33 @@ func TestRenderCommitWalkStatic_ignoresTerminalHeight(t *testing.T) {
 	}
 }
 
+// The target label is a remote tag name (see the walk.go counterpart): the
+// title is where an operator reads what they are about to install, so a
+// bidi override there is a spoof of exactly the string that matters.
+func TestRenderCommitWalkStatic_sanitisesVersionLabels(t *testing.T) {
+	in := makeCommitInput(Options{NoColor: true})
+	in.Target = "v9.9.9" + rloRune + "0.0.1v"
+	out := RenderCommitWalkStatic(in)
+	if strings.ContainsRune(out, 0x202E) {
+		t.Errorf("bidi override survived into the title\n--- got ---\n%q", out)
+	}
+	if !strings.Contains(out, "v9.9.90.0.1v") {
+		t.Errorf("scrubbed label should still render its own characters\n--- got ---\n%q", out)
+	}
+}
+
+// A commit subject is remote and git constrains nothing in it, so a bare CR
+// can overwrite the line an operator already read. The static render goes
+// straight to stdout, where that lands in log files too.
+func TestRenderCommitWalkStatic_sanitisesCommitSubjects(t *testing.T) {
+	in := makeCommitInput(Options{NoColor: true})
+	in.Commits.Commits[0].Subject = "harmless subject\rrewritten by carriage return"
+	out := RenderCommitWalkStatic(in)
+	if strings.ContainsAny(out, "\r\x08\x07") {
+		t.Errorf("terminal-acting control byte survived\n--- got ---\n%q", out)
+	}
+}
+
 func TestRenderCommitWalkStatic_keepsTruncationNotice(t *testing.T) {
 	in := makeCommitInput(Options{NoColor: true})
 	in.Commits.TotalCommits = 400 // more than the compare API returned

--- a/cli/internal/ui/commitlist_walk_test.go
+++ b/cli/internal/ui/commitlist_walk_test.go
@@ -47,6 +47,47 @@ func TestCommitWalk_renderHeader(t *testing.T) {
 	}
 }
 
+func TestRenderCommitWalkStatic_carriesEveryCommit(t *testing.T) {
+	out := RenderCommitWalkStatic(makeCommitInput(Options{NoColor: true}))
+	for _, want := range []string{
+		"v0.7.3-dev.5", "v0.7.3-dev.9", "3 commits",
+		"feat(cli): per-version Highlights walk",
+		"fix(selfupdate): pagination cap",
+		"chore(deps): bump",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("static render missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+	// The whole point of the static render: nothing to press, so nothing
+	// may advertise a key. A footer here would be an instruction the
+	// caller has already moved past by the time it is read.
+	if strings.Contains(out, "[j/k]") || strings.Contains(out, "[enter]") {
+		t.Errorf("static render must carry no key footer\n--- got ---\n%s", out)
+	}
+}
+
+// The static render is not height-bounded: the interactive walk caps its
+// viewport at the terminal height, and a static block that inherited that
+// cap would silently drop commits the operator is about to install.
+func TestRenderCommitWalkStatic_ignoresTerminalHeight(t *testing.T) {
+	in := makeCommitInput(Options{NoColor: true})
+	in.Height = 3
+	out := RenderCommitWalkStatic(in)
+	if !strings.Contains(out, "chore(deps): bump") {
+		t.Errorf("last commit dropped on a short terminal\n--- got ---\n%s", out)
+	}
+}
+
+func TestRenderCommitWalkStatic_keepsTruncationNotice(t *testing.T) {
+	in := makeCommitInput(Options{NoColor: true})
+	in.Commits.TotalCommits = 400 // more than the compare API returned
+	out := RenderCommitWalkStatic(in)
+	if !strings.Contains(out, "400") {
+		t.Errorf("static render should report the full commit count\n--- got ---\n%s", out)
+	}
+}
+
 func TestCommitWalk_emptyRange(t *testing.T) {
 	in := makeCommitInput(Options{NoColor: true})
 	in.Commits = selfupdate.CommitRange{TotalCommits: 0}

--- a/cli/internal/ui/ui.go
+++ b/cli/internal/ui/ui.go
@@ -227,6 +227,25 @@ func (u *UI) Step(msg string) {
 	_, _ = fmt.Fprintf(u.w, "%s %s\n", u.brand.Render(icon), u.bold.Render(stripControl(msg)))
 }
 
+// StepAlways prints a step that survives --quiet.
+//
+// For the step whose whole value is that it was not a prompt: an install
+// that proceeded because a config key answered for the operator leaves no
+// other trace of having been unattended, and --quiet is exactly the mode
+// such a run is invoked in. Still suppressed in JSON mode, where human text
+// on stdout would corrupt the document.
+func (u *UI) StepAlways(msg string) {
+	if u.jsonMode {
+		return
+	}
+	icon := u.icon(IconInProgress, PlainIconInProgress)
+	if u.plain {
+		_, _ = fmt.Fprintf(u.w, "%s %s\n", icon, stripControl(msg))
+		return
+	}
+	_, _ = fmt.Fprintf(u.w, "%s %s\n", u.brand.Render(icon), u.bold.Render(stripControl(msg)))
+}
+
 // Success prints a success status line (green).
 // Suppressed in quiet mode (--quiet = errors only) and JSON mode.
 func (u *UI) Success(msg string) {

--- a/cli/internal/ui/ui_test.go
+++ b/cli/internal/ui/ui_test.go
@@ -679,6 +679,25 @@ func TestHintCategories(t *testing.T) {
 	})
 }
 
+// StepAlways is the counterpart of WarnAlways: it exists for the step whose
+// whole value is surviving the flag an unattended run sets, so a test that
+// only proved it prints normally would prove nothing.
+func TestStepAlways_survivesQuietButNotJSON(t *testing.T) {
+	t.Parallel()
+
+	var quiet bytes.Buffer
+	NewUIWithOptions(&quiet, Options{Quiet: true}).StepAlways("installed without confirmation")
+	if !strings.Contains(quiet.String(), "installed without confirmation") {
+		t.Errorf("StepAlways must survive --quiet, got %q", quiet.String())
+	}
+
+	var jsonMode bytes.Buffer
+	NewUIWithOptions(&jsonMode, Options{JSON: true}).StepAlways("installed without confirmation")
+	if jsonMode.Len() != 0 {
+		t.Errorf("StepAlways must stay out of JSON output, got %q", jsonMode.String())
+	}
+}
+
 func TestSpinnerQuietMode(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer

--- a/cli/internal/ui/walk.go
+++ b/cli/internal/ui/walk.go
@@ -132,7 +132,6 @@ type walkModel struct {
 type changelogContents struct {
 	highlights string // empty if no Highlights block
 	commits    string // never empty (always falls back to commit log)
-	header     string // "── v0.7.3 ────────"
 }
 
 // newWalkModel constructs the bubbletea model for the supplied batch input.
@@ -140,26 +139,8 @@ type changelogContents struct {
 // viewport can swap between them without re-running the renderer on every
 // keypress.
 func newWalkModel(in WalkBatchInput) walkModel {
-	view := in.InitialView
-	if view != viewCommits {
-		view = viewHighlights
-	}
-	contents := make([]changelogContents, len(in.Versions))
-	toggleable := make([]bool, len(in.Versions))
-	for i, r := range in.Versions {
-		hl, ok := selfupdate.ExtractHighlights(r.Body)
-		toggleable[i] = ok
-		var hlRendered string
-		if ok {
-			hlRendered = RenderHighlights(hl, in.Options)
-		}
-		commitsRendered := RenderCommits(selfupdate.ExtractCommits(r.Body), in.Options)
-		contents[i] = changelogContents{
-			highlights: hlRendered,
-			commits:    commitsRendered,
-			header:     versionHeader(r, in.Options),
-		}
-	}
+	view := normalizeChangelogView(in.InitialView)
+	contents, toggleable := buildChangelogContents(in.Versions, in.Options)
 
 	width, height := initialDimensions(in.Width, in.Height)
 	m := walkModel{
@@ -179,6 +160,77 @@ func newWalkModel(in WalkBatchInput) walkModel {
 	m.viewport = vp
 	m.loadCurrentContent()
 	return m
+}
+
+// buildChangelogContents pre-renders both views for every version and reports
+// per-version toggleability (false when the release carries no Highlights
+// block). Shared by the interactive model and RenderWalkStatic so "what does
+// this release render as" has one answer.
+func buildChangelogContents(versions []selfupdate.Release, opts Options) ([]changelogContents, []bool) {
+	contents := make([]changelogContents, len(versions))
+	toggleable := make([]bool, len(versions))
+	for i, r := range versions {
+		hl, ok := selfupdate.ExtractHighlights(r.Body)
+		toggleable[i] = ok
+		var hlRendered string
+		if ok {
+			hlRendered = RenderHighlights(hl, opts)
+		}
+		contents[i] = changelogContents{
+			highlights: hlRendered,
+			commits:    RenderCommits(selfupdate.ExtractCommits(r.Body), opts),
+		}
+	}
+	return contents, toggleable
+}
+
+// normalizeChangelogView resolves an unset or unrecognised view to the
+// highlights default, so a config value this binary does not know cannot
+// leave the walk rendering nothing.
+func normalizeChangelogView(view changelogView) changelogView {
+	if view == viewCommits {
+		return viewCommits
+	}
+	return viewHighlights
+}
+
+// selectContent picks which pre-rendered view a version displays: a release
+// with no Highlights block only ever has a commit log to show, whatever view
+// the caller asked for.
+func selectContent(c changelogContents, toggleable bool, view changelogView) string {
+	if !toggleable || view == viewCommits {
+		return c.commits
+	}
+	return c.highlights
+}
+
+// RenderWalkStatic renders every version in the input as one plain string:
+// header, the fallback note where the release has no Highlights block, then
+// the content. No batching, no viewport and no key footer -- the caller
+// prints the block and the terminal's scrollback holds it.
+func RenderWalkStatic(in WalkBatchInput) string {
+	if len(in.Versions) == 0 {
+		return ""
+	}
+	view := normalizeChangelogView(in.InitialView)
+	width, _ := initialDimensions(in.Width, in.Height)
+	contents, toggleable := buildChangelogContents(in.Versions, in.Options)
+
+	var sb strings.Builder
+	for i, r := range in.Versions {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(renderVersionHeader(r, i, len(in.Versions), width, in.Options))
+		sb.WriteByte('\n')
+		if !toggleable[i] {
+			sb.WriteString(RenderFallbackNote(in.Options))
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(selectContent(contents[i], toggleable[i], view))
+		sb.WriteByte('\n')
+	}
+	return sb.String()
 }
 
 // initialDimensions provides sane fallback values when the caller does not
@@ -399,17 +451,7 @@ func (m *walkModel) loadCurrentContent() {
 		m.viewport.SetContent("")
 		return
 	}
-	c := m.contents[m.idx]
-	if !m.toggleable[m.idx] {
-		// Force commits view when no highlights exist.
-		m.viewport.SetContent(c.commits)
-		return
-	}
-	if m.view == viewHighlights {
-		m.viewport.SetContent(c.highlights)
-	} else {
-		m.viewport.SetContent(c.commits)
-	}
+	m.viewport.SetContent(selectContent(m.contents[m.idx], m.toggleable[m.idx], m.view))
 }
 
 // onLastInBatch reports whether the current version is the last one in this
@@ -463,20 +505,24 @@ func (m walkModel) renderView() string {
 // renderHeader builds the version-separator line at the top of each version
 // view: "── v0.7.3 ───────────────── [1/3]".
 func (m walkModel) renderHeader() string {
-	c := m.contents[m.idx]
-	pos := fmt.Sprintf("[%d/%d]", m.idx+1, len(m.versions))
+	return renderVersionHeader(m.versions[m.idx], m.idx, len(m.versions), m.width, m.opts)
+}
+
+// renderVersionHeader renders one version's separator line. Shared by the
+// interactive model and RenderWalkStatic.
+func renderVersionHeader(r selfupdate.Release, idx, total, width int, opts Options) string {
+	pos := fmt.Sprintf("[%d/%d]", idx+1, total)
 	prefix := "── "
-	if m.opts.Plain {
+	if opts.Plain {
 		prefix = "-- "
 	}
-	tag := c.header // already styled
-	rule := strings.Repeat(separatorRune(m.opts), separatorWidth(m.width, tagPlainWidth(m.versions[m.idx].TagName), len(pos)))
-	plain := m.opts.NoColor || m.opts.Plain
+	rule := strings.Repeat(separatorRune(opts), separatorWidth(width, tagPlainWidth(r.TagName), len(pos)))
+	plain := opts.NoColor || opts.Plain
 	muted := lipgloss.NewStyle()
 	if !plain {
 		muted = muted.Foreground(colorMuted)
 	}
-	return muted.Render(prefix) + tag + " " + muted.Render(rule+" "+pos)
+	return muted.Render(prefix) + versionHeader(r, opts) + " " + muted.Render(rule+" "+pos)
 }
 
 // separatorRune returns the box-drawing rune used for the version separator,

--- a/cli/internal/ui/walk.go
+++ b/cli/internal/ui/walk.go
@@ -1,8 +1,10 @@
-// Package ui walk.go contains the bubbletea-based per-version Highlights
-// walk used by `synthorg update` to show release context between installed
-// and target versions. One Program runs per batch of <=3 versions; the
-// caller is responsible for orchestrating multiple batches and threading
-// session-level toggle state across them via WalkBatchResult.FinalView.
+// Package ui walk.go contains the per-version Highlights rendering used by
+// `synthorg update` to show release context between installed and target
+// versions, in two presentations over one set of pre-rendered content: an
+// interactive bubbletea Program, one per batch of <=3 versions, with the
+// caller orchestrating the batches and threading session-level toggle state
+// across them via WalkBatchResult.FinalView; and RenderWalkStatic, which
+// returns every version as a plain string for callers that cannot page.
 package ui
 
 import (
@@ -67,9 +69,10 @@ type WalkBatchInput struct {
 	Width, Height int
 	// Options carries colour / plain / quiet flags from GlobalOpts.
 	Options Options
-	// Output is the writer bubbletea drives. The walk gate guarantees the
-	// writer is a TTY before RunWalkBatch is invoked, so this is the same
-	// stream the surrounding command writes summary / fallback lines to.
+	// Output is the writer bubbletea drives. RunWalkBatch is reached only
+	// when the caller selects its interactive presentation, which requires
+	// a TTY writer, so this is the same stream the surrounding command
+	// writes summary / fallback lines to.
 	// Falls back to os.Stdout when nil so existing call sites that haven't
 	// been updated still work.
 	Output io.Writer
@@ -303,13 +306,17 @@ func (m walkModel) viewportHeight() int {
 // versionHeader renders the "── v0.7.3 ─────────────── [1/3]" line shown
 // above every version's content. The position indicator is added in
 // walkModel.View() so it can include the live idx.
+//
+// The tag name is remote: git's ref rules keep control bytes out of it, but
+// they permit the bidi overrides that reorder what an operator reads in the
+// one string identifying what is about to be installed.
 func versionHeader(r selfupdate.Release, opts Options) string {
 	plain := opts.NoColor || opts.Plain
 	style := lipgloss.NewStyle()
 	if !plain {
 		style = style.Foreground(colorBrand).Bold(true)
 	}
-	return style.Render(r.TagName)
+	return style.Render(SanitizeUntrustedLine(r.TagName))
 }
 
 // Init implements tea.Model. We request an initial window size so the

--- a/cli/internal/ui/walk_test.go
+++ b/cli/internal/ui/walk_test.go
@@ -107,6 +107,57 @@ func TestWalk_cTogglesView(t *testing.T) {
 	}
 }
 
+func TestRenderWalkStatic_carriesEveryRelease(t *testing.T) {
+	// Height 30 fits one batch interactively; the static render must ignore
+	// both the batch size and the viewport cap and emit all five.
+	out := RenderWalkStatic(makeWalkInput(t, 5, nil, true, viewHighlights))
+	for i := range 5 {
+		tag := "v0.7." + string(rune('0'+i))
+		if !strings.Contains(out, tag) {
+			t.Errorf("static render missing %s\n--- got ---\n%s", tag, out)
+		}
+		if !strings.Contains(out, "Bullet for "+tag) {
+			t.Errorf("static render missing highlights for %s\n--- got ---\n%s", tag, out)
+		}
+		if !strings.Contains(out, "["+string(rune('1'+i))+"/5]") {
+			t.Errorf("static render missing position marker for %s\n--- got ---\n%s", tag, out)
+		}
+	}
+	if strings.Contains(out, "[j/k]") || strings.Contains(out, "[enter]") {
+		t.Errorf("static render must carry no key footer\n--- got ---\n%s", out)
+	}
+}
+
+func TestRenderWalkStatic_honoursCommitsView(t *testing.T) {
+	out := RenderWalkStatic(makeWalkInput(t, 1, nil, true, viewCommits))
+	if !strings.Contains(out, "commit for v0.7.0") {
+		t.Errorf("commits view should render the commit log\n--- got ---\n%s", out)
+	}
+	if strings.Contains(out, "Bullet for v0.7.0") {
+		t.Errorf("commits view should not render highlights\n--- got ---\n%s", out)
+	}
+}
+
+// A release predating AI highlights has only a commit log to show, whatever
+// view was asked for, and says so -- same rule the interactive walk applies
+// in loadCurrentContent.
+func TestRenderWalkStatic_fallsBackForReleaseWithoutHighlights(t *testing.T) {
+	out := RenderWalkStatic(makeWalkInput(t, 1, map[int]bool{0: true}, true, viewHighlights))
+	if !strings.Contains(out, "No AI highlights") {
+		t.Errorf("missing fallback note\n--- got ---\n%s", out)
+	}
+	if !strings.Contains(out, "basic feature") {
+		t.Errorf("missing commit log\n--- got ---\n%s", out)
+	}
+}
+
+func TestRenderWalkStatic_emptyInput(t *testing.T) {
+	in := makeWalkInput(t, 0, nil, true, viewHighlights)
+	if out := RenderWalkStatic(in); out != "" {
+		t.Errorf("no versions should render nothing, got %q", out)
+	}
+}
+
 func TestWalk_cIgnoredOnNonToggleable(t *testing.T) {
 	in := makeWalkInput(t, 1, map[int]bool{0: true}, true, viewHighlights)
 	m := newWalkModel(in)

--- a/cli/internal/ui/walk_test.go
+++ b/cli/internal/ui/walk_test.go
@@ -151,6 +151,21 @@ func TestRenderWalkStatic_fallsBackForReleaseWithoutHighlights(t *testing.T) {
 	}
 }
 
+// A tag name is remote and git permits bidi overrides in a ref, so the
+// version string identifying what is about to be installed can be made to
+// read as something else. It must never reach the terminal as authored.
+func TestRenderWalkStatic_sanitisesTagName(t *testing.T) {
+	in := makeWalkInput(t, 1, nil, true, viewHighlights)
+	in.Versions[0].TagName = "v9.9.9" + rloRune + "0.0.1v"
+	out := RenderWalkStatic(in)
+	if strings.ContainsRune(out, 0x202E) {
+		t.Errorf("bidi override survived into the header\n--- got ---\n%q", out)
+	}
+	if !strings.Contains(out, "v9.9.90.0.1v") {
+		t.Errorf("scrubbed tag should still render its own characters\n--- got ---\n%q", out)
+	}
+}
+
 func TestRenderWalkStatic_emptyInput(t *testing.T) {
 	in := makeWalkInput(t, 0, nil, true, viewHighlights)
 	if out := RenderWalkStatic(in); out != "" {

--- a/docs/reference/cli-config-subcommands.md
+++ b/docs/reference/cli-config-subcommands.md
@@ -58,13 +58,29 @@ The warning is **not** suppressed under `--quiet` or `--json`; a safety-critical
 - **NATS URLs**: must use `nats://`, `tls://`, or `nats+tls://` scheme and include a host.
 - **NATS stream prefix**: uppercase alphanumerics with `_` or `-`. Matches `[A-Z0-9][A-Z0-9_-]*`.
 
+## `auto_update_cli`
+
+Boolean, default `false`. Answers the `synthorg update` install confirm (`Update CLI from vX to vY?`) with yes, and prints the changelog instead of paging it, so an update runs start to finish without a key press while still showing what it installs. The install itself announces that the setting answered for you, so nothing is skipped silently.
+
+It covers the CLI binary alone. The compose apply, image pull and container restart that follow keep their own keys (`auto_apply_compose`, `auto_pull`, `auto_restart`), so a fully unattended `synthorg update` sets all four.
+
 ## `changelog_view`
 
-Enum, either `highlights` (default) or `commits`. Sets the default view for the `synthorg update` upgrade walk between installed and target releases. `highlights` shows the AI-generated three-section summary; `commits` shows the Release Please commit-based changelog. Inside the walk, `c` toggles between the two views for the current session without modifying the persisted value.
+Enum, either `highlights` (default) or `commits`. Sets the default view for the `synthorg update` changelog between installed and target releases. `highlights` shows the AI-generated three-section summary; `commits` shows the Release Please commit-based changelog. In the interactive walk, `c` toggles between the two views for the current session without modifying the persisted value.
 
-On the `dev` channel the setting is moot: dev pre-releases have no Highlights block, so the walk always renders a single combined commit list fetched by paginating the GitHub list-commits endpoint (`/repos/.../commits?sha=&per_page=25&page=N`) backwards from the target release until the installed commit SHA is encountered. The compare endpoint is deliberately not used because it inlines a `files[]` patch array per commit and routinely overruns the API response cap on multi-hundred-file release ranges.
+The changelog is presented one of three ways, decided per invocation:
 
-When the walk cannot render (network failure, the installed dev pre-release tag was pruned from the remote, or the range is empty) the CLI prints an explicit `Warn` line explaining the cause and falls back to the terse offline notice; it never silently degrades.
+| Presentation | When | Behaviour |
+|---|---|---|
+| Interactive walk | a terminal on stdin and stdout, no `--yes` or `--quiet`, `auto_update_cli` off | scrollable pager, three releases per screen, advanced with `enter` |
+| Static | anything else: `auto_update_cli` on, `--yes`, `--quiet`, or output redirected to a file or pipe | every release printed in full, no keys, no height cap |
+| Suppressed | `--json` | no human-readable output at all |
+
+Only `--json` loses the content. What an update is about to install is worth showing even when nothing is going to ask about it, so every other non-interactive context downgrades to the static print rather than dropping to a one-line notice.
+
+On the `dev` channel `changelog_view` is moot: dev pre-releases have no Highlights block, so the changelog is always a single combined commit list fetched by paginating the GitHub list-commits endpoint (`/repos/.../commits?sha=&per_page=25&page=N`) backwards from the target release until the installed commit SHA is encountered. The compare endpoint is deliberately not used because it inlines a `files[]` patch array per commit and routinely overruns the API response cap on multi-hundred-file release ranges.
+
+When the changelog cannot be fetched (network failure, the installed dev pre-release tag was pruned from the remote, or the range is empty) the CLI prints an explicit `Warn` line explaining the cause and falls back to the terse offline notice; it never silently degrades.
 
 ## See also
 

--- a/docs/reference/cli-config-subcommands.md
+++ b/docs/reference/cli-config-subcommands.md
@@ -60,7 +60,7 @@ The warning is **not** suppressed under `--quiet` or `--json`; a safety-critical
 
 ## `auto_update_cli`
 
-Boolean, default `false`. Answers the `synthorg update` install confirm (`Update CLI from vX to vY?`) with yes, and prints the changelog instead of paging it, so an update runs start to finish without a key press while still showing what it installs. The install itself announces that the setting answered for you, so nothing is skipped silently.
+Boolean, default `false`. Answers the `synthorg update` install confirm (`Update CLI from vX to vY?`) with yes, and prints the changelog instead of paging it, so an update runs start to finish without a key press while still showing what it installs. The install announces that the setting answered for you, and that line survives `--quiet` (the mode an unattended run is invoked in), so an install nobody confirmed always leaves a record saying so.
 
 It covers the CLI binary alone. The compose apply, image pull and container restart that follow keep their own keys (`auto_apply_compose`, `auto_pull`, `auto_restart`), so a fully unattended `synthorg update` sets all four.
 
@@ -72,11 +72,15 @@ The changelog is presented one of three ways, decided per invocation:
 
 | Presentation | When | Behaviour |
 |---|---|---|
-| Interactive walk | a terminal on stdin and stdout, no `--yes` or `--quiet`, `auto_update_cli` off | scrollable pager, three releases per screen, advanced with `enter` |
-| Static | anything else: `auto_update_cli` on, `--yes`, `--quiet`, or output redirected to a file or pipe | every release printed in full, no keys, no height cap |
+| Interactive walk | a terminal on **both** stdin and stdout, no `--yes` or `--quiet`, `auto_update_cli` off | scrollable pager, advanced with `enter` |
+| Static | anything else: `auto_update_cli` on, `--yes`, `--quiet`, stdin not a terminal (piped or redirected), or stdout redirected to a file or pipe | everything printed in full, no keys, no height cap |
 | Suppressed | `--json` | no human-readable output at all |
 
-Only `--json` loses the content. What an update is about to install is worth showing even when nothing is going to ask about it, so every other non-interactive context downgrades to the static print rather than dropping to a one-line notice.
+Both triggers on the input side count independently: `synthorg update < /dev/null` renders static even on a terminal with no flags set, because there is no one there to answer a pager.
+
+On the stable channel the interactive walk moves three releases at a time; the dev channel has no batches, being one continuous commit list either way (see below).
+
+Only `--json` loses the content, and `--quiet` is deliberately not an exception: what an update is about to install is worth showing even when nothing is going to ask about it, so every other non-interactive context downgrades to the static print rather than dropping to a one-line notice. That covers the whole presentation, not just the release bodies: the summary index, the per-release publish dates and markers, and the fallback notice on a fetch failure all survive `--quiet` too, because half a record is worse than none.
 
 On the `dev` channel `changelog_view` is moot: dev pre-releases have no Highlights block, so the changelog is always a single combined commit list fetched by paginating the GitHub list-commits endpoint (`/repos/.../commits?sha=&per_page=25&page=N`) backwards from the target release until the installed commit SHA is encountered. The compare endpoint is deliberately not used because it inlines a `files[]` patch array per commit and routinely overruns the API response cap on multi-hundred-file release ranges.
 

--- a/docs/reference/cli-env-vars.md
+++ b/docs/reference/cli-env-vars.md
@@ -22,7 +22,7 @@ The "Used by" column distinguishes three relationships to the CLI:
 | `SYNTHORG_WEB_PORT` | CLI | Override web dashboard port |
 | `SYNTHORG_CHANNEL` | CLI | Override release channel (stable / dev) |
 | `SYNTHORG_IMAGE_TAG` | CLI | Override container image tag |
-| `SYNTHORG_AUTO_UPDATE_CLI` | CLI | Auto-accept CLI self-updates |
+| `SYNTHORG_AUTO_UPDATE_CLI` | CLI | Auto-accept CLI self-updates; the changelog is printed rather than paged |
 | `SYNTHORG_AUTO_PULL` | CLI | Auto-accept container image pulls |
 | `SYNTHORG_AUTO_RESTART` | CLI | Auto-restart containers after update |
 | `SYNTHORG_TELEMETRY_ENABLED` | CLI | Enable anonymous project telemetry (true / false) |


### PR DESCRIPTION
## Summary

`synthorg update` rendered its changelog in a blocking bubbletea pager **before** asking anything, and `auto_update_cli` only auto-answered the install confirm that came *after* it. Setting the key still left the operator holding a key press. The old gate also threw the changelog away entirely under `--yes` / `--quiet` / `--json` / non-TTY, printing a one-line "New version available" notice instead, so you chose between seeing what you were installing and not being blocked by it.

The binary show-or-skip gate becomes a three-way `resolveWalkMode`:

| Presentation | When | Behaviour |
|---|---|---|
| Interactive | terminal on **both** stdin and stdout, no `--yes`/`--quiet`, `auto_update_cli` off | today's pager, unchanged |
| Static | anything else: `auto_update_cli` on, `--yes`, `--quiet`, non-terminal stdin, or redirected stdout | whole changelog printed, no keys, no height cap |
| Suppressed | `--json` only | nothing |

The value deciding the mode is the same `auto_update_cli` verdict that already answered the confirm, so one read owns both. Two new pure renderers (`RenderCommitWalkStatic`, `RenderWalkStatic`) produce the static block, sharing the title, version-header and content-selection helpers with the interactive models so the two presentations cannot drift.

`--quiet` is deliberately not an exception, and that applies to the **whole** presentation rather than just the release bodies: the summary index carries publish dates and Highlights markers that appear nowhere else, and the fallback notice is the only output there is when the fetch fails. Half a record reads complete and is not. The auto-accept announcement (`auto_update_cli is set: installing vX without confirmation`) survives `--quiet` too, via a new `ui.StepAlways` mirroring the existing `WarnAlways`, because `--quiet` is exactly the mode an unattended install is invoked in.

## Security

The static path writes remote-sourced release text straight to stdout, including into pipes, redirected log files and captured CI output that never received it before. Two gaps closed:

- **`stripANSI` matched CSI and OSC only.** Bare CR, backspace, BEL, VT, FF and the non-CSI introducers (DCS, APC, and the two-byte `ESC c` full terminal reset) all passed through. Git constrains none of them in a commit subject or an author name. It is now `sanitizeUntrusted`, which sweeps every C0/C1 control and DEL behind the escape regex, keeping only the newlines and tabs the layout needs.
- **Tag names and version labels were never scrubbed at all.** `versionHeader` and `commitWalkTitle` rendered them raw. Git's ref rules keep control bytes out of a tag, but permit Unicode bidi overrides and zero-width characters, which can visually reorder or hide characters in the exact version string an operator reads immediately before consenting to an install. `SanitizeUntrustedLine` now covers those code points and is applied at every site that renders a remote version label, including the release index and the confirm prompt (which renders through huh and applies none of the UI's own scrubbing).

## Also

- `cli/cmd/update.go` was 818 lines, over the 800-line convention. The re-exec machinery moves to a sibling `cli/cmd/update_reexec.go`, taking it to 717.
- `confirmStartWalk` deleted: it could no longer return false, so it was a second answer to a question `resolveWalkMode` now owns.
- Four stale comments corrected, including a `runDevCommitWalk` docstring that claimed a scrollable bubbletea program in the branch that runs neither.

## Test plan

- `go -C cli test ./...` green; `golangci-lint run` and `go vet ./...` clean.
- New coverage: the three-way mode resolution; both static renderers (content completeness, no height cap, no key footer, `changelog_view` honoured, fallback for a release with no Highlights block); the sanitiser against CR / BS / BEL / VT / FF / RIS / C1 / bidi / zero-width, and its line variant against layout-breaking whitespace; tag and commit-subject scrubbing at the render sites; and the `--quiet` static path end to end, including `runChangelogWalk` itself so the wiring is covered and not just the walk beneath it.
- Verified live against the real GitHub API with a version-stamped build in a scratch data dir, on the dev channel with `auto_update_cli=true`: the full commit list printed, the announcement named the setting, and the download, signature verification, replace and re-exec all ran with zero input. Repeated under `--quiet` to confirm the changelog and the announcement both survive the flag.

## Review coverage

Pre-reviewed by 5 agents (go-reviewer, go-security-reviewer, go-conventions-enforcer, docs-consistency, comment-quality-rot). 10 findings, all verified against the code and all addressed: 1 Critical, 4 Major, 3 Medium, 2 Minor. The Critical (`--quiet` half-suppressing the static changelog) was found independently by two agents from opposite directions.

No linked issue: this came from a question about why `auto_update_cli` still prompted.
