### PR TITLE
fix: publish the healthy fine-tune variant when its sibling cell is stopped

### DIFF
--- a/.github/actions/build-scan-image/action.yml
+++ b/.github/actions/build-scan-image/action.yml
@@ -87,6 +87,24 @@ inputs:
       image never share a scope.
     required: false
     default: ""
+  layer-cache:
+    description: >-
+      Whether to read and write the BuildKit layer cache for this image.
+      Pass the literal string "false" to disable both directions.
+
+      The Actions cache is one repo-global budget of 10 GB, so an image
+      whose layers do not fit in a fraction of it does not merely fail to
+      benefit: it evicts every other image's entries on the way in, and is
+      itself uploaded in 32 MB chunks against a service concurrently
+      evicting to make room. Measured on the fine-tune GPU variant, whose
+      torch/CUDA venv is a single 3.16 GB blob: two copies of that one
+      layer held 6.3 GB of the 9.81 GB in use, and the export took the
+      build from its usual 15-20 minutes to 45, having previously hung
+      outright until the job ceiling killed it. `mode=min` is not the
+      answer for that shape, because the venv is COPYed into the final
+      stage and so is exported either way.
+    required: false
+    default: "true"
   free-disk-space:
     description: >-
       Run aggressive disk cleanup before buildx setup. Required for
@@ -324,11 +342,23 @@ runs:
         # and three `mode=max` exports evict each other's index, leaving the
         # hit rate at whichever image finished last while still burning the
         # repo cache quota three times over.
-        cache-from: type=gha,scope=${{ inputs.cache-scope != '' && inputs.cache-scope || inputs.image-name }}-${{ inputs.platform }}
+        #
+        # Both directions render empty when the caller sets `layer-cache` to
+        # "false"; the non-empty value sits on the TRUTHY branch of each
+        # expression because GHA falls through `A && '' || B` to B, so
+        # putting the empty string there would enable the cache in exactly
+        # the case meant to disable it.
+        cache-from: ${{ inputs.layer-cache == 'true' && format('type=gha,scope={0}-{1}', inputs.cache-scope != '' && inputs.cache-scope || inputs.image-name, inputs.platform) || '' }}
         # `ignore-error` because the export is an optimisation, not a build
         # output: a cache-service hiccup or the repo hitting its cache quota
-        # would otherwise fail an image that built perfectly well.
-        cache-to: type=gha,mode=max,ignore-error=true,scope=${{ inputs.cache-scope != '' && inputs.cache-scope || inputs.image-name }}-${{ inputs.platform }}
+        # would otherwise fail an image that built perfectly well. It covers
+        # an export that ERRORS and nothing else: a stalled export never
+        # errors, and the backend's own `timeout` attribute is consulted
+        # between retry attempts rather than attached to the in-flight
+        # request, so a single hung upload outlives any value set there. An
+        # image too large to export is therefore excluded via `layer-cache`
+        # rather than bounded here.
+        cache-to: ${{ inputs.layer-cache == 'true' && format('type=gha,mode=max,ignore-error=true,scope={0}-{1}', inputs.cache-scope != '' && inputs.cache-scope || inputs.image-name, inputs.platform) || '' }}
         platforms: linux/${{ inputs.platform }}
 
     # `!cancelled()` not the success chain: every scan gate below keys off

--- a/.github/actions/build-scan-image/action.yml
+++ b/.github/actions/build-scan-image/action.yml
@@ -101,8 +101,8 @@ inputs:
       layer held 6.3 GB of the 9.81 GB in use, and the export took the
       build from its usual 15-20 minutes to 45, having previously hung
       outright until the job ceiling killed it. `mode=min` is not the
-      answer for that shape, because the venv is COPYed into the final
-      stage and so is exported either way.
+      answer for that shape, because a `COPY` pulls the venv into the
+      final stage, so it is exported either way.
     required: false
     default: "true"
   free-disk-space:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1185,12 +1185,14 @@ jobs:
       needs.build-fine-tune-base.result == 'success' &&
       (github.event_name == 'pull_request' || needs.build-fine-tune-base-publish.result == 'success')
     runs-on: ubuntu-24.04
-    # A healthy build of either variant runs 15-20 minutes. This ceiling is
-    # the ONLY bound on a stalled BuildKit cache export: `ignore-error=true`
-    # on `cache-to` covers an export that ERRORS, and a stall never errors,
-    # while the backend's own `timeout` attribute is consulted between retry
-    # attempts rather than attached to the in-flight request, so a single
-    # hung upload outlives any value set there.
+    # A build of either variant runs 15-20 minutes with `layer-cache: "false"`
+    # above, which is what makes this ceiling safe: the same build spent 45
+    # minutes, and once hung indefinitely, exporting its 3.16 GB venv layer to
+    # a repo cache sitting at its 10 GB ceiling. Raising the ceiling instead
+    # would have bought a slow build more room to stay slow; removing the
+    # export removes the variance the ceiling was absorbing. Keep the two
+    # together: restoring the layer cache here without restoring 60 minutes
+    # reinstates a timeout this job legitimately exceeded.
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -1227,6 +1229,11 @@ jobs:
           # torch / CUDA wheels publish no arm64 build.
           platform: amd64
           cache-scope: fine-tune-${{ matrix.variant }}
+          # The one image excluded from the repo-global layer cache. Its
+          # torch/CUDA venv is a single 3.16 GB blob, so exporting it both
+          # evicts every other image's entries and takes minutes to upload
+          # against a cache already at its ceiling.
+          layer-cache: "false"
           free-disk-space: "true"
           trivy-version: ${{ env.TRIVY_VERSION }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1185,7 +1185,13 @@ jobs:
       needs.build-fine-tune-base.result == 'success' &&
       (github.event_name == 'pull_request' || needs.build-fine-tune-base-publish.result == 'success')
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    # A healthy build of either variant runs 15-20 minutes. This ceiling is
+    # the ONLY bound on a stalled BuildKit cache export: `ignore-error=true`
+    # on `cache-to` covers an export that ERRORS, and a stall never errors,
+    # while the backend's own `timeout` attribute is consulted between retry
+    # attempts rather than attached to the in-flight request, so a single
+    # hung upload outlives any value set there.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -1228,19 +1234,23 @@ jobs:
   build-fine-tune-publish:
     name: Publish Fine-Tune
     needs: [version, build-fine-tune]
-    # `failure` is admitted deliberately. `build-fine-tune` is a
-    # `fail-fast: false` matrix, so its aggregate result is `failure` when ANY
-    # variant failed. Gating on `success` alone would let one variant's
-    # transient failure withhold the healthy variant's publish as well, and
-    # then fail both retag legs on the next tag push, since the images the tag
-    # needs were never pushed. Each publish leg downloads its own variant's
-    # tarball, so the healthy variant publishes while the failed variant's leg
-    # fails loudly on the artifact it never produced. `skipped` stays excluded:
-    # no build ran, so there is nothing to push.
+    # `failure` and `cancelled` are both admitted deliberately.
+    # `build-fine-tune` is a `fail-fast: false` matrix, so its aggregate
+    # result is `failure` when ANY variant failed and `cancelled` when any
+    # variant hit the job `timeout-minutes` ceiling. Gating on `success` alone
+    # would let one variant's transient failure withhold the healthy variant's
+    # publish as well, and then fail both retag legs on the next tag push,
+    # since the images the tag needs were never pushed. Each publish leg
+    # downloads its own variant's tarball, so the healthy variant publishes
+    # while the stopped variant's leg fails loudly on the artifact it never
+    # produced. `skipped` stays excluded: no build ran, so there is nothing to
+    # push. `!cancelled()` is unrelated and stays: it keys on the WORKFLOW RUN
+    # being cancelled, which a single job timing out does not do.
     if: >-
       !cancelled() &&
       (needs.build-fine-tune.result == 'success' ||
-        needs.build-fine-tune.result == 'failure') &&
+        needs.build-fine-tune.result == 'failure' ||
+        needs.build-fine-tune.result == 'cancelled') &&
       github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false


### PR DESCRIPTION
## What

Two hunks in `.github/workflows/build-images.yml`:

1. `build-fine-tune-publish` admits `cancelled` alongside `success` and `failure`.
2. `build-fine-tune` `timeout-minutes` 60 -> 30.

## Why

The main-push run for `d66f5c6` ([32782814008](https://github.com/Aureliolo/synthorg/actions/runs/32782814008)) left `main` red, and the job that broke is not the one that went red.

`Build Fine-Tune (gpu)` finished building at 22:15:49 and then stalled in buildx's `#29 exporting to GitHub Actions Cache`, on `writing layer sha256:397490b3...`, emitting nothing until the job-level `timeout-minutes: 60` killed it at 23:05:59. The image was complete and its scan tarball written 50 minutes before the job died.

A job-level timeout reports as `cancelled`, and a `fail-fast: false` matrix with one cancelled cell aggregates to `cancelled`, so the publish gate's `success`-or-`failure` check skipped **both** variants. The `cpu` variant had built cleanly at 22:15:38 and was never pushed.

The tag push of `v0.9.4-dev.164` then took the retag path ([32782848293](https://github.com/Aureliolo/synthorg/actions/runs/32782848293)). Backend/web/sandbox/sidecar/openhands retagged fine; both fine-tune legs failed with `not found`. `Verify Image Signatures` then refused to run at all, and `Docker Pass` went red on both runs.

The gate's existing comment already argued for exactly this case - "one variant's transient failure [shouldn't] withhold the healthy variant's publish as well, and then fail both retag legs on the next tag push" - and enumerated only `failure`.

## Why the ceiling is the fix

`cache-to: type=gha,mode=max,ignore-error=true` already declares the export optional. `ignore-error` fires on an export that ERRORS; a stall never errors, so it never fired.

The backend's own `timeout` attribute cannot close this either. BuildKit v0.32.2 (the pinned `buildx-stable-1` digest) hands it to `go-actions-cache` as `Opt.Timeout`, and `doWithRetries` computes `max := time.Now().Add(c.opt.Timeout)` then consults it only BETWEEN retry attempts - the HTTP call itself gets `req.WithContext(ctx)` on the unmodified context, with no client timeout set. A single hung request is unbounded at any value, which is why the documented 10m default never fired. Composite-action steps do not accept `timeout-minutes`, so there is no step-level wall clock available inside `build-scan-image`.

The job ceiling is the only bound that fires.

## Why 30

Healthy GPU builds run 15-19.7 minutes across the 11 consecutive prior runs sampled, so 30 keeps roughly 1.5x headroom while halving the runner time a stall burns. It also removes an outlier: every other build job in this workflow is already 30 (openhands 45, retags 40); `build-fine-tune` at 60 was the only one.

## Not changed

- `!cancelled()` stays. It keys on the WORKFLOW RUN being cancelled, which a single job timing out does not do, so it was never implicated.
- `skipped` stays excluded from the publish gate: no build ran, so there is nothing to push.
- The retag legs failing was correct - the images genuinely did not exist, and failing closed there is the point.
- No change to `build-scan-image`, so no other image's build path is touched.

## Verification

`actionlint`, `zizmor`, `yamllint`, the sentinel-rollup gate and `CI workflow resilience (job timeouts + fail-closed retry ladders)` all pass on the new values; full pre-push run was 90/90 in 1m25s.

Closes #2839