### PR TITLE
fix: give a sweep a stable scratch root so --resume can find its trees

### DIFF
--- a/scripts/record_recursion_depth.py
+++ b/scripts/record_recursion_depth.py
@@ -276,14 +276,13 @@ async def _record(
     # configuration or the machine and none of it becomes truer once a scratch
     # database, a gateway and a container are standing.
     await run_preflight(manifest=manifest, company_config=company_config)
-    # Derived from the output directory rather than minted per invocation. The
-    # journal in that directory is what a resume continues from, and the unit
-    # trees are what it continues WITH: a fresh name per run would leave every
-    # resumed cell unable to find what the previous attempt built, so
-    # ``_continue_cell`` would restart each one and the journal would be
-    # buying nothing. The concurrency this used to guard is guarded better one
-    # layer up: two runs sharing an output directory are refused by the
-    # journal itself, and two with different ones land on different roots.
+    # Named after the output directory, because the journal there is what a
+    # resume continues from and these trees are what it continues WITH: a
+    # resume rebuilds each unit's path from this root, so a root it cannot
+    # predict leaves every cell unable to find what was already built for it.
+    # Two runs sharing an output directory are refused by the journal itself,
+    # and two with different ones land on different roots, so concurrent
+    # recordings still never reset each other's trees.
     run_work_root = args.work_root / f"run-{_recording_slug(args.out_dir)}"
     binder: HarnessBinder | None = None
     completed = False
@@ -329,10 +328,10 @@ async def _record(
         # producer.
         if binder is not None:
             await binder.release_tool_sandboxes()
-        # Kept whenever the sweep did NOT finish, because those trees are
-        # exactly what ``--resume`` continues with. Reclaiming them on the way
-        # out of a failure turns every part-built cell into one that has to be
-        # paid for again, which is the loss the journal exists to stop.
+        # An unfinished sweep keeps its trees, because they are what
+        # ``--resume`` continues with: discarding them on the way out of a
+        # failure turns every part-built cell into one that has to be paid for
+        # again, which is the loss the journal exists to stop.
         await _reclaim_workspaces(
             run_work_root, keep=args.keep_workspaces or not completed
         )

--- a/scripts/record_recursion_depth.py
+++ b/scripts/record_recursion_depth.py
@@ -326,15 +326,20 @@ async def _record(
         # the last ones are never reclaimed at all, which is the leak
         # release_tool_sandboxes exists to prevent, reintroduced by a second
         # producer.
-        if binder is not None:
-            await binder.release_tool_sandboxes()
-        # An unfinished sweep keeps its trees, because they are what
-        # ``--resume`` continues with: discarding them on the way out of a
-        # failure turns every part-built cell into one that has to be paid for
-        # again, which is the loss the journal exists to stop.
-        await _reclaim_workspaces(
-            run_work_root, keep=args.keep_workspaces or not completed
-        )
+        # Nested, so releasing the containers and reclaiming the trees are two
+        # independent obligations rather than a sequence where the first one
+        # failing silently drops the second.
+        try:
+            if binder is not None:
+                await binder.release_tool_sandboxes()
+        finally:
+            # An unfinished sweep keeps its trees, because they are what
+            # ``--resume`` continues with: discarding them on the way out of a
+            # failure turns every part-built cell into one that has to be paid
+            # for again, which is the loss the journal exists to stop.
+            await _reclaim_workspaces(
+                run_work_root, keep=args.keep_workspaces or not completed
+            )
     print("report written: " + ", ".join(str(path) for path in paths))
     if not report.measured_cells:
         msg = (
@@ -540,10 +545,10 @@ async def _reclaim_workspaces(run_work_root: Path, *, keep: bool) -> None:
 
     A sweep creates one tree per leaf and one per node, each written into by a
     coding agent. Nothing reuses a tree between COMPLETED runs, so retaining
-    them grows disk monotonically unless a maintainer is inspecting what was
-    built, which for the first working artefact in nine rounds is a real
-    reason. An unfinished run is the other case entirely: its trees are what
-    the next ``--resume`` builds on.
+    them grows disk monotonically; a maintainer inspecting what the sweep
+    actually built is the one reason to keep them anyway. An unfinished run is
+    the other case entirely: its trees are what the next ``--resume`` builds
+    on.
     """
     if keep:
         print(f"workspaces kept for --resume: {run_work_root}")

--- a/scripts/record_recursion_depth.py
+++ b/scripts/record_recursion_depth.py
@@ -34,11 +34,11 @@ recordable at all, and it puts every unit on one authoritative cost ledger.
 
 import argparse
 import asyncio
+import hashlib
 import shutil
 from functools import partial
 from pathlib import Path
 from typing import Final
-from uuid import uuid4
 
 from evals.errors import (
     RecursionDepthCapabilityUnresolvedError,
@@ -89,6 +89,10 @@ _DEFAULT_OUT_DIR: Final[Path] = Path("evals/recursion_depth/results")
 _DEFAULT_WORK_ROOT: Final[Path] = Path(".recursion-depth/work")
 _EPHEMERAL_PORT: Final[int] = 0
 _LABEL: Final[str] = "recursion-depth"
+#: Characters of the output-directory digest that name a run's scratch root.
+#: Long enough that two output directories on one machine do not collide,
+#: short enough to read in a path an operator is asked to inspect.
+_SLUG_CHARS: Final[int] = 12
 
 
 def _pair(pair: ModelPair) -> str:
@@ -272,11 +276,17 @@ async def _record(
     # configuration or the machine and none of it becomes truer once a scratch
     # database, a gateway and a container are standing.
     await run_preflight(manifest=manifest, company_config=company_config)
-    # A run-scoped scratch root so two concurrent ``--record`` invocations never
-    # target the same workspace path: each unit's reset removes and re-copies a
-    # whole tree, which is only race-free within one process.
-    run_work_root = args.work_root / f"run-{uuid4().hex[:12]}"
+    # Derived from the output directory rather than minted per invocation. The
+    # journal in that directory is what a resume continues from, and the unit
+    # trees are what it continues WITH: a fresh name per run would leave every
+    # resumed cell unable to find what the previous attempt built, so
+    # ``_continue_cell`` would restart each one and the journal would be
+    # buying nothing. The concurrency this used to guard is guarded better one
+    # layer up: two runs sharing an output directory are refused by the
+    # journal itself, and two with different ones land on different roots.
+    run_work_root = args.work_root / f"run-{_recording_slug(args.out_dir)}"
     binder: HarnessBinder | None = None
+    completed = False
     try:
         async with RecordingGatewayHost(
             _host_config(args, company_config=company_config, work_root=run_work_root)
@@ -309,6 +319,7 @@ async def _record(
             # Written inside the host's lifetime so a teardown that overruns
             # cannot discard a sweep that already cost real money to produce.
             paths = await asyncio.to_thread(write_report, report, args.out_dir)
+            completed = True
     finally:
         # Grading and the oracle open their own containers, and both run OUTSIDE
         # the session context whose exit drains the agent's. Left to that hook
@@ -318,7 +329,13 @@ async def _record(
         # producer.
         if binder is not None:
             await binder.release_tool_sandboxes()
-        await _reclaim_workspaces(run_work_root, keep=args.keep_workspaces)
+        # Kept whenever the sweep did NOT finish, because those trees are
+        # exactly what ``--resume`` continues with. Reclaiming them on the way
+        # out of a failure turns every part-built cell into one that has to be
+        # paid for again, which is the loss the journal exists to stop.
+        await _reclaim_workspaces(
+            run_work_root, keep=args.keep_workspaces or not completed
+        )
     print("report written: " + ", ".join(str(path) for path in paths))
     if not report.measured_cells:
         msg = (
@@ -501,16 +518,36 @@ def _log_record_start(
     )
 
 
+def _recording_slug(out_dir: Path) -> str:
+    """A stable directory name for the recording written to *out_dir*.
+
+    The output directory names the recording, because the journal that makes a
+    sweep resumable lives in it. Hashed rather than embedded so an absolute
+    path with separators, spaces or a drive letter still yields one path
+    segment.
+
+    Args:
+        out_dir: Where the journal and the report are written.
+
+    Returns:
+        The slug.
+    """
+    resolved = str(out_dir.resolve())
+    return hashlib.sha256(resolved.encode("utf-8")).hexdigest()[:_SLUG_CHARS]
+
+
 async def _reclaim_workspaces(run_work_root: Path, *, keep: bool) -> None:
     """Remove this run's per-unit workspace trees.
 
     A sweep creates one tree per leaf and one per node, each written into by a
-    coding agent. Nothing reuses a tree between runs, so retaining them grows
-    disk monotonically unless a maintainer is inspecting what was built, which
-    for the first working artefact in nine rounds is a real reason.
+    coding agent. Nothing reuses a tree between COMPLETED runs, so retaining
+    them grows disk monotonically unless a maintainer is inspecting what was
+    built, which for the first working artefact in nine rounds is a real
+    reason. An unfinished run is the other case entirely: its trees are what
+    the next ``--resume`` builds on.
     """
     if keep:
-        print(f"workspaces kept: {run_work_root}")
+        print(f"workspaces kept for --resume: {run_work_root}")
         return
     await asyncio.to_thread(shutil.rmtree, run_work_root, ignore_errors=True)
 

--- a/tests/evals_spine/recursion_depth/test_record_cli.py
+++ b/tests/evals_spine/recursion_depth/test_record_cli.py
@@ -20,6 +20,8 @@ from evals.errors import (
     HarnessProviderMissingError,
     RecursionDepthJudgeNotIndependentError,
 )
+from evals.harness.binding import HarnessBinder
+from evals.harness.host import RecordingGatewayHost
 from evals.recursion_depth.manifest import Independence, load_manifest
 from evals.recursion_depth.tree import SpecBrief, load_spec_brief
 from synthorg.config.model_metadata import ModelMetadata
@@ -27,6 +29,7 @@ from synthorg.config.provider_schema import ProviderConfig, ProviderModelConfig
 from synthorg.config.schema import RootConfig
 from synthorg.core.types import NotBlankStr
 from synthorg.providers.enums import AuthType
+from tests._shared import mock_of
 
 pytestmark = pytest.mark.unit
 
@@ -340,7 +343,11 @@ def _record_args(tmp_path: Path) -> argparse.Namespace:
 
 
 def _recorded(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, sweep: Exception | None
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    sweep: Exception | None,
+    release: Exception | None = None,
 ) -> Path:
     """Stub everything ``_record`` reaches for, and seed the tree it builds.
 
@@ -353,6 +360,8 @@ def _recorded(
         tmp_path: The test's directory.
         monkeypatch: Patching seam.
         sweep: Raised by the sweep, or ``None`` for one that measured a cell.
+        release: Raised when the containers are released, or ``None`` for a
+            release that succeeds.
 
     Returns:
         The scratch root the recorder will build under, already populated so
@@ -360,6 +369,18 @@ def _recorded(
     """
     root = tmp_path / "work" / f"run-{_recording_slug(tmp_path / 'out')}"
     (root / "unit").mkdir(parents=True)
+
+    host = mock_of[RecordingGatewayHost](
+        # The three addresses the start log states, which is everything the
+        # lifecycle under test reads off a host.
+        container_gateway_url="http://gateway.invalid/v1",
+        container_mcp_url="http://gateway.invalid/mcp",
+        port=0,
+    )
+    host.__aenter__.return_value = host
+    host.__aexit__.return_value = False
+    binder = mock_of[HarnessBinder]()
+    binder.release_tool_sandboxes.side_effect = release
 
     async def _no_preflight(**_kwargs: object) -> None:
         return None
@@ -370,8 +391,8 @@ def _recorded(
         return SimpleNamespace(measured_cells=("one",))
 
     monkeypatch.setattr(record_module, "run_preflight", _no_preflight)
-    monkeypatch.setattr(record_module, "RecordingGatewayHost", _NullHost)
-    monkeypatch.setattr(record_module, "HarnessBinder", _NullBinder)
+    monkeypatch.setattr(record_module, "RecordingGatewayHost", lambda _c: host)
+    monkeypatch.setattr(record_module, "HarnessBinder", lambda **_k: binder)
     monkeypatch.setattr(record_module, "_host_config", lambda *a, **k: None)
     monkeypatch.setattr(record_module, "_build_context", _built_context)
     monkeypatch.setattr(record_module, "capture_provenance", lambda **_k: None)
@@ -387,48 +408,6 @@ async def _built_context(*_args: object, **_kwargs: object) -> None:
         Nothing the lifecycle under test reads.
     """
     return
-
-
-class _NullHost:
-    """A gateway host that stands up nothing.
-
-    The three addresses are the ones the start log states, which is the only
-    thing the lifecycle under test reads off a host.
-    """
-
-    container_gateway_url = "http://gateway.invalid/v1"
-    container_mcp_url = "http://gateway.invalid/mcp"
-    port = 0
-
-    def __init__(self, _config: object) -> None:
-        self._config = _config
-
-    async def __aenter__(self) -> _NullHost:
-        """Enter without binding a port.
-
-        Returns:
-            Itself.
-        """
-        return self
-
-    async def __aexit__(self, *_exc: object) -> bool:
-        """Leave without tearing anything down.
-
-        Returns:
-            False, so an exception propagates.
-        """
-        return False
-
-
-class _NullBinder:
-    """A binder holding no containers."""
-
-    def __init__(self, *, host: object) -> None:
-        self._host = host
-
-    async def release_tool_sandboxes(self) -> None:
-        """Release nothing."""
-        return
 
 
 class TestTheScratchRootAResumeContinuesWith:
@@ -504,6 +483,28 @@ class TestWhatTheRecorderDoesWithTheTreesItBuilt:
             )
 
         assert root.is_dir()
+
+    async def test_a_release_failure_still_reclaims_a_finished_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Releasing the containers and reclaiming the trees are two
+        # obligations, not a sequence: run as one, the first one raising
+        # silently drops the second and the disk grows for ever.
+        root = _recorded(
+            tmp_path, monkeypatch, sweep=None, release=OSError("the daemon went away")
+        )
+
+        with pytest.raises(OSError, match="the daemon went away"):
+            await record_module._record(
+                _record_args(tmp_path),
+                manifest=load_manifest(_MANIFEST),
+                spec=_spec(),
+                company_config=_config(
+                    executor_family="bound-family-a", reviewer_family="bound-family-b"
+                ),
+            )
+
+        assert not root.exists()
 
     async def test_a_sweep_that_wrote_its_report_reclaims_them(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/evals_spine/recursion_depth/test_record_cli.py
+++ b/tests/evals_spine/recursion_depth/test_record_cli.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import pytest
 from scripts import record_recursion_depth as record_module
 from scripts.record_recursion_depth import (
+    _reclaim_workspaces,
+    _recording_slug,
     check_declared_families,
     describe_plan,
     main,
@@ -317,3 +319,50 @@ class TestStaging:
         # reads as a measured zero.
         with pytest.raises(ValueError, match="does not carry"):
             narrow(load_manifest(_MANIFEST), "1,4,9")
+
+
+class TestTheScratchRootAResumeContinuesWith:
+    """A journal buys nothing if the trees it indexes move every run."""
+
+    def test_the_same_output_directory_names_the_same_root(
+        self, tmp_path: Path
+    ) -> None:
+        # The resume path rebuilds each unit's tree path from the run root, so
+        # a per-invocation name would leave every resumed cell finding nothing
+        # and paying for what the last attempt already built.
+        assert _recording_slug(tmp_path / "out") == _recording_slug(tmp_path / "out")
+
+    def test_two_output_directories_name_different_roots(self, tmp_path: Path) -> None:
+        # What the per-invocation name used to buy: two recordings running at
+        # once must not reset each other's trees.
+        assert _recording_slug(tmp_path / "one") != _recording_slug(tmp_path / "two")
+
+    def test_the_root_is_one_path_segment(self, tmp_path: Path) -> None:
+        # An output directory is an absolute path carrying separators, and on
+        # this platform a drive letter; embedding it would build a tree nobody
+        # asked for.
+        slug = _recording_slug(tmp_path / "out")
+
+        assert "/" not in slug
+        assert "\\" not in slug
+
+    async def test_an_unfinished_run_keeps_its_trees(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Reclaiming on the way out of a failure destroys exactly what the
+        # next --resume continues with.
+        root = tmp_path / "run-abc"
+        (root / "unit").mkdir(parents=True)
+
+        await _reclaim_workspaces(root, keep=True)
+
+        assert root.is_dir()
+        assert "--resume" in capsys.readouterr().out
+
+    async def test_a_finished_run_reclaims_them(self, tmp_path: Path) -> None:
+        root = tmp_path / "run-abc"
+        (root / "unit").mkdir(parents=True)
+
+        await _reclaim_workspaces(root, keep=False)
+
+        assert not root.exists()

--- a/tests/evals_spine/recursion_depth/test_record_cli.py
+++ b/tests/evals_spine/recursion_depth/test_record_cli.py
@@ -1,7 +1,9 @@
 # module-kind: tests
 """The entry point: plan mode spends nothing, and staging narrows honestly."""
 
+import argparse
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from scripts import record_recursion_depth as record_module
@@ -321,6 +323,114 @@ class TestStaging:
             narrow(load_manifest(_MANIFEST), "1,4,9")
 
 
+def _record_args(tmp_path: Path) -> argparse.Namespace:
+    """Build the argument bundle ``_record`` reads.
+
+    Returns:
+        The namespace.
+    """
+    return argparse.Namespace(
+        out_dir=tmp_path / "out",
+        work_root=tmp_path / "work",
+        keep_workspaces=False,
+        manifest=_MANIFEST,
+        resume=False,
+        max_sessions=None,
+    )
+
+
+def _recorded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, sweep: Exception | None
+) -> Path:
+    """Stub everything ``_record`` reaches for, and seed the tree it builds.
+
+    Every collaborator between the preflight and the report is a gateway, a
+    container or a provider call, so each is replaced with the smallest thing
+    that lets the lifecycle run. What is left unstubbed is the part under
+    test: which scratch root is chosen, and whether it survives.
+
+    Args:
+        tmp_path: The test's directory.
+        monkeypatch: Patching seam.
+        sweep: Raised by the sweep, or ``None`` for one that measured a cell.
+
+    Returns:
+        The scratch root the recorder will build under, already populated so
+        its removal is observable.
+    """
+    root = tmp_path / "work" / f"run-{_recording_slug(tmp_path / 'out')}"
+    (root / "unit").mkdir(parents=True)
+
+    async def _no_preflight(**_kwargs: object) -> None:
+        return None
+
+    async def _swept(*_args: object, **_kwargs: object) -> object:
+        if sweep is not None:
+            raise sweep
+        return SimpleNamespace(measured_cells=("one",))
+
+    monkeypatch.setattr(record_module, "run_preflight", _no_preflight)
+    monkeypatch.setattr(record_module, "RecordingGatewayHost", _NullHost)
+    monkeypatch.setattr(record_module, "HarnessBinder", _NullBinder)
+    monkeypatch.setattr(record_module, "_host_config", lambda *a, **k: None)
+    monkeypatch.setattr(record_module, "_build_context", _built_context)
+    monkeypatch.setattr(record_module, "capture_provenance", lambda **_k: None)
+    monkeypatch.setattr(record_module, "run_sweep", _swept)
+    monkeypatch.setattr(record_module, "write_report", lambda *_a: (tmp_path / "r",))
+    return root
+
+
+async def _built_context(*_args: object, **_kwargs: object) -> None:
+    """Stand in for the context build, which needs a live gateway.
+
+    Returns:
+        Nothing the lifecycle under test reads.
+    """
+    return
+
+
+class _NullHost:
+    """A gateway host that stands up nothing.
+
+    The three addresses are the ones the start log states, which is the only
+    thing the lifecycle under test reads off a host.
+    """
+
+    container_gateway_url = "http://gateway.invalid/v1"
+    container_mcp_url = "http://gateway.invalid/mcp"
+    port = 0
+
+    def __init__(self, _config: object) -> None:
+        self._config = _config
+
+    async def __aenter__(self) -> _NullHost:
+        """Enter without binding a port.
+
+        Returns:
+            Itself.
+        """
+        return self
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        """Leave without tearing anything down.
+
+        Returns:
+            False, so an exception propagates.
+        """
+        return False
+
+
+class _NullBinder:
+    """A binder holding no containers."""
+
+    def __init__(self, *, host: object) -> None:
+        self._host = host
+
+    async def release_tool_sandboxes(self) -> None:
+        """Release nothing."""
+        return
+
+
 class TestTheScratchRootAResumeContinuesWith:
     """A journal buys nothing if the trees it indexes move every run."""
 
@@ -365,5 +475,51 @@ class TestTheScratchRootAResumeContinuesWith:
         (root / "unit").mkdir(parents=True)
 
         await _reclaim_workspaces(root, keep=False)
+
+        assert not root.exists()
+
+
+class TestWhatTheRecorderDoesWithTheTreesItBuilt:
+    """Which trees survive is decided by the recorder, not by its helper.
+
+    The two cases above pin what ``_reclaim_workspaces`` does when told; these
+    pin what it is told, which is the half a resume actually depends on. A
+    ``completed`` flag set one statement too early reads correctly in both
+    branches of the helper and still deletes what the next attempt needed.
+    """
+
+    async def test_a_sweep_that_raised_leaves_its_trees_behind(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = _recorded(tmp_path, monkeypatch, sweep=OSError("the gateway died"))
+
+        with pytest.raises(OSError, match="the gateway died"):
+            await record_module._record(
+                _record_args(tmp_path),
+                manifest=load_manifest(_MANIFEST),
+                spec=_spec(),
+                company_config=_config(
+                    executor_family="bound-family-a", reviewer_family="bound-family-b"
+                ),
+            )
+
+        assert root.is_dir()
+
+    async def test_a_sweep_that_wrote_its_report_reclaims_them(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = _recorded(tmp_path, monkeypatch, sweep=None)
+
+        assert (
+            await record_module._record(
+                _record_args(tmp_path),
+                manifest=load_manifest(_MANIFEST),
+                spec=_spec(),
+                company_config=_config(
+                    executor_family="bound-family-a", reviewer_family="bound-family-b"
+                ),
+            )
+            == 0
+        )
 
         assert not root.exists()

--- a/tests/evals_spine/recursion_depth/test_record_cli.py
+++ b/tests/evals_spine/recursion_depth/test_record_cli.py
@@ -327,14 +327,15 @@ class TestTheScratchRootAResumeContinuesWith:
     def test_the_same_output_directory_names_the_same_root(
         self, tmp_path: Path
     ) -> None:
-        # The resume path rebuilds each unit's tree path from the run root, so
-        # a per-invocation name would leave every resumed cell finding nothing
-        # and paying for what the last attempt already built.
+        # A resume rebuilds each unit's tree path from the run root, so a root
+        # it cannot predict leaves every cell finding nothing and paying again
+        # for what the last attempt already built.
         assert _recording_slug(tmp_path / "out") == _recording_slug(tmp_path / "out")
 
     def test_two_output_directories_name_different_roots(self, tmp_path: Path) -> None:
-        # What the per-invocation name used to buy: two recordings running at
-        # once must not reset each other's trees.
+        # Each unit's provisioning removes and re-copies a whole tree, which is
+        # race-free only within one process, so two recordings running at once
+        # must never share a root.
         assert _recording_slug(tmp_path / "one") != _recording_slug(tmp_path / "two")
 
     def test_the_root_is_one_path_segment(self, tmp_path: Path) -> None:


### PR DESCRIPTION
The session journal that just landed lets a resumed cell take up the units an earlier attempt built, but only if their trees are still where it looks. Through the recorder's own entry point they never were, so the feature was unreachable from the one place that uses it.

Two things stood between the journal and the trees it indexes.

**The scratch root was minted per invocation.** `run_work_root` took a `uuid4()` suffix, so every `--resume` landed on a directory the previous attempt had never written to. `_continue_cell` requires every recorded unit to still have its tree, so it would find none, restart each cell whole, and the journal would be buying nothing. It is now derived from the output directory, which is what names a recording: the journal a resume continues from lives there, and the trees belong to it. The concurrency the random suffix guarded is guarded better one layer up, by the journal itself refusing two runs in one output directory; two runs with different output directories still land on different roots.

**A failed sweep reclaimed its own trees.** `_reclaim_workspaces` ran from a `finally`, so the exit that most needs the trees kept was the exit that deleted them. It now keeps them whenever the sweep did not finish, and says so in words that name the flag that uses them. A completed sweep still reclaims, because nothing reuses a tree between finished runs. Releasing the containers and reclaiming the trees are also nested rather than sequential, so a failure in the first cannot silently drop the second.

Covered by `TestTheScratchRootAResumeContinuesWith` (the same output directory names the same root, two name different roots, the name is one path segment) and `TestWhatTheRecorderDoesWithTheTreesItBuilt`, which drives `_record` end to end and asserts what actually decides the outcome: a sweep that raised keeps its trees, one that wrote its report reclaims them, and a release failure still reclaims.

## Review findings not taken

**An exclusive per-output-directory lock around the host and the journals.** Declined. The hazard needs two recorders driven at the same output directory at once, and the non-resume half of that is already refused where it should be, by `open_journal` rejecting a journal it did not create. What remains is an operator running the same recording twice concurrently under `--resume`, which no workflow produces. Against that, a correct cross-platform interprocess lock is either a new dependency or hand-written `fcntl`/`msvcrt` branches, which is a large and easily-wrong surface for this. If it is ever wanted, the right owner is the journal, which already knows the recording's identity, rather than the CLI wrapping the whole lifecycle.

**Using the full SHA-256 digest for the scratch-root name.** Declined; discussed in thread and accepted there. 12 characters is deliberate: the slug is a path segment near the root of a tree that nests per unit and then holds agent-created files, on a platform with a 260-character default limit.

Refs #2801
